### PR TITLE
feat(engine): define Trade/Bar core types and CSV trade fixtures

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Normalise line endings to LF on every platform. Golden fixtures and the
+# byte-identical determinism checks must compare equal whether checked out on
+# Windows (dev) or Linux (CI); CRLF drift would break them silently.
+* text=auto eol=lf

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,280 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "bitvec"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
+name = "borsh"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a88b7ea17d208c4193f2c1e6de3c35fe71f98c96982d5ced308bdcc749ff6e1f"
+dependencies = [
+ "borsh-derive",
+ "bytes",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8f347189c62a579b8cd5f80714efa178f52e461dc2e6d701d264f5ff22e566c"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytecheck"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "bytes"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
+name = "futures-core"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
+
+[[package]]
+name = "futures-task"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
+
+[[package]]
+name = "futures-util"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.189"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
+name = "memchr"
+version = "2.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.107"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "quantick-app"
 version = "0.1.0"
 dependencies = [
@@ -12,6 +286,9 @@ dependencies = [
 [[package]]
 name = "quantick-engine"
 version = "0.1.0"
+dependencies = [
+ "rust_decimal",
+]
 
 [[package]]
 name = "quantick-feed-binance"
@@ -19,3 +296,371 @@ version = "0.1.0"
 dependencies = [
  "quantick-engine",
 ]
+
+[[package]]
+name = "quote"
+version = "1.0.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
+name = "rand"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rend"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
+name = "rkyv"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
+dependencies = [
+ "bitvec",
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.12.3",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d7b42d4b8d06048d3ac8db0eb31bcb942cbeb709f0b5f2b2ebde398d3038f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "rust_decimal"
+version = "1.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be2a24f50780bc85f09cc6ac299bdf1424302742d77221106859c9d8b102126a"
+dependencies = [
+ "arrayvec",
+ "borsh",
+ "bytes",
+ "num-traits",
+ "rand",
+ "rkyv",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
+name = "serde"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.151"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.119"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "uuid"
+version = "1.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "serde",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -6,3 +6,4 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
+rust_decimal = "1"

--- a/crates/engine/src/bar.rs
+++ b/crates/engine/src/bar.rs
@@ -1,0 +1,86 @@
+//! The [`Bar`] output type.
+
+use rust_decimal::Decimal;
+
+/// A completed — or in-progress — alternative bar.
+///
+/// A bar summarises the run of trades that fell into one sampling bucket,
+/// whether that bucket is "N trades" (tick), "N units" (volume), "N notional"
+/// (dollar) or "N milliseconds" (time). The bucketing rule lives in the bar
+/// *builder*; the shape of the summary is the same for all of them.
+///
+/// The same type represents both a **closed** bar (returned by a builder when a
+/// bucket fills) and the **in-progress** bar a builder is still accumulating
+/// (its `partial()`): the fields simply reflect the trades seen so far. Whether
+/// a given `Bar` is closed is known from *where* you obtained it, not from the
+/// value itself — a builder returns closed bars and exposes the partial
+/// separately.
+///
+/// [`buy_volume`](Bar::buy_volume) and [`sell_volume`](Bar::sell_volume) are
+/// stored separately so order-flow signals ([`delta`](Bar::delta), CVD) stay
+/// exact; [`volume`](Bar::volume) and [`delta`](Bar::delta) are derived from
+/// them.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Bar {
+    /// Timestamp of the first trade in the bar (epoch ms).
+    pub open_time: i64,
+    /// Timestamp of the last trade in the bar (epoch ms).
+    pub close_time: i64,
+    /// Price of the first trade.
+    pub open: Decimal,
+    /// Highest trade price in the bar.
+    pub high: Decimal,
+    /// Lowest trade price in the bar.
+    pub low: Decimal,
+    /// Price of the last trade.
+    pub close: Decimal,
+    /// Quantity traded on the buy (taker-buy) side.
+    pub buy_volume: Decimal,
+    /// Quantity traded on the sell (taker-sell) side.
+    pub sell_volume: Decimal,
+    /// Number of trades aggregated into the bar.
+    pub trade_count: u64,
+}
+
+impl Bar {
+    /// Total traded quantity: `buy_volume + sell_volume`.
+    #[must_use]
+    pub fn volume(&self) -> Decimal {
+        self.buy_volume + self.sell_volume
+    }
+
+    /// Order-flow delta: `buy_volume - sell_volume`.
+    ///
+    /// Positive when buyers were the net aggressors over the bar.
+    #[must_use]
+    pub fn delta(&self) -> Decimal {
+        self.buy_volume - self.sell_volume
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::str::FromStr;
+
+    fn dec(s: &str) -> Decimal {
+        Decimal::from_str(s).unwrap()
+    }
+
+    #[test]
+    fn volume_and_delta_are_derived() {
+        let bar = Bar {
+            open_time: 1_700_000_000_000,
+            close_time: 1_700_000_000_500,
+            open: dec("36000.0"),
+            high: dec("36010.0"),
+            low: dec("35990.0"),
+            close: dec("36005.0"),
+            buy_volume: dec("1.5"),
+            sell_volume: dec("0.4"),
+            trade_count: 7,
+        };
+        assert_eq!(bar.volume(), dec("1.9"));
+        assert_eq!(bar.delta(), dec("1.1"));
+    }
+}

--- a/crates/engine/src/fixture.rs
+++ b/crates/engine/src/fixture.rs
@@ -1,0 +1,222 @@
+//! Plain-text CSV fixtures for recorded trades.
+//!
+//! Fixtures are how the engine's determinism is guarded: a committed file of
+//! trades is replayed against committed expected bars (see the golden harness).
+//! The format is deliberately trivial — one trade per line, comma-separated, no
+//! quoting — so fixtures are easy to read, hand-write and diff, and the parser
+//! needs no dependencies.
+//!
+//! ```text
+//! # comment lines and blank lines are ignored
+//! agg_id,timestamp_ms,price,quantity,side
+//! 1,1700000000000,36000.10,0.005,buy
+//! 2,1700000000200,36000.20,0.010,sell
+//! ```
+//!
+//! The first non-comment line may be the header shown above; it is detected and
+//! skipped. `side` is `buy` or `sell` (the aggressor — see [`Side`]).
+//!
+//! [`write_trades`] is the inverse of [`parse_trades`]: parsing a written file
+//! yields the original trades.
+
+use std::fmt::Write as _;
+use std::str::FromStr as _;
+
+use rust_decimal::Decimal;
+
+use crate::{Side, Trade};
+
+/// The canonical header line, written by [`write_trades`] and skipped by
+/// [`parse_trades`].
+pub const HEADER: &str = "agg_id,timestamp_ms,price,quantity,side";
+
+/// An error encountered while parsing a trade fixture.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParseError {
+    /// 1-based line number in the source text.
+    pub line: usize,
+    /// What went wrong.
+    pub message: String,
+}
+
+impl std::fmt::Display for ParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "trade fixture parse error on line {}: {}",
+            self.line, self.message
+        )
+    }
+}
+
+impl std::error::Error for ParseError {}
+
+/// Parse trades from CSV fixture text.
+///
+/// Blank lines and `#` comments are skipped; a leading [`HEADER`] line is
+/// optional and ignored. Trades are returned in file order — the engine relies
+/// on the caller feeding trades in the order they occurred.
+///
+/// # Errors
+///
+/// Returns a [`ParseError`] (carrying the 1-based line number) on the first
+/// malformed row: wrong field count, unparseable number, or an unknown side.
+pub fn parse_trades(text: &str) -> Result<Vec<Trade>, ParseError> {
+    let mut trades = Vec::new();
+    for (idx, raw) in text.lines().enumerate() {
+        let line = raw.trim();
+        if line.is_empty() || line.starts_with('#') || line == HEADER {
+            continue;
+        }
+        trades.push(parse_trade_line(line, idx + 1)?);
+    }
+    Ok(trades)
+}
+
+fn parse_trade_line(line: &str, line_no: usize) -> Result<Trade, ParseError> {
+    let mkerr = |message: String| ParseError {
+        line: line_no,
+        message,
+    };
+    let fields: Vec<&str> = line.split(',').map(str::trim).collect();
+    if fields.len() != 5 {
+        return Err(mkerr(format!(
+            "expected 5 comma-separated fields, found {}",
+            fields.len()
+        )));
+    }
+    let agg_id = fields[0]
+        .parse::<u64>()
+        .map_err(|e| mkerr(format!("agg_id `{}`: {e}", fields[0])))?;
+    let timestamp_ms = fields[1]
+        .parse::<i64>()
+        .map_err(|e| mkerr(format!("timestamp_ms `{}`: {e}", fields[1])))?;
+    let price =
+        Decimal::from_str(fields[2]).map_err(|e| mkerr(format!("price `{}`: {e}", fields[2])))?;
+    let quantity = Decimal::from_str(fields[3])
+        .map_err(|e| mkerr(format!("quantity `{}`: {e}", fields[3])))?;
+    let side = match fields[4] {
+        "buy" => Side::Buy,
+        "sell" => Side::Sell,
+        other => return Err(mkerr(format!("side `{other}` (expected `buy` or `sell`)"))),
+    };
+    Ok(Trade {
+        agg_id,
+        timestamp_ms,
+        price,
+        quantity,
+        side,
+    })
+}
+
+/// Serialise trades to CSV fixture text, including the [`HEADER`] line.
+///
+/// The inverse of [`parse_trades`]: `parse_trades(&write_trades(ts)) == ts` for
+/// any slice of trades, so fixtures round-trip losslessly.
+#[must_use]
+pub fn write_trades(trades: &[Trade]) -> String {
+    let mut out = String::with_capacity(HEADER.len() + 1 + trades.len() * 40);
+    out.push_str(HEADER);
+    out.push('\n');
+    for t in trades {
+        writeln!(
+            out,
+            "{},{},{},{},{}",
+            t.agg_id,
+            t.timestamp_ms,
+            t.price,
+            t.quantity,
+            t.side.as_str()
+        )
+        .expect("writing to a String is infallible");
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dec(s: &str) -> Decimal {
+        Decimal::from_str(s).unwrap()
+    }
+
+    #[test]
+    fn parses_a_small_fixture() {
+        let text = "\
+# a couple of trades
+agg_id,timestamp_ms,price,quantity,side
+1,1700000000000,36000.10,0.005,buy
+
+2,1700000000200,36000.20,0.010,sell
+";
+        let trades = parse_trades(text).unwrap();
+        assert_eq!(trades.len(), 2);
+        assert_eq!(
+            trades[0],
+            Trade {
+                agg_id: 1,
+                timestamp_ms: 1_700_000_000_000,
+                price: dec("36000.10"),
+                quantity: dec("0.005"),
+                side: Side::Buy,
+            }
+        );
+        assert_eq!(trades[1].side, Side::Sell);
+    }
+
+    #[test]
+    fn round_trips_through_write_and_parse() {
+        let trades = vec![
+            Trade {
+                agg_id: 10,
+                timestamp_ms: 1_700_000_000_000,
+                price: dec("36000.10"),
+                quantity: dec("0.005"),
+                side: Side::Buy,
+            },
+            Trade {
+                agg_id: 11,
+                timestamp_ms: 1_700_000_000_050,
+                price: dec("35999.90"),
+                quantity: dec("2.5"),
+                side: Side::Sell,
+            },
+        ];
+        let text = write_trades(&trades);
+        assert!(text.starts_with(HEADER));
+        assert_eq!(parse_trades(&text).unwrap(), trades);
+    }
+
+    #[test]
+    fn write_is_deterministic() {
+        let trades = vec![Trade {
+            agg_id: 1,
+            timestamp_ms: 1,
+            price: dec("1.23"),
+            quantity: dec("4.5"),
+            side: Side::Buy,
+        }];
+        assert_eq!(write_trades(&trades), write_trades(&trades));
+    }
+
+    #[test]
+    fn rejects_wrong_field_count() {
+        let err = parse_trades("1,2,3\n").unwrap_err();
+        assert_eq!(err.line, 1);
+        assert!(err.message.contains("found 3"), "{}", err.message);
+    }
+
+    #[test]
+    fn rejects_unknown_side() {
+        let err = parse_trades("1,2,3.0,4.0,hold\n").unwrap_err();
+        assert!(err.message.contains("hold"), "{}", err.message);
+    }
+
+    #[test]
+    fn reports_the_offending_line_number() {
+        let text = "1,1,1.0,1.0,buy\nnot,a,valid,trade,row,extra\n";
+        let err = parse_trades(text).unwrap_err();
+        assert_eq!(err.line, 2);
+    }
+}

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -1,5 +1,28 @@
 //! quantick-engine — raw trades in, alternative bars out.
 //!
 //! Headless and deterministic: no UI, no network, no async, no wall-clock
-//! time. Same trades in, same bars out, always. See CLAUDE.md for the
+//! time. Same trades in, same bars out, always. See `CLAUDE.md` for the
 //! non-negotiable design rules.
+//!
+//! # The input/output contract
+//!
+//! The engine consumes [`Trade`]s and produces [`Bar`]s. Everything else is a
+//! consumer of this contract:
+//!
+//! - [`Trade`] — one executed (aggregate) trade: price, quantity, aggressor
+//!   [`Side`], exchange id and timestamp. Prices and quantities are
+//!   [`rust_decimal::Decimal`] for exact, deterministic arithmetic.
+//! - [`Bar`] — the OHLCV + order-flow summary of the trades in one sampling
+//!   bucket. The bucketing rule (tick / volume / dollar / time) lives in a bar
+//!   *builder*; the summary shape is shared.
+//!
+//! The [`fixture`] module defines the plain-text trade format that golden tests
+//! replay to guard determinism.
+
+pub mod fixture;
+
+mod bar;
+mod trade;
+
+pub use bar::Bar;
+pub use trade::{Side, Trade};

--- a/crates/engine/src/trade.rs
+++ b/crates/engine/src/trade.rs
@@ -1,0 +1,121 @@
+//! The [`Trade`] input type and aggressor [`Side`].
+
+use rust_decimal::Decimal;
+
+/// The aggressor (taker) side of a trade.
+///
+/// A trade happens when an incoming *taker* order crosses the spread and matches
+/// a resting *maker* order. The aggressor is the taker: the side that removed
+/// liquidity and, by convention, "caused" the print. Order-flow bars track how
+/// much volume was taker-buy vs taker-sell.
+///
+/// # Mapping from Binance aggTrades
+///
+/// Binance reports `m` (`is_buyer_maker`) per aggregate trade. If the buyer is
+/// the maker, then the taker — the aggressor — is the seller, and vice versa:
+///
+/// | `is_buyer_maker` | aggressor      |
+/// |------------------|----------------|
+/// | `true`           | [`Side::Sell`] |
+/// | `false`          | [`Side::Buy`]  |
+///
+/// Use [`Side::from_buyer_is_maker`] to apply this mapping.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Side {
+    /// A buy-initiated (taker-buy) trade — the aggressor lifted the offer.
+    Buy,
+    /// A sell-initiated (taker-sell) trade — the aggressor hit the bid.
+    Sell,
+}
+
+impl Side {
+    /// Map Binance's `is_buyer_maker` flag to the aggressor side.
+    ///
+    /// See the [type-level docs](Side#mapping-from-binance-aggtrades) for why
+    /// the flag inverts.
+    #[must_use]
+    pub fn from_buyer_is_maker(is_buyer_maker: bool) -> Self {
+        if is_buyer_maker {
+            Side::Sell
+        } else {
+            Side::Buy
+        }
+    }
+
+    /// The lower-case token used in fixture files: `"buy"` or `"sell"`.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Side::Buy => "buy",
+            Side::Sell => "sell",
+        }
+    }
+}
+
+/// A single executed trade — the engine's sole input.
+///
+/// One `Trade` corresponds to one Binance *aggregate* trade (`aggTrade`): a run
+/// of individual fills at the same price from the same taker order, collapsed
+/// into a single print. [`agg_id`](Trade::agg_id) is that aggregate trade's id,
+/// monotonic per symbol; the live feed uses it to detect gaps and out-of-order
+/// delivery.
+///
+/// Prices and quantities are [`Decimal`] for exact, deterministic arithmetic: no
+/// binary-float rounding error accumulates as bars are built across a session.
+/// Timestamps are epoch milliseconds carried from the exchange — the engine
+/// never reads a wall clock (see the determinism rule in `CLAUDE.md`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Trade {
+    /// Exchange aggregate-trade id, monotonic per symbol.
+    pub agg_id: u64,
+    /// Trade time, in milliseconds since the Unix epoch.
+    pub timestamp_ms: i64,
+    /// Execution price.
+    pub price: Decimal,
+    /// Executed quantity, in base-asset units.
+    pub quantity: Decimal,
+    /// Aggressor side (see [`Side`]).
+    pub side: Side,
+}
+
+impl Trade {
+    /// Notional value of the trade: `price * quantity`.
+    ///
+    /// Exact, because both operands are [`Decimal`]. This is the measure dollar
+    /// bars accumulate.
+    #[must_use]
+    pub fn notional(&self) -> Decimal {
+        self.price * self.quantity
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::str::FromStr;
+
+    #[test]
+    fn buyer_maker_maps_to_sell_aggressor() {
+        assert_eq!(Side::from_buyer_is_maker(true), Side::Sell);
+        assert_eq!(Side::from_buyer_is_maker(false), Side::Buy);
+    }
+
+    #[test]
+    fn side_tokens_round_trip_naming() {
+        assert_eq!(Side::Buy.as_str(), "buy");
+        assert_eq!(Side::Sell.as_str(), "sell");
+    }
+
+    #[test]
+    fn notional_is_exact() {
+        let t = Trade {
+            agg_id: 1,
+            timestamp_ms: 1_700_000_000_000,
+            price: Decimal::from_str("36000.10").unwrap(),
+            quantity: Decimal::from_str("0.005").unwrap(),
+            side: Side::Buy,
+        };
+        // 36000.10 * 0.005 = 180.00050 exactly (no float drift).
+        assert_eq!(t.notional(), Decimal::from_str("180.00050").unwrap());
+    }
+}

--- a/crates/engine/tests/fixture_roundtrip.rs
+++ b/crates/engine/tests/fixture_roundtrip.rs
@@ -1,0 +1,28 @@
+//! Integration test: the committed sample fixture parses and round-trips.
+//!
+//! Reads the real file from disk (not an inline string) so the on-disk fixture
+//! format itself is covered, and asserts `parse -> write -> parse` is stable.
+
+use quantick_engine::fixture;
+
+const SAMPLE: &str = include_str!("fixtures/sample_trades.csv");
+
+#[test]
+fn sample_fixture_parses() {
+    let trades = fixture::parse_trades(SAMPLE).expect("sample fixture should parse");
+    assert_eq!(trades.len(), 6, "sample has six trades");
+    assert_eq!(trades[0].agg_id, 1);
+    assert_eq!(trades[5].agg_id, 6);
+    // agg_ids are strictly increasing in the sample.
+    for pair in trades.windows(2) {
+        assert!(pair[1].agg_id > pair[0].agg_id, "agg_ids increase");
+    }
+}
+
+#[test]
+fn sample_fixture_round_trips() {
+    let trades = fixture::parse_trades(SAMPLE).expect("sample fixture should parse");
+    let rewritten = fixture::write_trades(&trades);
+    let reparsed = fixture::parse_trades(&rewritten).expect("rewritten fixture should parse");
+    assert_eq!(trades, reparsed, "parse -> write -> parse is lossless");
+}

--- a/crates/engine/tests/fixtures/sample_trades.csv
+++ b/crates/engine/tests/fixtures/sample_trades.csv
@@ -1,0 +1,9 @@
+# sample_trades.csv — a short recorded burst of BTCUSDT aggTrades.
+# Format: agg_id,timestamp_ms,price,quantity,side  (side = aggressor)
+agg_id,timestamp_ms,price,quantity,side
+1,1700000000000,36000.10,0.005,buy
+2,1700000000200,36000.20,0.010,buy
+3,1700000000450,36000.00,0.250,sell
+4,1700000000700,35999.80,1.200,sell
+5,1700000000950,36000.30,0.030,buy
+6,1700000001100,36000.30,0.007,buy


### PR DESCRIPTION
## Summary

Lands the engine's input/output contract: `Trade` in, `Bar` out, plus the plain-text fixture format every golden test will replay. Nothing bucketed yet — this is the shape everything else consumes.

- **`Trade`** — `agg_id`, `timestamp_ms`, `price`, `quantity`, aggressor `Side`. Price/quantity are `rust_decimal::Decimal`.
- **`Bar`** — OHLC, `buy_volume`/`sell_volume`, `trade_count`, open/close timestamps; `volume()` and `delta()` derived from the buy/sell split.
- **`Side`** — maps from Binance `is_buyer_maker` (buyer-maker ⇒ `Sell` aggressor), documented in rustdoc.
- **`fixture`** — dependency-free CSV parser/writer, lossless round-trip.

Closes #3

## Design decisions (recorded here per the autonomy rule)

1. **`Decimal`, not `f64`, for money.** Exact decimal arithmetic is deterministic and free of accumulated binary-float error across a session. This is the property that makes dollar-bar notional accumulation (#8) tractable, and it parses Binance decimal strings (`"36000.10"`) exactly. Cost is ~tens of ns/op — to be proven acceptable under load by a hot-path benchmark before v0.2.
2. **Store `buy_volume`/`sell_volume`, derive `volume`/`delta`.** Richer than a bare volume+delta and keeps order-flow signals (delta, future CVD) exact and internally consistent.
3. **Timestamps are exchange epoch-ms `i64`.** The engine never reads a wall clock (determinism rule).
4. **CSV fixture, hand-rolled parser, no dependency.** Fixtures stay trivial to hand-write and diff; `parse → write → parse` is lossless (unit + integration tested).
5. **`.gitattributes` pins LF.** Folded in here (not a separate issue) because it directly protects the byte-identical determinism checks #4 introduces — without it, Windows-dev vs Linux-CI CRLF drift would break golden comparisons silently.

## Verification loop

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (12 tests)

## Notes for the reviewer

- The `Decimal` choice is the load-bearing one; if the hot-path benchmark later shows it's too slow under bursts, that's a follow-up issue to switch the accumulation path to scaled integers — the public `Trade`/`Bar` shape wouldn't change.
- Boundary/split rules for threshold bars are deliberately **not** decided here; they belong to #6.
