### PR TITLE
chore(tooling): add project skills for the issue->branch->PR workflow

### DIFF
--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: issue
+description: Turn an idea into a well-formed GitHub issue with context, scope and acceptance criteria, correct labels, milestone and board placement. Use when the user types /issue <idea> or asks to create or file an issue.
+---
+
+# Create a well-formed issue
+
+## Steps
+
+1. **Vague-idea check**: if there is no concrete deliverable yet, suggest opening a GitHub Discussion instead and stop. Issues are actionable work items only.
+
+2. **Gather** — ask at most 2–3 questions, and only for what cannot be inferred:
+   - **Context** — what problem this solves, why it matters
+   - **Scope** — what is in, and what is explicitly out
+   - **Acceptance criteria** — checkboxes answering "how do we know it's done"
+
+3. **Title**: `type(area): imperative description`, matching existing issues (e.g. `feat(engine): tick bars (close after N trades)`). Everything in English.
+
+4. **Create** with `gh issue create --body-file -` using body sections `## Context`, `## Scope`, `## Acceptance criteria`. Apply one `area:*` label plus one `type:*` label (or `bug`), and the current milestone (`v0.1 - Engine core`) unless told otherwise.
+
+5. **Add to the board** in Todo:
+
+   ```sh
+   ITEM=$(gh project item-add 1 --owner milocaetano --url <issue-url> --format json --jq '.id')
+   gh project item-edit --id "$ITEM" --project-id PVT_kwHOA0fkv84BeK9c \
+     --field-id PVTSSF_lAHOA0fkv84BeK9czhYnKUg --single-select-option-id f75ad846
+   ```
+
+6. **Report** the issue number and URL.
+
+## Label reference
+
+- Areas: `area:engine`, `area:feed`, `area:app`
+- Types: `type:feat`, `type:fix`, `type:docs`, `type:test`, `type:ci`, `bug`

--- a/.claude/skills/new-task/SKILL.md
+++ b/.claude/skills/new-task/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: new-task
+description: Start work on a GitHub issue the right way - read it, branch from updated main with the correct prefix, move the board card to In Progress. Use when the user types /new-task <issue-number> or asks to start or pick up an issue.
+---
+
+# Start work on an issue
+
+Argument: the issue number (e.g. `/new-task 3`). If missing, list open issues in the current milestone (`gh issue list --milestone "v0.1 - Engine core"`) and ask which one to pick.
+
+## Steps
+
+1. **Read the issue**: `gh issue view <N>`. If it does not exist or is already closed, stop and report. Summarize scope and acceptance criteria back to the user — they become the work checklist.
+
+2. **Guard the working tree**: `git status --short` must be clean. If not, stop and ask what to do with the pending changes — never carry unrelated work into a new branch.
+
+3. **Branch from updated main**:
+
+   ```sh
+   git checkout main
+   git pull origin main
+   git checkout -b <prefix>/<short-kebab-slug>
+   ```
+
+   Prefix from the issue's labels: `bug` or `type:fix` → `fix/`, `type:docs` → `docs/`, everything else → `feat/`. Slug: short kebab-case from the issue title.
+
+4. **Move the board card to In Progress** (project "quantick roadmap"):
+
+   ```sh
+   ITEM=$(gh project item-list 1 --owner milocaetano --format json \
+     --jq '.items[] | select(.content.number==<N>) | .id')
+   # If empty, the issue is not on the board yet - add it first:
+   # ITEM=$(gh project item-add 1 --owner milocaetano --url <issue-url> --format json --jq '.id')
+   gh project item-edit --id "$ITEM" --project-id PVT_kwHOA0fkv84BeK9c \
+     --field-id PVTSSF_lAHOA0fkv84BeK9czhYnKUg --single-select-option-id 47fc9ee4
+   ```
+
+5. **Report**: branch name, card moved, and the acceptance criteria as a checklist. For `area:engine` issues, remind: test-first — fixture trades and expected bars are written before the implementation.
+
+## Board reference (project 1)
+
+- Project ID: `PVT_kwHOA0fkv84BeK9c`
+- Status field ID: `PVTSSF_lAHOA0fkv84BeK9czhYnKUg`
+- Status options: Todo `f75ad846` · In Progress `47fc9ee4` · Done `98236657`

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: ship
+description: Deliver the current branch - run the full verification loop, commit, push, open a PR with Closes #N, and watch CI until green. Use when the user types /ship or asks to finish or deliver the current task.
+---
+
+# Ship the current branch
+
+## Guards
+
+- Never ship from `main`. If `git branch --show-current` says `main`, stop and point the user to `/new-task`.
+- Identify the linked issue before opening the PR: check the board card in In Progress, the branch name, or conversation context. If ambiguous, ask the user which issue this closes.
+
+## Steps
+
+1. **Verification loop** — run in order, stop at the first failure and fix it before continuing. Never ship red:
+
+   ```sh
+   cargo fmt --all
+   cargo fmt --all -- --check
+   cargo clippy --workspace --all-targets -- -D warnings
+   cargo build --workspace
+   cargo test --workspace
+   ```
+
+2. **Commit** anything pending: conventional style (`feat: ...`, `fix: ...`), imperative mood, English.
+
+3. **Push**: `git push -u origin <branch>`.
+
+4. **Open the PR** following the repo template (`.github/PULL_REQUEST_TEMPLATE.md`): summary of what and why, `Closes #<N>`, the four verification-loop boxes checked (they just ran), notes for the reviewer. Use `gh pr create --body-file -` with a heredoc.
+
+5. **Watch CI**: `gh pr checks <pr> --watch`. If checks have not registered yet, find the run with `gh run list --branch <branch>` and use `gh run watch <id> --exit-status`. Red → read the failing log, fix, push, repeat.
+
+6. **Report** the PR URL and CI status. Do **not** merge unless the user asks. When they do: `gh pr merge <pr> --merge --delete-branch` — the `Closes #N` closes the issue and the board card moves to Done automatically.


### PR DESCRIPTION
## Summary

Adds three Claude Code project skills under `.claude/skills/` that encode the repo's workflow so no step can be skipped:

- `/new-task <issue>` — read the issue, branch from updated main with the correct prefix, move the board card to In Progress
- `/ship` — run the full verification loop, commit, push, open a PR with `Closes #N`, watch CI until green
- `/issue` — turn an idea into a well-formed issue (context / scope / acceptance criteria), labeled, milestoned and added to the board

Closes #12

## Verification loop

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo build --workspace`
- [x] `cargo test --workspace`

## Notes for the reviewer

Markdown-only change; no Rust code touched. The skills hardcode the project board IDs (project 1, Status field and option IDs) — if the board is ever recreated, those references need updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
