### PR TITLE
feat(app): frame-time and feed-lag instrumentation with tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,6 +49,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android-activity"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1595,6 +1604,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1729,6 +1747,15 @@ name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "num-traits"
@@ -2250,6 +2277,7 @@ dependencies = [
  "rust_decimal",
  "tokio",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -2455,6 +2483,23 @@ checksum = "c5102a6aaa05aa011a238e178e6bca86d2cb56fc9f586d37cb80f5bca6e07759"
 dependencies = [
  "bitflags 2.13.1",
 ]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rend"
@@ -3228,6 +3273,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
 ]
 
 [[package]]
@@ -3236,9 +3293,16 @@ version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
  "sharded-slab",
+ "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -3351,6 +3415,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -11,6 +11,7 @@ quantick-feed-binance = { path = "../feed-binance" }
 rust_decimal = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "net", "time"] }
 tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 eframe = { version = "0.29", default-features = false, features = [
     "glow",
     "wayland",

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -1,12 +1,12 @@
-//! The egui application: drains the live feed and renders bars as they form.
+//! The egui application: drains the live feed, renders bars, surfaces metrics.
 //!
-//! All coordinate math lives in [`crate::chart`] (pure, tested) and all trade →
-//! bar logic in [`crate::state`] (pure, tested). This layer drains the feed
-//! channel each frame, hands trades to the engine via [`ChartState`], and turns
-//! the resulting bars into egui shapes — including an honest divider between
-//! backfilled history and live ticks.
+//! Coordinate math lives in [`crate::chart`] (pure, tested), trade → bar logic
+//! in [`crate::state`] (pure, tested), and metric math in [`crate::metrics`]
+//! (pure, tested). This layer owns the clocks and the tracing, drains the feed
+//! channel each frame, and turns everything into egui shapes — candles, the
+//! backfill/live divider, and a performance overlay.
 
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use eframe::egui;
 use tokio::sync::mpsc;
@@ -15,6 +15,7 @@ use quantick_engine::Bar;
 
 use crate::chart::{PriceScale, TimeAxis, to_f64};
 use crate::feed::FeedEvent;
+use crate::metrics::{self, FrameStats};
 use crate::state::ChartState;
 
 const UP: egui::Color32 = egui::Color32::from_rgb(38, 166, 154);
@@ -22,6 +23,11 @@ const DOWN: egui::Color32 = egui::Color32::from_rgb(239, 83, 80);
 const BACKGROUND: egui::Color32 = egui::Color32::from_rgb(19, 23, 34);
 const DIVIDER: egui::Color32 = egui::Color32::from_rgb(240, 185, 11);
 const MUTED: egui::Color32 = egui::Color32::from_rgb(150, 160, 175);
+const OVERLAY: egui::Color32 = egui::Color32::from_rgb(210, 218, 226);
+const WARN: egui::Color32 = egui::Color32::from_rgb(255, 99, 71);
+
+/// How often the perf summary is logged (not every frame).
+const SUMMARY_INTERVAL: Duration = Duration::from_secs(2);
 
 /// The quantick chart window.
 pub struct QuantickApp {
@@ -29,6 +35,13 @@ pub struct QuantickApp {
     events: mpsc::Receiver<FeedEvent>,
     symbol: String,
     tick_size: u64,
+
+    frames: FrameStats,
+    last_frame: Option<Instant>,
+    latest_trade_ms: Option<i64>,
+    live_trades: u64,
+    trades_since_summary: u64,
+    last_summary: Instant,
 }
 
 impl QuantickApp {
@@ -45,19 +58,81 @@ impl QuantickApp {
             events,
             symbol: symbol.into(),
             tick_size,
+            frames: FrameStats::new(120),
+            last_frame: None,
+            latest_trade_ms: None,
+            live_trades: 0,
+            trades_since_summary: 0,
+            last_summary: Instant::now(),
         }
     }
 
-    /// Drain every feed event available this frame into the engine.
+    /// Drain every feed event available this frame into the engine, tracking the
+    /// latest trade timestamp and live-trade counts for the metrics.
     fn drain_feed(&mut self) {
         loop {
             match self.events.try_recv() {
-                Ok(FeedEvent::Backfilled(trades)) => self.state.ingest_backfill(&trades),
-                Ok(FeedEvent::Live(trade)) => self.state.ingest_live(&trade),
-                // Empty (nothing pending) or Disconnected (feed gone): stop draining.
+                Ok(FeedEvent::Backfilled(trades)) => {
+                    if let Some(last) = trades.last() {
+                        self.latest_trade_ms = Some(last.timestamp_ms);
+                    }
+                    self.state.ingest_backfill(&trades);
+                }
+                Ok(FeedEvent::Live(trade)) => {
+                    self.latest_trade_ms = Some(trade.timestamp_ms);
+                    self.live_trades += 1;
+                    self.trades_since_summary += 1;
+                    self.state.ingest_live(&trade);
+                }
+                // Empty (nothing pending) or Disconnected (feed gone): stop.
                 Err(_) => break,
             }
         }
+    }
+
+    /// Periodically log a perf summary and warn on threshold breaches.
+    fn maybe_emit_summary(&mut self, now: Instant) {
+        let elapsed = now - self.last_summary;
+        if elapsed < SUMMARY_INTERVAL {
+            return;
+        }
+        let rate = self.trades_since_summary as f64 / elapsed.as_secs_f64();
+        let lag = metrics::feed_lag_ms(metrics::wall_clock_ms(), self.latest_trade_ms);
+        let avg = self.frames.avg_ms().unwrap_or(0.0);
+        let worst = self.frames.worst_ms().unwrap_or(0.0);
+        let fps = self.frames.fps().unwrap_or(0.0);
+
+        tracing::info!(
+            target: "quantick::app",
+            fps = fps as i64,
+            frame_avg_ms = avg,
+            frame_worst_ms = worst,
+            feed_lag_ms = lag,
+            trades_per_s = rate,
+            live_trades = self.live_trades,
+            "perf summary"
+        );
+        if avg > metrics::SLOW_FRAME_MS {
+            tracing::warn!(
+                target: "quantick::app",
+                frame_avg_ms = avg,
+                threshold_ms = metrics::SLOW_FRAME_MS,
+                "slow frames: the chart is not keeping up"
+            );
+        }
+        if let Some(l) = lag
+            && l > metrics::HIGH_LAG_MS
+        {
+            tracing::warn!(
+                target: "quantick::app",
+                feed_lag_ms = l,
+                threshold_ms = metrics::HIGH_LAG_MS,
+                "high feed lag: trades are arriving well behind their timestamps"
+            );
+        }
+
+        self.trades_since_summary = 0;
+        self.last_summary = now;
     }
 
     fn draw_chart(&self, painter: &egui::Painter, area: egui::Rect) {
@@ -139,16 +214,90 @@ impl QuantickApp {
             MUTED,
         );
     }
+
+    /// A top-right overlay with FPS, frame time and feed lag; values that breach
+    /// a threshold are drawn in the warning colour.
+    fn draw_overlay(&self, painter: &egui::Painter, area: egui::Rect) {
+        let avg = self.frames.avg_ms();
+        let lag = metrics::feed_lag_ms(metrics::wall_clock_ms(), self.latest_trade_ms);
+
+        let fps_color = if avg.is_some_and(|a| a > metrics::SLOW_FRAME_MS) {
+            WARN
+        } else {
+            OVERLAY
+        };
+        let lag_color = if lag.is_some_and(|l| l > metrics::HIGH_LAG_MS) {
+            WARN
+        } else {
+            OVERLAY
+        };
+        let lag_text = match lag {
+            Some(l) => format!("feed lag {l} ms"),
+            None => "feed lag —".to_string(),
+        };
+
+        let lines: [(String, egui::Color32); 4] = [
+            (
+                format!(
+                    "{:>4.0} fps  {:>5.1} ms",
+                    self.frames.fps().unwrap_or(0.0),
+                    avg.unwrap_or(0.0)
+                ),
+                fps_color,
+            ),
+            (
+                format!("worst {:>5.1} ms", self.frames.worst_ms().unwrap_or(0.0)),
+                OVERLAY,
+            ),
+            (lag_text, lag_color),
+            (format!("{} live trades", self.live_trades), OVERLAY),
+        ];
+
+        let font = egui::FontId::monospace(12.0);
+        let pad = 8.0;
+        let line_h = 16.0;
+        let box_w = 180.0;
+        let box_h = lines.len() as f32 * line_h + pad;
+        let top_right = egui::pos2(area.right() - 8.0 - box_w, area.top() + 8.0);
+        let backdrop = egui::Rect::from_min_size(top_right, egui::vec2(box_w, box_h));
+        painter.rect_filled(
+            backdrop,
+            egui::Rounding::same(4.0),
+            egui::Color32::from_black_alpha(150),
+        );
+
+        let mut y = backdrop.top() + pad / 2.0;
+        let right = backdrop.right() - pad;
+        for (text, color) in &lines {
+            painter.text(
+                egui::pos2(right, y),
+                egui::Align2::RIGHT_TOP,
+                text,
+                font.clone(),
+                *color,
+            );
+            y += line_h;
+        }
+    }
 }
 
 impl eframe::App for QuantickApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        let now = Instant::now();
+        if let Some(last) = self.last_frame {
+            self.frames.record((now - last).as_secs_f32() * 1000.0);
+        }
+        self.last_frame = Some(now);
+
         self.drain_feed();
+        self.maybe_emit_summary(now);
+
         egui::CentralPanel::default()
             .frame(egui::Frame::none().fill(BACKGROUND))
             .show(ctx, |ui| {
                 let area = ui.available_rect_before_wrap();
                 self.draw_chart(ui.painter(), area);
+                self.draw_overlay(ui.painter(), area);
             });
         // Live feed: keep polling the channel ~60×/s without busy-spinning.
         ctx.request_repaint_after(Duration::from_millis(16));

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -2,19 +2,42 @@
 //!
 //! A consumer of `quantick-engine`, never the other way around. On startup it
 //! backfills recent BTCUSDT aggTrades over REST so the chart opens populated,
-//! then streams live trades on top, forming bars in real time.
+//! then streams live trades on top, forming bars in real time. Frame time and
+//! feed lag are surfaced on screen and in structured logs.
 
 use eframe::egui;
+use tracing_subscriber::EnvFilter;
 
 mod app;
 mod chart;
 mod feed;
+mod metrics;
 mod state;
 
 const SYMBOL: &str = "BTCUSDT";
 const TICK_SIZE: u64 = 50;
 
+/// Install the tracing subscriber. Feed and app events flow to stderr; the level
+/// is controlled by `RUST_LOG` (default `quantick=info`). The engine emits
+/// nothing, so logging can never affect its determinism.
+fn init_tracing() {
+    let filter =
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("quantick=info"));
+    tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_target(true)
+        .init();
+}
+
 fn main() -> eframe::Result {
+    init_tracing();
+    tracing::info!(
+        target: "quantick::app",
+        symbol = SYMBOL,
+        tick_size = TICK_SIZE,
+        "starting quantick"
+    );
+
     let events = feed::spawn(SYMBOL);
 
     let options = eframe::NativeOptions {

--- a/crates/app/src/metrics.rs
+++ b/crates/app/src/metrics.rs
@@ -1,0 +1,128 @@
+//! Performance metrics: frame times, FPS and feed lag.
+//!
+//! Tick charts update at high frequency, so the app must stay smooth under live
+//! bursts. This module holds the pure, unit-tested metric math (rolling frame
+//! stats, lag, threshold checks); the app owns the clocks and the tracing that
+//! surfaces it. The engine is never involved — it stays log-free and
+//! deterministic.
+
+use std::collections::VecDeque;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// A frame slower than this (≈ 50 FPS) is flagged as a hitch.
+pub const SLOW_FRAME_MS: f32 = 20.0;
+
+/// Feed lag beyond this many milliseconds is flagged (exchange → screen).
+pub const HIGH_LAG_MS: i64 = 5_000;
+
+/// A rolling window of recent frame durations (milliseconds).
+#[derive(Debug)]
+pub struct FrameStats {
+    samples: VecDeque<f32>,
+    capacity: usize,
+}
+
+impl FrameStats {
+    /// A window holding the last `capacity` frame durations.
+    #[must_use]
+    pub fn new(capacity: usize) -> Self {
+        let capacity = capacity.max(1);
+        Self {
+            samples: VecDeque::with_capacity(capacity),
+            capacity,
+        }
+    }
+
+    /// Record one frame's duration in milliseconds, evicting the oldest.
+    pub fn record(&mut self, frame_ms: f32) {
+        if self.samples.len() == self.capacity {
+            self.samples.pop_front();
+        }
+        self.samples.push_back(frame_ms);
+    }
+
+    /// Mean frame time over the window, or `None` if no frames yet.
+    #[must_use]
+    pub fn avg_ms(&self) -> Option<f32> {
+        if self.samples.is_empty() {
+            return None;
+        }
+        Some(self.samples.iter().sum::<f32>() / self.samples.len() as f32)
+    }
+
+    /// Rolling FPS derived from the mean frame time.
+    #[must_use]
+    pub fn fps(&self) -> Option<f32> {
+        self.avg_ms()
+            .map(|ms| if ms > 0.0 { 1000.0 / ms } else { f32::INFINITY })
+    }
+
+    /// Worst (longest) frame in the window.
+    #[must_use]
+    pub fn worst_ms(&self) -> Option<f32> {
+        self.samples
+            .iter()
+            .copied()
+            .fold(None, |acc, x| Some(acc.map_or(x, |a: f32| a.max(x))))
+    }
+}
+
+/// Current wall-clock time in epoch milliseconds (app-only; never the engine).
+#[must_use]
+pub fn wall_clock_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+/// Feed lag: how far behind the latest trade's timestamp we are right now.
+///
+/// `None` until a trade has been seen. Can be slightly negative if the local
+/// clock is behind the exchange's — reported as-is (honest), not clamped.
+#[must_use]
+pub fn feed_lag_ms(now_ms: i64, latest_trade_ms: Option<i64>) -> Option<i64> {
+    latest_trade_ms.map(|t| now_ms - t)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_stats_report_none() {
+        let s = FrameStats::new(8);
+        assert!(s.avg_ms().is_none());
+        assert!(s.fps().is_none());
+        assert!(s.worst_ms().is_none());
+    }
+
+    #[test]
+    fn avg_fps_and_worst() {
+        let mut s = FrameStats::new(8);
+        s.record(10.0);
+        s.record(20.0);
+        s.record(30.0);
+        assert!((s.avg_ms().unwrap() - 20.0).abs() < 0.001);
+        assert!((s.fps().unwrap() - 50.0).abs() < 0.001); // 1000 / 20
+        assert!((s.worst_ms().unwrap() - 30.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn window_evicts_oldest() {
+        let mut s = FrameStats::new(2);
+        s.record(100.0);
+        s.record(10.0);
+        s.record(20.0); // evicts 100
+        assert!((s.avg_ms().unwrap() - 15.0).abs() < 0.001);
+        assert!((s.worst_ms().unwrap() - 20.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn lag_is_now_minus_trade_time() {
+        assert_eq!(feed_lag_ms(1_000, Some(600)), Some(400));
+        assert_eq!(feed_lag_ms(1_000, None), None);
+        // Local clock behind the exchange: negative lag, reported honestly.
+        assert_eq!(feed_lag_ms(500, Some(600)), Some(-100));
+    }
+}

--- a/crates/feed-binance/tests/anomaly_tracing.rs
+++ b/crates/feed-binance/tests/anomaly_tracing.rs
@@ -41,20 +41,23 @@ fn trade(agg_id: u64, ts: i64) -> Trade {
 
 fn capture(body: impl FnOnce()) -> String {
     let buf = Arc::new(Mutex::new(Vec::new()));
+    // Disable ANSI explicitly: a workspace build can unify the `ansi` feature
+    // into tracing-subscriber (the app pulls it), and colour codes would split
+    // `key=value` fields and break the substring assertions below. Off here, the
+    // output is plain regardless of which features other crates enable.
     let subscriber = tracing_subscriber::fmt()
         .with_writer(SharedBuf(buf.clone()))
         .with_max_level(tracing::Level::WARN)
+        .with_ansi(false)
         .finish();
     tracing::subscriber::with_default(subscriber, body);
     String::from_utf8(buf.lock().unwrap().clone()).unwrap()
 }
 
-// Both anomalies are checked in ONE test on purpose. The two checks share the
-// `warn!` callsite, and `tracing` caches callsite interest globally; running two
-// capture tests in parallel races on that cache (concurrent `with_default`
-// swaps can cache the callsite as "not interested" and drop the events). A
-// single sequential test touches the callsite from one thread only, so it's
-// deterministic. See #40.
+// Both anomalies are checked in one sequential test: they share the `warn!`
+// callsite, and keeping them on one thread avoids any interaction with
+// tracing's global callsite-interest cache. Robustness against ANSI output is
+// handled in `capture` above (`.with_ansi(false)`). See #40.
 #[test]
 fn anomalies_are_logged_with_structured_fields() {
     // A gap: 2,3,4 missing between agg_id 1 and 5.


### PR DESCRIPTION
## Summary

Surfaces performance so degradation is visible and investigable. The engine stays log-free (determinism); only the app and feed emit.

- **`metrics.rs`** — pure, unit-tested `FrameStats` (rolling frame times → avg / fps / worst) plus feed-lag and threshold helpers.
- **`app.rs`** — measures per-frame time and feed lag (`wall-clock now − latest trade timestamp`), counts live trades / trades-per-sec, draws a top-right overlay (FPS, frame ms, feed lag, live count) with warning colour on threshold breach, and logs a structured perf summary every 2s (not per frame), warning on slow frames / high lag.
- **`main.rs`** — installs the tracing subscriber (`RUST_LOG` / `EnvFilter`, default `quantick=info`) so feed + app events flow to stdout.

Closes #34

## Design decisions

1. **Metric math is pure and CI-tested; the app owns the clocks.** `FrameStats` and `feed_lag_ms` have no I/O, so they're unit-tested (rolling window eviction, avg/fps/worst, negative lag reported honestly). The `Instant`/`SystemTime` reads live in the app — wall-clock is fine there; only the engine must avoid it.
2. **Summaries every 2s, not per frame.** Logging each frame would drown the log; a periodic summary plus per-breach warnings keeps "a log excerpt explains what happened" true without noise. The overlay updates every frame for the live view.
3. **Feed lag = now − trade timestamp.** End-to-end latency (exchange → screen), reported as-is (even if slightly negative when the local clock trails the exchange) rather than clamped — honest.
4. **Subscriber in the app binary, not any library.** Libraries emit `tracing` events; the binary owns the process-wide subscriber. `RUST_LOG` controls it. The engine has no `tracing` dependency at all, so logging cannot touch its determinism.

## Verification loop

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (app: 14 tests, incl. all metric math)

## Notes for the reviewer

**Ran locally with `RUST_LOG=quantick=info`** — the structured log reads end-to-end:
```
INFO quantick::app: starting quantick symbol="BTCUSDT" tick_size=50
INFO backfill{symbol="BTCUSDT" target=500 pages=1}: quantick::feed: backfill complete fetched=500 pages=1
INFO quantick::app: backfill ready count=500
INFO quantick::feed: aggTrade websocket connected url="wss://stream.binance.com:9443/ws/btcusdt@aggTrade"
INFO quantick::app: perf summary fps=59 frame_avg_ms=16.85 feed_lag_ms=602 trades_per_s=0.49 live_trades=1
```
59 FPS, ~600ms feed lag under a live BTCUSDT stream — smooth, and every boundary (feed, app) is legible from the log alone.
