### PR TITLE
feat(app): bar-type selector (tick/volume/dollar/time)

### DIFF
--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -1,14 +1,17 @@
-//! The egui application: drains the live feed, renders bars, surfaces metrics.
+//! The egui application: drains the live feed, renders bars, surfaces metrics,
+//! and lets the user switch bar type live.
 //!
 //! Coordinate math lives in [`crate::chart`] (pure, tested), trade → bar logic
-//! in [`crate::state`] (pure, tested), and metric math in [`crate::metrics`]
-//! (pure, tested). This layer owns the clocks and the tracing, drains the feed
-//! channel each frame, and turns everything into egui shapes — candles, the
-//! backfill/live divider, and a performance overlay.
+//! and the bar-type dispatch in [`crate::state`] (pure, tested), and metric math
+//! in [`crate::metrics`] (pure, tested). This layer owns the clocks, the tracing
+//! and the widgets, drains the feed each frame, and turns everything into egui
+//! shapes.
 
 use std::time::{Duration, Instant};
 
 use eframe::egui;
+use rust_decimal::Decimal;
+use rust_decimal::prelude::{FromPrimitive as _, ToPrimitive as _};
 use tokio::sync::mpsc;
 
 use quantick_engine::Bar;
@@ -16,7 +19,7 @@ use quantick_engine::Bar;
 use crate::chart::{PriceScale, TimeAxis, to_f64};
 use crate::feed::FeedEvent;
 use crate::metrics::{self, FrameStats};
-use crate::state::ChartState;
+use crate::state::{BarKind, BarSpec, ChartState};
 
 const UP: egui::Color32 = egui::Color32::from_rgb(38, 166, 154);
 const DOWN: egui::Color32 = egui::Color32::from_rgb(239, 83, 80);
@@ -29,12 +32,23 @@ const WARN: egui::Color32 = egui::Color32::from_rgb(255, 99, 71);
 /// How often the perf summary is logged (not every frame).
 const SUMMARY_INTERVAL: Duration = Duration::from_secs(2);
 
+/// Convert a UI `f64` parameter to a positive `Decimal` for a builder threshold.
+fn dec_from_f64(x: f64) -> Decimal {
+    Decimal::from_f64(x.max(1e-8)).unwrap_or(Decimal::ONE)
+}
+
 /// The quantick chart window.
 pub struct QuantickApp {
     state: ChartState,
     events: mpsc::Receiver<FeedEvent>,
     symbol: String,
-    tick_size: u64,
+
+    // Bar-type selector state (one parameter retained per kind).
+    kind: BarKind,
+    tick_n: u64,
+    volume_units: f64,
+    dollar_notional: f64,
+    time_interval_ms: i64,
 
     frames: FrameStats,
     last_frame: Option<Instant>,
@@ -45,19 +59,34 @@ pub struct QuantickApp {
 }
 
 impl QuantickApp {
-    /// Create the app for `symbol`, building tick bars of `tick_size`, draining
-    /// `events` from the feed thread.
+    /// Create the app for `symbol` starting from `spec`, draining `events`.
     #[must_use]
     pub fn new(
         symbol: impl Into<String>,
-        tick_size: u64,
+        spec: BarSpec,
         events: mpsc::Receiver<FeedEvent>,
     ) -> Self {
+        // Defaults for every kind, with the initial spec's parameter applied.
+        let mut tick_n = 50;
+        let mut volume_units = 5.0;
+        let mut dollar_notional = 500_000.0;
+        let mut time_interval_ms = 1_000;
+        match &spec {
+            BarSpec::Tick(n) => tick_n = *n,
+            BarSpec::Volume(u) => volume_units = u.to_f64().unwrap_or(volume_units),
+            BarSpec::Dollar(d) => dollar_notional = d.to_f64().unwrap_or(dollar_notional),
+            BarSpec::Time(ms) => time_interval_ms = *ms,
+        }
+
         Self {
-            state: ChartState::new(tick_size),
+            kind: spec.kind(),
+            state: ChartState::new(spec),
             events,
             symbol: symbol.into(),
-            tick_size,
+            tick_n,
+            volume_units,
+            dollar_notional,
+            time_interval_ms,
             frames: FrameStats::new(120),
             last_frame: None,
             latest_trade_ms: None,
@@ -65,6 +94,61 @@ impl QuantickApp {
             trades_since_summary: 0,
             last_summary: Instant::now(),
         }
+    }
+
+    /// The bar spec implied by the current selector state.
+    fn current_spec(&self) -> BarSpec {
+        match self.kind {
+            BarKind::Tick => BarSpec::Tick(self.tick_n.max(1)),
+            BarKind::Volume => BarSpec::Volume(dec_from_f64(self.volume_units)),
+            BarKind::Dollar => BarSpec::Dollar(dec_from_f64(self.dollar_notional)),
+            BarKind::Time => BarSpec::Time(self.time_interval_ms.max(1)),
+        }
+    }
+
+    /// The bar-type selector: a combo for the kind and a drag for its parameter.
+    fn draw_controls(&mut self, ui: &mut egui::Ui) {
+        ui.horizontal(|ui| {
+            ui.label("bar type:");
+            egui::ComboBox::from_id_salt("bar_kind")
+                .selected_text(self.kind.label())
+                .show_ui(ui, |ui| {
+                    for kind in BarKind::ALL {
+                        ui.selectable_value(&mut self.kind, kind, kind.label());
+                    }
+                });
+            ui.separator();
+            match self.kind {
+                BarKind::Tick => {
+                    ui.label("N trades");
+                    ui.add(egui::DragValue::new(&mut self.tick_n).range(1.0..=5000.0));
+                }
+                BarKind::Volume => {
+                    ui.label("units");
+                    ui.add(
+                        egui::DragValue::new(&mut self.volume_units)
+                            .range(0.1..=1000.0)
+                            .speed(0.1),
+                    );
+                }
+                BarKind::Dollar => {
+                    ui.label("notional");
+                    ui.add(
+                        egui::DragValue::new(&mut self.dollar_notional)
+                            .range(1000.0..=1_000_000_000.0)
+                            .speed(1000.0),
+                    );
+                }
+                BarKind::Time => {
+                    ui.label("interval ms");
+                    ui.add(
+                        egui::DragValue::new(&mut self.time_interval_ms)
+                            .range(100.0..=600_000.0)
+                            .speed(100.0),
+                    );
+                }
+            }
+        });
     }
 
     /// Drain every feed event available this frame into the engine, tracking the
@@ -84,7 +168,6 @@ impl QuantickApp {
                     self.trades_since_summary += 1;
                     self.state.ingest_live(&trade);
                 }
-                // Empty (nothing pending) or Disconnected (feed gone): stop.
                 Err(_) => break,
             }
         }
@@ -110,6 +193,7 @@ impl QuantickApp {
             feed_lag_ms = lag,
             trades_per_s = rate,
             live_trades = self.live_trades,
+            bar_spec = self.state.spec().summary(),
             "perf summary"
         );
         if avg > metrics::SLOW_FRAME_MS {
@@ -203,8 +287,11 @@ impl QuantickApp {
             None => (0, bars.len()),
         };
         let header = format!(
-            "{} · tick({}) · {} backfilled + {} live bars",
-            self.symbol, self.tick_size, backfilled, live
+            "{} · {} · {} backfilled + {} live bars",
+            self.symbol,
+            self.state.spec().summary(),
+            backfilled,
+            live
         );
         painter.text(
             egui::pos2(plot.left(), plot.top()),
@@ -291,6 +378,15 @@ impl eframe::App for QuantickApp {
 
         self.drain_feed();
         self.maybe_emit_summary(now);
+
+        egui::TopBottomPanel::top("controls")
+            .frame(egui::Frame::none().fill(BACKGROUND).inner_margin(8.0))
+            .show(ctx, |ui| {
+                ui.visuals_mut().override_text_color = Some(OVERLAY);
+                self.draw_controls(ui);
+            });
+        // Apply any selector change (no-op if unchanged).
+        self.state.set_spec(self.current_spec());
 
         egui::CentralPanel::default()
             .frame(egui::Frame::none().fill(BACKGROUND))

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -8,6 +8,8 @@
 use eframe::egui;
 use tracing_subscriber::EnvFilter;
 
+use crate::state::BarSpec;
+
 mod app;
 mod chart;
 mod feed;
@@ -50,6 +52,12 @@ fn main() -> eframe::Result {
     eframe::run_native(
         "quantick",
         options,
-        Box::new(move |_cc| Ok(Box::new(app::QuantickApp::new(SYMBOL, TICK_SIZE, events)))),
+        Box::new(move |_cc| {
+            Ok(Box::new(app::QuantickApp::new(
+                SYMBOL,
+                BarSpec::Tick(TICK_SIZE),
+                events,
+            )))
+        }),
     )
 }

--- a/crates/app/src/state.rs
+++ b/crates/app/src/state.rs
@@ -1,65 +1,200 @@
-//! Chart state: trades in (backfill + live), bars out.
+//! Chart state: trades in (backfill + live), bars out — for any bar type.
 //!
-//! This is the app's side of the "one engine, three consumers" boundary. It
-//! owns a single [`BarBuilder`] and feeds it both the backfilled history and the
-//! live trades through the *same* code path — the chart is just another engine
-//! consumer. It also records where backfilled data ends and live data begins so
-//! the two can be labelled honestly on screen (never silently merged).
+//! This is the app's side of the "one engine, four consumers" boundary. It
+//! retains every trade and feeds them through whichever [`BarBuilder`] the user
+//! has selected; switching the bar type rebuilds the bars from the retained
+//! trades through a freshly configured builder — the same deterministic engine
+//! code path, just a different measure. It also records where backfilled data
+//! ends and live data begins so the two can be labelled honestly.
 //!
-//! No egui, no async here, so the ingest logic is unit-tested in CI.
+//! No egui, no async here, so the ingest, dispatch and rebuild logic is
+//! unit-tested in CI.
 
-use quantick_engine::{Bar, BarBuilder, TickBarBuilder, Trade};
+use quantick_engine::{
+    Bar, BarBuilder, DollarBarBuilder, TickBarBuilder, TimeBarBuilder, Trade, VolumeBarBuilder,
+};
+use rust_decimal::Decimal;
 
-/// The bars derived from the trade stream, plus the backfill/live boundary.
+/// Which alternative bar type the chart is showing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BarKind {
+    /// Close every N trades.
+    Tick,
+    /// Close every N units of traded quantity.
+    Volume,
+    /// Close every N notional (price × quantity).
+    Dollar,
+    /// Close every N milliseconds of trade time.
+    Time,
+}
+
+impl BarKind {
+    /// All bar kinds, for building a selector.
+    pub const ALL: [BarKind; 4] = [
+        BarKind::Tick,
+        BarKind::Volume,
+        BarKind::Dollar,
+        BarKind::Time,
+    ];
+
+    /// A short display label.
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            BarKind::Tick => "tick",
+            BarKind::Volume => "volume",
+            BarKind::Dollar => "dollar",
+            BarKind::Time => "time",
+        }
+    }
+}
+
+/// A bar type together with its threshold parameter.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BarSpec {
+    /// N trades per bar.
+    Tick(u64),
+    /// N units of quantity per bar.
+    Volume(Decimal),
+    /// N notional per bar.
+    Dollar(Decimal),
+    /// N milliseconds per bar.
+    Time(i64),
+}
+
+impl BarSpec {
+    /// The kind, discarding the parameter.
+    #[must_use]
+    pub fn kind(&self) -> BarKind {
+        match self {
+            BarSpec::Tick(_) => BarKind::Tick,
+            BarSpec::Volume(_) => BarKind::Volume,
+            BarSpec::Dollar(_) => BarKind::Dollar,
+            BarSpec::Time(_) => BarKind::Time,
+        }
+    }
+
+    /// Construct the matching engine builder. This is the whole "bar type →
+    /// builder" dispatch: one place, four consumers of the same engine.
+    #[must_use]
+    pub fn build(&self) -> Box<dyn BarBuilder> {
+        match self {
+            BarSpec::Tick(n) => Box::new(TickBarBuilder::new(*n)),
+            BarSpec::Volume(units) => Box::new(VolumeBarBuilder::new(*units)),
+            BarSpec::Dollar(notional) => Box::new(DollarBarBuilder::new(*notional)),
+            BarSpec::Time(ms) => Box::new(TimeBarBuilder::new(*ms)),
+        }
+    }
+
+    /// A human-readable summary, e.g. `tick(50)` or `dollar(500000)`.
+    #[must_use]
+    pub fn summary(&self) -> String {
+        match self {
+            BarSpec::Tick(n) => format!("tick({n})"),
+            BarSpec::Volume(u) => format!("volume({u})"),
+            BarSpec::Dollar(d) => format!("dollar({d})"),
+            BarSpec::Time(ms) => format!("time({ms}ms)"),
+        }
+    }
+}
+
+/// The bars derived from the retained trade stream, plus the backfill/live
+/// boundary, for the currently selected [`BarSpec`].
 pub struct ChartState {
-    builder: TickBarBuilder,
+    spec: BarSpec,
+    builder: Box<dyn BarBuilder>,
+    trades: Vec<Trade>,
+    backfill_trade_count: usize,
+    backfill_done: bool,
     bars: Vec<Bar>,
     partial: Option<Bar>,
-    /// Number of bars that closed purely from backfilled trades. Bars at this
-    /// index and beyond contain at least one live trade. `None` until backfill
-    /// has been ingested.
     backfill_boundary: Option<usize>,
 }
 
 impl ChartState {
-    /// A fresh chart building tick bars of `tick_size` trades each.
+    /// A fresh chart building bars per `spec`.
     #[must_use]
-    pub fn new(tick_size: u64) -> Self {
+    pub fn new(spec: BarSpec) -> Self {
+        let builder = spec.build();
         Self {
-            builder: TickBarBuilder::new(tick_size),
+            spec,
+            builder,
+            trades: Vec::new(),
+            backfill_trade_count: 0,
+            backfill_done: false,
             bars: Vec::new(),
             partial: None,
             backfill_boundary: None,
         }
     }
 
-    /// Ingest the backfilled history as one batch, then mark the boundary.
-    ///
-    /// The boundary is the count of bars fully formed from backfill. Any bar
-    /// still forming when backfill ends will be completed by live trades, so it
-    /// counts as live (it sits at or past the boundary).
+    /// Ingest the backfilled history as one batch (call once, before any live
+    /// trades), then mark the boundary.
     pub fn ingest_backfill(&mut self, trades: &[Trade]) {
+        self.trades.extend_from_slice(trades);
+        self.backfill_trade_count = self.trades.len();
+        self.backfill_done = true;
         for trade in trades {
-            self.push(trade);
+            if let Some(bar) = self.builder.push(trade) {
+                self.bars.push(bar);
+            }
         }
         self.backfill_boundary = Some(self.bars.len());
         self.refresh_partial();
     }
 
-    /// Ingest one live trade.
+    /// Ingest one live trade, incrementally (no full rebuild).
     pub fn ingest_live(&mut self, trade: &Trade) {
-        self.push(trade);
-        self.refresh_partial();
-    }
-
-    fn push(&mut self, trade: &Trade) {
+        self.trades.push(trade.clone());
         if let Some(bar) = self.builder.push(trade) {
             self.bars.push(bar);
         }
+        self.refresh_partial();
+    }
+
+    /// Switch the bar type/parameter, rebuilding all bars from the retained
+    /// trades. A no-op if `spec` is unchanged.
+    pub fn set_spec(&mut self, spec: BarSpec) {
+        if spec == self.spec {
+            return;
+        }
+        self.spec = spec;
+        self.rebuild();
+    }
+
+    /// Replay every retained trade through a fresh builder for the current spec,
+    /// recomputing the bars and the backfill/live boundary.
+    fn rebuild(&mut self) {
+        let mut builder = self.spec.build();
+        let mut bars = Vec::new();
+        let mut boundary = None;
+        for (i, trade) in self.trades.iter().enumerate() {
+            if self.backfill_done && i == self.backfill_trade_count {
+                boundary = Some(bars.len());
+            }
+            if let Some(bar) = builder.push(trade) {
+                bars.push(bar);
+            }
+        }
+        // Backfill covered every retained trade (no live yet): boundary is the
+        // end of the bar list.
+        if self.backfill_done && boundary.is_none() {
+            boundary = Some(bars.len());
+        }
+        self.partial = builder.partial().cloned();
+        self.builder = builder;
+        self.bars = bars;
+        self.backfill_boundary = boundary;
     }
 
     fn refresh_partial(&mut self) {
         self.partial = self.builder.partial().cloned();
+    }
+
+    /// The current bar spec.
+    #[must_use]
+    pub fn spec(&self) -> &BarSpec {
+        &self.spec
     }
 
     /// The closed bars.
@@ -85,50 +220,89 @@ impl ChartState {
 mod tests {
     use super::*;
     use quantick_engine::Side;
-    use rust_decimal::Decimal;
+    use std::str::FromStr as _;
+
+    fn dec(s: &str) -> Decimal {
+        Decimal::from_str(s).unwrap()
+    }
 
     fn trade(agg_id: u64) -> Trade {
         Trade {
             agg_id,
-            timestamp_ms: 1000 + agg_id as i64,
-            price: Decimal::from(100),
-            quantity: Decimal::ONE,
+            timestamp_ms: 1000 + agg_id as i64 * 100,
+            price: dec("100"),
+            quantity: dec("1.0"),
             side: Side::Buy,
         }
     }
 
     #[test]
+    fn build_dispatches_every_kind() {
+        // Tick(1) closes on the first trade; the others simply must build and
+        // accept a trade without panicking.
+        for spec in [
+            BarSpec::Tick(1),
+            BarSpec::Volume(dec("1.0")),
+            BarSpec::Dollar(dec("100")),
+            BarSpec::Time(1),
+        ] {
+            let kind = spec.kind();
+            let mut builder = spec.build();
+            let closed = builder.push(&trade(1));
+            if kind == BarKind::Tick {
+                assert!(closed.is_some(), "tick(1) closes immediately");
+            }
+        }
+    }
+
+    #[test]
     fn backfill_and_live_go_through_the_same_builder() {
-        let mut s = ChartState::new(2); // close every 2 trades
-        // 3 backfill trades -> 1 closed bar + a 1-trade partial.
+        let mut s = ChartState::new(BarSpec::Tick(2));
         s.ingest_backfill(&[trade(1), trade(2), trade(3)]);
         assert_eq!(s.bars().len(), 1);
         assert_eq!(s.backfill_boundary(), Some(1));
-        assert!(s.partial().is_some());
 
-        // A live trade extends the partial to 2 trades, closing bar index 1 —
-        // the boundary bar, made of backfill trade 3 + live trade 4.
         s.ingest_live(&trade(4));
+        assert_eq!(s.bars().len(), 2);
+        assert_eq!(s.backfill_boundary(), Some(1), "boundary does not move");
+    }
+
+    #[test]
+    fn switching_bar_type_rebuilds_from_retained_trades() {
+        let mut s = ChartState::new(BarSpec::Tick(2));
+        let trades: Vec<Trade> = (1..=6).map(trade).collect();
+        s.ingest_backfill(&trades); // tick(2): 6 trades -> 3 bars
+        assert_eq!(s.bars().len(), 3);
+
+        s.set_spec(BarSpec::Tick(3)); // rebuild: 6 trades -> 2 bars
         assert_eq!(s.bars().len(), 2);
         assert_eq!(
             s.backfill_boundary(),
-            Some(1),
-            "boundary marks where live begins and does not move"
+            Some(2),
+            "all six are backfill -> boundary at the end"
         );
     }
 
     #[test]
-    fn boundary_is_none_before_backfill() {
-        let mut s = ChartState::new(5);
-        s.ingest_live(&trade(1));
-        assert_eq!(s.backfill_boundary(), None);
+    fn boundary_is_recomputed_across_a_switch() {
+        let mut s = ChartState::new(BarSpec::Tick(2));
+        s.ingest_backfill(&[trade(1), trade(2), trade(3)]); // 1 bar + partial
+        s.ingest_live(&trade(4)); // closes bar 2 (backfill 3 + live 4)
+        assert_eq!(s.bars().len(), 2);
+        assert_eq!(s.backfill_boundary(), Some(1));
+
+        // tick(4): 4 trades -> 1 bar. The first 3 (backfill) close 0 bars.
+        s.set_spec(BarSpec::Tick(4));
+        assert_eq!(s.bars().len(), 1);
+        assert_eq!(s.backfill_boundary(), Some(0));
     }
 
     #[test]
-    fn empty_backfill_sets_a_zero_boundary() {
-        let mut s = ChartState::new(5);
-        s.ingest_backfill(&[]);
-        assert_eq!(s.backfill_boundary(), Some(0));
-        assert!(s.bars().is_empty());
+    fn setting_the_same_spec_is_a_noop() {
+        let mut s = ChartState::new(BarSpec::Tick(2));
+        s.ingest_backfill(&[trade(1), trade(2)]);
+        let before = s.bars().len();
+        s.set_spec(BarSpec::Tick(2));
+        assert_eq!(s.bars().len(), before);
     }
 }


### PR DESCRIPTION
## Summary

quantick's whole point is alternative bars, so the chart now switches between tick, volume, dollar and time bars live — the same engine, four consumers.

- **`state.rs`** — `BarKind` + `BarSpec` with a `build()` dispatch that constructs the matching engine builder (`Box<dyn BarBuilder>`). `ChartState` now **retains every trade**; `ingest` is incremental, and `set_spec` rebuilds all bars from the retained trades through a fresh builder, recomputing the backfill/live boundary.
- **`app.rs`** — a top control panel with a bar-type combo + a per-kind parameter `DragValue`; changes apply via `set_spec` (no-op when unchanged). The header and perf-summary log carry the active spec.

Closes #35

## Design decisions

1. **One dispatch, `Box<dyn BarBuilder>`.** `BarSpec::build()` is the single place that maps a bar type to an engine builder — the "one engine, four consumers" rule made concrete. The trait is object-safe, so a boxed builder lets `ChartState` hold any of the four uniformly.
2. **Retain trades; incremental live, full rebuild on switch.** Live trades push incrementally (cheap); only a bar-type change replays the retained buffer through a fresh builder. Because the engine is deterministic, the incremental and replay paths agree.
3. **Boundary recomputed on rebuild.** The backfill/live divider is a *bar index*, which changes with the bar type — so `rebuild` recounts how many bars the backfilled trades close under the new spec. Covered by `boundary_is_recomputed_across_a_switch`.
4. **UI params retained per kind.** Switching kinds preserves each kind's parameter, so flipping back and forth doesn't reset your settings.

## Verification loop

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (app: 16 tests, incl. dispatch/rebuild/boundary)

## Notes for the reviewer

- **Ran locally:** the chart stays smooth (59 fps, ~13 ms feed lag under live trades) with the selector panel; the perf summary logs `bar_spec="tick(50)"`. The switching *logic* (dispatch, rebuild, boundary recompute) is unit-tested rather than relying on clicking the dropdown.
- **This completes milestone v0.3 — Desktop chart.** `cargo run -p quantick-app` opens a chart that backfills, streams live, forms bars in real time, labels backfilled-vs-live, surfaces frame time / feed lag, and switches between all four alternative bar types.
