### PR TITLE
feat(app): load more past history on demand, with configurable depth

### DIFF
--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -17,7 +17,7 @@ use tokio::sync::mpsc;
 use quantick_engine::Bar;
 
 use crate::chart::{PriceScale, to_f64};
-use crate::feed::FeedEvent;
+use crate::feed::{FeedCommand, FeedEvent, FeedHandle};
 use crate::metrics::{self, FrameStats};
 use crate::price_view::PriceView;
 use crate::state::{BarKind, BarSpec, ChartState};
@@ -88,7 +88,13 @@ fn fmt_time(ms: i64) -> String {
 pub struct QuantickApp {
     state: ChartState,
     events: mpsc::Receiver<FeedEvent>,
+    commands: mpsc::Sender<FeedCommand>,
     symbol: String,
+
+    // How many older trades to pull per "load older" click, and how many
+    // trades have been backfilled in total (for the readout).
+    history_step: usize,
+    history_trades: usize,
 
     // Bar-type selector state (one parameter retained per kind).
     kind: BarKind,
@@ -123,11 +129,7 @@ pub struct QuantickApp {
 impl QuantickApp {
     /// Create the app for `symbol` starting from `spec`, draining `events`.
     #[must_use]
-    pub fn new(
-        symbol: impl Into<String>,
-        spec: BarSpec,
-        events: mpsc::Receiver<FeedEvent>,
-    ) -> Self {
+    pub fn new(symbol: impl Into<String>, spec: BarSpec, feed: FeedHandle) -> Self {
         // Defaults for every kind, with the initial spec's parameter applied.
         let mut tick_n = 50;
         let mut volume_units = 5.0;
@@ -143,8 +145,11 @@ impl QuantickApp {
         Self {
             kind: spec.kind(),
             state: ChartState::new(spec),
-            events,
+            events: feed.events,
+            commands: feed.commands,
             symbol: symbol.into(),
+            history_step: 2000,
+            history_trades: 0,
             tick_n,
             volume_units,
             dollar_notional,
@@ -218,10 +223,47 @@ impl QuantickApp {
                 }
             }
             ui.separator();
+            // History: pull older trades on demand, N per click.
+            ui.label("history +");
+            ui.add(
+                egui::DragValue::new(&mut self.history_step)
+                    .range(500.0..=50_000.0)
+                    .speed(100.0),
+            );
+            if ui
+                .button("⟲ load older")
+                .on_hover_text("fetch older trades and prepend them")
+                .clicked()
+            {
+                self.request_older_history();
+            }
+            ui.label(format!("({} trades)", self.history_trades));
+            ui.separator();
             if ui.button("⚙ style").clicked() {
                 self.show_style = !self.show_style;
             }
         });
+    }
+
+    /// Ask the feed thread to fetch and prepend `history_step` older trades.
+    /// Non-blocking: if a request is already queued, this frame's click is
+    /// dropped rather than piling up commands.
+    fn request_older_history(&mut self) {
+        match self.commands.try_send(FeedCommand::LoadOlder {
+            count: self.history_step.max(1),
+        }) {
+            Ok(()) => tracing::info!(
+                target: "quantick::app",
+                count = self.history_step,
+                "requested older history"
+            ),
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                tracing::debug!(target: "quantick::app", "older-history request already pending");
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                tracing::warn!(target: "quantick::app", "feed command channel closed");
+            }
+        }
     }
 
     /// The current background colour as an egui `Color32`.
@@ -275,7 +317,14 @@ impl QuantickApp {
                     if let Some(last) = trades.last() {
                         self.latest_trade_ms = Some(last.timestamp_ms);
                     }
+                    self.history_trades += trades.len();
                     self.state.ingest_backfill(&trades);
+                }
+                Ok(FeedEvent::HistoryPrepended(trades)) => {
+                    // Older bars shift every index up; keep the view steady.
+                    self.history_trades += trades.len();
+                    let added = self.state.prepend_history(&trades);
+                    self.viewport.shift_right_edge(added);
                 }
                 Ok(FeedEvent::Live(trade)) => {
                     self.latest_trade_ms = Some(trade.timestamp_ms);

--- a/crates/app/src/feed.rs
+++ b/crates/app/src/feed.rs
@@ -3,33 +3,64 @@
 //! A background thread runs a tokio runtime that first backfills recent history
 //! over REST, then streams live trades (with reconnect + gap detection). Both
 //! are pushed onto a channel the UI drains each frame via `try_recv` — no async
-//! on the UI thread.
+//! on the UI thread. The UI can also send commands back (e.g. "load older
+//! history"), which the feed thread services between live trades.
 
 use tokio::sync::mpsc;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 use quantick_engine::Trade;
 use quantick_feed_binance::{
-    BINANCE_WS_BASE, Backoff, BinanceHttp, agg_trade_url, backfill, run_with_reconnect,
+    BINANCE_WS_BASE, Backoff, BinanceHttp, agg_trade_url, backfill, backfill_before,
+    run_with_reconnect,
 };
 
-/// How many recent trades to backfill so the chart opens populated.
-pub const BACKFILL_TARGET: usize = 500;
+/// Default number of recent trades to backfill so the chart opens populated,
+/// when `QUANTICK_BACKFILL` is unset. One REST page.
+pub const DEFAULT_BACKFILL_TARGET: usize = 1000;
 
 /// A message from the feed thread to the UI, tagged by source so the chart can
 /// label backfilled vs live data honestly.
 pub enum FeedEvent {
     /// The whole backfilled history, delivered as one batch.
     Backfilled(Vec<Trade>),
+    /// Older history pulled on demand, to prepend in front of what's loaded.
+    HistoryPrepended(Vec<Trade>),
     /// One live trade.
     Live(Trade),
 }
 
-/// Start the feed for `symbol` on a background thread, returning the receiver
-/// the UI drains. Dropping the receiver stops the feed.
+/// A command from the UI to the feed thread.
+pub enum FeedCommand {
+    /// Fetch `count` more trades older than the earliest one loaded.
+    LoadOlder { count: usize },
+}
+
+/// The UI's handle on a running feed: events to drain, commands to send.
+pub struct FeedHandle {
+    /// Feed → UI: backfill, prepended history and live trades.
+    pub events: mpsc::Receiver<FeedEvent>,
+    /// UI → feed: on-demand history loading.
+    pub commands: mpsc::Sender<FeedCommand>,
+}
+
+/// The initial backfill depth: `QUANTICK_BACKFILL` if it parses to a positive
+/// integer, else [`DEFAULT_BACKFILL_TARGET`].
 #[must_use]
-pub fn spawn(symbol: &str) -> mpsc::Receiver<FeedEvent> {
+pub fn initial_backfill_target() -> usize {
+    std::env::var("QUANTICK_BACKFILL")
+        .ok()
+        .and_then(|v| v.trim().parse::<usize>().ok())
+        .filter(|&n| n > 0)
+        .unwrap_or(DEFAULT_BACKFILL_TARGET)
+}
+
+/// Start the feed for `symbol` on a background thread, returning the handle the
+/// UI drains and sends commands through. Dropping the handle stops the feed.
+#[must_use]
+pub fn spawn(symbol: &str) -> FeedHandle {
     let (tx, rx) = mpsc::channel(4096);
+    let (cmd_tx, cmd_rx) = mpsc::channel(16);
     let symbol = symbol.to_string();
     std::thread::Builder::new()
         .name("quantick-feed".into())
@@ -39,18 +70,30 @@ pub fn spawn(symbol: &str) -> mpsc::Receiver<FeedEvent> {
                 .enable_all()
                 .build()
                 .expect("build feed runtime");
-            runtime.block_on(feed_task(symbol, tx));
+            runtime.block_on(feed_task(symbol, tx, cmd_rx));
         })
         .expect("spawn feed thread");
-    rx
+    FeedHandle {
+        events: rx,
+        commands: cmd_tx,
+    }
 }
 
-async fn feed_task(symbol: String, tx: mpsc::Sender<FeedEvent>) {
-    // 1. Backfill recent history so the chart opens populated.
+async fn feed_task(
+    symbol: String,
+    tx: mpsc::Sender<FeedEvent>,
+    mut cmd_rx: mpsc::Receiver<FeedCommand>,
+) {
     let http = BinanceHttp::new();
-    match backfill(&http, &symbol, BACKFILL_TARGET).await {
+    let target = initial_backfill_target();
+
+    // 1. Backfill recent history so the chart opens populated. Remember the
+    //    earliest agg_id so we can page further back on demand.
+    let mut earliest_id: Option<u64> = None;
+    match backfill(&http, &symbol, target).await {
         Ok(trades) => {
-            info!(target: "quantick::app", symbol, count = trades.len(), "backfill ready");
+            earliest_id = trades.first().map(|t| t.agg_id);
+            info!(target: "quantick::app", symbol, count = trades.len(), target, "backfill ready");
             if tx.send(FeedEvent::Backfilled(trades)).await.is_err() {
                 return; // UI gone
             }
@@ -65,7 +108,8 @@ async fn feed_task(symbol: String, tx: mpsc::Sender<FeedEvent>) {
     }
 
     // 2. Stream live trades on top, reconnecting as needed. run_with_reconnect
-    //    speaks Trade; a small forwarder tags each as a live FeedEvent.
+    //    speaks Trade; the loop below tags each as a live FeedEvent and, in the
+    //    same select, services UI commands between trades.
     let (live_tx, mut live_rx) = mpsc::channel::<Trade>(4096);
     let url = agg_trade_url(BINANCE_WS_BASE, &symbol);
     // Fixed seed: a single desktop client, so jitter needs no cross-client
@@ -73,10 +117,64 @@ async fn feed_task(symbol: String, tx: mpsc::Sender<FeedEvent>) {
     let backoff = Backoff::for_feed(0x9E37_79B9_7F4A_7C15);
     let reconnect = tokio::spawn(async move { run_with_reconnect(&url, &live_tx, backoff).await });
 
-    while let Some(trade) = live_rx.recv().await {
-        if tx.send(FeedEvent::Live(trade)).await.is_err() {
-            break; // UI gone
+    loop {
+        tokio::select! {
+            maybe_trade = live_rx.recv() => {
+                match maybe_trade {
+                    Some(trade) => {
+                        if tx.send(FeedEvent::Live(trade)).await.is_err() {
+                            break; // UI gone
+                        }
+                    }
+                    None => break, // stream ended
+                }
+            }
+            maybe_cmd = cmd_rx.recv() => {
+                match maybe_cmd {
+                    Some(FeedCommand::LoadOlder { count }) => {
+                        earliest_id = load_older(&http, &symbol, earliest_id, count, &tx).await;
+                        if tx.is_closed() {
+                            break; // UI gone
+                        }
+                    }
+                    None => break, // UI dropped the command sender: it's gone
+                }
+            }
         }
     }
     reconnect.abort();
+}
+
+/// Fetch `count` trades older than `earliest`, send them to the UI, and return
+/// the new earliest agg_id (unchanged if nothing older was available or a fetch
+/// failed). `None` earliest means there is no history to page back from.
+async fn load_older(
+    http: &BinanceHttp,
+    symbol: &str,
+    earliest: Option<u64>,
+    count: usize,
+    tx: &mpsc::Sender<FeedEvent>,
+) -> Option<u64> {
+    let Some(before) = earliest else {
+        warn!(target: "quantick::app", "load older ignored: no history to page back from");
+        return None;
+    };
+    match backfill_before(http, symbol, before, count).await {
+        Ok(older) if !older.is_empty() => {
+            let new_earliest = older.first().map(|t| t.agg_id);
+            info!(target: "quantick::app", symbol, count = older.len(), "older history ready");
+            if tx.send(FeedEvent::HistoryPrepended(older)).await.is_err() {
+                return earliest; // UI gone; caller notices via tx.is_closed()
+            }
+            new_earliest
+        }
+        Ok(_) => {
+            info!(target: "quantick::app", symbol, "no older history available");
+            earliest
+        }
+        Err(e) => {
+            error!(target: "quantick::app", symbol, %e, "load older failed");
+            earliest
+        }
+    }
 }

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -43,7 +43,7 @@ fn main() -> eframe::Result {
         "starting quantick"
     );
 
-    let events = feed::spawn(SYMBOL);
+    let feed = feed::spawn(SYMBOL);
 
     let options = eframe::NativeOptions {
         viewport: egui::ViewportBuilder::default()
@@ -59,7 +59,7 @@ fn main() -> eframe::Result {
             Ok(Box::new(app::QuantickApp::new(
                 SYMBOL,
                 BarSpec::Tick(TICK_SIZE),
-                events,
+                feed,
             )))
         }),
     )

--- a/crates/app/src/state.rs
+++ b/crates/app/src/state.rs
@@ -143,6 +143,30 @@ impl ChartState {
         self.refresh_partial();
     }
 
+    /// Prepend older backfilled history to the front of the retained stream.
+    ///
+    /// `trades` must be strictly older than everything already retained (the
+    /// feed guarantees this by paging backward from the earliest known
+    /// `agg_id`). Because count-based bars (tick/volume/dollar) are grouped from
+    /// the first trade, adding older trades re-aligns every bar — so this rebuilds
+    /// the whole series through the same deterministic engine path rather than
+    /// pretending the existing bars are untouched (data-honesty rule). The
+    /// backfill/live boundary is recomputed. Returns how many net bars were added
+    /// so the caller can keep the visible window steady.
+    pub fn prepend_history(&mut self, trades: &[Trade]) -> usize {
+        if trades.is_empty() {
+            return 0;
+        }
+        let bars_before = self.bars.len();
+        let mut combined = Vec::with_capacity(trades.len() + self.trades.len());
+        combined.extend_from_slice(trades);
+        combined.append(&mut self.trades);
+        self.trades = combined;
+        self.backfill_trade_count += trades.len();
+        self.rebuild();
+        self.bars.len().saturating_sub(bars_before)
+    }
+
     /// Ingest one live trade, incrementally (no full rebuild).
     pub fn ingest_live(&mut self, trade: &Trade) {
         self.trades.push(trade.clone());
@@ -295,6 +319,36 @@ mod tests {
         s.set_spec(BarSpec::Tick(4));
         assert_eq!(s.bars().len(), 1);
         assert_eq!(s.backfill_boundary(), Some(0));
+    }
+
+    #[test]
+    fn prepend_history_adds_older_bars_and_keeps_boundary() {
+        let mut s = ChartState::new(BarSpec::Tick(2));
+        s.ingest_backfill(&[trade(5), trade(6), trade(7), trade(8)]); // 2 bars
+        s.ingest_live(&trade(9)); // opens a partial, still 2 closed bars
+        assert_eq!(s.bars().len(), 2);
+        assert_eq!(s.backfill_boundary(), Some(2));
+
+        // Pull in the four older trades 1..=4.
+        let added = s.prepend_history(&[trade(1), trade(2), trade(3), trade(4)]);
+        // tick(2) over 1..=8 backfill = 4 closed bars; trade 9 is the partial.
+        assert_eq!(s.bars().len(), 4);
+        assert_eq!(added, 2, "two net bars were prepended");
+        assert_eq!(
+            s.backfill_boundary(),
+            Some(4),
+            "all eight retained backfill trades are history"
+        );
+    }
+
+    #[test]
+    fn prepend_empty_history_is_a_noop() {
+        let mut s = ChartState::new(BarSpec::Tick(2));
+        s.ingest_backfill(&[trade(1), trade(2)]);
+        let before = s.bars().len();
+        let added = s.prepend_history(&[]);
+        assert_eq!(added, 0);
+        assert_eq!(s.bars().len(), before);
     }
 
     #[test]

--- a/crates/app/src/viewport.rs
+++ b/crates/app/src/viewport.rs
@@ -98,6 +98,16 @@ impl Viewport {
         self.follow = true;
     }
 
+    /// Account for `added` bars newly prepended at the front of the series: shift
+    /// the right-edge bar index by the same amount so the visible window keeps
+    /// showing the same bars instead of jumping. A no-op while following live —
+    /// the newest bar, and thus the right edge, is unchanged.
+    pub fn shift_right_edge(&mut self, added: usize) {
+        if !self.follow && added > 0 {
+            self.right_bar += added as f32;
+        }
+    }
+
     /// The x-pixel centre of bar `index`, given the chart's right edge x and the
     /// series length. The newest bar sits half a candle in from `chart_right`.
     #[must_use]
@@ -200,6 +210,24 @@ mod tests {
             start < end && (898..=900).contains(&start),
             "start = {start}"
         );
+    }
+
+    #[test]
+    fn shift_right_edge_keeps_the_history_view_steady() {
+        let mut v = Viewport::new();
+        v.pan_pixels(24.0, 10); // leave follow; right edge at bar 6 of 10
+        let before = v.right_edge_bar(10);
+        v.shift_right_edge(100); // 100 older bars prepended (total now 110)
+        assert!(!v.follows_live());
+        assert!((v.right_edge_bar(110) - (before + 100.0)).abs() < 0.001);
+    }
+
+    #[test]
+    fn shift_right_edge_is_a_noop_while_following() {
+        let mut v = Viewport::new(); // follows the newest
+        v.shift_right_edge(100);
+        assert!(v.follows_live());
+        assert_eq!(v.right_edge_bar(110), 109.0);
     }
 
     #[test]

--- a/crates/feed-binance/src/backfill.rs
+++ b/crates/feed-binance/src/backfill.rs
@@ -210,6 +210,76 @@ pub async fn backfill<S: AggTradeSource>(
     Ok(trades)
 }
 
+/// Backfill up to `count` trades *older than* `before_id`, ascending by agg_id.
+///
+/// Pages backward from `before_id` (exclusive) until `count` older trades are
+/// collected or the earliest trade is reached. Returns the trades closest to
+/// `before_id` so they sit contiguously in front of the history already loaded;
+/// returns fewer than `count` (or empty) when there is not that much older
+/// history. Deduping through a [`BTreeMap`] keeps the merge ordered and
+/// deterministic.
+///
+/// # Errors
+///
+/// Returns [`FeedError`] on any fetch/decode/map failure. Mapping fails fast: a
+/// malformed price is surfaced, never silently dropped (data-honesty rule).
+#[instrument(target = "quantick::feed", skip(source), fields(pages = tracing::field::Empty))]
+pub async fn backfill_before<S: AggTradeSource>(
+    source: &S,
+    symbol: &str,
+    before_id: u64,
+    count: usize,
+) -> Result<Vec<Trade>, FeedError> {
+    if before_id == 0 || count == 0 {
+        return Ok(Vec::new()); // nothing older exists, or nothing requested
+    }
+    let mut collected: BTreeMap<u64, AggTrade> = BTreeMap::new();
+    let mut pages = 0u32;
+    // Exclusive upper bound of the region still to fetch.
+    let mut cursor = before_id;
+
+    while collected.len() < count && cursor > 0 {
+        let from = cursor.saturating_sub(u64::from(MAX_PAGE_LIMIT));
+        let batch = source.fetch(symbol, Some(from), MAX_PAGE_LIMIT).await?;
+        pages += 1;
+        let before = collected.len();
+        for t in batch {
+            if t.agg_id < before_id {
+                collected.entry(t.agg_id).or_insert(t);
+            }
+        }
+        if from == 0 {
+            break; // reached the very first trade
+        }
+        if collected.len() == before {
+            debug!(target: "quantick::feed", "no new older trades from page; stopping");
+            break; // no progress; avoid looping forever
+        }
+        cursor = from;
+    }
+
+    // Keep the `count` closest to `before_id` (the most recent of the older
+    // trades), ascending, and map to engine trades.
+    let all: Vec<&AggTrade> = collected.values().collect();
+    let start = all.len().saturating_sub(count);
+    let trades = all[start..]
+        .iter()
+        .map(|a| a.to_trade())
+        .collect::<Result<Vec<Trade>, _>>()?;
+
+    tracing::Span::current().record("pages", pages);
+    info!(
+        target: "quantick::feed",
+        symbol,
+        before_id,
+        count,
+        fetched = trades.len(),
+        pages,
+        "older backfill complete"
+    );
+    Ok(trades)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -309,6 +379,97 @@ mod tests {
             }],
         };
         let err = backfill(&source, "BTCUSDT", 10).await.unwrap_err();
+        assert!(matches!(err, FeedError::Map(_)), "{err}");
+    }
+
+    #[tokio::test]
+    async fn backfill_before_returns_the_trades_just_before_the_id() {
+        let source = FakeSource::with_count(2500);
+        // The 500 trades immediately older than id 2000 are ids 1500..=1999.
+        let trades = backfill_before(&source, "BTCUSDT", 2000, 500)
+            .await
+            .unwrap();
+        assert_eq!(trades.len(), 500);
+        assert_eq!(trades.first().unwrap().agg_id, 1500);
+        assert_eq!(trades.last().unwrap().agg_id, 1999);
+        for pair in trades.windows(2) {
+            assert!(pair[1].agg_id > pair[0].agg_id);
+        }
+    }
+
+    #[tokio::test]
+    async fn backfill_before_pages_backward_across_multiple_requests() {
+        let source = FakeSource::with_count(2500);
+        // 1500 older than 2000 spans two pages: ids 500..=1999.
+        let trades = backfill_before(&source, "BTCUSDT", 2000, 1500)
+            .await
+            .unwrap();
+        assert_eq!(trades.len(), 1500);
+        assert_eq!(trades.first().unwrap().agg_id, 500);
+        assert_eq!(trades.last().unwrap().agg_id, 1999);
+    }
+
+    #[tokio::test]
+    async fn backfill_before_returns_all_when_older_history_is_short() {
+        let source = FakeSource::with_count(30);
+        // Only ids 1..=9 are older than 10, fewer than the 100 requested.
+        let trades = backfill_before(&source, "BTCUSDT", 10, 100).await.unwrap();
+        assert_eq!(trades.len(), 9);
+        assert_eq!(trades.first().unwrap().agg_id, 1);
+        assert_eq!(trades.last().unwrap().agg_id, 9);
+    }
+
+    #[tokio::test]
+    async fn backfill_before_the_first_trade_is_empty() {
+        let source = FakeSource::with_count(500);
+        assert!(
+            backfill_before(&source, "BTCUSDT", 1, 100)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        assert!(
+            backfill_before(&source, "BTCUSDT", 0, 100)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn backfill_before_zero_count_is_empty() {
+        let source = FakeSource::with_count(500);
+        assert!(
+            backfill_before(&source, "BTCUSDT", 200, 0)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn backfill_before_fails_fast_on_bad_data() {
+        let source = FakeSource {
+            trades: vec![
+                AggTrade {
+                    agg_id: 1,
+                    price: "oops".to_string(),
+                    quantity: "1.0".to_string(),
+                    trade_time_ms: 0,
+                    is_buyer_maker: false,
+                },
+                AggTrade {
+                    agg_id: 2,
+                    price: "100.0".to_string(),
+                    quantity: "1.0".to_string(),
+                    trade_time_ms: 1,
+                    is_buyer_maker: false,
+                },
+            ],
+        };
+        let err = backfill_before(&source, "BTCUSDT", 2, 10)
+            .await
+            .unwrap_err();
         assert!(matches!(err, FeedError::Map(_)), "{err}");
     }
 

--- a/crates/feed-binance/src/lib.rs
+++ b/crates/feed-binance/src/lib.rs
@@ -15,7 +15,7 @@ pub mod reconnect;
 pub mod stream;
 pub mod wire;
 
-pub use backfill::{AggTradeSource, BinanceHttp, FeedError, backfill};
+pub use backfill::{AggTradeSource, BinanceHttp, FeedError, backfill, backfill_before};
 pub use continuity::{Anomaly, ContinuityTracker};
 pub use reconnect::{Backoff, run_with_reconnect};
 pub use stream::{BINANCE_WS_BASE, agg_trade_url, run_agg_trade_stream};


### PR DESCRIPTION
## What & why

The chart only backfilled a fixed **500** recent trades on startup — with `tick(50)` that is ~10 candles, far too little past to read. This adds a way to pull in **more history from the past**, both **configurable at startup** and **loadable on demand**, so you can see a much better chart.

Closes #53.

## Changes

- **`feed-binance` — `backfill_before(source, symbol, before_id, count)`**: a pure function that pages backward from an `agg_id`, collecting up to `count` older aggTrades contiguous with the history already loaded (ascending by `agg_id`). Same data-honesty rule as `backfill` — a malformed trade fails fast.
- **`app/feed.rs`**: a UI → feed command channel (`FeedCommand::LoadOlder { count }`) and a new `FeedEvent::HistoryPrepended`. The feed thread tracks the earliest `agg_id` and services load-older commands between live trades with `tokio::select!`. **Initial backfill depth is configurable via the `QUANTICK_BACKFILL` env var** (default 1000).
- **`app/state.rs` — `prepend_history`**: inserts older trades at the front of the retained stream and rebuilds bars through the same deterministic engine path. Count-based bars (tick/volume/dollar) group from the first trade, so adding older data re-aligns every bar — rebuilt honestly rather than pretending existing bars are untouched. The backfill/live boundary stays correct.
- **`app/viewport.rs` — `shift_right_edge`**: shifts the right-edge bar index by the number of prepended bars so the visible window stays put instead of jumping (no-op while following the live edge).
- **`app/app.rs`**: a **"⟲ load older"** button with a configurable per-click step (`history +`) and a trades-loaded readout in the controls bar; drains `HistoryPrepended`, prepends into state, and shifts the viewport.

## How to use

- **More history at startup**: `QUANTICK_BACKFILL=5000 cargo run -p quantick-app` (PowerShell: `$env:QUANTICK_BACKFILL=5000; cargo run -p quantick-app`).
- **More history while running**: set `history +` to the number of trades per click and press **⟲ load older**; each click prepends that many older trades. Drag left to view them.

## Acceptance criteria (issue #53)

- [x] `backfill_before` is pure and unit-tested (paging backward, dedup, short/empty history, fail-fast on bad data)
- [x] "load older" pulls more past trades and prepends them without disturbing live data; the view does not jump
- [x] Initial backfill depth configurable (`QUANTICK_BACKFILL`); per-click step configurable in the UI
- [x] `prepend_history` and `shift_right_edge` are pure and unit-tested; boundary stays correct
- [x] Verification loop green (fmt, clippy -D warnings, build, test)

## Verification

All four mandatory checks pass locally:

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo build --workspace`
- `cargo test --workspace` — 37 app + 24 feed tests, incl. 10 new (6 `backfill_before`, 2 `prepend_history`, 2 `shift_right_edge`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
