### PR TITLE
perf(engine): add dependency-free hot-path benchmark

### DIFF
--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -7,3 +7,7 @@ license.workspace = true
 
 [dependencies]
 rust_decimal = "1"
+
+[[bench]]
+name = "hot_path"
+harness = false

--- a/crates/engine/benches/hot_path.rs
+++ b/crates/engine/benches/hot_path.rs
@@ -1,0 +1,82 @@
+//! Hot-path benchmark: how fast can each builder ingest trades?
+//!
+//! Tick charts update at high frequency, so the engine must keep up with live
+//! trade bursts. This benchmark pushes a large, deterministic synthetic burst
+//! through every builder and reports per-trade throughput. It is intentionally
+//! dependency-free (no criterion) to keep the engine's dep tree small and CI
+//! compile fast; run it with `cargo bench -p quantick-engine`.
+//!
+//! The workload is fully deterministic (derived from the trade index, no rng or
+//! wall clock affects its *shape*), so throughput is comparable across commits.
+//! A meaningful drop between runs is a regression to investigate as a bug.
+
+use std::hint::black_box;
+use std::time::Instant;
+
+use quantick_engine::{
+    BarBuilder, DollarBarBuilder, Side, TickBarBuilder, TimeBarBuilder, Trade, VolumeBarBuilder,
+};
+use rust_decimal::Decimal;
+
+/// Build a deterministic burst of `n` trades around a 36000 base price.
+///
+/// Generation happens outside the timed region, so only the push loop — the
+/// real hot path — is measured.
+fn make_trades(n: usize) -> Vec<Trade> {
+    let base = Decimal::from(36_000);
+    let mut trades = Vec::with_capacity(n);
+    for i in 0..n {
+        // Price wiggles in a deterministic ±5.00 band in 0.10 steps.
+        let tick = (i % 100) as i64 - 50;
+        let price = base + Decimal::new(tick, 1);
+        // Quantity cycles 0.001 .. 1.000.
+        let quantity = Decimal::new(((i % 1000) + 1) as i64, 3);
+        let side = if i % 2 == 0 { Side::Buy } else { Side::Sell };
+        trades.push(Trade {
+            agg_id: i as u64,
+            timestamp_ms: 1_700_000_000_000 + i as i64,
+            price,
+            quantity,
+            side,
+        });
+    }
+    trades
+}
+
+/// Time pushing every trade through `builder`, printing throughput.
+fn bench<B: BarBuilder>(name: &str, mut builder: B, trades: &[Trade]) {
+    let start = Instant::now();
+    let mut closed = 0usize;
+    for trade in trades {
+        if builder.push(black_box(trade)).is_some() {
+            closed += 1;
+        }
+    }
+    let elapsed = start.elapsed();
+    let millions_per_sec = trades.len() as f64 / elapsed.as_secs_f64() / 1e6;
+    let ns_per = elapsed.as_secs_f64() * 1e9 / trades.len() as f64;
+    println!(
+        "{name:14} {n} trades in {elapsed:>10.2?}  =>  {millions_per_sec:6.1} M trades/s  {ns_per:6.1} ns/trade  ({closed} bars)",
+        n = trades.len(),
+    );
+    black_box(closed);
+}
+
+fn main() {
+    let n = 5_000_000;
+    println!("hot-path benchmark: {n} deterministic trades per builder\n");
+    let trades = make_trades(n);
+
+    bench("tick(100)", TickBarBuilder::new(100), &trades);
+    bench(
+        "volume(50)",
+        VolumeBarBuilder::new(Decimal::from(50)),
+        &trades,
+    );
+    bench(
+        "dollar(1e7)",
+        DollarBarBuilder::new(Decimal::from(10_000_000)),
+        &trades,
+    );
+    bench("time(1000ms)", TimeBarBuilder::new(1000), &trades);
+}


### PR DESCRIPTION
## Summary

A lightweight benchmark that pushes 5M deterministic synthetic trades through each builder and reports per-trade throughput. Run with `cargo bench -p quantick-engine`.

Closes #21

## Baseline (this machine, `--release`)

```
tick(100)      5000000 trades in   276.43ms  =>  18.1 M trades/s  55.3 ns/trade  (50000 bars)
volume(50)     5000000 trades in   302.32ms  =>  16.5 M trades/s  60.5 ns/trade  (49722 bars)
dollar(1e7)    5000000 trades in   361.49ms  =>  13.8 M trades/s  72.3 ns/trade  (9000 bars)
time(1000ms)   5000000 trades in   291.46ms  =>  17.2 M trades/s  58.3 ns/trade  (4999 bars)
```

**This validates the `Decimal` decision from #3.** 13.8–18.1M trades/s single-threaded is orders of magnitude above any realistic Binance aggTrade rate (a busy BTCUSDT does low thousands/s), so the exact-arithmetic choice costs nothing we can't afford. A meaningful drop between runs is now a regression to investigate as a bug.

## Design decisions

1. **No `criterion`.** A hand-rolled `Instant`-timed loop keeps the engine's dependency tree minimal (CLAUDE.md "small and focused") and CI compile fast. Statistical rigor isn't needed to answer "can the engine keep up with a live feed" — the margin is ~1000×.
2. **`harness = false` bench, deterministic input.** Trade generation happens outside the timed region, so only the push loop is measured; the workload shape is derived from the trade index (no rng/wall-clock), so runs are comparable.

## Verification loop

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (compiles the bench)
- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (34 engine unit tests; the bench is **not** run by `cargo test`)

## Notes for the reviewer

- The bench is compiled by `cargo clippy --all-targets` (so it's lint-clean) but never executed in CI — benchmark timing shouldn't gate CI. It's a manual tool + a documented baseline.
