### PR TITLE
feat(app): configurable candle styling (Exocharts-like)

### DIFF
--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -20,11 +20,14 @@ use crate::chart::{PriceScale, TimeAxis, to_f64};
 use crate::feed::FeedEvent;
 use crate::metrics::{self, FrameStats};
 use crate::state::{BarKind, BarSpec, ChartState};
+use crate::style::CandleStyle;
 use crate::viewport::Viewport;
 
-const UP: egui::Color32 = egui::Color32::from_rgb(38, 166, 154);
-const DOWN: egui::Color32 = egui::Color32::from_rgb(239, 83, 80);
-const BACKGROUND: egui::Color32 = egui::Color32::from_rgb(19, 23, 34);
+/// Convert an sRGB `[u8; 3]` style colour to an egui `Color32`.
+fn color32([r, g, b]: [u8; 3]) -> egui::Color32 {
+    egui::Color32::from_rgb(r, g, b)
+}
+
 const DIVIDER: egui::Color32 = egui::Color32::from_rgb(240, 185, 11);
 const MUTED: egui::Color32 = egui::Color32::from_rgb(150, 160, 175);
 const OVERLAY: egui::Color32 = egui::Color32::from_rgb(210, 218, 226);
@@ -61,6 +64,10 @@ pub struct QuantickApp {
     viewport: Viewport,
     // Pointer position over the plot this frame, for the crosshair.
     hover_pos: Option<egui::Pos2>,
+
+    // Candle appearance + whether the style panel is open.
+    style: CandleStyle,
+    show_style: bool,
 
     frames: FrameStats,
     last_frame: Option<Instant>,
@@ -101,6 +108,8 @@ impl QuantickApp {
             time_interval_ms,
             viewport: Viewport::new(),
             hover_pos: None,
+            style: CandleStyle::default(),
+            show_style: false,
             frames: FrameStats::new(120),
             last_frame: None,
             latest_trade_ms: None,
@@ -162,7 +171,53 @@ impl QuantickApp {
                     );
                 }
             }
+            ui.separator();
+            if ui.button("⚙ style").clicked() {
+                self.show_style = !self.show_style;
+            }
         });
+    }
+
+    /// The current background colour as an egui `Color32`.
+    fn bg(&self) -> egui::Color32 {
+        color32(self.style.background)
+    }
+
+    /// The floating candle-style settings panel (shown when `show_style`).
+    fn draw_style_panel(&mut self, ctx: &egui::Context) {
+        let mut open = self.show_style;
+        egui::Window::new("candle style")
+            .open(&mut open)
+            .resizable(false)
+            .show(ctx, |ui| {
+                let s = &mut self.style;
+                ui.horizontal(|ui| {
+                    ui.label("up (bull)");
+                    ui.color_edit_button_srgb(&mut s.bull);
+                });
+                ui.horizontal(|ui| {
+                    ui.label("down (bear)");
+                    ui.color_edit_button_srgb(&mut s.bear);
+                });
+                ui.checkbox(&mut s.show_wicks, "show wicks");
+                ui.checkbox(&mut s.wick_matches_body, "wick matches body");
+                if !s.wick_matches_body {
+                    ui.horizontal(|ui| {
+                        ui.label("wick");
+                        ui.color_edit_button_srgb(&mut s.wick);
+                    });
+                }
+                ui.add(egui::Slider::new(&mut s.body_width_frac, 0.1..=1.0).text("body width"));
+                ui.horizontal(|ui| {
+                    ui.label("background");
+                    ui.color_edit_button_srgb(&mut s.background);
+                });
+                ui.separator();
+                if ui.button("reset to defaults").clicked() {
+                    *s = CandleStyle::default();
+                }
+            });
+        self.show_style = open;
     }
 
     /// Drain every feed event available this frame into the engine, tracking the
@@ -268,7 +323,7 @@ impl QuantickApp {
     }
 
     fn draw_chart(&self, painter: &egui::Painter, area: egui::Rect) {
-        painter.rect_filled(area, egui::Rounding::ZERO, BACKGROUND);
+        painter.rect_filled(area, egui::Rounding::ZERO, self.bg());
         let plot = area.shrink(16.0);
 
         let closed = self.state.bars();
@@ -316,7 +371,7 @@ impl QuantickApp {
             chart_rect.left(),
             chart_rect.right(),
             visible_count,
-            0.7,
+            self.style.clamped_width_frac(),
             24.0,
         );
 
@@ -325,10 +380,18 @@ impl QuantickApp {
 
         for (offset, bar) in visible_closed.iter().enumerate() {
             let local = (closed_start - start) + offset;
-            draw_candle(painter, &axis, &scale, local, bar, false);
+            draw_candle(painter, &axis, &scale, local, bar, false, &self.style);
         }
         if let Some(partial) = partial_visible {
-            draw_candle(painter, &axis, &scale, closed.len() - start, partial, true);
+            draw_candle(
+                painter,
+                &axis,
+                &scale,
+                closed.len() - start,
+                partial,
+                true,
+                &self.style,
+            );
         }
 
         self.draw_backfill_divider(painter, &axis, chart_rect, start, end);
@@ -558,17 +621,19 @@ impl eframe::App for QuantickApp {
         self.drain_feed();
         self.maybe_emit_summary(now);
 
+        let bg = self.bg();
         egui::TopBottomPanel::top("controls")
-            .frame(egui::Frame::none().fill(BACKGROUND).inner_margin(8.0))
+            .frame(egui::Frame::none().fill(bg).inner_margin(8.0))
             .show(ctx, |ui| {
                 ui.visuals_mut().override_text_color = Some(OVERLAY);
                 self.draw_controls(ui);
             });
         // Apply any selector change (no-op if unchanged).
         self.state.set_spec(self.current_spec());
+        self.draw_style_panel(ctx);
 
         egui::CentralPanel::default()
-            .frame(egui::Frame::none().fill(BACKGROUND))
+            .frame(egui::Frame::none().fill(bg))
             .show(ctx, |ui| {
                 let area = ui.available_rect_before_wrap();
                 self.handle_navigation(ui, area);
@@ -589,18 +654,22 @@ fn draw_candle(
     index: usize,
     bar: &Bar,
     forming: bool,
+    style: &CandleStyle,
 ) {
     let xc = axis.x_center(index);
     let half = axis.bar_width() / 2.0;
-    let color = if bar.close >= bar.open { UP } else { DOWN };
+    let up = bar.close >= bar.open;
+    let color = color32(style.body_color(up));
 
-    painter.line_segment(
-        [
-            egui::pos2(xc, scale.y(to_f64(bar.high))),
-            egui::pos2(xc, scale.y(to_f64(bar.low))),
-        ],
-        egui::Stroke::new(1.0_f32, color),
-    );
+    if style.show_wicks {
+        painter.line_segment(
+            [
+                egui::pos2(xc, scale.y(to_f64(bar.high))),
+                egui::pos2(xc, scale.y(to_f64(bar.low))),
+            ],
+            egui::Stroke::new(1.0_f32, color32(style.wick_color(up))),
+        );
+    }
 
     let y_open = scale.y(to_f64(bar.open));
     let y_close = scale.y(to_f64(bar.close));

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -15,6 +15,7 @@ mod chart;
 mod feed;
 mod metrics;
 mod state;
+mod style;
 mod viewport;
 
 const SYMBOL: &str = "BTCUSDT";

--- a/crates/app/src/style.rs
+++ b/crates/app/src/style.rs
@@ -1,0 +1,125 @@
+//! User-configurable candle appearance.
+//!
+//! Colours are sRGB `[u8; 3]` triples (not egui `Color32`), so this module is
+//! egui-free and the derivation logic — colour selection, width clamping — is
+//! unit-tested in CI. The app converts to `Color32` at draw time and binds the
+//! fields to egui colour pickers, which speak `[u8; 3]` directly.
+
+/// How candles are drawn: colours, wicks and body width.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct CandleStyle {
+    /// Body colour for up (close ≥ open) candles.
+    pub bull: [u8; 3],
+    /// Body colour for down candles.
+    pub bear: [u8; 3],
+    /// Wick colour, used when [`wick_matches_body`](CandleStyle::wick_matches_body) is off.
+    pub wick: [u8; 3],
+    /// When true, wicks take the candle's body colour (common in modern charts).
+    pub wick_matches_body: bool,
+    /// Whether to draw wicks at all.
+    pub show_wicks: bool,
+    /// Body width as a fraction of the bar slot, in `[0.1, 1.0]`.
+    pub body_width_frac: f32,
+    /// Chart background colour.
+    pub background: [u8; 3],
+}
+
+impl Default for CandleStyle {
+    /// Exocharts-like defaults: teal-green up, red down, wick matches body, on a
+    /// dark background.
+    fn default() -> Self {
+        Self {
+            bull: [38, 166, 154],
+            bear: [239, 83, 80],
+            wick: [150, 160, 175],
+            wick_matches_body: true,
+            show_wicks: true,
+            body_width_frac: 0.7,
+            background: [19, 23, 34],
+        }
+    }
+}
+
+impl CandleStyle {
+    /// The body colour for an up (`true`) or down (`false`) candle.
+    #[must_use]
+    pub fn body_color(&self, up: bool) -> [u8; 3] {
+        if up { self.bull } else { self.bear }
+    }
+
+    /// The wick colour for an up/down candle, honouring
+    /// [`wick_matches_body`](CandleStyle::wick_matches_body).
+    #[must_use]
+    pub fn wick_color(&self, up: bool) -> [u8; 3] {
+        if self.wick_matches_body {
+            self.body_color(up)
+        } else {
+            self.wick
+        }
+    }
+
+    /// The body width fraction, clamped to a sane `[0.1, 1.0]` so a candle is
+    /// always visible and never wider than its slot.
+    #[must_use]
+    pub fn clamped_width_frac(&self) -> f32 {
+        self.body_width_frac.clamp(0.1, 1.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_are_exocharts_like() {
+        let s = CandleStyle::default();
+        assert_eq!(s.bull, [38, 166, 154]);
+        assert_eq!(s.bear, [239, 83, 80]);
+        assert!(s.wick_matches_body);
+        assert!(s.show_wicks);
+    }
+
+    #[test]
+    fn body_color_picks_by_direction() {
+        let s = CandleStyle::default();
+        assert_eq!(s.body_color(true), s.bull);
+        assert_eq!(s.body_color(false), s.bear);
+    }
+
+    #[test]
+    fn wick_matches_body_when_enabled() {
+        let matched = CandleStyle {
+            wick_matches_body: true,
+            ..Default::default()
+        };
+        assert_eq!(matched.wick_color(true), matched.bull);
+        assert_eq!(matched.wick_color(false), matched.bear);
+
+        let fixed = CandleStyle {
+            wick_matches_body: false,
+            wick: [1, 2, 3],
+            ..Default::default()
+        };
+        assert_eq!(fixed.wick_color(true), [1, 2, 3]);
+        assert_eq!(fixed.wick_color(false), [1, 2, 3]);
+    }
+
+    #[test]
+    fn width_is_clamped() {
+        let over = CandleStyle {
+            body_width_frac: 5.0,
+            ..Default::default()
+        };
+        assert!((over.clamped_width_frac() - 1.0).abs() < f32::EPSILON);
+        let under = CandleStyle {
+            body_width_frac: 0.0,
+            ..Default::default()
+        };
+        assert!((under.clamped_width_frac() - 0.1).abs() < f32::EPSILON);
+        let mid = CandleStyle {
+            body_width_frac: 0.5,
+            ..Default::default()
+        };
+        assert!((mid.clamped_width_frac() - 0.5).abs() < f32::EPSILON);
+    }
+}


### PR DESCRIPTION
## Summary

Candle appearance is now user-configurable and applies live — the "configure the candles like Exocharts" ask.

- **`style.rs`** — `CandleStyle` (egui-free, sRGB `[u8; 3]` colours): bull/bear body colours, wick colour + "wick matches body", show-wicks toggle, body-width fraction (clamped), background. Exocharts-like defaults; the colour/width logic is unit-tested.
- **`app.rs`** — a **⚙ style** button opens a floating settings window (colour pickers, toggles, body-width slider, "reset to defaults"). The renderer reads `CandleStyle` instead of hard-coded constants, so changes apply immediately.

Closes #45

## Design decisions

1. **Colours as `[u8; 3]`, not egui `Color32`.** Keeps `style.rs` egui-free (so its logic is unit-tested in CI) *and* binds directly to egui's `color_edit_button_srgb(&mut [u8; 3])` — no conversion glue in the panel. The renderer converts to `Color32` at draw time.
2. **Body width via the existing `TimeAxis` body-fraction.** The style's clamped width fraction feeds `TimeAxis::new`, so "body width" reuses the tested layout math rather than a parallel path.
3. **"Wick matches body" toggle.** The modern-chart default (wicks take the candle colour), with an explicit wick colour when you want the classic look.
4. **Removed the old `UP`/`DOWN`/`BACKGROUND` constants** — they're now `CandleStyle` fields, so there's a single source of truth for candle appearance.

## Verification loop

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (app: 30 tests, incl. 4 `CandleStyle` tests)

## Notes for the reviewer

- The `CandleStyle` derivations (colour-by-direction, wick-matches-body, width clamping) are unit-tested; the panel is standard egui widgets bound to those fields. The app runs stably with the button wired. Interactive colour-picking is a quick human click-test (open ⚙ style, drag a colour) — the default look is unchanged, so nothing regresses if you don't touch it.
- **This completes milestone v0.3.1 — Chart UX (Exocharts-like):** drag-to-pan, scroll-to-zoom, follow/scroll-through-history, a right-side price axis with round labels + gridlines + crosshair, and configurable candles.
