### PR TITLE
chore(ci): install desktop GUI system dependencies on Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install desktop GUI dependencies
+        # quantick-app (egui/eframe + winit) needs these to build/link on Linux.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libxkbcommon-dev libwayland-dev \
+            libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt


### PR DESCRIPTION
## Summary

Adds an apt step to CI installing the egui/eframe + winit build/link dependencies (`libxkbcommon-dev`, `libwayland-dev`, `libxcb-*`) before the cargo steps, so the upcoming `quantick-app` GUI builds cleanly on the Linux runner. Done proactively so no app PR opens with a red build discovering a missing system lib.

Closes #31

## Verification loop

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo build --workspace`
- [x] `cargo test --workspace`

(No Rust change — the four checks are unaffected locally; the real change is the CI environment, validated by this PR's own CI run.)

## Notes for the reviewer

- Minimal set chosen: `x11` support in winit dlopens `libX11` at runtime (no build dep), so only xkbcommon (keyboard), wayland (the wayland backend links at build), and xcb are installed. If a later app PR surfaces another missing lib, it's a one-line addition here.
