### PR TITLE
feat: add CI pipeline and make verification loop explicit in CLAUDE.md

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+      - uses: Swatinem/rust-cache@v2
+      - name: Format
+        run: cargo fmt --all -- --check
+      - name: Lint
+        run: cargo clippy --workspace --all-targets -- -D warnings
+      - name: Build
+        run: cargo build --workspace
+      - name: Test
+        run: cargo test --workspace

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,8 +26,18 @@ Dependency direction is one-way: `app` / `feed-binance` → `engine`. Never add 
 - **Data honesty**: inferred or incomplete data is labeled as such, never silently patched.
 - **Small and focused**: this is not a trading platform. Build bars, show bars, expose bars to code.
 
+## Verification loop (mandatory)
+
+Every change must pass all four checks before commit — no exceptions:
+
+1. `cargo fmt --all -- --check`
+2. `cargo clippy --workspace --all-targets -- -D warnings`
+3. `cargo build --workspace`
+4. `cargo test --workspace`
+
+CI (`.github/workflows/ci.yml`) enforces the same four checks on every PR and on pushes to `main`. After pushing a PR, watch CI with `gh pr checks <n> --watch` and fix any failure before requesting review or merging. A PR with red CI is never merged.
+
 ## Workflow
 
 - Engine code is developed test-first: write fixture trades + expected bars, then implement until green.
-- Run `cargo test --workspace` and clippy before any commit.
 - Branches: `feat/<desc>`, `fix/<desc>`, `docs/<desc>`. Commit messages: conventional style (`feat: ...`, `fix: ...`), imperative mood, English.


### PR DESCRIPTION
## Summary

Closes the verification loop remotely, per Anthropic's "give Claude a way to verify its work" guidance:

- **`.github/workflows/ci.yml`** — GitHub Actions running the same four checks used locally, on every PR and push to `main`:
  1. `cargo fmt --all -- --check`
  2. `cargo clippy --workspace --all-targets -- -D warnings`
  3. `cargo build --workspace`
  4. `cargo test --workspace`

  Uses `dtolnay/rust-toolchain@stable` + `Swatinem/rust-cache` for fast runs.
- **CLAUDE.md** — new "Verification loop (mandatory)" section making the rule explicit: all four checks before any commit, CI must be green before merge, and the agent watches CI with `gh pr checks <n> --watch`.

## Verification

All four checks pass locally on this branch. This PR itself is the first run of the new CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
