### PR TITLE
feat(app): vertical price navigation — drag chart to pan, drag axis to zoom

### DIFF
--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -19,6 +19,7 @@ use quantick_engine::Bar;
 use crate::chart::{PriceScale, TimeAxis, to_f64};
 use crate::feed::FeedEvent;
 use crate::metrics::{self, FrameStats};
+use crate::price_view::PriceView;
 use crate::state::{BarKind, BarSpec, ChartState};
 use crate::style::CandleStyle;
 use crate::viewport::Viewport;
@@ -47,6 +48,16 @@ fn dec_from_f64(x: f64) -> Decimal {
     Decimal::from_f64(x.max(1e-8)).unwrap_or(Decimal::ONE)
 }
 
+/// Split the padded plot area into the candle chart (left) and the right price
+/// gutter, so both the input handler and the renderer agree on the boundary.
+fn plot_split(area: egui::Rect) -> (egui::Rect, egui::Rect) {
+    let plot = area.shrink(16.0);
+    let split_x = (plot.right() - AXIS_GUTTER).max(plot.left() + 20.0);
+    let chart = egui::Rect::from_min_max(plot.min, egui::pos2(split_x, plot.bottom()));
+    let gutter = egui::Rect::from_min_max(egui::pos2(split_x, plot.top()), plot.max);
+    (chart, gutter)
+}
+
 /// The quantick chart window.
 pub struct QuantickApp {
     state: ChartState,
@@ -62,6 +73,12 @@ pub struct QuantickApp {
 
     // Pan/zoom navigation over the bar series.
     viewport: Viewport,
+    // Manual price-axis pan/zoom (auto-fit until the user drags vertically).
+    price_view: PriceView,
+    // Last frame's auto-fit price range and chart height, for pixel↔price maths
+    // in the input handler (which runs before the draw computes them).
+    last_auto_range: Option<(f64, f64)>,
+    last_chart_height: f32,
     // Pointer position over the plot this frame, for the crosshair.
     hover_pos: Option<egui::Pos2>,
 
@@ -107,6 +124,9 @@ impl QuantickApp {
             dollar_notional,
             time_interval_ms,
             viewport: Viewport::new(),
+            price_view: PriceView::new(),
+            last_auto_range: None,
+            last_chart_height: 1.0,
             hover_pos: None,
             style: CandleStyle::default(),
             show_style: false,
@@ -288,43 +308,81 @@ impl QuantickApp {
         self.last_summary = now;
     }
 
-    /// Handle mouse navigation over the plot: drag to pan, scroll to zoom,
-    /// double-click to snap back to the live edge.
+    /// Handle mouse navigation, TradingView-style:
+    /// - drag the chart area → pan time (x) and price (y);
+    /// - scroll over the chart → zoom time;
+    /// - drag the right price gutter → zoom the price scale (stretch candles);
+    /// - scroll over the gutter → zoom the price scale;
+    /// - double-click → reset to the live edge and auto-fit price.
     fn handle_navigation(&mut self, ui: &egui::Ui, area: egui::Rect) {
-        let plot = area.shrink(16.0);
-        let response = ui.interact(
-            plot,
+        let (chart_rect, axis_rect) = plot_split(area);
+        let auto = self.last_auto_range;
+        let height = self.last_chart_height;
+
+        let chart = ui.interact(
+            chart_rect,
             egui::Id::new("chart_nav"),
             egui::Sense::click_and_drag(),
         );
-        self.hover_pos = response.hover_pos();
+        self.hover_pos = chart.hover_pos();
 
         let total = self.state.bars().len() + usize::from(self.state.partial().is_some());
-        if total == 0 {
-            return;
-        }
 
-        if response.dragged() {
-            let slot = plot.width() / self.viewport.visible_bars().max(1.0);
+        if total > 0 && chart.dragged() {
+            let drag = chart.drag_delta();
+            // Horizontal → time pan.
+            let slot = chart_rect.width() / self.viewport.visible_bars().max(1.0);
             if slot > 0.0 {
-                self.viewport.pan(response.drag_delta().x / slot, total);
+                self.viewport.pan(drag.x / slot, total);
+            }
+            // Vertical → price pan. Dragging down moves the view to higher prices.
+            if let Some(auto) = auto
+                && drag.y != 0.0
+                && height > 1.0
+            {
+                let (lo, hi) = self.price_view.resolve(auto);
+                let price_per_px = (hi - lo) / f64::from(height);
+                self.price_view.pan(f64::from(drag.y) * price_per_px, auto);
             }
         }
-        if response.double_clicked() {
+        if chart.double_clicked() {
             self.viewport.snap_to_live();
+            self.price_view.reset();
         }
-        if response.hovered() {
+        if chart.hovered() {
             let scroll = ui.input(|i| i.raw_scroll_delta.y);
             if scroll.abs() > 0.0 {
                 // Scroll up (positive) zooms in; each notch is a gentle step.
                 self.viewport.zoom(2.0_f32.powf(-scroll / 300.0));
             }
         }
+
+        // Right price gutter: drag or scroll to zoom the price scale.
+        let axis = ui.interact(
+            axis_rect,
+            egui::Id::new("axis_nav"),
+            egui::Sense::click_and_drag(),
+        );
+        if let Some(auto) = auto {
+            if axis.dragged() {
+                // Drag down → expand span (smaller candles); up → compress (bigger).
+                let factor = f64::from(axis.drag_delta().y / 150.0).exp();
+                self.price_view.zoom(factor, auto);
+            }
+            if axis.double_clicked() {
+                self.price_view.reset();
+            }
+            if axis.hovered() {
+                let scroll = ui.input(|i| i.raw_scroll_delta.y);
+                if scroll.abs() > 0.0 {
+                    self.price_view.zoom(f64::from(-scroll / 200.0).exp(), auto);
+                }
+            }
+        }
     }
 
-    fn draw_chart(&self, painter: &egui::Painter, area: egui::Rect) {
+    fn draw_chart(&mut self, painter: &egui::Painter, area: egui::Rect) {
         painter.rect_filled(area, egui::Rounding::ZERO, self.bg());
-        let plot = area.shrink(16.0);
 
         let closed = self.state.bars();
         let partial = self.state.partial();
@@ -340,14 +398,7 @@ impl QuantickApp {
             return;
         }
 
-        // Reserve a gutter on the right for the price axis.
-        let chart_rect = egui::Rect::from_min_max(
-            plot.min,
-            egui::pos2(
-                (plot.right() - AXIS_GUTTER).max(plot.left() + 20.0),
-                plot.bottom(),
-            ),
-        );
+        let (chart_rect, _axis_rect) = plot_split(area);
 
         let (start, end) = self.viewport.visible_range(total);
         let visible_count = end.saturating_sub(start).max(1);
@@ -358,7 +409,8 @@ impl QuantickApp {
         let visible_closed = &closed[closed_start..closed_end];
         let partial_visible = partial.filter(|_| closed.len() >= start && closed.len() < end);
 
-        let Some(scale) = PriceScale::auto(
+        // Auto-fit the visible bars, then apply any manual price pan/zoom.
+        let Some(auto_scale) = PriceScale::auto(
             visible_closed,
             partial_visible,
             chart_rect.top(),
@@ -367,6 +419,10 @@ impl QuantickApp {
         ) else {
             return;
         };
+        let auto_range = auto_scale.range();
+        let (lo, hi) = self.price_view.resolve(auto_range);
+        let scale = PriceScale::from_range(lo, hi, chart_rect.top(), chart_rect.bottom());
+
         let axis = TimeAxis::new(
             chart_rect.left(),
             chart_rect.right(),
@@ -396,7 +452,12 @@ impl QuantickApp {
 
         self.draw_backfill_divider(painter, &axis, chart_rect, start, end);
         self.draw_crosshair(painter, chart_rect, &scale);
-        self.draw_header(painter, plot);
+        self.draw_header(painter, chart_rect);
+
+        // Cache the auto range + height for next frame's input handler, which
+        // runs before the draw and needs them for pixel↔price conversion.
+        self.last_auto_range = Some(auto_range);
+        self.last_chart_height = chart_rect.height();
     }
 
     /// Right-hand price axis: round-number gridlines and labels.
@@ -527,13 +588,19 @@ impl QuantickApp {
         } else {
             "history · double-click for live"
         };
+        let price_mode = if self.price_view.is_auto() {
+            ""
+        } else {
+            " · price: manual (double-click to auto-fit)"
+        };
         let header = format!(
-            "{} · {} · {} backfilled + {} live bars · {}",
+            "{} · {} · {} backfilled + {} live bars · {}{}",
             self.symbol,
             self.state.spec().summary(),
             backfilled,
             live,
-            mode
+            mode,
+            price_mode
         );
         painter.text(
             egui::pos2(plot.left(), plot.top()),

--- a/crates/app/src/chart.rs
+++ b/crates/app/src/chart.rs
@@ -62,6 +62,25 @@ impl PriceScale {
         })
     }
 
+    /// A scale over an explicit `[lo, hi]` price range mapped to `[top, bottom]`
+    /// pixels. Used when the price axis is under manual pan/zoom rather than
+    /// auto-fitting the visible bars.
+    #[must_use]
+    pub fn from_range(lo: f64, hi: f64, top: f32, bottom: f32) -> Self {
+        // Guard against an inverted or zero span.
+        let (lo, hi) = if hi > lo {
+            (lo, hi)
+        } else {
+            (lo - 0.5, lo + 0.5)
+        };
+        Self {
+            lo,
+            hi,
+            top,
+            bottom,
+        }
+    }
+
     /// The y-pixel for `price`.
     #[must_use]
     pub fn y(&self, price: f64) -> f32 {

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -14,6 +14,7 @@ mod app;
 mod chart;
 mod feed;
 mod metrics;
+mod price_view;
 mod state;
 mod style;
 mod viewport;

--- a/crates/app/src/price_view.rs
+++ b/crates/app/src/price_view.rs
@@ -1,0 +1,117 @@
+//! Manual price-axis control (vertical pan and zoom).
+//!
+//! By default the price axis auto-fits the visible bars. Once the user drags the
+//! chart vertically (pan) or drags the price gutter (zoom), the axis switches to
+//! an explicit `(lo, hi)` range that holds as new bars arrive — TradingView
+//! behaviour — until reset back to auto-fit. This is the pure state behind that,
+//! unit-tested in CI.
+
+/// The vertical price view: auto-fit, or a manual price range.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct PriceView {
+    /// `Some((lo, hi))` when the user has taken manual control; `None` auto-fits.
+    manual: Option<(f64, f64)>,
+}
+
+impl PriceView {
+    /// A view that auto-fits the visible bars.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Whether the axis is auto-fitting (not under manual control).
+    #[must_use]
+    pub fn is_auto(&self) -> bool {
+        self.manual.is_none()
+    }
+
+    /// The `(lo, hi)` range to display: the manual range if set, else `auto`.
+    #[must_use]
+    pub fn resolve(&self, auto: (f64, f64)) -> (f64, f64) {
+        self.manual.unwrap_or(auto)
+    }
+
+    /// Return to auto-fitting the visible bars.
+    pub fn reset(&mut self) {
+        self.manual = None;
+    }
+
+    /// Pan the price window by `delta` price units (shifts both bounds), taking
+    /// manual control from the current resolved range.
+    pub fn pan(&mut self, delta: f64, auto: (f64, f64)) {
+        if delta == 0.0 || !delta.is_finite() {
+            return;
+        }
+        let (lo, hi) = self.resolve(auto);
+        self.manual = Some((lo + delta, hi + delta));
+    }
+
+    /// Zoom the price span by `factor` around its centre: `> 1` expands the span
+    /// (smaller candles), `< 1` compresses it (bigger candles).
+    pub fn zoom(&mut self, factor: f64, auto: (f64, f64)) {
+        if factor <= 0.0 || !factor.is_finite() {
+            return;
+        }
+        let (lo, hi) = self.resolve(auto);
+        let center = f64::midpoint(lo, hi);
+        let half = ((hi - lo) / 2.0 * factor).max(1e-9);
+        self.manual = Some((center - half, center + half));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const AUTO: (f64, f64) = (100.0, 110.0);
+
+    #[test]
+    fn auto_by_default() {
+        let v = PriceView::new();
+        assert!(v.is_auto());
+        assert_eq!(v.resolve(AUTO), AUTO);
+    }
+
+    #[test]
+    fn pan_shifts_both_bounds_and_takes_manual_control() {
+        let mut v = PriceView::new();
+        v.pan(5.0, AUTO); // shift up by 5
+        assert!(!v.is_auto());
+        assert_eq!(v.resolve(AUTO), (105.0, 115.0));
+
+        // A different auto range is now ignored — the manual range holds.
+        assert_eq!(v.resolve((200.0, 210.0)), (105.0, 115.0));
+    }
+
+    #[test]
+    fn zoom_scales_span_around_center() {
+        let mut v = PriceView::new();
+        // center 105, span 10. factor 2 -> span 20 -> (95, 115).
+        v.zoom(2.0, AUTO);
+        assert_eq!(v.resolve(AUTO), (95.0, 115.0));
+
+        // factor 0.5 from the current (95,115): center 105, span 20 -> 10 -> (100,110).
+        v.zoom(0.5, AUTO);
+        let (lo, hi) = v.resolve(AUTO);
+        assert!((lo - 100.0).abs() < 1e-9 && (hi - 110.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn reset_returns_to_auto() {
+        let mut v = PriceView::new();
+        v.pan(5.0, AUTO);
+        v.reset();
+        assert!(v.is_auto());
+        assert_eq!(v.resolve(AUTO), AUTO);
+    }
+
+    #[test]
+    fn degenerate_inputs_are_ignored() {
+        let mut v = PriceView::new();
+        v.pan(f64::NAN, AUTO);
+        v.zoom(0.0, AUTO);
+        v.zoom(-1.0, AUTO);
+        assert!(v.is_auto(), "no-op operations don't take manual control");
+    }
+}


### PR DESCRIPTION
## Summary

TradingView-style price-axis control:
- **Drag the chart** (centre) — pans **time** (horizontal) *and* **price** (vertical): the chart moves up/down/sideways with the mouse.
- **Drag the right price gutter** up/down — **zooms the price scale**, stretching or compressing the candles (and the axis).
- Scroll over the chart zooms time; scroll over the gutter zooms price. **Double-click** resets to the live edge + auto-fit.

Closes #49

## Design decisions

1. **`PriceView`: auto-fit by default, manual `(lo, hi)` once touched.** Like the horizontal follow-live model (#43), the price axis auto-fits the visible bars until you pan/zoom it; then it holds an *absolute* range that new bars don't drift — you inspect a fixed price window until you double-click to reset. Pure and unit-tested (pan/zoom/resolve/reset, degenerate-input no-ops).
2. **Chart drag pans both axes; gutter drag zooms price.** Matches TradingView: grab the canvas to move freely, grab the scale to stretch it. One `plot_split` helper gives the input handler and the renderer the same chart/gutter boundary.
3. **The input handler runs before the draw, so it reads a one-frame-cached auto range + height** for pixel↔price conversion. The auto range barely changes frame to frame, so the lag is imperceptible, and it avoids recomputing the visible slice twice per frame.
4. **`PriceScale::from_range`** lets the grid, labels, crosshair and candles all follow the resolved (possibly manual) range — one source of truth.

## Verification loop

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (app: 35 tests, incl. 5 `PriceView` tests)

## Notes for the reviewer

- `PriceView` (the load-bearing logic) is unit-tested; the egui drag/scroll mapping is thin glue. I tried to auto-verify the drag with simulated mouse events, but couldn't reliably target the window on a busy multi-window desktop (a File Explorer intercepted the drag), so **the drag *directions* are best confirmed interactively**. If vertical pan or axis-zoom feels inverted, each is a one-line sign flip in `handle_navigation` (the `drag.y`/`scroll` sign in the `pan`/`zoom` calls).
