### PR TITLE
feat(feed): reconnect with backoff and gap/out-of-order detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -570,6 +570,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -720,6 +726,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1088,6 +1095,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1230,6 +1246,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1413,6 +1438,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "sharded-slab",
+ "thread_local",
+ "tracing-core",
 ]
 
 [[package]]

--- a/crates/feed-binance/Cargo.toml
+++ b/crates/feed-binance/Cargo.toml
@@ -18,3 +18,4 @@ tracing = "0.1"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "macros"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }

--- a/crates/feed-binance/src/continuity.rs
+++ b/crates/feed-binance/src/continuity.rs
@@ -1,0 +1,237 @@
+//! Gap, out-of-order, duplicate and backwards-timestamp detection.
+//!
+//! A long-running live feed can drop trades, deliver them out of order, or
+//! repeat them across a reconnect. The data-honesty rule says such holes must be
+//! detected and labelled, never silently patched. [`ContinuityTracker`] watches
+//! the `agg_id` and timestamp sequence and reports every anomaly — both as a
+//! returned value (so a consumer can label the data) and as a structured,
+//! labelled `tracing` event (so a log excerpt alone explains what happened).
+//!
+//! This is deterministic and does not run inside the engine: the engine still
+//! only ever sees ordered `Trade`s and emits nothing.
+
+use tracing::warn;
+
+use quantick_engine::Trade;
+
+/// A break in the expected trade sequence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Anomaly {
+    /// One or more aggregate trades between `expected_agg_id` and `got_agg_id`
+    /// were never delivered.
+    Gap {
+        /// The agg_id we expected next (last seen + 1).
+        expected_agg_id: u64,
+        /// The agg_id we actually got.
+        got_agg_id: u64,
+        /// How many ids were skipped.
+        missing: u64,
+    },
+    /// A trade arrived with an agg_id lower than one already seen.
+    OutOfOrder {
+        /// The highest agg_id seen so far.
+        last_agg_id: u64,
+        /// The (lower) agg_id that just arrived.
+        got_agg_id: u64,
+    },
+    /// The same agg_id arrived twice.
+    Duplicate {
+        /// The repeated agg_id.
+        agg_id: u64,
+    },
+    /// A trade's timestamp went backwards relative to the previous trade.
+    BackwardsTimestamp {
+        /// The previous trade's timestamp (epoch ms).
+        last_ms: i64,
+        /// The (earlier) timestamp that just arrived.
+        got_ms: i64,
+    },
+}
+
+impl Anomaly {
+    /// Emit a structured, labelled `tracing` warning for this anomaly.
+    fn trace(self) {
+        match self {
+            Anomaly::Gap {
+                expected_agg_id,
+                got_agg_id,
+                missing,
+            } => warn!(
+                target: "quantick::feed",
+                kind = "gap",
+                expected_agg_id,
+                got_agg_id,
+                missing,
+                "aggTrade gap: {missing} trade(s) missing between {expected_agg_id} and {got_agg_id}"
+            ),
+            Anomaly::OutOfOrder {
+                last_agg_id,
+                got_agg_id,
+            } => warn!(
+                target: "quantick::feed",
+                kind = "out_of_order",
+                last_agg_id,
+                got_agg_id,
+                "aggTrade out of order: {got_agg_id} arrived after {last_agg_id}"
+            ),
+            Anomaly::Duplicate { agg_id } => warn!(
+                target: "quantick::feed",
+                kind = "duplicate",
+                agg_id,
+                "aggTrade duplicate: {agg_id} seen again"
+            ),
+            Anomaly::BackwardsTimestamp { last_ms, got_ms } => warn!(
+                target: "quantick::feed",
+                kind = "backwards_timestamp",
+                last_ms,
+                got_ms,
+                "aggTrade timestamp went backwards: {got_ms} after {last_ms}"
+            ),
+        }
+    }
+}
+
+/// Tracks trade-sequence continuity across a (possibly reconnecting) stream.
+///
+/// State is intentionally minimal — the highest agg_id and the last timestamp —
+/// so it can be owned by a reconnect loop and detect gaps that span a dropped
+/// connection.
+#[derive(Debug, Default, Clone)]
+pub struct ContinuityTracker {
+    highest_agg_id: Option<u64>,
+    last_timestamp_ms: Option<i64>,
+}
+
+impl ContinuityTracker {
+    /// A fresh tracker with no history.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Observe one trade, returning any anomalies it introduced.
+    ///
+    /// Each returned anomaly is also emitted as a structured `tracing` warning.
+    /// The trade is *not* dropped — detection labels the hole, it doesn't patch
+    /// it; the caller still forwards the trade.
+    pub fn observe(&mut self, trade: &Trade) -> Vec<Anomaly> {
+        let mut anomalies = Vec::new();
+
+        if let Some(highest) = self.highest_agg_id {
+            if trade.agg_id == highest {
+                anomalies.push(Anomaly::Duplicate {
+                    agg_id: trade.agg_id,
+                });
+            } else if trade.agg_id < highest {
+                anomalies.push(Anomaly::OutOfOrder {
+                    last_agg_id: highest,
+                    got_agg_id: trade.agg_id,
+                });
+            } else if trade.agg_id > highest + 1 {
+                anomalies.push(Anomaly::Gap {
+                    expected_agg_id: highest + 1,
+                    got_agg_id: trade.agg_id,
+                    missing: trade.agg_id - highest - 1,
+                });
+            }
+        }
+
+        if let Some(last_ms) = self.last_timestamp_ms
+            && trade.timestamp_ms < last_ms
+        {
+            anomalies.push(Anomaly::BackwardsTimestamp {
+                last_ms,
+                got_ms: trade.timestamp_ms,
+            });
+        }
+
+        for anomaly in &anomalies {
+            anomaly.trace();
+        }
+
+        // Track the highest agg_id (so a later reorder doesn't fabricate gaps)
+        // and the actual last timestamp.
+        self.highest_agg_id = Some(
+            self.highest_agg_id
+                .map_or(trade.agg_id, |h| h.max(trade.agg_id)),
+        );
+        self.last_timestamp_ms = Some(trade.timestamp_ms);
+
+        anomalies
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use quantick_engine::Side;
+    use rust_decimal::Decimal;
+
+    fn trade(agg_id: u64, ts: i64) -> Trade {
+        Trade {
+            agg_id,
+            timestamp_ms: ts,
+            price: Decimal::ONE,
+            quantity: Decimal::ONE,
+            side: Side::Buy,
+        }
+    }
+
+    #[test]
+    fn contiguous_ids_have_no_anomaly() {
+        let mut t = ContinuityTracker::new();
+        assert!(t.observe(&trade(1, 10)).is_empty());
+        assert!(t.observe(&trade(2, 20)).is_empty());
+        assert!(t.observe(&trade(3, 30)).is_empty());
+    }
+
+    #[test]
+    fn detects_a_gap() {
+        let mut t = ContinuityTracker::new();
+        t.observe(&trade(1, 10));
+        let a = t.observe(&trade(5, 20));
+        assert_eq!(
+            a,
+            vec![Anomaly::Gap {
+                expected_agg_id: 2,
+                got_agg_id: 5,
+                missing: 3
+            }]
+        );
+    }
+
+    #[test]
+    fn detects_duplicate_and_out_of_order() {
+        let mut t = ContinuityTracker::new();
+        t.observe(&trade(10, 100));
+        assert_eq!(
+            t.observe(&trade(10, 100)),
+            vec![Anomaly::Duplicate { agg_id: 10 }]
+        );
+        // A lower id after 10 is out of order (and its earlier timestamp is
+        // flagged too).
+        let a = t.observe(&trade(7, 90));
+        assert!(a.contains(&Anomaly::OutOfOrder {
+            last_agg_id: 10,
+            got_agg_id: 7
+        }));
+        assert!(a.contains(&Anomaly::BackwardsTimestamp {
+            last_ms: 100,
+            got_ms: 90
+        }));
+    }
+
+    #[test]
+    fn a_reorder_does_not_fabricate_a_later_gap() {
+        // 1, 3 (gap of 2), then 2 (out of order). The next contiguous id after
+        // the highest (3) is 4 — arriving 4 must be clean, not a phantom gap.
+        let mut t = ContinuityTracker::new();
+        t.observe(&trade(1, 10));
+        t.observe(&trade(3, 30)); // gap
+        t.observe(&trade(2, 20)); // out of order + backwards ts
+        assert!(
+            t.observe(&trade(4, 40)).is_empty(),
+            "4 follows the highest (3) contiguously"
+        );
+    }
+}

--- a/crates/feed-binance/src/lib.rs
+++ b/crates/feed-binance/src/lib.rs
@@ -10,8 +10,12 @@
 //! later milestones.
 
 pub mod backfill;
+pub mod continuity;
+pub mod reconnect;
 pub mod stream;
 pub mod wire;
 
 pub use backfill::{AggTradeSource, BinanceHttp, FeedError, backfill};
+pub use continuity::{Anomaly, ContinuityTracker};
+pub use reconnect::{Backoff, run_with_reconnect};
 pub use stream::{BINANCE_WS_BASE, agg_trade_url, run_agg_trade_stream};

--- a/crates/feed-binance/src/reconnect.rs
+++ b/crates/feed-binance/src/reconnect.rs
@@ -1,0 +1,170 @@
+//! Reconnecting live feed: exponential backoff + continuity tracking.
+//!
+//! Wraps the single-connection [`run_agg_trade_stream`](crate::stream) in a loop
+//! that reconnects on drop or error, backing off exponentially (with jitter) so
+//! a persistent outage doesn't hammer Binance. A single [`ContinuityTracker`]
+//! lives across reconnects, so a gap that opens *during* a disconnect is
+//! detected when the stream resumes.
+
+use std::time::Duration;
+
+use tokio::sync::mpsc::Sender;
+use tracing::{info, warn};
+
+use quantick_engine::Trade;
+
+use crate::continuity::ContinuityTracker;
+use crate::stream::run_agg_trade_stream;
+
+/// Exponential backoff with equal-jitter, deterministic given a seed.
+///
+/// Delay for attempt `n` is `min(base * 2^n, max)`, then jittered into
+/// `[capped/2, capped]`. The jitter comes from a seeded xorshift, so the delay
+/// sequence is reproducible in tests (no rng dependency, and the feed's timing
+/// need not be — and is not — engine-deterministic; the seed just makes tests
+/// stable). Jitter avoids many clients reconnecting in lockstep.
+#[derive(Debug, Clone)]
+pub struct Backoff {
+    base_ms: u64,
+    max_ms: u64,
+    attempt: u32,
+    rng: u64,
+}
+
+impl Backoff {
+    /// A backoff between `base` and `max`, seeded for reproducible jitter.
+    #[must_use]
+    pub fn new(base: Duration, max: Duration, seed: u64) -> Self {
+        Self {
+            base_ms: base.as_millis().max(1) as u64,
+            max_ms: max.as_millis().max(1) as u64,
+            attempt: 0,
+            rng: seed | 1, // xorshift must not be seeded with 0
+        }
+    }
+
+    /// Sensible defaults for a live market-data feed: 500 ms base, 30 s ceiling.
+    #[must_use]
+    pub fn for_feed(seed: u64) -> Self {
+        Self::new(Duration::from_millis(500), Duration::from_secs(30), seed)
+    }
+
+    fn next_rand(&mut self) -> f64 {
+        let mut x = self.rng;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        self.rng = x;
+        (x >> 11) as f64 / (1u64 << 53) as f64
+    }
+
+    /// The delay before the next reconnect attempt, advancing the counter.
+    pub fn next_delay(&mut self) -> Duration {
+        let factor = 1u64.checked_shl(self.attempt.min(31)).unwrap_or(u64::MAX);
+        let capped = self.base_ms.saturating_mul(factor).min(self.max_ms);
+        let half = capped / 2;
+        let jitter = (half as f64 * self.next_rand()) as u64;
+        self.attempt = self.attempt.saturating_add(1);
+        Duration::from_millis(half + jitter)
+    }
+
+    /// Reset the attempt counter (call after a healthy connection).
+    pub fn reset(&mut self) {
+        self.attempt = 0;
+    }
+
+    /// The number of delays handed out since the last reset.
+    #[must_use]
+    pub fn attempt(&self) -> u32 {
+        self.attempt
+    }
+}
+
+/// Run the live aggTrade feed forever, reconnecting with backoff.
+///
+/// Forwards trades to `tx`, tracking continuity across reconnects. A healthy
+/// connection (one that forwarded at least one trade) resets the backoff, so
+/// only sustained failure escalates the delay. Returns when the consumer drops
+/// the receiver.
+pub async fn run_with_reconnect(url: &str, tx: &Sender<Trade>, mut backoff: Backoff) {
+    let mut tracker = ContinuityTracker::new();
+    loop {
+        match run_agg_trade_stream(url, tx, &mut tracker).await {
+            Ok(forwarded) => {
+                if forwarded > 0 {
+                    backoff.reset();
+                }
+                if tx.is_closed() {
+                    info!(target: "quantick::feed", "consumer gone; stopping reconnect loop");
+                    return;
+                }
+                info!(target: "quantick::feed", forwarded, "stream ended cleanly; reconnecting");
+            }
+            Err(error) => {
+                warn!(target: "quantick::feed", %error, "stream error; reconnecting");
+            }
+        }
+        if tx.is_closed() {
+            return;
+        }
+        let delay = backoff.next_delay();
+        info!(
+            target: "quantick::feed",
+            attempt = backoff.attempt(),
+            delay_ms = delay.as_millis() as u64,
+            "backing off before reconnect"
+        );
+        tokio::time::sleep(delay).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn backoff_grows_and_is_capped() {
+        let base = Duration::from_millis(100);
+        let max = Duration::from_millis(3200);
+        let mut b = Backoff::new(base, max, 12345);
+
+        // Attempt 0: capped = 100, delay in [50, 100].
+        let d0 = b.next_delay().as_millis() as u64;
+        assert!((50..=100).contains(&d0), "d0 = {d0}");
+
+        // Collect a run of delays; each stays within its capped bound and the
+        // ceiling is respected once 2^n * base exceeds max.
+        let mut delays = vec![d0];
+        for _ in 0..9 {
+            delays.push(b.next_delay().as_millis() as u64);
+        }
+        for d in &delays {
+            assert!(*d <= max.as_millis() as u64, "delay {d} exceeds max");
+        }
+        // By later attempts the cap (3200) is hit, so delay is in [1600, 3200].
+        let late = *delays.last().unwrap();
+        assert!((1600..=3200).contains(&late), "late = {late}");
+    }
+
+    #[test]
+    fn reset_returns_to_the_base_delay() {
+        let mut b = Backoff::new(Duration::from_millis(100), Duration::from_secs(30), 7);
+        for _ in 0..5 {
+            let _ = b.next_delay();
+        }
+        assert_eq!(b.attempt(), 5);
+        b.reset();
+        assert_eq!(b.attempt(), 0);
+        let d = b.next_delay().as_millis() as u64;
+        assert!((50..=100).contains(&d), "post-reset delay = {d}");
+    }
+
+    #[test]
+    fn jitter_is_deterministic_for_a_given_seed() {
+        let seq = |seed| {
+            let mut b = Backoff::new(Duration::from_millis(100), Duration::from_secs(30), seed);
+            (0..5).map(|_| b.next_delay()).collect::<Vec<_>>()
+        };
+        assert_eq!(seq(42), seq(42), "same seed => same delays");
+    }
+}

--- a/crates/feed-binance/src/stream.rs
+++ b/crates/feed-binance/src/stream.rs
@@ -16,6 +16,7 @@ use tracing::{debug, info, warn};
 use quantick_engine::Trade;
 
 use crate::backfill::FeedError;
+use crate::continuity::ContinuityTracker;
 use crate::wire;
 
 /// Binance's public single-stream WebSocket base URL.
@@ -40,15 +41,23 @@ pub fn decode_text(text: &str) -> Result<Trade, FeedError> {
 
 /// Connect to `url` and forward decoded trades on `tx` until the socket closes.
 ///
-/// Server pings are answered with pongs (Binance disconnects otherwise). A frame
-/// that fails to decode is logged and skipped rather than tearing down the whole
-/// stream. Returns `Ok(())` on a clean server close or when the consumer drops
-/// `tx`; returns [`FeedError`] on a transport error.
+/// Each trade is passed through `tracker` first, so gaps, reorders and
+/// duplicates are detected and logged (the tracker is owned by the reconnect
+/// loop, so it spans reconnects). Server pings are answered with pongs (Binance
+/// disconnects otherwise). A frame that fails to decode is logged and skipped
+/// rather than tearing down the whole stream.
+///
+/// Returns the number of trades forwarded — on a clean server close, or when the
+/// consumer drops `tx`. Returns [`FeedError`] on a transport error.
 ///
 /// # Errors
 ///
 /// Returns [`FeedError::Http`] on connection or socket errors.
-pub async fn run_agg_trade_stream(url: &str, tx: &Sender<Trade>) -> Result<(), FeedError> {
+pub async fn run_agg_trade_stream(
+    url: &str,
+    tx: &Sender<Trade>,
+    tracker: &mut ContinuityTracker,
+) -> Result<u64, FeedError> {
     info!(target: "quantick::feed", url, "connecting aggTrade websocket");
     let (mut ws, _resp) = tokio_tungstenite::connect_async(url)
         .await
@@ -61,10 +70,13 @@ pub async fn run_agg_trade_stream(url: &str, tx: &Sender<Trade>) -> Result<(), F
         match msg {
             Message::Text(text) => match decode_text(text.as_str()) {
                 Ok(trade) => {
+                    // Detect (and log) any sequence anomaly, but still forward
+                    // the trade — labelling a hole, not patching it.
+                    let _ = tracker.observe(&trade);
                     forwarded += 1;
                     if tx.send(trade).await.is_err() {
                         debug!(target: "quantick::feed", forwarded, "consumer dropped; stopping stream");
-                        return Ok(());
+                        return Ok(forwarded);
                     }
                 }
                 Err(error) => {
@@ -78,13 +90,13 @@ pub async fn run_agg_trade_stream(url: &str, tx: &Sender<Trade>) -> Result<(), F
             }
             Message::Close(frame) => {
                 info!(target: "quantick::feed", ?frame, forwarded, "server closed the websocket");
-                return Ok(());
+                return Ok(forwarded);
             }
             Message::Pong(_) | Message::Binary(_) | Message::Frame(_) => {}
         }
     }
     debug!(target: "quantick::feed", forwarded, "websocket stream ended");
-    Ok(())
+    Ok(forwarded)
 }
 
 #[cfg(test)]
@@ -124,7 +136,10 @@ mod tests {
     async fn live_stream_forwards_a_few_trades() {
         let (tx, mut rx) = tokio::sync::mpsc::channel(64);
         let url = agg_trade_url(BINANCE_WS_BASE, "BTCUSDT");
-        let handle = tokio::spawn(async move { run_agg_trade_stream(&url, &tx).await });
+        let handle = tokio::spawn(async move {
+            let mut tracker = ContinuityTracker::new();
+            run_agg_trade_stream(&url, &tx, &mut tracker).await
+        });
 
         let mut seen = 0;
         while seen < 5 {

--- a/crates/feed-binance/tests/anomaly_tracing.rs
+++ b/crates/feed-binance/tests/anomaly_tracing.rs
@@ -1,0 +1,77 @@
+//! Verifies that a continuity anomaly produces a structured, labelled tracing
+//! event — the "a log excerpt alone explains what happened" requirement.
+
+use std::sync::{Arc, Mutex};
+
+use quantick_engine::{Side, Trade};
+use quantick_feed_binance::ContinuityTracker;
+use rust_decimal::Decimal;
+use tracing_subscriber::fmt::MakeWriter;
+
+/// A `MakeWriter` that appends every log line to a shared buffer.
+#[derive(Clone)]
+struct SharedBuf(Arc<Mutex<Vec<u8>>>);
+
+impl std::io::Write for SharedBuf {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.lock().unwrap().extend_from_slice(buf);
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> MakeWriter<'a> for SharedBuf {
+    type Writer = SharedBuf;
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}
+
+fn trade(agg_id: u64, ts: i64) -> Trade {
+    Trade {
+        agg_id,
+        timestamp_ms: ts,
+        price: Decimal::ONE,
+        quantity: Decimal::ONE,
+        side: Side::Buy,
+    }
+}
+
+fn capture(body: impl FnOnce()) -> String {
+    let buf = Arc::new(Mutex::new(Vec::new()));
+    let subscriber = tracing_subscriber::fmt()
+        .with_writer(SharedBuf(buf.clone()))
+        .with_max_level(tracing::Level::WARN)
+        .finish();
+    tracing::subscriber::with_default(subscriber, body);
+    String::from_utf8(buf.lock().unwrap().clone()).unwrap()
+}
+
+#[test]
+fn a_gap_is_logged_with_structured_fields() {
+    let out = capture(|| {
+        let mut t = ContinuityTracker::new();
+        t.observe(&trade(1, 10));
+        t.observe(&trade(5, 20)); // gap: 2,3,4 missing
+    });
+
+    assert!(out.contains("quantick::feed"), "target missing: {out}");
+    assert!(out.contains("aggTrade gap"), "message missing: {out}");
+    assert!(out.contains("expected_agg_id=2"), "field missing: {out}");
+    assert!(out.contains("got_agg_id=5"), "field missing: {out}");
+    assert!(out.contains("missing=3"), "field missing: {out}");
+}
+
+#[test]
+fn a_backwards_timestamp_is_logged() {
+    let out = capture(|| {
+        let mut t = ContinuityTracker::new();
+        t.observe(&trade(1, 100));
+        t.observe(&trade(2, 90)); // timestamp goes backwards
+    });
+    assert!(out.contains("backwards"), "message missing: {out}");
+    assert!(out.contains("last_ms=100"), "field missing: {out}");
+    assert!(out.contains("got_ms=90"), "field missing: {out}");
+}


### PR DESCRIPTION
## Summary

The resilience + data-honesty layer for the live feed: detect and label sequence anomalies, and keep the connection alive across drops.

- **`ContinuityTracker`** watches `agg_id`/timestamp continuity and reports **gap / out-of-order / duplicate / backwards-timestamp** anomalies — as a returned value *and* a structured, labelled `tracing` warning.
- **`Backoff`** — exponential + equal-jitter, seeded (deterministic in tests).
- **`run_with_reconnect`** — reconnect loop owning one tracker across reconnects.

Closes #26

## Design decisions

1. **Anomalies are labelled, never patched.** `observe` logs the hole and returns it, but the trade still forwards — the data-honesty rule says incomplete data is *labelled*, not silently repaired or dropped. Each anomaly is a `warn!` under `quantick::feed` with a `kind` and structured fields, so a log excerpt alone explains what happened (verified by a capturing-subscriber integration test).
2. **Track the highest agg_id, not the last.** A reorder (`1, 3, 2`) must not make the *next* contiguous id (`4`) look like a phantom gap. Comparing against the highest-seen id keeps gap detection correct across reorders.
3. **Seeded jitter, no `rand` dependency, no test sleeps.** `Backoff` uses a seeded xorshift so the delay *sequence* is unit-testable deterministically without ever sleeping. The feed's wall-clock timing is not — and need not be — engine-deterministic; the seed just stabilises tests. Equal jitter (`[capped/2, capped]`) avoids near-zero reconnect spam.
4. **One tracker across reconnects.** Owned by `run_with_reconnect` and threaded into `run_agg_trade_stream`, so a gap that opens *during* a disconnect is detected the moment the stream resumes. A healthy connection (≥1 trade forwarded) resets the backoff.
5. **Nothing here runs in the engine.** The engine still only ever sees ordered `Trade`s and emits no logs — determinism intact.

## Verification loop

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (feed: 18 unit + 4 integration; 2 live tests ignored)

## Notes for the reviewer

- The "structured tracing verified by a capturing subscriber" AC is met by `tests/anomaly_tracing.rs`, which installs a buffer-backed `fmt` subscriber and asserts the emitted event carries `expected_agg_id`, `got_agg_id`, `missing`, the `quantick::feed` target, and the message.
- **This completes milestone v0.2 — Live feed.** REST backfill + live WS + reconnect/gap detection are all in place and validated against real Binance (via the manual `#[ignore]`d tests).
