### PR TITLE
feat(app): configurable aggression bubbles with versioned presets

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -1,0 +1,49 @@
+# config/
+
+Project configuration that is **tracked in git**. quantick reads these from the
+working directory it runs in (the repository root, for `cargo run`).
+
+| File | What it is | Tracked? |
+|---|---|---|
+| `config/bubbles.toml` | Named looks for the **aggression bubbles** panel (bubble size, the consumption mark, the trail, colours, labels). Written by the panel's `save` button; safe to edit by hand. | yes — this is the point |
+| `crates/app/config/feeds.toml` | Built-in feed/symbol list, compiled into the binary as the fallback. | yes |
+| `crates/app/config/bubbles.toml` | Built-in bubble presets, compiled in as the fallback. | yes |
+| `./quantick.toml` | **Local** feed/symbol override for one machine (which broker contracts your terminal really has). | no — gitignored |
+
+Rule of thumb: anything that describes *how the project reads the market* is
+tracked here, so it can be reviewed and rolled back like code. Anything that
+describes *this machine* stays out of git (`quantick.toml`).
+
+## Overriding a path
+
+- `QUANTICK_CONFIG=/path/to/feeds.toml` — feeds and symbols.
+- `QUANTICK_BUBBLES=/path/to/bubbles.toml` — bubble presets.
+
+Both fall back to the file in the working directory, then to the copy compiled
+into the binary. A missing file is fine; a malformed feed config is a hard error
+(a bad config must never be guessed at), while a malformed presets file only
+falls back to the built-in presets and reports the error in the panel — losing
+the chart over a bad colour triple would be the worse failure.
+
+## bubbles.toml
+
+```toml
+active = "default"        # the preset the panel opens on ("" = none)
+
+[[presets]]
+name = "default"
+cluster_ms = 200          # merge compatible prints inside this window
+
+[presets.bubbles]         # everything visual; every key is optional
+max_radius = 15.0
+side_offset = 3.5         # buys nudged up, sells down, so both sides are readable
+front_width = 3.0         # the vertical consumption mark ("risco")
+trail_length = 18.0       # the glow into the consumed side ("rastro")
+buy_color = [46, 224, 150]  # omit to follow the chart theme
+```
+
+A preset only describes how bubbles **look**. Turning the layer on stays a live
+decision in the panel, so having this file can never start capture by itself.
+Quantities (`min_quantity`, `size_reference_quantity`) are in the symbol's own
+units — contracts on the mini index, coins on Binance — so a size-based preset
+says which market it was built for.

--- a/config/bubbles.toml
+++ b/config/bubbles.toml
@@ -1,0 +1,130 @@
+# quantick — named looks for the AGGRESSION BUBBLES panel.
+#
+# This is the file the panel reads and writes (override with QUANTICK_BUBBLES).
+# It is tracked in git on purpose: a bubble setup that reads the tape well is
+# worth reviewing and rolling back like code. See README.md in this folder.
+#
+# Quantities are in the symbol's own units: contracts on the mini index, coins
+# on Binance. A `min_quantity` that hides noise on WIN$N hides everything on
+# BTCUSDT, so size-based presets say which market they were built for.
+#
+# Colour overrides are optional `[r, g, b]` triples. Leave a colour out and it
+# follows the chart theme.
+#
+# A preset only describes how bubbles LOOK. Turning the layer on stays a live
+# decision in the panel, so having this file can never start capture by itself.
+
+active = "default"
+
+[[presets]]
+name = "default"
+cluster_ms = 200
+
+[presets.bubbles]
+min_radius = 2.0
+max_radius = 15.0
+opacity = 0.78
+outline_width = 1.0
+halo_strength = 0.12
+detail_min_radius = 4.0
+size_reference = "visible_p99"
+size_reference_quantity = 100.0
+min_quantity = 0.0
+side_offset = 3.5
+show_consumption_front = true
+front_width = 3.0
+front_length_scale = 2.1
+show_impact_ring = true
+impact_ring_width = 2.2
+trail_length = 18.0
+trail_opacity = 0.62
+show_quantity_labels = true
+show_trade_count = true
+label_min_radius = 16.0
+
+# A fast tape with hundreds of prints per minute: smaller dots, harder
+# clustering, no labels. Reading direction and size beats reading numbers.
+[[presets]]
+name = "dense tape"
+cluster_ms = 500
+
+[presets.bubbles]
+min_radius = 1.5
+max_radius = 11.0
+opacity = 0.7
+outline_width = 0.0
+halo_strength = 0.08
+detail_min_radius = 6.0
+size_reference = "visible_p99"
+size_reference_quantity = 100.0
+min_quantity = 0.0
+side_offset = 4.5
+show_consumption_front = true
+front_width = 2.0
+front_length_scale = 1.6
+show_impact_ring = false
+impact_ring_width = 2.2
+trail_length = 10.0
+trail_opacity = 0.45
+show_quantity_labels = false
+show_trade_count = false
+label_min_radius = 20.0
+
+# Only what moves the book: everything under 10 contracts is hidden and the
+# scale is pinned, so a bubble means the same size all session. Built for the
+# B3 mini index (WIN$N / WDO$N).
+[[presets]]
+name = "mini index sweeps"
+cluster_ms = 200
+
+[presets.bubbles]
+min_radius = 3.0
+max_radius = 22.0
+opacity = 0.85
+outline_width = 1.2
+halo_strength = 0.16
+detail_min_radius = 4.0
+size_reference = "fixed"
+size_reference_quantity = 200.0
+min_quantity = 10.0
+side_offset = 5.0
+show_consumption_front = true
+front_width = 3.5
+front_length_scale = 2.4
+show_impact_ring = true
+impact_ring_width = 2.6
+trail_length = 22.0
+trail_opacity = 0.7
+show_quantity_labels = true
+show_trade_count = true
+label_min_radius = 14.0
+
+# For studying who is eating whom: the bubble shrinks and the consumption mark
+# takes over — a wide, bright front and a long trail into the consumed side.
+[[presets]]
+name = "consumption focus"
+cluster_ms = 200
+
+[presets.bubbles]
+min_radius = 2.0
+max_radius = 12.0
+opacity = 0.55
+outline_width = 0.0
+halo_strength = 0.06
+detail_min_radius = 3.0
+size_reference = "visible_max"
+size_reference_quantity = 100.0
+min_quantity = 0.0
+side_offset = 6.0
+show_consumption_front = true
+front_width = 5.0
+front_length_scale = 3.2
+show_impact_ring = true
+impact_ring_width = 3.0
+trail_length = 40.0
+trail_opacity = 0.85
+show_quantity_labels = false
+show_trade_count = false
+label_min_radius = 16.0
+front_color = [255, 246, 205]
+trail_color = [255, 190, 90]

--- a/crates/app/config/bubbles.toml
+++ b/crates/app/config/bubbles.toml
@@ -1,0 +1,130 @@
+# quantick — built-in aggression bubble presets (FALLBACK ONLY).
+#
+# Compiled into the binary so the app runs with no external file. The file the
+# panel actually reads and writes is `config/bubbles.toml` at the repository
+# root — edit that one. See config/README.md.
+#
+# Quantities are in the symbol's own units: contracts on the mini index, coins
+# on Binance. A `min_quantity` that hides noise on WIN$N hides everything on
+# BTCUSDT, so size-based presets say which market they were built for.
+#
+# Colour overrides are optional `[r, g, b]` triples. Leave a colour out and it
+# follows the chart theme.
+#
+# A preset only describes how bubbles LOOK. Turning the layer on stays a live
+# decision in the panel, so having this file can never start capture by itself.
+
+active = "default"
+
+[[presets]]
+name = "default"
+cluster_ms = 200
+
+[presets.bubbles]
+min_radius = 2.0
+max_radius = 15.0
+opacity = 0.78
+outline_width = 1.0
+halo_strength = 0.12
+detail_min_radius = 4.0
+size_reference = "visible_p99"
+size_reference_quantity = 100.0
+min_quantity = 0.0
+side_offset = 3.5
+show_consumption_front = true
+front_width = 3.0
+front_length_scale = 2.1
+show_impact_ring = true
+impact_ring_width = 2.2
+trail_length = 18.0
+trail_opacity = 0.62
+show_quantity_labels = true
+show_trade_count = true
+label_min_radius = 16.0
+
+# A fast tape with hundreds of prints per minute: smaller dots, harder
+# clustering, no labels. Reading direction and size beats reading numbers.
+[[presets]]
+name = "dense tape"
+cluster_ms = 500
+
+[presets.bubbles]
+min_radius = 1.5
+max_radius = 11.0
+opacity = 0.7
+outline_width = 0.0
+halo_strength = 0.08
+detail_min_radius = 6.0
+size_reference = "visible_p99"
+size_reference_quantity = 100.0
+min_quantity = 0.0
+side_offset = 4.5
+show_consumption_front = true
+front_width = 2.0
+front_length_scale = 1.6
+show_impact_ring = false
+impact_ring_width = 2.2
+trail_length = 10.0
+trail_opacity = 0.45
+show_quantity_labels = false
+show_trade_count = false
+label_min_radius = 20.0
+
+# Only what moves the book: everything under 10 contracts is hidden and the
+# scale is pinned, so a bubble means the same size all session. Built for the
+# B3 mini index (WIN$N / WDO$N).
+[[presets]]
+name = "mini index sweeps"
+cluster_ms = 200
+
+[presets.bubbles]
+min_radius = 3.0
+max_radius = 22.0
+opacity = 0.85
+outline_width = 1.2
+halo_strength = 0.16
+detail_min_radius = 4.0
+size_reference = "fixed"
+size_reference_quantity = 200.0
+min_quantity = 10.0
+side_offset = 5.0
+show_consumption_front = true
+front_width = 3.5
+front_length_scale = 2.4
+show_impact_ring = true
+impact_ring_width = 2.6
+trail_length = 22.0
+trail_opacity = 0.7
+show_quantity_labels = true
+show_trade_count = true
+label_min_radius = 14.0
+
+# For studying who is eating whom: the bubble shrinks and the consumption mark
+# takes over — a wide, bright front and a long trail into the consumed side.
+[[presets]]
+name = "consumption focus"
+cluster_ms = 200
+
+[presets.bubbles]
+min_radius = 2.0
+max_radius = 12.0
+opacity = 0.55
+outline_width = 0.0
+halo_strength = 0.06
+detail_min_radius = 3.0
+size_reference = "visible_max"
+size_reference_quantity = 100.0
+min_quantity = 0.0
+side_offset = 6.0
+show_consumption_front = true
+front_width = 5.0
+front_length_scale = 3.2
+show_impact_ring = true
+impact_ring_width = 3.0
+trail_length = 40.0
+trail_opacity = 0.85
+show_quantity_labels = false
+show_trade_count = false
+label_min_radius = 16.0
+front_color = [255, 246, 205]
+trail_color = [255, 190, 90]

--- a/crates/app/src/bubble_presets.rs
+++ b/crates/app/src/bubble_presets.rs
@@ -236,10 +236,19 @@ pub fn save(file: &BubblePresetFile) -> Result<PathBuf, String> {
         std::fs::create_dir_all(parent)
             .map_err(|error| format!("{}: {error}", parent.display()))?;
     }
-    let body = toml::to_string_pretty(file).map_err(|error| error.to_string())?;
-    let text = format!("{PRESET_FILE_HEADER}{body}");
+    let text = render(file)?;
     std::fs::write(&path, text).map_err(|error| format!("{}: {error}", path.display()))?;
     Ok(path)
+}
+
+/// Render the presets file as the exact text a save writes.
+///
+/// Split out of [`save`] so the bytes that land in a tracked file can be
+/// asserted in a test without touching the filesystem: this file only earns
+/// being in git if a save produces a diff a human can read.
+fn render(file: &BubblePresetFile) -> Result<String, String> {
+    let body = toml::to_string(file).map_err(|error| error.to_string())?;
+    Ok(format!("{PRESET_FILE_HEADER}{body}"))
 }
 
 const PRESET_FILE_HEADER: &str = "\
@@ -299,11 +308,12 @@ mod tests {
         assert_eq!(other.retention_ms, HeatmapConfig::default().retention_ms);
         assert_eq!(other.gamma, HeatmapConfig::default().gamma);
 
-        // And a full file round trip preserves it byte-for-byte in meaning.
+        // And a full round trip through the real write path — the one `save`
+        // uses — preserves it byte-for-byte in meaning.
         let mut file = BubblePresetFile::default();
         file.upsert(preset.clone());
         file.active = "mine".to_owned();
-        let text = toml::to_string_pretty(&file).expect("serialize");
+        let text = render(&file).expect("render");
         assert_eq!(parse(&text).expect("reparse"), file);
 
         config.bubbles.side_offset = 0.0;
@@ -361,6 +371,49 @@ mod tests {
         assert!(
             file.active.is_empty(),
             "an active name that resolves to nothing is cleared"
+        );
+    }
+
+    #[test]
+    fn a_save_writes_a_file_a_human_can_review() {
+        // The file is tracked in git so a look that reads the tape well can be
+        // reviewed and rolled back like code — which only holds if a save
+        // produces a readable diff. TOML floats are f64, so an f32 written
+        // straight through prints its binary expansion (0.78 becomes
+        // 0.7799999713897705) and every save turns into noise.
+        let mut file = BubblePresetFile::default();
+        file.upsert(BubblePreset {
+            name: "default".to_owned(),
+            cluster_ms: DEFAULT_BUBBLE_CLUSTER_MS,
+            bubbles: BubbleStyle {
+                front_color: Some([255, 246, 205]),
+                ..BubbleStyle::default()
+            },
+        });
+        file.active = "default".to_owned();
+
+        let text = render(&file).expect("render");
+        assert!(
+            text.starts_with(PRESET_FILE_HEADER),
+            "the explanatory header survives a save:\n{text}"
+        );
+        assert!(
+            text.contains("opacity = 0.78"),
+            "floats stay short:\n{text}"
+        );
+        assert!(
+            text.contains("front_length_scale = 2.1"),
+            "floats stay short:\n{text}"
+        );
+        assert!(!text.contains("0.7799"), "no binary expansions:\n{text}");
+        assert!(
+            text.contains("front_color = [255, 246, 205]"),
+            "colour triples stay on one line, as config/README.md documents:\n{text}"
+        );
+        assert_eq!(
+            parse(&text).expect("reparse"),
+            file,
+            "and it still means exactly what it meant"
         );
     }
 

--- a/crates/app/src/bubble_presets.rs
+++ b/crates/app/src/bubble_presets.rs
@@ -1,0 +1,372 @@
+//! Named, versioned presets for the aggression-bubble panel.
+//!
+//! A preset is the "aggression bubbles" panel captured under a name: how prints
+//! are clustered and every visual choice in [`BubbleStyle`]. They live in
+//! [`PRESETS_PATH`] — `config/bubbles.toml`, a tracked file next to the rest of
+//! the project's configuration — so a look that works on the mini index is
+//! shared, reviewed and rolled back like code. See `config/README.md`.
+//!
+//! Resolution order mirrors [`crate::config`]: the [`PRESETS_ENV`] path, then
+//! [`PRESETS_PATH`] relative to the working directory, then the built-in file
+//! embedded at compile time.
+//!
+//! Unlike the feed configuration, a broken presets file is **not** fatal: the
+//! chart keeps running on the embedded presets and the parse error is returned
+//! to the caller, which shows it in the panel and logs it. Losing the tape
+//! because a colour tuple has three commas would be the worse failure — but the
+//! error is never swallowed either.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::orderflow::{BubbleStyle, HeatmapConfig, config::DEFAULT_BUBBLE_CLUSTER_MS};
+
+/// Environment variable naming an explicit presets file.
+pub const PRESETS_ENV: &str = "QUANTICK_BUBBLES";
+
+/// Tracked presets file, read and written relative to the working directory.
+///
+/// Under `config/` rather than the repository root: the name alone should say
+/// what the file is, and project configuration belongs in one obvious place.
+pub const PRESETS_PATH: &str = "config/bubbles.toml";
+
+/// Built-in presets, compiled in so the app works with no external file.
+const EMBEDDED_DEFAULT: &str = include_str!("../config/bubbles.toml");
+
+const fn default_cluster_ms() -> i64 {
+    DEFAULT_BUBBLE_CLUSTER_MS
+}
+
+/// One named snapshot of the aggression-bubble panel's *appearance*.
+///
+/// Deliberately not a switch: whether the layer draws at all stays a live
+/// decision in the UI, so opening the chart with a presets file present can
+/// never turn capture on by itself.
+///
+/// Field order matters: TOML requires plain values before tables, so
+/// [`bubbles`](Self::bubbles) stays last.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct BubblePreset {
+    /// Unique, human-chosen name shown in the picker.
+    pub name: String,
+    /// Temporal window used to cluster compatible prints, in milliseconds.
+    #[serde(default = "default_cluster_ms")]
+    pub cluster_ms: i64,
+    /// Every visual choice for the bubbles themselves.
+    #[serde(default)]
+    pub bubbles: BubbleStyle,
+}
+
+impl BubblePreset {
+    /// Capture the current panel state under `name`.
+    #[must_use]
+    pub fn capture(name: impl Into<String>, config: &HeatmapConfig) -> Self {
+        Self {
+            name: name.into(),
+            cluster_ms: config.bubble_cluster_ms,
+            bubbles: config.bubbles.clone(),
+        }
+    }
+
+    /// Apply this preset over `config`, touching nothing outside the panel —
+    /// and never the layer's own switch.
+    pub fn apply_to(&self, config: &mut HeatmapConfig) {
+        config.bubble_cluster_ms = self.cluster_ms;
+        config.bubbles = self.bubbles.clone();
+    }
+}
+
+/// The presets file as a whole.
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+pub struct BubblePresetFile {
+    /// Name of the preset the panel opens on. Empty means "none".
+    #[serde(default)]
+    pub active: String,
+    /// Every stored preset, in file order.
+    #[serde(default)]
+    pub presets: Vec<BubblePreset>,
+}
+
+impl BubblePresetFile {
+    /// The preset stored under `name`, if any.
+    #[must_use]
+    pub fn get(&self, name: &str) -> Option<&BubblePreset> {
+        self.presets.iter().find(|preset| preset.name == name)
+    }
+
+    /// Store `preset`, replacing any existing one with the same name.
+    pub fn upsert(&mut self, preset: BubblePreset) {
+        match self
+            .presets
+            .iter_mut()
+            .find(|stored| stored.name == preset.name)
+        {
+            Some(stored) => *stored = preset,
+            None => self.presets.push(preset),
+        }
+    }
+
+    /// Remove `name`, reporting whether it existed.
+    pub fn remove(&mut self, name: &str) -> bool {
+        let before = self.presets.len();
+        self.presets.retain(|preset| preset.name != name);
+        if self.active == name {
+            self.active.clear();
+        }
+        self.presets.len() != before
+    }
+
+    /// Drop unusable entries and clamp every stored style.
+    ///
+    /// Nameless or duplicate presets are the only things discarded; a preset
+    /// with out-of-range numbers is kept and clamped, so hand-editing the file
+    /// never costs the whole entry.
+    fn sanitize(&mut self) {
+        let mut seen: Vec<String> = Vec::with_capacity(self.presets.len());
+        self.presets.retain_mut(|preset| {
+            preset.name = preset.name.trim().to_owned();
+            if preset.name.is_empty() || seen.contains(&preset.name) {
+                return false;
+            }
+            seen.push(preset.name.clone());
+            preset.cluster_ms = preset
+                .cluster_ms
+                .clamp(0, crate::orderflow::config::MAX_BUBBLE_CLUSTER_MS);
+            preset.bubbles.sanitize();
+            true
+        });
+        let active = std::mem::take(&mut self.active).trim().to_owned();
+        if self.get(&active).is_some() {
+            self.active = active;
+        }
+    }
+}
+
+/// Where a loaded presets file came from.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PresetSource {
+    /// An explicit path from [`PRESETS_ENV`].
+    EnvPath(PathBuf),
+    /// [`PRESETS_PATH`] relative to the working directory.
+    WorkingDir(PathBuf),
+    /// The built-in presets embedded in the binary.
+    Embedded,
+}
+
+impl std::fmt::Display for PresetSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::EnvPath(path) | Self::WorkingDir(path) => write!(f, "{}", path.display()),
+            Self::Embedded => write!(f, "<built-in>"),
+        }
+    }
+}
+
+/// Parse presets from TOML text, sanitizing what survives.
+///
+/// # Errors
+///
+/// Returns the parser's message when the text is not a valid presets file.
+pub fn parse(text: &str) -> Result<BubblePresetFile, String> {
+    let mut file: BubblePresetFile = toml::from_str(text).map_err(|error| error.to_string())?;
+    file.sanitize();
+    Ok(file)
+}
+
+/// The built-in presets. Validated by a test, so this never fails in practice.
+#[must_use]
+pub fn embedded() -> BubblePresetFile {
+    parse(EMBEDDED_DEFAULT).unwrap_or_default()
+}
+
+/// Path the panel reads from and writes to.
+#[must_use]
+pub fn presets_path() -> PathBuf {
+    std::env::var_os(PRESETS_ENV).map_or_else(|| PathBuf::from(PRESETS_PATH), PathBuf::from)
+}
+
+/// Load presets, falling back to the embedded file.
+///
+/// Returns the presets, where they came from, and — when an external file
+/// exists but could not be read or parsed — the error to surface. In that case
+/// the returned presets are the embedded ones, and the source says so.
+#[must_use]
+pub fn load() -> (BubblePresetFile, PresetSource, Option<String>) {
+    let (path, source): (PathBuf, fn(PathBuf) -> PresetSource) = match std::env::var_os(PRESETS_ENV)
+    {
+        Some(raw) => (PathBuf::from(raw), PresetSource::EnvPath),
+        None => (PathBuf::from(PRESETS_PATH), PresetSource::WorkingDir),
+    };
+    if !Path::new(&path).is_file() {
+        return (embedded(), PresetSource::Embedded, None);
+    }
+    match std::fs::read_to_string(&path) {
+        Ok(text) => match parse(&text) {
+            Ok(file) => (file, source(path), None),
+            Err(message) => (
+                embedded(),
+                PresetSource::Embedded,
+                Some(format!("{}: {message}", path.display())),
+            ),
+        },
+        Err(error) => (
+            embedded(),
+            PresetSource::Embedded,
+            Some(format!("cannot read {}: {error}", path.display())),
+        ),
+    }
+}
+
+/// Write `file` to [`presets_path`], returning where it landed.
+///
+/// Creates the parent directory when missing, so saving works in a fresh
+/// checkout or when the app runs from somewhere without a `config/` yet.
+///
+/// # Errors
+///
+/// Returns a human-readable message when the file cannot be serialized or
+/// written.
+pub fn save(file: &BubblePresetFile) -> Result<PathBuf, String> {
+    let path = presets_path();
+    if let Some(parent) = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        std::fs::create_dir_all(parent)
+            .map_err(|error| format!("{}: {error}", parent.display()))?;
+    }
+    let body = toml::to_string_pretty(file).map_err(|error| error.to_string())?;
+    let text = format!("{PRESET_FILE_HEADER}{body}");
+    std::fs::write(&path, text).map_err(|error| format!("{}: {error}", path.display()))?;
+    Ok(path)
+}
+
+const PRESET_FILE_HEADER: &str = "\
+# quantick — aggression bubble presets.
+#
+# Written by the \"aggression bubbles\" panel (save), and safe to edit by hand:
+# this file is the versioned record of how the tape is read. See README.md in
+# this folder.
+# `active` names the preset the panel opens on. Colour overrides are optional
+# `[r, g, b]` triples; leave them out to follow the chart theme.
+
+";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::orderflow::BubbleSizeReference;
+
+    #[test]
+    fn the_embedded_file_parses_and_carries_a_valid_active_preset() {
+        let file = parse(EMBEDDED_DEFAULT).expect("embedded presets");
+        assert!(!file.presets.is_empty());
+        assert!(
+            file.get(&file.active).is_some(),
+            "active preset '{}' must exist",
+            file.active
+        );
+        for preset in &file.presets {
+            assert!(preset.bubbles.max_radius >= preset.bubbles.min_radius);
+        }
+    }
+
+    #[test]
+    fn a_preset_round_trips_through_the_panel_state() {
+        let mut config = HeatmapConfig {
+            bubble_cluster_ms: 50,
+            bubbles: BubbleStyle {
+                side_offset: 9.0,
+                size_reference: BubbleSizeReference::VisibleMax,
+                sell_color: Some([10, 20, 30]),
+                ..BubbleStyle::default()
+            },
+            ..HeatmapConfig::default()
+        };
+        let preset = BubblePreset::capture("mine", &config);
+
+        let mut other = HeatmapConfig::default();
+        preset.apply_to(&mut other);
+        assert_eq!(other.bubbles, config.bubbles);
+        assert_eq!(other.bubble_cluster_ms, 50);
+        // Nothing outside the bubble panel moves — least of all the switch that
+        // would start recording trades.
+        assert_eq!(
+            other.show_aggressions,
+            HeatmapConfig::default().show_aggressions
+        );
+        assert_eq!(other.retention_ms, HeatmapConfig::default().retention_ms);
+        assert_eq!(other.gamma, HeatmapConfig::default().gamma);
+
+        // And a full file round trip preserves it byte-for-byte in meaning.
+        let mut file = BubblePresetFile::default();
+        file.upsert(preset.clone());
+        file.active = "mine".to_owned();
+        let text = toml::to_string_pretty(&file).expect("serialize");
+        assert_eq!(parse(&text).expect("reparse"), file);
+
+        config.bubbles.side_offset = 0.0;
+        assert_ne!(BubblePreset::capture("mine", &config), preset);
+    }
+
+    #[test]
+    fn upsert_replaces_by_name_and_remove_clears_the_active_selection() {
+        let mut file = BubblePresetFile::default();
+        file.upsert(BubblePreset::capture("a", &HeatmapConfig::default()));
+        file.upsert(BubblePreset::capture("b", &HeatmapConfig::default()));
+        let mut louder = HeatmapConfig::default();
+        louder.bubbles.max_radius = 40.0;
+        file.upsert(BubblePreset::capture("a", &louder));
+        file.active = "a".to_owned();
+
+        assert_eq!(
+            file.presets.len(),
+            2,
+            "same name replaces, never duplicates"
+        );
+        assert_eq!(file.get("a").unwrap().bubbles.max_radius, 40.0);
+        assert!(file.remove("a"));
+        assert!(!file.remove("a"));
+        assert!(file.active.is_empty());
+    }
+
+    #[test]
+    fn sanitizing_drops_nameless_and_duplicate_entries_but_clamps_the_rest() {
+        let text = r#"
+            active = "ghost"
+
+            [[presets]]
+            name = "  "
+
+            [[presets]]
+            name = "loud"
+            cluster_ms = 999999
+            [presets.bubbles]
+            max_radius = 5000.0
+
+            [[presets]]
+            name = "loud"
+            [presets.bubbles]
+            max_radius = 8.0
+        "#;
+        let file = parse(text).expect("parse");
+        assert_eq!(file.presets.len(), 1);
+        assert_eq!(file.presets[0].name, "loud");
+        assert_eq!(
+            file.presets[0].bubbles.max_radius,
+            crate::orderflow::MAX_BUBBLE_MAX_RADIUS
+        );
+        assert!(file.presets[0].cluster_ms <= crate::orderflow::config::MAX_BUBBLE_CLUSTER_MS);
+        assert!(
+            file.active.is_empty(),
+            "an active name that resolves to nothing is cleared"
+        );
+    }
+
+    #[test]
+    fn a_malformed_file_is_reported_rather_than_parsed() {
+        let error = parse("presets = [").expect_err("malformed");
+        assert!(!error.is_empty());
+    }
+}

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -12,6 +12,7 @@ use tracing_subscriber::EnvFilter;
 use crate::state::BarSpec;
 
 mod app;
+mod bubble_presets;
 mod candle_view;
 mod chart;
 mod config;

--- a/crates/app/src/orderflow/config.rs
+++ b/crates/app/src/orderflow/config.rs
@@ -136,6 +136,28 @@ pub enum BubbleSizeReference {
     Fixed,
 }
 
+/// Decimal places kept when a bubble float is written to the presets file.
+///
+/// Four is past the precision any pixel radius or alpha carries, and well
+/// inside what `f32` represents exactly enough to survive a round trip.
+const SERIALIZED_FLOAT_PLACES: i32 = 4;
+
+/// Serialize an `f32` as a short decimal.
+///
+/// TOML floats are `f64`, so an `f32` promoted straight through prints its
+/// exact binary expansion: `0.78` is written back as `0.7799999713897705`.
+/// Presets are tracked in git precisely so a look can be reviewed and rolled
+/// back like code, and a diff of noise defeats that — this is the write path
+/// for every visual float, so rounding here fixes the file for all of them.
+fn serialize_short_f32<S>(value: &f32, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    let scale = 10_f64.powi(SERIALIZED_FLOAT_PLACES);
+    let rounded = (f64::from(*value) * scale).round() / scale;
+    serializer.serialize_f64(rounded)
+}
+
 /// Everything the "aggression bubbles" panel owns: bubble geometry, colour,
 /// labels and the two marks a bubble draws when it ate resting liquidity — the
 /// vertical consumption front (the "risco") and the trail that leaks into the
@@ -149,18 +171,24 @@ pub enum BubbleSizeReference {
 #[serde(default)]
 pub struct BubbleStyle {
     /// Radius of the smallest drawn print, in pixels.
+    #[serde(serialize_with = "serialize_short_f32")]
     pub min_radius: f32,
     /// Radius of a full-size print, in pixels. Area stays proportional to
     /// quantity between the two.
+    #[serde(serialize_with = "serialize_short_f32")]
     pub max_radius: f32,
     /// Alpha of the bubble fill.
+    #[serde(serialize_with = "serialize_short_f32")]
     pub opacity: f32,
     /// Rim stroke width; zero draws no rim.
+    #[serde(serialize_with = "serialize_short_f32")]
     pub outline_width: f32,
     /// Soft halo drawn behind the fill, as a fraction of full alpha.
+    #[serde(serialize_with = "serialize_short_f32")]
     pub halo_strength: f32,
     /// Bubbles below this radius are drawn as a plain dot (no halo, rim or
     /// impact ring). Raising it trades detail for frame time on a fast tape.
+    #[serde(serialize_with = "serialize_short_f32")]
     pub detail_min_radius: f32,
     /// How the full-size reference quantity is chosen.
     pub size_reference: BubbleSizeReference,
@@ -179,28 +207,35 @@ pub struct BubbleStyle {
     /// Deliberately unfaithful to the exact price — with a one-tick spread both
     /// sides land on the same row and stack into an unreadable line. Zero
     /// restores exact price placement.
+    #[serde(serialize_with = "serialize_short_f32")]
     pub side_offset: f32,
     /// Whether a bubble that ate resting liquidity draws its vertical
     /// consumption front.
     pub show_consumption_front: bool,
     /// Width of that front, in pixels.
+    #[serde(serialize_with = "serialize_short_f32")]
     pub front_width: f32,
     /// Half-length of the front as a multiple of the bubble radius.
+    #[serde(serialize_with = "serialize_short_f32")]
     pub front_length_scale: f32,
     /// Whether a consuming bubble draws a ring around its rim.
     pub show_impact_ring: bool,
     /// Width of that ring, in pixels.
+    #[serde(serialize_with = "serialize_short_f32")]
     pub impact_ring_width: f32,
     /// Length of the consumption trail leaking to the right, in pixels. Zero
     /// draws no trail.
+    #[serde(serialize_with = "serialize_short_f32")]
     pub trail_length: f32,
     /// Alpha of the trail at the bubble's edge; it fades to nothing.
+    #[serde(serialize_with = "serialize_short_f32")]
     pub trail_opacity: f32,
     /// Whether large bubbles print their quantity.
     pub show_quantity_labels: bool,
     /// Whether large bubbles print how many trades they cluster.
     pub show_trade_count: bool,
     /// Smallest radius that gets a label at all.
+    #[serde(serialize_with = "serialize_short_f32")]
     pub label_min_radius: f32,
     /// Buy-side colour override; absent follows the theme.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/app/src/orderflow/config.rs
+++ b/crates/app/src/orderflow/config.rs
@@ -1,6 +1,7 @@
 //! Sanitized runtime configuration for the order-book heatmap.
 
 use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
 
 /// Shortest history window accepted by the UI.
 pub const MIN_RETENTION_MS: i64 = 1_000;
@@ -40,6 +41,8 @@ pub const DEFAULT_BUBBLE_MAX_RADIUS: f32 = 15.0;
 pub const MIN_BUBBLE_MAX_RADIUS: f32 = 4.0;
 /// Largest accepted maximum bubble radius.
 pub const MAX_BUBBLE_MAX_RADIUS: f32 = 48.0;
+/// Largest accepted radius for the smallest drawn bubble.
+pub const MAX_BUBBLE_MIN_RADIUS: f32 = 12.0;
 
 /// Renderer-only price grouping layered over the exact capture buckets.
 ///
@@ -114,6 +117,196 @@ impl IntensityMode {
     }
 }
 
+/// How the quantity that maps to a full-size bubble is chosen.
+///
+/// `VisibleP99` keeps one outlier sweep from shrinking every other print to a
+/// dot, at the cost of making the top 1% all render at the maximum radius.
+/// `VisibleMax` restores a strict ordering (the biggest print is the only one
+/// at full size); `Fixed` pins the scale so bubble size means the same thing
+/// across sessions and symbols.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BubbleSizeReference {
+    /// 99th percentile of the visible clustered prints.
+    #[default]
+    VisibleP99,
+    /// The largest visible clustered print.
+    VisibleMax,
+    /// An explicit quantity, [`BubbleStyle::size_reference_quantity`].
+    Fixed,
+}
+
+/// Everything the "aggression bubbles" panel owns: bubble geometry, colour,
+/// labels and the two marks a bubble draws when it ate resting liquidity — the
+/// vertical consumption front (the "risco") and the trail that leaks into the
+/// consumed side (the "rastro").
+///
+/// Every field here is display-only. [`min_quantity`](Self::min_quantity) and
+/// the size reference reach the projection, but only to decide which bubbles
+/// are drawn and how large — never what is captured, retained, or associated
+/// with an L2 reduction.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct BubbleStyle {
+    /// Radius of the smallest drawn print, in pixels.
+    pub min_radius: f32,
+    /// Radius of a full-size print, in pixels. Area stays proportional to
+    /// quantity between the two.
+    pub max_radius: f32,
+    /// Alpha of the bubble fill.
+    pub opacity: f32,
+    /// Rim stroke width; zero draws no rim.
+    pub outline_width: f32,
+    /// Soft halo drawn behind the fill, as a fraction of full alpha.
+    pub halo_strength: f32,
+    /// Bubbles below this radius are drawn as a plain dot (no halo, rim or
+    /// impact ring). Raising it trades detail for frame time on a fast tape.
+    pub detail_min_radius: f32,
+    /// How the full-size reference quantity is chosen.
+    pub size_reference: BubbleSizeReference,
+    /// Quantity mapped to [`max_radius`](Self::max_radius) when the reference
+    /// is [`BubbleSizeReference::Fixed`].
+    pub size_reference_quantity: f64,
+    /// Prints below this exact quantity are not drawn. Zero draws everything.
+    ///
+    /// Display-only and applied *after* liquidity association, so hiding small
+    /// prints never turns an aggression-aligned reduction into an
+    /// unattributed one.
+    pub min_quantity: f64,
+    /// Vertical separation, in pixels, between the two sides: buy bubbles are
+    /// nudged up (they lift the ask), sell bubbles down (they hit the bid).
+    ///
+    /// Deliberately unfaithful to the exact price — with a one-tick spread both
+    /// sides land on the same row and stack into an unreadable line. Zero
+    /// restores exact price placement.
+    pub side_offset: f32,
+    /// Whether a bubble that ate resting liquidity draws its vertical
+    /// consumption front.
+    pub show_consumption_front: bool,
+    /// Width of that front, in pixels.
+    pub front_width: f32,
+    /// Half-length of the front as a multiple of the bubble radius.
+    pub front_length_scale: f32,
+    /// Whether a consuming bubble draws a ring around its rim.
+    pub show_impact_ring: bool,
+    /// Width of that ring, in pixels.
+    pub impact_ring_width: f32,
+    /// Length of the consumption trail leaking to the right, in pixels. Zero
+    /// draws no trail.
+    pub trail_length: f32,
+    /// Alpha of the trail at the bubble's edge; it fades to nothing.
+    pub trail_opacity: f32,
+    /// Whether large bubbles print their quantity.
+    pub show_quantity_labels: bool,
+    /// Whether large bubbles print how many trades they cluster.
+    pub show_trade_count: bool,
+    /// Smallest radius that gets a label at all.
+    pub label_min_radius: f32,
+    /// Buy-side colour override; absent follows the theme.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub buy_color: Option<[u8; 3]>,
+    /// Sell-side colour override; absent follows the theme.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sell_color: Option<[u8; 3]>,
+    /// Consumption-front colour override; absent follows the theme.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub front_color: Option<[u8; 3]>,
+    /// Trail colour override; absent follows the front colour.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trail_color: Option<[u8; 3]>,
+    /// Label colour override; absent follows the theme.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label_color: Option<[u8; 3]>,
+}
+
+impl Default for BubbleStyle {
+    fn default() -> Self {
+        Self {
+            // Area stays quantity-proportional: the minimum keeps the smallest
+            // print a subtle dot, the maximum lets a real sweep dominate.
+            min_radius: 2.0,
+            max_radius: DEFAULT_BUBBLE_MAX_RADIUS,
+            opacity: DEFAULT_BUBBLE_OPACITY,
+            outline_width: 1.0,
+            halo_strength: 0.12,
+            detail_min_radius: 4.0,
+            size_reference: BubbleSizeReference::VisibleP99,
+            size_reference_quantity: 100.0,
+            min_quantity: 0.0,
+            side_offset: 3.5,
+            show_consumption_front: true,
+            front_width: 3.0,
+            front_length_scale: 2.1,
+            show_impact_ring: true,
+            impact_ring_width: 2.2,
+            trail_length: 18.0,
+            trail_opacity: 0.62,
+            show_quantity_labels: true,
+            show_trade_count: true,
+            // Only the largest bubbles get a (text-layout-costly) label.
+            label_min_radius: 16.0,
+            buy_color: None,
+            sell_color: None,
+            front_color: None,
+            trail_color: None,
+            label_color: None,
+        }
+    }
+}
+
+impl BubbleStyle {
+    /// Clamp every numeric field to a value that is safe for geometry and math.
+    pub fn sanitize(&mut self) {
+        self.min_radius = finite_clamp(self.min_radius, 0.5, MAX_BUBBLE_MIN_RADIUS, 2.0);
+        self.max_radius = finite_clamp(
+            self.max_radius,
+            self.min_radius,
+            MAX_BUBBLE_MAX_RADIUS,
+            DEFAULT_BUBBLE_MAX_RADIUS,
+        );
+        self.opacity = finite_clamp(self.opacity, 0.05, 1.0, DEFAULT_BUBBLE_OPACITY);
+        self.outline_width = finite_clamp(self.outline_width, 0.0, 6.0, 1.0);
+        self.halo_strength = finite_clamp(self.halo_strength, 0.0, 1.0, 0.12);
+        self.detail_min_radius = finite_clamp(self.detail_min_radius, 0.0, 32.0, 4.0);
+        if !self.size_reference_quantity.is_finite() || self.size_reference_quantity <= 0.0 {
+            self.size_reference_quantity = 100.0;
+        }
+        if !self.min_quantity.is_finite() || self.min_quantity < 0.0 {
+            self.min_quantity = 0.0;
+        }
+        self.side_offset = finite_clamp(self.side_offset, 0.0, 40.0, 3.5);
+        self.front_width = finite_clamp(self.front_width, 0.5, 12.0, 3.0);
+        self.front_length_scale = finite_clamp(self.front_length_scale, 0.2, 8.0, 2.1);
+        self.impact_ring_width = finite_clamp(self.impact_ring_width, 0.5, 8.0, 2.2);
+        self.trail_length = finite_clamp(self.trail_length, 0.0, 120.0, 18.0);
+        self.trail_opacity = finite_clamp(self.trail_opacity, 0.0, 1.0, 0.62);
+        self.label_min_radius = finite_clamp(self.label_min_radius, 4.0, 64.0, 16.0);
+    }
+
+    /// Exact quantity below which a print is not drawn, if any.
+    #[must_use]
+    pub fn min_quantity_decimal(&self) -> Option<Decimal> {
+        (self.min_quantity > 0.0)
+            .then(|| Decimal::from_f64_retain(self.min_quantity))
+            .flatten()
+    }
+
+    /// Explicit full-size quantity, when the reference is fixed.
+    #[must_use]
+    pub fn fixed_reference_decimal(&self) -> Option<Decimal> {
+        Decimal::from_f64_retain(self.size_reference_quantity)
+            .filter(|value| *value > Decimal::ZERO)
+    }
+}
+
+fn finite_clamp(value: f32, low: f32, high: f32, fallback: f32) -> f32 {
+    if value.is_finite() {
+        value.clamp(low, high)
+    } else {
+        fallback.clamp(low, high)
+    }
+}
+
 /// Settings shared by history retention and the pure projection layer.
 ///
 /// The two visual layers are independent switches: [`enabled`](Self::enabled)
@@ -153,10 +346,10 @@ pub struct HeatmapConfig {
     ///
     /// Zero keeps raw, one-trade-per-bubble projection.
     pub bubble_cluster_ms: i64,
-    /// Maximum alpha contributed by an aggression bubble.
-    pub bubble_opacity: f32,
-    /// On-screen radius, in points, of the largest aggression bubble.
-    pub bubble_max_radius: f32,
+    /// Everything else the aggression-bubble panel owns: geometry (including
+    /// the alpha and largest radius this used to carry as two flat fields),
+    /// colour, consumption marks and labels.
+    pub bubbles: BubbleStyle,
     /// Whether factual displayed-liquidity reductions are projected.
     pub show_liquidity_events: bool,
     /// Smallest reduction fraction whose *unattributed* (depth-only) marker is
@@ -205,8 +398,7 @@ impl Default for HeatmapConfig {
             gamma: 1.8,
             show_aggressions: false,
             bubble_cluster_ms: DEFAULT_BUBBLE_CLUSTER_MS,
-            bubble_opacity: DEFAULT_BUBBLE_OPACITY,
-            bubble_max_radius: DEFAULT_BUBBLE_MAX_RADIUS,
+            bubbles: BubbleStyle::default(),
             show_liquidity_events: true,
             min_unattributed_reduction: 0.5,
             min_unattributed_pull_share: 0.25,
@@ -265,16 +457,7 @@ impl HeatmapConfig {
         }
         self.min_unattributed_pull_share = self.min_unattributed_pull_share.clamp(0.0, 1.0);
         self.bubble_cluster_ms = self.bubble_cluster_ms.clamp(0, MAX_BUBBLE_CLUSTER_MS);
-        if !self.bubble_opacity.is_finite() {
-            self.bubble_opacity = DEFAULT_BUBBLE_OPACITY;
-        }
-        self.bubble_opacity = self.bubble_opacity.clamp(0.05, 1.0);
-        if !self.bubble_max_radius.is_finite() {
-            self.bubble_max_radius = DEFAULT_BUBBLE_MAX_RADIUS;
-        }
-        self.bubble_max_radius = self
-            .bubble_max_radius
-            .clamp(MIN_BUBBLE_MAX_RADIUS, MAX_BUBBLE_MAX_RADIUS);
+        self.bubbles.sanitize();
         self.liquidity_correlation_ms = self
             .liquidity_correlation_ms
             .clamp(0, MAX_LIQUIDITY_CORRELATION_MS);
@@ -309,8 +492,8 @@ mod tests {
         assert!(!config.show_aggressions);
         assert!(!config.any_layer_enabled());
         assert_eq!(config.bubble_cluster_ms, DEFAULT_BUBBLE_CLUSTER_MS);
-        assert_eq!(config.bubble_opacity, DEFAULT_BUBBLE_OPACITY);
-        assert_eq!(config.bubble_max_radius, DEFAULT_BUBBLE_MAX_RADIUS);
+        assert_eq!(config.bubbles.opacity, DEFAULT_BUBBLE_OPACITY);
+        assert_eq!(config.bubbles.max_radius, DEFAULT_BUBBLE_MAX_RADIUS);
         assert!(config.show_liquidity_events);
         assert_eq!(
             config.liquidity_correlation_ms,
@@ -332,8 +515,11 @@ mod tests {
             opacity: f32::NAN,
             gamma: -1.0,
             bubble_cluster_ms: i64::MAX,
-            bubble_opacity: f32::NAN,
-            bubble_max_radius: 900.0,
+            bubbles: BubbleStyle {
+                opacity: f32::NAN,
+                max_radius: 900.0,
+                ..BubbleStyle::default()
+            },
             liquidity_correlation_ms: i64::MIN,
             max_history_runs: 0,
             max_history_bytes: 0,
@@ -352,8 +538,8 @@ mod tests {
         assert_eq!(config.opacity, 0.9);
         assert_eq!(config.gamma, 1.0);
         assert_eq!(config.bubble_cluster_ms, MAX_BUBBLE_CLUSTER_MS);
-        assert_eq!(config.bubble_opacity, DEFAULT_BUBBLE_OPACITY);
-        assert_eq!(config.bubble_max_radius, MAX_BUBBLE_MAX_RADIUS);
+        assert_eq!(config.bubbles.opacity, DEFAULT_BUBBLE_OPACITY);
+        assert_eq!(config.bubbles.max_radius, MAX_BUBBLE_MAX_RADIUS);
         assert_eq!(config.liquidity_correlation_ms, 0);
         assert_eq!(config.max_history_runs, 1);
         assert_eq!(config.max_history_bytes, 1_024);
@@ -412,6 +598,78 @@ mod tests {
             config.intensity_mode,
             IntensityMode::Fixed(Decimal::from(25))
         );
+    }
+
+    #[test]
+    fn bubble_defaults_separate_the_two_sides_and_stay_bounded() {
+        let bubbles = HeatmapConfig::default().bubbles;
+        assert!(bubbles.max_radius > bubbles.min_radius);
+        assert!(
+            bubbles.side_offset > 0.0,
+            "buy and sell must not stack on the same row by default"
+        );
+        assert!(bubbles.show_consumption_front);
+        assert_eq!(bubbles.size_reference, BubbleSizeReference::VisibleP99);
+        assert_eq!(bubbles.min_quantity, 0.0, "nothing is hidden by default");
+        assert_eq!(bubbles.min_quantity_decimal(), None);
+    }
+
+    #[test]
+    fn bubble_style_sanitizes_invalid_geometry() {
+        let mut style = BubbleStyle {
+            min_radius: f32::NAN,
+            max_radius: -3.0,
+            opacity: 12.0,
+            front_width: 0.0,
+            trail_length: f32::INFINITY,
+            side_offset: -5.0,
+            min_quantity: -1.0,
+            size_reference_quantity: 0.0,
+            ..BubbleStyle::default()
+        };
+        style.sanitize();
+        assert_eq!(style.min_radius, 2.0);
+        assert!(style.max_radius >= style.min_radius);
+        assert_eq!(style.opacity, 1.0);
+        assert_eq!(style.front_width, 0.5);
+        assert_eq!(style.trail_length, 18.0);
+        assert_eq!(style.side_offset, 0.0);
+        assert_eq!(style.min_quantity, 0.0);
+        assert_eq!(style.size_reference_quantity, 100.0);
+    }
+
+    #[test]
+    fn sanitizing_the_heatmap_config_also_sanitizes_its_bubbles() {
+        let config = HeatmapConfig {
+            bubbles: BubbleStyle {
+                opacity: f32::NAN,
+                ..BubbleStyle::default()
+            },
+            ..HeatmapConfig::default()
+        }
+        .sanitized();
+        assert_eq!(config.bubbles.opacity, 0.78);
+    }
+
+    #[test]
+    fn bubble_style_round_trips_through_toml() {
+        // Presets are stored as TOML, so an unserializable field (a bare
+        // `None`, say) would break saving at runtime instead of at build time.
+        let style = BubbleStyle {
+            buy_color: Some([1, 2, 3]),
+            size_reference: BubbleSizeReference::Fixed,
+            min_quantity: 2.5,
+            ..BubbleStyle::default()
+        };
+        let text = toml::to_string(&style).expect("serialize");
+        let parsed: BubbleStyle = toml::from_str(&text).expect("parse");
+        assert_eq!(parsed, style);
+        assert!(!text.contains("sell_color"), "absent overrides stay absent");
+
+        // A partial document keeps every untouched field at its default.
+        let partial: BubbleStyle = toml::from_str("max_radius = 30.0").expect("parse partial");
+        assert_eq!(partial.max_radius, 30.0);
+        assert_eq!(partial.min_radius, BubbleStyle::default().min_radius);
     }
 
     #[test]

--- a/crates/app/src/orderflow/mod.rs
+++ b/crates/app/src/orderflow/mod.rs
@@ -16,8 +16,8 @@ pub mod timeline;
 // the public DTOs here gives later renderers one stable import surface.
 #[allow(unused_imports)]
 pub use config::{
-    DisplayGrouping, HeatmapConfig, HeatmapTheme, IntensityMode, MAX_BUBBLE_MAX_RADIUS,
-    MIN_BUBBLE_MAX_RADIUS,
+    BubbleSizeReference, BubbleStyle, DisplayGrouping, HeatmapConfig, HeatmapTheme, IntensityMode,
+    MAX_BUBBLE_MAX_RADIUS, MAX_BUBBLE_MIN_RADIUS, MIN_BUBBLE_MAX_RADIUS,
 };
 #[allow(unused_imports)]
 pub use grouping::{

--- a/crates/app/src/orderflow/projection.rs
+++ b/crates/app/src/orderflow/projection.rs
@@ -3,7 +3,7 @@
 use rust_decimal::Decimal;
 use rust_decimal::prelude::{FromPrimitive as _, ToPrimitive as _};
 
-use super::config::IntensityMode;
+use super::config::{BubbleSizeReference, IntensityMode};
 use super::grouping::{EffectiveGrouping, GroupedLiquidity, GroupingWindow, sweep_grouped_runs};
 use super::history::{AggressorSide, LiquidityHistory, RestingSide};
 pub use super::interaction::LiquidityEvidence;
@@ -356,8 +356,19 @@ pub fn project(
         effective_grouping,
         config.bubble_cluster_ms,
     );
-    let aggression_reference =
-        percentile_99(aggression_clusters.iter().map(|cluster| cluster.quantity));
+    // Computed over every visible cluster, before the display filter below:
+    // hiding small prints must not silently rescale the ones left on screen.
+    let aggression_reference = match config.bubbles.size_reference {
+        BubbleSizeReference::VisibleP99 => {
+            percentile_99(aggression_clusters.iter().map(|cluster| cluster.quantity))
+        }
+        BubbleSizeReference::VisibleMax => aggression_clusters
+            .iter()
+            .map(|cluster| cluster.quantity)
+            .max()
+            .unwrap_or(Decimal::ZERO),
+        BubbleSizeReference::Fixed => config.bubbles.fixed_reference_decimal().unwrap_or_default(),
+    };
 
     let mut events = if config.show_liquidity_events {
         liquidity_events(&grouped.transitions)
@@ -401,6 +412,13 @@ pub fn project(
                 .then_with(|| a.event_id.cmp(&b.event_id))
         });
         events.truncate(config.max_visible_cells);
+    }
+
+    // Display floor for bubbles. Applied after association so a hidden small
+    // print still counts as the evidence behind an aligned reduction: the
+    // marker keeps saying "a trade ate this", the tape just stays readable.
+    if let Some(floor) = config.bubbles.min_quantity_decimal() {
+        aggression_clusters.retain(|cluster| cluster.quantity >= floor);
     }
 
     let dropped_aggressions = if config.show_aggressions {
@@ -598,7 +616,7 @@ fn normalized_area_size(quantity: Decimal, reference: Decimal) -> f32 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::orderflow::config::{DisplayGrouping, HeatmapConfig};
+    use crate::orderflow::config::{BubbleStyle, DisplayGrouping, HeatmapConfig};
     use crate::orderflow::history::LiquidityHistory;
     use quantick_engine::{Bar, Side, Trade};
     use quantick_orderbook::BookSide;
@@ -691,6 +709,169 @@ mod tests {
         let full = normalized_area_size(Decimal::from(100), Decimal::from(100));
         assert!((quarter - 0.5).abs() < f32::EPSILON);
         assert_eq!(full, 1.0);
+    }
+
+    /// Four prints an order of magnitude apart, so the size ladder is visible.
+    /// Clustering is off: these must stay four distinct bubbles.
+    fn history_with_a_size_ladder(config: HeatmapConfig) -> LiquidityHistory {
+        let mut history = LiquidityHistory::new(HeatmapConfig {
+            bubble_cluster_ms: 0,
+            ..config
+        });
+        history.install_snapshot(100, 1, snapshot(10)).unwrap();
+        for (id, quantity) in [(1_u64, "1"), (2, "10"), (3, "50"), (4, "200")] {
+            history.record_aggression(&Trade {
+                agg_id: id,
+                // Spread across time so clustering cannot merge them.
+                timestamp_ms: 200 + (id as i64) * 100,
+                price: dec("101"),
+                quantity: dec(quantity),
+                side: Side::Buy,
+            });
+        }
+        history
+            .apply_delta(900, &BookDelta::new(10, 10, vec![], vec![]))
+            .unwrap();
+        history
+    }
+
+    fn ladder_sizes(config: HeatmapConfig) -> Vec<(Decimal, f32)> {
+        let history = history_with_a_size_ladder(config);
+        let projection = project(
+            &history,
+            &BarTimeline::from_bars(0, &[bar(0, 1_000)], None, None),
+            PriceWindow::new(dec("98"), dec("103")).unwrap(),
+        );
+        let mut sizes: Vec<(Decimal, f32)> = projection
+            .aggressions
+            .iter()
+            .map(|aggression| (aggression.quantity, aggression.size))
+            .collect();
+        sizes.sort_by_key(|pair| pair.0);
+        sizes
+    }
+
+    #[test]
+    fn big_prints_read_as_big_bubbles_under_every_size_reference() {
+        // The size factor drives radius through area, so it must grow strictly
+        // with quantity and reach 1.0 (the maximum radius) for the reference
+        // print. This is the "can I see the large trades?" guarantee.
+        let sizes = ladder_sizes(HeatmapConfig {
+            bubbles: BubbleStyle {
+                size_reference: BubbleSizeReference::VisibleMax,
+                ..BubbleStyle::default()
+            },
+            ..config()
+        });
+        assert_eq!(sizes.len(), 4);
+        for pair in sizes.windows(2) {
+            assert!(
+                pair[1].1 > pair[0].1,
+                "size must grow with quantity: {pair:?}"
+            );
+        }
+        assert_eq!(
+            sizes.last().unwrap().1,
+            1.0,
+            "the biggest print is full size"
+        );
+        // Area proportionality: a quarter of the reference quantity is half the
+        // size factor, i.e. a quarter of the drawn area.
+        let fifty = sizes.iter().find(|(qty, _)| *qty == dec("50")).unwrap().1;
+        assert!(
+            (fifty - 0.5).abs() < 1e-6,
+            "50/200 must map to 0.5, got {fifty}"
+        );
+
+        // A fixed reference pins the scale: the same print keeps the same size
+        // no matter what else is visible, and anything above it saturates.
+        let fixed = ladder_sizes(HeatmapConfig {
+            bubbles: BubbleStyle {
+                size_reference: BubbleSizeReference::Fixed,
+                size_reference_quantity: 50.0,
+                ..BubbleStyle::default()
+            },
+            ..config()
+        });
+        assert_eq!(
+            fixed.iter().find(|(qty, _)| *qty == dec("50")).unwrap().1,
+            1.0
+        );
+        assert_eq!(
+            fixed.last().unwrap().1,
+            1.0,
+            "a print above the fixed reference clamps instead of overflowing"
+        );
+        let small = fixed.first().unwrap().1;
+        assert!(small > 0.0 && small < 0.2, "1/50 stays a dot, got {small}");
+    }
+
+    #[test]
+    fn hiding_small_prints_is_display_only_and_keeps_the_scale() {
+        let bubbles = BubbleStyle {
+            size_reference: BubbleSizeReference::VisibleMax,
+            min_quantity: 20.0,
+            ..BubbleStyle::default()
+        };
+        let sizes = ladder_sizes(HeatmapConfig {
+            bubbles,
+            ..config()
+        });
+        let quantities: Vec<Decimal> = sizes.iter().map(|(qty, _)| *qty).collect();
+        assert_eq!(quantities, vec![dec("50"), dec("200")]);
+        // The reference still comes from every visible print, so the surviving
+        // bubbles keep the size they had before the floor was raised.
+        assert!((sizes[0].1 - 0.5).abs() < 1e-6);
+        assert_eq!(sizes[1].1, 1.0);
+    }
+
+    #[test]
+    fn a_hidden_print_still_explains_the_reduction_it_caused() {
+        // The floor is applied after association, so a small print that ate a
+        // wall keeps the reduction marked as aggression-aligned even though the
+        // bubble itself is not drawn. Hiding noise must never rewrite evidence.
+        let mut history = LiquidityHistory::new(HeatmapConfig {
+            bubbles: BubbleStyle {
+                min_quantity: 100.0,
+                ..BubbleStyle::default()
+            },
+            ..config()
+        });
+        history.install_snapshot(100, 1, snapshot(10)).unwrap();
+        history.record_aggression(&Trade {
+            agg_id: 7,
+            timestamp_ms: 400,
+            price: dec("101"),
+            quantity: dec("3"),
+            side: Side::Buy,
+        });
+        // Ask 101: 4 -> 1, right after the print.
+        history
+            .apply_delta(
+                450,
+                &BookDelta::new(11, 11, vec![], vec![level("101", "1")]),
+            )
+            .unwrap();
+        history
+            .apply_delta(900, &BookDelta::new(12, 12, vec![], vec![]))
+            .unwrap();
+
+        let projection = project(
+            &history,
+            &BarTimeline::from_bars(0, &[bar(0, 1_000)], None, None),
+            PriceWindow::new(dec("98"), dec("103")).unwrap(),
+        );
+        assert!(
+            projection.aggressions.is_empty(),
+            "a 3-lot print is under the 100 floor"
+        );
+        let aligned = projection
+            .liquidity_events
+            .iter()
+            .find(|event| event.price_bucket == dec("101"))
+            .expect("the reduction is still projected");
+        assert_eq!(aligned.evidence, LiquidityEvidence::AggressionAligned);
+        assert!(aligned.matched_quantity > Decimal::ZERO);
     }
 
     #[test]

--- a/crates/app/src/orderflow_render.rs
+++ b/crates/app/src/orderflow_render.rs
@@ -12,7 +12,10 @@ use quantick_orderbook::BookSide;
 use rust_decimal::Decimal;
 use rust_decimal::prelude::ToPrimitive as _;
 
-use crate::orderflow::{HeatmapConfig, HeatmapProjection, HeatmapTheme, LiquidityEvidence};
+use crate::orderflow::{
+    AggressionPrimitive, BubbleStyle, HeatmapConfig, HeatmapProjection, HeatmapTheme,
+    LiquidityEvidence,
+};
 use crate::viewport::Viewport;
 
 // A perceptually smoother Bookmap-style thermal ramp. It keeps the signature
@@ -62,12 +65,8 @@ pub(crate) struct OrderflowRenderStyle {
     pub(crate) min_cell_height: f32,
     /// Strength of the soft edge laid behind each heat cell.
     pub(crate) edge_glow: f32,
-    pub(crate) bubble_min_radius: f32,
-    pub(crate) bubble_max_radius: f32,
-    pub(crate) bubble_opacity: f32,
-    pub(crate) show_quantity_labels: bool,
-    pub(crate) show_trade_count: bool,
-    pub(crate) label_min_radius: f32,
+    /// Every user-owned bubble choice, straight from the settings panel.
+    pub(crate) bubbles: BubbleStyle,
     pub(crate) show_gap_labels: bool,
     pub(crate) show_legend: bool,
     /// Whether the L2 depth layer is active. The legend only advertises keys
@@ -90,15 +89,7 @@ impl Default for OrderflowRenderStyle {
             // Off by default: the per-cell glow doubles the heatmap's quad count,
             // which is the single biggest render cost on a dense book.
             edge_glow: 0.0,
-            // Area stays quantity-proportional: the minimum keeps the smallest
-            // print a subtle dot, the maximum lets a real sweep dominate.
-            bubble_min_radius: 2.0,
-            bubble_max_radius: 15.0,
-            bubble_opacity: 0.78,
-            show_quantity_labels: true,
-            show_trade_count: true,
-            // Only the largest bubbles get a (text-layout-costly) label.
-            label_min_radius: 16.0,
+            bubbles: BubbleStyle::default(),
             show_gap_labels: true,
             show_legend: true,
             depth_layer: true,
@@ -110,16 +101,16 @@ impl Default for OrderflowRenderStyle {
 }
 
 impl OrderflowRenderStyle {
-    /// Resolve the renderer-owned choices that have a corresponding user
-    /// setting. Bubble alpha and maximum radius now come from the aggression
-    /// panel; the remaining geometry stays renderer-owned.
+    /// Resolve every renderer choice that has a corresponding user setting.
+    ///
+    /// The whole bubble vocabulary — alpha, radii, marks, colours — now comes
+    /// from the aggression panel in one struct.
     #[must_use]
     pub(crate) fn from_config(config: &HeatmapConfig, canvas_background: egui::Color32) -> Self {
         Self {
             theme: config.theme,
+            bubbles: config.bubbles.clone(),
             show_legend: config.show_legend,
-            bubble_opacity: config.bubble_opacity,
-            bubble_max_radius: config.bubble_max_radius,
             depth_layer: config.enabled,
             aggression_layer: config.show_aggressions,
             canvas_background,
@@ -133,13 +124,81 @@ impl OrderflowRenderStyle {
         style.heat_opacity = finite_clamp(style.heat_opacity, 0.0, 1.0, 1.0);
         style.min_cell_height = finite_clamp(style.min_cell_height, 0.5, 12.0, 1.5);
         style.edge_glow = finite_clamp(style.edge_glow, 0.0, 1.0, 0.18);
-        style.bubble_min_radius = finite_clamp(style.bubble_min_radius, 1.0, 24.0, 2.75);
-        style.bubble_max_radius =
-            finite_clamp(style.bubble_max_radius, style.bubble_min_radius, 64.0, 13.0);
-        style.bubble_opacity = finite_clamp(style.bubble_opacity, 0.05, 1.0, 0.78);
-        style.label_min_radius = finite_clamp(style.label_min_radius, 4.0, 64.0, 8.5);
+        style.bubbles.sanitize();
         style.legend_max_width = finite_clamp(style.legend_max_width, 160.0, 2_000.0, 690.0);
         style
+    }
+}
+
+/// Bubble colours after the panel's overrides are laid over the theme.
+///
+/// Resolved per draw call and never written back into [`Palette`]: the same
+/// theme colours keep driving the liquidity-response layer, which the bubble
+/// panel does not own.
+#[derive(Debug, Clone, Copy)]
+struct BubbleColors {
+    buy: egui::Color32,
+    sell: egui::Color32,
+    front: egui::Color32,
+    trail: egui::Color32,
+    text: egui::Color32,
+}
+
+impl BubbleColors {
+    fn resolve(palette: &Palette, bubbles: &BubbleStyle) -> Self {
+        let front = bubbles.front_color.map_or(palette.consumption, opaque_rgb);
+        Self {
+            buy: bubbles.buy_color.map_or(palette.buy, opaque_rgb),
+            sell: bubbles.sell_color.map_or(palette.sell, opaque_rgb),
+            front,
+            // The trail is the front's own glow, so it follows it by default.
+            trail: bubbles.trail_color.map_or(front, opaque_rgb),
+            text: bubbles.label_color.map_or(palette.bubble_text, opaque_rgb),
+        }
+    }
+
+    const fn for_side(self, side: Side) -> egui::Color32 {
+        match side {
+            Side::Buy => self.buy,
+            Side::Sell => self.sell,
+        }
+    }
+}
+
+fn opaque_rgb(rgb: [u8; 3]) -> egui::Color32 {
+    egui::Color32::from_rgb(rgb[0], rgb[1], rgb[2])
+}
+
+/// The theme's own bubble colours, so the settings panel can show what
+/// "follows the theme" actually looks like next to a custom swatch.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ThemeBubbleRgb {
+    pub(crate) buy: [u8; 3],
+    pub(crate) sell: [u8; 3],
+    pub(crate) front: [u8; 3],
+    pub(crate) text: [u8; 3],
+}
+
+#[must_use]
+pub(crate) fn theme_bubble_rgb(theme: HeatmapTheme) -> ThemeBubbleRgb {
+    let palette = Palette::for_theme(theme);
+    let rgb = |color: egui::Color32| [color.r(), color.g(), color.b()];
+    ThemeBubbleRgb {
+        buy: rgb(palette.buy),
+        sell: rgb(palette.sell),
+        front: rgb(palette.consumption),
+        text: rgb(palette.bubble_text),
+    }
+}
+
+/// Vertical nudge, in pixels, that keeps the two sides off the same row.
+///
+/// Buy aggression lifts the ask, sell aggression hits the bid, so buys sit
+/// slightly above the print and sells slightly below. Screen y grows downward.
+const fn side_offset_y(side: Side, offset: f32) -> f32 {
+    match side {
+        Side::Buy => -offset,
+        Side::Sell => offset,
     }
 }
 
@@ -451,7 +510,14 @@ pub(crate) fn draw_liquidity_events(painter: &egui::Painter, context: &RenderCon
         if !context.layout.chart_rect.contains(center) {
             continue;
         }
-        let r = bubble_radius(trade.size, style.bubble_min_radius, style.bubble_max_radius);
+        // Follow the bubble's own vertical nudge, so the carved gap stays
+        // centred on the bubble that will be drawn over it.
+        let center = center + egui::vec2(0.0, side_offset_y(trade.side, style.bubbles.side_offset));
+        let r = bubble_radius(
+            trade.size,
+            style.bubbles.min_radius,
+            style.bubbles.max_radius,
+        );
         // Carve from the bubble's midriff rightward: the eaten wall still
         // touches the bubble's left half (the bubble reads as biting into
         // it), while re-stacked liquidity cannot slide through to the right.
@@ -588,46 +654,58 @@ pub(crate) fn draw_liquidity_events(painter: &egui::Painter, context: &RenderCon
 /// sideways and the prints stack into a horizontal band.
 pub(crate) fn draw_aggression_bubbles(painter: &egui::Painter, context: &RenderContext<'_>) {
     let style = context.style.sanitized();
+    let bubbles = &style.bubbles;
     let palette = Palette::for_theme(style.theme);
+    let colors = BubbleColors::resolve(&palette, bubbles);
     let clip = painter.with_clip_rect(context.layout.chart_rect);
     let right_edge = context.layout.chart_rect.right();
 
-    // Consumption glow behind the bubbles, so a bubble's own fill never hides it.
-    let mut glow_mesh = egui::Mesh::default();
-    for trade in &context.projection.aggressions {
-        if trade.matched_fraction <= 0.0 && trade.liquidity_event_ids.is_empty() {
-            continue;
-        }
+    let center_of = |trade: &AggressionPrimitive| {
         let center = egui::pos2(context.layout.x(trade.x), context.layout.y(trade.y));
-        if !context.layout.chart_rect.contains(center) {
-            continue;
+        context
+            .layout
+            .chart_rect
+            .contains(center)
+            .then(|| center + egui::vec2(0.0, side_offset_y(trade.side, bubbles.side_offset)))
+    };
+    let radius_of = |size: f32| bubble_radius(size, bubbles.min_radius, bubbles.max_radius);
+    let front_half_length = |radius: f32| radius * bubbles.front_length_scale + 6.0;
+
+    // Consumption trail behind the bubbles, so a bubble's own fill never hides it.
+    if bubbles.trail_length > 0.0 {
+        let mut trail_mesh = egui::Mesh::default();
+        for trade in &context.projection.aggressions {
+            if trade.matched_fraction <= 0.0 && trade.liquidity_event_ids.is_empty() {
+                continue;
+            }
+            let Some(center) = center_of(trade) else {
+                continue;
+            };
+            let hh = front_half_length(radius_of(trade.size));
+            add_gradient_rect(
+                &mut trail_mesh,
+                egui::Rect::from_min_max(
+                    egui::pos2(center.x, center.y - hh),
+                    egui::pos2(
+                        (center.x + bubbles.trail_length).min(right_edge),
+                        center.y + hh,
+                    ),
+                ),
+                colors.trail.gamma_multiply(bubbles.trail_opacity),
+                egui::Color32::TRANSPARENT,
+            );
         }
-        let radius = bubble_radius(trade.size, style.bubble_min_radius, style.bubble_max_radius);
-        let hh = radius * 2.1 + 6.0;
-        add_gradient_rect(
-            &mut glow_mesh,
-            egui::Rect::from_min_max(
-                egui::pos2(center.x, center.y - hh),
-                egui::pos2((center.x + 18.0).min(right_edge), center.y + hh),
-            ),
-            palette.consumption.gamma_multiply(0.62),
-            egui::Color32::TRANSPARENT,
-        );
-    }
-    if !glow_mesh.is_empty() {
-        clip.add(egui::Shape::mesh(glow_mesh));
+        if !trail_mesh.is_empty() {
+            clip.add(egui::Shape::mesh(trail_mesh));
+        }
     }
 
     for trade in &context.projection.aggressions {
-        let center = egui::pos2(context.layout.x(trade.x), context.layout.y(trade.y));
-        if !context.layout.chart_rect.contains(center) {
+        let Some(center) = center_of(trade) else {
             continue;
-        }
-        let radius = bubble_radius(trade.size, style.bubble_min_radius, style.bubble_max_radius);
-        let color = match trade.side {
-            Side::Buy => palette.buy,
-            Side::Sell => palette.sell,
         };
+        let radius = radius_of(trade.size);
+        let color = colors.for_side(trade.side);
         let linked_reduction =
             trade.matched_fraction > 0.0 || !trade.liquidity_event_ids.is_empty();
 
@@ -635,20 +713,19 @@ pub(crate) fn draw_aggression_bubbles(painter: &egui::Painter, context: &RenderC
         // The full dressing (halo, rim, impact ring) is reserved for bubbles
         // big enough to read it, which also keeps the per-frame tessellation
         // budget flat no matter how fast the tape runs.
-        let dressed = radius >= 4.0;
-        if dressed {
-            clip.circle_filled(
-                center,
-                radius + 2.5,
-                color.gamma_multiply(0.12 + 0.06 * finite_unit(trade.size)),
-            );
+        let dressed = radius >= bubbles.detail_min_radius;
+        if dressed && bubbles.halo_strength > 0.0 {
+            // The halo opens up a little with size, so a sweep reads heavier
+            // than a routine print even at the same rim colour.
+            let halo = (bubbles.halo_strength * (1.0 + 0.5 * finite_unit(trade.size))).min(1.0);
+            clip.circle_filled(center, radius + 2.5, color.gamma_multiply(halo));
         }
-        clip.circle_filled(center, radius, color.gamma_multiply(style.bubble_opacity));
-        if dressed {
+        clip.circle_filled(center, radius, color.gamma_multiply(bubbles.opacity));
+        if dressed && bubbles.outline_width > 0.0 {
             clip.circle_stroke(
                 center,
                 radius,
-                egui::Stroke::new(1.0_f32, color.gamma_multiply(0.96)),
+                egui::Stroke::new(bubbles.outline_width, color.gamma_multiply(0.96)),
             );
         }
 
@@ -656,36 +733,38 @@ pub(crate) fn draw_aggression_bubbles(painter: &egui::Painter, context: &RenderC
             // Vertical consumption front on the bubble: this print ate resting
             // liquidity at this exact price.
             let strength = finite_unit(trade.matched_fraction).max(0.25);
-            let hh = radius * 2.1 + 6.0;
-            clip.line_segment(
-                [
-                    egui::pos2(center.x, center.y - hh),
-                    egui::pos2(center.x, center.y + hh),
-                ],
-                egui::Stroke::new(3.0_f32, palette.consumption.gamma_multiply(1.0)),
-            );
-            if dressed {
+            if bubbles.show_consumption_front {
+                let hh = front_half_length(radius);
+                clip.line_segment(
+                    [
+                        egui::pos2(center.x, center.y - hh),
+                        egui::pos2(center.x, center.y + hh),
+                    ],
+                    egui::Stroke::new(bubbles.front_width, colors.front),
+                );
+            }
+            if dressed && bubbles.show_impact_ring {
                 clip.circle_stroke(
                     center,
                     radius + 2.2,
                     egui::Stroke::new(
-                        2.2_f32,
-                        palette.consumption.gamma_multiply(0.75 + strength * 0.25),
+                        bubbles.impact_ring_width,
+                        colors.front.gamma_multiply(0.75 + strength * 0.25),
                     ),
                 );
             }
         }
 
-        if radius >= style.label_min_radius
+        if radius >= bubbles.label_min_radius
             && let Some(label) = bubble_label(
                 trade.quantity,
                 trade.trade_count,
-                style.show_quantity_labels,
-                style.show_trade_count,
+                bubbles.show_quantity_labels,
+                bubbles.show_trade_count,
             )
         {
             let font = egui::FontId::proportional((radius * 0.68).clamp(8.0, 11.0));
-            let galley = clip.layout_no_wrap(label, font, palette.bubble_text);
+            let galley = clip.layout_no_wrap(label, font, colors.text);
             if galley.size().x <= radius * 1.78 && galley.size().y <= radius * 1.45 {
                 let pos = center - galley.size() / 2.0;
                 clip.galley(
@@ -693,7 +772,7 @@ pub(crate) fn draw_aggression_bubbles(painter: &egui::Painter, context: &RenderC
                     galley.clone(),
                     egui::Color32::from_black_alpha(190),
                 );
-                clip.galley(pos, galley, palette.bubble_text);
+                clip.galley(pos, galley, colors.text);
             }
         }
     }
@@ -706,7 +785,12 @@ pub(crate) fn draw_compact_legend(painter: &egui::Painter, context: &RenderConte
     if !style.show_legend || context.layout.chart_rect.width() < 150.0 {
         return;
     }
-    let palette = Palette::for_theme(style.theme);
+    // The legend is a key for what is on screen, so the aggression swatches
+    // follow the bubble panel's colour overrides.
+    let mut palette = Palette::for_theme(style.theme);
+    let colors = BubbleColors::resolve(&palette, &style.bubbles);
+    palette.buy = colors.buy;
+    palette.sell = colors.sell;
     let clip = painter.with_clip_rect(context.layout.chart_rect);
     let multiple = context.projection.effective_grouping.multiple;
     let liquidity_label = if multiple > 1 {
@@ -947,16 +1031,21 @@ pub(crate) fn draw_preview(ui: &mut egui::Ui, config: &HeatmapConfig) -> egui::R
     }
 
     if config.show_aggressions {
+        let bubbles = &style.bubbles;
+        let colors = BubbleColors::resolve(&palette, bubbles);
+        // Two prints at fixed normalized sizes, so every slider (radius range,
+        // opacity, rim, front, trail, side offset) shows its effect here.
         draw_preview_bubble(
             &painter,
             egui::pos2(
                 egui::lerp(chart.left()..=chart.right(), 0.58),
                 egui::lerp(chart.top()..=chart.bottom(), 0.27),
             ),
-            11.0,
-            palette.buy,
+            bubble_radius(0.85, bubbles.min_radius, bubbles.max_radius),
+            Side::Buy,
             config.show_liquidity_events,
-            &palette,
+            bubbles,
+            &colors,
         );
         draw_preview_bubble(
             &painter,
@@ -964,10 +1053,11 @@ pub(crate) fn draw_preview(ui: &mut egui::Ui, config: &HeatmapConfig) -> egui::R
                 egui::lerp(chart.left()..=chart.right(), 0.43),
                 egui::lerp(chart.top()..=chart.bottom(), 0.72),
             ),
-            8.0,
-            palette.sell,
+            bubble_radius(0.45, bubbles.min_radius, bubbles.max_radius),
+            Side::Sell,
             false,
-            &palette,
+            bubbles,
+            &colors,
         );
     }
 
@@ -1159,46 +1249,67 @@ fn normalized_rect(bounds: egui::Rect, x0: f32, x1: f32, y0: f32, y1: f32) -> eg
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 fn draw_preview_bubble(
     painter: &egui::Painter,
     center: egui::Pos2,
     radius: f32,
-    color: egui::Color32,
+    side: Side,
     linked_reduction: bool,
-    palette: &Palette,
+    bubbles: &BubbleStyle,
+    colors: &BubbleColors,
 ) {
-    let hh = radius * 1.7 + 2.0;
-    if linked_reduction {
-        // Consumption glow behind the bubble (drawn first so the fill sits on
+    let center = center + egui::vec2(0.0, side_offset_y(side, bubbles.side_offset));
+    let color = colors.for_side(side);
+    let hh = radius * bubbles.front_length_scale + 6.0;
+    if linked_reduction && bubbles.trail_length > 0.0 {
+        // Consumption trail behind the bubble (drawn first so the fill sits on
         // top), matching the live "aggression eating a wall" marker.
         let mut mesh = egui::Mesh::default();
         add_gradient_rect(
             &mut mesh,
             egui::Rect::from_min_max(
                 egui::pos2(center.x, center.y - hh),
-                egui::pos2(center.x + 7.0, center.y + hh),
+                egui::pos2(center.x + bubbles.trail_length, center.y + hh),
             ),
-            palette.consumption.gamma_multiply(0.22),
+            colors.trail.gamma_multiply(bubbles.trail_opacity),
             egui::Color32::TRANSPARENT,
         );
         painter.add(egui::Shape::mesh(mesh));
     }
-    painter.circle_filled(center, radius + 2.5, color.gamma_multiply(0.14));
-    painter.circle_filled(center, radius, color.gamma_multiply(0.82));
-    painter.circle_stroke(center, radius, egui::Stroke::new(1.0_f32, color));
-    if linked_reduction {
-        painter.line_segment(
-            [
-                egui::pos2(center.x, center.y - hh),
-                egui::pos2(center.x, center.y + hh),
-            ],
-            egui::Stroke::new(1.6_f32, palette.consumption.gamma_multiply(0.9)),
+    let dressed = radius >= bubbles.detail_min_radius;
+    if dressed && bubbles.halo_strength > 0.0 {
+        painter.circle_filled(
+            center,
+            radius + 2.5,
+            color.gamma_multiply(bubbles.halo_strength),
         );
+    }
+    painter.circle_filled(center, radius, color.gamma_multiply(bubbles.opacity));
+    if dressed && bubbles.outline_width > 0.0 {
         painter.circle_stroke(
             center,
-            radius + 1.6,
-            egui::Stroke::new(1.3_f32, palette.consumption.gamma_multiply(0.9)),
+            radius,
+            egui::Stroke::new(bubbles.outline_width, color),
         );
+    }
+    if linked_reduction {
+        if bubbles.show_consumption_front {
+            painter.line_segment(
+                [
+                    egui::pos2(center.x, center.y - hh),
+                    egui::pos2(center.x, center.y + hh),
+                ],
+                egui::Stroke::new(bubbles.front_width, colors.front),
+            );
+        }
+        if dressed && bubbles.show_impact_ring {
+            painter.circle_stroke(
+                center,
+                radius + 2.2,
+                egui::Stroke::new(bubbles.impact_ring_width, colors.front.gamma_multiply(0.9)),
+            );
+        }
     }
 }
 
@@ -1831,9 +1942,12 @@ mod tests {
             heat_opacity: f32::NAN,
             min_cell_height: f32::INFINITY,
             edge_glow: -1.0,
-            bubble_min_radius: f32::NAN,
-            bubble_max_radius: -4.0,
-            label_min_radius: f32::NAN,
+            bubbles: BubbleStyle {
+                min_radius: f32::NAN,
+                max_radius: -4.0,
+                label_min_radius: f32::NAN,
+                ..BubbleStyle::default()
+            },
             legend_max_width: f32::NAN,
             ..OrderflowRenderStyle::default()
         }
@@ -1841,8 +1955,49 @@ mod tests {
         assert_eq!(style.heat_opacity, 1.0);
         assert_eq!(style.min_cell_height, 1.5);
         assert_eq!(style.edge_glow, 0.0);
-        assert!(style.bubble_max_radius >= style.bubble_min_radius);
+        assert!(style.bubbles.max_radius >= style.bubbles.min_radius);
+        assert!(style.bubbles.label_min_radius.is_finite());
         assert!(style.legend_max_width.is_finite());
+    }
+
+    #[test]
+    fn buy_and_sell_bubbles_are_nudged_to_opposite_sides() {
+        // Screen y grows downward: buys sit above the print, sells below.
+        assert!(side_offset_y(Side::Buy, 4.0) < 0.0);
+        assert!(side_offset_y(Side::Sell, 4.0) > 0.0);
+        assert_eq!(side_offset_y(Side::Buy, 0.0), 0.0);
+        assert_eq!(
+            side_offset_y(Side::Buy, 4.0).abs(),
+            side_offset_y(Side::Sell, 4.0).abs()
+        );
+    }
+
+    #[test]
+    fn bubble_colours_fall_back_to_the_theme_and_the_trail_follows_the_front() {
+        let palette = Palette::for_theme(HeatmapTheme::Bookmap);
+        let default = BubbleColors::resolve(&palette, &BubbleStyle::default());
+        assert_eq!(default.buy, palette.buy);
+        assert_eq!(default.sell, palette.sell);
+        assert_eq!(default.trail, palette.consumption);
+
+        let overridden = BubbleColors::resolve(
+            &palette,
+            &BubbleStyle {
+                buy_color: Some([1, 2, 3]),
+                front_color: Some([9, 9, 9]),
+                ..BubbleStyle::default()
+            },
+        );
+        assert_eq!(overridden.buy, egui::Color32::from_rgb(1, 2, 3));
+        assert_eq!(
+            overridden.sell, palette.sell,
+            "untouched side keeps the theme"
+        );
+        assert_eq!(
+            overridden.trail,
+            egui::Color32::from_rgb(9, 9, 9),
+            "the trail follows the front colour unless overridden itself"
+        );
     }
 
     #[test]

--- a/crates/app/src/orderflow_render.rs
+++ b/crates/app/src/orderflow_render.rs
@@ -202,6 +202,176 @@ const fn side_offset_y(side: Side, offset: f32) -> f32 {
     }
 }
 
+/// Gap, in pixels, between a bubble's rim and the halo drawn behind it.
+const HALO_PADDING_PX: f32 = 2.5;
+/// Gap, in pixels, between a bubble's rim and its impact ring.
+const IMPACT_RING_PADDING_PX: f32 = 2.2;
+/// Pixels added beyond `front_length_scale × radius`, so the consumption mark
+/// on even the smallest bubble is long enough to read as a mark.
+const FRONT_END_PADDING_PX: f32 = 6.0;
+/// How far the halo opens up at full print size, as a fraction of
+/// `halo_strength`: a sweep reads heavier than a routine print of the same
+/// colour, without needing a second colour for it.
+const HALO_SIZE_BOOST: f32 = 0.5;
+/// Rim alpha relative to the fill. A hair below opaque keeps the rim reading
+/// as the bubble's edge rather than as a separate ring on a dark canvas.
+const RIM_ALPHA: f32 = 0.96;
+/// Impact-ring alpha every consuming print gets, before the matched share.
+const IMPACT_RING_BASE_ALPHA: f32 = 0.75;
+/// Share of the impact ring's alpha that tracks how much of the print actually
+/// matched resting liquidity, so a full sweep rings brighter than a nibble.
+const IMPACT_RING_MATCH_ALPHA: f32 = 0.25;
+/// Matched-fraction floor for the consumption marks: a barely matched print
+/// still ate something, so it still leaves a visible mark.
+const MIN_MATCH_STRENGTH: f32 = 0.25;
+
+/// Label font size as a fraction of the bubble radius, and the range it is
+/// held to: too small to read is pointless, too large stops fitting inside.
+const LABEL_FONT_SCALE: f32 = 0.68;
+/// See [`LABEL_FONT_SCALE`].
+const LABEL_MIN_FONT_PX: f32 = 8.0;
+/// See [`LABEL_FONT_SCALE`].
+const LABEL_MAX_FONT_PX: f32 = 11.0;
+/// How far a laid-out label may spill past the radius before it is dropped.
+/// Wider than tall: a bubble is a circle, and text is a horizontal band across
+/// its middle, where there is more room.
+const LABEL_MAX_WIDTH_SCALE: f32 = 1.78;
+/// See [`LABEL_MAX_WIDTH_SCALE`].
+const LABEL_MAX_HEIGHT_SCALE: f32 = 1.45;
+/// Drop shadow that keeps a label legible over any fill colour.
+const LABEL_SHADOW_OFFSET_PX: egui::Vec2 = egui::vec2(1.0, 1.0);
+/// See [`LABEL_SHADOW_OFFSET_PX`].
+const LABEL_SHADOW_ALPHA: u8 = 190;
+
+/// Normalized sizes of the two sample prints in the settings preview: one
+/// near full size and one routine print, so the radius range is visible.
+const PREVIEW_LARGE_PRINT_SIZE: f32 = 0.85;
+/// See [`PREVIEW_LARGE_PRINT_SIZE`].
+const PREVIEW_SMALL_PRINT_SIZE: f32 = 0.45;
+/// Matched fraction of the preview's consuming print. Mid-range, so the
+/// impact ring shows neither its floor nor its ceiling.
+const PREVIEW_MATCHED_FRACTION: f32 = 0.6;
+
+/// Half-length, in pixels, of the vertical consumption front on a bubble of
+/// this radius.
+fn front_half_length(radius: f32, bubbles: &BubbleStyle) -> f32 {
+    radius * bubbles.front_length_scale + FRONT_END_PADDING_PX
+}
+
+/// Halo alpha for a print of this normalized size.
+fn halo_alpha(size: f32, bubbles: &BubbleStyle) -> f32 {
+    (bubbles.halo_strength * (1.0 + HALO_SIZE_BOOST * finite_unit(size))).min(1.0)
+}
+
+/// Impact-ring alpha for a print that matched this fraction of resting
+/// liquidity.
+fn impact_ring_alpha(matched_fraction: f32) -> f32 {
+    IMPACT_RING_BASE_ALPHA
+        + finite_unit(matched_fraction).max(MIN_MATCH_STRENGTH) * IMPACT_RING_MATCH_ALPHA
+}
+
+/// The consumption trail leaking to the right of a bubble, stopped at
+/// `right_edge` so it never paints past the chart.
+fn trail_rect(
+    center: egui::Pos2,
+    half_length: f32,
+    trail_length: f32,
+    right_edge: f32,
+) -> egui::Rect {
+    egui::Rect::from_min_max(
+        egui::pos2(center.x, center.y - half_length),
+        egui::pos2(
+            (center.x + trail_length).min(right_edge),
+            center.y + half_length,
+        ),
+    )
+}
+
+/// One aggression bubble, already placed in screen space.
+#[derive(Debug, Clone, Copy)]
+struct BubbleMark {
+    center: egui::Pos2,
+    radius: f32,
+    side: Side,
+    /// Normalized print size, which opens up the halo.
+    size: f32,
+    /// Fraction of the print matched against resting liquidity, when it ate
+    /// any. `None` draws no consumption marks.
+    matched: Option<f32>,
+}
+
+/// Draw one bubble: halo, fill, rim and — when the print ate resting
+/// liquidity — the vertical consumption front and the impact ring.
+///
+/// The live chart and the settings preview both draw through here, so the
+/// preview cannot drift into showing something the chart does not draw. The
+/// trail is the one mark left out: on the chart every trail is batched into a
+/// single mesh behind all the bubbles, which is a draw-order decision rather
+/// than a per-bubble one.
+fn draw_bubble(
+    painter: &egui::Painter,
+    mark: BubbleMark,
+    bubbles: &BubbleStyle,
+    colors: &BubbleColors,
+) {
+    let BubbleMark {
+        center,
+        radius,
+        side,
+        size,
+        matched,
+    } = mark;
+    let color = colors.for_side(side);
+
+    // Small prints are the common case on a busy tape: one cheap dot each.
+    // The full dressing (halo, rim, impact ring) is reserved for bubbles
+    // big enough to read it, which also keeps the per-frame tessellation
+    // budget flat no matter how fast the tape runs.
+    let dressed = radius >= bubbles.detail_min_radius;
+    if dressed && bubbles.halo_strength > 0.0 {
+        painter.circle_filled(
+            center,
+            radius + HALO_PADDING_PX,
+            color.gamma_multiply(halo_alpha(size, bubbles)),
+        );
+    }
+    painter.circle_filled(center, radius, color.gamma_multiply(bubbles.opacity));
+    if dressed && bubbles.outline_width > 0.0 {
+        painter.circle_stroke(
+            center,
+            radius,
+            egui::Stroke::new(bubbles.outline_width, color.gamma_multiply(RIM_ALPHA)),
+        );
+    }
+
+    // This print ate resting liquidity at this exact price.
+    let Some(matched_fraction) = matched else {
+        return;
+    };
+    if bubbles.show_consumption_front {
+        let half_length = front_half_length(radius, bubbles);
+        painter.line_segment(
+            [
+                egui::pos2(center.x, center.y - half_length),
+                egui::pos2(center.x, center.y + half_length),
+            ],
+            egui::Stroke::new(bubbles.front_width, colors.front),
+        );
+    }
+    if dressed && bubbles.show_impact_ring {
+        painter.circle_stroke(
+            center,
+            radius + IMPACT_RING_PADDING_PX,
+            egui::Stroke::new(
+                bubbles.impact_ring_width,
+                colors
+                    .front
+                    .gamma_multiply(impact_ring_alpha(matched_fraction)),
+            ),
+        );
+    }
+}
+
 /// Mapping between normalized projection coordinates and the chart viewport.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct ProjectedLayout<'a> {
@@ -669,7 +839,6 @@ pub(crate) fn draw_aggression_bubbles(painter: &egui::Painter, context: &RenderC
             .then(|| center + egui::vec2(0.0, side_offset_y(trade.side, bubbles.side_offset)))
     };
     let radius_of = |size: f32| bubble_radius(size, bubbles.min_radius, bubbles.max_radius);
-    let front_half_length = |radius: f32| radius * bubbles.front_length_scale + 6.0;
 
     // Consumption trail behind the bubbles, so a bubble's own fill never hides it.
     if bubbles.trail_length > 0.0 {
@@ -681,16 +850,10 @@ pub(crate) fn draw_aggression_bubbles(painter: &egui::Painter, context: &RenderC
             let Some(center) = center_of(trade) else {
                 continue;
             };
-            let hh = front_half_length(radius_of(trade.size));
+            let half_length = front_half_length(radius_of(trade.size), bubbles);
             add_gradient_rect(
                 &mut trail_mesh,
-                egui::Rect::from_min_max(
-                    egui::pos2(center.x, center.y - hh),
-                    egui::pos2(
-                        (center.x + bubbles.trail_length).min(right_edge),
-                        center.y + hh,
-                    ),
-                ),
+                trail_rect(center, half_length, bubbles.trail_length, right_edge),
                 colors.trail.gamma_multiply(bubbles.trail_opacity),
                 egui::Color32::TRANSPARENT,
             );
@@ -705,55 +868,20 @@ pub(crate) fn draw_aggression_bubbles(painter: &egui::Painter, context: &RenderC
             continue;
         };
         let radius = radius_of(trade.size);
-        let color = colors.for_side(trade.side);
         let linked_reduction =
             trade.matched_fraction > 0.0 || !trade.liquidity_event_ids.is_empty();
-
-        // Small prints are the common case on a busy tape: one cheap dot each.
-        // The full dressing (halo, rim, impact ring) is reserved for bubbles
-        // big enough to read it, which also keeps the per-frame tessellation
-        // budget flat no matter how fast the tape runs.
-        let dressed = radius >= bubbles.detail_min_radius;
-        if dressed && bubbles.halo_strength > 0.0 {
-            // The halo opens up a little with size, so a sweep reads heavier
-            // than a routine print even at the same rim colour.
-            let halo = (bubbles.halo_strength * (1.0 + 0.5 * finite_unit(trade.size))).min(1.0);
-            clip.circle_filled(center, radius + 2.5, color.gamma_multiply(halo));
-        }
-        clip.circle_filled(center, radius, color.gamma_multiply(bubbles.opacity));
-        if dressed && bubbles.outline_width > 0.0 {
-            clip.circle_stroke(
+        draw_bubble(
+            &clip,
+            BubbleMark {
                 center,
                 radius,
-                egui::Stroke::new(bubbles.outline_width, color.gamma_multiply(0.96)),
-            );
-        }
-
-        if linked_reduction {
-            // Vertical consumption front on the bubble: this print ate resting
-            // liquidity at this exact price.
-            let strength = finite_unit(trade.matched_fraction).max(0.25);
-            if bubbles.show_consumption_front {
-                let hh = front_half_length(radius);
-                clip.line_segment(
-                    [
-                        egui::pos2(center.x, center.y - hh),
-                        egui::pos2(center.x, center.y + hh),
-                    ],
-                    egui::Stroke::new(bubbles.front_width, colors.front),
-                );
-            }
-            if dressed && bubbles.show_impact_ring {
-                clip.circle_stroke(
-                    center,
-                    radius + 2.2,
-                    egui::Stroke::new(
-                        bubbles.impact_ring_width,
-                        colors.front.gamma_multiply(0.75 + strength * 0.25),
-                    ),
-                );
-            }
-        }
+                side: trade.side,
+                size: trade.size,
+                matched: linked_reduction.then_some(trade.matched_fraction),
+            },
+            bubbles,
+            &colors,
+        );
 
         if radius >= bubbles.label_min_radius
             && let Some(label) = bubble_label(
@@ -763,14 +891,18 @@ pub(crate) fn draw_aggression_bubbles(painter: &egui::Painter, context: &RenderC
                 bubbles.show_trade_count,
             )
         {
-            let font = egui::FontId::proportional((radius * 0.68).clamp(8.0, 11.0));
+            let font = egui::FontId::proportional(
+                (radius * LABEL_FONT_SCALE).clamp(LABEL_MIN_FONT_PX, LABEL_MAX_FONT_PX),
+            );
             let galley = clip.layout_no_wrap(label, font, colors.text);
-            if galley.size().x <= radius * 1.78 && galley.size().y <= radius * 1.45 {
+            if galley.size().x <= radius * LABEL_MAX_WIDTH_SCALE
+                && galley.size().y <= radius * LABEL_MAX_HEIGHT_SCALE
+            {
                 let pos = center - galley.size() / 2.0;
                 clip.galley(
-                    pos + egui::vec2(1.0, 1.0),
+                    pos + LABEL_SHADOW_OFFSET_PX,
                     galley.clone(),
-                    egui::Color32::from_black_alpha(190),
+                    egui::Color32::from_black_alpha(LABEL_SHADOW_ALPHA),
                 );
                 clip.galley(pos, galley, colors.text);
             }
@@ -1037,25 +1169,31 @@ pub(crate) fn draw_preview(ui: &mut egui::Ui, config: &HeatmapConfig) -> egui::R
         // opacity, rim, front, trail, side offset) shows its effect here.
         draw_preview_bubble(
             &painter,
-            egui::pos2(
-                egui::lerp(chart.left()..=chart.right(), 0.58),
-                egui::lerp(chart.top()..=chart.bottom(), 0.27),
-            ),
-            bubble_radius(0.85, bubbles.min_radius, bubbles.max_radius),
-            Side::Buy,
-            config.show_liquidity_events,
+            PreviewBubble {
+                center: egui::pos2(
+                    egui::lerp(chart.left()..=chart.right(), 0.58),
+                    egui::lerp(chart.top()..=chart.bottom(), 0.27),
+                ),
+                size: PREVIEW_LARGE_PRINT_SIZE,
+                side: Side::Buy,
+                linked_reduction: config.show_liquidity_events,
+            },
+            chart.right(),
             bubbles,
             &colors,
         );
         draw_preview_bubble(
             &painter,
-            egui::pos2(
-                egui::lerp(chart.left()..=chart.right(), 0.43),
-                egui::lerp(chart.top()..=chart.bottom(), 0.72),
-            ),
-            bubble_radius(0.45, bubbles.min_radius, bubbles.max_radius),
-            Side::Sell,
-            false,
+            PreviewBubble {
+                center: egui::pos2(
+                    egui::lerp(chart.left()..=chart.right(), 0.43),
+                    egui::lerp(chart.top()..=chart.bottom(), 0.72),
+                ),
+                size: PREVIEW_SMALL_PRINT_SIZE,
+                side: Side::Sell,
+                linked_reduction: false,
+            },
+            chart.right(),
             bubbles,
             &colors,
         );
@@ -1249,68 +1387,67 @@ fn normalized_rect(bounds: egui::Rect, x0: f32, x1: f32, y0: f32, y1: f32) -> eg
     )
 }
 
-#[allow(clippy::too_many_arguments)]
+/// One sample print in the settings preview.
+#[derive(Debug, Clone, Copy)]
+struct PreviewBubble {
+    center: egui::Pos2,
+    /// Normalized print size, as the projection would report it.
+    size: f32,
+    side: Side,
+    /// Whether this sample ate resting liquidity, so it shows the marks.
+    linked_reduction: bool,
+}
+
+/// Draw one preview print exactly the way the chart would draw it.
+///
+/// Everything past the trail goes through [`draw_bubble`], the same function
+/// the live chart uses: a preview that renders its own approximation would
+/// send the user tuning sliders against a picture the chart never produces.
 fn draw_preview_bubble(
     painter: &egui::Painter,
-    center: egui::Pos2,
-    radius: f32,
-    side: Side,
-    linked_reduction: bool,
+    preview: PreviewBubble,
+    right_edge: f32,
     bubbles: &BubbleStyle,
     colors: &BubbleColors,
 ) {
+    let PreviewBubble {
+        center,
+        size,
+        side,
+        linked_reduction,
+    } = preview;
     let center = center + egui::vec2(0.0, side_offset_y(side, bubbles.side_offset));
-    let color = colors.for_side(side);
-    let hh = radius * bubbles.front_length_scale + 6.0;
+    let radius = bubble_radius(size, bubbles.min_radius, bubbles.max_radius);
     if linked_reduction && bubbles.trail_length > 0.0 {
         // Consumption trail behind the bubble (drawn first so the fill sits on
-        // top), matching the live "aggression eating a wall" marker.
+        // top). On the chart this is batched across every bubble; here there
+        // are two, so one mesh each costs nothing.
         let mut mesh = egui::Mesh::default();
         add_gradient_rect(
             &mut mesh,
-            egui::Rect::from_min_max(
-                egui::pos2(center.x, center.y - hh),
-                egui::pos2(center.x + bubbles.trail_length, center.y + hh),
+            trail_rect(
+                center,
+                front_half_length(radius, bubbles),
+                bubbles.trail_length,
+                right_edge,
             ),
             colors.trail.gamma_multiply(bubbles.trail_opacity),
             egui::Color32::TRANSPARENT,
         );
         painter.add(egui::Shape::mesh(mesh));
     }
-    let dressed = radius >= bubbles.detail_min_radius;
-    if dressed && bubbles.halo_strength > 0.0 {
-        painter.circle_filled(
-            center,
-            radius + 2.5,
-            color.gamma_multiply(bubbles.halo_strength),
-        );
-    }
-    painter.circle_filled(center, radius, color.gamma_multiply(bubbles.opacity));
-    if dressed && bubbles.outline_width > 0.0 {
-        painter.circle_stroke(
+    draw_bubble(
+        painter,
+        BubbleMark {
             center,
             radius,
-            egui::Stroke::new(bubbles.outline_width, color),
-        );
-    }
-    if linked_reduction {
-        if bubbles.show_consumption_front {
-            painter.line_segment(
-                [
-                    egui::pos2(center.x, center.y - hh),
-                    egui::pos2(center.x, center.y + hh),
-                ],
-                egui::Stroke::new(bubbles.front_width, colors.front),
-            );
-        }
-        if dressed && bubbles.show_impact_ring {
-            painter.circle_stroke(
-                center,
-                radius + 2.2,
-                egui::Stroke::new(bubbles.impact_ring_width, colors.front.gamma_multiply(0.9)),
-            );
-        }
-    }
+            side,
+            size,
+            matched: linked_reduction.then_some(PREVIEW_MATCHED_FRACTION),
+        },
+        bubbles,
+        colors,
+    );
 }
 
 fn draw_preview_legend(
@@ -1970,6 +2107,94 @@ mod tests {
             side_offset_y(Side::Buy, 4.0).abs(),
             side_offset_y(Side::Sell, 4.0).abs()
         );
+    }
+
+    /// Paint through `draw` off-screen and return the shapes it emitted.
+    fn painted(draw: impl Fn(&egui::Painter)) -> String {
+        let ctx = egui::Context::default();
+        let output = ctx.run(egui::RawInput::default(), |ctx| {
+            draw(&ctx.layer_painter(egui::LayerId::background()));
+        });
+        format!("{:?}", output.shapes)
+    }
+
+    #[test]
+    fn the_preview_draws_a_bubble_exactly_the_way_the_chart_does() {
+        // The preview is the instrument the user tunes the sliders against, so
+        // it must not render its own approximation. Both paths go through
+        // draw_bubble; with the trail off (the one mark the chart batches
+        // separately) they must emit identical shapes.
+        let bubbles = BubbleStyle {
+            trail_length: 0.0,
+            ..BubbleStyle::default()
+        };
+        let colors = BubbleColors::resolve(&Palette::for_theme(HeatmapTheme::Bookmap), &bubbles);
+        let at = egui::pos2(120.0, 80.0);
+        let radius = bubble_radius(
+            PREVIEW_LARGE_PRINT_SIZE,
+            bubbles.min_radius,
+            bubbles.max_radius,
+        );
+
+        let live = painted(|painter| {
+            draw_bubble(
+                painter,
+                BubbleMark {
+                    center: at + egui::vec2(0.0, side_offset_y(Side::Buy, bubbles.side_offset)),
+                    radius,
+                    side: Side::Buy,
+                    size: PREVIEW_LARGE_PRINT_SIZE,
+                    matched: Some(PREVIEW_MATCHED_FRACTION),
+                },
+                &bubbles,
+                &colors,
+            );
+        });
+        let preview = painted(|painter| {
+            draw_preview_bubble(
+                painter,
+                PreviewBubble {
+                    center: at,
+                    size: PREVIEW_LARGE_PRINT_SIZE,
+                    side: Side::Buy,
+                    linked_reduction: true,
+                },
+                f32::INFINITY,
+                &bubbles,
+                &colors,
+            );
+        });
+        assert!(
+            live.contains("Circle"),
+            "the sample must actually draw a bubble: {live}"
+        );
+        assert_eq!(live, preview);
+    }
+
+    #[test]
+    fn bubble_marks_scale_with_size_and_matched_share() {
+        let bubbles = BubbleStyle::default();
+        // The front grows with the radius, and never collapses to nothing on
+        // the smallest bubble.
+        assert!(front_half_length(10.0, &bubbles) > front_half_length(2.0, &bubbles));
+        assert!(front_half_length(0.0, &bubbles) >= FRONT_END_PADDING_PX);
+        // A sweep haloes brighter than a routine print, and alpha stays legal.
+        assert!(halo_alpha(1.0, &bubbles) > halo_alpha(0.0, &bubbles));
+        assert!(halo_alpha(1.0, &bubbles) <= 1.0);
+        assert_eq!(
+            halo_alpha(0.0, &bubbles),
+            bubbles.halo_strength,
+            "an unsized print gets the plain halo"
+        );
+        assert!(
+            halo_alpha(f32::NAN, &bubbles).is_finite(),
+            "a non-finite size must not poison the alpha"
+        );
+        // The ring brightens with the share of the print that matched, from a
+        // floor that keeps a nibble visible.
+        assert!(impact_ring_alpha(1.0) > impact_ring_alpha(0.0));
+        assert!(impact_ring_alpha(0.0) >= IMPACT_RING_BASE_ALPHA);
+        assert!(impact_ring_alpha(1.0) <= 1.0);
     }
 
     #[test]

--- a/crates/app/src/orderflow_view.rs
+++ b/crates/app/src/orderflow_view.rs
@@ -440,29 +440,27 @@ impl OrderflowView {
     /// Saving writes the whole presets file, so what the panel shows and what
     /// the repository holds never drift apart.
     fn draw_bubble_presets(&mut self, ui: &mut egui::Ui) {
-        let names: Vec<String> = self
-            .presets
-            .presets
-            .iter()
-            .map(|preset| preset.name.clone())
-            .collect();
+        // The picker reads the stored presets while the closure below wants to
+        // mutate them, so it hands back an index and the name is read after.
+        // Cloning every name each frame would be the other way out, and this
+        // runs on the render thread.
         let mut chosen = None;
         ui.horizontal(|ui| {
             ui.label("preset");
             let selected = if self.presets.active.is_empty() {
-                "— custom —".to_owned()
+                "— custom —"
             } else {
-                self.presets.active.clone()
+                self.presets.active.as_str()
             };
             egui::ComboBox::from_id_salt("bubble_preset")
                 .selected_text(selected)
                 .show_ui(ui, |ui| {
-                    for name in &names {
+                    for (index, preset) in self.presets.presets.iter().enumerate() {
                         if ui
-                            .selectable_label(self.presets.active == *name, name)
+                            .selectable_label(self.presets.active == preset.name, &preset.name)
                             .clicked()
                         {
-                            chosen = Some(name.clone());
+                            chosen = Some(index);
                         }
                     }
                 });
@@ -499,7 +497,13 @@ impl OrderflowView {
                 self.persist_presets(format!("preset '{name}' removed"));
             }
         });
-        if let Some(name) = chosen {
+        if let Some(index) = chosen
+            && let Some(name) = self
+                .presets
+                .presets
+                .get(index)
+                .map(|preset| preset.name.clone())
+        {
             self.apply_preset(&name);
         }
         ui.small(format!("presets · {}", self.presets_source));

--- a/crates/app/src/orderflow_view.rs
+++ b/crates/app/src/orderflow_view.rs
@@ -16,9 +16,10 @@ use quantick_feed_binance::depth::DepthEvent;
 use rust_decimal::Decimal;
 use rust_decimal::prelude::{FromPrimitive as _, ToPrimitive as _};
 
+use crate::bubble_presets::{self, BubblePreset, BubblePresetFile, PresetSource};
 use crate::orderflow::{
-    DisplayGrouping, HeatmapConfig, HeatmapTheme, IntensityMode, MAX_BUBBLE_MAX_RADIUS,
-    MIN_BUBBLE_MAX_RADIUS,
+    BubbleSizeReference, DisplayGrouping, HeatmapConfig, HeatmapTheme, IntensityMode,
+    MAX_BUBBLE_MAX_RADIUS, MAX_BUBBLE_MIN_RADIUS, MIN_BUBBLE_MAX_RADIUS,
 };
 use crate::orderflow_engine::{
     BookPublished, CaptureStatus, OrderflowHealth, PROJECTION_INTERVAL, ProjectionLayout,
@@ -27,6 +28,7 @@ use crate::orderflow_engine::{
 use crate::orderflow_render::{
     OrderflowRenderStyle, ProjectedLayout, RenderContext, draw_aggression_bubbles,
     draw_compact_legend, draw_heatmap_background, draw_liquidity_events, draw_preview,
+    theme_bubble_rgb,
 };
 use crate::orderflow_worker::{BookCommand, BookWorker};
 use crate::viewport::Viewport;
@@ -63,13 +65,49 @@ pub struct OrderflowView {
     pending_capture_grouping_previous: Option<Decimal>,
     last_requested_layout: Option<ProjectionLayout>,
     last_request_at: Option<Instant>,
+    /// Named bubble looks, loaded from the versionable presets file.
+    presets: BubblePresetFile,
+    /// Where those presets came from, shown in the panel.
+    presets_source: PresetSource,
+    /// Name being typed for the next save.
+    preset_name_draft: String,
+    /// Last preset action (or failure), shown verbatim in the panel.
+    preset_status: Option<String>,
 }
 
 impl OrderflowView {
     #[must_use]
     pub fn new(symbol: impl Into<String>) -> Self {
         let symbol = symbol.into();
-        let config = HeatmapConfig::default();
+        let mut config = HeatmapConfig::default();
+        // The presets file is the record of how the tape should look, so the
+        // chart opens on its active preset instead of the compiled defaults.
+        let (presets, presets_source, load_error) = bubble_presets::load();
+        let mut preset_status = None;
+        if let Some(message) = load_error {
+            tracing::error!(
+                target: "quantick::app",
+                schema_version = 1_u8,
+                event_code = "BUBBLE_PRESETS_UNREADABLE",
+                error = message.as_str(),
+                action = "using_built_in_presets",
+                "bubble presets file could not be read; built-in presets are in use"
+            );
+            preset_status = Some(format!("presets not loaded — {message}"));
+        }
+        if let Some(active) = presets.get(&presets.active) {
+            active.apply_to(&mut config);
+        }
+        tracing::info!(
+            target: "quantick::app",
+            schema_version = 1_u8,
+            event_code = "BUBBLE_PRESETS_LOADED",
+            source = %presets_source,
+            stored = presets.presets.len(),
+            active = presets.active.as_str(),
+            "bubble presets resolved"
+        );
+        let preset_name_draft = presets.active.clone();
         let base_grouping = config.price_grouping;
         Self {
             worker: BookWorker::spawn(&symbol),
@@ -83,6 +121,10 @@ impl OrderflowView {
             pending_capture_grouping_previous: None,
             last_requested_layout: None,
             last_request_at: None,
+            presets,
+            presets_source,
+            preset_name_draft,
+            preset_status,
         }
     }
 
@@ -393,6 +435,332 @@ impl OrderflowView {
         self.worker.send(BookCommand::ResetSummaryCounters);
     }
 
+    /// Picker, save and reload for the named bubble looks.
+    ///
+    /// Saving writes the whole presets file, so what the panel shows and what
+    /// the repository holds never drift apart.
+    fn draw_bubble_presets(&mut self, ui: &mut egui::Ui) {
+        let names: Vec<String> = self
+            .presets
+            .presets
+            .iter()
+            .map(|preset| preset.name.clone())
+            .collect();
+        let mut chosen = None;
+        ui.horizontal(|ui| {
+            ui.label("preset");
+            let selected = if self.presets.active.is_empty() {
+                "— custom —".to_owned()
+            } else {
+                self.presets.active.clone()
+            };
+            egui::ComboBox::from_id_salt("bubble_preset")
+                .selected_text(selected)
+                .show_ui(ui, |ui| {
+                    for name in &names {
+                        if ui
+                            .selectable_label(self.presets.active == *name, name)
+                            .clicked()
+                        {
+                            chosen = Some(name.clone());
+                        }
+                    }
+                });
+            if ui
+                .small_button("↻")
+                .on_hover_text("reload the presets file from disk, discarding unsaved tweaks")
+                .clicked()
+            {
+                self.reload_presets();
+            }
+        });
+        ui.horizontal(|ui| {
+            ui.add(
+                egui::TextEdit::singleline(&mut self.preset_name_draft)
+                    .hint_text("preset name")
+                    .desired_width(150.0),
+            );
+            if ui
+                .button("save")
+                .on_hover_text("write the current bubble settings to the presets file")
+                .clicked()
+            {
+                self.save_preset();
+            }
+            let removable = !self.preset_name_draft.trim().is_empty()
+                && self.presets.get(self.preset_name_draft.trim()).is_some();
+            if ui
+                .add_enabled(removable, egui::Button::new("delete"))
+                .on_hover_text("remove this preset from the file")
+                .clicked()
+            {
+                let name = self.preset_name_draft.trim().to_owned();
+                self.presets.remove(&name);
+                self.persist_presets(format!("preset '{name}' removed"));
+            }
+        });
+        if let Some(name) = chosen {
+            self.apply_preset(&name);
+        }
+        ui.small(format!("presets · {}", self.presets_source));
+        if let Some(status) = &self.preset_status {
+            ui.small(status.clone());
+        }
+    }
+
+    fn apply_preset(&mut self, name: &str) {
+        let Some(preset) = self.presets.get(name).cloned() else {
+            return;
+        };
+        preset.apply_to(&mut self.config);
+        self.presets.active = preset.name.clone();
+        self.preset_name_draft = preset.name.clone();
+        self.preset_status = Some(format!("'{}' applied", preset.name));
+    }
+
+    fn save_preset(&mut self) {
+        let name = self.preset_name_draft.trim().to_owned();
+        if name.is_empty() {
+            self.preset_status = Some("name the preset before saving".to_owned());
+            return;
+        }
+        self.presets
+            .upsert(BubblePreset::capture(&name, &self.config));
+        self.presets.active = name.clone();
+        self.persist_presets(format!("'{name}' saved"));
+    }
+
+    fn persist_presets(&mut self, success: String) {
+        match bubble_presets::save(&self.presets) {
+            Ok(path) => {
+                self.presets_source = PresetSource::WorkingDir(path.clone());
+                self.preset_status = Some(format!("{success} → {}", path.display()));
+            }
+            Err(message) => {
+                tracing::error!(
+                    target: "quantick::app",
+                    schema_version = 1_u8,
+                    event_code = "BUBBLE_PRESETS_NOT_SAVED",
+                    error = message.as_str(),
+                    action = "keep_settings_in_memory_only",
+                    "bubble presets could not be written; the current look is in memory only"
+                );
+                self.preset_status = Some(format!("not saved — {message}"));
+            }
+        }
+    }
+
+    fn reload_presets(&mut self) {
+        let (presets, source, error) = bubble_presets::load();
+        self.presets = presets;
+        self.presets_source = source;
+        match error {
+            Some(message) => {
+                tracing::error!(
+                    target: "quantick::app",
+                    schema_version = 1_u8,
+                    event_code = "BUBBLE_PRESETS_UNREADABLE",
+                    error = message.as_str(),
+                    action = "using_built_in_presets",
+                    "bubble presets file could not be read; built-in presets are in use"
+                );
+                self.preset_status = Some(format!("presets not loaded — {message}"));
+            }
+            None => {
+                let active = self.presets.active.clone();
+                if active.is_empty() {
+                    self.preset_status = Some("presets reloaded".to_owned());
+                } else {
+                    self.apply_preset(&active);
+                    self.preset_status = Some(format!("reloaded · '{active}' applied"));
+                }
+            }
+        }
+    }
+
+    /// Every visual choice for the bubbles themselves, grouped so the section
+    /// stays readable: size and placement, the marks a consuming print leaves,
+    /// labels, and colour.
+    fn draw_bubble_controls(&mut self, ui: &mut egui::Ui) {
+        let theme_rgb = theme_bubble_rgb(self.config.theme);
+        let bubbles = &mut self.config.bubbles;
+
+        egui::CollapsingHeader::new("size & placement")
+            .id_salt("bubble_size_section")
+            .default_open(true)
+            .show(ui, |ui| {
+                ui.add(
+                    egui::Slider::new(&mut bubbles.min_radius, 0.5..=MAX_BUBBLE_MIN_RADIUS)
+                        .text("smallest print px"),
+                )
+                .on_hover_text("floor radius, so the quietest print is still a visible dot");
+                ui.add(
+                    egui::Slider::new(
+                        &mut bubbles.max_radius,
+                        MIN_BUBBLE_MAX_RADIUS..=MAX_BUBBLE_MAX_RADIUS,
+                    )
+                    .text("biggest print px"),
+                )
+                .on_hover_text(
+                    "radius of a full-size print; bubble *area* stays proportional to \
+                         quantity between the two limits",
+                );
+                if bubbles.max_radius < bubbles.min_radius {
+                    bubbles.max_radius = bubbles.min_radius;
+                }
+                ui.horizontal(|ui| {
+                    ui.label("full size at");
+                    egui::ComboBox::from_id_salt("bubble_size_reference")
+                        .selected_text(size_reference_label(bubbles.size_reference))
+                        .show_ui(ui, |ui| {
+                            ui.selectable_value(
+                                &mut bubbles.size_reference,
+                                BubbleSizeReference::VisibleP99,
+                                "Auto · visible P99",
+                            );
+                            ui.selectable_value(
+                                &mut bubbles.size_reference,
+                                BubbleSizeReference::VisibleMax,
+                                "Auto · largest visible",
+                            );
+                            ui.selectable_value(
+                                &mut bubbles.size_reference,
+                                BubbleSizeReference::Fixed,
+                                "Fixed quantity",
+                            );
+                        })
+                        .response
+                        .on_hover_text(
+                            "P99 keeps one outlier sweep from shrinking everything else, but \
+                             the top 1% all render at the maximum radius. 'Largest visible' \
+                             restores a strict order; a fixed quantity makes bubble size mean \
+                             the same thing across sessions.",
+                        );
+                });
+                if bubbles.size_reference == BubbleSizeReference::Fixed {
+                    ui.add(
+                        egui::DragValue::new(&mut bubbles.size_reference_quantity)
+                            .range(0.000_001..=1_000_000_000.0)
+                            .speed(1.0)
+                            .prefix("full size qty "),
+                    )
+                    .on_hover_text("quantity drawn at the maximum radius, in the symbol's units");
+                }
+                ui.add(
+                    egui::DragValue::new(&mut bubbles.min_quantity)
+                        .range(0.0..=1_000_000_000.0)
+                        .speed(0.5)
+                        .prefix("hide below qty "),
+                )
+                .on_hover_text(
+                    "display-only floor: smaller prints are not drawn. Applied after liquidity \
+                     association, so a hidden print still counts as the evidence behind a \
+                     consumption mark. Zero draws everything.",
+                );
+                ui.add(
+                    egui::Slider::new(&mut bubbles.side_offset, 0.0..=20.0)
+                        .text("side separation px"),
+                )
+                .on_hover_text(
+                    "buy bubbles are nudged up, sell bubbles down: a buy lifts the ask, a sell \
+                     hits the bid, so they are not on the same row. With a one-tick spread they \
+                     would otherwise stack into an unreadable line. Zero pins both to the exact \
+                     price.",
+                );
+                ui.add(egui::Slider::new(&mut bubbles.opacity, 0.05..=1.0).text("fill opacity"));
+                ui.add(
+                    egui::Slider::new(&mut bubbles.outline_width, 0.0..=4.0).text("rim width px"),
+                )
+                .on_hover_text("zero draws no rim");
+                ui.add(egui::Slider::new(&mut bubbles.halo_strength, 0.0..=0.6).text("halo"))
+                    .on_hover_text("soft glow behind the fill; opens up a little with size");
+                ui.add(
+                    egui::Slider::new(&mut bubbles.detail_min_radius, 0.0..=20.0)
+                        .text("detail from px"),
+                )
+                .on_hover_text(
+                    "bubbles smaller than this are plain dots (no halo, rim or impact ring). \
+                     Raising it buys frame time on a fast tape.",
+                );
+            });
+
+        egui::CollapsingHeader::new("consumption marks")
+            .id_salt("bubble_consumption_section")
+            .default_open(true)
+            .show(ui, |ui| {
+                ui.small(
+                    "Drawn only when a print aligned with a factual L2 reduction — the bubble \
+                     ate resting liquidity.",
+                );
+                ui.checkbox(
+                    &mut bubbles.show_consumption_front,
+                    "vertical front through the bubble",
+                );
+                ui.add_enabled(
+                    bubbles.show_consumption_front,
+                    egui::Slider::new(&mut bubbles.front_width, 0.5..=10.0).text("front width px"),
+                );
+                ui.add_enabled(
+                    bubbles.show_consumption_front,
+                    egui::Slider::new(&mut bubbles.front_length_scale, 0.5..=6.0)
+                        .text("front length × radius"),
+                );
+                ui.checkbox(&mut bubbles.show_impact_ring, "impact ring on the rim");
+                ui.add_enabled(
+                    bubbles.show_impact_ring,
+                    egui::Slider::new(&mut bubbles.impact_ring_width, 0.5..=6.0)
+                        .text("ring width px"),
+                )
+                .on_hover_text("brightness of the ring also tracks how much of the print matched");
+                ui.add(
+                    egui::Slider::new(&mut bubbles.trail_length, 0.0..=80.0)
+                        .text("trail length px"),
+                )
+                .on_hover_text(
+                    "the glow leaking into the consumed side, marking where the wall ended; \
+                     zero draws no trail",
+                );
+                ui.add_enabled(
+                    bubbles.trail_length > 0.0,
+                    egui::Slider::new(&mut bubbles.trail_opacity, 0.0..=1.0).text("trail opacity"),
+                );
+            });
+
+        egui::CollapsingHeader::new("labels")
+            .id_salt("bubble_label_section")
+            .show(ui, |ui| {
+                ui.checkbox(
+                    &mut bubbles.show_quantity_labels,
+                    "quantity inside the bubble",
+                );
+                ui.checkbox(&mut bubbles.show_trade_count, "×N clustered prints");
+                ui.add(
+                    egui::Slider::new(&mut bubbles.label_min_radius, 4.0..=48.0)
+                        .text("label from px"),
+                )
+                .on_hover_text(
+                    "only bubbles this big get a label, and only when the text fits inside",
+                );
+            });
+
+        egui::CollapsingHeader::new("colours")
+            .id_salt("bubble_colour_section")
+            .show(ui, |ui| {
+                let front_fallback = bubbles.front_color.unwrap_or(theme_rgb.front);
+                color_override(ui, "buy", &mut bubbles.buy_color, theme_rgb.buy);
+                color_override(ui, "sell", &mut bubbles.sell_color, theme_rgb.sell);
+                color_override(
+                    ui,
+                    "consumption front",
+                    &mut bubbles.front_color,
+                    theme_rgb.front,
+                );
+                color_override(ui, "trail", &mut bubbles.trail_color, front_fallback);
+                color_override(ui, "label", &mut bubbles.label_color, theme_rgb.text);
+                ui.small("Unset colours follow the chart theme.");
+            });
+    }
+
     /// Draw the docked order-flow panels and return whether capture must
     /// restart because the base capture resolution changed.
     ///
@@ -641,11 +1009,11 @@ impl OrderflowView {
                     self.config = HeatmapConfig {
                         enabled: self.config.enabled,
                         price_grouping,
-                        // The bubble layer owns its own panel and its own reset.
+                        // The bubble layer owns its own panel and its own reset,
+                        // so its whole look (and the preset it came from) stays.
                         show_aggressions: self.config.show_aggressions,
                         bubble_cluster_ms: self.config.bubble_cluster_ms,
-                        bubble_opacity: self.config.bubble_opacity,
-                        bubble_max_radius: self.config.bubble_max_radius,
+                        bubbles: self.config.bubbles.clone(),
                         ..HeatmapConfig::default()
                     };
                 }
@@ -677,6 +1045,12 @@ impl OrderflowView {
                         ui.small(
                             "This layer is independent: it keeps drawing with L2 capture off.",
                         );
+                        draw_preview(ui, &self.config).on_hover_text(
+                            "Deterministic preview: every control below shows its effect here, without waiting for a trade.",
+                        );
+                        ui.separator();
+
+                        self.draw_bubble_presets(ui);
                         ui.separator();
 
                         ui.checkbox(&mut self.config.show_aggressions, "show aggression bubbles")
@@ -690,11 +1064,13 @@ impl OrderflowView {
                                     .selected_text(cluster_label(self.config.bubble_cluster_ms))
                                     .show_ui(ui, |ui| {
                                         for (milliseconds, label) in [
-                                            (0, "Raw"),
+                                            (0, "Raw · one bubble per print"),
                                             (50, "50 ms"),
                                             (100, "100 ms"),
                                             (200, "200 ms"),
                                             (500, "500 ms"),
+                                            (1_000, "1 s"),
+                                            (2_000, "2 s"),
                                         ] {
                                             ui.selectable_value(
                                                 &mut self.config.bubble_cluster_ms,
@@ -706,22 +1082,9 @@ impl OrderflowView {
                             })
                             .response
                             .on_hover_text(
-                                "merge compatible prints inside this window into one bubble; Raw keeps one bubble per trade",
+                                "merge compatible prints (same side, same price range) inside this window into one bubble; quantities are summed exactly",
                             );
-                            ui.add(
-                                egui::Slider::new(&mut self.config.bubble_opacity, 0.05..=1.0)
-                                    .text("bubble opacity"),
-                            );
-                            ui.add(
-                                egui::Slider::new(
-                                    &mut self.config.bubble_max_radius,
-                                    MIN_BUBBLE_MAX_RADIUS..=MAX_BUBBLE_MAX_RADIUS,
-                                )
-                                .text("largest bubble px"),
-                            )
-                            .on_hover_text(
-                                "area stays quantity-proportional; this only sets how big the biggest print draws",
-                            );
+                            self.draw_bubble_controls(ui);
                         });
 
                         ui.separator();
@@ -736,11 +1099,19 @@ impl OrderflowView {
                                 health.dropped_aggressions
                             ));
                         }
-                        if ui.button("reset bubble visuals").clicked() {
+                        if ui
+                            .button("reset bubble visuals")
+                            .on_hover_text("only this panel; L2 and history settings stay as they are")
+                            .clicked()
+                        {
                             let defaults = HeatmapConfig::default();
                             self.config.bubble_cluster_ms = defaults.bubble_cluster_ms;
-                            self.config.bubble_opacity = defaults.bubble_opacity;
-                            self.config.bubble_max_radius = defaults.bubble_max_radius;
+                            self.config.bubbles = defaults.bubbles;
+                            // No stored preset is on screen any more, so the
+                            // picker must not keep claiming one.
+                            self.presets.active.clear();
+                            self.preset_status =
+                                Some("bubble defaults restored (not saved)".to_owned());
                         }
                     });
             });
@@ -822,10 +1193,113 @@ fn cluster_label(milliseconds: i64) -> String {
     }
 }
 
+const fn size_reference_label(reference: BubbleSizeReference) -> &'static str {
+    match reference {
+        BubbleSizeReference::VisibleP99 => "Auto · visible P99",
+        BubbleSizeReference::VisibleMax => "Auto · largest visible",
+        BubbleSizeReference::Fixed => "Fixed quantity",
+    }
+}
+
+/// One optional colour: a swatch that adopts the override the moment it is
+/// touched, and a way back to the theme.
+fn color_override(ui: &mut egui::Ui, label: &str, value: &mut Option<[u8; 3]>, fallback: [u8; 3]) {
+    ui.horizontal(|ui| {
+        let mut rgb = value.unwrap_or(fallback);
+        if ui.color_edit_button_srgb(&mut rgb).changed() {
+            *value = Some(rgb);
+        }
+        ui.label(label);
+        if value.is_some() {
+            if ui
+                .small_button("theme")
+                .on_hover_text("follow the chart theme again")
+                .clicked()
+            {
+                *value = None;
+            }
+        } else {
+            ui.weak("(theme)");
+        }
+    });
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::orderflow::{BubbleSizeReference, BubbleStyle};
     use quantick_orderbook::{BookCoverage, BookDelta, BookLevel, BookSnapshot};
+
+    /// Lay the docked panels out for real, off-screen, so a broken nested
+    /// layout or a duplicated widget id fails here instead of on the chart.
+    /// Both panels are open at once: they share the left dock and the bubble
+    /// controls must not collide with the L2 ones.
+    #[test]
+    fn the_bubble_panel_lays_out_every_control() {
+        let ctx = egui::Context::default();
+        let mut view = OrderflowView::new("BTCUSDT");
+        view.toggle_bubbles_panel();
+        view.toggle_l2_panel();
+        let frame = |view: &mut OrderflowView| {
+            ctx.run(egui::RawInput::default(), |ctx| {
+                view.draw_panels(ctx);
+            })
+        };
+        // Two frames: the second one re-uses the ids the first allocated.
+        frame(&mut view);
+        frame(&mut view);
+
+        // Now the conditional branches: fixed size reference (extra field),
+        // marks turned off, no trail, and a custom colour instead of the theme.
+        view.config.bubbles.size_reference = BubbleSizeReference::Fixed;
+        view.config.bubbles.show_consumption_front = false;
+        view.config.bubbles.show_impact_ring = false;
+        view.config.bubbles.trail_length = 0.0;
+        view.config.bubbles.buy_color = Some([1, 2, 3]);
+        view.config.bubbles.min_quantity = 5.0;
+        frame(&mut view);
+
+        // And with bubbles switched off the controls are disabled, not gone.
+        view.config.show_aggressions = false;
+        let output = frame(&mut view);
+        assert!(
+            !output.shapes.is_empty(),
+            "the panel must still paint when bubbles are hidden"
+        );
+        assert!(view.show_bubbles_panel);
+    }
+
+    #[test]
+    fn presets_apply_only_the_bubble_section() {
+        let mut view = OrderflowView::new("BTCUSDT");
+        let before = view.config.clone();
+        view.presets.upsert(BubblePreset {
+            name: "wide".to_owned(),
+            cluster_ms: 100,
+            bubbles: BubbleStyle {
+                max_radius: 42.0,
+                side_offset: 8.0,
+                ..BubbleStyle::default()
+            },
+        });
+        view.apply_preset("wide");
+        assert_eq!(view.config.bubbles.max_radius, 42.0);
+        assert_eq!(view.config.bubble_cluster_ms, 100);
+        assert_eq!(view.presets.active, "wide");
+        assert_eq!(view.preset_name_draft, "wide");
+        // Untouched: the layer switch, retention, grouping, gamma, capture bucket.
+        assert_eq!(view.config.show_aggressions, before.show_aggressions);
+        assert_eq!(view.config.retention_ms, before.retention_ms);
+        assert_eq!(view.config.display_grouping, before.display_grouping);
+        assert_eq!(view.config.gamma, before.gamma);
+        assert_eq!(view.config.price_grouping, before.price_grouping);
+
+        // An unknown name changes nothing at all.
+        let after = view.config.clone();
+        view.apply_preset("nope");
+        assert_eq!(view.config, after);
+        assert_eq!(view.presets.active, "wide");
+    }
 
     fn snapshot_event(generation: u64) -> DepthEvent {
         DepthEvent::Snapshot {


### PR DESCRIPTION
@
The bubble layer had two knobs (alpha, largest radius) and everything else baked
into the renderer, so the marks that carry the meaning — the vertical consumption
front and the trail into the consumed side — could not be tuned or even seen for
what they were. Sideways markets made it worse: with a one-tick spread both sides
land on the same row and stack into a line.

## What changed

- Every bubble choice moves into one `BubbleStyle` on the panel: radii, fill, rim,
  halo, detail threshold, the consumption front and the impact ring, the trail,
  labels, and per-element colour overrides that fall back to the theme.
- Buy bubbles are nudged up and sell bubbles down (a buy lifts the ask, a sell hits
  the bid) — deliberately unfaithful to the exact price so both sides stay readable
  on a one-tick spread.
- The full-size reference is now a choice (visible P99, largest visible, or a fixed
  quantity) instead of a hard-coded visible P99 that drew the largest 1% all at the
  maximum radius. Bubble area was already proportional to quantity.
- A display-only quantity floor, applied *after* liquidity association, so a hidden
  small print still counts as the evidence behind an aggression-aligned reduction.
- Looks are named presets in `config/bubbles.toml`, tracked in git so a setup that
  reads the tape well can be reviewed and rolled back like code.
- `bubble_opacity` and `bubble_max_radius` are absorbed into `BubbleStyle` rather
  than duplicated, keeping the radius limits #66 introduced.

## Design rules honoured

- A preset describes appearance only — it can never switch the layer on, keeping
  the "adding the feature changes nothing until asked" rule from #66.
- A malformed presets file is not fatal: the built-in presets take over, and the
  error is shown in the panel and logged rather than silently swallowed.

## Verification

All four checks pass on this branch: `cargo fmt --all -- --check`,
`cargo clippy --workspace --all-targets -- -D warnings`, `cargo build --workspace`,
`cargo test --workspace` (343 passed, 0 failed, 2 ignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@