### PR TITLE
feat(engine): volume bars closing after N units traded

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -27,9 +27,11 @@ mod builder;
 pub mod threshold;
 mod tick;
 mod trade;
+mod volume;
 
 pub use bar::Bar;
 pub use builder::BarBuilder;
 pub use threshold::{Measure, ThresholdBarBuilder};
 pub use tick::{TickBarBuilder, TickMeasure};
 pub use trade::{Side, Trade};
+pub use volume::{VolumeBarBuilder, VolumeMeasure};

--- a/crates/engine/src/volume.rs
+++ b/crates/engine/src/volume.rs
@@ -1,0 +1,109 @@
+//! Volume bars — close after `N` units traded.
+//!
+//! Volume bars close when accumulated traded quantity reaches `N`. A 10-unit
+//! trade weighs 10× a 1-unit trade, so bars normalise by real traded quantity
+//! instead of by event count (tick bars). They are the [generic threshold
+//! accumulator](crate::ThresholdBarBuilder) with the measure "traded quantity"
+//! ([`VolumeMeasure`]).
+//!
+//! Because a single large trade is never split (see the threshold module's
+//! boundary rule), a volume bar can overshoot `N` — a 25-unit trade closes a
+//! 10-unit bar as one 25-unit bar.
+
+use rust_decimal::Decimal;
+
+use crate::{Bar, BarBuilder, ThresholdBarBuilder, Trade, threshold::Measure};
+
+/// The volume measure: every trade contributes its traded quantity.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct VolumeMeasure;
+
+impl Measure for VolumeMeasure {
+    fn of(&self, trade: &Trade) -> Decimal {
+        trade.quantity
+    }
+}
+
+/// Builds volume bars: closes once accumulated traded quantity reaches `units`.
+///
+/// A thin wrapper over [`ThresholdBarBuilder`] with [`VolumeMeasure`]. Feed
+/// trades in order with [`push`](BarBuilder::push); the bar closes on the trade
+/// that brings cumulative quantity to `units` or beyond.
+#[derive(Debug, Clone)]
+pub struct VolumeBarBuilder {
+    inner: ThresholdBarBuilder<VolumeMeasure>,
+}
+
+impl VolumeBarBuilder {
+    /// Create a builder that closes a bar every `units` of traded quantity.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `units <= 0` (see [`ThresholdBarBuilder::new`]).
+    #[must_use]
+    pub fn new(units: Decimal) -> Self {
+        Self {
+            inner: ThresholdBarBuilder::new(units, VolumeMeasure),
+        }
+    }
+
+    /// The configured per-bar traded quantity.
+    #[must_use]
+    pub fn units(&self) -> Decimal {
+        self.inner.threshold()
+    }
+}
+
+impl BarBuilder for VolumeBarBuilder {
+    fn push(&mut self, trade: &Trade) -> Option<Bar> {
+        self.inner.push(trade)
+    }
+
+    fn partial(&self) -> Option<&Bar> {
+        self.inner.partial()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Side;
+    use std::str::FromStr as _;
+
+    fn dec(s: &str) -> Decimal {
+        Decimal::from_str(s).unwrap()
+    }
+
+    fn trade(price: &str, qty: &str, side: Side) -> Trade {
+        Trade {
+            agg_id: 0,
+            timestamp_ms: 0,
+            price: dec(price),
+            quantity: dec(qty),
+            side,
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "bar threshold must be > 0")]
+    fn rejects_zero_units() {
+        let _ = VolumeBarBuilder::new(Decimal::ZERO);
+    }
+
+    #[test]
+    fn units_reports_configured_threshold() {
+        assert_eq!(VolumeBarBuilder::new(dec("5.0")).units(), dec("5.0"));
+    }
+
+    #[test]
+    fn closes_when_quantity_reaches_the_threshold() {
+        let mut b = VolumeBarBuilder::new(dec("5"));
+        assert!(b.push(&trade("100.0", "2.0", Side::Buy)).is_none());
+        assert!(b.push(&trade("100.0", "2.0", Side::Buy)).is_none());
+        let bar = b
+            .push(&trade("100.0", "1.0", Side::Buy))
+            .expect("reaches 5.0");
+        assert_eq!(bar.volume(), dec("5.0"));
+        assert_eq!(bar.trade_count, 3);
+    }
+}

--- a/crates/engine/tests/fixtures/volume_t5_expected.csv
+++ b/crates/engine/tests/fixtures/volume_t5_expected.csv
@@ -1,0 +1,9 @@
+# Expected volume bars for volume_trades.csv with threshold = 5.0. Hand-computed.
+#   Bar 0 = trades 1,2,3: vol 5.5 (overshoot 0.5), buy 2.0+1.5=3.5, sell 2.0,
+#           high 101.0, low 100.0, close 100.5.
+#   Bar 1 = trade 4 alone: the 8.0-unit trade crosses the threshold whole and
+#           forms a single overshooting bar (vol 8.0, sell 8.0). Not split.
+# Trades 5,6 remain a 3.0-unit partial and are not a closed bar.
+open_time,close_time,open,high,low,close,buy_volume,sell_volume,trade_count
+1000,1200,100.0,101.0,100.0,100.5,3.5,2.0,3
+1300,1300,102.0,102.0,102.0,102.0,0,8.0,1

--- a/crates/engine/tests/fixtures/volume_trades.csv
+++ b/crates/engine/tests/fixtures/volume_trades.csv
@@ -1,0 +1,12 @@
+# Trades for the volume-bar golden test, threshold = 5.0 units.
+#   Trades 1-3 (2.0+2.0+1.5=5.5) close bar 0 with a small overshoot.
+#   Trade 4 is a single 8.0-unit trade that crosses the threshold ALONE —
+#     the boundary case: it forms its own bar, whole, overshooting to 8.0.
+#   Trades 5-6 (1.0+2.0=3.0) stay a partial.
+agg_id,timestamp_ms,price,quantity,side
+1,1000,100.0,2.0,buy
+2,1100,101.0,2.0,sell
+3,1200,100.5,1.5,buy
+4,1300,102.0,8.0,sell
+5,1400,103.0,1.0,buy
+6,1500,101.0,2.0,buy

--- a/crates/engine/tests/golden_volume.rs
+++ b/crates/engine/tests/golden_volume.rs
@@ -1,0 +1,32 @@
+//! Golden test for volume bars, including the large-trade boundary case.
+
+use quantick_engine::{VolumeBarBuilder, fixture, golden};
+use rust_decimal::Decimal;
+use std::str::FromStr as _;
+
+const TRADES: &str = include_str!("fixtures/volume_trades.csv");
+const EXPECTED: &str = include_str!("fixtures/volume_t5_expected.csv");
+
+fn dec(s: &str) -> Decimal {
+    Decimal::from_str(s).unwrap()
+}
+
+#[test]
+fn volume_bars_match_golden() {
+    golden::assert_golden(|| VolumeBarBuilder::new(dec("5.0")), TRADES, EXPECTED);
+}
+
+#[test]
+fn large_trade_forms_its_own_overshooting_bar() {
+    let trades = fixture::parse_trades(TRADES).unwrap();
+    let bars = golden::replay(&mut VolumeBarBuilder::new(dec("5.0")), &trades);
+    // Bar 1 is the single 8.0-unit trade: whole, overshooting 5.0, not split.
+    assert_eq!(bars.len(), 2);
+    assert_eq!(bars[1].trade_count, 1, "the big trade is not split");
+    assert_eq!(
+        bars[1].volume(),
+        dec("8.0"),
+        "overshoot to 8.0, not capped at 5.0"
+    );
+    assert_eq!(bars[1].sell_volume, dec("8.0"));
+}


### PR DESCRIPTION
## Summary

Volume bars close when accumulated traded quantity reaches `N`, normalising by real quantity instead of event count. Built entirely on the generic threshold accumulator (#6) — no logic duplicated from tick bars.

- **`VolumeMeasure`** (`of = trade.quantity`) + **`VolumeBarBuilder::new(units)`**.
- Golden test reproduces a hand-computed fixture whose **trade 4 is a single 8.0-unit trade crossing the 5.0 threshold alone** — it forms one whole, overshooting bar, exercising the #6 boundary rule end-to-end.

Closes #7

## Design decisions

1. **`VolumeBarBuilder` is a wrapper, like `TickBarBuilder`.** Same shape: a marker `Measure` + a thin newtype exposing a domain-named constructor (`new(units: Decimal)`) and accessor (`units()`). Zero closing logic here.
2. **Threshold is `Decimal`, not `f64`.** Volume thresholds are exact quantities; a `Decimal` threshold compares exactly against the `Decimal` accumulator, so the close point is deterministic.

## Verification loop

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (34 tests)

## Notes for the reviewer

- No duplicated code from tick bars (AC): the only volume-specific code is the one-line `VolumeMeasure::of` and the wrapper's constructor/accessor. The OHLCV/delta folding and close rule are the shared `ThresholdBarBuilder`.
