### PR TITLE
fix(engine,feed-mt5): saturate feed arithmetic instead of panicking on overflow

### DIFF
--- a/crates/engine/src/bar.rs
+++ b/crates/engine/src/bar.rs
@@ -44,17 +44,21 @@ pub struct Bar {
 
 impl Bar {
     /// Total traded quantity: `buy_volume + sell_volume`.
+    ///
+    /// Saturates rather than panicking on the (physically impossible) overflow,
+    /// so a corrupt or adversarial feed can never crash a caller reading a bar.
     #[must_use]
     pub fn volume(&self) -> Decimal {
-        self.buy_volume + self.sell_volume
+        self.buy_volume.saturating_add(self.sell_volume)
     }
 
     /// Order-flow delta: `buy_volume - sell_volume`.
     ///
-    /// Positive when buyers were the net aggressors over the bar.
+    /// Positive when buyers were the net aggressors over the bar. Saturates
+    /// rather than panicking on overflow (see [`volume`](Bar::volume)).
     #[must_use]
     pub fn delta(&self) -> Decimal {
-        self.buy_volume - self.sell_volume
+        self.buy_volume.saturating_sub(self.sell_volume)
     }
 }
 

--- a/crates/engine/src/imbalance.rs
+++ b/crates/engine/src/imbalance.rs
@@ -115,7 +115,7 @@ impl ImbalanceBarBuilder {
         );
         Self {
             target_trades,
-            alpha_b: Decimal::from(2) / Decimal::from(target_trades + 1),
+            alpha_b: Decimal::from(2) / Decimal::from(target_trades.saturating_add(1)),
             e_t: Decimal::from(target_trades),
             e_b: Decimal::ZERO,
             theta: Decimal::ZERO,
@@ -149,7 +149,9 @@ impl ImbalanceBarBuilder {
         let closed_len = Decimal::from(self.count);
         let updated = ALPHA_T * closed_len + (Decimal::ONE - ALPHA_T) * self.e_t;
         let min = Decimal::from(self.target_trades) / Decimal::from(4);
-        let max = Decimal::from(CAP_MULT * self.target_trades);
+        // Saturating to match `should_close`'s hard cap and stay panic-free for
+        // any configured `target_trades`.
+        let max = Decimal::from(CAP_MULT.saturating_mul(self.target_trades));
         self.e_t = updated.clamp(min, max);
         self.warmed_up = true;
         self.theta = Decimal::ZERO;
@@ -169,7 +171,7 @@ impl BarBuilder for ImbalanceBarBuilder {
             Side::Buy => Decimal::ONE,
             Side::Sell => -Decimal::ONE,
         };
-        self.theta += b;
+        self.theta = self.theta.saturating_add(b);
         self.e_b = self.alpha_b * b + (Decimal::ONE - self.alpha_b) * self.e_b;
 
         if self.should_close() {

--- a/crates/engine/src/threshold.rs
+++ b/crates/engine/src/threshold.rs
@@ -89,7 +89,11 @@ impl<M: Measure> BarBuilder for ThresholdBarBuilder<M> {
             None => self.current = Some(open_bar(trade)),
             Some(bar) => extend_bar(bar, trade),
         }
-        self.acc += self.measure.of(trade);
+        // Saturating: the measure comes from untrusted feed data and must never
+        // panic the builder on overflow. A saturated accumulator is `>= threshold`
+        // and simply closes the bar — deterministic, and identical to exact
+        // arithmetic for every representable total.
+        self.acc = self.acc.saturating_add(self.measure.of(trade));
         if self.acc >= self.threshold {
             self.acc = Decimal::ZERO;
             self.current.take()
@@ -125,9 +129,11 @@ pub(crate) fn extend_bar(bar: &mut Bar, trade: &Trade) {
     bar.low = bar.low.min(trade.price);
     bar.close = trade.price;
     bar.close_time = trade.timestamp_ms;
+    // Saturating for the same reason as the accumulator: untrusted feed
+    // quantities must not panic the builder if a running side total overflows.
     match trade.side {
-        Side::Buy => bar.buy_volume += trade.quantity,
-        Side::Sell => bar.sell_volume += trade.quantity,
+        Side::Buy => bar.buy_volume = bar.buy_volume.saturating_add(trade.quantity),
+        Side::Sell => bar.sell_volume = bar.sell_volume.saturating_add(trade.quantity),
     }
     bar.trade_count += 1;
 }
@@ -208,5 +214,24 @@ mod tests {
             "next bar started from zero, so 9 < 10 does not close"
         );
         assert_eq!(b.partial().unwrap().volume(), dec("9"));
+    }
+
+    #[test]
+    fn extreme_measure_saturates_and_closes_without_panicking() {
+        // An adversarial/corrupt feed quantity near Decimal::MAX must not panic
+        // the accumulator: it saturates, crosses the threshold, and closes the
+        // bar (which is `>= threshold` by construction).
+        let mut b = ThresholdBarBuilder::new(dec("10"), QtyMeasure);
+        let huge = Trade {
+            agg_id: 0,
+            timestamp_ms: 0,
+            price: Decimal::from_str("1.0").unwrap(),
+            quantity: Decimal::MAX,
+            side: Side::Buy,
+        };
+        let bar = b.push(&huge).expect("the saturated measure closes the bar");
+        assert_eq!(bar.trade_count, 1);
+        // The bar's own volume also saturates rather than panicking.
+        assert_eq!(bar.volume(), Decimal::MAX);
     }
 }

--- a/crates/engine/src/trade.rs
+++ b/crates/engine/src/trade.rs
@@ -81,11 +81,17 @@ pub struct Trade {
 impl Trade {
     /// Notional value of the trade: `price * quantity`.
     ///
-    /// Exact, because both operands are [`Decimal`]. This is the measure dollar
-    /// bars accumulate.
+    /// Exact for every realistic print, because both operands are [`Decimal`].
+    /// The multiplication **saturates** at [`Decimal::MAX`] instead of panicking
+    /// on the (physically impossible) overflow: prices and quantities arrive
+    /// from an untrusted feed (a live exchange socket, or the local MT5 bridge
+    /// any process can dial), and a corrupt or adversarial print near
+    /// `Decimal::MAX` must never panic a bar builder, backtest or bot. Saturation
+    /// keeps the engine deterministic — realistic values are unaffected — while
+    /// honouring the "never panic on feed input" rule the feeds already follow.
     #[must_use]
     pub fn notional(&self) -> Decimal {
-        self.price * self.quantity
+        self.price.saturating_mul(self.quantity)
     }
 }
 
@@ -117,5 +123,19 @@ mod tests {
         };
         // 36000.10 * 0.005 = 180.00050 exactly (no float drift).
         assert_eq!(t.notional(), Decimal::from_str("180.00050").unwrap());
+    }
+
+    #[test]
+    fn notional_saturates_instead_of_panicking_on_overflow() {
+        // A corrupt or adversarial feed print near Decimal::MAX must not panic a
+        // dollar-bar builder, backtest or bot: the product saturates.
+        let t = Trade {
+            agg_id: 1,
+            timestamp_ms: 0,
+            price: Decimal::MAX,
+            quantity: Decimal::from(2),
+            side: Side::Buy,
+        };
+        assert_eq!(t.notional(), Decimal::MAX);
     }
 }

--- a/crates/feed-mt5/src/map.rs
+++ b/crates/feed-mt5/src/map.rs
@@ -172,7 +172,10 @@ impl TickMapper {
     pub fn new(mode: SideMode, server_utc_offset_s: i64) -> Self {
         Self {
             mode,
-            offset_ms: server_utc_offset_s * 1000,
+            // Saturating: the offset is declared by the bridge (any local
+            // process may connect), so an absurd value must not panic the feed
+            // task via i64 overflow. A realistic offset (±14 h) is unaffected.
+            offset_ms: server_utc_offset_s.saturating_mul(1000),
             prev_price: None,
             prev_side: None,
             stats: MapStats::default(),
@@ -182,7 +185,7 @@ impl TickMapper {
     /// Refresh the server-time offset (heartbeats may recompute it, e.g.
     /// across a DST change on brokers that observe one).
     pub fn set_server_utc_offset_s(&mut self, offset_s: i64) {
-        self.offset_ms = offset_s * 1000;
+        self.offset_ms = offset_s.saturating_mul(1000);
     }
 
     /// Map one tick. Updates the tick-rule state and the stats ledger.
@@ -240,7 +243,9 @@ impl TickMapper {
                 MapOutcome::Trade {
                     trade: Trade {
                         agg_id: tick.seq,
-                        timestamp_ms: tick.time_ms - self.offset_ms,
+                        // Saturating: `time_ms` and `offset_ms` both originate
+                        // from the untrusted bridge; overflow must not panic.
+                        timestamp_ms: tick.time_ms.saturating_sub(self.offset_ms),
                         price,
                         quantity: Decimal::from(tick.volume),
                         side,
@@ -416,6 +421,30 @@ mod tests {
             panic!("expected trade");
         };
         assert_eq!(trade.timestamp_ms, (1_784_824_300_000 + 2) + 3_600_000);
+    }
+
+    #[test]
+    fn extreme_server_offset_does_not_panic() {
+        // The hello's `server_utc_offset_s` comes from the bridge, which any
+        // local process can impersonate. An absurd offset must not overflow the
+        // i64 conversion (`offset_s * 1000`, then `time_ms - offset_ms`) and
+        // panic the feed task — the arithmetic saturates instead.
+        let mut m = TickMapper::new(SideMode::TickRule, i64::MAX);
+        m.map(&tick(1, "100", 1, 0)); // context
+        let MapOutcome::Trade { trade, .. } = m.map(&tick(2, "101", 1, 0)) else {
+            panic!("expected trade");
+        };
+        // offset_ms saturates to i64::MAX; a positive time_ms minus it stays a
+        // (large) negative in range — no panic.
+        assert!(trade.timestamp_ms < 0);
+
+        // A crafted heartbeat offset refresh must be equally safe. offset_ms
+        // saturates to i64::MIN, so `time_ms - i64::MIN` saturates to i64::MAX.
+        m.set_server_utc_offset_s(i64::MIN);
+        let MapOutcome::Trade { trade, .. } = m.map(&tick(3, "102", 1, 0)) else {
+            panic!("expected trade");
+        };
+        assert_eq!(trade.timestamp_ms, i64::MAX);
     }
 
     #[test]


### PR DESCRIPTION
## Security review outcome

Full security pass over the workspace (feeds, bridge, order book, engine arithmetic, config, dependencies). The codebase is very defensive: bounded line reader + size caps and timeouts on the MT5 socket, TLS via `rustls` + webpki roots with no `accept_invalid_certs`, typed parse errors everywhere, an atomic/validated order book, `#![forbid(unsafe_code)]`, and no risky `unwrap`/indexing on untrusted input.

**One consistent flaw stood out:** several arithmetic operations on values that come from **untrusted feed input** use panicking operators, so overflow crashes instead of being handled. That contradicts the project's own "never panic on feed input — label and drop" rule (which the feeds follow everywhere else) and the determinism guarantee.

## What can panic, and how it's reachable

| Location | Expression | Reachability |
|---|---|---|
| `engine/trade.rs` | `notional() = price * quantity` (Decimal `*` panics on overflow, all profiles) | **In the live app**: `DollarBarBuilder` is the default bar spec and runs on the hot trade path. A print near `Decimal::MAX` (a crafted MT5 tick, or corrupt/MITM'd feed bytes) panics the bar builder. |
| `engine/threshold.rs`, `bar.rs`, `imbalance.rs` | `acc +=`, `buy/sell_volume +=`, `volume()/delta()`, `theta +=`, `CAP_MULT * target_trades` | Same untrusted-quantity path; `should_close` already used `saturating_mul` while `close_bar` did not — inconsistent. |
| `feed-mt5/map.rs` | `server_utc_offset_s * 1000`, `time_ms - offset_ms` (i64) | **Any local process** can dial the bridge on `127.0.0.1:9100` and send a crafted `hello`/`heartbeat`/tick. Dev builds keep `overflow-checks` on, so this panics the feed task in the normally-run binary — killing the feed silently, which also breaks the "nothing charting always has a visible, logged reason" guarantee. |

## Fix

Switch every one of these to `saturating_add` / `saturating_sub` / `saturating_mul`.

- **Determinism preserved:** saturation differs from exact arithmetic *only* when overflow would otherwise panic. Realistic prices/quantities/offsets are byte-for-byte identical, so all existing golden/snapshot tests pass unchanged.
- **Honest behaviour on absurd input:** a saturated accumulator is `>= threshold` and simply closes the bar; a saturated offset yields an in-range timestamp — no crash, consistent with how the feeds already drop/label bad data.

Added focused tests: `notional_saturates_instead_of_panicking_on_overflow`, `extreme_measure_saturates_and_closes_without_panicking`, `extreme_server_offset_does_not_panic`.

## Verification

All four mandatory checks pass locally:
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo build --workspace`
- `cargo test --workspace`

## Not changed (noted, out of scope)

- `metatrader.listen_addr` is config-driven and defaults to `127.0.0.1`; a user could set `0.0.0.0` and expose the bridge to the LAN. Left as the operator's choice — worth a doc warning if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)