### PR TITLE
fix(feed): serialise the anomaly-tracing capture test

### DIFF
--- a/crates/feed-binance/tests/anomaly_tracing.rs
+++ b/crates/feed-binance/tests/anomaly_tracing.rs
@@ -49,29 +49,42 @@ fn capture(body: impl FnOnce()) -> String {
     String::from_utf8(buf.lock().unwrap().clone()).unwrap()
 }
 
+// Both anomalies are checked in ONE test on purpose. The two checks share the
+// `warn!` callsite, and `tracing` caches callsite interest globally; running two
+// capture tests in parallel races on that cache (concurrent `with_default`
+// swaps can cache the callsite as "not interested" and drop the events). A
+// single sequential test touches the callsite from one thread only, so it's
+// deterministic. See #40.
 #[test]
-fn a_gap_is_logged_with_structured_fields() {
-    let out = capture(|| {
+fn anomalies_are_logged_with_structured_fields() {
+    // A gap: 2,3,4 missing between agg_id 1 and 5.
+    let gap = capture(|| {
         let mut t = ContinuityTracker::new();
         t.observe(&trade(1, 10));
-        t.observe(&trade(5, 20)); // gap: 2,3,4 missing
+        t.observe(&trade(5, 20));
     });
+    assert!(gap.contains("quantick::feed"), "target missing: {gap}");
+    assert!(gap.contains("aggTrade gap"), "message missing: {gap}");
+    assert!(gap.contains("expected_agg_id=2"), "field missing: {gap}");
+    assert!(gap.contains("got_agg_id=5"), "field missing: {gap}");
+    assert!(gap.contains("missing=3"), "field missing: {gap}");
 
-    assert!(out.contains("quantick::feed"), "target missing: {out}");
-    assert!(out.contains("aggTrade gap"), "message missing: {out}");
-    assert!(out.contains("expected_agg_id=2"), "field missing: {out}");
-    assert!(out.contains("got_agg_id=5"), "field missing: {out}");
-    assert!(out.contains("missing=3"), "field missing: {out}");
-}
-
-#[test]
-fn a_backwards_timestamp_is_logged() {
-    let out = capture(|| {
+    // A backwards timestamp: 90 arrives after 100.
+    let backwards = capture(|| {
         let mut t = ContinuityTracker::new();
         t.observe(&trade(1, 100));
-        t.observe(&trade(2, 90)); // timestamp goes backwards
+        t.observe(&trade(2, 90));
     });
-    assert!(out.contains("backwards"), "message missing: {out}");
-    assert!(out.contains("last_ms=100"), "field missing: {out}");
-    assert!(out.contains("got_ms=90"), "field missing: {out}");
+    assert!(
+        backwards.contains("backwards"),
+        "message missing: {backwards}"
+    );
+    assert!(
+        backwards.contains("last_ms=100"),
+        "field missing: {backwards}"
+    );
+    assert!(
+        backwards.contains("got_ms=90"),
+        "field missing: {backwards}"
+    );
 }


### PR DESCRIPTION
## Summary

The two capturing-subscriber tests in `anomaly_tracing.rs` ran in parallel and both emitted through the same `warn!` callsite. `tracing` caches callsite interest globally and rebuilds it on each dispatcher change; two concurrent `with_default` swaps could cache the callsite as "not interested" during the swap window, dropping the events for **both** tests (0 passed) — flakily, surfacing only under CI's scheduling (it went red on the unrelated PR #39).

Merge the two into one sequential test so a single thread ever touches the callsite. Deterministic across 8 local runs; assertions unchanged.

Closes #40

## Verification loop

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (ran the test 8× — passes every time)

## Notes for the reviewer

- The alternative (a shared `Mutex` keeping two named tests) works too, but merging is simpler and the two checks are cheap and closely related. The reasoning is documented in a comment referencing this issue so a future maintainer doesn't "helpfully" split them back into parallel tests.
