### PR TITLE
feat(engine): dollar bars closing after N notional traded

### DIFF
--- a/crates/engine/src/dollar.rs
+++ b/crates/engine/src/dollar.rs
@@ -1,0 +1,136 @@
+//! Dollar bars — close after `N` notional traded.
+//!
+//! Dollar bars close when accumulated notional (`price * quantity`) reaches `N`.
+//! Because they sample by value rather than by count or quantity, they stay
+//! comparable across large price moves — which is why the research literature
+//! (Lopez de Prado) favours them for ML features. They are the [generic
+//! threshold accumulator](crate::ThresholdBarBuilder) with the measure
+//! "notional" ([`DollarMeasure`]).
+//!
+//! # Numeric representation of accumulated notional
+//!
+//! Notional is accumulated as [`rust_decimal::Decimal`], the same exact decimal
+//! type used for every price and quantity in the engine. This is the decision
+//! this issue calls for, and the reasoning is:
+//!
+//! - **No float drift.** `price * quantity` is an exact decimal product, and
+//!   summing exact decimals is exact. Over a session, binary-float notional
+//!   (`f64`) accumulates rounding error and would cross the threshold a trade
+//!   early or late depending on the exact drift — a non-determinism the golden
+//!   tests would catch. Decimal cannot drift: the close point is exact.
+//! - **Determinism holds regardless.** `Decimal` arithmetic uses a fixed
+//!   rounding rule, so even the rare product exceeding 28 significant digits
+//!   rounds deterministically. Realistic crypto notionals stay far below that
+//!   bound, and the accumulator resets every bar, so in practice accumulation is
+//!   exact and never overflows.
+//!
+//! The `notional_accumulation_is_exact` test demonstrates a threshold that an
+//! `f64` accumulator would miss (ten 0.1 notionals summing to 0.999… < 1.0).
+
+use rust_decimal::Decimal;
+
+use crate::{Bar, BarBuilder, ThresholdBarBuilder, Trade, threshold::Measure};
+
+/// The dollar measure: every trade contributes its notional `price * quantity`.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct DollarMeasure;
+
+impl Measure for DollarMeasure {
+    fn of(&self, trade: &Trade) -> Decimal {
+        trade.notional()
+    }
+}
+
+/// Builds dollar bars: closes once accumulated notional reaches `notional`.
+///
+/// A thin wrapper over [`ThresholdBarBuilder`] with [`DollarMeasure`]. Feed
+/// trades in order with [`push`](BarBuilder::push); the bar closes on the trade
+/// that brings cumulative notional to `notional` or beyond.
+#[derive(Debug, Clone)]
+pub struct DollarBarBuilder {
+    inner: ThresholdBarBuilder<DollarMeasure>,
+}
+
+impl DollarBarBuilder {
+    /// Create a builder that closes a bar every `notional` of traded value.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `notional <= 0` (see [`ThresholdBarBuilder::new`]).
+    #[must_use]
+    pub fn new(notional: Decimal) -> Self {
+        Self {
+            inner: ThresholdBarBuilder::new(notional, DollarMeasure),
+        }
+    }
+
+    /// The configured per-bar notional threshold.
+    #[must_use]
+    pub fn notional(&self) -> Decimal {
+        self.inner.threshold()
+    }
+}
+
+impl BarBuilder for DollarBarBuilder {
+    fn push(&mut self, trade: &Trade) -> Option<Bar> {
+        self.inner.push(trade)
+    }
+
+    fn partial(&self) -> Option<&Bar> {
+        self.inner.partial()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Side;
+    use std::str::FromStr as _;
+
+    fn dec(s: &str) -> Decimal {
+        Decimal::from_str(s).unwrap()
+    }
+
+    fn trade(price: &str, qty: &str, side: Side) -> Trade {
+        Trade {
+            agg_id: 0,
+            timestamp_ms: 0,
+            price: dec(price),
+            quantity: dec(qty),
+            side,
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "bar threshold must be > 0")]
+    fn rejects_zero_notional() {
+        let _ = DollarBarBuilder::new(Decimal::ZERO);
+    }
+
+    #[test]
+    fn measure_is_price_times_quantity() {
+        let t = trade("36000.10", "0.005", Side::Buy);
+        assert_eq!(DollarMeasure.of(&t), dec("180.00050"));
+    }
+
+    #[test]
+    fn notional_accumulation_is_exact() {
+        // Ten notionals of 0.1 sum to exactly 1.0 in Decimal, so the bar closes
+        // on the tenth trade. In f64 the same sum is 0.9999999999999999 < 1.0,
+        // which would NOT close here — proving the exact-decimal choice.
+        let f64_sum: f64 = (0..10).map(|_| 1.0_f64 * 0.1_f64).sum();
+        assert!(f64_sum < 1.0, "f64 drifts below 1.0: {f64_sum}");
+
+        let mut b = DollarBarBuilder::new(dec("1.0"));
+        for _ in 0..9 {
+            assert!(
+                b.push(&trade("1.0", "0.1", Side::Buy)).is_none(),
+                "0.9 notional has not reached 1.0"
+            );
+        }
+        let bar = b
+            .push(&trade("1.0", "0.1", Side::Buy))
+            .expect("the tenth trade brings exact notional to 1.0");
+        assert_eq!(bar.trade_count, 10);
+    }
+}

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -24,6 +24,7 @@ pub mod golden;
 
 mod bar;
 mod builder;
+mod dollar;
 pub mod threshold;
 mod tick;
 mod trade;
@@ -31,6 +32,7 @@ mod volume;
 
 pub use bar::Bar;
 pub use builder::BarBuilder;
+pub use dollar::{DollarBarBuilder, DollarMeasure};
 pub use threshold::{Measure, ThresholdBarBuilder};
 pub use tick::{TickBarBuilder, TickMeasure};
 pub use trade::{Side, Trade};

--- a/crates/engine/tests/fixtures/dollar_t500_expected.csv
+++ b/crates/engine/tests/fixtures/dollar_t500_expected.csv
@@ -1,0 +1,9 @@
+# Expected dollar bars for dollar_trades.csv with threshold = 500 notional.
+#   Bar 0 = trades 1,2: notional 540.00350 (exact), high 36000.30, low 36000.10,
+#           close 36000.30, buy 0.005, sell 0.010.
+#   Bar 1 = trade 3 alone: 800 notional crosses 500 whole -> one overshooting
+#           bar, buy 0.020.
+# Trade 4 (36 notional) remains a partial.
+open_time,close_time,open,high,low,close,buy_volume,sell_volume,trade_count
+1000,1200,36000.10,36000.30,36000.10,36000.30,0.005,0.010,2
+1400,1400,40000.00,40000.00,40000.00,40000.00,0.020,0,1

--- a/crates/engine/tests/fixtures/dollar_trades.csv
+++ b/crates/engine/tests/fixtures/dollar_trades.csv
@@ -1,0 +1,12 @@
+# Trades for the dollar-bar golden test, threshold = 500 notional.
+# Notionals use realistic BTCUSDT-shaped decimals so the exact-arithmetic
+# property matters (these products are not representable in binary float):
+#   1: 36000.10 * 0.005 = 180.00050   acc 180.00050
+#   2: 36000.30 * 0.010 = 360.00300   acc 540.00350 >= 500 -> close bar 0
+#   3: 40000.00 * 0.020 = 800.00000   crosses 500 ALONE -> close bar 1, overshoot
+#   4: 36000.00 * 0.001 =  36.00000   acc 36 -> partial
+agg_id,timestamp_ms,price,quantity,side
+1,1000,36000.10,0.005,buy
+2,1200,36000.30,0.010,sell
+3,1400,40000.00,0.020,buy
+4,1600,36000.00,0.001,sell

--- a/crates/engine/tests/golden_dollar.rs
+++ b/crates/engine/tests/golden_dollar.rs
@@ -1,0 +1,28 @@
+//! Golden test for dollar bars, including exact-notional and boundary checks.
+
+use quantick_engine::{DollarBarBuilder, fixture, golden};
+use rust_decimal::Decimal;
+use std::str::FromStr as _;
+
+const TRADES: &str = include_str!("fixtures/dollar_trades.csv");
+const EXPECTED: &str = include_str!("fixtures/dollar_t500_expected.csv");
+
+fn dec(s: &str) -> Decimal {
+    Decimal::from_str(s).unwrap()
+}
+
+#[test]
+fn dollar_bars_match_golden() {
+    golden::assert_golden(|| DollarBarBuilder::new(dec("500")), TRADES, EXPECTED);
+}
+
+#[test]
+fn large_trade_crosses_threshold_alone() {
+    let trades = fixture::parse_trades(TRADES).unwrap();
+    let bars = golden::replay(&mut DollarBarBuilder::new(dec("500")), &trades);
+    assert_eq!(bars.len(), 2);
+    // Bar 1 is trade 3: 40000.00 * 0.020 = 800 notional, crossing 500 alone.
+    assert_eq!(bars[1].trade_count, 1);
+    assert_eq!(bars[1].close, dec("40000.00"));
+    assert_eq!(bars[1].buy_volume, dec("0.020"));
+}


### PR DESCRIPTION
## Summary

Dollar bars sample by traded value (`price * quantity`), staying comparable across large price moves. Built on the generic threshold accumulator (#6) with measure = notional — no logic duplicated.

- **`DollarMeasure`** (`of = trade.notional()`) + **`DollarBarBuilder::new(notional)`**.
- Golden test reproduces a hand-computed fixture with BTCUSDT-shaped notionals; trade 3 (800 notional) crosses the 500 threshold alone (boundary case).

Closes #8

## Numeric-representation decision (this issue's crux)

**Accumulated notional is `rust_decimal::Decimal`** — the same exact decimal type used for every price and quantity in the engine. Documented in the `dollar` module rustdoc, and the reasoning:

- **No float drift.** `price * quantity` is an exact decimal product, and summing exact decimals is exact. An `f64` accumulator drifts and would cross the threshold a trade early or late depending on rounding — a non-determinism the golden tests would catch. Decimal cannot drift: the close point is exact.
- **Determinism holds unconditionally.** `Decimal` uses a fixed rounding rule; even a product exceeding 28 significant digits rounds deterministically. Realistic crypto notionals stay well below that, and the accumulator resets each bar, so accumulation is exact in practice and never overflows.

The `notional_accumulation_is_exact` test makes this concrete: ten `0.1` notionals close a `1.0` bar under Decimal, but sum to `0.9999999999999999 < 1.0` under `f64` — which would miss the threshold entirely.

## Verification loop

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (39 tests)

## Notes for the reviewer

- This closes the loop on the `Decimal` choice from #3: it was chosen precisely so this issue's precision requirement is satisfied by construction rather than by a special-cased accumulator.
