### PR TITLE
feat(mt5): order-flow depth for the mini index, on one shared pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 /quantick.toml
 # Python bytecode from the design lab
 __pycache__/
+
+# Server-time offset the MT5 bridge measures and remembers (per machine).
+.quantick_bridge_cache.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2314,6 +2314,7 @@ name = "quantick-feed-mt5"
 version = "0.1.0"
 dependencies = [
  "quantick-engine",
+ "quantick-orderbook",
  "rust_decimal",
  "serde",
  "serde_json",
@@ -2866,6 +2867,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3169,6 +3180,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",

--- a/bridge/mt5/PROTOCOL.md
+++ b/bridge/mt5/PROTOCOL.md
@@ -5,19 +5,24 @@ dials out** (MQL5 sockets are client-only); the quantick feed listens
 (default `127.0.0.1:9100`). One connection = one session. The stream is
 one-way: bridge → feed.
 
+Two bridges implement it — `quantick_bridge.py` (outside the terminal, via the
+official Python package) and `QuantickBridge.mq5` (inside it) — and the feed
+accepts either without knowing the difference. The protocol is the contract;
+the bridges are interchangeable.
+
 The executable counterpart of this document is
 `crates/feed-mt5/src/protocol.rs` — its tests parse the verbatim lines shown
-here. If you change one, change both.
+here. If you change one, change all three.
 
 ## Session shape
 
 ```
-hello                    exactly once, first line
-backfill_start           optional block, at most once, right after hello
-  tick × N               historical ticks (CopyTicks)
+hello                        exactly once, first line
+backfill_start               optional block, at most once, right after hello
+  tick × N                   historical ticks (CopyTicks)
 backfill_end
-tick | heartbeat × …     live, until the session ends
-bye                      optional clean goodbye
+tick | book | heartbeat × …  live, until the session ends
+bye                          optional clean goodbye
 ```
 
 ## Messages
@@ -25,7 +30,7 @@ bye                      optional clean goodbye
 ### hello
 
 ```json
-{"type":"hello","schema":1,"bridge":"quantick-mt5-bridge","bridge_version":"0.1.0","symbol":"WIN$N","broker_symbol":"WINQ26","digits":0,"server_utc_offset_s":-10800}
+{"type":"hello","schema":1,"bridge":"quantick-mt5-bridge","bridge_version":"0.2.0","symbol":"WIN$N","broker_symbol":"WINQ26","digits":0,"server_utc_offset_s":-10800,"book_levels":20,"tick_size":"5"}
 ```
 
 - `schema` — protocol version; the feed refuses a mismatch.
@@ -34,6 +39,17 @@ bye                      optional clean goodbye
 - `server_utc_offset_s` — **the honesty field**: MT5 stamps ticks in *server
   wall time encoded as epoch*. True UTC = `time_ms − server_utc_offset_s×1000`.
   Computed live as `TimeTradeServer() − TimeGMT()` (B3: −10800).
+- `book_levels` — *optional*. Present only when this session can actually send
+  depth (`MarketBookAdd` succeeded): `SYMBOL_TICKS_BOOKDEPTH`, i.e. the most
+  levels per side the terminal exposes. **Absent means no book** — either a
+  bridge older than schema 1's depth support, or a symbol/account without a
+  DOM. The feed reports that instead of drawing an empty heatmap.
+- `tick_size` — *optional*, `SYMBOL_TRADE_TICK_SIZE` as an exact decimal
+  string. The instrument's real price grid (WIN: `"5"`), so the consumer does
+  not render liquidity on rows that can never hold any.
+
+Both depth fields are additive within schema 1: a bridge that predates them
+still connects and still streams ticks.
 
 ### tick
 
@@ -53,6 +69,36 @@ bye                      optional clean goodbye
   not reject. **Known pathology**: some B3 brokers set BUY on every tick —
   the feed's tick-rule side policy exists because of this (verified
   2026-07-23 on WIN$N: 100% of live and history ticks carried `flags=1080`).
+
+### book
+
+```json
+{"type":"book","seq":7,"time_ms":1784824300802,"bids":[["177795","3"],["177790","12"]],"asks":[["177800","5"]]}
+```
+
+One **complete image** of the Depth of Market. MT5 has no incremental book
+protocol: `OnBookEvent` fires and `MarketBookGet` returns the whole visible
+DOM, with no update ids of any kind. The feed diffs successive images into the
+snapshot-plus-delta form the rest of quantick speaks
+(`quantick_orderbook::SnapshotDiffer`).
+
+- `seq` — bridge-assigned, monotonic from 1 per session, **independent of tick
+  `seq`**. Only for detecting images lost in transport; a gap makes the feed
+  open a new capture generation rather than diff across an unobserved moment.
+- `time_ms` — server time (see hello), taken as
+  `max(SYMBOL_TIME_MSC, TimeTradeServer()×1000)` so the book timeline keeps
+  moving when quotes go quiet.
+- `bids`/`asks` — `["price","quantity"]` pairs, exact decimal strings, in
+  whatever order the terminal returned them (the feed sorts and sums
+  duplicates). Prices carry `digits` decimals.
+- Limit levels only. `BOOK_TYPE_*_MARKET` rows are orders waiting to cross,
+  not resting liquidity, and the bridge excludes them.
+- The bridge sends an image only when it differs from the previous one, and at
+  most every `InpBookMinIntervalMs` (default 20 ms).
+
+Empty sides are legitimate (auction, halted book), not an error. A **crossed**
+image (best bid ≥ best ask) is real during B3's pre-open auction; the feed
+rejects and counts it, keeping the last uncrossed image.
 
 ### heartbeat
 

--- a/bridge/mt5/QuantickBridge.mq5
+++ b/bridge/mt5/QuantickBridge.mq5
@@ -4,9 +4,15 @@
 //| Attach this Expert Advisor to a chart of the symbol you want in    |
 //| quantick (e.g. WIN$N). It dials the quantick feed's local TCP      |
 //| listener and streams newline-delimited JSON: a hello, a backfill   |
-//| block from CopyTicks, then live ticks and heartbeats. The protocol |
-//| contract lives in PROTOCOL.md next to this file; the Rust decoder  |
-//| in crates/feed-mt5 is its executable counterpart.                  |
+//| block from CopyTicks, then live ticks, Depth of Market images and  |
+//| heartbeats. The protocol contract lives in PROTOCOL.md next to     |
+//| this file; the Rust decoder in crates/feed-mt5 is its executable   |
+//| counterpart.                                                       |
+//|                                                                    |
+//| The book is sent as a *complete image* every time it changes: MT5  |
+//| has no incremental book protocol, MarketBookGet only ever returns  |
+//| the whole visible DOM. The feed diffs successive images, so only   |
+//| real changes travel further into quantick.                         |
 //|                                                                    |
 //| No credentials are involved anywhere: the terminal is already      |
 //| logged in and the socket never leaves this machine.                |
@@ -24,10 +30,12 @@ input int    InpBackfillMinutes  = 30;          // History to send on connect
 input int    InpHeartbeatSeconds = 5;           // Heartbeat interval
 input int    InpRetrySeconds     = 5;           // Reconnect backoff
 input int    InpSendTimeoutMs    = 5000;        // Max ms one send may block
+input bool   InpStreamBook       = true;        // Stream Depth of Market
+input int    InpBookMinIntervalMs= 20;          // Min ms between book images (0 = every change)
 
 #define SCHEMA_VERSION 1
 #define BRIDGE_NAME    "quantick-mt5-bridge"
-#define BRIDGE_VERSION "0.1.1"
+#define BRIDGE_VERSION "0.2.0"
 
 int      g_socket           = INVALID_HANDLE;
 ulong    g_seq              = 0; // per-session tick sequence, from 1
@@ -36,6 +44,13 @@ long     g_last_msc         = 0; // cursor: newest tick time already pumped
 int      g_sent_at_last_msc = 0; // ticks already sent sharing g_last_msc
 datetime g_last_heartbeat   = 0;
 datetime g_next_retry       = 0;
+
+bool     g_book_subscribed  = false; // MarketBookAdd succeeded
+ulong    g_book_seq         = 0;     // per-session book image number, from 1
+ulong    g_book_sent        = 0;
+ulong    g_book_skipped     = 0;     // images identical to the previous one
+long     g_book_last_ms     = 0;     // throttle cursor (local ms)
+string   g_book_last_body   = "";    // last image's levels, for change detection
 
 //+------------------------------------------------------------------+
 //| Structured Experts-tab logging (AI-first: parseable, coded).      |
@@ -130,6 +145,97 @@ bool SendTick(const MqlTick &tick)
   }
 
 //+------------------------------------------------------------------+
+//| One book level's quantity. volume_real carries the accurate value |
+//| where a venue has fractional lots; B3 volumes are whole contracts |
+//| and print as integers so images stay small.                       |
+//+------------------------------------------------------------------+
+string BookVolumeText(const MqlBookInfo &item)
+  {
+   double v = (item.volume_real > 0.0) ? item.volume_real : (double)item.volume;
+   if(v <= 0.0)
+      return("0");
+   if(MathAbs(v - MathRound(v)) < 1e-9)
+      return(IntegerToString((long)MathRound(v)));
+   return(DoubleToString(v, 2));
+  }
+
+//+------------------------------------------------------------------+
+//| Send one complete Depth of Market image.                          |
+//|                                                                   |
+//| Two filters keep the terminal's main thread and the socket quiet  |
+//| without losing anything the chart could show: a minimum interval, |
+//| and a comparison against the last image (MT5 fires OnBookEvent    |
+//| for changes that leave the visible limit book untouched).         |
+//| False = the socket is broken.                                     |
+//+------------------------------------------------------------------+
+bool SendBook()
+  {
+   if(g_socket == INVALID_HANDLE || !InpStreamBook || !g_book_subscribed)
+      return(true);
+
+   long now_ms = (long)(GetMicrosecondCount() / 1000);
+   if(InpBookMinIntervalMs > 0 && (now_ms - g_book_last_ms) < InpBookMinIntervalMs)
+      return(true);
+
+   MqlBookInfo book[];
+   if(!MarketBookGet(_Symbol, book))
+      return(true); // transient; the next book event retries
+
+   string bids = "";
+   string asks = "";
+   int    n    = ArraySize(book);
+   for(int i = 0; i < n; i++)
+     {
+      // BOOK_TYPE_*_MARKET rows are orders waiting to cross, not resting
+      // liquidity at a price: they carry no level to draw.
+      if(book[i].type != BOOK_TYPE_BUY && book[i].type != BOOK_TYPE_SELL)
+         continue;
+      if(book[i].price <= 0.0)
+         continue;
+      string level = StringFormat("[\"%s\",\"%s\"]",
+                                  DoubleToString(book[i].price, _Digits),
+                                  BookVolumeText(book[i]));
+      if(book[i].type == BOOK_TYPE_BUY)
+        {
+         if(StringLen(bids) > 0)
+            StringAdd(bids, ",");
+         StringAdd(bids, level);
+        }
+      else
+        {
+         if(StringLen(asks) > 0)
+            StringAdd(asks, ",");
+         StringAdd(asks, level);
+        }
+     }
+
+   string body = StringFormat("\"bids\":[%s],\"asks\":[%s]", bids, asks);
+   if(body == g_book_last_body)
+     {
+      g_book_skipped++;
+      return(true); // identical image: sending it would only cost bandwidth
+     }
+   g_book_last_body = body;
+   g_book_last_ms   = now_ms;
+
+   // SYMBOL_TIME_MSC is the last quote's instant; in a quiet book it stops
+   // moving, so the coarser server clock takes over and the book timeline
+   // never stalls behind the trade timeline.
+   long stamp     = (long)SymbolInfoInteger(_Symbol, SYMBOL_TIME_MSC);
+   long server_ms = (long)TimeTradeServer() * 1000;
+   if(server_ms > stamp)
+      stamp = server_ms;
+
+   g_book_seq++;
+   string line = StringFormat("{\"type\":\"book\",\"seq\":%I64u,\"time_ms\":%I64d,%s}",
+                              g_book_seq, stamp, body);
+   if(!SendLine(line))
+      return(false);
+   g_book_sent++;
+   return(true);
+  }
+
+//+------------------------------------------------------------------+
 //| Session preamble + recent history, right after connecting.        |
 //+------------------------------------------------------------------+
 bool StartSession()
@@ -137,16 +243,34 @@ bool StartSession()
    g_seq              = 0;
    g_ticks_sent       = 0;
    g_sent_at_last_msc = 0;
+   g_book_seq         = 0;
+   g_book_sent        = 0;
+   g_book_skipped     = 0;
+   g_book_last_body   = "";
 
    string basis = SymbolInfoString(_Symbol, SYMBOL_BASIS);
    if(basis == "")
       basis = _Symbol;
 
+   // Depth fields are announced only when this session can actually deliver
+   // depth. Omitting them is the honest "no book here" the feed relies on to
+   // tell the chart why the heatmap is empty.
+   string depth = "";
+   if(g_book_subscribed)
+     {
+      long   levels    = SymbolInfoInteger(_Symbol, SYMBOL_TICKS_BOOKDEPTH);
+      double tick_size = SymbolInfoDouble(_Symbol, SYMBOL_TRADE_TICK_SIZE);
+      depth = StringFormat(",\"book_levels\":%I64d", levels);
+      if(tick_size > 0.0)
+         StringAdd(depth, StringFormat(",\"tick_size\":\"%s\"",
+                                       DoubleToString(tick_size, _Digits)));
+     }
+
    string hello = StringFormat(
       "{\"type\":\"hello\",\"schema\":%d,\"bridge\":\"%s\",\"bridge_version\":\"%s\","
-      "\"symbol\":\"%s\",\"broker_symbol\":\"%s\",\"digits\":%d,\"server_utc_offset_s\":%I64d}",
+      "\"symbol\":\"%s\",\"broker_symbol\":\"%s\",\"digits\":%d,\"server_utc_offset_s\":%I64d%s}",
       SCHEMA_VERSION, BRIDGE_NAME, BRIDGE_VERSION,
-      _Symbol, basis, _Digits, ServerUtcOffsetSeconds());
+      _Symbol, basis, _Digits, ServerUtcOffsetSeconds(), depth);
    if(!SendLine(hello))
       return(false);
 
@@ -280,16 +404,40 @@ void MaybeHeartbeat()
       "\"ticks_sent\":%I64u,\"server_utc_offset_s\":%I64d}",
       g_seq, (long)TimeTradeServer() * 1000, g_ticks_sent, ServerUtcOffsetSeconds());
    if(!SendLine(line))
+     {
       Disconnect("heartbeat send failed");
+      return;
+     }
+   if(g_book_subscribed)
+      LogEvent("BRIDGE_BOOK_STATS",
+               StringFormat("\"images_sent\":%I64u,\"images_skipped\":%I64u",
+                            g_book_sent, g_book_skipped));
   }
 
 //+------------------------------------------------------------------+
 int OnInit()
   {
    EventSetMillisecondTimer(200);
+   if(InpStreamBook)
+     {
+      // Subscribing before any connection means the terminal is already
+      // maintaining the DOM when the first quantick session starts.
+      g_book_subscribed = MarketBookAdd(_Symbol);
+      if(g_book_subscribed)
+         LogEvent("BRIDGE_BOOK_SUBSCRIBED",
+                  StringFormat("\"book_levels\":%I64d,\"min_interval_ms\":%d",
+                               SymbolInfoInteger(_Symbol, SYMBOL_TICKS_BOOKDEPTH),
+                               InpBookMinIntervalMs));
+      else
+         LogEvent("BRIDGE_BOOK_SUBSCRIBE_FAILED",
+                  StringFormat("\"mql_error\":%d,\"hint\":\"this symbol may have no Depth "
+                               "of Market on this account; ticks still stream\"",
+                               GetLastError()));
+     }
    LogEvent("BRIDGE_STARTING",
-            StringFormat("\"host\":\"%s\",\"port\":%d,\"backfill_minutes\":%d",
-                         InpHost, InpPort, InpBackfillMinutes));
+            StringFormat("\"host\":\"%s\",\"port\":%d,\"backfill_minutes\":%d,\"stream_book\":%s",
+                         InpHost, InpPort, InpBackfillMinutes,
+                         (g_book_subscribed ? "true" : "false")));
    return(INIT_SUCCEEDED);
   }
 
@@ -302,6 +450,11 @@ void OnDeinit(const int reason)
       SocketClose(g_socket);
       g_socket = INVALID_HANDLE;
      }
+   if(g_book_subscribed)
+     {
+      MarketBookRelease(_Symbol);
+      g_book_subscribed = false;
+     }
    EventKillTimer();
    LogEvent("BRIDGE_STOPPED", StringFormat("\"deinit_reason\":%d", reason));
   }
@@ -310,6 +463,17 @@ void OnDeinit(const int reason)
 void OnTick()
   {
    Pump(); // low latency path; OnTimer is the safety net
+  }
+
+//+------------------------------------------------------------------+
+//| The DOM changed: forward the new image.                           |
+//+------------------------------------------------------------------+
+void OnBookEvent(const string &symbol)
+  {
+   if(symbol != _Symbol)
+      return;
+   if(!SendBook())
+      Disconnect("book send failed");
   }
 
 //+------------------------------------------------------------------+

--- a/bridge/mt5/README.md
+++ b/bridge/mt5/README.md
@@ -1,11 +1,54 @@
 # MT5 bridge setup
 
-`QuantickBridge.mq5` streams a chart's ticks to quantick over a local socket.
-MQL5 is the terminal's C++-family language; the EA runs inside the already
-logged-in terminal, so **no credentials exist anywhere in this path** and
-nothing ever leaves `127.0.0.1`.
+Two bridges stream a symbol's ticks **and its Depth of Market** into quantick.
+They speak the same wire protocol (PROTOCOL.md) into the same local socket, so
+quantick cannot tell which one dialed it — pick whichever fits the day. Neither
+involves credentials: the terminal is already logged in and nothing ever leaves
+`127.0.0.1`.
 
-## Install (once)
+| | `quantick_bridge.py` | `QuantickBridge.mq5` |
+|---|---|---|
+| Setup | one command | compile, copy, drag onto a chart |
+| Runs | outside, attaches by IPC | inside the terminal |
+| Book updates | polls (~5 ms) | pushed by `OnBookEvent` |
+| Survives terminal restart | reconnects | restarts with the terminal |
+
+**Start here — you probably do not have to start anything.** Selecting a
+MetaTrader feed makes quantick launch `quantick_bridge.py` itself: it waits a
+few seconds first, so a bridge you already started, or an EA sitting on a
+chart, is used instead of being fought. All it needs is the official package
+(`pip install MetaTrader5`) and a running, logged-in terminal. Turn it off with
+`bridge_autostart = false`, or point `bridge_command` somewhere else, under
+`[metatrader]` in your config.
+
+To run it by hand anyway — to see its log lines up close, or to feed a quantick
+that is not yours:
+
+```
+python bridge/mt5/quantick_bridge.py --symbol WINQ26
+```
+
+Options worth knowing:
+`--port` (default 9100), `--backfill-minutes` (720 — a whole B3 session),
+`--backfill-max-ticks` (200 000; the newest win and the log says how many were
+left behind), `--no-book`, `--book-poll-ms` (5), `--utc-offset-s`.
+
+The terminal keeps far more history than you would guess — a probe on
+2026-07-24 found 1.25 M ticks for that day alone and 36 M over 30 days, with a
+full day returning in under a second. The cap exists for what happens after:
+every backfilled tick becomes a line on the socket and a bar on the chart.
+
+The one thing it will refuse to do is guess: MetaTrader stamps everything in
+server wall time and exposes no server clock to outside processes, so the
+offset is measured from a *moving* tick. Run it once while the market trades
+and it caches the value; start it cold outside market hours and it stops with
+`BRIDGE_UTC_OFFSET_UNKNOWN` rather than mislabelling every timestamp. Pass
+`--utc-offset-s -10800` (B3) to skip the wait.
+
+The rest of this page is the Expert Advisor, which trades setup cost for
+event-accurate book updates.
+
+## Install the EA (once)
 
 1. **Compile** (either way):
    - MetaEditor: open `QuantickBridge.mq5`, press F7; or
@@ -19,16 +62,35 @@ nothing ever leaves `127.0.0.1`.
    `BRIDGE_CONNECT_FAILED` with that hint.
 4. ✔ *Allow Algo Trading* (toolbar button) so the EA runs.
 
-## Run
+## Run the EA
 
 1. Start quantick with a MetaTrader feed selected — it listens on
    `127.0.0.1:9100` (configurable, `[metatrader]` in `quantick.toml`) and
    logs `MT5_LISTENING`.
 2. Open a chart of the symbol quantick expects (e.g. **WIN$N**) and drag
    `QuantickBridge` onto it. Inputs: host/port, backfill minutes (default 30),
-   heartbeat seconds.
+   heartbeat seconds, plus the depth pair below.
 3. The Experts tab prints `BRIDGE_SESSION_STARTED` with the backfill count;
    quantick logs `MT5_HELLO_OK` and the chart populates.
+
+## Depth of Market (book heatmap)
+
+`InpStreamBook` (default on) subscribes to the symbol's DOM and sends a
+complete book image whenever it changes; `InpBookMinIntervalMs` (default 20)
+caps how often. MT5 has no incremental book protocol — `MarketBookGet` only
+ever returns the whole visible DOM — so the feed diffs successive images into
+the same snapshot-plus-delta stream the Binance path produces, and the heatmap
+runs on one shared pipeline.
+
+Two limits are real and are labelled rather than hidden:
+
+- The terminal exposes only the top levels (`SYMBOL_TICKS_BOOKDEPTH`), so
+  coverage is reported as *limited* and liquidity leaving that window shows as
+  removed. It is not the whole exchange book and quantick never says it is.
+- Not every symbol or account has a DOM. When `MarketBookAdd` fails the EA
+  logs `BRIDGE_BOOK_SUBSCRIBE_FAILED`, ticks keep streaming, and quantick says
+  `MT5_BOOK_UNSUPPORTED_BY_BRIDGE` instead of drawing an empty heatmap. The
+  same message appears for an EA compiled before depth support.
 
 Symbol must match: the EA streams the chart it is attached to, and the feed
 refuses a hello for a different symbol (`MT5_SYMBOL_MISMATCH`).
@@ -37,9 +99,15 @@ refuses a hello for a different symbol (`MT5_SYMBOL_MISMATCH`).
 
 Both sides speak structured logs:
 
+- **Python bridge (stderr)**: JSON lines with the same `event_code`
+  vocabulary — `BRIDGE_STARTING`, `BRIDGE_TERMINAL_ATTACH_FAILED`,
+  `BRIDGE_UTC_OFFSET*`, `BRIDGE_SESSION_STARTED`, `BRIDGE_BOOK_STATS`,
+  `BRIDGE_DISCONNECTED`.
 - **EA (Experts tab)**: JSON lines with `event_code` — `BRIDGE_STARTING`,
   `BRIDGE_CONNECT_FAILED` (feed not running / URL not allowed),
-  `BRIDGE_SESSION_STARTED`, `BRIDGE_DISCONNECTED` (+ retry).
+  `BRIDGE_SESSION_STARTED`, `BRIDGE_DISCONNECTED` (+ retry),
+  `BRIDGE_BOOK_SUBSCRIBED` / `BRIDGE_BOOK_SUBSCRIBE_FAILED`, and
+  `BRIDGE_BOOK_STATS` every heartbeat (images sent vs skipped as unchanged).
 - **quantick (stderr, `QUANTICK_LOG_FORMAT=json`)**: the full `MT5_*` event
   table in `crates/feed-mt5/src/lib.rs`.
 

--- a/bridge/mt5/quantick_bridge.py
+++ b/bridge/mt5/quantick_bridge.py
@@ -1,0 +1,573 @@
+#!/usr/bin/env python3
+"""Stream a MetaTrader 5 symbol's ticks and Depth of Market to quantick.
+
+This is the *simple* bridge: it attaches to the already-running, already
+logged-in terminal through the official ``MetaTrader5`` package and dials
+quantick's local listener, speaking the same newline-delimited JSON protocol as
+``QuantickBridge.mq5``. Nothing needs to be compiled, copied into the terminal,
+or dragged onto a chart, and no credentials exist anywhere in this path — the
+socket never leaves ``127.0.0.1``.
+
+    python bridge/mt5/quantick_bridge.py --symbol WINQ26
+
+The protocol contract lives in PROTOCOL.md next to this file, and
+``crates/feed-mt5`` is its executable counterpart. quantick cannot tell which
+bridge dialed it, which is the point: pick whichever fits the day.
+
+Honest difference from the Expert Advisor
+-----------------------------------------
+The EA runs *inside* the terminal, so ``OnBookEvent`` hands it every book change
+at the instant it happens. This script is an outside observer: MetaTrader
+exposes no push API to external processes, so it polls. Reading the book costs
+about 0.06 ms (the package is a native DLL; Python only supplies the calling
+convention), so polling every few milliseconds is cheap — but a change that
+appears and disappears between two polls is a change quantick never sees. That
+is a real fidelity gap, it is inherent to being outside the terminal, and it is
+the reason the EA still exists as the higher-fidelity option.
+
+Server time
+-----------
+MT5 stamps everything in *server wall time encoded as epoch seconds*, and the
+Python API exposes no equivalent of MQL5's ``TimeTradeServer()``. The offset is
+therefore measured from a fresh tick and snapped to the 15-minute grid every
+real timezone uses, then cached. When neither a fresh tick nor a cached value is
+available (first run outside market hours), the script refuses to start rather
+than guessing an offset and mislabelling every timestamp downstream.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import socket
+import sys
+import time
+from pathlib import Path
+
+try:
+    import MetaTrader5 as mt5
+except ImportError:  # pragma: no cover - environment problem, not logic
+    print(
+        '{"event_code":"BRIDGE_NO_MT5_PACKAGE",'
+        '"hint":"pip install MetaTrader5"}',
+        file=sys.stderr,
+    )
+    raise SystemExit(2) from None
+
+SCHEMA_VERSION = 1
+BRIDGE_NAME = "quantick-mt5-bridge-py"
+BRIDGE_VERSION = "0.1.0"
+
+#: Timezone offsets are whole 15-minute steps everywhere on earth, so snapping
+#: to that grid removes the millisecond of tick latency from the measurement.
+OFFSET_GRID_S = 15 * 60
+#: Where a measured offset is remembered between runs.
+CACHE_PATH = Path(__file__).with_name(".quantick_bridge_cache.json")
+
+
+def log(event_code: str, **fields: object) -> None:
+    """Emit one structured line, matching what the EA prints to Experts."""
+    payload = {"event_code": event_code, **fields}
+    print(json.dumps(payload, separators=(",", ":")), file=sys.stderr, flush=True)
+
+
+class BridgeExit(Exception):
+    """Fatal, with the reason already logged."""
+
+
+# --------------------------------------------------------------------------
+# Terminal
+# --------------------------------------------------------------------------
+
+
+def connect_terminal(symbol: str) -> None:
+    if not mt5.initialize():
+        log(
+            "BRIDGE_TERMINAL_ATTACH_FAILED",
+            mt5_error=str(mt5.last_error()),
+            hint="is the terminal running and logged in?",
+        )
+        raise BridgeExit
+    info = mt5.symbol_info(symbol)
+    if info is None:
+        log(
+            "BRIDGE_SYMBOL_NOT_FOUND",
+            symbol=symbol,
+            hint="check the exact contract name in Market Watch (e.g. WINQ26)",
+        )
+        raise BridgeExit
+    if not info.visible and not mt5.symbol_select(symbol, True):
+        log("BRIDGE_SYMBOL_SELECT_FAILED", symbol=symbol, mt5_error=str(mt5.last_error()))
+        raise BridgeExit
+
+
+def market_is_trading(symbol: str, observe_s: float = 2.0) -> bool:
+    """Whether ticks are arriving right now.
+
+    Deciding this from a tick's timestamp would be circular — the timestamp is
+    in the very clock we are trying to measure. Watching the timestamp *move*
+    is not: a tick that advances while we watch was produced while we watched.
+    """
+    first = mt5.symbol_info_tick(symbol)
+    if first is None or not first.time_msc:
+        return False
+    deadline = time.monotonic() + observe_s
+    while time.monotonic() < deadline:
+        time.sleep(0.05)
+        current = mt5.symbol_info_tick(symbol)
+        if current is not None and current.time_msc != first.time_msc:
+            return True
+    return False
+
+
+def measure_utc_offset_s(symbol: str, override: int | None) -> int:
+    """Server-time minus UTC, in seconds. See the module docstring."""
+    if override is not None:
+        log("BRIDGE_UTC_OFFSET", source="explicit", server_utc_offset_s=override)
+        return override
+
+    if market_is_trading(symbol):
+        tick = mt5.symbol_info_tick(symbol)
+        # The tick was produced moments ago, so its server timestamp minus now
+        # *is* the offset, give or take the transport latency the grid removes.
+        raw = tick.time_msc / 1000.0 - time.time()
+        snapped = round(raw / OFFSET_GRID_S) * OFFSET_GRID_S
+        log(
+            "BRIDGE_UTC_OFFSET",
+            source="live_tick",
+            server_utc_offset_s=snapped,
+            raw_s=round(raw, 3),
+        )
+        _cache_write(symbol, snapped)
+        return snapped
+    log("BRIDGE_UTC_OFFSET_MARKET_QUIET", symbol=symbol)
+
+    cached = _cache_read(symbol)
+    if cached is not None:
+        log(
+            "BRIDGE_UTC_OFFSET",
+            source="cache",
+            server_utc_offset_s=cached,
+            note="measured on an earlier run; re-measured on the next fresh tick",
+        )
+        return cached
+
+    log(
+        "BRIDGE_UTC_OFFSET_UNKNOWN",
+        symbol=symbol,
+        action="refuse_to_start",
+        hint=(
+            "no fresh tick and nothing cached: run once during market hours, "
+            "or pass --utc-offset-s (B3 brokers use -10800)"
+        ),
+    )
+    raise BridgeExit
+
+
+def _cache_read(symbol: str) -> int | None:
+    try:
+        return int(json.loads(CACHE_PATH.read_text("utf-8"))[symbol]["utc_offset_s"])
+    except (OSError, ValueError, KeyError, TypeError):
+        return None
+
+
+def _cache_write(symbol: str, offset_s: int) -> None:
+    try:
+        data = json.loads(CACHE_PATH.read_text("utf-8"))
+    except (OSError, ValueError):
+        data = {}
+    if not isinstance(data, dict):
+        data = {}
+    data[symbol] = {"utc_offset_s": offset_s}
+    try:
+        CACHE_PATH.write_text(json.dumps(data, indent=2), "utf-8")
+    except OSError:
+        pass  # a read-only checkout is not worth failing the feed over
+
+
+# --------------------------------------------------------------------------
+# Wire
+# --------------------------------------------------------------------------
+
+
+class Session:
+    """One connection to quantick: framing, cursors and message building."""
+
+    def __init__(self, sock: socket.socket, symbol: str, args: argparse.Namespace) -> None:
+        self.sock = sock
+        self.symbol = symbol
+        self.args = args
+        self.seq = 0
+        self.ticks_sent = 0
+        self.book_seq = 0
+        self.book_sent = 0
+        self.book_skipped = 0
+        self.offset_s = 0
+        self.digits = 0
+        self.book_subscribed = False
+        # Cursor: MT5 ticks share milliseconds, so it takes both the newest
+        # millisecond sent and how many ticks at that millisecond already went.
+        self.cursor_msc = 0
+        self.sent_at_cursor = 0
+        self.last_book_body: str | None = None
+        self.last_book_ms = 0.0
+        self.last_heartbeat = 0.0
+
+    # -- framing ----------------------------------------------------------
+
+    def send(self, message: dict) -> None:
+        line = json.dumps(message, separators=(",", ":")) + "\n"
+        self.sock.sendall(line.encode("utf-8"))
+
+    def price(self, value: float) -> str:
+        return f"{value:.{self.digits}f}"
+
+    def server_now_ms(self) -> int:
+        return int((time.time() + self.offset_s) * 1000)
+
+    # -- session ----------------------------------------------------------
+
+    def start(self, offset_s: int) -> None:
+        info = mt5.symbol_info(self.symbol)
+        if info is None:
+            raise BridgeExit
+        self.offset_s = offset_s
+        self.digits = int(info.digits)
+
+        hello = {
+            "type": "hello",
+            "schema": SCHEMA_VERSION,
+            "bridge": BRIDGE_NAME,
+            "bridge_version": BRIDGE_VERSION,
+            "symbol": self.symbol,
+            "broker_symbol": info.basis or self.symbol,
+            "digits": self.digits,
+            "server_utc_offset_s": offset_s,
+        }
+        # Depth fields are announced only when this session can really deliver
+        # depth. Omitting them is the honest "no book here" quantick relies on
+        # to explain an empty heatmap instead of drawing one.
+        if self.args.book:
+            self.book_subscribed = bool(mt5.market_book_add(self.symbol))
+            if self.book_subscribed:
+                hello["book_levels"] = int(info.ticks_bookdepth)
+                if info.trade_tick_size > 0:
+                    hello["tick_size"] = self.price(info.trade_tick_size)
+            else:
+                log(
+                    "BRIDGE_BOOK_SUBSCRIBE_FAILED",
+                    symbol=self.symbol,
+                    mt5_error=str(mt5.last_error()),
+                    hint="this symbol may have no Depth of Market; ticks still stream",
+                )
+        self.send(hello)
+
+        self.backfill()
+        log(
+            "BRIDGE_SESSION_STARTED",
+            symbol=self.symbol,
+            host=self.args.host,
+            port=self.args.port,
+            book=self.book_subscribed,
+            server_utc_offset_s=offset_s,
+        )
+
+    def backfill(self) -> None:
+        """Recent history, so the chart opens populated.
+
+        The terminal keeps the whole session (and weeks behind it) on disk and
+        returns a day in a fraction of a second, so the window is generous. The
+        cap is about what happens *after*: every tick becomes a JSON line on the
+        socket and a bar on the chart, and a full B3 day is over a million of
+        them. When the window holds more than the cap, the newest ones win —
+        and the log says how many were left behind rather than implying the
+        chart starts at the open.
+        """
+        now_s = int(time.time() + self.offset_s)
+        from_s = now_s - self.args.backfill_minutes * 60
+        ticks = mt5.copy_ticks_range(self.symbol, from_s, now_s, mt5.COPY_TICKS_ALL)
+        available = 0 if ticks is None else len(ticks)
+        if ticks is None:
+            log("BRIDGE_BACKFILL_FAILED", mt5_error=str(mt5.last_error()))
+        elif available > self.args.backfill_max_ticks:
+            ticks = ticks[-self.args.backfill_max_ticks :]
+            log(
+                "BRIDGE_BACKFILL_TRUNCATED",
+                symbol=self.symbol,
+                available=available,
+                sending=len(ticks),
+                dropped_oldest=available - len(ticks),
+                action="keep_newest",
+            )
+        count = 0 if ticks is None else len(ticks)
+
+        # An empty block still gets both markers: backfill_end is the
+        # "history is done" signal quantick's loader waits on.
+        self.send({"type": "backfill_start", "count_hint": count})
+        for tick in ticks if ticks is not None else ():
+            self.send_tick(tick)
+        self.send({"type": "backfill_end"})
+
+        if count:
+            self.cursor_msc = int(ticks[-1]["time_msc"])
+            self.sent_at_cursor = sum(
+                1 for t in ticks if int(t["time_msc"]) == self.cursor_msc
+            )
+        else:
+            self.cursor_msc = now_s * 1000
+            self.sent_at_cursor = 0
+
+    def send_tick(self, tick) -> None:
+        self.seq += 1
+        self.send(
+            {
+                "type": "tick",
+                "seq": self.seq,
+                "time_ms": int(tick["time_msc"]),
+                "bid": self.price(float(tick["bid"])),
+                "ask": self.price(float(tick["ask"])),
+                "last": self.price(float(tick["last"])),
+                "volume": int(tick["volume"]),
+                "flags": int(tick["flags"]),
+            }
+        )
+        self.ticks_sent += 1
+
+    # -- pumps ------------------------------------------------------------
+
+    def pump_ticks(self) -> None:
+        """Forward every tick newer than the cursor, exactly once."""
+        # The request floor is whole seconds; the (msc, count-at-msc) cursor
+        # below is what actually guarantees no tick is sent twice.
+        ticks = mt5.copy_ticks_from(
+            self.symbol, self.cursor_msc // 1000, 4096, mt5.COPY_TICKS_ALL
+        )
+        if ticks is None or not len(ticks):
+            return
+        at_cursor_seen = 0
+        for tick in ticks:
+            msc = int(tick["time_msc"])
+            if msc < self.cursor_msc:
+                continue
+            if msc == self.cursor_msc:
+                at_cursor_seen += 1
+                if at_cursor_seen <= self.sent_at_cursor:
+                    continue
+                self.send_tick(tick)
+                self.sent_at_cursor += 1
+            else:
+                self.send_tick(tick)
+                self.cursor_msc = msc
+                self.sent_at_cursor = 1
+                at_cursor_seen = 0
+
+    def pump_book(self) -> None:
+        """Send one complete DOM image, when it differs from the last one."""
+        if not self.book_subscribed:
+            return
+        now = time.monotonic() * 1000.0
+        if now - self.last_book_ms < self.args.book_min_interval_ms:
+            return
+        book = mt5.market_book_get(self.symbol)
+        if not book:
+            return
+
+        bids, asks = [], []
+        for item in book:
+            # BOOK_TYPE_*_MARKET rows are orders waiting to cross, not resting
+            # liquidity at a price: they carry no level to draw.
+            if item.type == mt5.BOOK_TYPE_BUY:
+                side = bids
+            elif item.type == mt5.BOOK_TYPE_SELL:
+                side = asks
+            else:
+                continue
+            if item.price <= 0:
+                continue
+            volume = item.volume_dbl if item.volume_dbl > 0 else float(item.volume)
+            side.append([self.price(item.price), _volume_text(volume)])
+
+        body = json.dumps({"bids": bids, "asks": asks}, separators=(",", ":"))
+        if body == self.last_book_body:
+            self.book_skipped += 1
+            return
+        self.last_book_body = body
+        self.last_book_ms = now
+
+        self.book_seq += 1
+        tick = mt5.symbol_info_tick(self.symbol)
+        stamp = max(
+            int(tick.time_msc) if tick is not None else 0,
+            self.server_now_ms(),
+        )
+        self.send(
+            {
+                "type": "book",
+                "seq": self.book_seq,
+                "time_ms": stamp,
+                "bids": bids,
+                "asks": asks,
+            }
+        )
+        self.book_sent += 1
+
+    def maybe_heartbeat(self) -> None:
+        now = time.monotonic()
+        if now - self.last_heartbeat < self.args.heartbeat_seconds:
+            return
+        self.last_heartbeat = now
+        self.send(
+            {
+                "type": "heartbeat",
+                "seq_last": self.seq,
+                "time_ms": self.server_now_ms(),
+                "ticks_sent": self.ticks_sent,
+                "server_utc_offset_s": self.offset_s,
+            }
+        )
+        if self.book_subscribed:
+            log(
+                "BRIDGE_BOOK_STATS",
+                symbol=self.symbol,
+                images_sent=self.book_sent,
+                images_skipped=self.book_skipped,
+            )
+
+    def close(self, reason: str) -> None:
+        if self.book_subscribed:
+            mt5.market_book_release(self.symbol)
+            self.book_subscribed = False
+        try:
+            self.send({"type": "bye", "reason": reason})
+        except OSError:
+            pass
+
+
+def _volume_text(volume: float) -> str:
+    """Whole contracts print as integers; fractional lots keep two decimals."""
+    if abs(volume - round(volume)) < 1e-9:
+        return str(int(round(volume)))
+    return f"{volume:.2f}"
+
+
+# --------------------------------------------------------------------------
+# Loop
+# --------------------------------------------------------------------------
+
+
+def run_session(args: argparse.Namespace, offset_s: int) -> None:
+    with socket.create_connection((args.host, args.port), timeout=10) as sock:
+        sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+        session = Session(sock, args.symbol, args)
+        session.start(offset_s)
+        tick_interval = args.tick_poll_ms / 1000.0
+        book_interval = args.book_poll_ms / 1000.0
+        next_tick = next_book = time.monotonic()
+        try:
+            while True:
+                now = time.monotonic()
+                if now >= next_tick:
+                    session.pump_ticks()
+                    next_tick = now + tick_interval
+                if now >= next_book:
+                    session.pump_book()
+                    next_book = now + book_interval
+                session.maybe_heartbeat()
+                # Sleep to the nearest due deadline instead of spinning: the
+                # terminal reads cost microseconds, the waiting is the loop.
+                idle = min(next_tick, next_book) - time.monotonic()
+                if idle > 0:
+                    time.sleep(min(idle, 0.05))
+        except KeyboardInterrupt:
+            session.close("interrupted")
+            raise
+        except OSError as error:
+            session.close("socket error")
+            raise ConnectionError(str(error)) from error
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--symbol", default="WINQ26", help="contract to stream")
+    parser.add_argument("--host", default="127.0.0.1", help="quantick listener host")
+    parser.add_argument("--port", type=int, default=9100, help="quantick listener port")
+    parser.add_argument(
+        "--backfill-minutes",
+        type=int,
+        default=720,
+        help="history window to send on connect (default covers a whole B3 session)",
+    )
+    parser.add_argument(
+        "--backfill-max-ticks",
+        type=int,
+        default=200_000,
+        help="hard cap on backfilled ticks; the newest ones win",
+    )
+    parser.add_argument("--heartbeat-seconds", type=float, default=5.0)
+    parser.add_argument("--retry-seconds", type=float, default=5.0)
+    parser.add_argument(
+        "--no-book",
+        dest="book",
+        action="store_false",
+        help="stream ticks only, no Depth of Market",
+    )
+    parser.add_argument(
+        "--book-poll-ms",
+        type=float,
+        default=5.0,
+        help="how often the book is read (a read costs ~0.06 ms)",
+    )
+    parser.add_argument(
+        "--book-min-interval-ms",
+        type=float,
+        default=20.0,
+        help="floor between two published images",
+    )
+    parser.add_argument("--tick-poll-ms", type=float, default=20.0)
+    parser.add_argument(
+        "--utc-offset-s",
+        type=int,
+        default=None,
+        help="server_time - utc, in seconds; measured from a fresh tick when omitted",
+    )
+    args = parser.parse_args()
+
+    try:
+        connect_terminal(args.symbol)
+    except BridgeExit:
+        return 2
+
+    log(
+        "BRIDGE_STARTING",
+        symbol=args.symbol,
+        host=args.host,
+        port=args.port,
+        backfill_minutes=args.backfill_minutes,
+        backfill_max_ticks=args.backfill_max_ticks,
+        stream_book=args.book,
+    )
+    try:
+        while True:
+            try:
+                offset_s = measure_utc_offset_s(args.symbol, args.utc_offset_s)
+            except BridgeExit:
+                return 2
+            try:
+                run_session(args, offset_s)
+            except (ConnectionError, OSError, socket.timeout) as error:
+                log(
+                    "BRIDGE_DISCONNECTED",
+                    reason=str(error) or type(error).__name__,
+                    retry_in_s=args.retry_seconds,
+                    hint="is quantick running and listening on this port?",
+                )
+                time.sleep(args.retry_seconds)
+    except KeyboardInterrupt:
+        log("BRIDGE_STOPPED", reason="interrupted")
+        return 0
+    finally:
+        mt5.shutdown()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -13,7 +13,7 @@ quantick-orderbook = { path = "../orderbook" }
 rust_decimal = "1"
 serde = { version = "1", features = ["derive"] }
 toml = "0.8"
-tokio = { version = "1", features = ["rt-multi-thread", "sync", "net", "time"] }
+tokio = { version = "1", features = ["rt-multi-thread", "sync", "net", "time", "process"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter", "json"] }
 eframe = { version = "0.29", default-features = false, features = [

--- a/crates/app/config/feeds.toml
+++ b/crates/app/config/feeds.toml
@@ -17,7 +17,7 @@ default_symbol = "BTCUSDT"
 #   id       — stable identifier, referenced by `default_feed` (unique).
 #   name     — label shown in the feed selector.
 #   provider — which backend streams it; maps to a code path.
-#              Supported today: "binance". Planned: "metatrader".
+#              Supported today: "binance", "metatrader".
 #   symbols  — the assets offered for this feed (first is its fallback).
 [[feeds]]
 id = "binance"
@@ -28,7 +28,9 @@ symbols = ["BTCUSDT", "ETHUSDT"]
 # MetaTrader 5, via the QuantickBridge EA (see bridge/mt5/README.md for the
 # one-time setup). The EA streams the chart it is attached to; the symbol
 # selected here must match that chart. B3 continuous contracts: WIN$N (mini
-# índice), WDO$N (mini dólar).
+# índice), WDO$N (mini dólar). The EA also streams Depth of Market, so the
+# book heatmap works here; note MT5 exposes only the top levels, and the chart
+# labels that coverage rather than implying a full book.
 [[feeds]]
 id = "metatrader"
 name = "MetaTrader 5"
@@ -45,3 +47,13 @@ symbols = ["WIN$N", "WDO$N"]
 [metatrader]
 listen_addr = "127.0.0.1:9100"
 side_source = "tick_rule"
+
+# quantick starts the bridge for you: selecting this feed is one action, not
+# two. It waits a few seconds first, so a bridge you already started by hand —
+# or the Expert Advisor sitting on a chart — is left alone and used instead.
+#   bridge_autostart — set false to always start the bridge yourself.
+#   bridge_command   — program plus arguments; --symbol/--host/--port are
+#                      appended from the running feed. Resolved against
+#                      quantick's working directory.
+bridge_autostart = true
+bridge_command = ["python", "bridge/mt5/quantick_bridge.py"]

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -18,7 +18,7 @@ use quantick_feed_binance::depth::DepthEvent;
 
 use crate::candle_view::{draw_candle, draw_style_window};
 use crate::chart::PriceScale;
-use crate::config::{AppConfig, ProviderKind};
+use crate::config::{AppConfig, FeedCapabilities, ProviderKind};
 use crate::feed::{self, FeedCommand, FeedEvent, FeedHandle};
 use crate::metrics::{self, FrameStats};
 use crate::orderflow_view::OrderflowView;
@@ -397,9 +397,17 @@ impl QuantickApp {
                     .range(500.0..=50_000.0)
                     .speed(100.0),
             );
+            let capabilities = self.capabilities();
             if ui
-                .button("⟲ load older")
-                .on_hover_text("fetch older trades and prepend them")
+                .add_enabled(
+                    capabilities.history_paging,
+                    egui::Button::new("⟲ load older"),
+                )
+                .on_hover_text(if capabilities.history_paging {
+                    "fetch older trades and prepend them"
+                } else {
+                    "this feed only streams forward; it cannot page older trades"
+                })
                 .clicked()
             {
                 self.request_older_history();
@@ -414,10 +422,7 @@ impl QuantickApp {
                 self.show_style = !self.show_style;
             }
             ui.separator();
-            let supports_book = matches!(
-                self.config.provider_of(&self.feed_id),
-                Some(ProviderKind::Binance)
-            );
+            let supports_book = capabilities.book_capture;
             let mut book_enabled = self.orderflow.enabled();
             let toggle = ui.add_enabled(
                 supports_book,
@@ -449,6 +454,17 @@ impl QuantickApp {
             ui.checkbox(&mut self.show_overlay, "📈 perf")
                 .on_hover_text("show fps / frame time / feed lag (bottom-left)");
         });
+    }
+
+    /// What the selected feed's backend can do.
+    ///
+    /// A feed missing from the config can do nothing — the selection is snapped
+    /// back on the next switch, and until then no affordance may promise data
+    /// nothing is streaming.
+    fn capabilities(&self) -> FeedCapabilities {
+        self.config
+            .provider_of(&self.feed_id)
+            .map_or(FeedCapabilities::none(), ProviderKind::capabilities)
     }
 
     /// Ask the feed thread to fetch and prepend `history_step` older trades.
@@ -486,10 +502,7 @@ impl QuantickApp {
     /// Start or stop the independent depth pipeline without touching aggTrades
     /// or candle construction. UI state changes only if the command is queued.
     fn request_book_capture(&mut self, enabled: bool) {
-        if !matches!(
-            self.config.provider_of(&self.feed_id),
-            Some(ProviderKind::Binance)
-        ) {
+        if !self.capabilities().book_capture {
             tracing::warn!(
                 target: "quantick::app",
                 schema_version = 1_u8,
@@ -590,7 +603,7 @@ impl QuantickApp {
             (self.feed_id, self.symbol) = self.active.clone();
             return;
         };
-        let resume_book_capture = self.orderflow.enabled() && provider == ProviderKind::Binance;
+        let resume_book_capture = self.orderflow.enabled() && provider.capabilities().book_capture;
 
         tracing::info!(
             target: "quantick::app",
@@ -1585,6 +1598,7 @@ mod tests {
             generation,
             observed_at_ms: 1_100,
             effective_at_ms: 999,
+            price_step: None,
             snapshot: BookSnapshot::new(
                 10,
                 vec![BookLevel::new(Decimal::from(99), Decimal::from(5)).unwrap()],
@@ -1791,6 +1805,7 @@ mod tests {
                 generation,
                 observed_at_ms: 1_100,
                 effective_at_ms: 999,
+                price_step: None,
                 snapshot: BookSnapshot::new(
                     10,
                     vec![BookLevel::new(Decimal::from(99), Decimal::from(5)).unwrap()],

--- a/crates/app/src/config.rs
+++ b/crates/app/src/config.rs
@@ -43,6 +43,51 @@ impl ProviderKind {
     pub fn is_implemented(self) -> bool {
         matches!(self, ProviderKind::Binance | ProviderKind::MetaTrader)
     }
+
+    /// What this provider's backend can do.
+    ///
+    /// The UI asks the capability, never the provider name: a feature gate
+    /// written as "is this Binance?" has to be found and edited every time a
+    /// venue is added, and silently withholds a feature the new venue supports.
+    #[must_use]
+    pub fn capabilities(self) -> FeedCapabilities {
+        match self {
+            ProviderKind::Binance => FeedCapabilities {
+                book_capture: true,
+                history_paging: true,
+            },
+            // The bridge streams the terminal's Depth of Market. Whether a
+            // given session really has one (symbol, account, EA version) is
+            // runtime information the feed reports honestly; it is not
+            // something to assume either way from here.
+            ProviderKind::MetaTrader => FeedCapabilities {
+                book_capture: true,
+                history_paging: false,
+            },
+        }
+    }
+}
+
+/// What a feed's backend can actually do, so UI affordances follow capability
+/// instead of a hard-coded list of providers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FeedCapabilities {
+    /// Can stream synchronized L2 depth for the order-flow heatmap.
+    pub book_capture: bool,
+    /// Can fetch trades older than what is loaded, on demand.
+    pub history_paging: bool,
+}
+
+impl FeedCapabilities {
+    /// Nothing is available — the honest answer for a feed that does not
+    /// resolve to a provider.
+    #[must_use]
+    pub fn none() -> Self {
+        Self {
+            book_capture: false,
+            history_paging: false,
+        }
+    }
 }
 
 /// Aggressor-side policy for MetaTrader feeds. MT5 tick flags are broker-
@@ -63,10 +108,24 @@ pub enum Mt5SideSource {
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 #[serde(default)]
 pub struct MetaTraderSettings {
-    /// Address the feed listens on; the QuantickBridge EA dials it.
+    /// Address the feed listens on; a bridge dials it.
     pub listen_addr: String,
     /// How the aggressor side of each trade is decided.
     pub side_source: Mt5SideSource,
+    /// Whether quantick starts a bridge itself when none dials in.
+    ///
+    /// Selecting a MetaTrader feed should be one action, not two. With this on,
+    /// the chart waits briefly for a bridge that is already running (a
+    /// hand-started script, or the Expert Advisor sitting on a chart) and only
+    /// then launches its own — so turning it on never fights a setup that
+    /// already works.
+    pub bridge_autostart: bool,
+    /// The bridge to launch, as program plus arguments.
+    ///
+    /// `--symbol`, `--host` and `--port` are appended from the running feed, so
+    /// this never has to repeat what quantick already knows. Resolved against
+    /// quantick's working directory.
+    pub bridge_command: Vec<String>,
 }
 
 impl Default for MetaTraderSettings {
@@ -74,7 +133,34 @@ impl Default for MetaTraderSettings {
         Self {
             listen_addr: "127.0.0.1:9100".to_string(),
             side_source: Mt5SideSource::TickRule,
+            bridge_autostart: true,
+            bridge_command: vec![
+                "python".to_string(),
+                "bridge/mt5/quantick_bridge.py".to_string(),
+            ],
         }
+    }
+}
+
+impl MetaTraderSettings {
+    /// Host and port a bridge should dial, parsed from [`listen_addr`](Self::listen_addr).
+    ///
+    /// Returns `None` when the address has no `host:port` shape — the autostart
+    /// then stays off rather than launching a bridge that cannot reach us.
+    #[must_use]
+    pub fn bridge_endpoint(&self) -> Option<(&str, &str)> {
+        let (host, port) = self.listen_addr.rsplit_once(':')?;
+        if host.is_empty() || port.parse::<u16>().is_err() {
+            return None;
+        }
+        // A wildcard bind is not an address to dial; loopback is what a local
+        // bridge actually reaches.
+        let host = if host == "0.0.0.0" || host == "[::]" {
+            "127.0.0.1"
+        } else {
+            host
+        };
+        Some((host, port))
     }
 }
 
@@ -324,6 +410,57 @@ mod tests {
         let config = parse(text, ConfigSource::Embedded).unwrap();
         assert_eq!(config.metatrader.listen_addr, "127.0.0.1:9200");
         assert_eq!(config.metatrader.side_source, Mt5SideSource::Flags);
+    }
+
+    #[test]
+    fn the_bridge_dial_address_comes_from_the_listen_address() {
+        let at = |addr: &str| MetaTraderSettings {
+            listen_addr: addr.to_string(),
+            ..MetaTraderSettings::default()
+        };
+        assert_eq!(
+            at("127.0.0.1:9100").bridge_endpoint(),
+            Some(("127.0.0.1", "9100"))
+        );
+        // A wildcard bind is not something a bridge can dial.
+        assert_eq!(
+            at("0.0.0.0:9100").bridge_endpoint(),
+            Some(("127.0.0.1", "9100"))
+        );
+        // Nothing dial-able: the caller must not launch a bridge that cannot
+        // reach us, so there is no address to hand it.
+        assert_eq!(at("9100").bridge_endpoint(), None);
+        assert_eq!(at("127.0.0.1:").bridge_endpoint(), None);
+        assert_eq!(at(":9100").bridge_endpoint(), None);
+        assert_eq!(at("127.0.0.1:not-a-port").bridge_endpoint(), None);
+    }
+
+    #[test]
+    fn bridge_autostart_is_on_by_default_and_overridable() {
+        let defaults = MetaTraderSettings::default();
+        assert!(defaults.bridge_autostart);
+        assert_eq!(defaults.bridge_command.first().unwrap(), "python");
+
+        let text = r#"
+            default_feed = "mt"
+            default_symbol = "WINQ26"
+            [[feeds]]
+            id = "mt"
+            name = "MetaTrader 5"
+            provider = "metatrader"
+            symbols = ["WINQ26"]
+            [metatrader]
+            bridge_autostart = false
+            bridge_command = ["py", "-3", "bridge/mt5/quantick_bridge.py"]
+        "#;
+        let config = parse(text, ConfigSource::Embedded).unwrap();
+        assert!(!config.metatrader.bridge_autostart);
+        assert_eq!(
+            config.metatrader.bridge_command,
+            ["py", "-3", "bridge/mt5/quantick_bridge.py"]
+        );
+        // Untouched keys keep their defaults.
+        assert_eq!(config.metatrader.listen_addr, "127.0.0.1:9100");
     }
 
     #[test]

--- a/crates/app/src/feed/metatrader.rs
+++ b/crates/app/src/feed/metatrader.rs
@@ -24,29 +24,62 @@
 //!   honest; silently inflating bars is not.)
 //! - **"Load older" is unsupported**: every request is answered with an empty
 //!   reply plus a structured warning, so the UI's loader always resolves.
-//! - Order-book capture is unsupported (the UI already disables the heatmap
-//!   for this provider); the depth channel stays open but forever empty.
+//! - **Order-book capture is supported** when the bridge declares a Depth of
+//!   Market. The terminal republishes a complete DOM image on every change and
+//!   `quantick-feed-mt5` diffs those into the same snapshot-plus-delta stream
+//!   Binance produces, so the heatmap runs on one shared pipeline. Capture is
+//!   a switch on the running session rather than a task to start and stop: the
+//!   book shares one socket with ticks, and MQL5 offers no back-channel to ask
+//!   the terminal to stop sending it.
 //!
 //! Synthetic ids caveat: `agg_id` restarts at 1 on every bridge session, so
 //! ids may repeat across reconnects within one chart lifetime. Bars are built
 //! from trade order, not ids, so the chart is unaffected; anything keying on
 //! `agg_id` across sessions must not, and this is the place that documents it.
 
+use std::process::Stdio;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use tokio::process::Command;
 use tokio::sync::mpsc;
 use tracing::{error, info, warn};
 
-use quantick_feed_mt5::{Mt5Event, Mt5Status, ServerConfig, SideMode, run_bridge_server};
+use quantick_feed_mt5::{
+    BookCaptureSwitch, Mt5Event, Mt5Status, ServerConfig, SideMode, run_bridge_server,
+};
 
 use crate::config::{MetaTraderSettings, Mt5SideSource};
 
 use super::{DepthEvent, FeedCommand, FeedEvent, FeedHandle};
+
+/// Depth events are independent from the established trade channel. Sized like
+/// the Binance backend's: a B3 book republishes far faster than the UI drains,
+/// and this absorbs bursts without either dropping deltas or stalling trades.
+const BOOK_EVENT_CHANNEL_CAPACITY: usize = 8_192;
+
+/// How long the autostart waits for a bridge that is already running before
+/// launching its own. Long enough for an attached Expert Advisor's reconnect
+/// cycle to notice the port, short enough that a cold start feels immediate.
+const BRIDGE_AUTOSTART_GRACE: Duration = Duration::from_secs(3);
+
+/// Gap between autostart attempts. The common failure is a terminal still
+/// starting up, which resolves in seconds.
+const BRIDGE_AUTOSTART_RETRY: Duration = Duration::from_secs(5);
+
+/// How many times the autostart relaunches an exiting bridge before leaving it
+/// alone. Every remaining failure (terminal closed, unknown symbol, unknown
+/// server offset) needs a human, and retrying it forever only buries the log
+/// line that says so.
+const BRIDGE_AUTOSTART_ATTEMPTS: u32 = 5;
 
 /// Start the MetaTrader feed for `symbol`: listen for the bridge on the
 /// configured address and translate its stream into [`FeedEvent`]s.
 #[must_use]
 pub fn spawn(symbol: &str, settings: &MetaTraderSettings) -> FeedHandle {
     let (tx, rx) = mpsc::channel(4096);
-    let (book_tx, book_rx) = mpsc::channel::<DepthEvent>(1);
+    let (book_tx, book_rx) = mpsc::channel::<DepthEvent>(BOOK_EVENT_CHANNEL_CAPACITY);
     let (cmd_tx, cmd_rx) = mpsc::channel(16);
     let symbol = symbol.to_string();
     let settings = settings.clone();
@@ -72,7 +105,7 @@ async fn feed_task(
     symbol: String,
     settings: MetaTraderSettings,
     tx: mpsc::Sender<FeedEvent>,
-    _book_tx: mpsc::Sender<DepthEvent>, // held open, forever empty: no depth from MT5
+    book_tx: mpsc::Sender<DepthEvent>,
     mut cmd_rx: mpsc::Receiver<FeedCommand>,
 ) {
     // Resolve the UI's initial history load immediately: there is no
@@ -88,6 +121,23 @@ async fn feed_task(
         Mt5SideSource::Flags => SideMode::Flags,
     };
 
+    // Selecting a MetaTrader feed is one action; starting a bridge by hand
+    // afterwards was the second one this removes. The supervisor holds off
+    // until it is sure nobody else is already feeding us.
+    let bridge_connected = Arc::new(AtomicBool::new(false));
+    let autostart = settings.bridge_autostart.then(|| {
+        tokio::spawn(supervise_bridge(
+            symbol.clone(),
+            settings.clone(),
+            Arc::clone(&bridge_connected),
+        ))
+    });
+
+    // The switch lives on this side of the server task so UI commands can flip
+    // depth capture without disturbing the bridge session or the trade stream.
+    let book_capture = BookCaptureSwitch::new();
+    server_cfg.book_capture = book_capture.clone();
+
     let (mt5_tx, mut mt5_rx) = mpsc::channel::<Mt5Event>(4096);
     let server = tokio::spawn(run_bridge_server(server_cfg, mt5_tx));
 
@@ -102,7 +152,12 @@ async fn feed_task(
         tokio::select! {
             maybe_event = mt5_rx.recv() => {
                 match maybe_event {
-                    Some(Mt5Event::Status(status)) => log_status(&symbol, &status),
+                    Some(Mt5Event::Status(status)) => {
+                        if matches!(status, Mt5Status::Connected { .. }) {
+                            bridge_connected.store(true, Ordering::Relaxed);
+                        }
+                        log_status(&symbol, &status);
+                    }
                     Some(Mt5Event::Backfilled(batch)) => {
                         if batch.is_empty() {
                             continue;
@@ -150,6 +205,16 @@ async fn feed_task(
                             }
                         }
                     }
+                    Some(Mt5Event::Depth(event)) => {
+                        // Backpressure rather than dropping: after the opening
+                        // snapshot every event is an absolute delta, and a
+                        // dropped one desynchronizes the book until the next
+                        // generation. A full buffer means the UI is stalled,
+                        // and the trade stream is buffered too.
+                        if book_tx.send(event).await.is_err() {
+                            break; // UI gone
+                        }
+                    }
                     Some(Mt5Event::Live(trade)) => {
                         forwarded_any = true;
                         last_forwarded_ms = last_forwarded_ms.max(trade.timestamp_ms);
@@ -180,7 +245,7 @@ async fn feed_task(
                                 "MT5 bridge listener crashed"
                             ),
                         }
-                        idle_serve_commands(&symbol, &tx, &mut cmd_rx).await;
+                        idle_serve_commands(&symbol, &tx, &mut cmd_rx, &book_capture).await;
                         return;
                     }
                 }
@@ -191,7 +256,7 @@ async fn feed_task(
             maybe_cmd = cmd_rx.recv() => {
                 match maybe_cmd {
                     Some(cmd) => {
-                        if !answer_command(&symbol, cmd, &tx).await {
+                        if !answer_command(&symbol, cmd, &tx, &book_capture).await {
                             break; // UI gone
                         }
                     }
@@ -201,6 +266,129 @@ async fn feed_task(
         }
     }
     server.abort();
+    // Dropping the supervisor's task drops the child handle, and the child was
+    // spawned with kill-on-drop: a bridge quantick started never outlives the
+    // feed that wanted it.
+    if let Some(autostart) = autostart {
+        autostart.abort();
+    }
+}
+
+/// Launch a bridge when nothing else is feeding us, and keep it alive.
+///
+/// Deliberately passive at the start: a bridge that is already running, or an
+/// Expert Advisor attached to a chart, gets the grace period to dial in. Only
+/// silence triggers a launch.
+async fn supervise_bridge(
+    symbol: String,
+    settings: MetaTraderSettings,
+    connected: Arc<AtomicBool>,
+) {
+    let Some((host, port)) = settings.bridge_endpoint() else {
+        warn!(
+            target: "quantick::app",
+            schema_version = 1_u8,
+            event_code = "MT5_BRIDGE_AUTOSTART_SKIPPED",
+            symbol = %symbol,
+            listen_addr = %settings.listen_addr,
+            action = "wait_for_manual_bridge",
+            "cannot derive a dial address from listen_addr; not starting a bridge"
+        );
+        return;
+    };
+    let Some((program, extra)) = settings.bridge_command.split_first() else {
+        warn!(
+            target: "quantick::app",
+            schema_version = 1_u8,
+            event_code = "MT5_BRIDGE_AUTOSTART_SKIPPED",
+            symbol = %symbol,
+            action = "wait_for_manual_bridge",
+            "bridge_command is empty; not starting a bridge"
+        );
+        return;
+    };
+
+    tokio::time::sleep(BRIDGE_AUTOSTART_GRACE).await;
+    for attempt in 1..=BRIDGE_AUTOSTART_ATTEMPTS {
+        if connected.load(Ordering::Relaxed) {
+            info!(
+                target: "quantick::app",
+                schema_version = 1_u8,
+                event_code = "MT5_BRIDGE_AUTOSTART_NOT_NEEDED",
+                symbol = %symbol,
+                action = "leave_running_bridge_alone",
+                "a bridge is already connected; quantick started none of its own"
+            );
+            return;
+        }
+
+        let mut command = Command::new(program);
+        command
+            .args(extra)
+            .arg("--symbol")
+            .arg(&symbol)
+            .arg("--host")
+            .arg(host)
+            .arg("--port")
+            .arg(port)
+            // The bridge speaks the same structured-log vocabulary, so letting
+            // it write to our streams keeps one story in one place.
+            .stdin(Stdio::null())
+            .kill_on_drop(true);
+
+        match command.spawn() {
+            Ok(mut child) => {
+                info!(
+                    target: "quantick::app",
+                    schema_version = 1_u8,
+                    event_code = "MT5_BRIDGE_SPAWNED",
+                    symbol = %symbol,
+                    program = %program,
+                    pid = child.id(),
+                    attempt,
+                    host,
+                    port,
+                    "started a bridge for this feed"
+                );
+                let status = child.wait().await;
+                warn!(
+                    target: "quantick::app",
+                    schema_version = 1_u8,
+                    event_code = "MT5_BRIDGE_EXITED",
+                    symbol = %symbol,
+                    attempt,
+                    max_attempts = BRIDGE_AUTOSTART_ATTEMPTS,
+                    status = ?status.map(|s| s.code()),
+                    action = "retry_after_backoff",
+                    "the bridge quantick started has exited"
+                );
+            }
+            Err(error) => {
+                warn!(
+                    target: "quantick::app",
+                    schema_version = 1_u8,
+                    event_code = "MT5_BRIDGE_SPAWN_FAILED",
+                    symbol = %symbol,
+                    program = %program,
+                    attempt,
+                    %error,
+                    action = "retry_after_backoff",
+                    "could not start the bridge (is it on PATH? is the working directory the repo?)"
+                );
+            }
+        }
+        tokio::time::sleep(BRIDGE_AUTOSTART_RETRY).await;
+    }
+
+    warn!(
+        target: "quantick::app",
+        schema_version = 1_u8,
+        event_code = "MT5_BRIDGE_AUTOSTART_GAVE_UP",
+        symbol = %symbol,
+        attempts = BRIDGE_AUTOSTART_ATTEMPTS,
+        action = "wait_for_manual_bridge",
+        "the bridge would not stay up; read its own log lines above for the reason"
+    );
 }
 
 /// After a fatal listener error, keep answering UI commands honestly (empty
@@ -209,16 +397,22 @@ async fn idle_serve_commands(
     symbol: &str,
     tx: &mpsc::Sender<FeedEvent>,
     cmd_rx: &mut mpsc::Receiver<FeedCommand>,
+    book_capture: &BookCaptureSwitch,
 ) {
     while let Some(cmd) = cmd_rx.recv().await {
-        if !answer_command(symbol, cmd, tx).await {
+        if !answer_command(symbol, cmd, tx, book_capture).await {
             return;
         }
     }
 }
 
 /// Answer one UI command. Returns false when the UI is gone.
-async fn answer_command(symbol: &str, cmd: FeedCommand, tx: &mpsc::Sender<FeedEvent>) -> bool {
+async fn answer_command(
+    symbol: &str,
+    cmd: FeedCommand,
+    tx: &mpsc::Sender<FeedEvent>,
+    book_capture: &BookCaptureSwitch,
+) -> bool {
     match cmd {
         FeedCommand::LoadOlder { count } => {
             warn!(
@@ -238,27 +432,35 @@ async fn answer_command(symbol: &str, cmd: FeedCommand, tx: &mpsc::Sender<FeedEv
             enabled,
             initial_generation,
         } => {
-            warn!(
+            if enabled {
+                book_capture.enable(initial_generation);
+            } else {
+                book_capture.disable();
+            }
+            info!(
                 target: "quantick::app",
                 schema_version = 1_u8,
-                event_code = "MT5_BOOK_CAPTURE_UNSUPPORTED",
+                event_code = "MT5_BOOK_CAPTURE_SET",
                 symbol,
                 enabled,
                 initial_generation,
-                action = "ignore",
-                "MT5 order-book capture is not implemented"
+                action = if enabled { "publish_depth" } else { "stop_publishing_depth" },
+                "book capture switched on the running bridge session"
             );
             true
         }
         FeedCommand::RestartBookCapture { initial_generation } => {
-            warn!(
+            // A fresh base generation retires whatever the previous one
+            // published; the next image opens a new snapshot.
+            book_capture.enable(initial_generation);
+            info!(
                 target: "quantick::app",
                 schema_version = 1_u8,
-                event_code = "MT5_BOOK_CAPTURE_UNSUPPORTED",
+                event_code = "MT5_BOOK_CAPTURE_RESTARTED",
                 symbol,
                 initial_generation,
-                action = "ignore",
-                "MT5 order-book capture is not implemented"
+                action = "resnapshot_on_next_image",
+                "book capture restarted at a fresh generation"
             );
             true
         }
@@ -310,6 +512,10 @@ mod tests {
         let settings = MetaTraderSettings {
             listen_addr: "127.0.0.1:0".to_string(),
             side_source: Mt5SideSource::TickRule,
+            // These tests are the bridge; a second one racing them would make
+            // the assertions depend on whether python happens to be installed.
+            bridge_autostart: false,
+            ..MetaTraderSettings::default()
         };
         spawn(symbol, &settings)
     }
@@ -358,6 +564,10 @@ mod tests {
         let settings = MetaTraderSettings {
             listen_addr: "127.0.0.1:19171".to_string(),
             side_source: Mt5SideSource::TickRule,
+            // These tests are the bridge; a second one racing them would make
+            // the assertions depend on whether python happens to be installed.
+            bridge_autostart: false,
+            ..MetaTraderSettings::default()
         };
         let mut feed = spawn("WIN$N", &settings);
         let Some(FeedEvent::Backfilled(empty)) = feed.events.recv().await else {
@@ -421,6 +631,10 @@ mod tests {
         let settings = MetaTraderSettings {
             listen_addr: "127.0.0.1:19172".to_string(),
             side_source: Mt5SideSource::TickRule,
+            // These tests are the bridge; a second one racing them would make
+            // the assertions depend on whether python happens to be installed.
+            bridge_autostart: false,
+            ..MetaTraderSettings::default()
         };
         let mut feed = spawn("WIN$N", &settings);
         let Some(FeedEvent::Backfilled(_)) = feed.events.recv().await else {

--- a/crates/app/src/orderflow_engine.rs
+++ b/crates/app/src/orderflow_engine.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use quantick_engine::{Bar, Trade};
-use quantick_feed_binance::depth::{DepthEvent, DepthResyncReason, DepthStatus};
+use quantick_orderbook::{DepthEvent, DepthResyncReason, DepthStatus};
 use rust_decimal::Decimal;
 use rust_decimal::prelude::{FromPrimitive as _, ToPrimitive as _};
 
@@ -41,6 +41,34 @@ fn snapshot_reference_price(snapshot: &quantick_orderbook::BookSnapshot) -> Opti
         (None, None) => return None,
     };
     price.to_f64()
+}
+
+/// Capture bucket for a generation, and how it was decided.
+///
+/// Two facts constrain it. The instrument's own tick size, when the feed states
+/// one, is the finest bucket that can ever hold liquidity — finer rows are
+/// permanently empty and paint the map with stripes (B3's mini index moves in
+/// 5-point steps, so a 2-point bucket wastes over half the rows). The price
+/// scale sets the coarsest useful one, since a dense book at a fine bucket
+/// explodes into RLE runs. The result honours both: at least one tick, always a
+/// whole number of ticks.
+fn capture_base(
+    price_step: Option<Decimal>,
+    reference_price: Option<f64>,
+) -> Option<(Decimal, &'static str)> {
+    let derived = reference_price.map(adaptive_base);
+    let Some(step) = price_step.filter(|step| *step > Decimal::ZERO) else {
+        return derived.map(|base| (base, "derived_from_price"));
+    };
+    match derived.filter(|derived| *derived > step) {
+        // Round up to a whole number of ticks: every bucket edge then falls on
+        // a real price the instrument can trade at.
+        Some(derived) => match (derived / step).ceil().checked_mul(step) {
+            Some(base) => Some((base, "price_step_multiple")),
+            None => Some((step, "instrument_price_step")),
+        },
+        None => Some((step, "instrument_price_step")),
+    }
 }
 
 /// A capture price bucket proportional to the asset's price, snapped to a
@@ -585,19 +613,23 @@ impl BookEngine {
             DepthEvent::Snapshot {
                 observed_at_ms,
                 effective_at_ms,
+                price_step,
                 snapshot,
                 ..
             } => {
                 self.invalidate_projection();
                 self.last_snapshot_observed_ms = Some(observed_at_ms);
-                // Size the capture bucket from the asset price before the first
-                // snapshot of a capture, so a dense book (BTC etc.) doesn't
-                // explode into runs. Skipped once the user picks a base by hand.
+                // Size the capture bucket before the first snapshot of a
+                // capture: from the instrument's tick size when the feed states
+                // one, otherwise from the asset price so a dense book (BTC etc.)
+                // doesn't explode into runs. Skipped once the user picks a base
+                // by hand.
                 if self.auto_base
                     && matches!(self.history.status(), HistoryStatus::Empty)
-                    && let Some(price) = snapshot_reference_price(&snapshot)
+                    && let Some((base, source)) =
+                        capture_base(price_step, snapshot_reference_price(&snapshot))
                 {
-                    self.apply_auto_base(adaptive_base(price));
+                    self.apply_auto_base(base, source);
                 }
                 if let Err(error) =
                     self.history
@@ -791,7 +823,7 @@ impl BookEngine {
 
     /// Adopt a price-derived capture bucket while history is still empty (so no
     /// data is discarded), keeping config and history in sync.
-    fn apply_auto_base(&mut self, base: Decimal) {
+    fn apply_auto_base(&mut self, base: Decimal, source: &'static str) {
         if base <= Decimal::ZERO || base == self.config.price_grouping {
             return;
         }
@@ -804,8 +836,9 @@ impl BookEngine {
                     event_code = "HEATMAP_AUTO_BASE",
                     symbol = self.symbol.as_str(),
                     base = %base,
-                    action = "size_capture_bucket_from_price",
-                    "auto-sized L2 capture bucket from asset price"
+                    source,
+                    action = "size_capture_bucket",
+                    "auto-sized L2 capture bucket"
                 );
             }
             Err(error) => {
@@ -890,6 +923,7 @@ fn resync_reason_code(reason: &DepthResyncReason) -> &'static str {
         DepthResyncReason::SnapshotTooOld { .. } => "snapshot_too_old",
         DepthResyncReason::SequenceGap { .. } => "sequence_gap",
         DepthResyncReason::SnapshotAttemptsExhausted { .. } => "snapshot_attempts_exhausted",
+        DepthResyncReason::SourceRestarted { cause } => cause,
     }
 }
 
@@ -917,6 +951,46 @@ mod tests {
     }
 
     #[test]
+    fn a_declared_tick_size_wins_over_the_price_heuristic_when_it_is_coarser() {
+        // B3's mini index: ~177 800 points, 5-point tick. The price heuristic
+        // alone would pick 2 and leave three rows in five permanently empty.
+        assert_eq!(
+            capture_base(Some(Decimal::from(5)), Some(177_800.0)),
+            Some((Decimal::from(5), "instrument_price_step"))
+        );
+        // Mini dollar: ~5 500, half-point tick — same story an order down.
+        assert_eq!(
+            capture_base(Some(Decimal::new(5, 1)), Some(5_500.0)),
+            Some((Decimal::new(5, 1), "instrument_price_step"))
+        );
+    }
+
+    #[test]
+    fn a_fine_tick_size_is_rounded_up_to_a_whole_number_of_ticks() {
+        // A dense book on a fine grid must still be captured at a bucket the
+        // price scale can afford — but on bucket edges that can really trade.
+        let (base, source) = capture_base(Some(Decimal::new(1, 2)), Some(200_000.0)).unwrap();
+        assert_eq!(source, "price_step_multiple");
+        assert!(base >= adaptive_base(200_000.0));
+        assert_eq!(base % Decimal::new(1, 2), Decimal::ZERO);
+    }
+
+    #[test]
+    fn an_undeclared_tick_size_falls_back_to_the_price_heuristic() {
+        assert_eq!(
+            capture_base(None, Some(65_000.0)),
+            Some((Decimal::from(1), "derived_from_price"))
+        );
+        // A non-positive declared step is not a price grid; ignore it.
+        assert_eq!(
+            capture_base(Some(Decimal::ZERO), Some(65_000.0)),
+            Some((Decimal::from(1), "derived_from_price"))
+        );
+        // Nothing known at all: leave the configured bucket alone.
+        assert_eq!(capture_base(None, None), None);
+    }
+
+    #[test]
     fn auto_base_sizes_the_capture_bucket_from_the_first_snapshot() {
         let mut engine = BookEngine::new("BTCUSDT");
         engine.set_enabled(true, 1);
@@ -926,6 +1000,7 @@ mod tests {
             generation: 1,
             observed_at_ms: 1_100,
             effective_at_ms: 1_000,
+            price_step: None,
             snapshot: BookSnapshot::new(
                 10,
                 vec![BookLevel::new(Decimal::from(64_999), Decimal::from(2)).unwrap()],
@@ -945,6 +1020,7 @@ mod tests {
             generation,
             observed_at_ms: 1_100,
             effective_at_ms: 999,
+            price_step: None,
             snapshot: BookSnapshot::new(
                 10,
                 vec![BookLevel::new(Decimal::from(99), Decimal::from(5)).unwrap()],

--- a/crates/app/src/orderflow_view.rs
+++ b/crates/app/src/orderflow_view.rs
@@ -12,7 +12,7 @@ use std::time::Instant;
 
 use eframe::egui;
 use quantick_engine::{Bar, Trade};
-use quantick_feed_binance::depth::DepthEvent;
+use quantick_orderbook::DepthEvent;
 use rust_decimal::Decimal;
 use rust_decimal::prelude::{FromPrimitive as _, ToPrimitive as _};
 
@@ -697,6 +697,7 @@ mod tests {
             generation,
             observed_at_ms: 1_100,
             effective_at_ms: 999,
+            price_step: None,
             snapshot: BookSnapshot::new(
                 10,
                 vec![BookLevel::new(Decimal::from(99), Decimal::from(5)).unwrap()],
@@ -786,6 +787,7 @@ mod tests {
             generation: 1,
             observed_at_ms: 1_100,
             effective_at_ms: 1_000,
+            price_step: None,
             snapshot: BookSnapshot::new(
                 10,
                 vec![BookLevel::new(Decimal::from(64_999), Decimal::from(2)).unwrap()],

--- a/crates/app/src/orderflow_worker.rs
+++ b/crates/app/src/orderflow_worker.rs
@@ -16,7 +16,7 @@ use std::sync::mpsc::{Receiver, Sender, channel};
 use std::sync::{Arc, Mutex};
 
 use quantick_engine::Trade;
-use quantick_feed_binance::depth::DepthEvent;
+use quantick_orderbook::DepthEvent;
 use rust_decimal::Decimal;
 
 use crate::orderflow::HeatmapConfig;

--- a/crates/feed-binance/src/depth/stream.rs
+++ b/crates/feed-binance/src/depth/stream.rs
@@ -16,7 +16,7 @@ use std::collections::VecDeque;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use futures_util::{SinkExt as _, StreamExt as _};
-use quantick_orderbook::{BookDelta, BookSnapshot};
+use quantick_orderbook::BookSnapshot;
 use tokio::net::TcpStream;
 use tokio::sync::mpsc::Sender;
 use tokio_tungstenite::{
@@ -71,122 +71,11 @@ impl DepthSessionConfig {
     }
 }
 
-/// Why a synchronized session must be discarded and rebuilt.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum DepthResyncReason {
-    /// The REST snapshot was older than the earliest eligible buffered update.
-    SnapshotTooOld {
-        /// Snapshot update id.
-        snapshot_update_id: u64,
-        /// First id in the event that could not bridge it.
-        first_update_id: u64,
-        /// Final id in that event.
-        final_update_id: u64,
-    },
-    /// At least one WebSocket update id was missed.
-    SequenceGap {
-        /// Next required update id.
-        expected_update_id: u64,
-        /// First received id.
-        first_update_id: u64,
-        /// Final received id.
-        final_update_id: u64,
-    },
-    /// Snapshot bootstrap retried too many times on one connection.
-    SnapshotAttemptsExhausted {
-        /// Number of attempted snapshots.
-        attempts: u32,
-    },
-}
-
-/// Consumer-visible depth lifecycle.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum DepthStatus {
-    /// WebSocket connection is being established.
-    Connecting,
-    /// WebSocket is open and updates are being buffered.
-    Buffering {
-        /// Configured hard buffer limit.
-        capacity: usize,
-    },
-    /// A REST snapshot is being fetched while the socket remains live.
-    SnapshotFetching {
-        /// Attempt number within this socket generation.
-        attempt: u32,
-        /// Updates already buffered.
-        buffered_updates: usize,
-    },
-    /// Snapshot and stream are continuous and consumer data is authoritative
-    /// within the declared snapshot coverage.
-    Synchronized {
-        /// Current final update id.
-        last_update_id: u64,
-        /// Current stored bid level count.
-        bid_levels: usize,
-        /// Current stored ask level count.
-        ask_levels: usize,
-    },
-    /// Current state is being discarded.
-    Resyncing {
-        /// Typed reason for the resync.
-        reason: DepthResyncReason,
-    },
-    /// A connection generation ended.
-    Disconnected {
-        /// Stable machine-readable error class.
-        error_class: &'static str,
-    },
-    /// Consumer cancellation stopped the reconnect loop.
-    Stopped,
-}
-
-/// Typed output consumed by the chart or another order-book client.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum DepthEvent {
-    /// Lifecycle/status transition.
-    Status {
-        /// Upper-case Binance symbol.
-        symbol: String,
-        /// Monotonic capture/session generation.
-        generation: u64,
-        /// New status.
-        status: DepthStatus,
-    },
-    /// Initial exchange-neutral snapshot, emitted exactly once per successful
-    /// generation before its first delta.
-    Snapshot {
-        /// Upper-case Binance symbol.
-        symbol: String,
-        /// Monotonic capture/session generation.
-        generation: u64,
-        /// Local epoch milliseconds when the REST response was observed.
-        ///
-        /// Binance's snapshot response has no exchange timestamp, so this is
-        /// intentionally labelled as local observation time.
-        observed_at_ms: i64,
-        /// Logical start time for the snapshot in the consumer timeline.
-        ///
-        /// A diff can be buffered before the REST response arrives, so its
-        /// exchange event time may precede `observed_at_ms`. This value is at
-        /// most one millisecond before the bridge event and never after the
-        /// local observation, preventing a false backwards-time delta while
-        /// keeping the observation timestamp available for diagnostics.
-        effective_at_ms: i64,
-        /// Validated exchange-neutral snapshot.
-        snapshot: BookSnapshot,
-    },
-    /// One applied absolute update.
-    Update {
-        /// Upper-case Binance symbol.
-        symbol: String,
-        /// Monotonic capture/session generation.
-        generation: u64,
-        /// Binance exchange event time (`E`).
-        event_time_ms: i64,
-        /// Validated exchange-neutral absolute delta.
-        delta: BookDelta,
-    },
-}
+// The depth stream vocabulary is provider-neutral domain code and lives in
+// `quantick-orderbook`, so a second venue (MetaTrader's DOM, via
+// `SnapshotDiffer`) can speak it without depending on this crate. Re-exported
+// here because this module's public surface is where consumers already look.
+pub use quantick_orderbook::stream::{DepthEvent, DepthResyncReason, DepthStatus};
 
 /// Failure ending one WebSocket generation.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -525,6 +414,9 @@ async fn bridge_snapshot(
                             observed_at_ms,
                             update.event_time_ms,
                         ),
+                        // Binance's depth stream never states a tick size;
+                        // the consumer sizes its buckets from the price.
+                        price_step: None,
                         snapshot,
                     },
                 )

--- a/crates/feed-mt5/Cargo.toml
+++ b/crates/feed-mt5/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 
 [dependencies]
 quantick-engine = { path = "../engine" }
+quantick-orderbook = { path = "../orderbook" }
 rust_decimal = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/feed-mt5/src/depth.rs
+++ b/crates/feed-mt5/src/depth.rs
@@ -1,0 +1,585 @@
+//! MetaTrader Depth of Market → the neutral depth-stream contract.
+//!
+//! MT5's book is the opposite shape from an exchange diff stream: no update
+//! ids, no incremental messages, no sequencing at all. `OnBookEvent` fires and
+//! `MarketBookGet` hands back the entire visible DOM. The bridge forwards those
+//! images verbatim (see [`crate::protocol::Book`]) and this module turns them
+//! into the same [`DepthEvent`] stream Binance produces, so everything
+//! downstream — order book, run-length liquidity history, heatmap projection —
+//! is shared rather than forked per venue.
+//!
+//! The conversion is [`SnapshotDiffer`]: first image becomes a snapshot,
+//! every later one becomes a delta of only the levels that moved. B3 republishes
+//! ~20 levels many times a second while typically one or two of them changed,
+//! so diffing here is what keeps the whole downstream cost proportional to real
+//! change rather than to event rate.
+//!
+//! # What MT5 does not provide, and what this module does about it
+//!
+//! - **No update ids** → synthetic, monotonic, generation-scoped (the differ's).
+//! - **Server wall time** → converted to UTC with the bridge's declared offset,
+//!   exactly like ticks, so book and trades share one timeline.
+//! - **Truncated depth** → coverage is always
+//!   [`BookCoverage::Limited`], never `Full`. Liquidity leaving the visible
+//!   window is reported as removed because that is all the terminal knows;
+//!   labelling the coverage is what keeps that honest.
+//! - **Market-order rows** (`BOOK_TYPE_*_MARKET`, no meaningful price) → skipped
+//!   and counted. They are not resting liquidity.
+//! - **Crossed images** (B3 publishes them during the pre-open auction) →
+//!   rejected and counted; the last uncrossed image stands.
+
+use std::str::FromStr as _;
+
+use rust_decimal::Decimal;
+use tracing::{info, warn};
+
+use quantick_orderbook::{
+    BookCoverage, BookLevel, DepthEvent, DepthStatus, ImageOutcome, SnapshotDiffer,
+};
+
+use crate::protocol::{Book, WireLevel};
+
+/// Depth levels assumed per side when the bridge declares no limit.
+///
+/// Only used to label coverage; nothing is truncated to it. B3 terminals
+/// typically expose a few tens of levels.
+const ASSUMED_BOOK_LEVELS: usize = 32;
+
+/// The honest ledger of everything the book mapper did with one session's
+/// images. All fields public on purpose: they are data, not behaviour.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct BookStats {
+    /// Images received from the bridge.
+    pub images: u64,
+    /// Images that opened a generation (one per generation).
+    pub snapshots: u64,
+    /// Images that produced an absolute delta.
+    pub deltas: u64,
+    /// Images identical to the previous one; nothing was published.
+    pub unchanged: u64,
+    /// Images rejected as crossed or locked (auction, stale terminal state).
+    pub crossed: u64,
+    /// Images rejected because a level was unparseable or negative.
+    pub malformed: u64,
+    /// Level rows skipped for having no usable price (MT5 market orders).
+    pub market_rows: u64,
+    /// Images whose timestamp went backwards and was held at the last value.
+    pub clamped_timestamps: u64,
+}
+
+impl BookStats {
+    /// Total images that changed the published book.
+    #[must_use]
+    pub fn published(&self) -> u64 {
+        self.snapshots + self.deltas
+    }
+
+    /// Total images that published nothing.
+    #[must_use]
+    pub fn skipped(&self) -> u64 {
+        self.unchanged + self.crossed + self.malformed
+    }
+
+    /// Emit the whole ledger as one structured log line (AI-first: a log
+    /// excerpt alone answers "why is the heatmap empty / stale?").
+    pub fn log_summary(&self, symbol: &str) {
+        info!(
+            target: "quantick::feed",
+            schema_version = 1_u8,
+            event_code = "MT5_BOOK_SUMMARY",
+            symbol,
+            images = self.images,
+            published = self.published(),
+            snapshots = self.snapshots,
+            deltas = self.deltas,
+            skipped = self.skipped(),
+            unchanged = self.unchanged,
+            crossed = self.crossed,
+            malformed = self.malformed,
+            market_rows = self.market_rows,
+            clamped_timestamps = self.clamped_timestamps,
+            "mt5 book mapping summary"
+        );
+    }
+}
+
+/// Stateful DOM image → [`DepthEvent`] mapper for one capture generation.
+///
+/// Deterministic: the same images with the same offset always produce the same
+/// events. Reusable scratch buffers keep the steady state free of per-image
+/// allocation apart from the emitted delta's own levels.
+#[derive(Debug)]
+pub struct BookMapper {
+    symbol: String,
+    generation: u64,
+    price_step: Option<Decimal>,
+    /// `server_time - utc`, in milliseconds (from hello, refreshed by
+    /// heartbeats) — the same conversion ticks use.
+    offset_ms: i64,
+    differ: SnapshotDiffer,
+    last_utc_ms: Option<i64>,
+    bids: Vec<BookLevel>,
+    asks: Vec<BookLevel>,
+    /// The honest ledger of everything mapped, skipped and why.
+    pub stats: BookStats,
+}
+
+impl BookMapper {
+    /// A mapper for `generation`, publishing events tagged with `symbol`.
+    ///
+    /// `book_levels` and `tick_size` come from the bridge's hello: the first
+    /// labels how much of the exchange book the terminal can see, the second
+    /// lets the consumer render on the instrument's real price grid.
+    #[must_use]
+    pub fn new(
+        symbol: impl Into<String>,
+        generation: u64,
+        book_levels: Option<u32>,
+        tick_size: Option<&str>,
+        server_utc_offset_s: i64,
+    ) -> Self {
+        let levels_per_side = book_levels
+            .and_then(|levels| usize::try_from(levels).ok())
+            .filter(|levels| *levels > 0)
+            .unwrap_or(ASSUMED_BOOK_LEVELS);
+        Self {
+            symbol: symbol.into(),
+            generation,
+            price_step: tick_size
+                .and_then(|size| Decimal::from_str(size).ok())
+                .filter(|size| *size > Decimal::ZERO),
+            // Saturating: the offset is declared by whatever dialed our port,
+            // so an absurd value must not panic the feed task.
+            offset_ms: server_utc_offset_s.saturating_mul(1000),
+            differ: SnapshotDiffer::new(BookCoverage::Limited { levels_per_side }),
+            last_utc_ms: None,
+            bids: Vec::new(),
+            asks: Vec::new(),
+            stats: BookStats::default(),
+        }
+    }
+
+    /// The generation this mapper currently publishes.
+    #[must_use]
+    pub fn generation(&self) -> u64 {
+        self.generation
+    }
+
+    /// Whether an image has been published since the last restart.
+    #[must_use]
+    pub fn is_synchronized(&self) -> bool {
+        self.differ.is_initialized()
+    }
+
+    /// Status describing the currently published book, for a consumer badge.
+    #[must_use]
+    pub fn synchronized_status(&self) -> DepthStatus {
+        let (bid_levels, ask_levels) = self.differ.level_counts();
+        DepthStatus::Synchronized {
+            last_update_id: self.differ.last_update_id(),
+            bid_levels,
+            ask_levels,
+        }
+    }
+
+    /// Refresh the server-time offset (heartbeats may recompute it, e.g.
+    /// across a DST change on brokers that observe one).
+    pub fn set_server_utc_offset_s(&mut self, offset_s: i64) {
+        self.offset_ms = offset_s.saturating_mul(1000);
+    }
+
+    /// Start publishing `generation` from a fresh snapshot.
+    ///
+    /// Continuity across a restart is never implied: the consumer sees a new
+    /// generation and can render the discontinuity instead of connecting
+    /// liquidity across it.
+    pub fn restart(&mut self, generation: u64) {
+        self.generation = generation;
+        self.differ.reset();
+        self.last_utc_ms = None;
+    }
+
+    /// Map one DOM image. Returns the event to publish, if any.
+    pub fn map(&mut self, image: &Book) -> Option<DepthEvent> {
+        self.stats.images += 1;
+
+        if read_levels(&image.bids, &mut self.bids, &mut self.stats).is_none()
+            || read_levels(&image.asks, &mut self.asks, &mut self.stats).is_none()
+        {
+            self.stats.malformed += 1;
+            warn_once(
+                self.stats.malformed,
+                "MT5_BOOK_MALFORMED",
+                &self.symbol,
+                image.seq,
+                "book image had an unparseable or negative level; keeping the previous image",
+            );
+            return None;
+        }
+
+        let event_time_ms = self.timeline_ms(image.time_ms);
+
+        match self.differ.observe(&self.bids, &self.asks) {
+            ImageOutcome::Snapshot(snapshot) => {
+                self.stats.snapshots += 1;
+                info!(
+                    target: "quantick::feed",
+                    schema_version = 1_u8,
+                    event_code = "MT5_BOOK_SYNCHRONIZED",
+                    symbol = %self.symbol,
+                    generation = self.generation,
+                    seq = image.seq,
+                    bid_levels = snapshot.bids().len(),
+                    ask_levels = snapshot.asks().len(),
+                    coverage = ?snapshot.coverage(),
+                    "first DOM image accepted; book capture is live"
+                );
+                Some(DepthEvent::Snapshot {
+                    symbol: self.symbol.clone(),
+                    generation: self.generation,
+                    // The terminal timestamps the image itself, so observation
+                    // and effect are the same instant — there is no separate
+                    // local fetch to distinguish, unlike a REST snapshot.
+                    observed_at_ms: event_time_ms,
+                    effective_at_ms: event_time_ms,
+                    price_step: self.price_step,
+                    snapshot,
+                })
+            }
+            ImageOutcome::Delta(delta) => {
+                self.stats.deltas += 1;
+                Some(DepthEvent::Update {
+                    symbol: self.symbol.clone(),
+                    generation: self.generation,
+                    event_time_ms,
+                    delta,
+                })
+            }
+            ImageOutcome::Unchanged => {
+                self.stats.unchanged += 1;
+                None
+            }
+            ImageOutcome::Crossed { best_bid, best_ask } => {
+                self.stats.crossed += 1;
+                warn_once(
+                    self.stats.crossed,
+                    "MT5_BOOK_CROSSED",
+                    &self.symbol,
+                    image.seq,
+                    "DOM image was crossed (auction?); keeping the last uncrossed image",
+                );
+                tracing::debug!(
+                    target: "quantick::feed",
+                    schema_version = 1_u8,
+                    event_code = "MT5_BOOK_CROSSED",
+                    symbol = %self.symbol,
+                    seq = image.seq,
+                    best_bid = %best_bid,
+                    best_ask = %best_ask,
+                    total_crossed = self.stats.crossed,
+                    "crossed DOM image rejected"
+                );
+                None
+            }
+        }
+    }
+
+    /// Convert server time to UTC and keep the published timeline monotonic.
+    ///
+    /// A book timestamp that goes backwards would be refused downstream and
+    /// cost the whole generation. Holding it at the last value keeps the
+    /// capture alive; the counter and log say how often it happened, so a
+    /// terminal with a jumping clock is diagnosable rather than invisible.
+    fn timeline_ms(&mut self, server_time_ms: i64) -> i64 {
+        let utc_ms = server_time_ms.saturating_sub(self.offset_ms);
+        let published = match self.last_utc_ms {
+            Some(last) if utc_ms < last => {
+                self.stats.clamped_timestamps += 1;
+                warn_once(
+                    self.stats.clamped_timestamps,
+                    "MT5_BOOK_TIME_BACKWARDS",
+                    &self.symbol,
+                    0,
+                    "DOM image timestamp went backwards; holding the previous instant",
+                );
+                last
+            }
+            _ => utc_ms,
+        };
+        self.last_utc_ms = Some(published);
+        published
+    }
+}
+
+/// Parse one side into `dst`. `None` means the image must be rejected whole:
+/// a book image is one atomic observation, and publishing it minus the rows we
+/// failed to read would invent liquidity that is not there.
+fn read_levels(src: &[WireLevel], dst: &mut Vec<BookLevel>, stats: &mut BookStats) -> Option<()> {
+    dst.clear();
+    dst.reserve(src.len());
+    for WireLevel(price, quantity) in src {
+        let (Ok(price), Ok(quantity)) = (Decimal::from_str(price), Decimal::from_str(quantity))
+        else {
+            return None;
+        };
+        if quantity < Decimal::ZERO {
+            return None;
+        }
+        // MT5 reports market-order rows with no usable price. They are orders
+        // waiting to cross, not resting liquidity at a level.
+        if price <= Decimal::ZERO {
+            stats.market_rows += 1;
+            continue;
+        }
+        match BookLevel::new(price, quantity) {
+            Ok(level) => dst.push(level),
+            Err(_) => return None,
+        }
+    }
+    Some(())
+}
+
+/// Log the first occurrence of a recurring condition at warn level. A crossed
+/// auction book repeats for minutes; one warning plus a counter in the session
+/// summary tells the story without flooding the log.
+fn warn_once(total: u64, event_code: &'static str, symbol: &str, seq: u64, message: &str) {
+    if total == 1 {
+        warn!(
+            target: "quantick::feed",
+            schema_version = 1_u8,
+            event_code,
+            symbol,
+            seq,
+            action = "keep_previous_image",
+            "{message}"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// B3's real offset: server time is UTC−3.
+    const OFFSET_S: i64 = -10_800;
+
+    fn wire(levels: &[(&str, &str)]) -> Vec<WireLevel> {
+        levels
+            .iter()
+            .map(|(price, quantity)| WireLevel((*price).to_string(), (*quantity).to_string()))
+            .collect()
+    }
+
+    fn image(seq: u64, time_ms: i64, bids: &[(&str, &str)], asks: &[(&str, &str)]) -> Book {
+        Book {
+            seq,
+            time_ms,
+            bids: wire(bids),
+            asks: wire(asks),
+        }
+    }
+
+    fn mapper() -> BookMapper {
+        BookMapper::new("WIN$N", 7, Some(20), Some("5"), OFFSET_S)
+    }
+
+    #[test]
+    fn the_first_image_is_a_snapshot_in_utc_with_the_declared_tick_size() {
+        let mut mapper = mapper();
+        let event = mapper
+            .map(&image(
+                1,
+                1_000,
+                &[("177795", "3"), ("177790", "12")],
+                &[("177800", "5")],
+            ))
+            .expect("first image publishes a snapshot");
+        let DepthEvent::Snapshot {
+            symbol,
+            generation,
+            observed_at_ms,
+            effective_at_ms,
+            price_step,
+            snapshot,
+        } = event
+        else {
+            panic!("expected a snapshot");
+        };
+        assert_eq!(symbol, "WIN$N");
+        assert_eq!(generation, 7);
+        // Server time minus the declared offset: 1000 - (-10_800_000).
+        assert_eq!(observed_at_ms, 1_000 + 10_800_000);
+        assert_eq!(effective_at_ms, observed_at_ms);
+        assert_eq!(price_step, Some(Decimal::from(5)));
+        assert_eq!(snapshot.bids().len(), 2);
+        assert_eq!(
+            snapshot.coverage(),
+            BookCoverage::Limited {
+                levels_per_side: 20
+            }
+        );
+        assert!(mapper.is_synchronized());
+    }
+
+    #[test]
+    fn a_republished_identical_image_publishes_nothing() {
+        let mut mapper = mapper();
+        let picture = image(1, 1_000, &[("177795", "3")], &[("177800", "5")]);
+        assert!(mapper.map(&picture).is_some());
+        assert!(
+            mapper
+                .map(&image(2, 1_100, &[("177795", "3")], &[("177800", "5")]))
+                .is_none()
+        );
+        assert_eq!(mapper.stats.unchanged, 1);
+        assert_eq!(mapper.stats.deltas, 0);
+    }
+
+    #[test]
+    fn a_changed_image_publishes_only_the_levels_that_moved() {
+        let mut mapper = mapper();
+        mapper.map(&image(
+            1,
+            1_000,
+            &[("177795", "3"), ("177790", "12")],
+            &[("177800", "5")],
+        ));
+        let event = mapper
+            .map(&image(
+                2,
+                1_500,
+                &[("177795", "1"), ("177790", "12")],
+                &[("177800", "5")],
+            ))
+            .expect("a changed image publishes a delta");
+        let DepthEvent::Update {
+            event_time_ms,
+            delta,
+            ..
+        } = event
+        else {
+            panic!("expected an update");
+        };
+        assert_eq!(event_time_ms, 1_500 + 10_800_000);
+        assert_eq!(delta.bids().len(), 1);
+        assert_eq!(delta.bids()[0].quantity(), Decimal::ONE);
+        assert!(delta.asks().is_empty());
+    }
+
+    #[test]
+    fn market_order_rows_are_skipped_and_counted() {
+        let mut mapper = mapper();
+        let event = mapper
+            .map(&image(
+                1,
+                1_000,
+                &[("0", "40"), ("177795", "3")],
+                &[("177800", "5")],
+            ))
+            .expect("a snapshot");
+        let DepthEvent::Snapshot { snapshot, .. } = event else {
+            panic!("expected a snapshot");
+        };
+        assert_eq!(snapshot.bids().len(), 1);
+        assert_eq!(mapper.stats.market_rows, 1);
+    }
+
+    #[test]
+    fn a_malformed_image_is_rejected_whole_and_the_previous_one_stands() {
+        let mut mapper = mapper();
+        mapper.map(&image(1, 1_000, &[("177795", "3")], &[("177800", "5")]));
+        assert!(
+            mapper
+                .map(&image(
+                    2,
+                    1_100,
+                    &[("not-a-price", "3")],
+                    &[("177800", "5")]
+                ))
+                .is_none()
+        );
+        assert!(
+            mapper
+                .map(&image(3, 1_200, &[("177795", "-3")], &[("177800", "5")]))
+                .is_none()
+        );
+        assert_eq!(mapper.stats.malformed, 2);
+        // The surviving image still diffs normally.
+        let event = mapper.map(&image(4, 1_300, &[("177795", "9")], &[("177800", "5")]));
+        assert!(matches!(event, Some(DepthEvent::Update { .. })));
+    }
+
+    #[test]
+    fn a_crossed_auction_image_is_rejected_and_counted() {
+        let mut mapper = mapper();
+        mapper.map(&image(1, 1_000, &[("177795", "3")], &[("177800", "5")]));
+        assert!(
+            mapper
+                .map(&image(2, 1_100, &[("177805", "3")], &[("177800", "5")]))
+                .is_none()
+        );
+        assert_eq!(mapper.stats.crossed, 1);
+        assert_eq!(mapper.stats.published(), 1);
+    }
+
+    #[test]
+    fn a_backwards_timestamp_is_held_not_published_backwards() {
+        let mut mapper = mapper();
+        mapper.map(&image(1, 5_000, &[("177795", "3")], &[("177800", "5")]));
+        let event = mapper
+            .map(&image(2, 4_000, &[("177795", "9")], &[("177800", "5")]))
+            .expect("a delta");
+        let DepthEvent::Update { event_time_ms, .. } = event else {
+            panic!("expected an update");
+        };
+        assert_eq!(event_time_ms, 5_000 + 10_800_000);
+        assert_eq!(mapper.stats.clamped_timestamps, 1);
+    }
+
+    #[test]
+    fn a_restart_opens_a_new_generation_with_a_fresh_snapshot() {
+        let mut mapper = mapper();
+        mapper.map(&image(1, 1_000, &[("177795", "3")], &[("177800", "5")]));
+        mapper.restart(8);
+        let event = mapper
+            .map(&image(2, 1_100, &[("177795", "3")], &[("177800", "5")]))
+            .expect("a fresh snapshot after the restart");
+        let DepthEvent::Snapshot {
+            generation,
+            snapshot,
+            ..
+        } = event
+        else {
+            panic!("expected a snapshot");
+        };
+        assert_eq!(generation, 8);
+        // Update ids never restart, so a late event from the old generation
+        // can never look current.
+        assert_eq!(snapshot.last_update_id(), 2);
+    }
+
+    #[test]
+    fn an_undeclared_tick_size_stays_undeclared() {
+        // Never invent a price grid: the consumer falls back to its own
+        // heuristic and labels it, rather than trusting a made-up step.
+        let mut mapper = BookMapper::new("WIN$N", 1, None, None, OFFSET_S);
+        let event = mapper
+            .map(&image(1, 1_000, &[("177795", "3")], &[("177800", "5")]))
+            .expect("a snapshot");
+        let DepthEvent::Snapshot {
+            price_step,
+            snapshot,
+            ..
+        } = event
+        else {
+            panic!("expected a snapshot");
+        };
+        assert_eq!(price_step, None);
+        assert_eq!(
+            snapshot.coverage(),
+            BookCoverage::Limited {
+                levels_per_side: ASSUMED_BOOK_LEVELS
+            }
+        );
+    }
+}

--- a/crates/feed-mt5/src/lib.rs
+++ b/crates/feed-mt5/src/lib.rs
@@ -2,15 +2,24 @@
 //! socket.
 //!
 //! MT5 offers no public REST/WebSocket API: market data lives inside the
-//! terminal. The bridge (`bridge/mt5/QuantickBridge.mq5`, MQL5 — the
-//! terminal's C++-family language) runs on a chart and dials out to this
-//! crate's TCP listener with newline-delimited JSON; this crate decodes,
-//! validates and maps those ticks into engine [`quantick_engine::Trade`]s.
+//! terminal. A *bridge* dials out to this crate's TCP listener with
+//! newline-delimited JSON; this crate decodes, validates and maps what arrives
+//! into engine [`quantick_engine::Trade`]s and [`quantick_orderbook::DepthEvent`]s.
 //! No credentials exist anywhere in this path — the terminal is already
 //! logged in, and the socket never leaves localhost.
 //!
+//! Two bridges ship, and this crate cannot tell them apart — the protocol is
+//! the contract, not the implementation:
+//!
+//! - `bridge/mt5/quantick_bridge.py` — attaches to the running terminal
+//!   through the official Python package and polls it. One command, no setup.
+//! - `bridge/mt5/QuantickBridge.mq5` — MQL5, runs on a chart inside the
+//!   terminal, so `OnBookEvent` pushes every book change at the instant it
+//!   happens. Costs a compile-and-attach; buys event-accurate depth.
+//!
 //! ```text
-//! MT5 terminal ── QuantickBridge.mq5 ──▶ TCP 127.0.0.1 ──▶ [stream] ──▶ [protocol] ──▶ [map] ──▶ Trade
+//! MT5 terminal ── QuantickBridge.mq5 ──▶ TCP 127.0.0.1 ──▶ [stream] ──▶ [protocol] ─┬─▶ [map]   ──▶ Trade
+//!                                                                                   └─▶ [depth] ──▶ DepthEvent
 //! ```
 //!
 //! # What MT5 does not provide, and what this crate does about it
@@ -20,7 +29,9 @@
 //! | Exchange trade id | synthetic per-session `seq` (gap-detectable) | [`map`], [`session`] |
 //! | UTC timestamps | bridge declares `server_utc_offset_s`; converted + refreshed | [`protocol`], [`map`] |
 //! | Reliable aggressor side | configurable [`map::SideMode`]; tick rule by default; drops counted | [`map`] |
-//! | Order-book depth | not implemented; the app never enables the heatmap for MT5 | app layer |
+//! | Incremental order-book updates | terminal republishes whole DOM images; diffed into snapshot + deltas | [`depth`] |
+//! | Book update ids | synthetic, monotonic, generation-scoped | [`depth`], `quantick_orderbook::SnapshotDiffer` |
+//! | Full book depth | coverage always labelled `Limited`, never `Full` | [`depth`] |
 //! | Older-history paging | unsupported; requests answered empty + logged | app layer |
 //!
 //! # AI-first diagnosis
@@ -53,20 +64,30 @@
 //! | `MT5_UNDECODABLE_LINE` | garbage on the wire (skipped, counted) | bridge/feed version skew |
 //! | `MT5_LINE_TOO_LONG` | line over 64 KiB; session dropped | not the bridge talking to us |
 //! | `MT5_MAP_SUMMARY` | per-session mapping ledger | audit drops & side sources here |
+//! | `MT5_BOOK_AVAILABLE` | bridge declares a DOM | — |
+//! | `MT5_BOOK_UNSUPPORTED_BY_BRIDGE` | no DOM on this session | recompile the EA, or the symbol has no book |
+//! | `MT5_BOOK_SYNCHRONIZED` | first DOM image accepted; heatmap is live | — |
+//! | `MT5_BOOK_CROSSED` | crossed image rejected (first occurrence) | normal during B3's pre-open auction |
+//! | `MT5_BOOK_MALFORMED` | unreadable level; whole image rejected | bridge/feed version skew |
+//! | `MT5_BOOK_TIME_BACKWARDS` | image timestamp went back; held | terminal clock jumped |
+//! | `MT5_BOOK_SUMMARY` | per-session book ledger | audit image/skip counts here |
 //!
 //! A `MT5_MAP_SUMMARY` where `side_from_flag` is ~100% buys would reveal the
 //! broken-flags pathology this crate's tick-rule default exists for (observed
 //! empirically on B3 `WIN$N`, 2026-07-23: every tick flagged BUY, `flags =
 //! 1080`). Re-verify any broker with `tools/mt5/record_ticks.py`.
 
+pub mod depth;
 pub mod map;
 pub mod protocol;
 pub mod session;
 pub mod stream;
 
+pub use depth::{BookMapper, BookStats};
 pub use map::{DropReason, MapOutcome, MapStats, SideMode, SideSource, TickMapper};
 pub use protocol::{BridgeMsg, Hello, ParseError, SCHEMA_VERSION, Tick, parse_line};
 pub use session::{SeqAnomaly, SeqTracker};
 pub use stream::{
-    DEFAULT_LISTEN_ADDR, Mt5Error, Mt5Event, Mt5Status, ServerConfig, run_bridge_server,
+    BookCaptureSwitch, DEFAULT_LISTEN_ADDR, Mt5Error, Mt5Event, Mt5Status, ServerConfig,
+    run_bridge_server,
 };

--- a/crates/feed-mt5/src/protocol.rs
+++ b/crates/feed-mt5/src/protocol.rs
@@ -14,6 +14,12 @@ use serde::Deserialize;
 
 /// The protocol schema version this decoder understands. A bridge announcing a
 /// different `schema` in its hello is refused — never half-parsed.
+///
+/// Depth of Market arrived as *optional* fields inside this same version
+/// rather than as a version bump: a bridge that predates it simply declares no
+/// [`book_levels`](Hello::book_levels), keeps streaming ticks, and the chart
+/// says the book is unavailable. Forcing every existing terminal to recompile
+/// its EA to keep charting trades would be a worse trade than that.
 pub const SCHEMA_VERSION: u32 = 1;
 
 /// MQL5 `MqlTick.flags` bits (shared vocabulary with the bridge). Real feeds
@@ -71,6 +77,8 @@ pub enum BridgeMsg {
     Hello(Hello),
     /// One MT5 tick (quote and/or trade — the flags say which).
     Tick(Tick),
+    /// One complete image of the Depth of Market.
+    Book(Book),
     /// Periodic liveness signal; also refreshes the server-time offset.
     Heartbeat(Heartbeat),
     /// The ticks that follow are history (from `CopyTicks`), not live.
@@ -108,6 +116,22 @@ pub struct Hello {
     pub digits: u32,
     /// `server_time - utc`, in seconds (B3 brokers: −10800).
     pub server_utc_offset_s: i64,
+    /// Smallest price increment the instrument trades in
+    /// (`SYMBOL_TRADE_TICK_SIZE`), as exact decimal digits. B3's mini index
+    /// moves in 5-point steps, so a consumer that renders liquidity on a finer
+    /// grid would leave every other row permanently empty.
+    ///
+    /// Absent from bridges older than the Depth of Market support.
+    #[serde(default)]
+    pub tick_size: Option<String>,
+    /// Maximum number of price levels per side this bridge can publish
+    /// (`SYMBOL_TICKS_BOOKDEPTH`), when it publishes depth at all.
+    ///
+    /// `None` means this bridge streams no book: either it predates the
+    /// feature or the terminal refused the DOM subscription. It is the honest
+    /// signal for "the heatmap has no data here", never an assumed zero.
+    #[serde(default)]
+    pub book_levels: Option<u32>,
 }
 
 /// One tick. `time_ms` is **server-time** epoch milliseconds (see [`Hello`]).
@@ -130,6 +154,42 @@ pub struct Tick {
     pub volume: u64,
     /// Raw `MqlTick.flags` word (see [`flags`]).
     pub flags: u32,
+}
+
+/// One price level on the wire: `["price", "quantity"]`.
+///
+/// A two-element array rather than an object because a book image repeats it
+/// dozens of times per message, many times a second — the field names would be
+/// most of the bytes. Both values are exact decimal strings, like tick prices.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct WireLevel(
+    /// Price.
+    pub String,
+    /// Total resting quantity at that price.
+    pub String,
+);
+
+/// One complete image of the Depth of Market.
+///
+/// MT5 has no incremental book protocol: `OnBookEvent` fires and
+/// `MarketBookGet` returns the whole visible DOM, with no update ids of any
+/// kind. The bridge therefore sends images and the feed diffs them (see
+/// [`crate::depth`]); `seq` exists only to detect images lost in transport,
+/// and is numbered per session independently of tick `seq`.
+///
+/// Levels are the *limit* book only. MT5 also reports market-order rows
+/// (`BOOK_TYPE_*_MARKET`), which carry no meaningful price and are excluded by
+/// the bridge — they are not resting liquidity.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct Book {
+    /// Bridge-assigned session image number, from 1.
+    pub seq: u64,
+    /// Server-time epoch milliseconds when the image was taken (see [`Hello`]).
+    pub time_ms: i64,
+    /// Resting buy levels, in whatever order the terminal returned them.
+    pub bids: Vec<WireLevel>,
+    /// Resting sell levels, in whatever order the terminal returned them.
+    pub asks: Vec<WireLevel>,
 }
 
 /// Liveness + offset refresh. A silent bridge (no ticks, no heartbeats) is
@@ -204,6 +264,50 @@ mod tests {
         assert_eq!(t.last, "177795");
         assert_eq!(t.volume, 3);
         assert_eq!(t.flags & flags::LAST, flags::LAST);
+    }
+
+    #[test]
+    fn hello_depth_fields_are_optional_so_older_bridges_still_connect() {
+        // A bridge predating Depth of Market: ticks keep flowing, the book is
+        // honestly absent rather than assumed empty.
+        let old = r#"{"type": "hello", "schema": 1, "bridge": "b", "bridge_version": "0",
+            "symbol": "WIN$N", "broker_symbol": "WINQ26", "digits": 0,
+            "server_utc_offset_s": -10800}"#;
+        let BridgeMsg::Hello(h) = parse_line(old).unwrap() else {
+            panic!("expected hello");
+        };
+        assert_eq!(h.tick_size, None);
+        assert_eq!(h.book_levels, None);
+
+        let with_book = r#"{"type": "hello", "schema": 1, "bridge": "b", "bridge_version": "0",
+            "symbol": "WIN$N", "broker_symbol": "WINQ26", "digits": 0,
+            "server_utc_offset_s": -10800, "tick_size": "5", "book_levels": 20}"#;
+        let BridgeMsg::Hello(h) = parse_line(with_book).unwrap() else {
+            panic!("expected hello");
+        };
+        assert_eq!(h.tick_size.as_deref(), Some("5"));
+        assert_eq!(h.book_levels, Some(20));
+    }
+
+    #[test]
+    fn a_book_image_parses_with_paired_level_arrays() {
+        let line = r#"{"type":"book","seq":7,"time_ms":1784824300802,
+            "bids":[["177795","3"],["177790","12"]],"asks":[["177800","5"]]}"#;
+        let BridgeMsg::Book(book) = parse_line(line).unwrap() else {
+            panic!("expected a book image");
+        };
+        assert_eq!(book.seq, 7);
+        assert_eq!(book.time_ms, 1_784_824_300_802);
+        assert_eq!(book.bids.len(), 2);
+        assert_eq!(book.bids[0], WireLevel("177795".into(), "3".into()));
+        assert_eq!(book.asks, vec![WireLevel("177800".into(), "5".into())]);
+
+        // An empty side is legitimate (auction, halted book), not an error.
+        let empty = r#"{"type":"book","seq":1,"time_ms":1,"bids":[],"asks":[]}"#;
+        let BridgeMsg::Book(book) = parse_line(empty).unwrap() else {
+            panic!("expected a book image");
+        };
+        assert!(book.bids.is_empty() && book.asks.is_empty());
     }
 
     #[test]

--- a/crates/feed-mt5/src/stream.rs
+++ b/crates/feed-mt5/src/stream.rs
@@ -10,6 +10,8 @@
 //! `event_code` (see the diagnosis table in the crate docs, `lib.rs`): an AI
 //! or operator can reconstruct a session from logs alone.
 
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::Duration;
 
 use tokio::io::{AsyncBufReadExt as _, BufReader};
@@ -18,7 +20,9 @@ use tokio::sync::mpsc;
 use tracing::{debug, info, warn};
 
 use quantick_engine::Trade;
+use quantick_orderbook::{DepthEvent, DepthResyncReason, DepthStatus};
 
+use crate::depth::BookMapper;
 use crate::map::{MapOutcome, SideMode, TickMapper};
 use crate::protocol::{self, BridgeMsg, SCHEMA_VERSION};
 use crate::session::SeqTracker;
@@ -30,6 +34,65 @@ pub const DEFAULT_LISTEN_ADDR: &str = "127.0.0.1:9100";
 /// bytes; anything larger is not the bridge, and an unbounded buffer would let
 /// any local process exhaust memory by streaming bytes without a newline.
 const MAX_LINE_BYTES: usize = 64 * 1024;
+
+/// Runtime switch controlling whether DOM images are published.
+///
+/// MT5's book shares one socket with ticks and MQL5 gives us no back-channel
+/// to ask the terminal to stop sending it, so "capture off" is a decision made
+/// here: images are decoded and dropped rather than published. That costs a
+/// JSON parse per image and nothing downstream — no book state, no history, no
+/// projection. The alternative (tearing down the bridge session) would take the
+/// trade stream down with it.
+///
+/// Cloning shares the switch; the consumer flips it from any thread.
+#[derive(Debug, Clone, Default)]
+pub struct BookCaptureSwitch(Arc<BookCaptureState>);
+
+#[derive(Debug, Default)]
+struct BookCaptureState {
+    enabled: AtomicBool,
+    /// Base generation chosen by the consumer. Each bridge session adds its own
+    /// offset on top, so a reconnect never reuses a generation.
+    base_generation: AtomicU64,
+}
+
+impl BookCaptureSwitch {
+    /// A switch that starts disabled.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Publish depth from `base_generation` onwards.
+    ///
+    /// A base above the previous one discards whatever the old generation
+    /// published; consumers use that to keep stale in-flight events from an
+    /// earlier capture out of fresh history.
+    pub fn enable(&self, base_generation: u64) {
+        self.0
+            .base_generation
+            .store(base_generation, Ordering::Relaxed);
+        self.0.enabled.store(true, Ordering::Release);
+    }
+
+    /// Stop publishing depth. The bridge session and the trade stream continue.
+    pub fn disable(&self) {
+        self.0.enabled.store(false, Ordering::Release);
+    }
+
+    /// Whether depth is currently published.
+    #[must_use]
+    pub fn is_enabled(&self) -> bool {
+        self.0.enabled.load(Ordering::Acquire)
+    }
+
+    fn state(&self) -> (bool, u64) {
+        // Acquire on `enabled` pairs with the release in `enable`, so a true
+        // read never sees a stale base generation.
+        let enabled = self.0.enabled.load(Ordering::Acquire);
+        (enabled, self.0.base_generation.load(Ordering::Relaxed))
+    }
+}
 
 /// How the bridge server behaves for one symbol.
 #[derive(Debug, Clone)]
@@ -45,10 +108,13 @@ pub struct ServerConfig {
     /// Max silence (no ticks, no heartbeats) before the bridge is presumed
     /// dead. The bridge heartbeats every ~5 s; 30 s means six missed beats.
     pub read_timeout: Duration,
+    /// Runtime switch for Depth of Market publication.
+    pub book_capture: BookCaptureSwitch,
 }
 
 impl ServerConfig {
-    /// Sensible defaults for `symbol` on [`DEFAULT_LISTEN_ADDR`].
+    /// Sensible defaults for `symbol` on [`DEFAULT_LISTEN_ADDR`], with depth
+    /// capture off (it costs nothing until a consumer asks for it).
     #[must_use]
     pub fn new(symbol: impl Into<String>) -> Self {
         Self {
@@ -57,6 +123,7 @@ impl ServerConfig {
             side_mode: SideMode::TickRule,
             hello_timeout: Duration::from_secs(10),
             read_timeout: Duration::from_secs(30),
+            book_capture: BookCaptureSwitch::new(),
         }
     }
 }
@@ -93,6 +160,11 @@ pub enum Mt5Event {
     Backfilled(Vec<Trade>),
     /// One live trade.
     Live(Trade),
+    /// One order-book event, in the provider-neutral depth vocabulary.
+    ///
+    /// Only produced while [`BookCaptureSwitch`] is enabled and the bridge
+    /// declares depth support.
+    Depth(DepthEvent),
 }
 
 /// A fatal server error (the non-fatal ones are events/logs).
@@ -167,6 +239,11 @@ pub async fn run_bridge_server(
         "listening for the MT5 bridge"
     );
 
+    // Every capture generation this server ever opens gets its own offset on
+    // top of the consumer's base, so no reconnect and no mid-session resync
+    // can reuse a generation a consumer already retired.
+    let mut generation_offset: u64 = 0;
+
     loop {
         if tx
             .send(Mt5Event::Status(Mt5Status::Waiting {
@@ -201,7 +278,7 @@ pub async fn run_bridge_server(
             }
         };
 
-        match serve_connection(stream, &config, &tx).await {
+        match serve_connection(stream, &config, &tx, &mut generation_offset).await {
             ConnEnd::UiGone => return Ok(()),
             ConnEnd::BridgeGone(reason) => {
                 info!(
@@ -224,10 +301,14 @@ pub async fn run_bridge_server(
 }
 
 /// Serve one bridge connection to completion.
+///
+/// `generation_offset` is the server-wide capture-generation cursor; this
+/// function advances it whenever depth capture needs a fresh generation.
 async fn serve_connection(
     stream: TcpStream,
     config: &ServerConfig,
     tx: &mpsc::Sender<Mt5Event>,
+    generation_offset: &mut u64,
 ) -> ConnEnd {
     let mut lines = BoundedLineReader::new(stream);
 
@@ -362,6 +443,8 @@ async fn serve_connection(
     let mut tracker = SeqTracker::new();
     let mut backfill: Option<Vec<Trade>> = None;
     let mut undecodable: u64 = 0;
+    let mut depth = DepthSession::new(&hello, config.symbol.clone());
+    depth.log_capability();
 
     let end = loop {
         let line = match tokio::time::timeout(config.read_timeout, lines.next_line()).await {
@@ -449,9 +532,28 @@ async fn serve_connection(
                     }
                 }
             }
+            Ok(BridgeMsg::Book(image)) => {
+                match depth
+                    .observe(image, &config.book_capture, generation_offset, tx)
+                    .await
+                {
+                    Ok(()) => {}
+                    Err(()) => break ConnEnd::UiGone,
+                }
+            }
             Ok(BridgeMsg::Heartbeat(hb)) => {
                 if let Some(offset) = hb.server_utc_offset_s {
                     mapper.set_server_utc_offset_s(offset);
+                    depth.set_server_utc_offset_s(offset);
+                }
+                // A heartbeat is the natural moment to notice that a consumer
+                // is waiting for depth this bridge cannot send.
+                if depth
+                    .report_missing_capability(&config.book_capture, tx)
+                    .await
+                    .is_err()
+                {
+                    break ConnEnd::UiGone;
                 }
                 debug!(
                     target: "quantick::feed",
@@ -515,7 +617,217 @@ async fn serve_connection(
         );
     }
     mapper.stats.log_summary(&config.symbol);
+    // A consumer that was capturing depth must hear that this generation ended,
+    // so it renders the discontinuity instead of connecting liquidity across it.
+    depth.close(tx).await;
     end
+}
+
+/// Depth capture state for one bridge connection.
+///
+/// Split out because it is the only stateful thing in the message loop besides
+/// tick mapping, and it must stay correct across three independent events: the
+/// consumer toggling capture, the terminal losing images, and the session
+/// ending.
+struct DepthSession {
+    symbol: String,
+    /// `None` when the bridge declared no Depth of Market support.
+    mapper: Option<BookMapper>,
+    /// Whether the consumer has been told a generation is open.
+    publishing: bool,
+    last_seq: Option<u64>,
+    missing_capability_reported: bool,
+}
+
+impl DepthSession {
+    fn new(hello: &protocol::Hello, symbol: String) -> Self {
+        Self {
+            mapper: hello.book_levels.map(|levels| {
+                BookMapper::new(
+                    symbol.clone(),
+                    0,
+                    Some(levels),
+                    hello.tick_size.as_deref(),
+                    hello.server_utc_offset_s,
+                )
+            }),
+            symbol,
+            publishing: false,
+            last_seq: None,
+            missing_capability_reported: false,
+        }
+    }
+
+    fn log_capability(&self) {
+        match &self.mapper {
+            Some(_) => info!(
+                target: "quantick::feed",
+                schema_version = 1_u8,
+                event_code = "MT5_BOOK_AVAILABLE",
+                symbol = %self.symbol,
+                "bridge declares Depth of Market support"
+            ),
+            None => info!(
+                target: "quantick::feed",
+                schema_version = 1_u8,
+                event_code = "MT5_BOOK_UNSUPPORTED_BY_BRIDGE",
+                symbol = %self.symbol,
+                action = "trades_only",
+                "bridge declares no Depth of Market; the heatmap will stay empty \
+                 (recompile bridge/mt5/QuantickBridge.mq5, or the terminal refused the DOM)"
+            ),
+        }
+    }
+
+    fn set_server_utc_offset_s(&mut self, offset_s: i64) {
+        if let Some(mapper) = self.mapper.as_mut() {
+            mapper.set_server_utc_offset_s(offset_s);
+        }
+    }
+
+    /// Handle one image. `Err(())` means the consumer is gone.
+    async fn observe(
+        &mut self,
+        image: protocol::Book,
+        capture: &BookCaptureSwitch,
+        generation_offset: &mut u64,
+        tx: &mpsc::Sender<Mt5Event>,
+    ) -> Result<(), ()> {
+        if self.mapper.is_none() {
+            // A bridge sending images it never declared is a version skew, not
+            // data to trust silently.
+            return Ok(());
+        }
+        let (enabled, base_generation) = capture.state();
+        let lost_images = self.images_lost(image.seq);
+        let mapper = self.mapper.as_mut().expect("checked above");
+        if !enabled {
+            if self.publishing {
+                let generation = mapper.generation();
+                self.publishing = false;
+                self.last_seq = None;
+                mapper.restart(generation); // next capture starts from a snapshot
+                send_depth_status(tx, &self.symbol, generation, DepthStatus::Stopped).await?;
+            }
+            return Ok(());
+        }
+
+        // Open a generation when capture starts, when the consumer moves its
+        // base, or when images were lost and the diff would silently bridge a
+        // moment we never observed.
+        let wanted = base_generation.saturating_add(*generation_offset);
+        if !self.publishing || mapper.generation() != wanted || lost_images {
+            if lost_images {
+                send_depth_status(
+                    tx,
+                    &self.symbol,
+                    mapper.generation(),
+                    DepthStatus::Resyncing {
+                        reason: DepthResyncReason::SourceRestarted {
+                            cause: "book_images_lost",
+                        },
+                    },
+                )
+                .await?;
+            }
+            *generation_offset = generation_offset.saturating_add(1);
+            let generation = base_generation.saturating_add(*generation_offset);
+            mapper.restart(generation);
+            self.publishing = true;
+            send_depth_status(tx, &self.symbol, generation, DepthStatus::Connecting).await?;
+        }
+        self.last_seq = Some(image.seq);
+
+        let Some(event) = mapper.map(&image) else {
+            return Ok(());
+        };
+        let synchronized =
+            matches!(event, DepthEvent::Snapshot { .. }).then(|| mapper.synchronized_status());
+        let generation = mapper.generation();
+        if tx.send(Mt5Event::Depth(event)).await.is_err() {
+            return Err(());
+        }
+        if let Some(status) = synchronized {
+            send_depth_status(tx, &self.symbol, generation, status).await?;
+        }
+        Ok(())
+    }
+
+    /// Whether images went missing (or the bridge restarted its counter)
+    /// between the last one and `seq`.
+    fn images_lost(&self, seq: u64) -> bool {
+        match self.last_seq {
+            Some(last) => seq != last.saturating_add(1),
+            None => false,
+        }
+    }
+
+    /// Tell a waiting consumer, once, that this bridge cannot supply depth.
+    async fn report_missing_capability(
+        &mut self,
+        capture: &BookCaptureSwitch,
+        tx: &mpsc::Sender<Mt5Event>,
+    ) -> Result<(), ()> {
+        let (enabled, base_generation) = capture.state();
+        if self.mapper.is_some() || self.missing_capability_reported || !enabled {
+            return Ok(());
+        }
+        self.missing_capability_reported = true;
+        warn!(
+            target: "quantick::feed",
+            schema_version = 1_u8,
+            event_code = "MT5_BOOK_UNSUPPORTED_BY_BRIDGE",
+            symbol = %self.symbol,
+            action = "report_disconnected",
+            "depth capture is on but this bridge sends no Depth of Market"
+        );
+        // Tagged with the consumer's own base generation: a status below the
+        // generation floor it is watching would be discarded as stale, and the
+        // chart would keep waiting for a book that is never coming.
+        send_depth_status(
+            tx,
+            &self.symbol,
+            base_generation,
+            DepthStatus::Disconnected {
+                error_class: "bridge_without_depth",
+            },
+        )
+        .await
+    }
+
+    /// End the generation when the bridge session ends.
+    async fn close(&mut self, tx: &mpsc::Sender<Mt5Event>) {
+        if let Some(mapper) = self.mapper.as_ref() {
+            mapper.stats.log_summary(&self.symbol);
+            if self.publishing {
+                let _ = send_depth_status(
+                    tx,
+                    &self.symbol,
+                    mapper.generation(),
+                    DepthStatus::Disconnected {
+                        error_class: "bridge_lost",
+                    },
+                )
+                .await;
+            }
+        }
+    }
+}
+
+/// Publish one depth status. `Err(())` means the consumer is gone.
+async fn send_depth_status(
+    tx: &mpsc::Sender<Mt5Event>,
+    symbol: &str,
+    generation: u64,
+    status: DepthStatus,
+) -> Result<(), ()> {
+    tx.send(Mt5Event::Depth(DepthEvent::Status {
+        symbol: symbol.to_string(),
+        generation,
+        status,
+    }))
+    .await
+    .map_err(|_| ())
 }
 
 /// First 120 chars of a line, for log context without flooding. Truncates on

--- a/crates/feed-mt5/tests/bridge_server.rs
+++ b/crates/feed-mt5/tests/bridge_server.rs
@@ -10,7 +10,10 @@ use tokio::net::TcpStream;
 use tokio::sync::mpsc;
 
 use quantick_engine::Side;
-use quantick_feed_mt5::{Mt5Event, Mt5Status, ServerConfig, SideMode, run_bridge_server};
+use quantick_feed_mt5::{
+    BookCaptureSwitch, Mt5Event, Mt5Status, ServerConfig, SideMode, run_bridge_server,
+};
+use quantick_orderbook::{DepthEvent, DepthStatus};
 
 /// A config bound to an ephemeral port with tight test timeouts.
 fn test_config(symbol: &str) -> ServerConfig {
@@ -20,6 +23,7 @@ fn test_config(symbol: &str) -> ServerConfig {
         side_mode: SideMode::TickRule,
         hello_timeout: Duration::from_millis(500),
         read_timeout: Duration::from_millis(1000),
+        book_capture: BookCaptureSwitch::new(),
     }
 }
 
@@ -33,15 +37,24 @@ async fn next_event(rx: &mut mpsc::Receiver<Mt5Event>) -> Mt5Event {
 
 /// Start a server and return (its bound addr, the event receiver).
 async fn start_server(symbol: &str) -> (String, mpsc::Receiver<Mt5Event>) {
+    let (addr, rx, _) = start_server_with_capture(symbol).await;
+    (addr, rx)
+}
+
+/// Same, keeping the depth switch so a test can turn capture on and off.
+async fn start_server_with_capture(
+    symbol: &str,
+) -> (String, mpsc::Receiver<Mt5Event>, BookCaptureSwitch) {
     let (tx, mut rx) = mpsc::channel(1024);
     let config = test_config(symbol);
+    let capture = config.book_capture.clone();
     tokio::spawn(async move {
         let _ = run_bridge_server(config, tx).await;
     });
     let Mt5Event::Status(Mt5Status::Waiting { addr }) = next_event(&mut rx).await else {
         panic!("expected the initial waiting status");
     };
-    (addr, rx)
+    (addr, rx, capture)
 }
 
 fn hello(symbol: &str) -> String {
@@ -49,6 +62,31 @@ fn hello(symbol: &str) -> String {
         "{{\"type\":\"hello\",\"schema\":1,\"bridge\":\"test\",\"bridge_version\":\"0\",\
          \"symbol\":\"{symbol}\",\"broker_symbol\":\"WINQ26\",\"digits\":0,\
          \"server_utc_offset_s\":-10800}}\n"
+    )
+}
+
+/// A hello from a bridge that streams Depth of Market.
+fn hello_with_book(symbol: &str) -> String {
+    format!(
+        "{{\"type\":\"hello\",\"schema\":1,\"bridge\":\"test\",\"bridge_version\":\"0\",         \"symbol\":\"{symbol}\",\"broker_symbol\":\"WINQ26\",\"digits\":0,         \"server_utc_offset_s\":-10800,\"book_levels\":5,\"tick_size\":\"5\"}}
+"
+    )
+}
+
+fn book(seq: u64, bids: &[(&str, &str)], asks: &[(&str, &str)]) -> String {
+    fn side(levels: &[(&str, &str)]) -> String {
+        levels
+            .iter()
+            .map(|(price, quantity)| format!("[\"{price}\",\"{quantity}\"]"))
+            .collect::<Vec<_>>()
+            .join(",")
+    }
+    format!(
+        "{{\"type\":\"book\",\"seq\":{seq},\"time_ms\":{},\"bids\":[{}],\"asks\":[{}]}}
+",
+        1_784_824_300_000_i64 + seq as i64,
+        side(bids),
+        side(asks)
     )
 }
 
@@ -234,4 +272,148 @@ async fn a_silent_bridge_is_dropped_and_the_server_waits_again() {
     let Mt5Event::Status(Mt5Status::Waiting { .. }) = next_event(&mut rx).await else {
         panic!("expected the server back in waiting");
     };
+}
+
+/// Drain events until the first depth one, ignoring trades and statuses.
+async fn next_depth(rx: &mut mpsc::Receiver<Mt5Event>) -> DepthEvent {
+    loop {
+        match next_event(rx).await {
+            Mt5Event::Depth(event) => return event,
+            other => {
+                if let Mt5Event::Status(Mt5Status::Lost { reason }) = other {
+                    panic!("session ended before any depth event: {reason}");
+                }
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn depth_images_become_a_snapshot_then_deltas_when_capture_is_on() {
+    let (addr, mut rx, capture) = start_server_with_capture("WIN$N").await;
+    capture.enable(1_000_000);
+
+    let mut sock = TcpStream::connect(&addr).await.unwrap();
+    let mut script = String::new();
+    script.push_str(&hello_with_book("WIN$N"));
+    script.push_str(&book(
+        1,
+        &[("177790", "12"), ("177795", "3")],
+        &[("177800", "5")],
+    ));
+    // One bid shrank; nothing else moved.
+    script.push_str(&book(
+        2,
+        &[("177790", "12"), ("177795", "1")],
+        &[("177800", "5")],
+    ));
+    sock.write_all(script.as_bytes()).await.unwrap();
+    sock.flush().await.unwrap();
+
+    // "Connecting" precedes the first image so a chart can say what it waits for.
+    let DepthEvent::Status {
+        generation,
+        status: DepthStatus::Connecting,
+        ..
+    } = next_depth(&mut rx).await
+    else {
+        panic!("expected the connecting status first");
+    };
+    // Above the consumer's base: a reconnect can never reuse a generation.
+    assert!(generation > 1_000_000, "generation was {generation}");
+
+    let DepthEvent::Snapshot {
+        symbol,
+        observed_at_ms,
+        price_step,
+        snapshot,
+        generation: snapshot_generation,
+        ..
+    } = next_depth(&mut rx).await
+    else {
+        panic!("expected the opening snapshot");
+    };
+    assert_eq!(symbol, "WIN$N");
+    assert_eq!(snapshot_generation, generation);
+    // Server time converted to UTC with the hello's −3 h offset.
+    assert_eq!(observed_at_ms, 1_784_824_300_001 + 10_800_000);
+    assert_eq!(price_step, Some(rust_decimal::Decimal::from(5)));
+    assert_eq!(snapshot.bids().len(), 2);
+    assert_eq!(snapshot.asks().len(), 1);
+    // The terminal's DOM is truncated by definition, and the hello said how far
+    // it goes — the chart must never present it as the whole exchange book.
+    assert_eq!(
+        snapshot.coverage(),
+        quantick_orderbook::BookCoverage::Limited { levels_per_side: 5 }
+    );
+
+    assert!(matches!(
+        next_depth(&mut rx).await,
+        DepthEvent::Status {
+            status: DepthStatus::Synchronized { .. },
+            ..
+        }
+    ));
+
+    let DepthEvent::Update { delta, .. } = next_depth(&mut rx).await else {
+        panic!("expected a delta for the changed level");
+    };
+    assert_eq!(delta.bids().len(), 1, "only the level that moved travels");
+    assert!(delta.asks().is_empty());
+}
+
+#[tokio::test]
+async fn depth_stays_silent_while_capture_is_off() {
+    let (addr, mut rx, _capture) = start_server_with_capture("WIN$N").await;
+
+    let mut sock = TcpStream::connect(&addr).await.unwrap();
+    let mut script = String::new();
+    script.push_str(&hello_with_book("WIN$N"));
+    script.push_str(&book(1, &[("177795", "3")], &[("177800", "5")]));
+    script.push_str(&tick(1, "177795", 3));
+    script.push_str(&tick(2, "177800", 1)); // uptick → a buy reaches the UI
+    script.push_str("{\"type\":\"bye\",\"reason\":\"test_done\"}\n");
+    sock.write_all(script.as_bytes()).await.unwrap();
+    sock.flush().await.unwrap();
+
+    // Trades still flow; not one depth event is published.
+    let mut trades = 0;
+    loop {
+        match next_event(&mut rx).await {
+            Mt5Event::Live(_) => trades += 1,
+            Mt5Event::Depth(event) => panic!("capture is off but got {event:?}"),
+            Mt5Event::Status(Mt5Status::Lost { .. }) => break,
+            _ => {}
+        }
+    }
+    assert_eq!(trades, 1);
+}
+
+#[tokio::test]
+async fn a_bridge_without_depth_says_so_instead_of_staying_silent() {
+    let (addr, mut rx, capture) = start_server_with_capture("WIN$N").await;
+    capture.enable(2_000_000);
+
+    let mut sock = TcpStream::connect(&addr).await.unwrap();
+    let mut script = String::new();
+    // The plain hello declares no book_levels: an older bridge, or a symbol
+    // with no DOM on this account.
+    script.push_str(&hello("WIN$N"));
+    script.push_str("{\"type\":\"heartbeat\",\"seq_last\":0,\"time_ms\":1,\"ticks_sent\":0}\n");
+    sock.write_all(script.as_bytes()).await.unwrap();
+    sock.flush().await.unwrap();
+
+    let DepthEvent::Status {
+        generation,
+        status:
+            DepthStatus::Disconnected {
+                error_class: "bridge_without_depth",
+            },
+        ..
+    } = next_depth(&mut rx).await
+    else {
+        panic!("expected an honest 'this bridge has no depth' status");
+    };
+    // At the consumer's own generation floor, so it is not discarded as stale.
+    assert_eq!(generation, 2_000_000);
 }

--- a/crates/feed-mt5/tests/fixture_replay.rs
+++ b/crates/feed-mt5/tests/fixture_replay.rs
@@ -18,8 +18,8 @@ use tokio::sync::mpsc;
 
 use quantick_engine::{Side, Trade};
 use quantick_feed_mt5::{
-    BridgeMsg, MapOutcome, Mt5Event, Mt5Status, ServerConfig, SideMode, TickMapper, parse_line,
-    run_bridge_server,
+    BookCaptureSwitch, BridgeMsg, MapOutcome, Mt5Event, Mt5Status, ServerConfig, SideMode,
+    TickMapper, parse_line, run_bridge_server,
 };
 
 const FIXTURE: &str = include_str!("fixtures/win_ticks.ndjson");
@@ -102,6 +102,7 @@ async fn tcp_replay_equals_the_pure_mapper() {
         side_mode: SideMode::TickRule,
         hello_timeout: Duration::from_secs(2),
         read_timeout: Duration::from_secs(2),
+        book_capture: BookCaptureSwitch::new(),
     };
     tokio::spawn(async move {
         let _ = run_bridge_server(config, tx).await;
@@ -121,6 +122,9 @@ async fn tcp_replay_equals_the_pure_mapper() {
             Mt5Event::Backfilled(batch) => streamed.extend(batch),
             Mt5Event::Status(Mt5Status::Lost { .. }) => break,
             Mt5Event::Status(_) => {}
+            // The fixture is a tick-only recording and capture is off, so
+            // depth must never appear on this path.
+            Mt5Event::Depth(event) => panic!("unexpected depth event: {event:?}"),
         }
     }
 

--- a/crates/orderbook/src/image.rs
+++ b/crates/orderbook/src/image.rs
@@ -1,0 +1,456 @@
+//! Turning full book images into snapshot-plus-delta streams.
+//!
+//! Venues publish depth in one of two shapes. Some send a starting image and
+//! then incremental updates carrying their own sequence ids (Binance). Others
+//! send a *complete image every time anything changes* and carry no ids at all
+//! — MetaTrader 5's DOM works this way: one `OnBookEvent`, one full
+//! `MarketBookGet` result.
+//!
+//! [`SnapshotDiffer`] converts the second shape into the first. It keeps the
+//! last accepted image, and for each new one emits only the levels that
+//! actually changed, numbered with synthetic monotonic update ids. Consumers
+//! then speak a single dialect: [`OrderBook`](crate::OrderBook) applies the
+//! result unchanged, and a run-length history downstream stores one transition
+//! per real change instead of a fresh full book many times a second.
+//!
+//! That is also why the diff lives here rather than in the consumer: a 40-level
+//! image republished 50 times a second is 2 000 levels/s of which typically a
+//! handful moved. Diffing at the source keeps everything after it proportional
+//! to real change.
+//!
+//! # Determinism
+//!
+//! Same images in, same events out. Levels are normalized (sorted by exact
+//! price, duplicates summed, non-positive prices and quantities dropped) before
+//! any comparison, so a source that reorders its levels between events produces
+//! no spurious updates.
+
+use rust_decimal::Decimal;
+
+use crate::{BookCoverage, BookDelta, BookLevel, BookSnapshot};
+
+/// One normalized price level: exact price and total resting quantity.
+type Level = (Decimal, Decimal);
+
+/// What one observed image means for a snapshot-plus-delta consumer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ImageOutcome {
+    /// First accepted image of this generation. Install it before any delta.
+    Snapshot(BookSnapshot),
+    /// Levels that changed since the previous image; zero quantity removes.
+    Delta(BookDelta),
+    /// The image matched the previous one exactly: nothing to publish.
+    ///
+    /// Real feeds emit these constantly — MT5 fires a book event whenever any
+    /// order in the DOM changes, including changes outside the visible depth
+    /// or in market-order rows this differ drops.
+    Unchanged,
+    /// The image was rejected because its best bid is at or above its best ask.
+    ///
+    /// A crossed image is not a bug to hide: B3 publishes one during the
+    /// pre-open auction, when the theoretical price is still forming. The
+    /// previous accepted image is kept and the caller decides what to say about
+    /// the skip — it must never be presented as live, uncrossed liquidity.
+    Crossed {
+        /// Highest bid in the rejected image.
+        best_bid: Decimal,
+        /// Lowest ask in the rejected image.
+        best_ask: Decimal,
+    },
+}
+
+/// Converts successive full book images into a snapshot and absolute deltas.
+///
+/// One differ tracks one generation. Call [`reset`](Self::reset) when
+/// continuity ends (the source restarted, the consumer resubscribed); the next
+/// image then starts a fresh [`ImageOutcome::Snapshot`].
+#[derive(Debug, Clone)]
+pub struct SnapshotDiffer {
+    coverage: BookCoverage,
+    bids: Vec<Level>,
+    asks: Vec<Level>,
+    // Scratch for the image being observed, reused so the steady state does not
+    // allocate: only the emitted delta's own vectors do.
+    next_bids: Vec<Level>,
+    next_asks: Vec<Level>,
+    last_update_id: u64,
+    initialized: bool,
+}
+
+impl SnapshotDiffer {
+    /// A differ awaiting its first image, declaring `coverage` on the snapshot
+    /// it will emit.
+    #[must_use]
+    pub fn new(coverage: BookCoverage) -> Self {
+        Self {
+            coverage,
+            bids: Vec::new(),
+            asks: Vec::new(),
+            next_bids: Vec::new(),
+            next_asks: Vec::new(),
+            last_update_id: 0,
+            initialized: false,
+        }
+    }
+
+    /// Update id carried by the most recently emitted event (0 before the
+    /// first snapshot).
+    #[must_use]
+    pub fn last_update_id(&self) -> u64 {
+        self.last_update_id
+    }
+
+    /// Whether an image has been accepted since construction or the last reset.
+    #[must_use]
+    pub fn is_initialized(&self) -> bool {
+        self.initialized
+    }
+
+    /// Number of levels currently held per side, as `(bids, asks)`.
+    #[must_use]
+    pub fn level_counts(&self) -> (usize, usize) {
+        (self.bids.len(), self.asks.len())
+    }
+
+    /// Forget the current image so the next one starts a new generation.
+    ///
+    /// Update ids keep advancing across a reset. They are only meaningful
+    /// inside one generation, and never reusing an id keeps a late event from a
+    /// discarded generation from looking current.
+    pub fn reset(&mut self) {
+        self.bids.clear();
+        self.asks.clear();
+        self.initialized = false;
+    }
+
+    /// Observe one complete image of the book.
+    ///
+    /// Levels may arrive in any order and may repeat a price (quantities are
+    /// summed). Entries with a non-positive price or quantity are dropped: MT5
+    /// reports market-order rows with no meaningful price, and an absent level
+    /// is exactly what "quantity zero" means in an image.
+    pub fn observe(&mut self, bids: &[BookLevel], asks: &[BookLevel]) -> ImageOutcome {
+        normalize(bids, &mut self.next_bids);
+        normalize(asks, &mut self.next_asks);
+
+        if let (Some(&(best_bid, _)), Some(&(best_ask, _))) =
+            (self.next_bids.last(), self.next_asks.first())
+            && best_bid >= best_ask
+        {
+            return ImageOutcome::Crossed { best_bid, best_ask };
+        }
+
+        if !self.initialized {
+            std::mem::swap(&mut self.bids, &mut self.next_bids);
+            std::mem::swap(&mut self.asks, &mut self.next_asks);
+            self.initialized = true;
+            self.last_update_id = self.last_update_id.saturating_add(1);
+            return ImageOutcome::Snapshot(BookSnapshot::new(
+                self.last_update_id,
+                levels(&self.bids),
+                levels(&self.asks),
+                self.coverage,
+            ));
+        }
+
+        let bid_updates = diff_side(&self.bids, &self.next_bids);
+        let ask_updates = diff_side(&self.asks, &self.next_asks);
+        if bid_updates.is_empty() && ask_updates.is_empty() {
+            return ImageOutcome::Unchanged;
+        }
+
+        std::mem::swap(&mut self.bids, &mut self.next_bids);
+        std::mem::swap(&mut self.asks, &mut self.next_asks);
+        self.last_update_id = self.last_update_id.saturating_add(1);
+        ImageOutcome::Delta(BookDelta::new(
+            self.last_update_id,
+            self.last_update_id,
+            bid_updates,
+            ask_updates,
+        ))
+    }
+}
+
+/// Copy usable entries into `dst`, sorted by price with duplicates summed.
+fn normalize(src: &[BookLevel], dst: &mut Vec<Level>) {
+    dst.clear();
+    dst.extend(
+        src.iter()
+            .filter(|level| level.price() > Decimal::ZERO && level.quantity() > Decimal::ZERO)
+            .map(|level| (level.price(), level.quantity())),
+    );
+    dst.sort_unstable_by_key(|level| level.0);
+
+    // Fold repeated prices into the first occurrence. A venue may split one
+    // price across rows; the book stores one quantity per price.
+    let mut write = 0;
+    for read in 1..dst.len() {
+        if dst[read].0 == dst[write].0 {
+            let merged = dst[write].1.saturating_add(dst[read].1);
+            dst[write].1 = merged;
+        } else {
+            write += 1;
+            dst[write] = dst[read];
+        }
+    }
+    if !dst.is_empty() {
+        dst.truncate(write + 1);
+    }
+}
+
+/// Absolute updates carrying `next` from `previous`, walking both sorted sides
+/// once. A level only present in `previous` is emitted with quantity zero.
+fn diff_side(previous: &[Level], next: &[Level]) -> Vec<BookLevel> {
+    let mut updates = Vec::new();
+    let (mut old, mut new) = (0, 0);
+    while old < previous.len() && new < next.len() {
+        let (old_price, old_quantity) = previous[old];
+        let (new_price, new_quantity) = next[new];
+        match old_price.cmp(&new_price) {
+            std::cmp::Ordering::Less => {
+                updates.push(level(old_price, Decimal::ZERO));
+                old += 1;
+            }
+            std::cmp::Ordering::Greater => {
+                updates.push(level(new_price, new_quantity));
+                new += 1;
+            }
+            std::cmp::Ordering::Equal => {
+                if old_quantity != new_quantity {
+                    updates.push(level(new_price, new_quantity));
+                }
+                old += 1;
+                new += 1;
+            }
+        }
+    }
+    updates.extend(
+        previous[old..]
+            .iter()
+            .map(|&(price, _)| level(price, Decimal::ZERO)),
+    );
+    updates.extend(
+        next[new..]
+            .iter()
+            .map(|&(price, quantity)| level(price, quantity)),
+    );
+    updates
+}
+
+fn levels(side: &[Level]) -> Vec<BookLevel> {
+    side.iter()
+        .map(|&(price, quantity)| level(price, quantity))
+        .collect()
+}
+
+/// Build a level whose validity `normalize` already guaranteed (positive price,
+/// non-negative quantity), skipping the checked constructor in the hot path.
+fn level(price: Decimal, quantity: Decimal) -> BookLevel {
+    BookLevel { price, quantity }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::OrderBook;
+    use std::str::FromStr as _;
+
+    fn dec(value: &str) -> Decimal {
+        Decimal::from_str(value).unwrap()
+    }
+
+    fn image(side: &[(&str, &str)]) -> Vec<BookLevel> {
+        side.iter()
+            .map(|(price, quantity)| BookLevel::new(dec(price), dec(quantity)).unwrap())
+            .collect()
+    }
+
+    fn differ() -> SnapshotDiffer {
+        SnapshotDiffer::new(BookCoverage::Limited {
+            levels_per_side: 10,
+        })
+    }
+
+    #[test]
+    fn the_first_image_becomes_a_snapshot() {
+        let mut differ = differ();
+        let outcome = differ.observe(
+            &image(&[("100", "3"), ("99", "5")]),
+            &image(&[("101", "4")]),
+        );
+        let ImageOutcome::Snapshot(snapshot) = outcome else {
+            panic!("expected a snapshot, got {outcome:?}");
+        };
+        assert_eq!(snapshot.last_update_id(), 1);
+        // Normalized: ascending by exact price, whatever order the source used.
+        assert_eq!(
+            snapshot
+                .bids()
+                .iter()
+                .map(|level| level.price())
+                .collect::<Vec<_>>(),
+            vec![dec("99"), dec("100")]
+        );
+        assert_eq!(
+            snapshot.coverage(),
+            BookCoverage::Limited {
+                levels_per_side: 10
+            }
+        );
+        assert_eq!(differ.level_counts(), (2, 1));
+        assert!(differ.is_initialized());
+    }
+
+    #[test]
+    fn an_identical_image_publishes_nothing() {
+        let mut differ = differ();
+        let bids = image(&[("100", "3")]);
+        let asks = image(&[("101", "4")]);
+        assert!(matches!(
+            differ.observe(&bids, &asks),
+            ImageOutcome::Snapshot(_)
+        ));
+        assert_eq!(differ.observe(&bids, &asks), ImageOutcome::Unchanged);
+        // A reordered image is still the same image.
+        assert_eq!(
+            differ.observe(&image(&[("100", "3")]), &image(&[("101", "4")])),
+            ImageOutcome::Unchanged
+        );
+        assert_eq!(differ.last_update_id(), 1);
+    }
+
+    #[test]
+    fn only_changed_levels_reach_the_delta() {
+        let mut differ = differ();
+        differ.observe(
+            &image(&[("99", "5"), ("100", "3")]),
+            &image(&[("101", "4"), ("102", "7")]),
+        );
+        // 99 unchanged, 100 shrinks, 98 appears; 101 vanishes, 102 unchanged.
+        let outcome = differ.observe(
+            &image(&[("98", "2"), ("99", "5"), ("100", "1")]),
+            &image(&[("102", "7")]),
+        );
+        let ImageOutcome::Delta(delta) = outcome else {
+            panic!("expected a delta, got {outcome:?}");
+        };
+        assert_eq!(delta.first_update_id(), 2);
+        assert_eq!(delta.final_update_id(), 2);
+        assert_eq!(
+            delta
+                .bids()
+                .iter()
+                .map(|l| (l.price(), l.quantity()))
+                .collect::<Vec<_>>(),
+            vec![(dec("98"), dec("2")), (dec("100"), dec("1"))]
+        );
+        assert_eq!(
+            delta
+                .asks()
+                .iter()
+                .map(|l| (l.price(), l.quantity()))
+                .collect::<Vec<_>>(),
+            vec![(dec("101"), Decimal::ZERO)]
+        );
+    }
+
+    #[test]
+    fn market_orders_and_empty_rows_are_dropped() {
+        // MT5 reports market-order rows with price 0 and pads with empties.
+        let mut differ = differ();
+        let bids = vec![
+            // A price-0 row never passes the checked constructor, which is
+            // exactly the shape the terminal reports for market orders.
+            level(Decimal::ZERO, dec("40")),
+            level(dec("100"), dec("3")),
+            level(dec("99"), Decimal::ZERO),
+        ];
+        let ImageOutcome::Snapshot(snapshot) = differ.observe(&bids, &image(&[("101", "1")]))
+        else {
+            panic!("expected a snapshot");
+        };
+        assert_eq!(snapshot.bids().len(), 1);
+        assert_eq!(snapshot.bids()[0].price(), dec("100"));
+    }
+
+    #[test]
+    fn duplicate_prices_are_summed_not_duplicated() {
+        let mut differ = differ();
+        let ImageOutcome::Snapshot(snapshot) =
+            differ.observe(&image(&[("100", "3"), ("100", "4")]), &[])
+        else {
+            panic!("expected a snapshot");
+        };
+        assert_eq!(snapshot.bids().len(), 1);
+        assert_eq!(snapshot.bids()[0].quantity(), dec("7"));
+    }
+
+    #[test]
+    fn a_crossed_image_is_rejected_and_the_previous_one_survives() {
+        let mut differ = differ();
+        differ.observe(&image(&[("100", "3")]), &image(&[("101", "4")]));
+        let outcome = differ.observe(&image(&[("102", "3")]), &image(&[("101", "4")]));
+        assert_eq!(
+            outcome,
+            ImageOutcome::Crossed {
+                best_bid: dec("102"),
+                best_ask: dec("101"),
+            }
+        );
+        assert_eq!(differ.last_update_id(), 1);
+        assert_eq!(differ.level_counts(), (1, 1));
+        // A locked book (bid == ask) is refused for the same reason.
+        assert!(matches!(
+            differ.observe(&image(&[("101", "3")]), &image(&[("101", "4")])),
+            ImageOutcome::Crossed { .. }
+        ));
+        // And the stream resumes from the surviving image, no snapshot needed.
+        assert!(matches!(
+            differ.observe(&image(&[("100", "9")]), &image(&[("101", "4")])),
+            ImageOutcome::Delta(_)
+        ));
+    }
+
+    #[test]
+    fn a_reset_starts_a_new_snapshot_without_reusing_update_ids() {
+        let mut differ = differ();
+        differ.observe(&image(&[("100", "3")]), &image(&[("101", "4")]));
+        differ.observe(&image(&[("100", "5")]), &image(&[("101", "4")]));
+        assert_eq!(differ.last_update_id(), 2);
+
+        differ.reset();
+        assert!(!differ.is_initialized());
+        let ImageOutcome::Snapshot(snapshot) =
+            differ.observe(&image(&[("100", "3")]), &image(&[("101", "4")]))
+        else {
+            panic!("expected a fresh snapshot after the reset");
+        };
+        assert_eq!(snapshot.last_update_id(), 3);
+    }
+
+    #[test]
+    fn the_emitted_stream_replays_into_an_orderbook() {
+        // The whole point: an image-only source drives the same core as a
+        // diff-based one, and the book stays equal to the latest image.
+        let mut differ = differ();
+        let mut book = OrderBook::new();
+        let images = [
+            (vec![("99", "5"), ("100", "3")], vec![("101", "4")]),
+            (vec![("99", "5"), ("100", "8")], vec![("101", "4")]),
+            (vec![("99", "5")], vec![("101", "1"), ("102", "6")]),
+        ];
+        for (bids, asks) in &images {
+            match differ.observe(&image(bids), &image(asks)) {
+                ImageOutcome::Snapshot(snapshot) => book.install_snapshot(snapshot).unwrap(),
+                ImageOutcome::Delta(delta) => {
+                    book.apply_delta(&delta).unwrap();
+                }
+                other => panic!("unexpected outcome {other:?}"),
+            }
+        }
+        let (last_bids, last_asks) = images.last().unwrap();
+        assert_eq!(book.bid_count(), last_bids.len());
+        assert_eq!(book.ask_count(), last_asks.len());
+        assert_eq!(book.last_update_id(), Some(differ.last_update_id()));
+    }
+}

--- a/crates/orderbook/src/lib.rs
+++ b/crates/orderbook/src/lib.rs
@@ -3,13 +3,23 @@
 //! This crate owns only market-depth domain rules: validated snapshots,
 //! absolute level updates and exchange update-id continuity. It deliberately
 //! contains no network, async runtime, wall clock, logging or UI code.
+//!
+//! It also owns the vocabulary feeds and consumers share when depth is
+//! *streamed* ([`stream`]) and the adapter that lets an image-only venue speak
+//! it ([`image`]). Both are pure domain code, and keeping them here is what
+//! stops a second venue from either inventing its own dialect or forcing the
+//! app to depend on an unrelated exchange's crate.
 
 #![forbid(unsafe_code)]
 
 mod book;
 mod error;
+pub mod image;
 mod model;
+pub mod stream;
 
 pub use book::{ApplyOutcome, OrderBook};
 pub use error::BookError;
+pub use image::{ImageOutcome, SnapshotDiffer};
 pub use model::{BookCoverage, BookDelta, BookLevel, BookSide, BookSnapshot};
+pub use stream::{DepthEvent, DepthResyncReason, DepthStatus};

--- a/crates/orderbook/src/stream.rs
+++ b/crates/orderbook/src/stream.rs
@@ -1,0 +1,186 @@
+//! Provider-neutral vocabulary for a synchronized depth stream.
+//!
+//! A consumer of live market depth needs three things regardless of where the
+//! data comes from: a lifecycle it can render honestly ([`DepthStatus`]), one
+//! authoritative starting image per generation, and absolute updates on top of
+//! it ([`DepthEvent`]). Those are pure domain concepts, so they live here next
+//! to [`OrderBook`](crate::OrderBook) rather than inside any one feed crate —
+//! otherwise every new venue would either invent its own dialect or make the
+//! app depend on an unrelated exchange's crate.
+//!
+//! The vocabulary deliberately says nothing about *how* a source stays
+//! synchronized. Binance publishes a REST snapshot plus incremental diffs with
+//! exchange update ids; MetaTrader's DOM publishes a complete image on every
+//! book event and has no ids at all. Both reach this contract — the second one
+//! through [`SnapshotDiffer`](crate::SnapshotDiffer), which turns full images
+//! into the same snapshot-then-delta shape.
+//!
+//! Update ids are therefore *the local stream's* ids: exchange-assigned where
+//! the venue has them, synthetic and monotonic where it does not. They order
+//! and gap-check one generation; they mean nothing across generations.
+
+use rust_decimal::Decimal;
+
+use crate::{BookDelta, BookSnapshot};
+
+/// Why a synchronized stream must be discarded and rebuilt.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DepthResyncReason {
+    /// The starting image was older than the earliest eligible buffered update.
+    SnapshotTooOld {
+        /// Snapshot update id.
+        snapshot_update_id: u64,
+        /// First id in the event that could not bridge it.
+        first_update_id: u64,
+        /// Final id in that event.
+        final_update_id: u64,
+    },
+    /// At least one update id was missed.
+    SequenceGap {
+        /// Next required update id.
+        expected_update_id: u64,
+        /// First received id.
+        first_update_id: u64,
+        /// Final received id.
+        final_update_id: u64,
+    },
+    /// Bootstrap retried too many times on one connection.
+    SnapshotAttemptsExhausted {
+        /// Number of attempted snapshots.
+        attempts: u32,
+    },
+    /// The source restarted its book without a sequence break we could bridge
+    /// (a bridge session ended, a terminal resubscribed, a venue reset).
+    ///
+    /// Sources whose images carry no ids use this instead of
+    /// [`SequenceGap`](Self::SequenceGap): there is no id to point at, only the
+    /// fact that continuity ended.
+    SourceRestarted {
+        /// Stable machine-readable cause.
+        cause: &'static str,
+    },
+}
+
+/// Consumer-visible depth lifecycle.
+///
+/// Not every source reaches every state: a venue with no bootstrap buffering
+/// goes straight from [`Connecting`](Self::Connecting) to
+/// [`Synchronized`](Self::Synchronized).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DepthStatus {
+    /// The transport is being established.
+    Connecting,
+    /// The transport is open and updates are being buffered until the starting
+    /// image arrives.
+    Buffering {
+        /// Configured hard buffer limit.
+        capacity: usize,
+    },
+    /// A starting image is being fetched while the transport stays live.
+    SnapshotFetching {
+        /// Attempt number within this connection generation.
+        attempt: u32,
+        /// Updates already buffered.
+        buffered_updates: usize,
+    },
+    /// Image and stream are continuous and consumer data is authoritative
+    /// within the declared snapshot coverage.
+    Synchronized {
+        /// Current final update id.
+        last_update_id: u64,
+        /// Current stored bid level count.
+        bid_levels: usize,
+        /// Current stored ask level count.
+        ask_levels: usize,
+    },
+    /// Current state is being discarded.
+    Resyncing {
+        /// Typed reason for the resync.
+        reason: DepthResyncReason,
+    },
+    /// A connection generation ended.
+    Disconnected {
+        /// Stable machine-readable error class.
+        error_class: &'static str,
+    },
+    /// Consumer cancellation stopped the reconnect loop.
+    Stopped,
+}
+
+/// Typed output consumed by a chart or another order-book client.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DepthEvent {
+    /// Lifecycle/status transition.
+    Status {
+        /// Symbol as the consumer configured it.
+        symbol: String,
+        /// Monotonic capture/session generation.
+        generation: u64,
+        /// New status.
+        status: DepthStatus,
+    },
+    /// Starting image, emitted exactly once per successful generation before
+    /// its first delta.
+    Snapshot {
+        /// Symbol as the consumer configured it.
+        symbol: String,
+        /// Monotonic capture/session generation.
+        generation: u64,
+        /// Local epoch milliseconds when the image was observed.
+        ///
+        /// Sources whose starting image carries no exchange timestamp report
+        /// local observation time here, and it is labelled as such.
+        observed_at_ms: i64,
+        /// Logical start time for the image in the consumer timeline.
+        ///
+        /// An update can be buffered before the image arrives, so its exchange
+        /// event time may precede `observed_at_ms`. This value is at most one
+        /// millisecond before the earliest bridged event and never after the
+        /// local observation, preventing a false backwards-time delta while
+        /// keeping the observation timestamp available for diagnostics.
+        effective_at_ms: i64,
+        /// Smallest price increment of the instrument, when the source knows
+        /// it. `None` means "not declared" — consumers must not invent one;
+        /// they may fall back to a heuristic and should label it as such.
+        ///
+        /// Rendering liquidity on buckets finer than the real increment leaves
+        /// permanently empty rows between real ones, so a source that knows its
+        /// tick size saves the consumer from guessing.
+        price_step: Option<Decimal>,
+        /// Validated snapshot.
+        snapshot: BookSnapshot,
+    },
+    /// One absolute update.
+    Update {
+        /// Symbol as the consumer configured it.
+        symbol: String,
+        /// Monotonic capture/session generation.
+        generation: u64,
+        /// Source event time in epoch milliseconds.
+        event_time_ms: i64,
+        /// Validated absolute delta.
+        delta: BookDelta,
+    },
+}
+
+impl DepthEvent {
+    /// The symbol every variant carries.
+    #[must_use]
+    pub fn symbol(&self) -> &str {
+        match self {
+            Self::Status { symbol, .. }
+            | Self::Snapshot { symbol, .. }
+            | Self::Update { symbol, .. } => symbol,
+        }
+    }
+
+    /// The capture generation every variant carries.
+    #[must_use]
+    pub fn generation(&self) -> u64 {
+        match self {
+            Self::Status { generation, .. }
+            | Self::Snapshot { generation, .. }
+            | Self::Update { generation, .. } => *generation,
+        }
+    }
+}


### PR DESCRIPTION
## Summary

The order-flow heatmap worked for Binance and refused MetaTrader, because the
two venues publish depth in opposite shapes. Binance sends a snapshot plus
incremental diffs carrying exchange update ids. MetaTrader has no incremental
book protocol at all: `OnBookEvent` fires and `MarketBookGet` hands back the
whole visible DOM, with no ids of any kind.

They meet in `quantick-orderbook`:

- **`stream`** now owns the depth vocabulary (`DepthEvent` / `DepthStatus` /
  `DepthResyncReason`) that lived inside `quantick-feed-binance`. A second venue
  no longer has to invent a dialect, and the app no longer depends on an
  unrelated exchange's crate to describe its own book. `feed-binance`
  re-exports it, so its public surface and its code path are unchanged.
- **`image::SnapshotDiffer`** converts full images into that contract: first
  image becomes a snapshot, every later one a delta of only the levels that
  moved. B3 republishes ~20 levels many times a second while typically one or
  two changed, so diffing at the source keeps book state, RLE history and
  projection proportional to real change rather than to event rate.

Built on top of that:

- **`bridge/mt5/quantick_bridge.py`** — a bridge that attaches to the running
  terminal through the official Python package. **quantick starts it itself**
  when a MetaTrader feed is selected, after a grace period that leaves an
  already-running bridge (or an attached EA) alone. Selecting the feed is one
  action again.
- **`QuantickBridge.mq5`** streams depth too, sending an image only when it
  differs from the last one, and announcing `tick_size` / `book_levels` as
  *optional* hello fields — an EA compiled before this still streams ticks.
- UI affordances follow **`FeedCapabilities`** instead of `provider == Binance`.
  "Load older" is honestly disabled for a forward-only feed; the heatmap is
  offered wherever depth exists.
- The capture bucket honours the instrument's **tick size**. The mini index
  moves in 5-point steps and the price heuristic alone picked 2, leaving three
  rows in five permanently empty.

## Honest limits, labelled rather than hidden

- Coverage is always `Limited` — the terminal shows only the top levels, never
  the whole exchange book.
- Crossed images (B3 publishes them during the pre-open auction) are rejected
  and counted; the last uncrossed image stands.
- A bridge with no DOM reports `bridge_without_depth` instead of drawing an
  empty heatmap.
- A truncated backfill logs how many ticks it left behind rather than implying
  the chart starts at the open.
- The Python bridge refuses to start when it cannot measure the server-time
  offset, instead of guessing one and mislabelling every timestamp.

## Verification loop

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo build --workspace`
- [x] `cargo test --workspace` — 350 tests, 0 failures

## Notes for the reviewer

**Verified against the live terminal (2026-07-24, B3 open):** 100 584 real
WINQ26 ticks mapped to 94 438 trades (`side_from_tick_rule=49910`,
`side_carried=44528`, `dropped=1`, `side_from_flag=0` — the B3 flag pathology
holding as documented); real book of 10 levels a side; capture bucket 5 from
the declared tick size; and the app starting its own bridge with no manual
step. A synthetic book run produced 1 snapshot + 1499 deltas with **zero gaps**,
which is what proves the differ→`OrderBook` path stays synchronized.

**Not yet exercised:** the live tick pump and moving-book deltas against an
open market — the session closed at 18:31 and the terminal tears the DOM down
afterwards. Backfill and the opening snapshot were exercised with real data.
The underlying `copy_ticks_from` call was verified separately to return real
ticks after a cursor.

**Worth eyes on:** the generation arithmetic in `DepthSession` (a bridge
reconnect and a mid-session image gap must never reuse a generation the
consumer retired); the backpressure choice in `feed/metatrader.rs` (awaiting
rather than dropping, because after the opening snapshot every event is an
absolute delta and a dropped one desynchronizes the book); and whether the
autostart's five-attempt cap is the right place to stop.

No linked issue — this came from a session goal, and the repo has no open
issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MquWcZMBfhWjbDM1QsdSvh
