### PR TITLE
docs: add contributing guide and GitHub issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,32 @@
+name: Bug report
+description: Something doesn't work as documented
+labels: ["bug"]
+body:
+  - type: textarea
+    id: what
+    attributes:
+      label: What happened
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. ...
+        2. ...
+    validations:
+      required: true
+  - type: input
+    id: env
+    attributes:
+      label: Environment
+      description: OS, `rustc --version`, commit hash
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Ideas, questions & design discussion
+    url: https://github.com/milocaetano/quantick/discussions
+    about: For anything that isn't an actionable work item yet — start here.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,38 @@
+name: Feature request
+description: Propose a new capability or improvement
+labels: ["type:feat"]
+body:
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: What problem does this solve? Why does it matter?
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Proposed scope
+      description: What is in scope — and what is explicitly out?
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: How do we know it's done? One checkbox per criterion.
+      placeholder: |
+        - [ ] ...
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - engine
+        - feed-binance
+        - app
+        - project / tooling
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+## Summary
+
+<!-- What does this PR do, and why? -->
+
+Closes #
+
+## Verification loop
+
+<!-- All four must pass locally before requesting review (see CONTRIBUTING.md). -->
+
+- [ ] `cargo fmt --all -- --check`
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
+- [ ] `cargo build --workspace`
+- [ ] `cargo test --workspace`
+
+## Notes for the reviewer
+
+<!-- Trade-offs, boundary cases you want eyes on, follow-ups. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# Contributing to quantick
+
+Thanks for your interest! The whole point of this project is to open up tooling that has historically been private, so ideas, questions and code are all welcome.
+
+- **Ideas, questions, design discussion** → [Discussions](https://github.com/milocaetano/quantick/discussions)
+- **Actionable work** (bugs, features with a defined scope) → [Issues](https://github.com/milocaetano/quantick/issues)
+
+## Getting started
+
+You need a stable Rust toolchain ([rustup](https://rustup.rs/)).
+
+```sh
+git clone https://github.com/milocaetano/quantick.git
+cd quantick
+cargo build --workspace
+cargo test --workspace
+```
+
+## Workflow
+
+Every change follows the same loop — including changes by the maintainer:
+
+1. **Start from an issue.** Pick one from the current milestone (issues labeled `good first issue` are a great entry point), or open a new one first. Comment on the issue so work isn't duplicated.
+2. **Branch** off `main`: `feat/<desc>`, `fix/<desc>` or `docs/<desc>`.
+3. **Engine code is test-first.** Write the fixture trades and expected bars before the implementation, then implement until green.
+4. **Run the verification loop** (below) locally.
+5. **Open a PR** that references the issue (`Closes #N`). CI runs the same checks; a PR with red CI is never merged.
+
+## Verification loop (mandatory)
+
+All four must pass before every commit — no exceptions:
+
+```sh
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo build --workspace
+cargo test --workspace
+```
+
+## Commit style
+
+Conventional style, imperative mood, English: `feat: ...`, `fix: ...`, `docs: ...`, `test: ...`.
+
+## Design rules
+
+These are non-negotiable; PRs that break them won't be merged (see `CLAUDE.md` for the full list):
+
+- **Determinism.** Same trades in → same bars out, always. No wall-clock time, randomness or iteration-order-dependent output inside the engine.
+- **One engine, three consumers.** Chart, backtest and bot consume the same aggregator code path — never fork bar-building logic per consumer.
+- **Data honesty.** Inferred or incomplete data is labeled as such, never silently patched.
+- **Small and focused.** This is not a trading platform. Build bars, show bars, expose bars to code.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ quantick exists to change that: **a free, open, programmable implementation of t
 
 ## Contributing
 
-The whole point of this project is to open up tooling that has historically been private. Ideas, use cases and design discussion are welcome right now — open an issue, even before there's code to review.
+The whole point of this project is to open up tooling that has historically been private. Ideas, use cases and design discussion are welcome right now — [start a discussion](https://github.com/milocaetano/quantick/discussions), even before there's code to review. Ready to contribute code? See [CONTRIBUTING.md](CONTRIBUTING.md) for the workflow.
 
 ## License
 


### PR DESCRIPTION
## Summary

Adds the community/process layer of the repo: a contributing guide documenting the workflow (issue -> branch -> PR -> green CI -> merge) and the mandatory verification loop, plus GitHub issue forms and a PR template so both are surfaced automatically in the UI. README now links to CONTRIBUTING.md and to Discussions.

Closes #10

## Verification loop

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo build --workspace`
- [x] `cargo test --workspace`

## Notes for the reviewer

Docs-only change; no engine code touched. Issue forms use YAML issue forms (not markdown templates) so fields are structured and labels are applied automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
