### PR TITLE
feat(app): Exocharts-like chart frame — price axis, grid and crosshair

### DIFF
--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -29,6 +29,12 @@ const DIVIDER: egui::Color32 = egui::Color32::from_rgb(240, 185, 11);
 const MUTED: egui::Color32 = egui::Color32::from_rgb(150, 160, 175);
 const OVERLAY: egui::Color32 = egui::Color32::from_rgb(210, 218, 226);
 const WARN: egui::Color32 = egui::Color32::from_rgb(255, 99, 71);
+const GRID: egui::Color32 = egui::Color32::from_rgb(35, 41, 54);
+const CROSSHAIR: egui::Color32 = egui::Color32::from_rgb(110, 120, 135);
+const TAG_BG: egui::Color32 = egui::Color32::from_rgb(55, 63, 80);
+
+/// Width of the right-hand price-axis gutter, in pixels.
+const AXIS_GUTTER: f32 = 60.0;
 
 /// How often the perf summary is logged (not every frame).
 const SUMMARY_INTERVAL: Duration = Duration::from_secs(2);
@@ -53,6 +59,8 @@ pub struct QuantickApp {
 
     // Pan/zoom navigation over the bar series.
     viewport: Viewport,
+    // Pointer position over the plot this frame, for the crosshair.
+    hover_pos: Option<egui::Pos2>,
 
     frames: FrameStats,
     last_frame: Option<Instant>,
@@ -92,6 +100,7 @@ impl QuantickApp {
             dollar_notional,
             time_interval_ms,
             viewport: Viewport::new(),
+            hover_pos: None,
             frames: FrameStats::new(120),
             last_frame: None,
             latest_trade_ms: None,
@@ -228,15 +237,17 @@ impl QuantickApp {
     /// double-click to snap back to the live edge.
     fn handle_navigation(&mut self, ui: &egui::Ui, area: egui::Rect) {
         let plot = area.shrink(16.0);
-        let total = self.state.bars().len() + usize::from(self.state.partial().is_some());
-        if total == 0 {
-            return;
-        }
         let response = ui.interact(
             plot,
             egui::Id::new("chart_nav"),
             egui::Sense::click_and_drag(),
         );
+        self.hover_pos = response.hover_pos();
+
+        let total = self.state.bars().len() + usize::from(self.state.partial().is_some());
+        if total == 0 {
+            return;
+        }
 
         if response.dragged() {
             let slot = plot.width() / self.viewport.visible_bars().max(1.0);
@@ -274,6 +285,15 @@ impl QuantickApp {
             return;
         }
 
+        // Reserve a gutter on the right for the price axis.
+        let chart_rect = egui::Rect::from_min_max(
+            plot.min,
+            egui::pos2(
+                (plot.right() - AXIS_GUTTER).max(plot.left() + 20.0),
+                plot.bottom(),
+            ),
+        );
+
         let (start, end) = self.viewport.visible_range(total);
         let visible_count = end.saturating_sub(start).max(1);
 
@@ -286,13 +306,22 @@ impl QuantickApp {
         let Some(scale) = PriceScale::auto(
             visible_closed,
             partial_visible,
-            plot.top(),
-            plot.bottom(),
+            chart_rect.top(),
+            chart_rect.bottom(),
             0.05,
         ) else {
             return;
         };
-        let axis = TimeAxis::new(plot.left(), plot.right(), visible_count, 0.7, 24.0);
+        let axis = TimeAxis::new(
+            chart_rect.left(),
+            chart_rect.right(),
+            visible_count,
+            0.7,
+            24.0,
+        );
+
+        // Grid + price labels first, behind the candles.
+        self.draw_price_axis(painter, chart_rect, &scale);
 
         for (offset, bar) in visible_closed.iter().enumerate() {
             let local = (closed_start - start) + offset;
@@ -302,8 +331,83 @@ impl QuantickApp {
             draw_candle(painter, &axis, &scale, closed.len() - start, partial, true);
         }
 
-        self.draw_backfill_divider(painter, &axis, plot, start, end);
+        self.draw_backfill_divider(painter, &axis, chart_rect, start, end);
+        self.draw_crosshair(painter, chart_rect, &scale);
         self.draw_header(painter, plot);
+    }
+
+    /// Right-hand price axis: round-number gridlines and labels.
+    fn draw_price_axis(&self, painter: &egui::Painter, chart_rect: egui::Rect, scale: &PriceScale) {
+        let (lo, hi) = scale.range();
+        let font = egui::FontId::monospace(11.0);
+        for tick in crate::chart::nice_ticks(lo, hi, 8) {
+            let y = scale.y(tick);
+            if y < chart_rect.top() || y > chart_rect.bottom() {
+                continue;
+            }
+            painter.line_segment(
+                [
+                    egui::pos2(chart_rect.left(), y),
+                    egui::pos2(chart_rect.right(), y),
+                ],
+                egui::Stroke::new(1.0_f32, GRID),
+            );
+            painter.text(
+                egui::pos2(chart_rect.right() + 6.0, y),
+                egui::Align2::LEFT_CENTER,
+                format!("{tick:.2}"),
+                font.clone(),
+                MUTED,
+            );
+        }
+        // The axis dividing line.
+        painter.line_segment(
+            [
+                egui::pos2(chart_rect.right(), chart_rect.top()),
+                egui::pos2(chart_rect.right(), chart_rect.bottom()),
+            ],
+            egui::Stroke::new(1.0_f32, GRID),
+        );
+    }
+
+    /// Crosshair following the pointer, with the price shown on the axis.
+    fn draw_crosshair(&self, painter: &egui::Painter, chart_rect: egui::Rect, scale: &PriceScale) {
+        let Some(pos) = self.hover_pos else {
+            return;
+        };
+        if !chart_rect.contains(pos) {
+            return;
+        }
+        let stroke = egui::Stroke::new(1.0_f32, CROSSHAIR);
+        painter.line_segment(
+            [
+                egui::pos2(pos.x, chart_rect.top()),
+                egui::pos2(pos.x, chart_rect.bottom()),
+            ],
+            stroke,
+        );
+        painter.line_segment(
+            [
+                egui::pos2(chart_rect.left(), pos.y),
+                egui::pos2(chart_rect.right(), pos.y),
+            ],
+            stroke,
+        );
+
+        // Price tag on the axis at the cursor height.
+        let price = scale.price_at(pos.y);
+        let galley = painter.layout_no_wrap(
+            format!("{price:.2}"),
+            egui::FontId::monospace(11.0),
+            egui::Color32::WHITE,
+        );
+        let text_pos = egui::pos2(chart_rect.right() + 6.0, pos.y - galley.size().y / 2.0);
+        let bg = egui::Rect::from_min_size(
+            text_pos - egui::vec2(3.0, 1.0),
+            galley.size() + egui::vec2(6.0, 2.0),
+        );
+        painter.rect_filled(bg, egui::Rounding::same(2.0), TAG_BG);
+        painter.galley(text_pos, galley, egui::Color32::WHITE);
     }
 
     /// A vertical marker separating backfilled history (left) from live (right),
@@ -312,7 +416,7 @@ impl QuantickApp {
         &self,
         painter: &egui::Painter,
         axis: &TimeAxis,
-        plot: egui::Rect,
+        chart_rect: egui::Rect,
         start: usize,
         end: usize,
     ) {
@@ -324,21 +428,24 @@ impl QuantickApp {
         }
         let x = axis
             .x_left(boundary - start)
-            .clamp(plot.left(), plot.right());
+            .clamp(chart_rect.left(), chart_rect.right());
         painter.line_segment(
-            [egui::pos2(x, plot.top()), egui::pos2(x, plot.bottom())],
+            [
+                egui::pos2(x, chart_rect.top()),
+                egui::pos2(x, chart_rect.bottom()),
+            ],
             egui::Stroke::new(1.0_f32, DIVIDER),
         );
         let font = egui::FontId::proportional(11.0);
         painter.text(
-            egui::pos2(x - 4.0, plot.bottom() - 4.0),
+            egui::pos2(x - 4.0, chart_rect.bottom() - 4.0),
             egui::Align2::RIGHT_BOTTOM,
             "backfill",
             font.clone(),
             MUTED,
         );
         painter.text(
-            egui::pos2(x + 4.0, plot.bottom() - 4.0),
+            egui::pos2(x + 4.0, chart_rect.bottom() - 4.0),
             egui::Align2::LEFT_BOTTOM,
             "live",
             font,

--- a/crates/app/src/chart.rs
+++ b/crates/app/src/chart.rs
@@ -72,6 +72,82 @@ impl PriceScale {
         let frac = ((self.hi - price) / span) as f32;
         self.top + frac * (self.bottom - self.top)
     }
+
+    /// The price at a given y-pixel — the inverse of [`y`](PriceScale::y), for a
+    /// crosshair readout.
+    #[must_use]
+    pub fn price_at(&self, y: f32) -> f64 {
+        let height = self.bottom - self.top;
+        if height.abs() < f32::EPSILON {
+            return f64::midpoint(self.lo, self.hi);
+        }
+        let frac = f64::from((y - self.top) / height); // 0 at top (hi), 1 at bottom (lo)
+        self.hi - frac * (self.hi - self.lo)
+    }
+
+    /// The padded `(lo, hi)` price range this scale covers.
+    #[must_use]
+    pub fn range(&self) -> (f64, f64) {
+        (self.lo, self.hi)
+    }
+}
+
+/// Round "nice" price ticks spanning `[lo, hi]`, aiming for about `target`
+/// labels, using Heckbert's nice-numbers algorithm so labels land on values
+/// like 100, 102.5, 105 rather than 100.37, 102.71, ….
+#[must_use]
+pub fn nice_ticks(lo: f64, hi: f64, target: usize) -> Vec<f64> {
+    if hi <= lo || target == 0 {
+        return Vec::new();
+    }
+    let step = nice_num(nice_num(hi - lo, false) / target as f64, true);
+    if step <= 0.0 || !step.is_finite() {
+        return Vec::new();
+    }
+    let first = (lo / step).ceil() * step;
+    let mut ticks = Vec::new();
+    let mut v = first;
+    // Guard the loop count in case of pathological inputs.
+    for _ in 0..(target * 4 + 8) {
+        if v > hi + step * 0.001 {
+            break;
+        }
+        if v >= lo - step * 0.001 {
+            ticks.push(v);
+        }
+        v += step;
+    }
+    ticks
+}
+
+/// A "nice" number near `range`: 1, 2, 5 or 10 × a power of ten. When `round`,
+/// picks the nearest nice value; otherwise the smallest nice value ≥ `range`.
+fn nice_num(range: f64, round: bool) -> f64 {
+    if range <= 0.0 || !range.is_finite() {
+        return 0.0;
+    }
+    let exp = range.log10().floor();
+    let frac = range / 10f64.powf(exp);
+    let nice = if round {
+        if frac < 1.5 {
+            1.0
+        } else if frac < 3.0 {
+            2.0
+        } else if frac < 7.0 {
+            5.0
+        } else {
+            10.0
+        }
+    } else if frac <= 1.0 {
+        1.0
+    } else if frac <= 2.0 {
+        2.0
+    } else if frac <= 5.0 {
+        5.0
+    } else {
+        10.0
+    };
+    nice * 10f64.powf(exp)
 }
 
 /// Horizontal bar-index → x-pixel mapping, packing `count` bars into a width.
@@ -197,5 +273,40 @@ mod tests {
     fn time_axis_handles_empty() {
         let axis = TimeAxis::new(0.0, 100.0, 0, 0.7, 20.0);
         assert!(axis.bar_width() >= 1.0);
+    }
+
+    #[test]
+    fn price_at_is_the_inverse_of_y() {
+        let bars = vec![bar("100.0", "110.0")];
+        let scale = PriceScale::auto(&bars, None, 0.0, 100.0, 0.0).unwrap();
+        for price in [100.0, 103.0, 107.5, 110.0] {
+            let y = scale.y(price);
+            assert!(
+                (scale.price_at(y) - price).abs() < 1e-6,
+                "price_at(y({price})) != {price}"
+            );
+        }
+    }
+
+    #[test]
+    fn nice_ticks_are_round_and_in_range() {
+        let ticks = nice_ticks(100.0, 110.0, 5);
+        assert!(!ticks.is_empty());
+        for t in &ticks {
+            assert!(*t >= 100.0 && *t <= 110.0, "tick {t} out of range");
+        }
+        let step = ticks[1] - ticks[0];
+        for pair in ticks.windows(2) {
+            assert!((pair[1] - pair[0] - step).abs() < 1e-9);
+        }
+        // 100..110 targeting ~5 gives a round 2.0 step: 100,102,...,110.
+        assert!((step - 2.0).abs() < 1e-9, "step = {step}");
+    }
+
+    #[test]
+    fn nice_ticks_handles_degenerate_ranges() {
+        assert!(nice_ticks(100.0, 100.0, 5).is_empty());
+        assert!(nice_ticks(110.0, 100.0, 5).is_empty());
+        assert!(nice_ticks(100.0, 110.0, 0).is_empty());
     }
 }


### PR DESCRIPTION
## Summary

Gives the chart a proper trading-chart frame: a right-hand price axis with round-number labels, subtle gridlines aligned to them, and a crosshair that follows the pointer with a price readout.

- **`chart.rs`** — `nice_ticks` (Heckbert nice-numbers) for round price labels; `PriceScale::price_at` (inverse of `y`) + `range()` for the axis and crosshair. All pure and unit-tested.
- **`app.rs`** — a right-hand gutter, round-number labels with gridlines, and a pointer crosshair with a price tag on the axis. Candles and the backfill divider now draw inside the chart area (excluding the gutter).

Closes #44

## Design decisions

1. **Nice-number ticks, not evenly-divided range.** Labels land on 65610 / 65615 / 65620 (a round 5.00 step) rather than 65611.3 / 65616.9 / … — Heckbert's algorithm picks a 1/2/5×10ⁿ step near the target count. Pure and tested.
2. **Price axis auto-scales with the viewport.** Because the labels derive from the *visible* `PriceScale` (from #43), zooming/panning re-labels the axis to the on-screen range, like Exocharts.
3. **`price_at` is the exact inverse of `y`** — the crosshair readout is the true price at the cursor, tested to round-trip.

## Verification loop

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (app: 26 tests, incl. `price_at` round-trip and `nice_ticks`)

## Notes for the reviewer

- **Verified with a screenshot** of the running app: the right-side price axis (65610 / 65615 / 65620 / 65625 labels), gridlines, green/red candles and the `backfill | live` divider all render as a trading chart. The crosshair follows the cursor (not in the still, since the pointer was off-chart).
