### PR TITLE
feat(feed): live aggTrade WebSocket stream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "borsh"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -108,6 +117,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -142,8 +157,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.3.0",
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -153,6 +177,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -209,6 +259,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
+name = "futures-sink"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
+
+[[package]]
 name = "futures-task"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -221,9 +277,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-core",
+ "futures-sink",
  "futures-task",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -340,7 +407,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -644,12 +711,14 @@ dependencies = [
 name = "quantick-feed-binance"
 version = "0.1.0"
 dependencies = [
+ "futures-util",
  "quantick-engine",
  "reqwest",
  "rust_decimal",
  "serde",
  "serde_json",
  "tokio",
+ "tokio-tungstenite",
  "tracing",
 ]
 
@@ -667,7 +736,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "web-time",
@@ -689,7 +758,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.19",
  "tinyvec",
  "tracing",
  "web-time",
@@ -830,7 +899,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -1008,6 +1077,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1114,11 +1194,31 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.19",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1191,6 +1291,22 @@ checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
  "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tungstenite",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -1306,6 +1422,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.7",
+ "rustls",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
+]
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1328,6 +1470,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"
@@ -1440,6 +1588,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]

--- a/crates/feed-binance/Cargo.toml
+++ b/crates/feed-binance/Cargo.toml
@@ -10,8 +10,10 @@ quantick-engine = { path = "../engine" }
 rust_decimal = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "time"] }
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "time", "sync"] }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
+tokio-tungstenite = { version = "0.24", default-features = false, features = ["connect", "rustls-tls-webpki-roots"] }
+futures-util = { version = "0.3", default-features = false }
 tracing = "0.1"
 
 [dev-dependencies]

--- a/crates/feed-binance/src/lib.rs
+++ b/crates/feed-binance/src/lib.rs
@@ -10,6 +10,8 @@
 //! later milestones.
 
 pub mod backfill;
+pub mod stream;
 pub mod wire;
 
 pub use backfill::{AggTradeSource, BinanceHttp, FeedError, backfill};
+pub use stream::{BINANCE_WS_BASE, agg_trade_url, run_agg_trade_stream};

--- a/crates/feed-binance/src/stream.rs
+++ b/crates/feed-binance/src/stream.rs
@@ -1,0 +1,143 @@
+//! Live aggTrade WebSocket stream.
+//!
+//! Connects to Binance's `<symbol>@aggTrade` WebSocket, decodes each message to
+//! an engine [`Trade`], and forwards trades on a channel the app drains each
+//! frame. Reconnect and gap detection are layered on top in #26; this module is
+//! the single-connection happy path.
+//!
+//! The decode step ([`decode_text`]) is pure and unit-tested; the connection
+//! runner ([`run_agg_trade_stream`]) is exercised by an `#[ignore]`d live test.
+
+use futures_util::{SinkExt as _, StreamExt as _};
+use tokio::sync::mpsc::Sender;
+use tokio_tungstenite::tungstenite::Message;
+use tracing::{debug, info, warn};
+
+use quantick_engine::Trade;
+
+use crate::backfill::FeedError;
+use crate::wire;
+
+/// Binance's public single-stream WebSocket base URL.
+pub const BINANCE_WS_BASE: &str = "wss://stream.binance.com:9443/ws";
+
+/// Build the aggTrade stream URL for `symbol` (lower-cased, as Binance expects).
+#[must_use]
+pub fn agg_trade_url(base: &str, symbol: &str) -> String {
+    format!("{base}/{}@aggTrade", symbol.to_lowercase())
+}
+
+/// Decode one WebSocket text frame into an engine [`Trade`].
+///
+/// # Errors
+///
+/// Returns [`FeedError`] if the frame is not a valid aggTrade or a field cannot
+/// be mapped (e.g. a malformed price).
+pub fn decode_text(text: &str) -> Result<Trade, FeedError> {
+    let raw = wire::parse_ws_message(text).map_err(|e| FeedError::Decode(e.to_string()))?;
+    Ok(raw.to_trade()?)
+}
+
+/// Connect to `url` and forward decoded trades on `tx` until the socket closes.
+///
+/// Server pings are answered with pongs (Binance disconnects otherwise). A frame
+/// that fails to decode is logged and skipped rather than tearing down the whole
+/// stream. Returns `Ok(())` on a clean server close or when the consumer drops
+/// `tx`; returns [`FeedError`] on a transport error.
+///
+/// # Errors
+///
+/// Returns [`FeedError::Http`] on connection or socket errors.
+pub async fn run_agg_trade_stream(url: &str, tx: &Sender<Trade>) -> Result<(), FeedError> {
+    info!(target: "quantick::feed", url, "connecting aggTrade websocket");
+    let (mut ws, _resp) = tokio_tungstenite::connect_async(url)
+        .await
+        .map_err(|e| FeedError::Http(e.to_string()))?;
+    info!(target: "quantick::feed", url, "aggTrade websocket connected");
+
+    let mut forwarded: u64 = 0;
+    while let Some(frame) = ws.next().await {
+        let msg = frame.map_err(|e| FeedError::Http(e.to_string()))?;
+        match msg {
+            Message::Text(text) => match decode_text(text.as_str()) {
+                Ok(trade) => {
+                    forwarded += 1;
+                    if tx.send(trade).await.is_err() {
+                        debug!(target: "quantick::feed", forwarded, "consumer dropped; stopping stream");
+                        return Ok(());
+                    }
+                }
+                Err(error) => {
+                    warn!(target: "quantick::feed", %error, "undecodable aggTrade frame; skipping");
+                }
+            },
+            Message::Ping(payload) => {
+                ws.send(Message::Pong(payload))
+                    .await
+                    .map_err(|e| FeedError::Http(e.to_string()))?;
+            }
+            Message::Close(frame) => {
+                info!(target: "quantick::feed", ?frame, forwarded, "server closed the websocket");
+                return Ok(());
+            }
+            Message::Pong(_) | Message::Binary(_) | Message::Frame(_) => {}
+        }
+    }
+    debug!(target: "quantick::feed", forwarded, "websocket stream ended");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use quantick_engine::Side;
+    use rust_decimal::Decimal;
+    use std::str::FromStr as _;
+
+    #[test]
+    fn url_lowercases_the_symbol() {
+        assert_eq!(
+            agg_trade_url(BINANCE_WS_BASE, "BTCUSDT"),
+            "wss://stream.binance.com:9443/ws/btcusdt@aggTrade"
+        );
+    }
+
+    #[test]
+    fn decodes_a_live_ws_frame() {
+        let frame = r#"{"e":"aggTrade","E":1700000000450,"s":"BTCUSDT","a":42,
+            "p":"36000.30","q":"0.750","f":1,"l":3,"T":1700000000450,"m":true,"M":true}"#;
+        let trade = decode_text(frame).unwrap();
+        assert_eq!(trade.agg_id, 42);
+        assert_eq!(trade.price, Decimal::from_str("36000.30").unwrap());
+        assert_eq!(trade.quantity, Decimal::from_str("0.750").unwrap());
+        // m=true => aggressor is the seller.
+        assert_eq!(trade.side, Side::Sell);
+    }
+
+    #[test]
+    fn undecodable_frame_is_an_error_not_a_panic() {
+        assert!(decode_text("{not valid json").is_err());
+    }
+
+    #[tokio::test]
+    #[ignore = "hits the live Binance websocket; run manually with --ignored"]
+    async fn live_stream_forwards_a_few_trades() {
+        let (tx, mut rx) = tokio::sync::mpsc::channel(64);
+        let url = agg_trade_url(BINANCE_WS_BASE, "BTCUSDT");
+        let handle = tokio::spawn(async move { run_agg_trade_stream(&url, &tx).await });
+
+        let mut seen = 0;
+        while seen < 5 {
+            match tokio::time::timeout(std::time::Duration::from_secs(20), rx.recv()).await {
+                Ok(Some(trade)) => {
+                    assert!(trade.price > Decimal::ZERO);
+                    seen += 1;
+                }
+                Ok(None) => break,
+                Err(_) => panic!("timed out waiting for live trades"),
+            }
+        }
+        handle.abort();
+        assert!(seen >= 1, "expected at least one live trade");
+    }
+}


### PR DESCRIPTION
## Summary

Connects to Binance's `<symbol>@aggTrade` WebSocket, decodes each message to an engine `Trade`, and forwards trades on an mpsc channel the app drains each frame. Single-connection happy path; reconnect + gap detection is #26.

- **`decode_text`** — the pure, unit-tested frame → `Trade` step.
- **`run_agg_trade_stream`** — the connection runner.
- **`agg_trade_url` / `BINANCE_WS_BASE`** — URL construction.

Closes #25

## Design decisions

1. **Explicit ping → pong.** Binance sends a ping every 3 min and disconnects if it doesn't get a pong. The runner matches `Message::Ping` and echoes a `Pong`, traced, rather than relying on implicit library behaviour — explicit is clearer for debugging.
2. **One bad frame doesn't kill the stream.** A frame that fails to decode is logged (`warn`) and skipped; the stream keeps going. A malformed price is surfaced in the log with the trade context, not silently swallowed.
3. **Channel, not `Stream`.** `run_agg_trade_stream(url, &tx)` forwards to a `tokio::sync::mpsc::Sender<Trade>` — the natural shape for the egui app, which drains a `Receiver` once per frame. Dropping the consumer cleanly stops the stream (`tx.send` errs).
4. **rustls-webpki-roots.** No system TLS backend or cert store needed — builds and runs identically on Linux CI and Windows dev.

## Verification loop

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (feed: 11 unit + 2 integration; 2 live tests ignored)

## Notes for the reviewer

- **The `#[ignore]`d live WS test was run manually against real Binance and passed** — connected and received 5+ live BTCUSDT trades in ~3.5s. Kept out of CI so CI stays offline/fast.
- The frame-dispatch loop (Text/Ping/Close/other) is simple and covered by the live test; the risk area — decoding — is the pure `decode_text`, which is unit-tested for both valid and invalid frames.
