### PR TITLE
feat(engine): time bars as the baseline reference

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -27,6 +27,7 @@ mod builder;
 mod dollar;
 pub mod threshold;
 mod tick;
+mod time;
 mod trade;
 mod volume;
 
@@ -35,5 +36,6 @@ pub use builder::BarBuilder;
 pub use dollar::{DollarBarBuilder, DollarMeasure};
 pub use threshold::{Measure, ThresholdBarBuilder};
 pub use tick::{TickBarBuilder, TickMeasure};
+pub use time::TimeBarBuilder;
 pub use trade::{Side, Trade};
 pub use volume::{VolumeBarBuilder, VolumeMeasure};

--- a/crates/engine/src/time.rs
+++ b/crates/engine/src/time.rs
@@ -1,0 +1,161 @@
+//! Time bars — the baseline reference, driven only by trade timestamps.
+//!
+//! Time bars close on fixed wall-clock intervals (1s, 1m, ...). They are not
+//! the point of quantick — the alternative bars are — but they are the baseline
+//! the alternative bars are compared against, on the chart and in research, and
+//! they are nearly free once the builder skeleton exists.
+//!
+//! Crucially, the interval boundary is derived **only from trade timestamps**,
+//! never from a wall clock: a trade at time `t` falls in the bucket starting at
+//! `floor(t / interval) * interval`. Reading the host clock would make the same
+//! fixture produce different bars on different runs — a determinism violation.
+//!
+//! # Empty-interval policy: skip, don't fabricate
+//!
+//! An interval in which no trade occurred produces **no bar**. The alternative:
+//! emitting an "empty" bar (volume 0, OHLC carried forward from the previous
+//! close) would fabricate a price for a moment that had no trade — inferred data
+//! presented as if it were sampled, which the data-honesty rule forbids. The
+//! alternative bars never have empty bars either, so skipping keeps the baseline
+//! consistent with them.
+//!
+//! The skip is not hidden: consecutive closed bars can be non-contiguous in
+//! time (a bar's `open_time` bucket may be several intervals after the previous
+//! bar's), and that gap is the honest record that no trades happened in between.
+
+use crate::threshold::{extend_bar, open_bar};
+use crate::{Bar, BarBuilder, Trade};
+
+/// Builds time bars: one bar per `interval_ms` interval that contains trades.
+///
+/// Feed trades in non-decreasing timestamp order with
+/// [`push`](BarBuilder::push); a bar closes when the first trade of a *later*
+/// interval arrives. Intervals with no trades are skipped (see the [module
+/// docs](self)).
+#[derive(Debug, Clone)]
+pub struct TimeBarBuilder {
+    interval_ms: i64,
+    bucket_start: i64,
+    current: Option<Bar>,
+}
+
+impl TimeBarBuilder {
+    /// Create a builder with the given interval, in milliseconds.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `interval_ms <= 0`: a non-positive interval has no meaningful
+    /// bucket boundary.
+    #[must_use]
+    pub fn new(interval_ms: i64) -> Self {
+        assert!(
+            interval_ms > 0,
+            "time bar interval must be > 0 ms, got {interval_ms}"
+        );
+        Self {
+            interval_ms,
+            bucket_start: 0,
+            current: None,
+        }
+    }
+
+    /// The configured interval, in milliseconds.
+    #[must_use]
+    pub fn interval_ms(&self) -> i64 {
+        self.interval_ms
+    }
+
+    /// The start (epoch ms) of the interval a trade at `timestamp_ms` belongs
+    /// to. Uses Euclidean division so it floors correctly for any timestamp.
+    fn bucket_of(&self, timestamp_ms: i64) -> i64 {
+        timestamp_ms.div_euclid(self.interval_ms) * self.interval_ms
+    }
+}
+
+impl BarBuilder for TimeBarBuilder {
+    fn push(&mut self, trade: &Trade) -> Option<Bar> {
+        let bucket = self.bucket_of(trade.timestamp_ms);
+        match &mut self.current {
+            // First trade: open the first bar; nothing closes yet.
+            None => {
+                self.current = Some(open_bar(trade));
+                self.bucket_start = bucket;
+                None
+            }
+            // Same interval: fold the trade into the forming bar.
+            Some(bar) if bucket == self.bucket_start => {
+                extend_bar(bar, trade);
+                None
+            }
+            // A later interval: close the current bar and open a fresh one for
+            // this trade. Any intervening empty intervals are simply skipped.
+            Some(_) => {
+                let closed = self.current.take();
+                self.current = Some(open_bar(trade));
+                self.bucket_start = bucket;
+                closed
+            }
+        }
+    }
+
+    fn partial(&self) -> Option<&Bar> {
+        self.current.as_ref()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Side;
+    use rust_decimal::Decimal;
+    use std::str::FromStr as _;
+
+    fn trade(ts: i64, price: &str, side: Side) -> Trade {
+        Trade {
+            agg_id: 0,
+            timestamp_ms: ts,
+            price: Decimal::from_str(price).unwrap(),
+            quantity: Decimal::from_str("1.0").unwrap(),
+            side,
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "time bar interval must be > 0 ms")]
+    fn rejects_non_positive_interval() {
+        let _ = TimeBarBuilder::new(0);
+    }
+
+    #[test]
+    fn trades_in_the_same_interval_share_a_bar() {
+        let mut b = TimeBarBuilder::new(1000);
+        assert!(b.push(&trade(1000, "100.0", Side::Buy)).is_none());
+        assert!(b.push(&trade(1999, "101.0", Side::Buy)).is_none());
+        assert_eq!(b.partial().unwrap().trade_count, 2);
+    }
+
+    #[test]
+    fn a_later_interval_closes_the_previous_bar() {
+        let mut b = TimeBarBuilder::new(1000);
+        assert!(b.push(&trade(1500, "100.0", Side::Buy)).is_none());
+        let closed = b
+            .push(&trade(2500, "101.0", Side::Buy))
+            .expect("new interval closes");
+        assert_eq!(closed.open_time, 1500);
+        assert_eq!(closed.close_time, 1500);
+    }
+
+    #[test]
+    fn empty_intervals_are_skipped_not_emitted() {
+        // Trade at 1500 (bucket 1000), then a jump to 4200 (bucket 4000):
+        // buckets 2000 and 3000 are empty and must not produce bars.
+        let mut b = TimeBarBuilder::new(1000);
+        assert!(b.push(&trade(1500, "100.0", Side::Buy)).is_none());
+        let closed = b
+            .push(&trade(4200, "103.0", Side::Buy))
+            .expect("closes bucket 1000");
+        assert_eq!(closed.open_time, 1500, "only the non-empty bucket closed");
+        // The forming bar jumps straight to bucket 4000 — no empty bars between.
+        assert_eq!(b.partial().unwrap().open_time, 4200);
+    }
+}

--- a/crates/engine/tests/fixtures/time_i1000_expected.csv
+++ b/crates/engine/tests/fixtures/time_i1000_expected.csv
@@ -1,0 +1,11 @@
+# Expected time bars for time_trades.csv with interval = 1000 ms. Hand-computed.
+#   Bar 0 = bucket [1000,2000), trades 1,2: high 101.0 low 100.0 close 101.0.
+#   Bar 1 = bucket [2000,3000), trade 3.
+#   Bar 2 = bucket [4000,5000), trades 4,5: high 104.0 low 103.0 close 104.0.
+# Bucket [3000,4000) is empty and, per the skip policy, has NO row here — the
+# gap between close_time 2100 and open_time 4200 is the honest record of it.
+# Trade 6 leaves a partial at [5000,6000) and is not a closed bar.
+open_time,close_time,open,high,low,close,buy_volume,sell_volume,trade_count
+1000,1500,100.0,101.0,100.0,101.0,1.0,2.0,2
+2100,2100,102.0,102.0,102.0,102.0,1.0,0,1
+4200,4800,103.0,104.0,103.0,104.0,1.0,3.0,2

--- a/crates/engine/tests/fixtures/time_trades.csv
+++ b/crates/engine/tests/fixtures/time_trades.csv
@@ -1,0 +1,12 @@
+# Trades for the time-bar golden test, interval = 1000 ms.
+# Buckets: [1000,2000) has trades 1,2; [2000,3000) has trade 3;
+#   [3000,4000) is EMPTY; [4000,5000) has trades 4,5; [5000,6000) has trade 6.
+# With the skip-empty policy, the empty [3000,4000) bucket produces NO bar, so
+# the closed sequence jumps 2000 -> 4000. Trade 6 leaves a partial at 5000.
+agg_id,timestamp_ms,price,quantity,side
+1,1000,100.0,1.0,buy
+2,1500,101.0,2.0,sell
+3,2100,102.0,1.0,buy
+4,4200,103.0,3.0,sell
+5,4800,104.0,1.0,buy
+6,5300,105.0,1.0,buy

--- a/crates/engine/tests/golden_time.rs
+++ b/crates/engine/tests/golden_time.rs
@@ -1,0 +1,31 @@
+//! Golden test for time bars, with an explicit empty-interval-policy check.
+
+use quantick_engine::{TimeBarBuilder, fixture, golden};
+
+const TRADES: &str = include_str!("fixtures/time_trades.csv");
+const EXPECTED: &str = include_str!("fixtures/time_i1000_expected.csv");
+
+#[test]
+fn time_bars_match_golden() {
+    golden::assert_golden(|| TimeBarBuilder::new(1000), TRADES, EXPECTED);
+}
+
+#[test]
+fn empty_bucket_3000_produces_no_bar() {
+    let trades = fixture::parse_trades(TRADES).unwrap();
+    let bars = golden::replay(&mut TimeBarBuilder::new(1000), &trades);
+
+    // Three closed bars, for buckets 1000, 2000 and 4000 — not four. The empty
+    // [3000,4000) bucket is absent.
+    assert_eq!(bars.len(), 3);
+    let buckets: Vec<i64> = bars.iter().map(|b| b.open_time / 1000 * 1000).collect();
+    assert_eq!(buckets, vec![1000, 2000, 4000]);
+    assert!(
+        !buckets.contains(&3000),
+        "the empty interval must not be fabricated as a bar"
+    );
+
+    // The gap is visible: bar 1 closes at 2100, bar 2 opens at 4200.
+    assert_eq!(bars[1].close_time, 2100);
+    assert_eq!(bars[2].open_time, 4200);
+}


### PR DESCRIPTION
## Summary

The baseline the alternative bars are compared against. Time bars close on fixed intervals, but the interval boundary is derived **only from trade timestamps** (`floor(t / interval) * interval`) — never a wall clock — so the same fixture always yields the same bars.

- **`TimeBarBuilder::new(interval_ms)`**, reusing the shared open/extend folding (no OHLCV logic duplicated).
- Golden test + explicit empty-interval assertions.

Closes #9

## The empty-interval decision

**Skip empty intervals — never fabricate an empty bar.** An interval with no trades produces no bar. The alternative (an empty bar with volume 0 and OHLC carried forward from the previous close) would fabricate a price for a moment that had no trade — inferred data dressed as sampled, which the data-honesty rule forbids. The alternative bars have no empty bars either, so skipping keeps the baseline consistent.

The skip is not hidden: consecutive closed bars can be non-contiguous in time, and that gap is the honest record that no trades happened. The golden fixture jumps from bucket 2000 to bucket 4000 across an empty 3000 bucket; `empty_bucket_3000_produces_no_bar` asserts the closed sequence is `[1000, 2000, 4000]` with a visible `2100 → 4200` gap.

## Verification loop

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (45 tests)

## Notes for the reviewer

- Zero wall-clock usage inside the engine (AC): the only time source is `trade.timestamp_ms`. `div_euclid` is used so bucketing floors correctly for any `i64`, not just positive epoch-ms.
- Time bars are the one builder that is *not* threshold-accumulator based (they close on a time boundary, not an accumulated measure), so they're a separate `BarBuilder` — but they still reuse the shared folding, honouring "one engine".

**This completes milestone v0.1 — Engine core.**
