### PR TITLE
feat(app): interactive chart navigation — drag to pan, scroll to zoom

### DIFF
--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -20,6 +20,7 @@ use crate::chart::{PriceScale, TimeAxis, to_f64};
 use crate::feed::FeedEvent;
 use crate::metrics::{self, FrameStats};
 use crate::state::{BarKind, BarSpec, ChartState};
+use crate::viewport::Viewport;
 
 const UP: egui::Color32 = egui::Color32::from_rgb(38, 166, 154);
 const DOWN: egui::Color32 = egui::Color32::from_rgb(239, 83, 80);
@@ -49,6 +50,9 @@ pub struct QuantickApp {
     volume_units: f64,
     dollar_notional: f64,
     time_interval_ms: i64,
+
+    // Pan/zoom navigation over the bar series.
+    viewport: Viewport,
 
     frames: FrameStats,
     last_frame: Option<Instant>,
@@ -87,6 +91,7 @@ impl QuantickApp {
             volume_units,
             dollar_notional,
             time_interval_ms,
+            viewport: Viewport::new(),
             frames: FrameStats::new(120),
             last_frame: None,
             latest_trade_ms: None,
@@ -219,15 +224,46 @@ impl QuantickApp {
         self.last_summary = now;
     }
 
+    /// Handle mouse navigation over the plot: drag to pan, scroll to zoom,
+    /// double-click to snap back to the live edge.
+    fn handle_navigation(&mut self, ui: &egui::Ui, area: egui::Rect) {
+        let plot = area.shrink(16.0);
+        let total = self.state.bars().len() + usize::from(self.state.partial().is_some());
+        if total == 0 {
+            return;
+        }
+        let response = ui.interact(
+            plot,
+            egui::Id::new("chart_nav"),
+            egui::Sense::click_and_drag(),
+        );
+
+        if response.dragged() {
+            let slot = plot.width() / self.viewport.visible_bars().max(1.0);
+            if slot > 0.0 {
+                self.viewport.pan(response.drag_delta().x / slot, total);
+            }
+        }
+        if response.double_clicked() {
+            self.viewport.snap_to_live();
+        }
+        if response.hovered() {
+            let scroll = ui.input(|i| i.raw_scroll_delta.y);
+            if scroll.abs() > 0.0 {
+                // Scroll up (positive) zooms in; each notch is a gentle step.
+                self.viewport.zoom(2.0_f32.powf(-scroll / 300.0));
+            }
+        }
+    }
+
     fn draw_chart(&self, painter: &egui::Painter, area: egui::Rect) {
         painter.rect_filled(area, egui::Rounding::ZERO, BACKGROUND);
         let plot = area.shrink(16.0);
 
-        let bars = self.state.bars();
+        let closed = self.state.bars();
         let partial = self.state.partial();
-        let count = bars.len() + usize::from(partial.is_some());
-
-        let Some(scale) = PriceScale::auto(bars, partial, plot.top(), plot.bottom(), 0.05) else {
+        let total = closed.len() + usize::from(partial.is_some());
+        if total == 0 {
             painter.text(
                 area.center(),
                 egui::Align2::CENTER_CENTER,
@@ -236,29 +272,59 @@ impl QuantickApp {
                 MUTED,
             );
             return;
+        }
+
+        let (start, end) = self.viewport.visible_range(total);
+        let visible_count = end.saturating_sub(start).max(1);
+
+        // The visible closed bars, plus the partial if it falls in view.
+        let closed_start = start.min(closed.len());
+        let closed_end = end.min(closed.len());
+        let visible_closed = &closed[closed_start..closed_end];
+        let partial_visible = partial.filter(|_| closed.len() >= start && closed.len() < end);
+
+        let Some(scale) = PriceScale::auto(
+            visible_closed,
+            partial_visible,
+            plot.top(),
+            plot.bottom(),
+            0.05,
+        ) else {
+            return;
         };
-        let axis = TimeAxis::new(plot.left(), plot.right(), count, 0.7, 24.0);
+        let axis = TimeAxis::new(plot.left(), plot.right(), visible_count, 0.7, 24.0);
 
-        for (index, bar) in bars.iter().enumerate() {
-            draw_candle(painter, &axis, &scale, index, bar, false);
+        for (offset, bar) in visible_closed.iter().enumerate() {
+            let local = (closed_start - start) + offset;
+            draw_candle(painter, &axis, &scale, local, bar, false);
         }
-        if let Some(partial) = partial {
-            draw_candle(painter, &axis, &scale, bars.len(), partial, true);
+        if let Some(partial) = partial_visible {
+            draw_candle(painter, &axis, &scale, closed.len() - start, partial, true);
         }
 
-        self.draw_backfill_divider(painter, &axis, plot);
+        self.draw_backfill_divider(painter, &axis, plot, start, end);
         self.draw_header(painter, plot);
     }
 
-    /// A vertical marker separating backfilled history (left) from live (right).
-    fn draw_backfill_divider(&self, painter: &egui::Painter, axis: &TimeAxis, plot: egui::Rect) {
+    /// A vertical marker separating backfilled history (left) from live (right),
+    /// drawn only when the boundary falls in the visible `[start, end)` window.
+    fn draw_backfill_divider(
+        &self,
+        painter: &egui::Painter,
+        axis: &TimeAxis,
+        plot: egui::Rect,
+        start: usize,
+        end: usize,
+    ) {
         let Some(boundary) = self.state.backfill_boundary() else {
             return;
         };
-        if boundary == 0 {
-            return; // nothing was backfilled
+        if boundary == 0 || boundary < start || boundary > end {
+            return; // nothing backfilled, or the divider is off-screen
         }
-        let x = axis.x_left(boundary).clamp(plot.left(), plot.right());
+        let x = axis
+            .x_left(boundary - start)
+            .clamp(plot.left(), plot.right());
         painter.line_segment(
             [egui::pos2(x, plot.top()), egui::pos2(x, plot.bottom())],
             egui::Stroke::new(1.0_f32, DIVIDER),
@@ -286,12 +352,18 @@ impl QuantickApp {
             Some(b) => (b, bars.len().saturating_sub(b)),
             None => (0, bars.len()),
         };
+        let mode = if self.viewport.follows_live() {
+            "● live"
+        } else {
+            "history · double-click for live"
+        };
         let header = format!(
-            "{} · {} · {} backfilled + {} live bars",
+            "{} · {} · {} backfilled + {} live bars · {}",
             self.symbol,
             self.state.spec().summary(),
             backfilled,
-            live
+            live,
+            mode
         );
         painter.text(
             egui::pos2(plot.left(), plot.top()),
@@ -392,6 +464,7 @@ impl eframe::App for QuantickApp {
             .frame(egui::Frame::none().fill(BACKGROUND))
             .show(ctx, |ui| {
                 let area = ui.available_rect_before_wrap();
+                self.handle_navigation(ui, area);
                 self.draw_chart(ui.painter(), area);
                 self.draw_overlay(ui.painter(), area);
             });

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -15,6 +15,7 @@ mod chart;
 mod feed;
 mod metrics;
 mod state;
+mod viewport;
 
 const SYMBOL: &str = "BTCUSDT";
 const TICK_SIZE: u64 = 50;

--- a/crates/app/src/viewport.rs
+++ b/crates/app/src/viewport.rs
@@ -1,0 +1,178 @@
+//! The scrollable/zoomable viewport over the bar series.
+//!
+//! Exocharts-style navigation: drag to pan through history, scroll to zoom.
+//! This is the pure state behind that — how many bars are visible (zoom) and
+//! which absolute bar sits at the right edge (pan) — with no egui or input
+//! handling, so it's unit-tested in CI.
+//!
+//! When the viewport is *following* the live edge, new bars keep it pinned to
+//! the newest bar; once you pan back into history it holds an absolute right
+//! edge, so incoming bars don't drift the view.
+
+/// Fewest bars that can fill the width (max zoom-in).
+pub const MIN_VISIBLE: f32 = 8.0;
+/// Most bars that can fill the width (max zoom-out).
+pub const MAX_VISIBLE: f32 = 5000.0;
+
+/// The visible window over a bar series.
+#[derive(Debug, Clone, Copy)]
+pub struct Viewport {
+    visible_bars: f32,
+    /// Absolute index of the rightmost visible bar (used only when not
+    /// following). Stored as `f32` so panning is smooth sub-bar.
+    right_index: f32,
+    follow: bool,
+}
+
+impl Default for Viewport {
+    fn default() -> Self {
+        Self {
+            visible_bars: 150.0,
+            right_index: 0.0,
+            follow: true,
+        }
+    }
+}
+
+impl Viewport {
+    /// A viewport following the live edge, showing ~150 bars.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// How many bars currently fill the width (fractional; drives candle width).
+    #[must_use]
+    pub fn visible_bars(&self) -> f32 {
+        self.visible_bars
+    }
+
+    /// Whether the right edge is pinned to the newest bar.
+    #[must_use]
+    pub fn follows_live(&self) -> bool {
+        self.follow
+    }
+
+    /// Zoom by a multiplicative factor: `< 1` zooms in (fewer, larger bars),
+    /// `> 1` zooms out. Anchored to the right edge.
+    pub fn zoom(&mut self, factor: f32) {
+        if factor > 0.0 && factor.is_finite() {
+            self.visible_bars = (self.visible_bars * factor).clamp(MIN_VISIBLE, MAX_VISIBLE);
+        }
+    }
+
+    /// Pan by `drag_bars`: positive drags the content right, revealing older
+    /// bars (the right edge moves into the past); negative moves toward the
+    /// present. Reaching the newest bar resumes following.
+    pub fn pan(&mut self, drag_bars: f32, total: usize) {
+        if total == 0 {
+            return;
+        }
+        let newest = (total - 1) as f32;
+        let current = if self.follow {
+            newest
+        } else {
+            self.right_index
+        };
+        let next = (current - drag_bars).clamp(0.0, newest);
+        self.right_index = next;
+        self.follow = next >= newest - 0.5;
+    }
+
+    /// Pin the right edge back to the newest bar.
+    pub fn snap_to_live(&mut self) {
+        self.follow = true;
+    }
+
+    /// The `[start, end)` absolute bar indices visible for a series of `total`
+    /// bars. `end` is exclusive.
+    #[must_use]
+    pub fn visible_range(&self, total: usize) -> (usize, usize) {
+        if total == 0 {
+            return (0, 0);
+        }
+        let vis = (self.visible_bars.round() as usize).max(1);
+        let end = if self.follow {
+            total
+        } else {
+            (self.right_index.round() as usize + 1).min(total)
+        };
+        let start = end.saturating_sub(vis);
+        (start, end)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_follows_live_and_shows_the_newest() {
+        let v = Viewport::new();
+        assert!(v.follows_live());
+        let (start, end) = v.visible_range(1000);
+        assert_eq!(end, 1000, "right edge at the newest");
+        assert_eq!(end - start, 150, "default ~150 visible");
+    }
+
+    #[test]
+    fn fewer_bars_than_the_window_shows_them_all() {
+        let v = Viewport::new();
+        assert_eq!(v.visible_range(10), (0, 10));
+    }
+
+    #[test]
+    fn zoom_clamps_between_min_and_max() {
+        let mut v = Viewport::new();
+        for _ in 0..100 {
+            v.zoom(0.5);
+        }
+        assert!((v.visible_bars() - MIN_VISIBLE).abs() < 0.001);
+        for _ in 0..100 {
+            v.zoom(2.0);
+        }
+        assert!((v.visible_bars() - MAX_VISIBLE).abs() < 0.001);
+    }
+
+    #[test]
+    fn panning_into_the_past_stops_following_and_holds() {
+        let mut v = Viewport::new();
+        // 500 bars, drag right by 100 bars -> right edge at index 399.
+        v.pan(100.0, 500);
+        assert!(!v.follows_live());
+        let (_, end) = v.visible_range(500);
+        assert_eq!(end, 400, "right edge index 399, exclusive end 400");
+
+        // New bars arrive (total 520) while not following: the view holds.
+        let (_, end2) = v.visible_range(520);
+        assert_eq!(end2, 400, "held view does not drift with new bars");
+    }
+
+    #[test]
+    fn panning_back_to_the_edge_resumes_following() {
+        let mut v = Viewport::new();
+        v.pan(100.0, 500);
+        assert!(!v.follows_live());
+        v.pan(-100.0, 500); // drag left back to the present
+        assert!(v.follows_live());
+    }
+
+    #[test]
+    fn snap_to_live_resumes_following() {
+        let mut v = Viewport::new();
+        v.pan(50.0, 500);
+        assert!(!v.follows_live());
+        v.snap_to_live();
+        assert!(v.follows_live());
+        assert_eq!(v.visible_range(500).1, 500);
+    }
+
+    #[test]
+    fn pan_cannot_go_before_the_first_bar() {
+        let mut v = Viewport::new();
+        v.pan(10_000.0, 500); // absurd drag into the past
+        let (start, end) = v.visible_range(500);
+        assert_eq!(end, 1, "right edge clamped to the first bar");
+        assert_eq!(start, 0);
+    }
+}


### PR DESCRIPTION
## Summary

Exocharts-style navigation over the retained bar history: **drag to pan** left/right through the past, **scroll to zoom** (candles grow/shrink), and **double-click to snap back to the live edge**.

- **`viewport.rs`** — a pure, unit-tested `Viewport`: visible-bar count (zoom) + an absolute right-edge index (pan) with a follow-live flag.
- **`app.rs`** — `handle_navigation` maps mouse drag → pan, wheel → zoom, double-click → snap to live. `draw_chart` renders only the visible slice, auto-scaling the price axis to what's on screen; the header shows a `● live` / `history` indicator.

Closes #43

## Design decisions

1. **Follow-live vs absolute right edge.** When following, the newest bar stays pinned as trades arrive. The moment you pan into history, the viewport switches to an *absolute* right-edge index, so incoming live bars **don't drift** your historical view — panning back to the edge (or double-click) resumes following. This is the honest behaviour: history you're inspecting stays put.
2. **Price axis auto-scales to the *visible* bars**, not all of them — so zooming/panning reveals the local price range, like a real trading chart.
3. **Zoom anchored to the right edge.** `visible_range` computes `start` from `end`, so zooming changes how many bars precede the right edge while keeping the newest in view — the natural "zoom toward the latest" feel.
4. **All navigation state is pure and CI-tested** (zoom clamping, pan-into-past-holds, resume-on-edge, snap, first-bar clamp). The egui input mapping is a thin adapter over it.

## Verification loop

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (app: 23 tests, incl. 7 viewport tests)

## Notes for the reviewer

- **Ran locally:** the chart renders and stays stable with navigation wired. The `Viewport` *logic* (directions, clamping, follow/hold) is unit-tested; the interactive *feel* (drag/scroll sensitivity, scroll direction) is best confirmed with a human click-test — if scroll-to-zoom feels inverted or the pan speed is off, those are one-line tweaks in `handle_navigation` (the `zoom` factor / `pan` mapping).
