### PR TITLE
fix: harden PR #58 review findings — MT5 I/O edges, reconnect dedup, depth backoff

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,11 +14,12 @@ Real-time alternative bar charts (tick / volume / dollar / imbalance bars) for o
 Cargo workspace, crates under `crates/`:
 
 - `engine` (package `quantick-engine`) — raw trades in, alternative bars out. Headless and deterministic: no UI, no network, no async. Everything else depends on it; it depends on nothing else in the workspace.
-- `feed-binance` (package `quantick-feed-binance`) — live aggTrades feed from Binance public endpoints; produces the trade stream the engine consumes.
+- `orderbook` (package `quantick-orderbook`) — deterministic local order-book core: validated snapshots, absolute level updates, update-id continuity. A pure domain crate like `engine` (no network, no async, no clock); depends on nothing else in the workspace.
+- `feed-binance` (package `quantick-feed-binance`) — live aggTrades feed from Binance public endpoints; produces the trade stream the engine consumes. Also captures synchronized L2 depth into `orderbook` state.
 - `feed-mt5` (package `quantick-feed-mt5`) — MetaTrader 5 tick feed. Listens on a local TCP socket for the QuantickBridge EA (`bridge/mt5/`, MQL5) running inside the logged-in terminal; no credentials anywhere. Side inference policy, synthetic ids and server-time conversion are documented in its `lib.rs`.
 - `app` (package `quantick-app`) — desktop chart (egui/wgpu planned). A consumer of the engine, never the other way around. Feeds and symbols come from config (`crates/app/config/feeds.toml`, overridable via `QUANTICK_CONFIG` or `./quantick.toml`), never hardcoded.
 
-Dependency direction is one-way: `app` / `feed-*` → `engine`. Never add a reverse edge. Feed crates never depend on each other.
+Dependency direction is one-way: `app` / `feed-*` → `engine` / `orderbook` (the domain crates). Never add a reverse edge. Feed crates never depend on each other.
 
 ## Non-negotiable design rules
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="logo/logo.png" alt="quantick logo" width="220">
+</p>
+
 # quantick
 
 **Real-time alternative bar charts for order flow trading — and one engine to take your research from chart to backtest to bot.**

--- a/bridge/mt5/PROTOCOL.md
+++ b/bridge/mt5/PROTOCOL.md
@@ -84,8 +84,11 @@ Clean goodbye (EA removed, terminal closing). Anything after it is ignored.
 ## Error handling contract
 
 - Unknown **fields** in a known message: ignored (forward compatibility).
-- Unknown message **type** / malformed line: the feed skips and counts it
-  (`MT5_UNDECODABLE_LINE`), the session survives.
+- Unknown message **type** / malformed line / invalid UTF-8 line: the feed
+  skips and counts it (`MT5_UNDECODABLE_LINE`), the session survives.
+- A line longer than **64 KiB** (orders of magnitude above any protocol
+  line): the session is dropped (`MT5_LINE_TOO_LONG`) — an unbounded buffer
+  would let any local process exhaust the feed's memory.
 - Wrong first message, schema or symbol mismatch: session refused, feed keeps
   listening.
 - A session that dies mid-backfill discards the partial block; the next

--- a/bridge/mt5/QuantickBridge.mq5
+++ b/bridge/mt5/QuantickBridge.mq5
@@ -15,7 +15,7 @@
 //| JSON object with an event_code, so logs are machine-readable.      |
 //+------------------------------------------------------------------+
 #property copyright "quantick"
-#property version   "1.000"
+#property version   "1.001"
 #property description "Streams ticks to the quantick chart over a local socket"
 
 input string InpHost             = "127.0.0.1"; // Feed host (quantick listener)
@@ -23,10 +23,11 @@ input int    InpPort             = 9100;        // Feed port
 input int    InpBackfillMinutes  = 30;          // History to send on connect
 input int    InpHeartbeatSeconds = 5;           // Heartbeat interval
 input int    InpRetrySeconds     = 5;           // Reconnect backoff
+input int    InpSendTimeoutMs    = 5000;        // Max ms one send may block
 
 #define SCHEMA_VERSION 1
 #define BRIDGE_NAME    "quantick-mt5-bridge"
-#define BRIDGE_VERSION "0.1.0"
+#define BRIDGE_VERSION "0.1.1"
 
 int      g_socket           = INVALID_HANDLE;
 ulong    g_seq              = 0; // per-session tick sequence, from 1
@@ -47,6 +48,12 @@ void LogEvent(const string event_code, const string detail)
 
 //+------------------------------------------------------------------+
 //| Send one NDJSON line. False = socket is broken.                   |
+//|                                                                   |
+//| SocketSend runs on the terminal's main thread and may write only  |
+//| part of the buffer (send timeout, full OS buffer — quantick not   |
+//| reading). Each attempt is bounded by SocketTimeouts (set at       |
+//| connect); the remainder is retried so a slow read never corrupts  |
+//| line framing, and zero progress means the socket is gone.         |
 //+------------------------------------------------------------------+
 bool SendLine(string payload)
   {
@@ -57,7 +64,23 @@ bool SendLine(string payload)
    int len = StringToCharArray(payload, bytes, 0, WHOLE_ARRAY, CP_UTF8) - 1;
    if(len <= 0)
       return(true);
-   return(SocketSend(g_socket, bytes, len) == len);
+   int sent = 0;
+   while(sent < len)
+     {
+      int wrote;
+      if(sent == 0)
+         wrote = SocketSend(g_socket, bytes, len);
+      else
+        {
+         uchar rest[];
+         ArrayCopy(rest, bytes, 0, sent, len - sent);
+         wrote = SocketSend(g_socket, rest, len - sent);
+        }
+      if(wrote <= 0)
+         return(false);
+      sent += wrote;
+     }
+   return(true);
   }
 
 //+------------------------------------------------------------------+
@@ -192,6 +215,9 @@ void TryConnect()
       g_next_retry = TimeLocal() + InpRetrySeconds;
       return;
      }
+   // Bound every send: without this, a stalled reader can freeze the
+   // terminal's main thread inside SocketSend indefinitely.
+   SocketTimeouts(g_socket, (uint)InpSendTimeoutMs, (uint)InpSendTimeoutMs);
    if(!StartSession())
       Disconnect("send failed during session start");
   }

--- a/crates/app/src/feed/metatrader.rs
+++ b/crates/app/src/feed/metatrader.rs
@@ -15,6 +15,13 @@
 //!   [`FeedEvent::HistoryPrepended`] — but only while no trade has been
 //!   forwarded yet; after that, recovered history is forwarded as live to
 //!   keep the retained stream ordered (logged as such, never silent).
+//! - **Reconnect overlap is dropped, not double-counted**: the bridge
+//!   re-sends its recent-history window on every session, and synthetic ids
+//!   restart, so the only stable cross-session key is time. Recovered trades
+//!   are forwarded only when strictly newer than the last forwarded trade;
+//!   the dropped overlap count is logged. (Trades sharing the last forwarded
+//!   millisecond are dropped too — losing a same-ms tick to a reconnect is
+//!   honest; silently inflating bars is not.)
 //! - **"Load older" is unsupported**: every request is answered with an empty
 //!   reply plus a structured warning, so the UI's loader always resolves.
 //! - Order-book capture is unsupported (the UI already disables the heatmap
@@ -87,6 +94,9 @@ async fn feed_task(
     // Whether any trade reached the UI yet: the first non-empty history block
     // may be prepended only into an empty chart (see module docs).
     let mut forwarded_any = false;
+    // Newest trade timestamp forwarded to the UI. Reconnect history overlaps
+    // what was already streamed live; only strictly-newer trades pass.
+    let mut last_forwarded_ms = i64::MIN;
 
     loop {
         tokio::select! {
@@ -98,23 +108,35 @@ async fn feed_task(
                             continue;
                         }
                         if forwarded_any {
-                            // Reconnect history: forwarding as live keeps the
-                            // retained stream ordered. Labelled, not hidden.
+                            // Reconnect history: forward only what the UI has
+                            // not already seen. Labelled, not hidden.
+                            let resent = batch.len();
+                            let fresh: Vec<_> = batch
+                                .into_iter()
+                                .filter(|t| t.timestamp_ms > last_forwarded_ms)
+                                .collect();
                             info!(
                                 target: "quantick::app",
                                 schema_version = 1_u8,
                                 event_code = "MT5_RECOVERED_HISTORY_AS_LIVE",
                                 symbol = %symbol,
-                                count = batch.len(),
-                                "bridge re-sent history after a reconnect; forwarding in stream order"
+                                count = fresh.len(),
+                                overlap_dropped = resent - fresh.len(),
+                                "bridge re-sent history after a reconnect; forwarding the unseen tail as live"
                             );
-                            for trade in batch {
+                            for trade in fresh {
+                                last_forwarded_ms = last_forwarded_ms.max(trade.timestamp_ms);
                                 if tx.send(FeedEvent::Live(trade)).await.is_err() {
                                     break;
                                 }
                             }
                         } else {
                             forwarded_any = true;
+                            last_forwarded_ms = batch
+                                .iter()
+                                .map(|t| t.timestamp_ms)
+                                .max()
+                                .unwrap_or(last_forwarded_ms);
                             info!(
                                 target: "quantick::app",
                                 schema_version = 1_u8,
@@ -130,6 +152,7 @@ async fn feed_task(
                     }
                     Some(Mt5Event::Live(trade)) => {
                         forwarded_any = true;
+                        last_forwarded_ms = last_forwarded_ms.max(trade.timestamp_ms);
                         if tx.send(FeedEvent::Live(trade)).await.is_err() {
                             break; // UI gone
                         }
@@ -389,5 +412,94 @@ mod tests {
         };
         assert_eq!(trade.agg_id, 3);
         assert_eq!(trade.side, quantick_engine::Side::Sell);
+    }
+
+    #[tokio::test]
+    async fn reconnect_history_overlap_is_dropped_not_double_counted() {
+        // The bridge re-sends its recent-history window on every session; the
+        // overlap with trades already forwarded must not inflate the bars.
+        let settings = MetaTraderSettings {
+            listen_addr: "127.0.0.1:19172".to_string(),
+            side_source: Mt5SideSource::TickRule,
+        };
+        let mut feed = spawn("WIN$N", &settings);
+        let Some(FeedEvent::Backfilled(_)) = feed.events.recv().await else {
+            panic!("expected the immediate empty backfill");
+        };
+
+        async fn connect() -> tokio::net::TcpStream {
+            for _ in 0..50 {
+                match tokio::net::TcpStream::connect("127.0.0.1:19172").await {
+                    Ok(s) => return s,
+                    Err(_) => tokio::time::sleep(Duration::from_millis(20)).await,
+                }
+            }
+            panic!("could not reach the feed listener");
+        }
+
+        fn tick(seq: u64, time_ms: i64, last: &str) -> String {
+            format!(
+                "{{\"type\":\"tick\",\"seq\":{seq},\"time_ms\":{time_ms},\"bid\":\"0\",\
+                 \"ask\":\"0\",\"last\":\"{last}\",\"volume\":1,\"flags\":1080}}\n"
+            )
+        }
+        const HELLO: &str = concat!(
+            "{\"type\":\"hello\",\"schema\":1,\"bridge\":\"test\",\"bridge_version\":\"0\",",
+            "\"symbol\":\"WIN$N\",\"broker_symbol\":\"WINQ26\",\"digits\":0,",
+            "\"server_utc_offset_s\":-10800}\n",
+        );
+
+        // Session 1: history (1000, 1001) then a live tick at 1002.
+        let mut sock = connect().await;
+        let mut script = String::from(HELLO);
+        script.push_str("{\"type\":\"backfill_start\",\"count_hint\":2}\n");
+        script.push_str(&tick(1, 1000, "100"));
+        script.push_str(&tick(2, 1001, "101"));
+        script.push_str("{\"type\":\"backfill_end\"}\n");
+        script.push_str(&tick(3, 1002, "100"));
+        sock.write_all(script.as_bytes()).await.unwrap();
+        sock.flush().await.unwrap();
+
+        let Some(FeedEvent::HistoryPrepended(history)) =
+            tokio::time::timeout(Duration::from_secs(5), feed.events.recv())
+                .await
+                .expect("timed out waiting for history")
+        else {
+            panic!("expected the bridge history as a prepend");
+        };
+        assert_eq!(history.len(), 1);
+        let Some(FeedEvent::Live(live)) =
+            tokio::time::timeout(Duration::from_secs(5), feed.events.recv())
+                .await
+                .expect("timed out waiting for the live trade")
+        else {
+            panic!("expected the live trade");
+        };
+        assert_eq!(live.timestamp_ms, 1002 + 10_800_000);
+
+        // Session 2 (reconnect): the re-sent window overlaps everything the
+        // UI already has, plus one genuinely new tick at 1003.
+        drop(sock);
+        let mut sock = connect().await;
+        let mut script = String::from(HELLO);
+        script.push_str("{\"type\":\"backfill_start\",\"count_hint\":4}\n");
+        script.push_str(&tick(1, 1000, "100"));
+        script.push_str(&tick(2, 1001, "101"));
+        script.push_str(&tick(3, 1002, "100"));
+        script.push_str(&tick(4, 1003, "102"));
+        script.push_str("{\"type\":\"backfill_end\"}\n");
+        sock.write_all(script.as_bytes()).await.unwrap();
+        sock.flush().await.unwrap();
+
+        // Only the unseen tail arrives; the overlap is dropped, not replayed.
+        let Some(FeedEvent::Live(fresh)) =
+            tokio::time::timeout(Duration::from_secs(5), feed.events.recv())
+                .await
+                .expect("timed out waiting for the post-reconnect trade")
+        else {
+            panic!("expected the unseen tail as a live trade");
+        };
+        assert_eq!(fresh.timestamp_ms, 1003 + 10_800_000);
+        assert_eq!(fresh.agg_id, 4);
     }
 }

--- a/crates/app/src/orderflow_view.rs
+++ b/crates/app/src/orderflow_view.rs
@@ -45,6 +45,11 @@ struct ProjectionLayout {
     first_bar_index: usize,
     slot_count: usize,
     extend_live_end: bool,
+    // Cell y-positions are normalized against the price window at build
+    // time, so a cached frame is only valid for the exact same window
+    // (bit-compared: any pan/zoom or auto-fit shift must rebuild).
+    price_low_bits: u64,
+    price_high_bits: u64,
 }
 
 struct ProjectionCache {
@@ -447,6 +452,8 @@ impl OrderflowView {
             first_bar_index,
             slot_count: closed.len() + usize::from(partial.is_some()),
             extend_live_end,
+            price_low_bits: price_range.0.to_bits(),
+            price_high_bits: price_range.1.to_bits(),
         };
         let now = Instant::now();
         if let Some(cache) = &self.projection_cache
@@ -1012,6 +1019,14 @@ mod tests {
         assert_eq!(view.projection_builds, 1);
         assert_eq!(view.projection_cache_hits, 1);
 
+        // A price-window change (pan/zoom, auto-fit shift) must rebuild:
+        // cached cell positions are normalized against the old window.
+        let panned = view
+            .project_visible(0, &bars, None, true, (97.0, 103.0))
+            .unwrap();
+        assert!(!Arc::ptr_eq(&first, &panned));
+        assert_eq!(view.projection_builds, 2);
+
         view.handle_depth_event(DepthEvent::Status {
             symbol: "BTCUSDT".to_owned(),
             generation: 10,
@@ -1027,7 +1042,7 @@ mod tests {
             .project_visible(0, &bars, None, true, (98.0, 102.0))
             .unwrap();
         assert!(!Arc::ptr_eq(&first, &after_gap));
-        assert_eq!(view.projection_builds, 2);
+        assert_eq!(view.projection_builds, 3);
     }
 
     #[test]

--- a/crates/feed-binance/src/depth/reconnect.rs
+++ b/crates/feed-binance/src/depth/reconnect.rs
@@ -18,6 +18,10 @@ use super::stream::{
 /// `config.initial_generation` is used verbatim for the first connection and
 /// incremented for every reconnect. A UI controller should seed it with its own
 /// monotonic capture epoch when depth is disabled and later re-enabled.
+///
+/// A session that reached synchronization resets the backoff (mirroring the
+/// aggTrade path), so only sustained failure escalates the reconnect delay —
+/// hours of healthy streaming never make the next blip wait longer.
 pub async fn run_depth_with_reconnect<S: DepthSnapshotSource>(
     ws_base_url: &str,
     symbol: &str,
@@ -31,7 +35,20 @@ pub async fn run_depth_with_reconnect<S: DepthSnapshotSource>(
     let mut generation = config.initial_generation;
 
     loop {
-        let result = run_depth_session(&url, &symbol, source, events, config, generation).await;
+        let mut synchronized = false;
+        let result = run_depth_session(
+            &url,
+            &symbol,
+            source,
+            events,
+            config,
+            generation,
+            &mut synchronized,
+        )
+        .await;
+        if synchronized {
+            backoff.reset();
+        }
         let error = match result {
             Ok(()) => {
                 // The current session runner is intentionally open-ended, but

--- a/crates/feed-binance/src/depth/stream.rs
+++ b/crates/feed-binance/src/depth/stream.rs
@@ -310,6 +310,10 @@ pub fn decode_depth_text(text: &str) -> Result<DepthUpdate, DepthWireError> {
 /// [`run_depth_with_reconnect`](super::reconnect::run_depth_with_reconnect) for
 /// a persistent feed.
 ///
+/// `synchronized` is set to `true` once the snapshot and stream bridge —
+/// the reconnect loop uses it to reset its backoff after a healthy session,
+/// so only sustained failure escalates the delay.
+///
 /// # Errors
 ///
 /// Returns [`DepthSessionError`] and never publishes an unbridged snapshot.
@@ -320,6 +324,7 @@ pub async fn run_depth_session<S: DepthSnapshotSource>(
     events: &Sender<DepthEvent>,
     config: DepthSessionConfig,
     generation: u64,
+    synchronized: &mut bool,
 ) -> Result<(), DepthSessionError> {
     let config = config.normalized();
     let symbol = symbol.to_uppercase();
@@ -421,6 +426,7 @@ pub async fn run_depth_session<S: DepthSnapshotSource>(
         .await?
         {
             BridgeOutcome::Synchronized => {
+                *synchronized = true;
                 return run_synchronized(&mut ws, &mut synchronizer, events, &symbol, generation)
                     .await;
             }
@@ -891,7 +897,18 @@ mod tests {
         };
         let url = format!("ws://{address}");
         let session = tokio::spawn(async move {
-            run_depth_session(&url, "BTCUSDT", &source, &events_tx, config, 40).await
+            let mut synchronized = false;
+            let result = run_depth_session(
+                &url,
+                "BTCUSDT",
+                &source,
+                &events_tx,
+                config,
+                40,
+                &mut synchronized,
+            )
+            .await;
+            (result, synchronized)
         });
 
         assert!(matches!(
@@ -959,11 +976,13 @@ mod tests {
         ));
 
         drop(events_rx);
-        let result = tokio::time::timeout(std::time::Duration::from_secs(1), session)
-            .await
-            .expect("session responds to consumer cancellation")
-            .unwrap();
+        let (result, synchronized) =
+            tokio::time::timeout(std::time::Duration::from_secs(1), session)
+                .await
+                .expect("session responds to consumer cancellation")
+                .unwrap();
         assert_eq!(result, Err(DepthSessionError::ConsumerClosed));
+        assert!(synchronized, "the reconnect loop resets backoff on this");
         server.abort();
     }
 }

--- a/crates/feed-mt5/src/lib.rs
+++ b/crates/feed-mt5/src/lib.rs
@@ -33,16 +33,25 @@
 //! |---|---|---|
 //! | `MT5_LISTENING` | feed is up, waiting | attach the EA to a chart |
 //! | `MT5_BIND_FAILED` | can't open the port | another quantick running; change `listen_addr` |
+//! | `MT5_ACCEPT_FAILED` | one accept failed; still listening | transient OS error |
 //! | `MT5_BRIDGE_CONNECTED` | socket open, no hello yet | — |
 //! | `MT5_HELLO_TIMEOUT` | connected but silent | wrong client dialed the port |
 //! | `MT5_SCHEMA_MISMATCH` | bridge too old/new | recompile the EA from this repo |
 //! | `MT5_SYMBOL_MISMATCH` | EA runs on another symbol's chart | attach it to the configured symbol |
 //! | `MT5_HELLO_OK` | session established | — |
 //! | `MT5_BACKFILL_START`/`_END` | history block | — |
+//! | `MT5_PARTIAL_BACKFILL_DISCARDED` | session died mid-history | next connection re-sends it |
+//! | `MT5_HEARTBEAT` | liveness + fresh offset (debug level) | — |
 //! | `MT5_SEQ_GAP` | ticks lost in transport | terminal overloaded? check EA logs |
+//! | `MT5_SEQ_NOT_MONOTONIC` | seq went backwards/repeated | EA bug or duplicated stream |
 //! | `MT5_BRIDGE_SILENT` | no data within timeout | terminal closed / market halted / EA removed |
+//! | `MT5_BRIDGE_EOF` | peer closed the socket | terminal closing or EA reload |
 //! | `MT5_BRIDGE_BYE` | clean shutdown | EA detached or terminal closing |
-//! | `MT5_UNDECODABLE_LINE` | garbage on the wire | bridge/feed version skew |
+//! | `MT5_BRIDGE_LOST` | session over; back to waiting | see the paired reason field |
+//! | `MT5_SOCKET_ERROR` | read failed mid-session | network stack; session restarts |
+//! | `MT5_PROTOCOL_VIOLATION` | message out of place | bridge/feed version skew |
+//! | `MT5_UNDECODABLE_LINE` | garbage on the wire (skipped, counted) | bridge/feed version skew |
+//! | `MT5_LINE_TOO_LONG` | line over 64 KiB; session dropped | not the bridge talking to us |
 //! | `MT5_MAP_SUMMARY` | per-session mapping ledger | audit drops & side sources here |
 //!
 //! A `MT5_MAP_SUMMARY` where `side_from_flag` is ~100% buys would reveal the

--- a/crates/feed-mt5/src/stream.rs
+++ b/crates/feed-mt5/src/stream.rs
@@ -26,6 +26,11 @@ use crate::session::SeqTracker;
 /// Default address the feed listens on for the bridge.
 pub const DEFAULT_LISTEN_ADDR: &str = "127.0.0.1:9100";
 
+/// Longest line the server will buffer. Protocol lines are a few hundred
+/// bytes; anything larger is not the bridge, and an unbounded buffer would let
+/// any local process exhaust memory by streaming bytes without a newline.
+const MAX_LINE_BYTES: usize = 64 * 1024;
+
 /// How the bridge server behaves for one symbol.
 #[derive(Debug, Clone)]
 pub struct ServerConfig {
@@ -135,12 +140,20 @@ pub async fn run_bridge_server(
     config: ServerConfig,
     tx: mpsc::Sender<Mt5Event>,
 ) -> Result<(), Mt5Error> {
-    let listener = TcpListener::bind(&config.listen_addr)
-        .await
-        .map_err(|e| Mt5Error::Bind {
+    let listener = TcpListener::bind(&config.listen_addr).await.map_err(|e| {
+        warn!(
+            target: "quantick::feed",
+            schema_version = 1_u8,
+            event_code = "MT5_BIND_FAILED",
+            addr = %config.listen_addr,
+            error = %e,
+            "cannot bind the bridge listen address"
+        );
+        Mt5Error::Bind {
             addr: config.listen_addr.clone(),
             message: e.to_string(),
-        })?;
+        }
+    })?;
     let bound = listener
         .local_addr()
         .map(|a| a.to_string())
@@ -216,7 +229,7 @@ async fn serve_connection(
     config: &ServerConfig,
     tx: &mpsc::Sender<Mt5Event>,
 ) -> ConnEnd {
-    let mut lines = BufReader::new(stream).lines();
+    let mut lines = BoundedLineReader::new(stream);
 
     // 1. The first message must be a hello that matches what we expect.
     let hello = match tokio::time::timeout(config.hello_timeout, lines.next_line()).await {
@@ -240,7 +253,7 @@ async fn serve_connection(
             );
             return ConnEnd::BridgeGone(format!("socket error before hello: {e}"));
         }
-        Ok(Ok(None)) => {
+        Ok(Ok(BoundedLine::Eof)) => {
             info!(
                 target: "quantick::feed",
                 schema_version = 1_u8,
@@ -249,7 +262,28 @@ async fn serve_connection(
             );
             return ConnEnd::BridgeGone("closed before hello".to_string());
         }
-        Ok(Ok(Some(line))) => match protocol::parse_line(&line) {
+        Ok(Ok(BoundedLine::TooLong)) => {
+            warn!(
+                target: "quantick::feed",
+                schema_version = 1_u8,
+                event_code = "MT5_LINE_TOO_LONG",
+                max_bytes = MAX_LINE_BYTES as u64,
+                "first line exceeded the size cap; dropping the connection"
+            );
+            return ConnEnd::BridgeGone("oversized hello".to_string());
+        }
+        Ok(Ok(BoundedLine::NotUtf8 { len })) => {
+            warn!(
+                target: "quantick::feed",
+                schema_version = 1_u8,
+                event_code = "MT5_UNDECODABLE_LINE",
+                error = "invalid utf-8",
+                line_bytes = len as u64,
+                "first line was not valid protocol; dropping the connection"
+            );
+            return ConnEnd::BridgeGone("undecodable hello".to_string());
+        }
+        Ok(Ok(BoundedLine::Line(line))) => match protocol::parse_line(&line) {
             Ok(BridgeMsg::Hello(h)) => h,
             Ok(other) => {
                 warn!(
@@ -351,7 +385,7 @@ async fn serve_connection(
                 );
                 break ConnEnd::BridgeGone(format!("socket error: {e}"));
             }
-            Ok(Ok(None)) => {
+            Ok(Ok(BoundedLine::Eof)) => {
                 info!(
                     target: "quantick::feed",
                     schema_version = 1_u8,
@@ -360,7 +394,30 @@ async fn serve_connection(
                 );
                 break ConnEnd::BridgeGone("eof".to_string());
             }
-            Ok(Ok(Some(line))) => line,
+            Ok(Ok(BoundedLine::TooLong)) => {
+                warn!(
+                    target: "quantick::feed",
+                    schema_version = 1_u8,
+                    event_code = "MT5_LINE_TOO_LONG",
+                    max_bytes = MAX_LINE_BYTES as u64,
+                    "peer streamed an oversized line; dropping the session"
+                );
+                break ConnEnd::BridgeGone("oversized line".to_string());
+            }
+            Ok(Ok(BoundedLine::NotUtf8 { len })) => {
+                undecodable += 1;
+                warn!(
+                    target: "quantick::feed",
+                    schema_version = 1_u8,
+                    event_code = "MT5_UNDECODABLE_LINE",
+                    error = "invalid utf-8",
+                    line_bytes = len as u64,
+                    total_undecodable = undecodable,
+                    "skipping an undecodable line"
+                );
+                continue;
+            }
+            Ok(Ok(BoundedLine::Line(line))) => line,
         };
         if line.trim().is_empty() {
             continue;
@@ -398,6 +455,7 @@ async fn serve_connection(
                 }
                 debug!(
                     target: "quantick::feed",
+                    schema_version = 1_u8,
                     event_code = "MT5_HEARTBEAT",
                     seq_last = hb.seq_last,
                     ticks_sent = hb.ticks_sent,
@@ -460,7 +518,127 @@ async fn serve_connection(
     end
 }
 
-/// First 120 chars of a line, for log context without flooding.
+/// First 120 chars of a line, for log context without flooding. Truncates on
+/// a char boundary: a byte-index slice would panic mid-codepoint.
 fn snippet(line: &str) -> &str {
-    &line[..line.len().min(120)]
+    match line.char_indices().nth(120) {
+        Some((i, _)) => &line[..i],
+        None => line,
+    }
+}
+
+/// One read from the bounded line reader.
+enum BoundedLine {
+    /// A complete UTF-8 line (terminator stripped).
+    Line(String),
+    /// A complete line that was not valid UTF-8; skippable, per PROTOCOL.md.
+    NotUtf8 {
+        /// Length of the rejected line, in bytes.
+        len: usize,
+    },
+    /// The peer streamed more than [`MAX_LINE_BYTES`] without a newline.
+    TooLong,
+    /// The peer closed the connection.
+    Eof,
+}
+
+/// What one `fill_buf` round decided (split out so the borrow of the reader's
+/// internal buffer ends before `consume`).
+enum ReadStep {
+    Eof,
+    Line(usize),
+    TooLong(usize),
+    More(usize),
+}
+
+/// A newline-delimited reader that never buffers more than
+/// [`MAX_LINE_BYTES`], unlike `AsyncBufReadExt::lines`. Cancel-safe: the only
+/// await is `fill_buf`, and bytes move out of the socket buffer and into the
+/// line buffer within a single poll.
+struct BoundedLineReader {
+    reader: BufReader<TcpStream>,
+    buf: Vec<u8>,
+}
+
+impl BoundedLineReader {
+    fn new(stream: TcpStream) -> Self {
+        Self {
+            reader: BufReader::new(stream),
+            buf: Vec::new(),
+        }
+    }
+
+    async fn next_line(&mut self) -> std::io::Result<BoundedLine> {
+        loop {
+            let step = {
+                let available = self.reader.fill_buf().await?;
+                if available.is_empty() {
+                    ReadStep::Eof
+                } else if let Some(pos) = available.iter().position(|&b| b == b'\n') {
+                    if self.buf.len() + pos > MAX_LINE_BYTES {
+                        ReadStep::TooLong(pos + 1)
+                    } else {
+                        self.buf.extend_from_slice(&available[..pos]);
+                        ReadStep::Line(pos + 1)
+                    }
+                } else if self.buf.len() + available.len() > MAX_LINE_BYTES {
+                    ReadStep::TooLong(available.len())
+                } else {
+                    self.buf.extend_from_slice(available);
+                    ReadStep::More(available.len())
+                }
+            };
+            match step {
+                ReadStep::Eof => {
+                    // A trailing unterminated line still counts, like
+                    // `lines()` behaves.
+                    if self.buf.is_empty() {
+                        return Ok(BoundedLine::Eof);
+                    }
+                    return Ok(Self::finish(std::mem::take(&mut self.buf)));
+                }
+                ReadStep::Line(consume) => {
+                    self.reader.consume(consume);
+                    return Ok(Self::finish(std::mem::take(&mut self.buf)));
+                }
+                ReadStep::TooLong(consume) => {
+                    self.reader.consume(consume);
+                    self.buf.clear();
+                    return Ok(BoundedLine::TooLong);
+                }
+                ReadStep::More(consume) => self.reader.consume(consume),
+            }
+        }
+    }
+
+    fn finish(mut line: Vec<u8>) -> BoundedLine {
+        if line.last() == Some(&b'\r') {
+            line.pop();
+        }
+        match String::from_utf8(line) {
+            Ok(text) => BoundedLine::Line(text),
+            Err(e) => BoundedLine::NotUtf8 {
+                len: e.as_bytes().len(),
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::snippet;
+
+    #[test]
+    fn snippet_truncates_on_char_boundaries() {
+        // 1 ASCII byte then two-byte chars: byte 120 falls mid-codepoint,
+        // which the old byte slice panicked on.
+        let line = format!("x{}", "é".repeat(200));
+        assert_eq!(snippet(&line).chars().count(), 120);
+
+        let short = "short line";
+        assert_eq!(snippet(short), short);
+
+        let exact: String = "a".repeat(120);
+        assert_eq!(snippet(&exact), exact);
+    }
 }

--- a/crates/feed-mt5/tests/bridge_server.rs
+++ b/crates/feed-mt5/tests/bridge_server.rs
@@ -160,6 +160,66 @@ async fn garbage_lines_are_skipped_not_fatal() {
 }
 
 #[tokio::test]
+async fn multibyte_garbage_is_skipped_without_panicking() {
+    // Regression: `snippet` used to slice at byte 120, panicking (and killing
+    // the whole listener) when that byte fell inside a multibyte char.
+    let (addr, mut rx) = start_server("WIN$N").await;
+    let mut sock = TcpStream::connect(&addr).await.unwrap();
+    let mut script = String::new();
+    script.push_str(&hello("WIN$N"));
+    script.push_str(&tick(1, "100", 1));
+    script.push_str(&format!("x{}\n", "é".repeat(200))); // byte 120 mid-char
+    script.push_str(&tick(2, "101", 1)); // still classified: buy
+    sock.write_all(script.as_bytes()).await.unwrap();
+
+    let _ = next_event(&mut rx).await; // Connected
+    let Mt5Event::Live(trade) = next_event(&mut rx).await else {
+        panic!("expected the trade after the multibyte garbage");
+    };
+    assert_eq!(trade.agg_id, 2);
+}
+
+#[tokio::test]
+async fn an_invalid_utf8_line_is_skipped_not_fatal() {
+    let (addr, mut rx) = start_server("WIN$N").await;
+    let mut sock = TcpStream::connect(&addr).await.unwrap();
+    let mut script = Vec::new();
+    script.extend_from_slice(hello("WIN$N").as_bytes());
+    script.extend_from_slice(tick(1, "100", 1).as_bytes());
+    script.extend_from_slice(&[0xff, 0xfe, 0xfd, b'\n']); // not UTF-8
+    script.extend_from_slice(tick(2, "101", 1).as_bytes());
+    sock.write_all(&script).await.unwrap();
+
+    let _ = next_event(&mut rx).await; // Connected
+    let Mt5Event::Live(trade) = next_event(&mut rx).await else {
+        panic!("expected the trade after the invalid utf-8 line");
+    };
+    assert_eq!(trade.agg_id, 2);
+}
+
+#[tokio::test]
+async fn an_oversized_line_ends_the_session_but_not_the_server() {
+    let (addr, mut rx) = start_server("WIN$N").await;
+    let mut sock = TcpStream::connect(&addr).await.unwrap();
+    sock.write_all(hello("WIN$N").as_bytes()).await.unwrap();
+    let _ = next_event(&mut rx).await; // Connected
+
+    // 65 KiB without a newline: crosses the 64 KiB cap, yet small enough to
+    // fit in the OS socket buffers so this write never races the server
+    // closing the connection.
+    let flood = vec![b'a'; 65 * 1024];
+    sock.write_all(&flood).await.unwrap();
+
+    let Mt5Event::Status(Mt5Status::Lost { reason }) = next_event(&mut rx).await else {
+        panic!("expected the oversized line to end the session");
+    };
+    assert_eq!(reason, "oversized line");
+    let Mt5Event::Status(Mt5Status::Waiting { .. }) = next_event(&mut rx).await else {
+        panic!("expected the server back in waiting");
+    };
+}
+
+#[tokio::test]
 async fn a_silent_bridge_is_dropped_and_the_server_waits_again() {
     let (addr, mut rx) = start_server("WIN$N").await;
     let mut sock = TcpStream::connect(&addr).await.unwrap();


### PR DESCRIPTION
## Summary

Post-merge review of #58 (four parallel reviewers + adversarial verification) found six major issues; this PR fixes the five correctness/robustness ones, one commit per concern:

- **feed-mt5**: \`snippet()\` panicked slicing mid-codepoint on multibyte garbage ≥120 bytes, killing the listener until app restart (char-boundary truncation + regression test); \`lines()\` buffered unboundedly, a memory-DoS from any local process (bounded 64 KiB reader, new \`MT5_LINE_TOO_LONG\` event, documented in PROTOCOL.md); invalid UTF-8 no longer tears down the session (skipped + counted per the PROTOCOL.md contract); \`MT5_BIND_FAILED\` emitted from the crate, heartbeat gains \`schema_version\`, diagnosis table synced with every emitted code.
- **bridge (MQL5)**: \`SocketSend\` had no timeout on the terminal main thread — a stalled reader froze the whole MT5 UI. \`SocketTimeouts\` set at connect (new \`InpSendTimeoutMs\`), partial sends retried instead of treated as broken. Compiles 0/0.
- **app**: MT5 reconnect history was forwarded as live with no dedup, silently inflating bars with ~30 min of double-counted trades on every reconnect — only strictly-newer trades pass now, dropped overlap counted in the log; heatmap projection cache now keys on the price window, fixing vertical lag versus candles while panning/zooming.
- **feed-binance**: depth reconnect backoff never reset after a healthy session (unlike the aggTrade path), permanently degrading recovery latency to the 15–30 s ceiling — reset after any synchronized session.
- **docs**: CLAUDE.md now lists the \`orderbook\` crate in the architecture map.

Deferred (perf/minor, no behavior bugs): orderbook's O(book) clone per delta, loopback-only bind enforcement, EA JSON escaping, snapshot REST weight tuning.

## Test plan

- \`cargo fmt --all -- --check\` / \`clippy --workspace --all-targets -- -D warnings\` / \`build\` / \`test --workspace\` — all green locally (~275 tests).
- New tests: multibyte-garbage regression (panicked before), invalid-UTF-8 survival, oversized-line session drop, reconnect-overlap dedup at the app layer, price-window cache invalidation, synchronized-flag assertion in the depth session test.
- \`QuantickBridge.mq5\` compiled via MetaEditor CLI: 0 errors, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)