### PR TITLE
feat(engine): tick bars closing every N trades

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -24,8 +24,10 @@ pub mod golden;
 
 mod bar;
 mod builder;
+mod tick;
 mod trade;
 
 pub use bar::Bar;
 pub use builder::BarBuilder;
+pub use tick::TickBarBuilder;
 pub use trade::{Side, Trade};

--- a/crates/engine/src/tick.rs
+++ b/crates/engine/src/tick.rs
@@ -1,0 +1,154 @@
+//! Tick bars — close a bar every `N` trades.
+//!
+//! Tick bars are the simplest activity-sampled bar type: count trades, close a
+//! bar every `N`. Unlike time bars, they sample faster when the market is busy
+//! and slower when it's quiet, so each bar carries a comparable amount of
+//! trading activity.
+//!
+//! This is the first real [`BarBuilder`], and it establishes the builder
+//! skeleton — accumulate an in-progress [`Bar`], finalise and emit it when the
+//! bucket fills — that volume and dollar bars reuse via the generic threshold
+//! accumulator (#6).
+
+use rust_decimal::Decimal;
+
+use crate::{Bar, BarBuilder, Side, Trade};
+
+/// Builds tick bars: one closed [`Bar`] per `N` trades.
+///
+/// Feed trades in order with [`push`](BarBuilder::push); every `N`th trade
+/// returns a closed bar. The in-progress bar is available via
+/// [`partial`](BarBuilder::partial) for rendering the forming bar on a chart.
+#[derive(Debug, Clone)]
+pub struct TickBarBuilder {
+    n: u64,
+    count: u64,
+    current: Option<Bar>,
+}
+
+impl TickBarBuilder {
+    /// Create a builder that closes a bar every `n` trades.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `n == 0`: a bar of zero trades is meaningless, and silently
+    /// coercing it would violate the data-honesty rule.
+    #[must_use]
+    pub fn new(n: u64) -> Self {
+        assert!(n >= 1, "tick bar size N must be >= 1, got {n}");
+        Self {
+            n,
+            count: 0,
+            current: None,
+        }
+    }
+
+    /// The configured bar size (trades per bar).
+    #[must_use]
+    pub fn size(&self) -> u64 {
+        self.n
+    }
+}
+
+impl BarBuilder for TickBarBuilder {
+    fn push(&mut self, trade: &Trade) -> Option<Bar> {
+        match &mut self.current {
+            None => self.current = Some(open_bar(trade)),
+            Some(bar) => extend_bar(bar, trade),
+        }
+        self.count += 1;
+        if self.count >= self.n {
+            self.count = 0;
+            self.current.take()
+        } else {
+            None
+        }
+    }
+
+    fn partial(&self) -> Option<&Bar> {
+        self.current.as_ref()
+    }
+}
+
+/// Start a fresh one-trade bar from `trade`.
+fn open_bar(trade: &Trade) -> Bar {
+    let (buy_volume, sell_volume) = split_volume(trade);
+    Bar {
+        open_time: trade.timestamp_ms,
+        close_time: trade.timestamp_ms,
+        open: trade.price,
+        high: trade.price,
+        low: trade.price,
+        close: trade.price,
+        buy_volume,
+        sell_volume,
+        trade_count: 1,
+    }
+}
+
+/// Fold `trade` into the in-progress `bar`.
+fn extend_bar(bar: &mut Bar, trade: &Trade) {
+    bar.high = bar.high.max(trade.price);
+    bar.low = bar.low.min(trade.price);
+    bar.close = trade.price;
+    bar.close_time = trade.timestamp_ms;
+    match trade.side {
+        Side::Buy => bar.buy_volume += trade.quantity,
+        Side::Sell => bar.sell_volume += trade.quantity,
+    }
+    bar.trade_count += 1;
+}
+
+/// A trade contributes its quantity to exactly one side.
+fn split_volume(trade: &Trade) -> (Decimal, Decimal) {
+    match trade.side {
+        Side::Buy => (trade.quantity, Decimal::ZERO),
+        Side::Sell => (Decimal::ZERO, trade.quantity),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr as _;
+
+    fn trade(agg_id: u64, ts: i64, price: &str, qty: &str, side: Side) -> Trade {
+        Trade {
+            agg_id,
+            timestamp_ms: ts,
+            price: Decimal::from_str(price).unwrap(),
+            quantity: Decimal::from_str(qty).unwrap(),
+            side,
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "tick bar size N must be >= 1")]
+    fn rejects_zero_size() {
+        let _ = TickBarBuilder::new(0);
+    }
+
+    #[test]
+    fn n1_closes_every_trade() {
+        let mut b = TickBarBuilder::new(1);
+        let bar = b.push(&trade(1, 10, "100.0", "1.0", Side::Buy)).unwrap();
+        assert_eq!(bar.trade_count, 1);
+        assert_eq!(bar.close, Decimal::from_str("100.0").unwrap());
+        assert!(b.partial().is_none(), "no partial right after a close");
+    }
+
+    #[test]
+    fn partial_accumulates_mid_stream() {
+        let mut b = TickBarBuilder::new(3);
+        assert!(b.push(&trade(1, 10, "100.0", "1.0", Side::Buy)).is_none());
+        assert!(b.push(&trade(2, 20, "101.0", "2.0", Side::Sell)).is_none());
+        let p = b.partial().expect("bar forming");
+        assert_eq!(p.trade_count, 2);
+        assert_eq!(p.high, Decimal::from_str("101.0").unwrap());
+        assert_eq!(p.low, Decimal::from_str("100.0").unwrap());
+        assert_eq!(p.buy_volume, Decimal::from_str("1.0").unwrap());
+        assert_eq!(p.sell_volume, Decimal::from_str("2.0").unwrap());
+        assert_eq!(p.open_time, 10);
+        assert_eq!(p.close_time, 20);
+    }
+}

--- a/crates/engine/tests/fixtures/tick_n3_expected.csv
+++ b/crates/engine/tests/fixtures/tick_n3_expected.csv
@@ -1,0 +1,7 @@
+# Expected tick bars for tick_trades.csv with N=3. Hand-computed.
+#   Bar 0 = trades 1,2,3: high=101.0 low=100.0 close=100.5, buy 1.0+2.0=3.0, sell 1.5
+#   Bar 1 = trades 4,5,6: high=103.0 low=101.5 close=101.5, buy 0.5+1.0=1.5, sell 2.0
+# Trade 7 stays a partial and is not a closed bar here.
+open_time,close_time,open,high,low,close,buy_volume,sell_volume,trade_count
+1000,1200,100.0,101.0,100.0,100.5,3.0,1.5,3
+1300,1500,102.0,103.0,101.5,101.5,1.5,2.0,3

--- a/crates/engine/tests/fixtures/tick_trades.csv
+++ b/crates/engine/tests/fixtures/tick_trades.csv
@@ -1,0 +1,10 @@
+# Trades for the tick-bar golden test. Seven trades; with N=3 this closes two
+# bars (trades 1-3, 4-6) and leaves trade 7 as an in-progress partial.
+agg_id,timestamp_ms,price,quantity,side
+1,1000,100.0,1.0,buy
+2,1100,101.0,2.0,buy
+3,1200,100.5,1.5,sell
+4,1300,102.0,0.5,buy
+5,1400,103.0,1.0,buy
+6,1500,101.5,2.0,sell
+7,1600,100.0,0.5,sell

--- a/crates/engine/tests/golden_tick.rs
+++ b/crates/engine/tests/golden_tick.rs
@@ -1,0 +1,35 @@
+//! Golden test for tick bars, plus mid-stream partial and delta checks.
+
+use quantick_engine::{BarBuilder, TickBarBuilder, fixture, golden};
+
+const TRADES: &str = include_str!("fixtures/tick_trades.csv");
+const EXPECTED_N3: &str = include_str!("fixtures/tick_n3_expected.csv");
+
+#[test]
+fn tick_bars_n3_match_golden() {
+    golden::assert_golden(|| TickBarBuilder::new(3), TRADES, EXPECTED_N3);
+}
+
+#[test]
+fn delta_matches_hand_computed() {
+    let trades = fixture::parse_trades(TRADES).unwrap();
+    let bars = golden::replay(&mut TickBarBuilder::new(3), &trades);
+    // Bar 0: buy 3.0 - sell 1.5 = 1.5; Bar 1: buy 1.5 - sell 2.0 = -0.5.
+    assert_eq!(bars[0].delta().to_string(), "1.5");
+    assert_eq!(bars[1].delta().to_string(), "-0.5");
+    assert_eq!(bars[0].volume().to_string(), "4.5");
+}
+
+#[test]
+fn trailing_trade_is_a_partial_not_a_closed_bar() {
+    let trades = fixture::parse_trades(TRADES).unwrap();
+    let mut builder = TickBarBuilder::new(3);
+    let closed = golden::replay(&mut builder, &trades);
+    assert_eq!(closed.len(), 2, "two full bars closed");
+
+    let partial = builder.partial().expect("trade 7 is forming a bar");
+    assert_eq!(partial.trade_count, 1);
+    assert_eq!(partial.open_time, 1600);
+    assert_eq!(partial.close_time, 1600);
+    assert_eq!(partial.sell_volume.to_string(), "0.5");
+}


### PR DESCRIPTION
## Summary

The first real `BarBuilder`. Counts trades and closes a bar every `N`, establishing the accumulate-an-in-progress-bar / finalise-and-emit skeleton that volume and dollar bars reuse via the generic accumulator (#6).

- `TickBarBuilder::new(N)`, `push()` emits a closed bar on every `N`th trade, `partial()` exposes the forming bar.
- Golden test reproduces a hand-computed N=3 fixture (committed first, per test-first); extra tests verify OHLCV, delta, timestamps and the mid-stream partial.

Closes #5

## Design decisions

1. **`new(0)` panics.** A zero-trade bar is meaningless; silently coercing `N=0` to `1` would violate the data-honesty rule. A clear panic at construction is the honest failure.
2. **`open_bar` / `extend_bar` / `split_volume` are extracted as private fns.** Tick bars only differ from volume/dollar bars in *when* to close — the OHLCV/delta folding is identical. Keeping it in small helpers makes #6's "lift onto the generic accumulator with behaviour unchanged" a move, not a rewrite.
3. **A closed bar leaves no partial.** After `push` returns a bar, `current` is `None` until the next trade opens a fresh one — `partial()` correctly reports "nothing forming" in that gap.

## Verification loop

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (25 tests: engine 20 + golden 5)

## Notes for the reviewer

- Boundary/overshoot rules don't apply to tick bars (measure is exactly 1/trade, so they close precisely at N). The interesting boundary case — a single trade overshooting the threshold — lands with volume/dollar bars (#6/#7), where it's exercised.
