### PR TITLE
feat(app): dock order-flow settings and split the aggression layer from L2

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,9 +120,23 @@ never restart the market-data pipelines.
 
 The chart can capture Binance Spot level-2 order-book depth and render a
 Bookmap-inspired liquidity map. It is **disabled by default** and must be
-enabled from the chart controls. The **⚙ L2** panel includes a deterministic
-preview of every visual state, so themes and grouping can be tuned without
-waiting for a rare live-book event.
+enabled from the chart controls. The **⚙ L2** button docks a settings panel to
+the left of the chart — the chart keeps the remaining width instead of being
+covered — including a deterministic preview of every visual state, so themes
+and grouping can be tuned without waiting for a rare live-book event.
+
+The order flow splits into two independent layers, each with its own toolbar
+switch and its own docked panel:
+
+- **book heatmap** (**⚙ L2**) — resting liquidity and liquidity-response
+  markers, built from the synchronized L2 depth pipeline.
+- **bubbles** (**⚙ bubbles**) — confirmed aggressive executions, built from the
+  aggregate-trade stream the chart already consumes.
+
+Neither switch touches the other. Bubbles render with L2 capture off (and for
+providers without a depth pipeline at all), and stopping the book leaves the
+bubbles running. Turning L2 capture off hides the map without discarding
+retained L2 history.
 
 The visualization follows a few data-honesty rules:
 
@@ -148,8 +162,10 @@ The chart exposes these settings:
 | Brightness | `0.9` | `0.05`–`1.0` |
 | Quiet liquidity curve | `1.8` | `0.25`–`2.0`; above one sinks quiet liquidity into the dark canvas so only real walls glow |
 | Intensity scale | Visible P99 | Automatic visible-window P99 or a fixed full-intensity quantity |
-| Aggression bubbles | On | Can be hidden independently of the heatmap |
+| Aggression bubbles | Off | Own toolbar switch and own panel; records and projects without L2 depth capture |
 | Bubble clustering | 200 ms | Raw, 50, 100, 200 or 500 ms |
+| Bubble opacity | `0.78` | `0.05`–`1.0` |
+| Largest bubble | `15 px` | `4`–`48 px`; area stays quantity-proportional |
 | Liquidity response | On / 250 ms | Bite or withdrawal-tail markers with a configurable 25–1,000 ms evidence window |
 | Legend | On | Explains liquidity brightness, buy/sell aggression, aligned depletion, unattributed reduction and L2 gaps |
 

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -436,14 +436,32 @@ impl QuantickApp {
             if ui
                 .add_enabled(
                     supports_book,
-                    egui::Button::new(self.orderflow.settings_button_label()),
+                    egui::Button::new(self.orderflow.l2_button_label()),
                 )
                 .on_hover_text(
-                    "Bookmap palette, non-destructive price ranges, bubbles and liquidity response",
+                    "dock the L2 panel: palette, non-destructive price ranges and liquidity response",
                 )
                 .clicked()
             {
-                self.orderflow.toggle_settings();
+                self.orderflow.toggle_l2_panel();
+            }
+            ui.separator();
+            // The aggression layer reads the trade stream the chart already
+            // consumes, so it needs no depth pipeline and no provider support.
+            let mut bubbles_enabled = self.orderflow.bubbles_enabled();
+            if ui
+                .checkbox(&mut bubbles_enabled, "bubbles")
+                .on_hover_text("confirmed executions as bubbles; independent of the book heatmap")
+                .changed()
+            {
+                self.orderflow.set_bubbles_enabled(bubbles_enabled);
+            }
+            if ui
+                .button(self.orderflow.bubbles_button_label())
+                .on_hover_text("dock the aggression-bubble panel: clustering, opacity and size")
+                .clicked()
+            {
+                self.orderflow.toggle_bubbles_panel();
             }
             ui.separator();
             ui.checkbox(&mut self.show_overlay, "📈 perf")
@@ -1120,7 +1138,7 @@ impl QuantickApp {
         // candle stays a clean divider — no liquidity band shows through it.
         // Where the price swept, the wall reads as consumed; bands survive only
         // in the gaps between candles and above/below each bar.
-        if orderflow_frame.is_some() {
+        if orderflow_frame.is_some() && self.orderflow.enabled() {
             let clear_bar = |xc: f32, bar: &quantick_engine::Bar| {
                 let top = scale.y(bar.high.to_f64().unwrap_or(0.0));
                 let bottom = scale.y(bar.low.to_f64().unwrap_or(0.0));
@@ -1501,7 +1519,9 @@ impl eframe::App for QuantickApp {
         self.maybe_switch_feed();
         self.state.set_spec(self.current_spec());
         self.draw_style_panel(ctx, now);
-        if self.orderflow.draw_settings(ctx) {
+        // Docked before the central panel so the chart keeps the remaining
+        // width instead of being covered by a floating window.
+        if self.orderflow.draw_panels(ctx) {
             self.restart_book_capture();
         }
 
@@ -1707,6 +1727,33 @@ mod tests {
         assert!(
             app.orderflow.enabled(),
             "closed command channel must preserve current capture state"
+        );
+    }
+
+    #[test]
+    fn bubble_toggle_needs_no_feed_command_and_leaves_capture_alone() {
+        let (mut app, _evt_tx, mut cmd_rx, _book_tx) = test_app();
+        assert!(!app.orderflow.enabled());
+        assert!(!app.orderflow.bubbles_enabled());
+
+        app.orderflow.set_bubbles_enabled(true);
+        assert!(app.orderflow.bubbles_enabled());
+        assert!(
+            !app.orderflow.enabled(),
+            "the bubble layer must not start L2 capture"
+        );
+        assert!(
+            cmd_rx.try_recv().is_err(),
+            "aggregate trades already flow; no feed command is needed"
+        );
+
+        app.request_book_capture(true);
+        cmd_rx.try_recv().expect("capture command");
+        app.request_book_capture(false);
+        cmd_rx.try_recv().expect("capture command");
+        assert!(
+            app.orderflow.bubbles_enabled(),
+            "stopping the book must not stop the bubbles"
         );
     }
 

--- a/crates/app/src/orderflow/config.rs
+++ b/crates/app/src/orderflow/config.rs
@@ -32,6 +32,14 @@ pub const MAX_BUBBLE_CLUSTER_MS: i64 = 2_000;
 pub const DEFAULT_LIQUIDITY_CORRELATION_MS: i64 = 250;
 /// Safe upper bound for depth/aggression correlation.
 pub const MAX_LIQUIDITY_CORRELATION_MS: i64 = 10_000;
+/// Default alpha applied to aggression bubbles.
+pub const DEFAULT_BUBBLE_OPACITY: f32 = 0.78;
+/// Default on-screen radius, in points, of the largest aggression bubble.
+pub const DEFAULT_BUBBLE_MAX_RADIUS: f32 = 15.0;
+/// Smallest accepted maximum bubble radius.
+pub const MIN_BUBBLE_MAX_RADIUS: f32 = 4.0;
+/// Largest accepted maximum bubble radius.
+pub const MAX_BUBBLE_MAX_RADIUS: f32 = 48.0;
 
 /// Renderer-only price grouping layered over the exact capture buckets.
 ///
@@ -108,11 +116,19 @@ impl IntensityMode {
 
 /// Settings shared by history retention and the pure projection layer.
 ///
-/// The default is deliberately disabled: merely adding the feature cannot
-/// change feed load, memory use or rendering behaviour of the existing chart.
+/// The two visual layers are independent switches: [`enabled`](Self::enabled)
+/// owns the L2 depth map, [`show_aggressions`](Self::show_aggressions) owns the
+/// aggression bubbles. Bubbles are built from the aggregate-trade stream the
+/// chart already consumes, so they never need the depth pipeline.
+///
+/// Both default to disabled: merely adding the feature cannot change feed load,
+/// memory use or rendering behaviour of the existing chart.
 #[derive(Debug, Clone, PartialEq)]
 pub struct HeatmapConfig {
-    /// Whether capture/projection is enabled.
+    /// Whether L2 depth capture/projection is enabled.
+    ///
+    /// Only the depth map depends on this: the aggression layer keeps working
+    /// with capture off.
     pub enabled: bool,
     /// Maximum age retained in memory, measured in exchange milliseconds.
     pub retention_ms: i64,
@@ -127,14 +143,20 @@ pub struct HeatmapConfig {
     pub opacity: f32,
     /// Colour-curve exponent. Values below one make quieter liquidity visible.
     pub gamma: f32,
-    /// Whether retained aggressive executions are projected.
+    /// Whether aggressive executions are retained and projected.
     ///
-    /// Hiding bubbles is a visual choice and never discards factual history.
+    /// This is the aggression layer's own switch: it needs the trade stream
+    /// only, so it turns on and off without touching L2 depth capture. Hiding
+    /// bubbles is a visual choice and never discards factual history.
     pub show_aggressions: bool,
     /// Temporal window used to cluster compatible aggressive prints.
     ///
     /// Zero keeps raw, one-trade-per-bubble projection.
     pub bubble_cluster_ms: i64,
+    /// Maximum alpha contributed by an aggression bubble.
+    pub bubble_opacity: f32,
+    /// On-screen radius, in points, of the largest aggression bubble.
+    pub bubble_max_radius: f32,
     /// Whether factual displayed-liquidity reductions are projected.
     pub show_liquidity_events: bool,
     /// Smallest reduction fraction whose *unattributed* (depth-only) marker is
@@ -181,8 +203,10 @@ impl Default for HeatmapConfig {
             // real walls glow — the Bookmap contrast. Below one paints a dense
             // book edge-to-edge (no walls stand out).
             gamma: 1.8,
-            show_aggressions: true,
+            show_aggressions: false,
             bubble_cluster_ms: DEFAULT_BUBBLE_CLUSTER_MS,
+            bubble_opacity: DEFAULT_BUBBLE_OPACITY,
+            bubble_max_radius: DEFAULT_BUBBLE_MAX_RADIUS,
             show_liquidity_events: true,
             min_unattributed_reduction: 0.5,
             min_unattributed_pull_share: 0.25,
@@ -200,6 +224,15 @@ impl Default for HeatmapConfig {
 }
 
 impl HeatmapConfig {
+    /// Whether any order-flow layer asks for capture and projection.
+    ///
+    /// The depth map and the aggression bubbles are independent: either one
+    /// alone keeps the pipeline alive, and neither can switch the other off.
+    #[must_use]
+    pub fn any_layer_enabled(&self) -> bool {
+        self.enabled || self.show_aggressions
+    }
+
     /// Return a copy whose numeric values are safe for allocation and math.
     #[must_use]
     pub fn sanitized(mut self) -> Self {
@@ -232,6 +265,16 @@ impl HeatmapConfig {
         }
         self.min_unattributed_pull_share = self.min_unattributed_pull_share.clamp(0.0, 1.0);
         self.bubble_cluster_ms = self.bubble_cluster_ms.clamp(0, MAX_BUBBLE_CLUSTER_MS);
+        if !self.bubble_opacity.is_finite() {
+            self.bubble_opacity = DEFAULT_BUBBLE_OPACITY;
+        }
+        self.bubble_opacity = self.bubble_opacity.clamp(0.05, 1.0);
+        if !self.bubble_max_radius.is_finite() {
+            self.bubble_max_radius = DEFAULT_BUBBLE_MAX_RADIUS;
+        }
+        self.bubble_max_radius = self
+            .bubble_max_radius
+            .clamp(MIN_BUBBLE_MAX_RADIUS, MAX_BUBBLE_MAX_RADIUS);
         self.liquidity_correlation_ms = self
             .liquidity_correlation_ms
             .clamp(0, MAX_LIQUIDITY_CORRELATION_MS);
@@ -263,8 +306,11 @@ mod tests {
         );
         assert!((0.0..=1.0).contains(&config.opacity));
         assert!(config.gamma > 0.0);
-        assert!(config.show_aggressions);
+        assert!(!config.show_aggressions);
+        assert!(!config.any_layer_enabled());
         assert_eq!(config.bubble_cluster_ms, DEFAULT_BUBBLE_CLUSTER_MS);
+        assert_eq!(config.bubble_opacity, DEFAULT_BUBBLE_OPACITY);
+        assert_eq!(config.bubble_max_radius, DEFAULT_BUBBLE_MAX_RADIUS);
         assert!(config.show_liquidity_events);
         assert_eq!(
             config.liquidity_correlation_ms,
@@ -286,6 +332,8 @@ mod tests {
             opacity: f32::NAN,
             gamma: -1.0,
             bubble_cluster_ms: i64::MAX,
+            bubble_opacity: f32::NAN,
+            bubble_max_radius: 900.0,
             liquidity_correlation_ms: i64::MIN,
             max_history_runs: 0,
             max_history_bytes: 0,
@@ -304,6 +352,8 @@ mod tests {
         assert_eq!(config.opacity, 0.9);
         assert_eq!(config.gamma, 1.0);
         assert_eq!(config.bubble_cluster_ms, MAX_BUBBLE_CLUSTER_MS);
+        assert_eq!(config.bubble_opacity, DEFAULT_BUBBLE_OPACITY);
+        assert_eq!(config.bubble_max_radius, MAX_BUBBLE_MAX_RADIUS);
         assert_eq!(config.liquidity_correlation_ms, 0);
         assert_eq!(config.max_history_runs, 1);
         assert_eq!(config.max_history_bytes, 1_024);
@@ -311,6 +361,23 @@ mod tests {
         assert_eq!(config.max_visible_cells, 1);
         assert_eq!(config.max_aggression_primitives, 1);
         assert_eq!(config.intensity_mode, IntensityMode::VisibleP99);
+    }
+
+    #[test]
+    fn each_visual_layer_switches_on_its_own() {
+        let bubbles_only = HeatmapConfig {
+            show_aggressions: true,
+            ..HeatmapConfig::default()
+        };
+        assert!(!bubbles_only.enabled);
+        assert!(bubbles_only.any_layer_enabled());
+
+        let depth_only = HeatmapConfig {
+            enabled: true,
+            ..HeatmapConfig::default()
+        };
+        assert!(!depth_only.show_aggressions);
+        assert!(depth_only.any_layer_enabled());
     }
 
     #[test]

--- a/crates/app/src/orderflow/mod.rs
+++ b/crates/app/src/orderflow/mod.rs
@@ -15,7 +15,10 @@ pub mod timeline;
 // This facade is intentionally wider than the first UI integration. Keeping
 // the public DTOs here gives later renderers one stable import surface.
 #[allow(unused_imports)]
-pub use config::{DisplayGrouping, HeatmapConfig, HeatmapTheme, IntensityMode};
+pub use config::{
+    DisplayGrouping, HeatmapConfig, HeatmapTheme, IntensityMode, MAX_BUBBLE_MAX_RADIUS,
+    MIN_BUBBLE_MAX_RADIUS,
+};
 #[allow(unused_imports)]
 pub use grouping::{
     EffectiveGrouping, GroupedLiquidity, GroupingWindow, LiquidityTransition, VisualLiquidityRun,

--- a/crates/app/src/orderflow/projection.rs
+++ b/crates/app/src/orderflow/projection.rs
@@ -4,7 +4,7 @@ use rust_decimal::Decimal;
 use rust_decimal::prelude::{FromPrimitive as _, ToPrimitive as _};
 
 use super::config::IntensityMode;
-use super::grouping::{EffectiveGrouping, GroupingWindow, sweep_grouped_runs};
+use super::grouping::{EffectiveGrouping, GroupedLiquidity, GroupingWindow, sweep_grouped_runs};
 use super::history::{AggressorSide, LiquidityHistory, RestingSide};
 pub use super::interaction::LiquidityEvidence;
 use super::interaction::{
@@ -225,30 +225,42 @@ pub fn project(
         config.price_grouping,
         prices.high - prices.low,
     );
-    if !config.enabled {
+    if !config.any_layer_enabled() {
         return HeatmapProjection::empty(false, effective_grouping);
     }
     let Some((time_start, time_end)) = timeline.timestamp_range() else {
         return HeatmapProjection::empty(true, effective_grouping);
     };
 
+    // The depth layer is projected only while L2 capture is on. Retained runs
+    // survive a capture toggle untouched — they simply stop being drawn, so the
+    // aggression layer can keep rendering without the map behind it.
+    let depth_enabled = config.enabled;
     let retained_start = history
         .retention_start_ms()
         .map_or(time_start, |start| start.max(time_start));
     let open_run_end_ms = history.latest_book_ms().unwrap_or(time_end);
-    let coverage: Vec<_> = history.coverage_segments().cloned().collect();
-    let grouped = sweep_grouped_runs(
-        history.runs_intersecting(retained_start, time_end),
-        coverage.iter(),
-        effective_grouping,
-        GroupingWindow {
-            start_ms: retained_start,
-            end_ms: time_end,
-            open_run_end_ms,
-            price_low: prices.low,
-            price_high: prices.high,
-        },
-    );
+    let coverage: Vec<_> = if depth_enabled {
+        history.coverage_segments().cloned().collect()
+    } else {
+        Vec::new()
+    };
+    let grouped = if depth_enabled {
+        sweep_grouped_runs(
+            history.runs_intersecting(retained_start, time_end),
+            coverage.iter(),
+            effective_grouping,
+            GroupingWindow {
+                start_ms: retained_start,
+                end_ms: time_end,
+                open_run_end_ms,
+                price_low: prices.low,
+                price_high: prices.high,
+            },
+        )
+    } else {
+        GroupedLiquidity::default()
+    };
 
     let mut drafts = Vec::new();
     for run in &grouped.runs {
@@ -450,53 +462,62 @@ pub fn project(
         })
         .collect();
 
-    let mut gaps: Vec<GapPrimitive> = history
-        .coverage_gaps()
-        .filter_map(|gap| {
-            let gap_end = gap.end_ms.unwrap_or(time_end);
-            if gap_end <= time_start || gap.start_ms >= time_end {
-                return None;
-            }
-            let x0 = timeline.locate_clamped(gap.start_ms.max(time_start))?;
-            let x1 = timeline.locate_clamped(gap_end.min(time_end))?;
-            (x1.normalized > x0.normalized).then(|| GapPrimitive {
-                from_generation: gap.from_generation,
-                to_generation: gap.to_generation,
-                x0: x0.normalized,
-                x1: x1.normalized,
-                reason: gap.reason.clone(),
+    // Coverage primitives describe the depth layer. With L2 capture off there
+    // is no map whose absence needs explaining, so a bubbles-only frame stays
+    // free of gap hatching.
+    let mut gaps: Vec<GapPrimitive> = if depth_enabled {
+        history
+            .coverage_gaps()
+            .filter_map(|gap| {
+                let gap_end = gap.end_ms.unwrap_or(time_end);
+                if gap_end <= time_start || gap.start_ms >= time_end {
+                    return None;
+                }
+                let x0 = timeline.locate_clamped(gap.start_ms.max(time_start))?;
+                let x1 = timeline.locate_clamped(gap_end.min(time_end))?;
+                (x1.normalized > x0.normalized).then(|| GapPrimitive {
+                    from_generation: gap.from_generation,
+                    to_generation: gap.to_generation,
+                    x0: x0.normalized,
+                    x1: x1.normalized,
+                    reason: gap.reason.clone(),
+                })
             })
-        })
-        .collect();
+            .collect()
+    } else {
+        Vec::new()
+    };
 
     // Historical trades can precede the first locally captured L2 snapshot.
     // Make that absence an explicit primitive instead of a transparent region
     // that could be mistaken for zero resting liquidity.
-    match history.coverage_segments().next() {
-        Some(first_coverage) if first_coverage.start_ms > time_start => {
-            let unavailable_end = first_coverage.start_ms.min(time_end);
-            if let (Some(x0), Some(x1)) = (
-                timeline.locate_clamped(time_start),
-                timeline.locate_clamped(unavailable_end),
-            ) && x1.normalized > x0.normalized
-            {
-                gaps.push(GapPrimitive {
-                    from_generation: None,
-                    to_generation: Some(first_coverage.generation),
-                    x0: x0.normalized,
-                    x1: x1.normalized,
-                    reason: "book_unavailable_before_capture".to_owned(),
-                });
+    if depth_enabled {
+        match history.coverage_segments().next() {
+            Some(first_coverage) if first_coverage.start_ms > time_start => {
+                let unavailable_end = first_coverage.start_ms.min(time_end);
+                if let (Some(x0), Some(x1)) = (
+                    timeline.locate_clamped(time_start),
+                    timeline.locate_clamped(unavailable_end),
+                ) && x1.normalized > x0.normalized
+                {
+                    gaps.push(GapPrimitive {
+                        from_generation: None,
+                        to_generation: Some(first_coverage.generation),
+                        x0: x0.normalized,
+                        x1: x1.normalized,
+                        reason: "book_unavailable_before_capture".to_owned(),
+                    });
+                }
             }
+            None => gaps.push(GapPrimitive {
+                from_generation: None,
+                to_generation: None,
+                x0: 0.0,
+                x1: 1.0,
+                reason: "book_unavailable_before_capture".to_owned(),
+            }),
+            Some(_) => {}
         }
-        None => gaps.push(GapPrimitive {
-            from_generation: None,
-            to_generation: None,
-            x0: 0.0,
-            x1: 1.0,
-            reason: "book_unavailable_before_capture".to_owned(),
-        }),
-        Some(_) => {}
     }
     gaps.sort_by(|a, b| a.x0.total_cmp(&b.x0).then_with(|| a.x1.total_cmp(&b.x1)));
 
@@ -618,6 +639,7 @@ mod tests {
     fn config() -> HeatmapConfig {
         HeatmapConfig {
             enabled: true,
+            show_aggressions: true,
             price_grouping: Decimal::ONE,
             ..HeatmapConfig::default()
         }
@@ -1025,6 +1047,77 @@ mod tests {
     }
 
     #[test]
+    fn bubbles_project_with_l2_capture_off() {
+        // The aggression layer only needs the trade stream. With depth capture
+        // off there is no map and no coverage story to tell, so cells and gap
+        // primitives stay empty while bubbles still project.
+        let mut history = LiquidityHistory::new(HeatmapConfig {
+            enabled: false,
+            bubble_cluster_ms: 0,
+            ..config()
+        });
+        for (id, price) in [(1_u64, "99.5"), (2, "100.5")] {
+            history.record_aggression(&Trade {
+                agg_id: id,
+                timestamp_ms: 200 + id as i64,
+                price: dec(price),
+                quantity: Decimal::ONE,
+                side: Side::Buy,
+            });
+        }
+        let projection = project(
+            &history,
+            &BarTimeline::from_bars(0, &[bar(0, 1_000)], None, None),
+            PriceWindow::new(dec("99"), dec("102")).unwrap(),
+        );
+        assert!(projection.enabled);
+        assert_eq!(projection.aggressions.len(), 2);
+        assert!(projection.cells.is_empty());
+        assert!(projection.gaps.is_empty());
+    }
+
+    #[test]
+    fn turning_l2_capture_off_hides_the_map_without_touching_bubbles_or_history() {
+        let mut history = LiquidityHistory::new(HeatmapConfig {
+            bubble_cluster_ms: 0,
+            ..config()
+        });
+        history.install_snapshot(100, 1, snapshot(10)).unwrap();
+        history.record_aggression(&Trade {
+            agg_id: 1,
+            timestamp_ms: 200,
+            price: dec("100.5"),
+            quantity: Decimal::ONE,
+            side: Side::Buy,
+        });
+        history
+            .apply_delta(900, &BookDelta::new(10, 10, vec![], vec![]))
+            .unwrap();
+        let timeline = BarTimeline::from_bars(0, &[bar(0, 1_000)], None, None);
+        let prices = PriceWindow::new(dec("99"), dec("102")).unwrap();
+        let before = project(&history, &timeline, prices);
+        assert!(!before.cells.is_empty());
+        assert_eq!(before.aggressions.len(), 1);
+        let runs_before = history.runs().count();
+
+        history
+            .update_config(HeatmapConfig {
+                enabled: false,
+                bubble_cluster_ms: 0,
+                ..config()
+            })
+            .unwrap();
+        let after = project(&history, &timeline, prices);
+        assert!(after.cells.is_empty(), "the map stops drawing");
+        assert_eq!(after.aggressions.len(), 1, "bubbles are untouched");
+        assert_eq!(
+            history.runs().count(),
+            runs_before,
+            "retained L2 history survives the toggle"
+        );
+    }
+
+    #[test]
     fn primitive_caps_report_dropped_items() {
         let limited = HeatmapConfig {
             max_visible_cells: 1,
@@ -1130,6 +1223,7 @@ mod tests {
     fn projects_partial_and_full_reductions_with_conserved_aggression_evidence() {
         let event_config = HeatmapConfig {
             enabled: true,
+            show_aggressions: true,
             price_grouping: Decimal::ONE,
             display_grouping: DisplayGrouping::Native,
             bubble_cluster_ms: 100,

--- a/crates/app/src/orderflow_engine.rs
+++ b/crates/app/src/orderflow_engine.rs
@@ -349,9 +349,15 @@ impl BookEngine {
         }
     }
 
-    #[must_use]
-    pub fn enabled(&self) -> bool {
+    #[cfg(test)]
+    pub(crate) fn enabled(&self) -> bool {
         self.config.enabled
+    }
+
+    /// Whether any layer (depth map or aggression bubbles) still wants frames.
+    #[must_use]
+    pub fn any_layer_enabled(&self) -> bool {
+        self.config.any_layer_enabled()
     }
 
     #[cfg(test)]
@@ -447,6 +453,11 @@ impl BookEngine {
         }
         self.config = config;
         self.invalidate_projection();
+        if !self.config.any_layer_enabled() {
+            // Nothing left to draw: release the frame instead of publishing a
+            // stale one that no layer would render.
+            self.last_frame = None;
+        }
         self.apply_non_grouping_config();
         self.log_config_changed(false, "reproject");
     }
@@ -524,8 +535,11 @@ impl BookEngine {
     }
 
     /// Record a factual aggregate trade for the aggression overlay.
+    ///
+    /// Aggressions come from the trade stream the chart already consumes, so
+    /// the bubble layer records with L2 capture off.
     pub fn record_trade(&mut self, trade: &Trade) {
-        if self.config.enabled {
+        if self.config.any_layer_enabled() {
             self.history.record_aggression(trade);
         }
     }
@@ -724,7 +738,7 @@ impl BookEngine {
 
     /// Build (or reuse) renderer-independent primitives for one request.
     pub(crate) fn project(&mut self, request: &ProjectionRequest) -> Option<Arc<VisibleOrderflow>> {
-        if !self.config.enabled {
+        if !self.config.any_layer_enabled() {
             return None;
         }
         let layout = request.layout();

--- a/crates/app/src/orderflow_render.rs
+++ b/crates/app/src/orderflow_render.rs
@@ -104,13 +104,15 @@ impl Default for OrderflowRenderStyle {
 
 impl OrderflowRenderStyle {
     /// Resolve the renderer-owned choices that have a corresponding user
-    /// setting. Bubble geometry remains independent so it can later be exposed
-    /// without growing the domain configuration again.
+    /// setting. Bubble alpha and maximum radius now come from the aggression
+    /// panel; the remaining geometry stays renderer-owned.
     #[must_use]
     pub(crate) fn from_config(config: &HeatmapConfig, canvas_background: egui::Color32) -> Self {
         Self {
             theme: config.theme,
             show_legend: config.show_legend,
+            bubble_opacity: config.bubble_opacity,
+            bubble_max_radius: config.bubble_max_radius,
             canvas_background,
             ..Self::default()
         }

--- a/crates/app/src/orderflow_render.rs
+++ b/crates/app/src/orderflow_render.rs
@@ -70,6 +70,11 @@ pub(crate) struct OrderflowRenderStyle {
     pub(crate) label_min_radius: f32,
     pub(crate) show_gap_labels: bool,
     pub(crate) show_legend: bool,
+    /// Whether the L2 depth layer is active. The legend only advertises keys
+    /// for layers that can actually draw something.
+    pub(crate) depth_layer: bool,
+    /// Whether the aggression layer is active.
+    pub(crate) aggression_layer: bool,
     pub(crate) legend_max_width: f32,
     /// Follows the chart canvas so the deterministic preview sits on the same
     /// ground as the live chart.
@@ -96,6 +101,8 @@ impl Default for OrderflowRenderStyle {
             label_min_radius: 16.0,
             show_gap_labels: true,
             show_legend: true,
+            depth_layer: true,
+            aggression_layer: true,
             legend_max_width: 690.0,
             canvas_background: egui::Color32::from_rgb(19, 23, 34),
         }
@@ -113,6 +120,8 @@ impl OrderflowRenderStyle {
             show_legend: config.show_legend,
             bubble_opacity: config.bubble_opacity,
             bubble_max_radius: config.bubble_max_radius,
+            depth_layer: config.enabled,
+            aggression_layer: config.show_aggressions,
             canvas_background,
             ..Self::default()
         }
@@ -705,20 +714,31 @@ pub(crate) fn draw_compact_legend(painter: &egui::Painter, context: &RenderConte
     } else {
         "liquidity".to_owned()
     };
-    let entries = [
-        (LegendGlyph::Heat, liquidity_label),
-        (LegendGlyph::Buy, "buy aggression".to_owned()),
-        (LegendGlyph::Sell, "sell aggression".to_owned()),
-        (
+    // Only key the layers that can draw. With L2 capture off the map, its
+    // depletion markers and its gaps are absent, and announcing them would
+    // describe a chart the viewer is not looking at.
+    let mut entries: Vec<(LegendGlyph, String)> = Vec::new();
+    if style.depth_layer {
+        entries.push((LegendGlyph::Heat, liquidity_label));
+    }
+    if style.aggression_layer {
+        entries.push((LegendGlyph::Buy, "buy aggression".to_owned()));
+        entries.push((LegendGlyph::Sell, "sell aggression".to_owned()));
+    }
+    if style.depth_layer {
+        entries.push((
             LegendGlyph::Aligned,
             "aggression-aligned depletion".to_owned(),
-        ),
-        (
+        ));
+        entries.push((
             LegendGlyph::DepthOnly,
             "L2 reduction (unattributed)".to_owned(),
-        ),
-        (LegendGlyph::Gap, "L2 gap".to_owned()),
-    ];
+        ));
+        entries.push((LegendGlyph::Gap, "L2 gap".to_owned()));
+    }
+    if entries.is_empty() {
+        return;
+    }
     let font = egui::FontId::proportional(10.0);
     let galleys: Vec<_> = entries
         .iter()

--- a/crates/app/src/orderflow_view.rs
+++ b/crates/app/src/orderflow_view.rs
@@ -784,8 +784,10 @@ fn panel_header(ui: &mut egui::Ui, title: &str, open: &mut bool) {
                 .color(egui::Color32::from_rgb(255, 222, 92)),
         );
         ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+            // `×` is Latin-1, so it renders in egui's default proportional
+            // font — the fancier ✕/✖ glyphs fall back to an empty box.
             if ui
-                .small_button("✕")
+                .small_button("×")
                 .on_hover_text("close this panel")
                 .clicked()
             {

--- a/crates/app/src/orderflow_view.rs
+++ b/crates/app/src/orderflow_view.rs
@@ -16,7 +16,10 @@ use quantick_feed_binance::depth::DepthEvent;
 use rust_decimal::Decimal;
 use rust_decimal::prelude::{FromPrimitive as _, ToPrimitive as _};
 
-use crate::orderflow::{DisplayGrouping, HeatmapConfig, HeatmapTheme, IntensityMode};
+use crate::orderflow::{
+    DisplayGrouping, HeatmapConfig, HeatmapTheme, IntensityMode, MAX_BUBBLE_MAX_RADIUS,
+    MIN_BUBBLE_MAX_RADIUS,
+};
 use crate::orderflow_engine::{
     BookPublished, CaptureStatus, OrderflowHealth, PROJECTION_INTERVAL, ProjectionLayout,
     ProjectionRequest, VisibleOrderflow,
@@ -52,7 +55,10 @@ pub struct OrderflowView {
     published: BookPublished,
     /// Engine bucket last adopted into the mirror, to detect auto-base moves.
     last_seen_base: Decimal,
-    show_settings: bool,
+    /// Whether the docked L2 (liquidity map) settings panel is open.
+    show_l2_panel: bool,
+    /// Whether the docked aggression-bubble settings panel is open.
+    show_bubbles_panel: bool,
     capture_grouping_draft: f64,
     pending_capture_grouping_previous: Option<Decimal>,
     last_requested_layout: Option<ProjectionLayout>,
@@ -71,7 +77,8 @@ impl OrderflowView {
             config,
             published: BookPublished::initial(),
             last_seen_base: base_grouping,
-            show_settings: false,
+            show_l2_panel: false,
+            show_bubbles_panel: false,
             capture_grouping_draft: base_grouping.to_f64().unwrap_or(0.01),
             pending_capture_grouping_previous: None,
             last_requested_layout: None,
@@ -95,9 +102,28 @@ impl OrderflowView {
         }
     }
 
+    /// Whether L2 depth capture is on. Says nothing about the bubble layer.
     #[must_use]
     pub fn enabled(&self) -> bool {
         self.config.enabled
+    }
+
+    /// Whether the aggression layer is on. Independent of the depth map: it
+    /// reads the trade stream the chart already consumes.
+    #[must_use]
+    pub fn bubbles_enabled(&self) -> bool {
+        self.config.show_aggressions
+    }
+
+    /// Toggle the aggression layer without touching L2 capture. No feed
+    /// command is needed — aggregate trades already flow for the candles.
+    pub fn set_bubbles_enabled(&mut self, enabled: bool) {
+        if self.config.show_aggressions == enabled {
+            return;
+        }
+        let before = self.config.clone();
+        self.config.show_aggressions = enabled;
+        self.commit_config_changes(before);
     }
 
     /// Latest exchange timestamp for which live book state is known, while
@@ -111,17 +137,29 @@ impl OrderflowView {
         self.published.live_end_ms
     }
 
-    pub fn toggle_settings(&mut self) {
-        self.show_settings = !self.show_settings;
+    pub fn toggle_l2_panel(&mut self) {
+        self.show_l2_panel = !self.show_l2_panel;
+    }
+
+    pub fn toggle_bubbles_panel(&mut self) {
+        self.show_bubbles_panel = !self.show_bubbles_panel;
     }
 
     #[must_use]
-    pub fn settings_button_label(&self) -> String {
+    pub fn l2_button_label(&self) -> String {
         match self.config.display_grouping {
             DisplayGrouping::Adaptive { .. } => "⚙ L2 · auto".to_owned(),
             DisplayGrouping::Native => "⚙ L2 · 1×".to_owned(),
             DisplayGrouping::Multiple(multiple) => format!("⚙ L2 · {multiple}×"),
         }
+    }
+
+    #[must_use]
+    pub fn bubbles_button_label(&self) -> String {
+        format!(
+            "⚙ bubbles · {}",
+            cluster_label(self.config.bubble_cluster_ms)
+        )
     }
 
     #[cfg(test)]
@@ -225,7 +263,7 @@ impl OrderflowView {
 
     /// Record a factual aggregate trade for the aggression overlay.
     pub fn record_trade(&mut self, trade: &Trade) {
-        if self.config.enabled {
+        if self.config.any_layer_enabled() {
             self.worker.send(BookCommand::Trade(trade.clone()));
         }
     }
@@ -247,7 +285,7 @@ impl OrderflowView {
         extend_live_end: bool,
         price_range: (f64, f64),
     ) -> Option<Arc<VisibleOrderflow>> {
-        if !self.config.enabled {
+        if !self.config.any_layer_enabled() {
             return None;
         }
         self.sync_published();
@@ -355,37 +393,43 @@ impl OrderflowView {
         self.worker.send(BookCommand::ResetSummaryCounters);
     }
 
-    /// Draw the floating settings window and return whether capture must
+    /// Draw the docked order-flow panels and return whether capture must
     /// restart because the base capture resolution changed.
-    pub fn draw_settings(&mut self, ctx: &egui::Context) -> bool {
-        if !self.show_settings {
+    ///
+    /// The L2 map and the aggression bubbles get one panel each, so neither
+    /// configuration hides behind the other's switch.
+    pub fn draw_panels(&mut self, ctx: &egui::Context) -> bool {
+        if !self.show_l2_panel && !self.show_bubbles_panel {
             return false;
         }
         self.sync_published();
         let before = self.config.clone();
-        let mut open = self.show_settings;
-        egui::Window::new("order flow · liquidity map")
-            .open(&mut open)
-            .default_width(420.0)
+        self.draw_l2_panel(ctx);
+        self.draw_bubbles_panel(ctx);
+        self.commit_config_changes(before)
+    }
+
+    /// Left dock for everything the depth map owns.
+    fn draw_l2_panel(&mut self, ctx: &egui::Context) {
+        if !self.show_l2_panel {
+            return;
+        }
+        let mut open = true;
+        egui::SidePanel::left("orderflow_l2_panel")
             .resizable(true)
+            .default_width(340.0)
+            .width_range(300.0..=620.0)
             .show(ctx, |ui| {
+                panel_header(ui, "L2 · LIQUIDITY MAP", &mut open);
                 egui::ScrollArea::vertical()
-                    .id_salt("orderflow_settings_scroll")
-                    .max_height(560.0)
+                    .id_salt("orderflow_l2_scroll")
                     .auto_shrink([false, false])
                     .show(ui, |ui| {
-                ui.horizontal(|ui| {
-                    ui.label(
-                        egui::RichText::new("BOOKMAP VIEW")
-                            .strong()
-                            .color(egui::Color32::from_rgb(255, 222, 92)),
-                    );
-                    ui.label(
-                        egui::RichText::new(self.published.status.label())
-                            .small()
-                            .color(status_color(&self.published.status)),
-                    );
-                });
+                ui.label(
+                    egui::RichText::new(self.published.status.label())
+                        .small()
+                        .color(status_color(&self.published.status)),
+                );
                 ui.small(
                     "Brightness is resting liquidity. Green/red bubbles are confirmed trades.",
                 );
@@ -480,33 +524,6 @@ impl OrderflowView {
                     egui::Slider::new(&mut self.config.gamma, 0.25..=2.0)
                         .text("quiet liquidity"),
                 );
-
-                ui.separator();
-                ui.strong("aggression bubbles");
-                ui.checkbox(&mut self.config.show_aggressions, "show confirmed executions")
-                    .on_hover_text("confirmed Binance aggTrades; color is the aggressor side");
-                ui.add_enabled_ui(self.config.show_aggressions, |ui| {
-                    ui.horizontal(|ui| {
-                        ui.label("cluster");
-                        egui::ComboBox::from_id_salt("heatmap_bubble_cluster")
-                            .selected_text(cluster_label(self.config.bubble_cluster_ms))
-                            .show_ui(ui, |ui| {
-                                for (milliseconds, label) in [
-                                    (0, "Raw"),
-                                    (50, "50 ms"),
-                                    (100, "100 ms"),
-                                    (200, "200 ms"),
-                                    (500, "500 ms"),
-                                ] {
-                                    ui.selectable_value(
-                                        &mut self.config.bubble_cluster_ms,
-                                        milliseconds,
-                                        label,
-                                    );
-                                }
-                            });
-                    });
-                });
 
                 ui.separator();
                 ui.strong("liquidity response");
@@ -617,22 +634,117 @@ impl OrderflowView {
                     "effective range {} · {}× base",
                     health.effective_grouping, health.effective_grouping_multiple
                 ));
-                if ui.button("reset Bookmap visuals").clicked() {
-                    let enabled = self.config.enabled;
+                if ui.button("reset L2 visuals").clicked() {
                     let price_grouping = self.config.price_grouping;
                     self.capture_grouping_draft =
                         price_grouping.to_f64().unwrap_or(self.capture_grouping_draft);
                     self.config = HeatmapConfig {
-                        enabled,
+                        enabled: self.config.enabled,
                         price_grouping,
+                        // The bubble layer owns its own panel and its own reset.
+                        show_aggressions: self.config.show_aggressions,
+                        bubble_cluster_ms: self.config.bubble_cluster_ms,
+                        bubble_opacity: self.config.bubble_opacity,
+                        bubble_max_radius: self.config.bubble_max_radius,
                         ..HeatmapConfig::default()
                     };
                 }
                     });
             });
-        self.show_settings = open;
+        self.show_l2_panel = open;
+    }
 
-        self.commit_config_changes(before)
+    /// Left dock for the aggression layer. Everything here is independent of
+    /// L2 capture: bubbles are built from the aggregate-trade stream.
+    fn draw_bubbles_panel(&mut self, ctx: &egui::Context) {
+        if !self.show_bubbles_panel {
+            return;
+        }
+        let mut open = true;
+        egui::SidePanel::left("orderflow_bubbles_panel")
+            .resizable(true)
+            .default_width(300.0)
+            .width_range(260.0..=520.0)
+            .show(ctx, |ui| {
+                panel_header(ui, "AGGRESSION BUBBLES", &mut open);
+                egui::ScrollArea::vertical()
+                    .id_salt("orderflow_bubbles_scroll")
+                    .auto_shrink([false, false])
+                    .show(ui, |ui| {
+                        ui.small(
+                            "Confirmed executions from the trade stream. Colour is the aggressor side; area is quantity.",
+                        );
+                        ui.small(
+                            "This layer is independent: it keeps drawing with L2 capture off.",
+                        );
+                        ui.separator();
+
+                        ui.checkbox(&mut self.config.show_aggressions, "show aggression bubbles")
+                            .on_hover_text(
+                                "records and projects confirmed trades; does not start or stop L2 depth capture",
+                            );
+                        ui.add_enabled_ui(self.config.show_aggressions, |ui| {
+                            ui.horizontal(|ui| {
+                                ui.label("cluster");
+                                egui::ComboBox::from_id_salt("heatmap_bubble_cluster")
+                                    .selected_text(cluster_label(self.config.bubble_cluster_ms))
+                                    .show_ui(ui, |ui| {
+                                        for (milliseconds, label) in [
+                                            (0, "Raw"),
+                                            (50, "50 ms"),
+                                            (100, "100 ms"),
+                                            (200, "200 ms"),
+                                            (500, "500 ms"),
+                                        ] {
+                                            ui.selectable_value(
+                                                &mut self.config.bubble_cluster_ms,
+                                                milliseconds,
+                                                label,
+                                            );
+                                        }
+                                    });
+                            })
+                            .response
+                            .on_hover_text(
+                                "merge compatible prints inside this window into one bubble; Raw keeps one bubble per trade",
+                            );
+                            ui.add(
+                                egui::Slider::new(&mut self.config.bubble_opacity, 0.05..=1.0)
+                                    .text("bubble opacity"),
+                            );
+                            ui.add(
+                                egui::Slider::new(
+                                    &mut self.config.bubble_max_radius,
+                                    MIN_BUBBLE_MAX_RADIUS..=MAX_BUBBLE_MAX_RADIUS,
+                                )
+                                .text("largest bubble px"),
+                            )
+                            .on_hover_text(
+                                "area stays quantity-proportional; this only sets how big the biggest print draws",
+                            );
+                        });
+
+                        ui.separator();
+                        let health = &self.published.health;
+                        ui.label(format!(
+                            "{} bubbles projected · {} aggressions retained",
+                            health.projection_aggressions, health.aggression_count
+                        ));
+                        if health.dropped_aggressions > 0 {
+                            ui.small(format!(
+                                "{} bubbles above the primitive cap were not drawn",
+                                health.dropped_aggressions
+                            ));
+                        }
+                        if ui.button("reset bubble visuals").clicked() {
+                            let defaults = HeatmapConfig::default();
+                            self.config.bubble_cluster_ms = defaults.bubble_cluster_ms;
+                            self.config.bubble_opacity = defaults.bubble_opacity;
+                            self.config.bubble_max_radius = defaults.bubble_max_radius;
+                        }
+                    });
+            });
+        self.show_bubbles_panel = open;
     }
 
     fn commit_config_changes(&mut self, before: HeatmapConfig) -> bool {
@@ -660,6 +772,28 @@ impl OrderflowView {
         }
         restart_required
     }
+}
+
+/// Title row shared by the docked panels, with the close affordance a floating
+/// window used to provide.
+fn panel_header(ui: &mut egui::Ui, title: &str, open: &mut bool) {
+    ui.horizontal(|ui| {
+        ui.label(
+            egui::RichText::new(title)
+                .strong()
+                .color(egui::Color32::from_rgb(255, 222, 92)),
+        );
+        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+            if ui
+                .small_button("✕")
+                .on_hover_text("close this panel")
+                .clicked()
+            {
+                *open = false;
+            }
+        });
+    });
+    ui.separator();
 }
 
 fn theme_label(theme: HeatmapTheme) -> &'static str {
@@ -753,6 +887,39 @@ mod tests {
             .expect("published frame");
         assert!(frame.projection.enabled);
         assert!(!frame.projection.cells.is_empty());
+    }
+
+    #[test]
+    fn bubbles_project_while_book_capture_stays_off() {
+        let mut view = OrderflowView::new("BTCUSDT");
+        view.set_bubbles_enabled(true);
+        assert!(!view.enabled(), "the bubble layer must not start capture");
+
+        view.record_trade(&Trade {
+            agg_id: 1,
+            timestamp_ms: 1_000,
+            price: Decimal::new(1_005, 1),
+            quantity: Decimal::ONE,
+            side: quantick_engine::Side::Buy,
+        });
+        view.flush_for_test();
+        assert_eq!(view.health().aggression_count, 1);
+
+        let bars = [bar(900, 1_100)];
+        view.project_visible(0, &bars, None, true, (98.0, 102.0));
+        view.flush_for_test();
+        let frame = view
+            .project_visible(0, &bars, None, true, (98.0, 102.0))
+            .expect("published frame");
+        assert_eq!(frame.projection.aggressions.len(), 1);
+        assert!(frame.projection.cells.is_empty(), "no map without capture");
+
+        // Turning the bubbles off closes the pipeline again.
+        view.set_bubbles_enabled(false);
+        assert!(
+            view.project_visible(0, &bars, None, true, (98.0, 102.0))
+                .is_none()
+        );
     }
 
     #[test]

--- a/crates/app/src/orderflow_worker.rs
+++ b/crates/app/src/orderflow_worker.rs
@@ -157,7 +157,7 @@ fn run(mut engine: BookEngine, rx: &Receiver<BookCommand>, shared: &Arc<Mutex<Bo
         // (layout equality + depth-cadence interval) decides whether this is
         // a real rebuild or a no-op, so a chatty batch stays cheap.
         if let Some(request) = &last_request
-            && engine.enabled()
+            && engine.any_layer_enabled()
         {
             engine.project(request);
         }


### PR DESCRIPTION
## Why

Two complaints about the order-flow UI:

1. The L2 settings opened as a floating window **on top of the chart** — you had to move it to see what you were configuring.
2. `HeatmapConfig::enabled` gated the whole pipeline, so **turning off the book also killed the aggression bubbles**. Bubbles need only the aggregate-trade stream the chart already consumes; there was no reason for them to depend on the depth pipeline.

## What changed

**Docked panels.** `egui::Window` → two `egui::SidePanel::left`, drawn before the `CentralPanel` so the chart cedes width instead of being covered. `⚙ L2` opens *L2 · LIQUIDITY MAP* (theme, price ranges, liquidity response, retention, capture resolution). `⚙ bubbles` opens *AGGRESSION BUBBLES* (clustering, opacity, largest-bubble size). Each has its own close button and its own reset.

**Independent layers.** `show_aggressions` is now the aggression layer's own switch, with a `bubbles` checkbox next to `book heatmap` in the toolbar — and it is *not* gated on provider support, since trades flow for every feed (MT5 included). `HeatmapConfig::any_layer_enabled()` replaces the `enabled` check at every gate: `record_trade` (view + engine), `project` (engine + pure projection) and the worker's project gate.

- Turning L2 capture off hides the map **without discarding retained L2 history**, and leaves gap primitives out of bubbles-only frames (there is no coverage story to tell when there is no map).
- The legend keys only the layers that can draw, and hides itself when neither is on.
- Bubble opacity and maximum radius were renderer-only; they are now config, which is what the existing `from_config` comment anticipated.

**Behaviour change:** bubbles now default to **off**, matching the depth map. Previously they came along for free when you enabled the book. That is the price of independence — they are one click away in the toolbar.

## Verification

All four checks green: `cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`, `cargo build --workspace`, `cargo test --workspace` (175 tests in `app`).

Four new tests pin the independence:

- `projection::bubbles_project_with_l2_capture_off` — cells and gaps empty, bubbles present.
- `projection::turning_l2_capture_off_hides_the_map_without_touching_bubbles_or_history` — retained run count unchanged across the toggle.
- `orderflow_view::bubbles_project_while_book_capture_stays_off` — full worker round trip with capture never enabled.
- `app::bubble_toggle_needs_no_feed_command_and_leaves_capture_alone` — no `FeedCommand` is emitted, and stopping the book leaves bubbles on.

Also smoke-tested against the live Binance feed: with `☐ book heatmap` + `☑ bubbles`, the L2 panel reports `book off · 0 runs · 0.0 MiB retained` while the bubble panel reports `31 bubbles projected · 37 aggressions retained` and the bubbles draw on the chart with no heatmap behind them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)