### PR TITLE
feat(engine): generic threshold accumulator; refactor tick onto it

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -24,10 +24,12 @@ pub mod golden;
 
 mod bar;
 mod builder;
+pub mod threshold;
 mod tick;
 mod trade;
 
 pub use bar::Bar;
 pub use builder::BarBuilder;
-pub use tick::TickBarBuilder;
+pub use threshold::{Measure, ThresholdBarBuilder};
+pub use tick::{TickBarBuilder, TickMeasure};
 pub use trade::{Side, Trade};

--- a/crates/engine/src/threshold.rs
+++ b/crates/engine/src/threshold.rs
@@ -1,0 +1,212 @@
+//! The generic threshold accumulator shared by tick, volume and dollar bars.
+//!
+//! Tick, volume and dollar bars are the *same* algorithm with a different
+//! accumulated measure: 1 per trade (tick), traded quantity (volume), or
+//! notional `price * quantity` (dollar). "One engine, three consumers" applies
+//! internally too — there is one closing rule here, parameterised by a
+//! [`Measure`], never three forked implementations.
+//!
+//! # Boundary rule: whole trades, overshoot allowed, no carry
+//!
+//! When a single trade pushes the accumulated measure to or past the threshold,
+//! **the whole trade is included in the bar it completes** — a trade is never
+//! split across two bars. A trade is an atomic market event; splitting one would
+//! fabricate synthetic sub-trades that never happened, violating the
+//! data-honesty rule.
+//!
+//! A consequence: volume and dollar bars can **overshoot** the threshold (a
+//! 25-unit trade closes a 10-unit bar as a single 25-unit bar). That is honest —
+//! real trades are not divisible. Tick bars never overshoot, because each trade
+//! contributes exactly 1 and the bar closes precisely at `N`.
+//!
+//! On close the accumulator **resets to zero — the overshoot is not carried**
+//! into the next bar. Each bar's accumulated measure is therefore exactly the
+//! sum of its own trades' measures, with no phantom offset borrowed from a
+//! previous bar. "This bar closed because its own trades reached the threshold"
+//! stays literally true.
+
+use rust_decimal::Decimal;
+
+use crate::{Bar, BarBuilder, Side, Trade};
+
+/// How much one trade contributes toward closing a bar.
+///
+/// Implementors are usually zero-sized markers ([`crate::TickMeasure`],
+/// volume, dollar). Custom measures let the same accumulator drive
+/// application-specific bar types without forking the closing logic.
+pub trait Measure {
+    /// The contribution of `trade` to the running total.
+    ///
+    /// Must be non-negative for the closing rule to make sense.
+    fn of(&self, trade: &Trade) -> Decimal;
+}
+
+/// Builds bars that close when an accumulated [`Measure`] reaches a threshold.
+///
+/// See the [module docs](self) for the boundary rule (whole trades, overshoot
+/// allowed, no carry). Tick, volume and dollar builders are this type with a
+/// different `M`.
+#[derive(Debug, Clone)]
+pub struct ThresholdBarBuilder<M: Measure> {
+    threshold: Decimal,
+    measure: M,
+    acc: Decimal,
+    current: Option<Bar>,
+}
+
+impl<M: Measure> ThresholdBarBuilder<M> {
+    /// Create a builder that closes a bar once the accumulated measure reaches
+    /// `threshold`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `threshold <= 0`: a non-positive threshold would close a bar on
+    /// (or before) the first trade forever. Coercing it silently would violate
+    /// the data-honesty rule.
+    pub fn new(threshold: Decimal, measure: M) -> Self {
+        assert!(
+            threshold > Decimal::ZERO,
+            "bar threshold must be > 0, got {threshold}"
+        );
+        Self {
+            threshold,
+            measure,
+            acc: Decimal::ZERO,
+            current: None,
+        }
+    }
+
+    /// The configured threshold.
+    #[must_use]
+    pub fn threshold(&self) -> Decimal {
+        self.threshold
+    }
+}
+
+impl<M: Measure> BarBuilder for ThresholdBarBuilder<M> {
+    fn push(&mut self, trade: &Trade) -> Option<Bar> {
+        match &mut self.current {
+            None => self.current = Some(open_bar(trade)),
+            Some(bar) => extend_bar(bar, trade),
+        }
+        self.acc += self.measure.of(trade);
+        if self.acc >= self.threshold {
+            self.acc = Decimal::ZERO;
+            self.current.take()
+        } else {
+            None
+        }
+    }
+
+    fn partial(&self) -> Option<&Bar> {
+        self.current.as_ref()
+    }
+}
+
+/// Start a fresh one-trade bar from `trade`.
+pub(crate) fn open_bar(trade: &Trade) -> Bar {
+    let (buy_volume, sell_volume) = split_volume(trade);
+    Bar {
+        open_time: trade.timestamp_ms,
+        close_time: trade.timestamp_ms,
+        open: trade.price,
+        high: trade.price,
+        low: trade.price,
+        close: trade.price,
+        buy_volume,
+        sell_volume,
+        trade_count: 1,
+    }
+}
+
+/// Fold `trade` into the in-progress `bar`.
+pub(crate) fn extend_bar(bar: &mut Bar, trade: &Trade) {
+    bar.high = bar.high.max(trade.price);
+    bar.low = bar.low.min(trade.price);
+    bar.close = trade.price;
+    bar.close_time = trade.timestamp_ms;
+    match trade.side {
+        Side::Buy => bar.buy_volume += trade.quantity,
+        Side::Sell => bar.sell_volume += trade.quantity,
+    }
+    bar.trade_count += 1;
+}
+
+/// A trade contributes its quantity to exactly one side.
+fn split_volume(trade: &Trade) -> (Decimal, Decimal) {
+    match trade.side {
+        Side::Buy => (trade.quantity, Decimal::ZERO),
+        Side::Sell => (Decimal::ZERO, trade.quantity),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr as _;
+
+    /// Test measure: accumulate traded quantity (a stand-in for volume bars,
+    /// which land in #7). Enough to exercise the boundary rule here.
+    struct QtyMeasure;
+    impl Measure for QtyMeasure {
+        fn of(&self, trade: &Trade) -> Decimal {
+            trade.quantity
+        }
+    }
+
+    fn trade(qty: &str) -> Trade {
+        Trade {
+            agg_id: 0,
+            timestamp_ms: 0,
+            price: Decimal::from_str("100.0").unwrap(),
+            quantity: Decimal::from_str(qty).unwrap(),
+            side: Side::Buy,
+        }
+    }
+
+    fn dec(s: &str) -> Decimal {
+        Decimal::from_str(s).unwrap()
+    }
+
+    #[test]
+    #[should_panic(expected = "bar threshold must be > 0")]
+    fn rejects_non_positive_threshold() {
+        let _ = ThresholdBarBuilder::new(Decimal::ZERO, QtyMeasure);
+    }
+
+    #[test]
+    fn a_single_trade_crossing_the_threshold_closes_a_whole_trade_bar() {
+        // threshold 10, one 25-unit trade: the trade is NOT split — it closes a
+        // single bar that overshoots to 25.
+        let mut b = ThresholdBarBuilder::new(dec("10"), QtyMeasure);
+        let bar = b
+            .push(&trade("25"))
+            .expect("the crossing trade closes a bar");
+        assert_eq!(bar.trade_count, 1, "the whole trade, not a fragment");
+        assert_eq!(bar.volume(), dec("25"), "overshoot kept, not split at 10");
+        assert!(
+            b.partial().is_none(),
+            "accumulator reset: no partial afterwards"
+        );
+    }
+
+    #[test]
+    fn overshoot_is_not_carried_into_the_next_bar() {
+        // 3 + 4 + 5 crosses 10 on the third trade (sum 12). The next trade
+        // starts a fresh bar from zero, not from the overshoot of 2.
+        let mut b = ThresholdBarBuilder::new(dec("10"), QtyMeasure);
+        assert!(b.push(&trade("3")).is_none());
+        assert!(b.push(&trade("4")).is_none());
+        let first = b.push(&trade("5")).expect("closes on the crossing trade");
+        assert_eq!(first.volume(), dec("12"), "12 = 3+4+5, whole trades");
+        assert_eq!(first.trade_count, 3);
+
+        // A fresh 9-unit trade must NOT close a bar; if the overshoot (2) were
+        // carried, 2 + 9 = 11 >= 10 would close here. It stays open.
+        assert!(
+            b.push(&trade("9")).is_none(),
+            "next bar started from zero, so 9 < 10 does not close"
+        );
+        assert_eq!(b.partial().unwrap().volume(), dec("9"));
+    }
+}

--- a/crates/engine/src/tick.rs
+++ b/crates/engine/src/tick.rs
@@ -5,25 +5,36 @@
 //! and slower when it's quiet, so each bar carries a comparable amount of
 //! trading activity.
 //!
-//! This is the first real [`BarBuilder`], and it establishes the builder
-//! skeleton — accumulate an in-progress [`Bar`], finalise and emit it when the
-//! bucket fills — that volume and dollar bars reuse via the generic threshold
-//! accumulator (#6).
+//! Tick bars are the [generic threshold accumulator](crate::ThresholdBarBuilder)
+//! with the measure "1 per trade" ([`TickMeasure`]). This module is the thin
+//! tick-specific layer: an integer `N` and a convenient constructor.
 
 use rust_decimal::Decimal;
 
-use crate::{Bar, BarBuilder, Side, Trade};
+use crate::{Bar, BarBuilder, ThresholdBarBuilder, Trade, threshold::Measure};
+
+/// The tick measure: every trade contributes exactly 1.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct TickMeasure;
+
+impl Measure for TickMeasure {
+    fn of(&self, _trade: &Trade) -> Decimal {
+        Decimal::ONE
+    }
+}
 
 /// Builds tick bars: one closed [`Bar`] per `N` trades.
 ///
-/// Feed trades in order with [`push`](BarBuilder::push); every `N`th trade
-/// returns a closed bar. The in-progress bar is available via
-/// [`partial`](BarBuilder::partial) for rendering the forming bar on a chart.
+/// A thin wrapper over [`ThresholdBarBuilder`] with [`TickMeasure`]. Feed trades
+/// in order with [`push`](BarBuilder::push); every `N`th trade returns a closed
+/// bar. The in-progress bar is available via [`partial`](BarBuilder::partial).
+///
+/// Because the measure is exactly 1 per trade, tick bars close precisely at `N`
+/// and never overshoot (unlike volume and dollar bars).
 #[derive(Debug, Clone)]
 pub struct TickBarBuilder {
     n: u64,
-    count: u64,
-    current: Option<Bar>,
+    inner: ThresholdBarBuilder<TickMeasure>,
 }
 
 impl TickBarBuilder {
@@ -38,8 +49,7 @@ impl TickBarBuilder {
         assert!(n >= 1, "tick bar size N must be >= 1, got {n}");
         Self {
             n,
-            count: 0,
-            current: None,
+            inner: ThresholdBarBuilder::new(Decimal::from(n), TickMeasure),
         }
     }
 
@@ -52,64 +62,18 @@ impl TickBarBuilder {
 
 impl BarBuilder for TickBarBuilder {
     fn push(&mut self, trade: &Trade) -> Option<Bar> {
-        match &mut self.current {
-            None => self.current = Some(open_bar(trade)),
-            Some(bar) => extend_bar(bar, trade),
-        }
-        self.count += 1;
-        if self.count >= self.n {
-            self.count = 0;
-            self.current.take()
-        } else {
-            None
-        }
+        self.inner.push(trade)
     }
 
     fn partial(&self) -> Option<&Bar> {
-        self.current.as_ref()
-    }
-}
-
-/// Start a fresh one-trade bar from `trade`.
-fn open_bar(trade: &Trade) -> Bar {
-    let (buy_volume, sell_volume) = split_volume(trade);
-    Bar {
-        open_time: trade.timestamp_ms,
-        close_time: trade.timestamp_ms,
-        open: trade.price,
-        high: trade.price,
-        low: trade.price,
-        close: trade.price,
-        buy_volume,
-        sell_volume,
-        trade_count: 1,
-    }
-}
-
-/// Fold `trade` into the in-progress `bar`.
-fn extend_bar(bar: &mut Bar, trade: &Trade) {
-    bar.high = bar.high.max(trade.price);
-    bar.low = bar.low.min(trade.price);
-    bar.close = trade.price;
-    bar.close_time = trade.timestamp_ms;
-    match trade.side {
-        Side::Buy => bar.buy_volume += trade.quantity,
-        Side::Sell => bar.sell_volume += trade.quantity,
-    }
-    bar.trade_count += 1;
-}
-
-/// A trade contributes its quantity to exactly one side.
-fn split_volume(trade: &Trade) -> (Decimal, Decimal) {
-    match trade.side {
-        Side::Buy => (trade.quantity, Decimal::ZERO),
-        Side::Sell => (Decimal::ZERO, trade.quantity),
+        self.inner.partial()
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::Side;
     use std::str::FromStr as _;
 
     fn trade(agg_id: u64, ts: i64, price: &str, qty: &str, side: Side) -> Trade {
@@ -126,6 +90,11 @@ mod tests {
     #[should_panic(expected = "tick bar size N must be >= 1")]
     fn rejects_zero_size() {
         let _ = TickBarBuilder::new(0);
+    }
+
+    #[test]
+    fn size_reports_configured_n() {
+        assert_eq!(TickBarBuilder::new(7).size(), 7);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Tick, volume and dollar bars are the same algorithm with a different accumulated measure. This lands the one shared closing rule and moves tick bars onto it — "one engine, three consumers" applied internally.

- **`Measure` trait** + **`ThresholdBarBuilder<M>`**: accumulate `measure.of(trade)`, close when it reaches the threshold; shared open/extend folding lives here.
- **`TickBarBuilder`** is now a thin wrapper over `ThresholdBarBuilder<TickMeasure>` (1 per trade). Public API unchanged, so the #5 golden test passes **byte-for-byte unchanged**.

Closes #6

## The boundary decision (the crux of this issue)

When a single trade pushes the accumulator to/past the threshold:

1. **The whole trade is included in the bar it completes — never split.** A trade is an atomic market event; splitting one fabricates synthetic sub-trades that never happened, violating the data-honesty rule. Consequence: volume/dollar bars can **overshoot** (a 25-unit trade closes a 10-unit bar as a single 25-unit bar), which is honest — real trades aren't divisible. Tick bars never overshoot (measure is exactly 1/trade).
2. **The accumulator resets to zero on close — the overshoot is not carried.** Each bar's accumulated measure is then exactly the sum of its own trades', with no phantom offset borrowed from the previous bar. "This bar closed because its own trades reached the threshold" stays literally true. Carrying would create a surprising cascade where one big trade pre-fills future bars.

Both are documented in the `threshold` module rustdoc and covered by explicit tests (`a_single_trade_crossing_the_threshold_closes_a_whole_trade_bar`, `overshoot_is_not_carried_into_the_next_bar`).

## Verification loop

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (29 tests; `golden_tick.rs` unchanged)

## Notes for the reviewer

- The boundary tests use a private `QtyMeasure` (quantity) inside the module rather than waiting for the public `VolumeMeasure` (#7), so #6 exercises the rule on the generic mechanism, self-contained.
- `ThresholdBarBuilder` and `Measure` are exported publicly so consumers can define custom bar types without forking the closing logic — the "one engine" boundary is extensible, not private.
