### PR TITLE
feat(replay): play recorded sessions through the live feed channel

### DIFF
--- a/.claude/skills/arch-review/SKILL.md
+++ b/.claude/skills/arch-review/SKILL.md
@@ -1,0 +1,219 @@
+---
+name: arch-review
+description: Architecture-first code review for quantick — checks that a change docks as a module, declares its performance impact, proves itself with tests, and hides nothing behind a magic number. Use when the user types /arch-review, asks for a code review, or asks whether a change is modular, extensible or fast enough.
+---
+
+# Architecture-first code review
+
+A new feature should dock like a spacecraft to the ISS: a standard port, no
+modification to the station. Review every change against that bar.
+
+This skill reviews *shape* — modularity, performance, extensibility, tests,
+naming. For bug hunting use `/code-review`; run both when the change is large.
+
+## Priority order
+
+When two findings pull in opposite directions, this order decides the call.
+State the order explicitly in the review when a trade-off is at stake.
+
+0. **Correctness and determinism** — not a trade-off, a precondition. Same
+   trades in, same bars out. See the non-negotiable rules in `CLAUDE.md`.
+1. **Performance.** The highest-ranked quality. Never spend runtime cost to
+   make code friendlier to read.
+2. **Modularity and extensibility.** The next feature must dock without
+   surgery on this one.
+3. **Tests that prove the behaviour**, so the next feature cannot break it
+   silently.
+4. **Standardisation.** One way to do a thing, repo-wide.
+5. **Human-friendliness.** Mandatory wherever it is free at runtime — better
+   names, honest units, a comment explaining a dense algorithm. Never a reason
+   to accept a slower path.
+
+Point 5 is not the lowest because it matters least. It is last because it is
+the only one that must yield when it collides with the others — and it almost
+never has to, since naming and comments compile away.
+
+## Scope the review
+
+```sh
+git diff main...HEAD --stat      # branch under review
+git diff --stat                  # uncommitted working diff
+gh pr diff <n>                   # a PR
+```
+
+Read the neighbouring code before judging any of it. The repo's existing
+pattern is the standard; a change that invents a second way to do something
+already solved is a finding, even when the new way is prettier in isolation.
+
+## The six dimensions
+
+### 1. The docking test — modularity and extensibility
+
+The question to answer for every new capability:
+
+> Could a second implementation of this be added by writing a new file and one
+> registration line, without editing any existing behaviour?
+
+If not, say exactly which file the next author would be forced to open, and
+what port would have prevented it.
+
+Look for:
+
+- **Type switches that grow.** `match` over a closed enum, `if is_replay`,
+  `if feed == "binance"` — every new variant reopens the same function. The
+  repo's own answer is capability-driven behaviour: UI gates on
+  `FeedCapabilities`, never on which source is playing. Follow that pattern.
+- **Ports vs. concrete types.** Does a consumer depend on a trait it needs, or
+  on a concrete producer it happens to have? Downcasting or matching on a
+  concrete feed type downstream is a broken port.
+- **Dependency direction.** `app` / `feed-*` → `engine` / `orderbook` /
+  `replay`, one way, and feed crates never depend on each other. A reverse
+  edge is a blocker, no exceptions.
+- **Forked logic.** Chart, backtest and bot share one aggregator code path.
+  Any per-consumer copy of bar building is a blocker.
+- **Blast radius.** Count the existing files the change modifies versus the
+  files it adds. A feature that is mostly edits to existing code either found
+  a missing abstraction or ignored one — decide which and say so.
+- **Additive by default.** Adding a capability must change nothing until it is
+  asked for: new options default to today's behaviour, and config presence
+  alone never activates anything.
+
+### 2. Performance impact — every change declares one
+
+No change ships without an answer to: **how often does this run?**
+
+Classify each touched path before judging it:
+
+| Path | Rate | Bar |
+| --- | --- | --- |
+| Aggregator, tick ingest | per trade | zero allocation, no locks |
+| Book state, depth projection | per depth update | bounded work, no full rescans |
+| Renderer, per-frame view | ~60 Hz | no per-frame recompute of stable data |
+| Config load, startup, panel edits | rare | clarity wins freely |
+
+Hot-path findings to hunt:
+
+- Allocation per event or per frame: `to_string`, `format!`, `collect()`,
+  `Vec` built and dropped every tick, `clone()` of a container.
+- `HashMap` where iteration order can reach the output — a determinism bug and
+  a cache-locality loss at once. Prefer `BTreeMap` / `Vec`.
+- Work that repeats per frame but only changes per event: recomputed
+  projections, re-sorted levels, re-parsed config. Cache and invalidate.
+- Locks or channel waits on the render thread; unbounded queues that grow
+  under a fast tape.
+- Per-element draw calls where the repo already batches into one mesh.
+- Growth that is worse than the data: an O(n²) pass over book levels is fine
+  on ten levels and fatal on a dense book.
+
+Rules for reporting performance:
+
+- Never assert "this is slow" without the call rate and the concrete cost
+  (allocations per call, extra passes, added lock). A guess stated as a
+  measurement is itself a finding against the reviewer.
+- If the cost is real but the magnitude is unclear, say so and name the
+  measurement that would settle it — the perf HUD frame time, a bench over a
+  fixture, a dense-book capture.
+- Cold-path micro-optimisation that costs clarity is a finding in reverse:
+  call it out and ask for the readable version back.
+
+### 3. Nothing hardcoded
+
+Every number that a human might one day want different lives in a named
+constant or in config — never inline at the point of use.
+
+- **Named constants** at module top, `SCREAMING_SNAKE_CASE`, unit in the name
+  (`_MS`, `_PX`, `_TICKS`, `_BYTES`). `const` and `static` cost nothing.
+- **Config** for anything a user tunes: feeds and symbols in
+  `crates/app/config/feeds.toml`, bubble looks in `config/bubbles.toml`,
+  overridable by env var. Symbols, endpoints, tick sizes and thresholds are
+  never literals in code.
+- A magic number in a renderer or a threshold buried in a condition is a
+  finding every time, including when it is "obviously" 2.0.
+- Config round-trips must survive a save: a writer that drops comments or
+  re-emits `0.78` as `0.7799999713897705` destroys the reason the file is
+  tracked in git. Check the write path, not just the read path.
+
+### 4. Tests that prove the change
+
+- Every new behaviour has a test that **fails without the change**. If you
+  cannot name that test, the behaviour is unproven — a blocker.
+- Engine work is test-first: fixture trades, expected bars, then code.
+  Determinism is guarded by golden/snapshot tests over fixed fixtures.
+- **Test the port, not just the feature.** When a change adds an extension
+  point, a second implementation — a fake is fine — must exercise it in a
+  test. One implementer never proves a trait is a port.
+- **Regression cover for what already worked.** The point of the suite is that
+  the next feature cannot break this one silently. Ask what existing test
+  would have caught this change if it were wrong; if none, that gap is the
+  finding.
+- Edge cases the domain actually produces: empty book, one-tick spread, zero
+  quantity, gap in update ids, overflow on feed arithmetic (saturate, never
+  panic), a session that ends mid-bar.
+
+### 5. Standardisation
+
+One way to do a thing. Compare against the existing repo answer for error
+types, module layout, config format, naming, logging, and the shape of a
+public API. A new local convention needs a stated reason or it is a finding.
+
+### 6. Human-friendly at zero runtime cost
+
+- Names carry intent and unit: `cluster_window_ms`, not `cw`; `visible_p99`,
+  not `ref_mode`. Renaming is free — demand it.
+- Complex algorithms get a comment in **English** explaining the *objective* —
+  why this exists and what it is trying to achieve — not a restatement of the
+  code. A dense projection or an adaptive threshold without that comment is a
+  finding.
+- Inferred or incomplete data is labelled as such in the code and in the UI,
+  never silently patched.
+- Prefer zero-cost clarity: newtypes over bare `f64`, exhaustive `match` over
+  `_ =>` catch-alls, early returns over nesting. All compile away.
+- No comment restating obvious code, and no dead or commented-out code.
+
+## Verify before reporting
+
+Reviews are judged on precision, not volume.
+
+1. Open the file and read the surrounding code — most "this is missing"
+   findings die here because the thing exists one function up.
+2. For each surviving finding, argue the opposite case for a moment: is this
+   already handled, deliberate, or out of scope for this change? Drop it if
+   the refutation holds.
+3. Confirm the four checks actually pass — do not take a claim on trust:
+
+```sh
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo build --workspace
+cargo test --workspace
+```
+
+A clean change gets a short review saying it is clean and why. Never pad.
+
+## Severity
+
+- **Blocker** — reverse dependency edge; forked aggregator logic; determinism
+  broken; hot-path regression; new behaviour with no test; a feature that
+  activates itself.
+- **Should fix** — hardcoded value; extension point that forces edits to
+  existing code; missing regression cover; unexplained complex algorithm;
+  misleading name or missing unit; a second way to do a solved thing.
+- **Consider** — clarity and structure improvements with no correctness,
+  performance or extensibility consequence.
+
+## Output
+
+Report findings with the `ReportFindings` tool when it is available, ranked
+most severe first, using categories `modularity`, `performance`,
+`hardcoded-values`, `test-coverage`, `standardisation`, `readability`. Without
+that tool, write the same list as markdown grouped by severity.
+
+Each finding: `file:line`, what is wrong, why it matters *in this order of
+priorities*, and the concrete fix — the trait to extract, the constant to
+name, the test to add. Never a vague "consider refactoring".
+
+Close with a verdict in three lines:
+
+- **Docking** — can the next feature attach without opening these files?
+- **Performance** — what got faster, slower, or stayed flat, and at what rate.
+- **Proof** — which test would fail if this change regressed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,11 +15,14 @@ Cargo workspace, crates under `crates/`:
 
 - `engine` (package `quantick-engine`) — raw trades in, alternative bars out. Headless and deterministic: no UI, no network, no async. Everything else depends on it; it depends on nothing else in the workspace.
 - `orderbook` (package `quantick-orderbook`) — deterministic local order-book core: validated snapshots, absolute level updates, update-id continuity. A pure domain crate like `engine` (no network, no async, no clock); depends on nothing else in the workspace.
+- `replay` (package `quantick-replay`) — recorded market-replay sessions: the CSV tick-file format (read, write and explain why a file was rejected), the folder scan behind the session browser, and the deterministic playback clock. A pure domain crate like `engine` — no network, no async, and it is *told* how much time passed rather than reading a clock; it depends only on `engine`.
 - `feed-binance` (package `quantick-feed-binance`) — live aggTrades feed from Binance public endpoints; produces the trade stream the engine consumes. Also captures synchronized L2 depth into `orderbook` state.
 - `feed-mt5` (package `quantick-feed-mt5`) — MetaTrader 5 tick feed. Listens on a local TCP socket for the QuantickBridge EA (`bridge/mt5/`, MQL5) running inside the logged-in terminal; no credentials anywhere. Side inference policy, synthetic ids and server-time conversion are documented in its `lib.rs`.
 - `app` (package `quantick-app`) — desktop chart (egui/wgpu planned). A consumer of the engine, never the other way around. Feeds and symbols come from config (`crates/app/config/feeds.toml`, overridable via `QUANTICK_CONFIG` or `./quantick.toml`), never hardcoded.
 
-Dependency direction is one-way: `app` / `feed-*` → `engine` / `orderbook` (the domain crates). Never add a reverse edge. Feed crates never depend on each other.
+Dependency direction is one-way: `app` / `feed-*` → `engine` / `orderbook` / `replay` (the domain crates). Never add a reverse edge. Feed crates never depend on each other.
+
+Market replay is a *source*, not a chart mode: `app/src/feed/replay.rs` releases a recorded session down the same `FeedEvent` channel a live venue uses, so bars, navigation and metrics run one code path. UI affordances gate on `FeedCapabilities`, never on "is this a replay?" — a recording reports no depth and no history paging, and the heatmap toggle disables itself from that alone.
 
 ## Non-negotiable design rules
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,6 +130,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "ashpd"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f3f79755c74fd155000314eb349864caa787c6592eace6c6882dad873d9c39"
+dependencies = [
+ "enumflags2",
+ "futures-channel",
+ "futures-util",
+ "rand 0.9.5",
+ "raw-window-handle",
+ "serde",
+ "serde_repr",
+ "tokio",
+ "url",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "zbus",
+]
+
+[[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -208,6 +263,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
 dependencies = [
  "objc2 0.5.2",
+]
+
+[[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2 0.6.4",
 ]
 
 [[package]]
@@ -598,6 +662,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags 2.13.1",
+ "block2 0.6.2",
+ "libc",
  "objc2 0.6.4",
 ]
 
@@ -763,6 +829,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "epaint"
 version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -806,6 +899,33 @@ name = "error-code"
 version = "3.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "fdeflate"
@@ -896,6 +1016,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
+name = "futures-io"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "futures-macro"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -914,6 +1064,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-core",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "pin-project-lite",
@@ -1176,6 +1327,12 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hexf-parse"
@@ -1829,7 +1986,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
 dependencies = [
  "bitflags 2.13.1",
- "block2",
+ "block2 0.5.1",
  "libc",
  "objc2 0.5.2",
  "objc2-core-data",
@@ -1845,6 +2002,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.13.1",
+ "block2 0.6.2",
  "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -1858,7 +2016,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
 dependencies = [
  "bitflags 2.13.1",
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-core-location",
  "objc2-foundation 0.2.2",
@@ -1870,7 +2028,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5ff520e9c33812fd374d8deecef01d4a840e7b41862d849513de77e44aa4889"
 dependencies = [
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
 ]
@@ -1882,7 +2040,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
 dependencies = [
  "bitflags 2.13.1",
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
 ]
@@ -1917,7 +2075,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
 dependencies = [
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
  "objc2-metal",
@@ -1929,7 +2087,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "000cfee34e683244f284252ee206a27953279d370e309649dc3ee317b37e5781"
 dependencies = [
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-contacts",
  "objc2-foundation 0.2.2",
@@ -1948,7 +2106,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
  "bitflags 2.13.1",
- "block2",
+ "block2 0.5.1",
  "dispatch",
  "libc",
  "objc2 0.5.2",
@@ -1982,7 +2140,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1a1ae721c5e35be65f01a03b6d2ac13a54cb4fa70d8a5da293d7b0020261398"
 dependencies = [
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
@@ -1995,7 +2153,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
 dependencies = [
  "bitflags 2.13.1",
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
 ]
@@ -2007,7 +2165,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
 dependencies = [
  "bitflags 2.13.1",
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
  "objc2-metal",
@@ -2030,7 +2188,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
 dependencies = [
  "bitflags 2.13.1",
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-cloud-kit",
  "objc2-core-data",
@@ -2050,7 +2208,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44fa5f9748dbfe1ca6c0b79ad20725a11eca7c2218bceb4b005cb1be26273bfe"
 dependencies = [
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
 ]
@@ -2062,7 +2220,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
 dependencies = [
  "bitflags 2.13.1",
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-core-location",
  "objc2-foundation 0.2.2",
@@ -2085,6 +2243,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "owned_ttf_parser"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2092,6 +2260,12 @@ checksum = "36820e9051aca1014ddc75770aab4d68bc1e9e632f0f5627c4086bc216fb583b"
 dependencies = [
  "ttf-parser",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -2194,6 +2368,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pollster"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2276,6 +2456,8 @@ dependencies = [
  "quantick-feed-binance",
  "quantick-feed-mt5",
  "quantick-orderbook",
+ "quantick-replay",
+ "rfd",
  "rust_decimal",
  "serde",
  "tokio",
@@ -2327,6 +2509,15 @@ name = "quantick-orderbook"
 version = "0.1.0"
 dependencies = [
  "rust_decimal",
+]
+
+[[package]]
+name = "quantick-replay"
+version = "0.1.0"
+dependencies = [
+ "quantick-engine",
+ "rust_decimal",
+ "serde_json",
 ]
 
 [[package]]
@@ -2428,8 +2619,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2454,12 +2655,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -2578,6 +2798,30 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "webpki-roots 1.0.9",
+]
+
+[[package]]
+name = "rfd"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef2bee61e6cffa4635c72d7d81a84294e28f0930db0ddcb0f66d10244674ebed"
+dependencies = [
+ "ashpd",
+ "block2 0.6.2",
+ "dispatch2",
+ "js-sys",
+ "log",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "pollster",
+ "raw-window-handle",
+ "urlencoding",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2808,6 +3052,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3088,6 +3343,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3183,6 +3451,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.61.2",
 ]
 
@@ -3476,6 +3745,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3515,7 +3795,14 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf-8"
@@ -3536,6 +3823,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 
@@ -4004,6 +4292,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -4085,7 +4382,7 @@ dependencies = [
  "android-activity",
  "atomic-waker",
  "bitflags 2.13.1",
- "block2",
+ "block2 0.5.1",
  "bytemuck",
  "calloop 0.13.0",
  "cfg_aliases 0.2.2",
@@ -4262,6 +4559,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe18fb60dc696039e738717b76eaea21e7a4489bbb1885020b43c94236d7e98a"
+dependencies = [
+ "async-broadcast",
+ "async-recursion",
+ "async-trait",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix 1.1.4",
+ "serde",
+ "serde_repr",
+ "tokio",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 1.0.4",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe96480bed92df2b442a1a30df364e12d08eed03aeb061f2b8dc6afb2be91119"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8bf88b4a3ff53e883001e0e0115b297a9d53c31b9c1edd2bfdd853e3428624e"
+dependencies = [
+ "serde",
+ "winnow 1.0.4",
+ "zvariant",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4346,3 +4699,44 @@ name = "zmij"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
+
+[[package]]
+name = "zvariant"
+version = "5.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee2a0bcd2a907786a456fff45aaaaf54c9ba5f50b71ae9ec1a4edd200c94911"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "url",
+ "winnow 1.0.4",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38a708216a18780796770bfe3f4739c7c83a3e8f789b755534bbbc06e4e23e12"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90cb9383f9b45290407a1258b202d3f8f01db719eb60b4e4055c6375af4fc7c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.119",
+ "winnow 1.0.4",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "3"
 members = [
     "crates/engine",
     "crates/orderbook",
+    "crates/replay",
     "crates/feed-binance",
     "crates/feed-mt5",
     "crates/app",

--- a/README.md
+++ b/README.md
@@ -122,6 +122,103 @@ layered after resting liquidity and before aggression bubbles:
 `heatmap → candle → aggression`. Appearance changes only trigger a redraw and
 never restart the market-data pipelines.
 
+## Market Replay
+
+Replay a recorded session and watch the chart build it print by print, at up to
+50× speed. Open it from **File → Market Replay…** (`Ctrl+R`), pick the folder
+holding your sessions, choose one and press **Play session**. A transport bar
+appears at the bottom of the window while a recording plays — and only then:
+
+```
+⏮ ⏸  REPLAY  WINJ26 · 2026-03-16  13:27:48   1× 2× 3× 5× 10× 20× 50×   57 650 / 86 313 prints  ✖
+▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬●────────────
+```
+
+`Space` toggles play/pause. Dragging or clicking the track seeks; the chart is
+rebuilt from the new position, because bars that already closed cannot be
+reopened. Idle stretches longer than two seconds of market time are skipped —
+lunch lulls and halts do not have to be watched in real time. Playback drives
+the chart through the same feed channel a live venue uses, so bars, navigation
+and metrics behave exactly as they do live, and nothing is ever labelled "live"
+while a recording is playing.
+
+Replay streams trades only. Depth is not in the file, so the L2 heatmap and
+aggression bubbles are unavailable during a replay and disable themselves.
+
+### Session file format
+
+One folder per instrument, one CSV per session day:
+
+```text
+<replay folder>/
+    WINJ26/
+        20260316.csv
+        20260317.csv
+```
+
+Files named `SYMBOL-YYYYMMDD.csv` directly in the folder are read too. Each file
+holds one executed trade per line, oldest first, preceded by `#` metadata:
+
+```text
+# quantick-replay 1
+# symbol=WINJ26
+# timezone=-03:00
+# side_source=bid_ask
+Date,Time,Price,Bid,Ask,Volume,Side
+2026-03-16,10:01:08.000,182035,182030,182035,12,B
+2026-03-16,10:01:09.250,182025,182025,182030,4,S
+```
+
+- **Required columns:** `Date`, `Time`, `Price`, `Volume`, `Side`.
+- **Optional columns:** `Bid`, `Ask`, `Id`. Any other column is ignored and
+  reported, so a file carrying extra data still loads.
+- Columns are matched **by name**, so their order is free.
+- `Date` is `YYYY-MM-DD`; `Time` is `HH:MM:SS` or `HH:MM:SS.mmm`, in the
+  timezone declared by `# timezone=` (UTC when the line is absent).
+- `Side` is the **aggressor**: `B` when the buyer lifted the offer, `S` when the
+  seller hit the bid. `A`/`ASK`/`BID` are rejected by name — those spellings mean
+  opposite sides at different vendors, and guessing would mirror the order flow.
+
+The layout follows what replay-capable platforms already do (an instrument/day
+folder tree, as in NinjaTrader's `db/replay/`), with the row format every
+tick-data vendor ships. A folder that does not load says exactly why, per file,
+with the fix and the whole format one click away in the browser.
+
+### Importing recordings
+
+MT5 order-flow recordings (NDJSON with `tick` and `book_update` events) convert
+to sessions with:
+
+```bash
+cargo run -p quantick-replay --example import_mt5_ndjson -- \
+    --in runtime/mt5_orderflow_20260316.ndjson \
+    --out /path/to/replay
+```
+
+| Option | Default | Behavior |
+| --- | --- | --- |
+| `--in <file>` | — | Recording to read; repeat for several |
+| `--out <folder>` | — | Replay folder to write into |
+| `--symbol <name>` | all | Keep only this instrument |
+| `--side-source <policy>` | `bid_ask` | `bid_ask` (position against the recorded quote, tick rule as fallback), `flags` (the broker's BUY/SELL tick flags) or `tick_rule` |
+| `--spread-within-second` | off | Even out prints inside each recorded second |
+| `--timezone <offset>` | from the data | Offset the rows are written in |
+
+The run reports how often each rule decided the aggressor side — including how
+often it disagreed with the broker's flags — and the policy is written into the
+session's `# side_source=` line. Recordings that stamp trades to the second are
+labelled `# time_resolution=1s`; `--spread-within-second` distributes prints
+evenly across each second for smoother playback and marks the session
+`1s_interpolated`, because those sub-second times are inferred.
+
+### Replay environment variables
+
+| Variable | Default | Behavior |
+| --- | --- | --- |
+| `QUANTICK_REPLAY_DIR` | unset | Folder the browser opens on |
+| `QUANTICK_REPLAY_AUTOSTART` | unset | Set to `1` to load and play the first session in that folder on startup (same code path as clicking **Play session**) |
+| `QUANTICK_REPLAY_SPEED` | `1` | Speed the autostarted session opens at |
+
 ## Optional L2 liquidity map
 
 The chart can capture Binance Spot level-2 order-book depth and render a
@@ -196,10 +293,11 @@ JSON logs include stable fields such as `schema_version`, `event_code`, symbol, 
 
 ## Architecture
 
-The project is a Cargo workspace of small, one-way-dependent crates (`app` / `feed-*` → `engine` / `orderbook`). Status today:
+The project is a Cargo workspace of small, one-way-dependent crates (`app` / `feed-*` → `engine` / `orderbook` / `replay`). Status today:
 
 - **Bar engine (Rust)** — ✅ raw trades in → alternative bars out; deterministic and headless, usable with no UI attached (`crates/engine`)
 - **Live feeds** — ✅ Binance aggTrades over public data, works out of the box with no API key (`crates/feed-binance`); ✅ MetaTrader 5 via a local bridge EA (`crates/feed-mt5`)
+- **Market replay** — ✅ recorded sessions played back through the live feed channel, at 1×–50× (`crates/replay`)
 - **Desktop app** — ✅ native chart (egui) showing bars form in real time, with a Bookmap-inspired L2 liquidity heatmap (`crates/app`)
 - **Bindings** — ⏳ Python bindings and a C API are planned, so the engine plugs into existing backtest stacks and bots in any language
 
@@ -218,6 +316,7 @@ The project is a Cargo workspace of small, one-way-dependent crates (`app` / `fe
 - [x] Imbalance bars (López de Prado information-driven sampling)
 - [x] MetaTrader 5 feed
 - [x] Bookmap-inspired L2 liquidity heatmap (egui/glow; wgpu migration still open)
+- [x] Market replay of recorded sessions (trades; depth replay still open)
 - [ ] CVD & delta visuals (engine already stores per-bar buy/sell volume and delta; charting them is next)
 - [ ] Python bindings
 - [ ] C API, so bots in C++ (or any language) can consume the engine

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -10,7 +10,11 @@ quantick-engine = { path = "../engine" }
 quantick-feed-binance = { path = "../feed-binance" }
 quantick-feed-mt5 = { path = "../feed-mt5" }
 quantick-orderbook = { path = "../orderbook" }
+quantick-replay = { path = "../replay" }
 rust_decimal = "1"
+# Native folder picker for Market Replay. Runs off the UI thread, so the OS
+# dialog never blocks a frame.
+rfd = { version = "0.15", default-features = false, features = ["xdg-portal", "tokio"] }
 serde = { version = "1", features = ["derive"] }
 toml = "0.8"
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "net", "time", "process"] }

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -34,7 +34,9 @@ fn color32([r, g, b, a]: [u8; 4]) -> egui::Color32 {
     egui::Color32::from_rgba_unmultiplied(r, g, b, a)
 }
 
-const DIVIDER: egui::Color32 = egui::Color32::from_rgb(240, 185, 11);
+/// The amber that marks "this is not live data": the backfill/live divider on
+/// the chart, and the market-replay transport.
+pub(crate) const DIVIDER: egui::Color32 = egui::Color32::from_rgb(240, 185, 11);
 /// Secondary text: labels, hints, anything that must not compete with data.
 pub(crate) const MUTED: egui::Color32 = egui::Color32::from_rgb(150, 160, 175);
 /// Primary text over the chart and the chrome.

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -19,10 +19,11 @@ use quantick_feed_binance::depth::DepthEvent;
 use crate::candle_view::{draw_candle, draw_style_window};
 use crate::chart::PriceScale;
 use crate::config::{AppConfig, FeedCapabilities, ProviderKind};
-use crate::feed::{self, FeedCommand, FeedEvent, FeedHandle};
+use crate::feed::{self, FeedCommand, FeedEvent, FeedHandle, ReplayLink};
 use crate::metrics::{self, FrameStats};
 use crate::orderflow_view::OrderflowView;
 use crate::price_view::PriceView;
+use crate::replay_view::{ReplayAction, ReplayView};
 use crate::state::{BarKind, BarSpec, ChartState};
 use crate::style::{CandlePreset, ChartStyle};
 use crate::timezone::TzOffset;
@@ -34,9 +35,12 @@ fn color32([r, g, b, a]: [u8; 4]) -> egui::Color32 {
 }
 
 const DIVIDER: egui::Color32 = egui::Color32::from_rgb(240, 185, 11);
-const MUTED: egui::Color32 = egui::Color32::from_rgb(150, 160, 175);
-const OVERLAY: egui::Color32 = egui::Color32::from_rgb(210, 218, 226);
-const WARN: egui::Color32 = egui::Color32::from_rgb(255, 99, 71);
+/// Secondary text: labels, hints, anything that must not compete with data.
+pub(crate) const MUTED: egui::Color32 = egui::Color32::from_rgb(150, 160, 175);
+/// Primary text over the chart and the chrome.
+pub(crate) const OVERLAY: egui::Color32 = egui::Color32::from_rgb(210, 218, 226);
+/// Something needs attention.
+pub(crate) const WARN: egui::Color32 = egui::Color32::from_rgb(255, 99, 71);
 const CROSSHAIR: egui::Color32 = egui::Color32::from_rgb(110, 120, 135);
 const TAG_BG: egui::Color32 = egui::Color32::from_rgb(55, 63, 80);
 
@@ -114,6 +118,13 @@ pub struct QuantickApp {
     feed_id: String,
     symbol: String,
     active: (String, String),
+
+    // Market Replay. `replay` is `Some` exactly while a recorded session is
+    // the chart's source; it is the one flag the rest of the UI checks, so
+    // replay never grows a second copy of "which mode are we in". The view
+    // owns the browser window and the transport bar.
+    replay: Option<ReplayLink>,
+    replay_view: ReplayView,
 
     // How many older trades to pull per "load older" click, and how many
     // trades have been backfilled in total (for the readout).
@@ -212,6 +223,8 @@ impl QuantickApp {
             book_capture_epoch: 0,
             book_channel_closed_reported: false,
             active: (feed_id.clone(), symbol.clone()),
+            replay: feed.replay,
+            replay_view: ReplayView::new(),
             config,
             feed_id,
             symbol,
@@ -253,6 +266,28 @@ impl QuantickApp {
         if std::env::var("QUANTICK_BOOK_AUTOSTART").is_ok_and(|value| value == "1") {
             app.request_book_capture(true);
         }
+        // Same convenience for Market Replay: open the folder named by
+        // QUANTICK_REPLAY_DIR and play its first session. One env var, the same
+        // code path a click takes, so a scripted run and a person get the same
+        // behaviour.
+        if std::env::var("QUANTICK_REPLAY_AUTOSTART").is_ok_and(|value| value == "1") {
+            let speed = std::env::var("QUANTICK_REPLAY_SPEED")
+                .ok()
+                .and_then(|value| value.trim().parse::<f32>().ok())
+                .filter(|speed| *speed > 0.0)
+                .unwrap_or(1.0);
+            let started = app.replay_view.autostart(speed);
+            tracing::info!(
+                target: "quantick::app",
+                schema_version = 1_u8,
+                event_code = "REPLAY_AUTOSTART",
+                folder = std::env::var(crate::replay_view::REPLAY_DIR_ENV).unwrap_or_default(),
+                speed,
+                started,
+                action = if started { "load_first_session" } else { "open_browser" },
+                "market replay autostart"
+            );
+        }
         app
     }
 
@@ -293,7 +328,26 @@ impl QuantickApp {
     }
 
     /// The feed + symbol selectors, both populated from the configuration.
+    ///
+    /// During a replay the selectors give way to what is actually playing: a
+    /// live venue cannot be picked without leaving the recording first, and a
+    /// combo that silently did so would throw away the session mid-run.
     fn draw_feed_selectors(&mut self, ui: &mut egui::Ui) {
+        if let Some(link) = &self.replay {
+            ui.label(egui::RichText::new("source:").color(MUTED));
+            ui.label(egui::RichText::new(link.label()).color(DIVIDER).strong())
+                .on_hover_text(format!(
+                    "Replaying {}\nSide source: {}",
+                    link.session.path.display(),
+                    link.session
+                        .header
+                        .side_source
+                        .as_deref()
+                        .unwrap_or("not recorded"),
+                ));
+            return;
+        }
+
         // Pre-collect owned option lists so the combo closures don't borrow
         // `self.config` while they mutate `self.feed_id` / `self.symbol`.
         // Providers that aren't streaming yet are labelled "(soon)" so the menu
@@ -480,6 +534,14 @@ impl QuantickApp {
     /// back on the next switch, and until then no affordance may promise data
     /// nothing is streaming.
     fn capabilities(&self) -> FeedCapabilities {
+        // A recorded session streams trades and nothing else: there is no depth
+        // in the file and no venue to page older history from. Answering
+        // honestly here is the whole gate — every affordance already asks the
+        // capability rather than the provider name, so the heatmap toggle and
+        // "load older" disable themselves during replay.
+        if self.replay.is_some() {
+            return FeedCapabilities::none();
+        }
         self.config
             .provider_of(&self.feed_id)
             .map_or(FeedCapabilities::none(), ProviderKind::capabilities)
@@ -608,6 +670,12 @@ impl QuantickApp {
     /// Respawn the feed and reset the chart when the selected feed or symbol
     /// differs from what is currently streaming. A no-op otherwise.
     fn maybe_switch_feed(&mut self) {
+        // A replay owns the chart until it is closed. The selectors are not
+        // drawn while it plays, so nothing can diverge here — but a stale
+        // selection must not respawn a live feed underneath the recording.
+        if self.replay.is_some() {
+            return;
+        }
         if self.active == (self.feed_id.clone(), self.symbol.clone()) {
             return;
         }
@@ -637,10 +705,11 @@ impl QuantickApp {
 
         // Dropping the old handle stops the old feed thread. The new feed starts
         // with a fresh backfill in flight.
-        let handle = feed::spawn(provider, &self.symbol, &self.config);
+        let handle = feed::spawn_live(provider, &self.symbol, &self.config);
         self.events = handle.events;
         self.book_events = handle.book_events;
         self.commands = handle.commands;
+        self.replay = handle.replay;
         self.book_channel_closed_reported = false;
 
         // Rebuild the chart from scratch for the new stream, keeping the current
@@ -729,8 +798,15 @@ impl QuantickApp {
     /// A floating timezone picker anchored to the bottom-right corner. The time
     /// axis relabels immediately on selection; the engine is untouched.
     fn draw_timezone_selector(&mut self, ctx: &egui::Context) {
+        // Panels shrink the context's available rect, so the picker rides above
+        // whatever claimed the bottom of the window — the replay transport, and
+        // anything docked there later — instead of sitting on top of it.
+        let bottom_inset = (ctx.screen_rect().bottom() - ctx.available_rect().bottom()).max(0.0);
         egui::Area::new(egui::Id::new("tz_selector"))
-            .anchor(egui::Align2::RIGHT_BOTTOM, egui::vec2(-10.0, -8.0))
+            .anchor(
+                egui::Align2::RIGHT_BOTTOM,
+                egui::vec2(-10.0, -8.0 - bottom_inset),
+            )
             .show(ctx, |ui| {
                 egui::Frame::popup(ui.style())
                     .fill(egui::Color32::from_black_alpha(150))
@@ -774,16 +850,46 @@ impl QuantickApp {
                     // Prepended bars are not closes; keep the live-tail hold.
                     self.last_total_bars = self.last_total_bars.saturating_add(added);
                 }
-                Ok(FeedEvent::Live(trade)) => {
-                    self.latest_trade_ms = Some(trade.timestamp_ms);
-                    self.live_trades += 1;
-                    self.trades_since_summary += 1;
-                    self.orderflow.record_trade(&trade);
-                    self.state.ingest_live(&trade);
+                Ok(FeedEvent::Live(trade)) => self.ingest_live_trade(&trade),
+                Ok(FeedEvent::LiveBatch(trades)) => {
+                    for trade in &trades {
+                        self.ingest_live_trade(trade);
+                    }
                 }
+                Ok(FeedEvent::Reset) => self.reset_market_state(),
                 Err(_) => break,
             }
         }
+    }
+
+    /// Ingest one live trade: bars, order flow and the metrics that follow it.
+    fn ingest_live_trade(&mut self, trade: &quantick_engine::Trade) {
+        self.latest_trade_ms = Some(trade.timestamp_ms);
+        self.live_trades += 1;
+        self.trades_since_summary += 1;
+        self.orderflow.record_trade(trade);
+        self.state.ingest_live(trade);
+    }
+
+    /// Throw away everything loaded and wait for the source to refill it.
+    ///
+    /// Sent by a source that rewound — seeking a replay, for instance. The
+    /// chart is rebuilt from the history that follows rather than patched,
+    /// because bars that already closed cannot be reopened.
+    fn reset_market_state(&mut self) {
+        self.state = ChartState::new(self.current_spec());
+        self.viewport = Viewport::new();
+        self.price_view = PriceView::new();
+        self.last_auto_range = None;
+        self.hover_pos = None;
+        self.history_trades = 0;
+        self.latest_trade_ms = None;
+        self.live_tail_hold = 0.0;
+        self.last_total_bars = 0;
+        // The refill arrives as one backfill batch; keep the loading indicator
+        // up until it lands.
+        self.pending_history_loads = 1;
+        self.orderflow.reset_for_symbol(self.symbol.clone());
     }
 
     /// Drain a bounded number of synchronized depth events. The separate
@@ -811,6 +917,19 @@ impl QuantickApp {
         }
     }
 
+    /// How far behind the wall clock the newest trade is — the health signal
+    /// for a live feed.
+    ///
+    /// `None` while a session is replaying: those prints are as old as the day
+    /// they were recorded, so measuring them against today's clock reports a
+    /// four-month lag and warns about a connection that is working perfectly.
+    fn trade_lag_ms(&self) -> Option<i64> {
+        if self.replay.is_some() {
+            return None;
+        }
+        metrics::feed_lag_ms(metrics::wall_clock_ms(), self.latest_trade_ms)
+    }
+
     /// Periodically log a perf summary and warn on threshold breaches.
     fn maybe_emit_summary(&mut self, now: Instant) {
         let elapsed = now - self.last_summary;
@@ -818,7 +937,7 @@ impl QuantickApp {
             return;
         }
         let rate = self.trades_since_summary as f64 / elapsed.as_secs_f64();
-        let lag = metrics::feed_lag_ms(metrics::wall_clock_ms(), self.latest_trade_ms);
+        let lag = self.trade_lag_ms();
         let avg = self.frames.avg_ms().unwrap_or(0.0);
         let cpu_avg = self.cpu_frames.avg_ms().unwrap_or(0.0);
         let worst = self.frames.worst_ms().unwrap_or(0.0);
@@ -881,6 +1000,12 @@ impl QuantickApp {
             candle_outline_width_px = self.style.candles.outline_width,
             chart_background_enabled = self.style.canvas.background_enabled,
             chart_grid_enabled = self.style.canvas.grid_enabled,
+            replay_active = self.replay.is_some(),
+            replay_speed = self.replay.as_ref().map(|r| r.status.speed()),
+            replay_playing = self.replay.as_ref().map(|r| r.status.is_playing()),
+            replay_progress = self.replay.as_ref().map(|r| r.status.progress()),
+            replay_played = self.replay.as_ref().map(|r| r.status.played()),
+            replay_total = self.replay.as_ref().map(|r| r.status.total()),
             action = "observe",
             "application health summary"
         );
@@ -1375,10 +1500,12 @@ impl QuantickApp {
             Some(b) => (b, bars.len().saturating_sub(b)),
             None => (0, bars.len()),
         };
-        let mode = if self.viewport.follows_live() {
-            "● live"
-        } else {
-            "history · double-click for live"
+        let mode = match (self.viewport.follows_live(), self.replay.is_some()) {
+            // Never label a recording "live", however current the chart looks.
+            // `▶` rather than `●`: the bundled fonts carry the transport glyph.
+            (true, true) => "▶ replay",
+            (true, false) => "● live",
+            (false, _) => "history · double-click for live",
         };
         let price_mode = if self.price_view.is_auto() {
             ""
@@ -1412,7 +1539,7 @@ impl QuantickApp {
             return;
         }
         let avg = self.frames.avg_ms();
-        let lag = metrics::feed_lag_ms(metrics::wall_clock_ms(), self.latest_trade_ms);
+        let lag = self.trade_lag_ms();
 
         let fps_color = if avg.is_some_and(|a| a > metrics::SLOW_FRAME_MS) {
             WARN
@@ -1424,9 +1551,16 @@ impl QuantickApp {
         } else {
             OVERLAY
         };
-        let lag_text = match lag {
-            Some(l) => format!("feed lag {l} ms"),
-            None => "feed lag —".to_string(),
+        // A recording has no lag to report — its prints are months old by
+        // design. The line says what is actually driving the chart instead.
+        let lag_text = match (&self.replay, lag) {
+            (Some(link), _) => format!(
+                "replay {:.0}×  {:.0}%",
+                link.status.speed(),
+                link.status.progress() * 100.0
+            ),
+            (None, Some(l)) => format!("feed lag {l} ms"),
+            (None, None) => "feed lag —".to_string(),
         };
 
         let lines: [(String, egui::Color32); 4] = [
@@ -1505,6 +1639,145 @@ impl QuantickApp {
     }
 }
 
+/// Opens the Market Replay browser. The one shortcut this feature claims.
+const REPLAY_SHORTCUT: egui::KeyboardShortcut =
+    egui::KeyboardShortcut::new(egui::Modifiers::CTRL, egui::Key::R);
+
+impl QuantickApp {
+    /// The window's menu bar: one line, two menus, nothing that duplicates a
+    /// control already on the toolbar below it.
+    fn draw_menu_bar(&mut self, ctx: &egui::Context) {
+        if ctx.input_mut(|i| i.consume_shortcut(&REPLAY_SHORTCUT)) {
+            self.replay_view.open_browser();
+        }
+
+        egui::TopBottomPanel::top("menu_bar")
+            .frame(
+                egui::Frame::none()
+                    .fill(self.chrome_bg())
+                    .inner_margin(egui::Margin::symmetric(6.0, 2.0)),
+            )
+            .show(ctx, |ui| {
+                ui.visuals_mut().override_text_color = Some(OVERLAY);
+                egui::menu::bar(ui, |ui| {
+                    ui.menu_button("File", |ui| {
+                        if ui
+                            .add(
+                                egui::Button::new("Market Replay…")
+                                    .shortcut_text(ui.ctx().format_shortcut(&REPLAY_SHORTCUT)),
+                            )
+                            .clicked()
+                        {
+                            self.replay_view.open_browser();
+                            ui.close_menu();
+                        }
+                        if self.replay.is_some() && ui.button("Close Replay").clicked() {
+                            self.close_replay();
+                            ui.close_menu();
+                        }
+                        ui.separator();
+                        if ui.button("Exit").clicked() {
+                            ui.ctx().send_viewport_cmd(egui::ViewportCommand::Close);
+                        }
+                    });
+                    ui.menu_button("Help", |ui| {
+                        if ui.button("Replay file format…").clicked() {
+                            self.replay_view.open_format_help();
+                            ui.close_menu();
+                        }
+                    });
+                });
+            });
+    }
+
+    /// Carry out what the replay interface asked for.
+    fn apply_replay_action(&mut self, action: ReplayAction) {
+        match action {
+            ReplayAction::Open(request) => self.open_replay(*request),
+            ReplayAction::Close => self.close_replay(),
+            ReplayAction::Control(control) => {
+                // A dropped transport click is not worth a retry queue: the
+                // worker drains commands every 8 ms, so a full channel means
+                // the click was already superseded.
+                if let Err(e) = self.commands.try_send(FeedCommand::Replay(control)) {
+                    tracing::debug!(
+                        target: "quantick::app",
+                        event_code = "REPLAY_COMMAND_DROPPED",
+                        reason = %e,
+                        "transport command not queued"
+                    );
+                }
+            }
+        }
+    }
+
+    /// Make a recorded session the chart's source, replacing whatever feed is
+    /// running. The live selection is untouched, so closing the replay comes
+    /// back to exactly the feed and symbol that were streaming before.
+    fn open_replay(&mut self, request: crate::feed::ReplayRequest) {
+        tracing::info!(
+            target: "quantick::app",
+            schema_version = 1_u8,
+            event_code = "REPLAY_OPENED",
+            session = %request.session.label(),
+            file = %request.session.path.display(),
+            trades = request.session.trades.len(),
+            speed = request.options.speed,
+            action = "replace_feed_source",
+            "opening a recorded session"
+        );
+
+        let handle = feed::spawn(feed::FeedSource::Replay(Box::new(request)), &self.config);
+        self.events = handle.events;
+        self.book_events = handle.book_events;
+        self.commands = handle.commands;
+        self.replay = handle.replay;
+        self.book_channel_closed_reported = false;
+
+        if let Some(link) = &self.replay {
+            self.symbol = link.symbol().to_string();
+        }
+        // Depth is not in a recording; the toggle is disabled by capability,
+        // and the view must not keep drawing a book from the live feed.
+        let generation = self.next_book_generation();
+        self.orderflow.set_enabled(false, generation);
+        self.reset_market_state();
+    }
+
+    /// Leave replay and put the live feed back.
+    fn close_replay(&mut self) {
+        if self.replay.take().is_none() {
+            return;
+        }
+        let (feed_id, symbol) = self.active.clone();
+        self.feed_id = feed_id;
+        self.symbol = symbol;
+        tracing::info!(
+            target: "quantick::app",
+            schema_version = 1_u8,
+            event_code = "REPLAY_CLOSED",
+            feed = %self.feed_id,
+            symbol = %self.symbol,
+            action = "respawn_live_feed",
+            "leaving market replay"
+        );
+
+        let Some(provider) = self.config.provider_of(&self.feed_id) else {
+            // The configuration changed under us; there is nothing to go back
+            // to, so the chart stays as it is rather than dying.
+            self.reset_market_state();
+            return;
+        };
+        let handle = feed::spawn_live(provider, &self.symbol, &self.config);
+        self.events = handle.events;
+        self.book_events = handle.book_events;
+        self.commands = handle.commands;
+        self.replay = handle.replay;
+        self.book_channel_closed_reported = false;
+        self.reset_market_state();
+    }
+}
+
 impl eframe::App for QuantickApp {
     fn update(&mut self, ctx: &egui::Context, frame: &mut eframe::Frame) {
         let now = Instant::now();
@@ -1521,12 +1794,18 @@ impl eframe::App for QuantickApp {
         self.maybe_emit_summary(now);
 
         let bg = self.bg();
+        self.draw_menu_bar(ctx);
         egui::TopBottomPanel::top("controls")
             .frame(egui::Frame::none().fill(self.chrome_bg()).inner_margin(8.0))
             .show(ctx, |ui| {
                 ui.visuals_mut().override_text_color = Some(OVERLAY);
                 self.draw_controls(ui);
             });
+        // The browser window and, while a session plays, the transport bar.
+        // Drawn before the chart so the bottom panel claims its strip first.
+        if let Some(action) = self.replay_view.draw(ctx, self.replay.as_ref()) {
+            self.apply_replay_action(action);
+        }
         // Respawn the feed if the feed/symbol selection changed (resets the
         // chart), then apply any bar-type change (no-op if unchanged).
         self.maybe_switch_feed();
@@ -1594,6 +1873,7 @@ mod tests {
                 events: evt_rx,
                 book_events: book_rx,
                 commands: cmd_tx,
+                replay: None,
             },
         );
         (app, evt_tx, cmd_rx, book_tx)
@@ -1706,6 +1986,7 @@ mod tests {
                 events: evt_rx,
                 book_events: book_rx,
                 commands: cmd_tx,
+                replay: None,
             },
         );
 

--- a/crates/app/src/feed/binance.rs
+++ b/crates/app/src/feed/binance.rs
@@ -47,6 +47,7 @@ pub fn spawn(symbol: &str) -> FeedHandle {
         events: rx,
         book_events: book_rx,
         commands: cmd_tx,
+        replay: None,
     }
 }
 
@@ -160,6 +161,11 @@ async fn feed_task(
                             &book_tx,
                         ));
                     }
+                    // Transport commands belong to a recorded session; a live
+                    // venue has no playhead to move. Ignored rather than
+                    // refused — the UI only shows the transport while a replay
+                    // is the source.
+                    Some(FeedCommand::Replay(_)) => {}
                     None => break, // UI dropped the command sender: it's gone
                 }
             }

--- a/crates/app/src/feed/metatrader.rs
+++ b/crates/app/src/feed/metatrader.rs
@@ -98,6 +98,7 @@ pub fn spawn(symbol: &str, settings: &MetaTraderSettings) -> FeedHandle {
         events: rx,
         book_events: book_rx,
         commands: cmd_tx,
+        replay: None,
     }
 }
 
@@ -464,6 +465,10 @@ async fn answer_command(
             );
             true
         }
+        // Transport commands belong to a recorded session; a live bridge has
+        // no playhead to move. Ignored rather than refused — the UI only shows
+        // the transport while a replay is the source.
+        FeedCommand::Replay(_) => true,
     }
 }
 

--- a/crates/app/src/feed/mod.rs
+++ b/crates/app/src/feed/mod.rs
@@ -5,13 +5,16 @@
 //! can send [`FeedCommand`]s back (e.g. "load older history"), serviced between
 //! live trades.
 //!
-//! Which backend runs is chosen at [`spawn`] time from a [`ProviderKind`], so
-//! the UI is provider-agnostic: it drains the same [`FeedHandle`] regardless of
-//! exchange. [`binance`] streams public aggTrades directly; [`metatrader`]
-//! listens for the local QuantickBridge EA (see `bridge/mt5/`).
+//! Which backend runs is chosen at [`spawn`] time from a [`FeedSource`], so the
+//! UI is provider-agnostic: it drains the same [`FeedHandle`] regardless of
+//! where the trades come from. [`binance`] streams public aggTrades directly;
+//! [`metatrader`] listens for the local QuantickBridge EA (see `bridge/mt5/`);
+//! [`replay`] plays a recorded session back through the very same channel, which
+//! is what lets market replay reuse the whole chart untouched.
 
 pub mod binance;
 pub mod metatrader;
+pub mod replay;
 
 use tokio::sync::mpsc;
 
@@ -19,6 +22,8 @@ use quantick_engine::Trade;
 pub use quantick_feed_binance::depth::DepthEvent;
 
 use crate::config::ProviderKind;
+
+pub use replay::{ReplayControl, ReplayLink, ReplayOptions, ReplayRequest};
 
 /// Default number of recent trades to backfill so the chart opens populated,
 /// when `QUANTICK_BACKFILL` is unset. One Binance REST page.
@@ -36,6 +41,19 @@ pub enum FeedEvent {
     HistoryPrepended(Vec<Trade>),
     /// One live trade.
     Live(Trade),
+    /// Several live trades that fell due together.
+    ///
+    /// A replay at 50× can release hundreds of prints between two frames, and a
+    /// per-trade channel message for each is pure overhead on both ends. Live
+    /// feeds keep sending [`FeedEvent::Live`]; the UI treats a batch exactly as
+    /// the trades in it, in order.
+    LiveBatch(Vec<Trade>),
+    /// Discard everything loaded and start over from an empty chart.
+    ///
+    /// Sent when a source rewinds — seeking a replay backwards, for instance.
+    /// Bars that were already closed cannot be un-closed, so the honest answer
+    /// is to rebuild from the new position rather than patch the series.
+    Reset,
 }
 
 /// A command from the UI to the feed thread.
@@ -54,6 +72,22 @@ pub enum FeedCommand {
         /// First generation assigned to the replacement capture.
         initial_generation: u64,
     },
+    /// Drive playback of a recorded session. Ignored by live feeds.
+    Replay(ReplayControl),
+}
+
+/// Where a feed's trades come from. One variant per backend, mirroring the
+/// [`spawn`] dispatch.
+pub enum FeedSource {
+    /// A live venue, selected from the configuration.
+    Live {
+        /// Which backend streams it.
+        provider: ProviderKind,
+        /// The instrument to stream.
+        symbol: String,
+    },
+    /// A recorded session, played back from disk.
+    Replay(Box<replay::ReplayRequest>),
 }
 
 /// The UI's handle on a running feed: events to drain, commands to send.
@@ -67,6 +101,10 @@ pub struct FeedHandle {
     pub book_events: mpsc::Receiver<DepthEvent>,
     /// UI → feed: on-demand history loading.
     pub commands: mpsc::Sender<FeedCommand>,
+    /// Present only while a recorded session is playing: what the transport bar
+    /// reads to draw itself. `None` means this is a live feed, which is the one
+    /// check the UI needs to tell the two modes apart.
+    pub replay: Option<ReplayLink>,
 }
 
 /// The initial backfill depth: `QUANTICK_BACKFILL` if it parses to a positive
@@ -80,21 +118,35 @@ pub fn initial_backfill_target() -> usize {
         .unwrap_or(DEFAULT_BACKFILL_TARGET)
 }
 
-/// Start the feed for `provider`/`symbol` on a background thread, returning the
-/// handle the UI drains and sends commands through. Dropping the handle stops
-/// the feed. Provider-specific settings come from `config`.
+/// Start the feed for `source` on a background thread, returning the handle the
+/// UI drains and sends commands through. Dropping the handle stops the feed.
+/// Provider-specific settings come from `config`.
 ///
-/// This is the whole "provider → backend" dispatch: one place, mirroring the
-/// [`ProviderKind`] variants. Adding a provider is a new arm here plus its
-/// module.
+/// This is the whole "source → backend" dispatch: one place, mirroring the
+/// [`FeedSource`] variants. Adding a source is a new arm here plus its module.
 #[must_use]
-pub fn spawn(
+pub fn spawn(source: FeedSource, config: &crate::config::AppConfig) -> FeedHandle {
+    match source {
+        FeedSource::Live { provider, symbol } => match provider {
+            ProviderKind::Binance => binance::spawn(&symbol),
+            ProviderKind::MetaTrader => metatrader::spawn(&symbol, &config.metatrader),
+        },
+        FeedSource::Replay(request) => replay::spawn(*request),
+    }
+}
+
+/// Start a live feed for `provider`/`symbol`. A shorthand for the common case.
+#[must_use]
+pub fn spawn_live(
     provider: ProviderKind,
     symbol: &str,
     config: &crate::config::AppConfig,
 ) -> FeedHandle {
-    match provider {
-        ProviderKind::Binance => binance::spawn(symbol),
-        ProviderKind::MetaTrader => metatrader::spawn(symbol, &config.metatrader),
-    }
+    spawn(
+        FeedSource::Live {
+            provider,
+            symbol: symbol.to_string(),
+        },
+        config,
+    )
 }

--- a/crates/app/src/feed/replay.rs
+++ b/crates/app/src/feed/replay.rs
@@ -295,17 +295,13 @@ fn play(
     let mut last = Instant::now();
     let mut reported_finished = false;
 
+    let mut drained = Vec::new();
     loop {
         // 1. Controls first, so a click is honoured before the next batch.
+        drained.clear();
         loop {
             match commands.try_recv() {
-                Ok(FeedCommand::Replay(control)) => {
-                    if !apply(control, &mut playhead, trades, &tx, &session) {
-                        return; // UI gone
-                    }
-                    reported_finished = false;
-                    last = Instant::now();
-                }
+                Ok(FeedCommand::Replay(control)) => drained.push(control),
                 // Live-feed commands have no meaning for a recording. Ignored
                 // rather than refused: the UI gates them by capability, and a
                 // stray one must not kill playback.
@@ -313,6 +309,21 @@ fn play(
                 Err(mpsc::error::TryRecvError::Empty) => break,
                 Err(mpsc::error::TryRecvError::Disconnected) => return,
             }
+        }
+        if !drained.is_empty() {
+            let (immediate, position) = coalesce(&drained);
+            for control in immediate {
+                if !apply(control, &mut playhead, trades, &tx, &session) {
+                    return; // UI gone
+                }
+            }
+            if let Some(control) = position
+                && !apply(control, &mut playhead, trades, &tx, &session)
+            {
+                return;
+            }
+            reported_finished = false;
+            last = Instant::now();
         }
 
         // 2. Release whatever the clock says is due.
@@ -349,6 +360,27 @@ fn play(
             TICK_PAUSED
         });
     }
+}
+
+/// Split a drained batch of controls into the ones applied in order and the one
+/// position command that survives.
+///
+/// Moving the playhead rebuilds the chart from the session's history — work
+/// proportional to the whole recording — so applying every queued seek would
+/// throw away all but the last rebuild. Only the newest position command
+/// (`Restart` or `SeekToFraction`) is kept, and it is applied after the others
+/// so the last thing asked for is where playback lands. Play, pause and speed
+/// are cheap and orthogonal, so they keep their order.
+fn coalesce(controls: &[ReplayControl]) -> (Vec<ReplayControl>, Option<ReplayControl>) {
+    let mut immediate = Vec::new();
+    let mut position = None;
+    for control in controls {
+        match control {
+            ReplayControl::Restart | ReplayControl::SeekToFraction(_) => position = Some(*control),
+            other => immediate.push(*other),
+        }
+    }
+    (immediate, position)
 }
 
 /// Apply one transport command. Returns `false` when the UI has gone away.
@@ -557,6 +589,35 @@ mod tests {
         // 60 prints one second apart: half way is 30 of them.
         assert_eq!(history.len(), 30);
         assert_eq!(history[0].side, Side::Buy);
+    }
+
+    #[test]
+    fn a_burst_of_seeks_rebuilds_the_chart_once() {
+        // A dragged seek handle can queue a command per frame; each rebuild
+        // re-sends the session's history, so only the last position may be
+        // applied. Play/pause/speed are orthogonal and keep their order.
+        let controls = [
+            ReplayControl::SeekToFraction(0.1),
+            ReplayControl::SetSpeed(10.0),
+            ReplayControl::SeekToFraction(0.4),
+            ReplayControl::Restart,
+            ReplayControl::Pause,
+            ReplayControl::SeekToFraction(0.9),
+        ];
+        let (immediate, position) = coalesce(&controls);
+        assert_eq!(
+            immediate,
+            vec![ReplayControl::SetSpeed(10.0), ReplayControl::Pause]
+        );
+        assert_eq!(position, Some(ReplayControl::SeekToFraction(0.9)));
+    }
+
+    #[test]
+    fn a_restart_after_a_seek_is_the_position_that_wins() {
+        let (immediate, position) =
+            coalesce(&[ReplayControl::SeekToFraction(0.8), ReplayControl::Restart]);
+        assert!(immediate.is_empty());
+        assert_eq!(position, Some(ReplayControl::Restart));
     }
 
     #[test]

--- a/crates/app/src/feed/replay.rs
+++ b/crates/app/src/feed/replay.rs
@@ -1,0 +1,601 @@
+//! Playing a recorded session back through the live-feed channel.
+//!
+//! Market replay is not a second chart mode: it is a *source*. The session's
+//! trades are released on a playback clock and pushed down the very same
+//! [`FeedEvent`] channel a live venue uses, so bar building, rendering,
+//! navigation and metrics run the code path they always run and cannot drift
+//! from live behaviour.
+//!
+//! Three things keep it smooth at 50×:
+//!
+//! - trades that fall due together travel as one [`FeedEvent::LiveBatch`], not
+//!   one channel message each;
+//! - the transport reads playback state from atomics, so drawing the bar costs
+//!   no lock and cannot block the worker;
+//! - a stalled UI (a dragged window, a slow frame) clamps the clock delta
+//!   instead of releasing a minute of market in one jump.
+//!
+//! The clock itself lives in [`quantick_replay::clock`], is deterministic, and
+//! never reads a wall clock — this module measures the time and tells it.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU32, AtomicUsize, Ordering};
+use std::time::{Duration, Instant};
+
+use tokio::sync::mpsc;
+
+use quantick_replay::{PlaybackConfig, Playhead, Session};
+
+use super::{FeedCommand, FeedEvent, FeedHandle};
+
+/// How often the worker wakes while playing. Finer than a 60 fps frame, so the
+/// chart never waits on the clock for a print that is already due.
+const TICK_PLAYING: Duration = Duration::from_millis(8);
+
+/// How often the worker wakes while paused — often enough to feel instant on
+/// the next click, rare enough to be free.
+const TICK_PAUSED: Duration = Duration::from_millis(33);
+
+/// Largest real-time step one advance may take, whatever the wall clock says.
+///
+/// A frame that took 2 s (a dragged window, a stalled GPU) must not release 100
+/// seconds of market at 50× in one lurch. The replay falls behind real time by
+/// the overrun instead, which is visible and honest.
+const MAX_DELTA_MS: f64 = 250.0;
+
+/// Room for a few frames of batches, so a brief UI stall does not stall the
+/// clock. Beyond that the worker blocks, which is the intended backpressure.
+const EVENT_CHANNEL_CAPACITY: usize = 64;
+
+/// What the UI asks the transport to do.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum ReplayControl {
+    /// Start playing (restarting first if the session already finished).
+    Play,
+    /// Stop advancing, keeping the position.
+    Pause,
+    /// Play if paused, pause if playing.
+    TogglePlay,
+    /// Change the speed multiplier; the position does not move.
+    SetSpeed(f32),
+    /// Jump to a fraction of the session, `0.0`..=`1.0`.
+    SeekToFraction(f32),
+    /// Jump back to the first print.
+    Restart,
+}
+
+/// How a session is opened.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ReplayOptions {
+    /// Speed to start at.
+    pub speed: f32,
+    /// Whether to start playing immediately.
+    pub autoplay: bool,
+    /// Market time that may pass with no prints before the clock skips ahead.
+    pub skip_idle_over_ms: Option<i64>,
+}
+
+impl Default for ReplayOptions {
+    fn default() -> Self {
+        Self {
+            speed: 1.0,
+            autoplay: true,
+            skip_idle_over_ms: Some(quantick_replay::clock::DEFAULT_SKIP_IDLE_MS),
+        }
+    }
+}
+
+/// Everything needed to start playing a session that is already loaded.
+#[derive(Debug, Clone)]
+pub struct ReplayRequest {
+    /// The loaded session. Shared, so the UI can read its metadata without
+    /// copying a few hundred thousand trades.
+    pub session: Arc<Session>,
+    /// How to open it.
+    pub options: ReplayOptions,
+}
+
+/// Playback state, published by the worker and read by the UI every frame.
+///
+/// Atomics rather than a mutex: the transport bar reads six numbers per frame
+/// and must never wait on the thread that is releasing trades.
+#[derive(Debug)]
+pub struct ReplayStatus {
+    position_ms: AtomicI64,
+    start_ms: AtomicI64,
+    end_ms: AtomicI64,
+    cursor: AtomicUsize,
+    total: AtomicUsize,
+    speed_bits: AtomicU32,
+    playing: AtomicBool,
+    finished: AtomicBool,
+}
+
+impl ReplayStatus {
+    fn new(playhead: &Playhead) -> Self {
+        let status = Self {
+            position_ms: AtomicI64::new(playhead.position_ms()),
+            start_ms: AtomicI64::new(playhead.start_ms()),
+            end_ms: AtomicI64::new(playhead.end_ms()),
+            cursor: AtomicUsize::new(playhead.cursor()),
+            total: AtomicUsize::new(playhead.total()),
+            speed_bits: AtomicU32::new(playhead.speed().to_bits()),
+            playing: AtomicBool::new(playhead.is_playing()),
+            finished: AtomicBool::new(playhead.is_finished()),
+        };
+        status.publish(playhead);
+        status
+    }
+
+    fn publish(&self, playhead: &Playhead) {
+        self.position_ms
+            .store(playhead.position_ms(), Ordering::Relaxed);
+        self.cursor.store(playhead.cursor(), Ordering::Relaxed);
+        self.speed_bits
+            .store(playhead.speed().to_bits(), Ordering::Relaxed);
+        self.playing.store(playhead.is_playing(), Ordering::Relaxed);
+        self.finished
+            .store(playhead.is_finished(), Ordering::Relaxed);
+    }
+
+    /// Market time reached, in epoch milliseconds.
+    #[must_use]
+    pub fn position_ms(&self) -> i64 {
+        self.position_ms.load(Ordering::Relaxed)
+    }
+
+    /// Timestamp of the session's first print.
+    #[must_use]
+    pub fn start_ms(&self) -> i64 {
+        self.start_ms.load(Ordering::Relaxed)
+    }
+
+    /// Timestamp of the session's last print.
+    #[must_use]
+    pub fn end_ms(&self) -> i64 {
+        self.end_ms.load(Ordering::Relaxed)
+    }
+
+    /// How many prints have been released.
+    #[must_use]
+    pub fn played(&self) -> usize {
+        self.cursor.load(Ordering::Relaxed)
+    }
+
+    /// How many prints the session holds.
+    #[must_use]
+    pub fn total(&self) -> usize {
+        self.total.load(Ordering::Relaxed)
+    }
+
+    /// The current speed multiplier.
+    #[must_use]
+    pub fn speed(&self) -> f32 {
+        f32::from_bits(self.speed_bits.load(Ordering::Relaxed))
+    }
+
+    /// Whether playback is running.
+    #[must_use]
+    pub fn is_playing(&self) -> bool {
+        self.playing.load(Ordering::Relaxed)
+    }
+
+    /// Whether the session has played out.
+    #[must_use]
+    pub fn is_finished(&self) -> bool {
+        self.finished.load(Ordering::Relaxed)
+    }
+
+    /// How far through the session playback is, `0.0`..=`1.0`.
+    #[must_use]
+    pub fn progress(&self) -> f32 {
+        let (start, end) = (self.start_ms(), self.end_ms());
+        let span = end.saturating_sub(start);
+        if span <= 0 {
+            return if self.is_finished() { 1.0 } else { 0.0 };
+        }
+        let elapsed = self.position_ms().saturating_sub(start) as f64;
+        (elapsed / span as f64).clamp(0.0, 1.0) as f32
+    }
+}
+
+/// The UI's window onto a playing session: what it is, and where it is.
+#[derive(Debug, Clone)]
+pub struct ReplayLink {
+    /// The session being played, for its symbol, day and timezone.
+    pub session: Arc<Session>,
+    /// Live playback state.
+    pub status: Arc<ReplayStatus>,
+}
+
+impl ReplayLink {
+    /// Instrument and day, e.g. `WINJ26 · 2026-03-16`.
+    #[must_use]
+    pub fn label(&self) -> String {
+        self.session.label()
+    }
+
+    /// The instrument being replayed.
+    #[must_use]
+    pub fn symbol(&self) -> &str {
+        &self.session.symbol
+    }
+}
+
+/// Start playing `request` on a background thread.
+///
+/// The returned handle carries the same channels a live feed does, plus a
+/// [`ReplayLink`]. Dropping it stops the worker.
+#[must_use]
+pub fn spawn(request: ReplayRequest) -> FeedHandle {
+    let (tx, rx) = mpsc::channel(EVENT_CHANNEL_CAPACITY);
+    // Replay streams no depth. The receiver exists so the UI drains one shape
+    // of handle; it simply never yields an event.
+    let (_book_tx, book_rx) = mpsc::channel(1);
+    let (cmd_tx, cmd_rx) = mpsc::channel(16);
+
+    let config = PlaybackConfig {
+        speed: request.options.speed,
+        skip_idle_over_ms: request.options.skip_idle_over_ms,
+        ..PlaybackConfig::default()
+    };
+    let mut playhead = Playhead::new(&request.session.trades, config);
+    if request.options.autoplay {
+        playhead.play();
+    }
+    let status = Arc::new(ReplayStatus::new(&playhead));
+    let link = ReplayLink {
+        session: Arc::clone(&request.session),
+        status: Arc::clone(&status),
+    };
+
+    let session = Arc::clone(&request.session);
+    std::thread::Builder::new()
+        .name("quantick-replay".into())
+        .spawn(move || play(session, playhead, status, tx, cmd_rx))
+        .expect("spawn replay thread");
+
+    FeedHandle {
+        events: rx,
+        book_events: book_rx,
+        commands: cmd_tx,
+        replay: Some(link),
+    }
+}
+
+/// The playback loop. Returns as soon as the UI drops its end of either channel.
+fn play(
+    session: Arc<Session>,
+    mut playhead: Playhead,
+    status: Arc<ReplayStatus>,
+    tx: mpsc::Sender<FeedEvent>,
+    mut commands: mpsc::Receiver<FeedCommand>,
+) {
+    tracing::info!(
+        target: "quantick::app",
+        schema_version = 1_u8,
+        event_code = "REPLAY_STARTED",
+        symbol = session.symbol.as_str(),
+        session = %session.label(),
+        file = %session.path.display(),
+        trades = session.trades.len(),
+        span_ms = session.span_ms(),
+        speed = playhead.speed(),
+        playing = playhead.is_playing(),
+        "replaying a recorded session"
+    );
+
+    // The chart opens empty and fills as the session plays; an empty backfill
+    // resolves the UI's initial "loading history" state right away.
+    if tx.blocking_send(FeedEvent::Backfilled(Vec::new())).is_err() {
+        return;
+    }
+
+    let trades = &session.trades[..];
+    let mut last = Instant::now();
+    let mut reported_finished = false;
+
+    loop {
+        // 1. Controls first, so a click is honoured before the next batch.
+        loop {
+            match commands.try_recv() {
+                Ok(FeedCommand::Replay(control)) => {
+                    if !apply(control, &mut playhead, trades, &tx, &session) {
+                        return; // UI gone
+                    }
+                    reported_finished = false;
+                    last = Instant::now();
+                }
+                // Live-feed commands have no meaning for a recording. Ignored
+                // rather than refused: the UI gates them by capability, and a
+                // stray one must not kill playback.
+                Ok(_) => {}
+                Err(mpsc::error::TryRecvError::Empty) => break,
+                Err(mpsc::error::TryRecvError::Disconnected) => return,
+            }
+        }
+
+        // 2. Release whatever the clock says is due.
+        let now = Instant::now();
+        let delta = (now.saturating_duration_since(last).as_secs_f64() * 1000.0).min(MAX_DELTA_MS);
+        last = now;
+
+        let batch = playhead.advance(trades, delta);
+        if !batch.is_empty() {
+            let due = trades[batch.range()].to_vec();
+            if tx.blocking_send(FeedEvent::LiveBatch(due)).is_err() {
+                return;
+            }
+        }
+        status.publish(&playhead);
+
+        if playhead.is_finished() && !reported_finished {
+            reported_finished = true;
+            tracing::info!(
+                target: "quantick::app",
+                schema_version = 1_u8,
+                event_code = "REPLAY_FINISHED",
+                symbol = session.symbol.as_str(),
+                session = %session.label(),
+                trades = playhead.total(),
+                action = "await_transport_command",
+                "recorded session played out"
+            );
+        }
+
+        std::thread::sleep(if playhead.is_playing() && !playhead.is_finished() {
+            TICK_PLAYING
+        } else {
+            TICK_PAUSED
+        });
+    }
+}
+
+/// Apply one transport command. Returns `false` when the UI has gone away.
+fn apply(
+    control: ReplayControl,
+    playhead: &mut Playhead,
+    trades: &[quantick_engine::Trade],
+    tx: &mpsc::Sender<FeedEvent>,
+    session: &Session,
+) -> bool {
+    match control {
+        ReplayControl::Play => playhead.play(),
+        ReplayControl::Pause => playhead.pause(),
+        ReplayControl::TogglePlay => playhead.toggle(),
+        ReplayControl::SetSpeed(speed) => {
+            playhead.set_speed(speed);
+            tracing::info!(
+                target: "quantick::app",
+                schema_version = 1_u8,
+                event_code = "REPLAY_SPEED_CHANGED",
+                symbol = session.symbol.as_str(),
+                speed = playhead.speed(),
+                "replay speed changed"
+            );
+        }
+        ReplayControl::Restart => {
+            playhead.restart();
+            return rebuild_from_cursor(playhead, trades, tx, session, "restart");
+        }
+        ReplayControl::SeekToFraction(fraction) => {
+            playhead.seek_to_fraction(trades, fraction);
+            return rebuild_from_cursor(playhead, trades, tx, session, "seek");
+        }
+    }
+    true
+}
+
+/// Rebuild the chart so it matches the playhead exactly.
+///
+/// Seeking either direction resends the whole session up to the new position as
+/// history. Bars already closed cannot be reopened, and a forward-only patch
+/// would leave the chart showing a series the position no longer explains — so
+/// both directions take the same honest path.
+fn rebuild_from_cursor(
+    playhead: &Playhead,
+    trades: &[quantick_engine::Trade],
+    tx: &mpsc::Sender<FeedEvent>,
+    session: &Session,
+    reason: &'static str,
+) -> bool {
+    let cursor = playhead.cursor();
+    tracing::info!(
+        target: "quantick::app",
+        schema_version = 1_u8,
+        event_code = "REPLAY_SEEK",
+        symbol = session.symbol.as_str(),
+        reason,
+        position_ms = playhead.position_ms(),
+        played = cursor,
+        total = playhead.total(),
+        action = "rebuild_chart_from_history",
+        "replay position moved"
+    );
+    if tx.blocking_send(FeedEvent::Reset).is_err() {
+        return false;
+    }
+    tx.blocking_send(FeedEvent::Backfilled(trades[..cursor].to_vec()))
+        .is_ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::path::PathBuf;
+
+    use quantick_engine::{Side, Trade};
+    use quantick_replay::ParseOptions;
+    use rust_decimal::Decimal;
+
+    /// `count` prints 10 ms apart from 10:00:00, so a session of any length
+    /// still moves strictly forward in time — which is what the format demands.
+    fn session(count: usize) -> Arc<Session> {
+        let mut text = String::from("# symbol=TEST\nDate,Time,Price,Volume,Side\n");
+        for i in 0..count {
+            let ms = i as i64 * 10;
+            text.push_str(&format!(
+                "2026-03-16,{:02}:{:02}:{:02}.{:03},{},1,B\n",
+                10 + ms / 3_600_000,
+                (ms / 60_000) % 60,
+                (ms / 1_000) % 60,
+                ms % 1_000,
+                100 + i
+            ));
+        }
+        Arc::new(
+            Session::from_text(
+                &PathBuf::from("replay/TEST/20260316.csv"),
+                &text,
+                ParseOptions::default(),
+            )
+            .expect("session"),
+        )
+    }
+
+    /// Drain events until `want` trades have arrived or the deadline passes.
+    fn collect(handle: &mut FeedHandle, want: usize) -> Vec<Trade> {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let mut trades = Vec::new();
+        while trades.len() < want && Instant::now() < deadline {
+            match handle.events.try_recv() {
+                Ok(FeedEvent::LiveBatch(batch)) => trades.extend(batch),
+                Ok(FeedEvent::Live(trade)) => trades.push(trade),
+                Ok(FeedEvent::Backfilled(batch)) => trades.extend(batch),
+                Ok(_) => {}
+                Err(mpsc::error::TryRecvError::Empty) => std::thread::sleep(TICK_PLAYING),
+                Err(mpsc::error::TryRecvError::Disconnected) => break,
+            }
+        }
+        trades
+    }
+
+    #[test]
+    fn a_session_plays_out_through_the_live_channel() {
+        let session = session(30);
+        let mut handle = spawn(ReplayRequest {
+            session,
+            options: ReplayOptions {
+                // 30 s of market time; at 50× that is well under a second.
+                speed: 50.0,
+                autoplay: true,
+                skip_idle_over_ms: Some(2_000),
+            },
+        });
+        let trades = collect(&mut handle, 30);
+        assert_eq!(trades.len(), 30);
+        assert_eq!(trades[0].price, Decimal::from(100));
+        assert_eq!(trades[29].price, Decimal::from(129));
+        assert!(
+            trades
+                .windows(2)
+                .all(|w| w[0].timestamp_ms <= w[1].timestamp_ms)
+        );
+
+        let link = handle.replay.as_ref().expect("replay link");
+        assert_eq!(link.symbol(), "TEST");
+        assert_eq!(link.status.total(), 30);
+    }
+
+    #[test]
+    fn a_paused_session_releases_nothing_until_play() {
+        let mut handle = spawn(ReplayRequest {
+            session: session(20),
+            options: ReplayOptions {
+                speed: 50.0,
+                autoplay: false,
+                ..Default::default()
+            },
+        });
+        let link = handle.replay.clone().expect("replay link");
+        assert!(!link.status.is_playing());
+
+        std::thread::sleep(Duration::from_millis(60));
+        assert!(collect(&mut handle, 1).is_empty(), "paused feed is silent");
+
+        handle
+            .commands
+            .blocking_send(FeedCommand::Replay(ReplayControl::Play))
+            .unwrap();
+        assert_eq!(collect(&mut handle, 20).len(), 20);
+        assert!(link.status.is_finished());
+        assert_eq!(link.status.progress(), 1.0);
+    }
+
+    #[test]
+    fn seeking_resets_the_chart_and_resends_history() {
+        let mut handle = spawn(ReplayRequest {
+            session: session(60),
+            options: ReplayOptions {
+                speed: 1.0,
+                autoplay: false,
+                ..Default::default()
+            },
+        });
+        handle
+            .commands
+            .blocking_send(FeedCommand::Replay(ReplayControl::SeekToFraction(0.5)))
+            .unwrap();
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let mut saw_reset = false;
+        let mut history = Vec::new();
+        while Instant::now() < deadline {
+            match handle.events.try_recv() {
+                Ok(FeedEvent::Reset) => saw_reset = true,
+                Ok(FeedEvent::Backfilled(batch)) if saw_reset => {
+                    history = batch;
+                    break;
+                }
+                Ok(_) => {}
+                Err(mpsc::error::TryRecvError::Empty) => std::thread::sleep(TICK_PLAYING),
+                Err(mpsc::error::TryRecvError::Disconnected) => break,
+            }
+        }
+        assert!(saw_reset, "a seek resets the chart");
+        // 60 prints one second apart: half way is 30 of them.
+        assert_eq!(history.len(), 30);
+        assert_eq!(history[0].side, Side::Buy);
+    }
+
+    #[test]
+    fn speed_changes_reach_the_playhead() {
+        let handle = spawn(ReplayRequest {
+            session: session(10),
+            options: ReplayOptions {
+                speed: 1.0,
+                autoplay: false,
+                ..Default::default()
+            },
+        });
+        let link = handle.replay.clone().expect("replay link");
+        handle
+            .commands
+            .blocking_send(FeedCommand::Replay(ReplayControl::SetSpeed(20.0)))
+            .unwrap();
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while link.status.speed() != 20.0 && Instant::now() < deadline {
+            std::thread::sleep(TICK_PLAYING);
+        }
+        assert_eq!(link.status.speed(), 20.0);
+    }
+
+    #[test]
+    fn dropping_the_handle_stops_the_worker() {
+        let handle = spawn(ReplayRequest {
+            session: session(20_000),
+            options: ReplayOptions::default(),
+        });
+        let link = handle.replay.clone().expect("replay link");
+        drop(handle);
+        // The worker holds the session Arc; once it exits, only the link's
+        // clone remains.
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while Arc::strong_count(&link.session) > 1 && Instant::now() < deadline {
+            std::thread::sleep(TICK_PAUSED);
+        }
+        assert_eq!(Arc::strong_count(&link.session), 1, "worker exited");
+    }
+}

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -24,6 +24,7 @@ mod orderflow_render;
 mod orderflow_view;
 mod orderflow_worker;
 mod price_view;
+mod replay_view;
 mod state;
 mod style;
 mod timezone;
@@ -100,7 +101,7 @@ fn main() -> eframe::Result {
         "starting quantick"
     );
 
-    let feed = feed::spawn(provider, &symbol, &config);
+    let feed = feed::spawn_live(provider, &symbol, &config);
 
     let icon = eframe::icon_data::from_png_bytes(include_bytes!("../assets/icon.png"))
         .expect("bundled assets/icon.png is a valid PNG");

--- a/crates/app/src/replay_view.rs
+++ b/crates/app/src/replay_view.rs
@@ -1,0 +1,746 @@
+//! Market Replay's interface: the session browser and the transport bar.
+//!
+//! Two rules shape it. The chart is the product, so replay adds exactly one menu
+//! entry and one bar that exists only while a recording is playing — nothing is
+//! added to the controls a live chart already carries. And a folder that does
+//! not load must say why in the interface, not in a log: the browser names the
+//! file, the line, what was found and what to change, with the whole format one
+//! click away.
+//!
+//! The view owns no playback state. It reads [`ReplayLink`] (atomics, published
+//! by the worker) and returns a [`ReplayAction`] for the app to carry out, so
+//! drawing can never block the thread releasing trades.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::mpsc::{Receiver, TryRecvError};
+
+use eframe::egui;
+
+use quantick_replay::clock::SPEEDS;
+use quantick_replay::format::{self, UtcOffset};
+use quantick_replay::{Library, ParseOptions, Session, SessionEntry, SessionError, library};
+
+use crate::app::{MUTED, OVERLAY, WARN};
+use crate::feed::{ReplayControl, ReplayLink, ReplayOptions, ReplayRequest};
+
+/// The accent this feature owns: the same amber the chart already uses for the
+/// backfill/live divider, so "this is not live data" reads the same way twice.
+const REPLAY_ACCENT: egui::Color32 = egui::Color32::from_rgb(240, 185, 11);
+
+/// Environment variable naming the folder the browser opens on.
+pub const REPLAY_DIR_ENV: &str = "QUANTICK_REPLAY_DIR";
+
+/// Height of the seek track, in pixels.
+const TRACK_HEIGHT: f32 = 6.0;
+
+/// What the replay interface asks the app to do.
+pub enum ReplayAction {
+    /// Start playing this session.
+    Open(Box<ReplayRequest>),
+    /// Drive the session that is already playing.
+    Control(ReplayControl),
+    /// Leave replay and go back to the live feed.
+    Close,
+}
+
+/// A load running on a worker thread, with the label to show while it runs.
+struct Loading {
+    label: String,
+    result: Receiver<Result<Session, SessionError>>,
+}
+
+/// The session browser's state. Owned by the app, drawn every frame.
+pub struct ReplayView {
+    browser_open: bool,
+    folder: String,
+    library: Option<Library>,
+    selected: Option<usize>,
+    loading: Option<Loading>,
+    picker: Option<Receiver<Option<PathBuf>>>,
+    error: Option<String>,
+    show_format: bool,
+    speed: f32,
+    autoplay: bool,
+}
+
+impl Default for ReplayView {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ReplayView {
+    /// A closed browser, opening on `QUANTICK_REPLAY_DIR` when it is set.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            browser_open: false,
+            folder: std::env::var(REPLAY_DIR_ENV).unwrap_or_default(),
+            library: None,
+            selected: None,
+            loading: None,
+            picker: None,
+            error: None,
+            show_format: false,
+            speed: 1.0,
+            autoplay: true,
+        }
+    }
+
+    /// Open the browser, rescanning the folder it already knows.
+    pub fn open_browser(&mut self) {
+        self.browser_open = true;
+        if self.library.is_none() && !self.folder.trim().is_empty() {
+            self.rescan();
+        }
+    }
+
+    /// Show the format reference on its own, from the Help menu.
+    pub fn open_format_help(&mut self) {
+        self.browser_open = true;
+        self.show_format = true;
+    }
+
+    /// Scan the configured folder and start its first session, without opening
+    /// the browser.
+    ///
+    /// The same path a click takes — scan, select, load on a worker — so what a
+    /// scripted run exercises is what a person gets. Returns whether a session
+    /// was found to load; a folder that yields nothing opens the browser
+    /// instead, where the reason is already spelled out.
+    pub fn autostart(&mut self, speed: f32) -> bool {
+        self.speed = speed;
+        self.autoplay = true;
+        self.rescan();
+        if self.selected_entry().is_none() {
+            self.browser_open = true;
+            return false;
+        }
+        self.load_selected();
+        true
+    }
+
+    /// Draw the browser and, while a session is playing, the transport bar.
+    ///
+    /// Returns at most one action per frame — a person clicks one thing at a
+    /// time, and folding several into a frame would let a stale click win.
+    pub fn draw(&mut self, ctx: &egui::Context, link: Option<&ReplayLink>) -> Option<ReplayAction> {
+        self.poll_picker();
+        let mut action = self.poll_loading();
+        if let Some(from_browser) = self.draw_browser(ctx) {
+            action = action.or(Some(from_browser));
+        }
+        if let Some(link) = link
+            && let Some(from_transport) = self.draw_transport(ctx, link)
+        {
+            action = action.or(Some(from_transport));
+        }
+        action
+    }
+
+    /// Take the result of a finished background load.
+    fn poll_loading(&mut self) -> Option<ReplayAction> {
+        let loading = self.loading.as_ref()?;
+        match loading.result.try_recv() {
+            Ok(Ok(session)) => {
+                self.loading = None;
+                self.browser_open = false;
+                self.error = None;
+                Some(ReplayAction::Open(Box::new(ReplayRequest {
+                    session: Arc::new(session),
+                    options: ReplayOptions {
+                        speed: self.speed,
+                        autoplay: self.autoplay,
+                        ..ReplayOptions::default()
+                    },
+                })))
+            }
+            Ok(Err(e)) => {
+                self.error = Some(format!("{e}\n{}", e.advice()));
+                self.loading = None;
+                None
+            }
+            Err(TryRecvError::Empty) => None,
+            Err(TryRecvError::Disconnected) => {
+                self.error = Some("the loader stopped before finishing".to_string());
+                self.loading = None;
+                None
+            }
+        }
+    }
+
+    /// Take the folder the native dialog came back with.
+    fn poll_picker(&mut self) {
+        let Some(picker) = self.picker.as_ref() else {
+            return;
+        };
+        match picker.try_recv() {
+            Ok(Some(folder)) => {
+                self.folder = folder.display().to_string();
+                self.picker = None;
+                self.rescan();
+            }
+            Ok(None) | Err(TryRecvError::Disconnected) => self.picker = None,
+            Err(TryRecvError::Empty) => {}
+        }
+    }
+
+    /// Scan the folder in the text field.
+    fn rescan(&mut self) {
+        let root = PathBuf::from(self.folder.trim());
+        let library = library::scan(&root);
+        tracing::info!(
+            target: "quantick::app",
+            schema_version = 1_u8,
+            event_code = "REPLAY_FOLDER_SCANNED",
+            folder = %root.display(),
+            sessions = library.sessions.len(),
+            problems = library.problems.len(),
+            "scanned a replay folder"
+        );
+        self.selected = (!library.sessions.is_empty()).then_some(0);
+        self.library = Some(library);
+        self.error = None;
+    }
+
+    /// Ask the operating system for a folder, off the UI thread so the dialog
+    /// never freezes a frame.
+    fn browse(&mut self) {
+        if self.picker.is_some() {
+            return;
+        }
+        let (tx, rx) = std::sync::mpsc::channel();
+        let start = PathBuf::from(self.folder.trim());
+        std::thread::Builder::new()
+            .name("quantick-replay-picker".into())
+            .spawn(move || {
+                let mut dialog = rfd::FileDialog::new().set_title("Choose a replay folder");
+                if start.is_dir() {
+                    dialog = dialog.set_directory(&start);
+                }
+                let _ = tx.send(dialog.pick_folder());
+            })
+            .expect("spawn folder picker thread");
+        self.picker = Some(rx);
+    }
+
+    /// Start loading the selected session on a worker thread.
+    fn load_selected(&mut self) {
+        let Some(entry) = self.selected_entry().cloned() else {
+            return;
+        };
+        let (tx, rx) = std::sync::mpsc::channel();
+        let path = entry.path.clone();
+        std::thread::Builder::new()
+            .name("quantick-replay-load".into())
+            .spawn(move || {
+                let _ = tx.send(Session::load(&path, ParseOptions::default()));
+            })
+            .expect("spawn replay loader thread");
+        self.loading = Some(Loading {
+            label: entry.label(),
+            result: rx,
+        });
+        self.error = None;
+    }
+
+    fn selected_entry(&self) -> Option<&SessionEntry> {
+        let library = self.library.as_ref()?;
+        library.sessions.get(self.selected?)
+    }
+
+    fn draw_browser(&mut self, ctx: &egui::Context) -> Option<ReplayAction> {
+        if !self.browser_open {
+            return None;
+        }
+        let mut open = true;
+        let mut load_clicked = false;
+
+        egui::Window::new("Market Replay")
+            .open(&mut open)
+            .collapsible(false)
+            .resizable(true)
+            .default_width(560.0)
+            .default_height(460.0)
+            .anchor(egui::Align2::CENTER_CENTER, egui::vec2(0.0, 0.0))
+            .show(ctx, |ui| {
+                ui.visuals_mut().override_text_color = Some(OVERLAY);
+                self.draw_folder_row(ui);
+                ui.add_space(10.0);
+                self.draw_session_list(ui);
+                ui.add_space(8.0);
+                self.draw_problems(ui);
+                self.draw_format_help(ui);
+                ui.add_space(6.0);
+                load_clicked = self.draw_start_row(ui);
+            });
+
+        self.browser_open = open;
+        if load_clicked {
+            self.load_selected();
+        }
+        None
+    }
+
+    fn draw_folder_row(&mut self, ui: &mut egui::Ui) {
+        ui.label(egui::RichText::new("Replay folder").color(MUTED).small());
+        ui.horizontal(|ui| {
+            let width = (ui.available_width() - 110.0).max(120.0);
+            let response = ui.add_sized(
+                [width, 24.0],
+                egui::TextEdit::singleline(&mut self.folder)
+                    .hint_text("…/replay")
+                    .desired_width(width),
+            );
+            if response.lost_focus() && ui.input(|i| i.key_pressed(egui::Key::Enter)) {
+                self.rescan();
+            }
+            if ui.button("Browse…").clicked() {
+                self.browse();
+            }
+            if ui
+                .button("↻")
+                .on_hover_text("Scan this folder again")
+                .clicked()
+            {
+                self.rescan();
+            }
+        });
+        if self.picker.is_some() {
+            ui.label(
+                egui::RichText::new("Waiting for the folder dialog…")
+                    .color(MUTED)
+                    .small(),
+            );
+        }
+    }
+
+    fn draw_session_list(&mut self, ui: &mut egui::Ui) {
+        ui.label(egui::RichText::new("Sessions").color(MUTED).small());
+        let frame = egui::Frame::none()
+            .fill(egui::Color32::from_black_alpha(60))
+            .inner_margin(8.0)
+            .rounding(4.0);
+
+        frame.show(ui, |ui| {
+            ui.set_min_height(150.0);
+            let Some(library) = self.library.as_ref() else {
+                ui.add_space(30.0);
+                ui.vertical_centered(|ui| {
+                    ui.label(
+                        egui::RichText::new("Choose the folder holding your recorded sessions.")
+                            .color(MUTED),
+                    );
+                });
+                return;
+            };
+            if library.sessions.is_empty() {
+                ui.add_space(24.0);
+                ui.vertical_centered(|ui| {
+                    ui.label(egui::RichText::new("No sessions in this folder.").color(WARN));
+                    ui.add_space(4.0);
+                    ui.label(
+                        egui::RichText::new(
+                            "quantick reads one CSV per session day, in a folder per instrument.",
+                        )
+                        .color(MUTED)
+                        .small(),
+                    );
+                });
+                return;
+            }
+
+            egui::ScrollArea::vertical()
+                .max_height(180.0)
+                .auto_shrink([false, true])
+                .show(ui, |ui| {
+                    for (index, entry) in library.sessions.iter().enumerate() {
+                        let selected = self.selected == Some(index);
+                        let response = ui.selectable_label(
+                            selected,
+                            egui::RichText::new(format!(
+                                "{}      {}",
+                                entry.label(),
+                                entry.size_label()
+                            )),
+                        );
+                        if response.clicked() {
+                            self.selected = Some(index);
+                        }
+                        if response.double_clicked() {
+                            self.selected = Some(index);
+                        }
+                        if !entry.notes.is_empty() {
+                            for note in &entry.notes {
+                                ui.label(
+                                    egui::RichText::new(format!("    {note}"))
+                                        .color(MUTED)
+                                        .small(),
+                                );
+                            }
+                        }
+                    }
+                });
+        });
+    }
+
+    fn draw_problems(&mut self, ui: &mut egui::Ui) {
+        let Some(library) = self.library.as_ref() else {
+            return;
+        };
+        if library.problems.is_empty() {
+            return;
+        }
+        let header = format!(
+            "{} file(s) were not loaded",
+            library
+                .problems
+                .iter()
+                .filter(|p| p.path.is_some())
+                .count()
+                .max(1)
+        );
+        egui::CollapsingHeader::new(egui::RichText::new(header).color(WARN))
+            .default_open(library.sessions.is_empty())
+            .show(ui, |ui| {
+                for problem in &library.problems {
+                    ui.horizontal_wrapped(|ui| {
+                        ui.label(
+                            egui::RichText::new(problem.subject())
+                                .color(OVERLAY)
+                                .monospace(),
+                        );
+                        ui.label(egui::RichText::new(&problem.detail).color(MUTED));
+                    });
+                    ui.label(
+                        egui::RichText::new(format!("    {}", problem.advice()))
+                            .color(MUTED)
+                            .small(),
+                    );
+                    ui.add_space(4.0);
+                }
+            });
+    }
+
+    fn draw_format_help(&mut self, ui: &mut egui::Ui) {
+        let label = if self.show_format {
+            "Hide the file format"
+        } else {
+            "Show the file format"
+        };
+        if ui
+            .link(egui::RichText::new(label).color(MUTED).small())
+            .clicked()
+        {
+            self.show_format = !self.show_format;
+        }
+        if !self.show_format {
+            return;
+        }
+        egui::Frame::none()
+            .fill(egui::Color32::from_black_alpha(90))
+            .inner_margin(8.0)
+            .rounding(4.0)
+            .show(ui, |ui| {
+                egui::ScrollArea::vertical()
+                    .max_height(220.0)
+                    .id_salt("replay_format_help")
+                    .show(ui, |ui| {
+                        ui.label(
+                            egui::RichText::new(format::FORMAT_HELP)
+                                .monospace()
+                                .small()
+                                .color(MUTED),
+                        );
+                    });
+            });
+    }
+
+    /// The bottom row: speed to start at, and the button that starts playback.
+    /// Returns whether the load was asked for.
+    fn draw_start_row(&mut self, ui: &mut egui::Ui) -> bool {
+        if let Some(error) = &self.error {
+            egui::Frame::none()
+                .fill(egui::Color32::from_rgba_unmultiplied(90, 30, 25, 120))
+                .inner_margin(8.0)
+                .rounding(4.0)
+                .show(ui, |ui| {
+                    ui.label(egui::RichText::new(error).color(WARN).small());
+                });
+            ui.add_space(6.0);
+        }
+
+        let mut clicked = false;
+        ui.horizontal(|ui| {
+            ui.label(egui::RichText::new("Start at").color(MUTED).small());
+            for speed in SPEEDS {
+                let selected = (self.speed - speed).abs() < f32::EPSILON;
+                if speed_chip(ui, speed, selected).clicked() {
+                    self.speed = speed;
+                }
+            }
+            ui.add_space(8.0);
+            ui.checkbox(&mut self.autoplay, "and play")
+                .on_hover_text("Leave unticked to open the session paused on its first print");
+
+            ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                if let Some(loading) = &self.loading {
+                    ui.add(egui::Spinner::new().size(14.0).color(MUTED));
+                    ui.label(
+                        egui::RichText::new(format!("Loading {}…", loading.label))
+                            .color(MUTED)
+                            .small(),
+                    );
+                    return;
+                }
+                let ready = self.selected_entry().is_some();
+                let button = egui::Button::new(
+                    egui::RichText::new("Play session").color(egui::Color32::BLACK),
+                )
+                .fill(REPLAY_ACCENT);
+                if ui
+                    .add_enabled(ready, button)
+                    .on_disabled_hover_text("Pick a session from the list first")
+                    .clicked()
+                {
+                    clicked = true;
+                }
+            });
+        });
+        clicked
+    }
+
+    /// The transport bar, docked at the bottom while a session is playing.
+    fn draw_transport(&mut self, ctx: &egui::Context, link: &ReplayLink) -> Option<ReplayAction> {
+        let mut action = None;
+        let status = &link.status;
+        let timezone = link.session.timezone();
+
+        egui::TopBottomPanel::bottom("replay_transport")
+            .frame(
+                egui::Frame::none()
+                    .fill(egui::Color32::from_rgb(24, 27, 34))
+                    .inner_margin(egui::Margin::symmetric(10.0, 6.0)),
+            )
+            .show(ctx, |ui| {
+                ui.visuals_mut().override_text_color = Some(OVERLAY);
+                ui.horizontal(|ui| {
+                    if ui
+                        .button("⏮")
+                        .on_hover_text("Back to the first print")
+                        .clicked()
+                    {
+                        action = Some(ReplayAction::Control(ReplayControl::Restart));
+                    }
+                    // The button states what it does, rather than toggling
+                    // blind: it reads the same status it draws, so a click
+                    // cannot invert a state that changed between frames.
+                    let playing = status.is_playing() && !status.is_finished();
+                    let (label, hint, control) = if playing {
+                        ("⏸", "Pause (Space)", ReplayControl::Pause)
+                    } else {
+                        ("▶", "Play (Space)", ReplayControl::Play)
+                    };
+                    if ui
+                        .button(egui::RichText::new(label).color(REPLAY_ACCENT))
+                        .on_hover_text(hint)
+                        .clicked()
+                    {
+                        action = Some(ReplayAction::Control(control));
+                    }
+
+                    ui.add_space(6.0);
+                    badge(ui, "REPLAY");
+                    ui.label(egui::RichText::new(link.label()).color(OVERLAY));
+                    ui.label(
+                        egui::RichText::new(clock_text(status.position_ms(), timezone))
+                            .monospace()
+                            .color(REPLAY_ACCENT),
+                    );
+
+                    ui.add_space(6.0);
+                    for speed in SPEEDS {
+                        let selected = (status.speed() - speed).abs() < f32::EPSILON;
+                        if speed_chip(ui, speed, selected).clicked() {
+                            action = Some(ReplayAction::Control(ReplayControl::SetSpeed(speed)));
+                        }
+                    }
+
+                    ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                        if ui
+                            .button("✖")
+                            .on_hover_text("Close the replay and go back to the live feed")
+                            .clicked()
+                        {
+                            action = Some(ReplayAction::Close);
+                        }
+                        ui.label(
+                            egui::RichText::new(format!(
+                                "{} / {} prints",
+                                thousands(status.played()),
+                                thousands(status.total())
+                            ))
+                            .color(MUTED)
+                            .small(),
+                        );
+                    });
+                });
+
+                ui.add_space(2.0);
+                if let Some(fraction) = seek_track(ui, status.progress()) {
+                    action = Some(ReplayAction::Control(ReplayControl::SeekToFraction(
+                        fraction,
+                    )));
+                }
+            });
+
+        // Space toggles playback, the way every media transport behaves. Only
+        // while nothing has keyboard focus, so typing in a field is untouched.
+        if ctx.memory(|m| m.focused().is_none()) && ctx.input(|i| i.key_pressed(egui::Key::Space)) {
+            action = Some(ReplayAction::Control(ReplayControl::TogglePlay));
+        }
+        action
+    }
+}
+
+/// A small speed button, e.g. `10×`.
+fn speed_chip(ui: &mut egui::Ui, speed: f32, selected: bool) -> egui::Response {
+    let text = if speed.fract() == 0.0 {
+        format!("{speed:.0}×")
+    } else {
+        format!("{speed}×")
+    };
+    let mut rich = egui::RichText::new(text).monospace().small();
+    if selected {
+        rich = rich.color(egui::Color32::BLACK).strong();
+    }
+    let mut button = egui::Button::new(rich).min_size(egui::vec2(30.0, 18.0));
+    if selected {
+        button = button.fill(REPLAY_ACCENT);
+    }
+    ui.add(button)
+}
+
+/// The amber `REPLAY` tag: the one loud thing on the bar.
+fn badge(ui: &mut egui::Ui, text: &str) {
+    egui::Frame::none()
+        .fill(REPLAY_ACCENT)
+        .inner_margin(egui::Margin::symmetric(6.0, 1.0))
+        .rounding(3.0)
+        .show(ui, |ui| {
+            ui.label(
+                egui::RichText::new(text)
+                    .color(egui::Color32::BLACK)
+                    .small()
+                    .strong(),
+            );
+        });
+}
+
+/// The seek track. Returns the fraction to jump to when dragged or clicked.
+fn seek_track(ui: &mut egui::Ui, progress: f32) -> Option<f32> {
+    let width = ui.available_width();
+    let (rect, response) = ui.allocate_exact_size(
+        egui::vec2(width, TRACK_HEIGHT + 8.0),
+        egui::Sense::click_and_drag(),
+    );
+    let track = egui::Rect::from_min_size(
+        egui::pos2(rect.left(), rect.center().y - TRACK_HEIGHT / 2.0),
+        egui::vec2(width, TRACK_HEIGHT),
+    );
+    let painter = ui.painter();
+    painter.rect_filled(track, 3.0, egui::Color32::from_rgb(45, 50, 60));
+    let filled = egui::Rect::from_min_size(
+        track.min,
+        egui::vec2(width * progress.clamp(0.0, 1.0), TRACK_HEIGHT),
+    );
+    painter.rect_filled(filled, 3.0, REPLAY_ACCENT);
+    painter.circle_filled(
+        egui::pos2(filled.right(), track.center().y),
+        if response.hovered() { 6.0 } else { 4.5 },
+        REPLAY_ACCENT,
+    );
+
+    if !(response.dragged() || response.clicked()) {
+        return None;
+    }
+    let pointer = response.interact_pointer_pos()?;
+    Some(((pointer.x - track.left()) / width.max(1.0)).clamp(0.0, 1.0))
+}
+
+/// `HH:MM:SS` of a replay position, read in the session's own timezone — the
+/// clock the trader watched that day, not the one on this machine.
+fn clock_text(position_ms: i64, timezone: UtcOffset) -> String {
+    let civil = format::civil_parts(position_ms, timezone);
+    format!("{:02}:{:02}:{:02}", civil.hour, civil.minute, civil.second)
+}
+
+/// Group a count so 231190 reads as 231 190.
+///
+/// A plain space, not a narrow no-break one: egui's bundled fonts have no glyph
+/// for U+202F and draw the missing-character box instead, which turns a count
+/// into `231□190`.
+fn thousands(value: usize) -> String {
+    let digits = value.to_string();
+    let mut out = String::with_capacity(digits.len() + digits.len() / 3);
+    for (index, ch) in digits.chars().enumerate() {
+        if index > 0 && (digits.len() - index).is_multiple_of(3) {
+            out.push(' ');
+        }
+        out.push(ch);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn counts_are_grouped_for_reading() {
+        assert_eq!(thousands(7), "7");
+        assert_eq!(thousands(1_000), "1 000");
+        assert_eq!(thousands(231_190), "231 190");
+    }
+
+    #[test]
+    fn the_clock_reads_in_the_sessions_own_timezone() {
+        // 2026-03-16 13:01:08 UTC is 10:01:08 on a B3 clock.
+        let ms = 1_773_666_068_000;
+        assert_eq!(clock_text(ms, UtcOffset::UTC), "13:01:08");
+        assert_eq!(
+            clock_text(ms, UtcOffset::parse("-03:00").unwrap()),
+            "10:01:08"
+        );
+    }
+
+    #[test]
+    fn a_fresh_view_is_closed_and_starts_at_one_times() {
+        let view = ReplayView::new();
+        assert!(!view.browser_open);
+        assert_eq!(view.speed, 1.0);
+        assert!(view.autoplay);
+        assert!(view.library.is_none());
+    }
+
+    #[test]
+    fn opening_the_browser_with_no_folder_scans_nothing() {
+        let mut view = ReplayView::new();
+        view.folder = String::new();
+        view.open_browser();
+        assert!(view.browser_open);
+        assert!(view.library.is_none(), "no folder, nothing to scan");
+    }
+
+    #[test]
+    fn scanning_a_missing_folder_reports_it_instead_of_failing() {
+        let mut view = ReplayView::new();
+        view.folder = "definitely/not/here".to_string();
+        view.rescan();
+        let library = view.library.as_ref().expect("scanned");
+        assert!(library.sessions.is_empty());
+        assert!(!library.problems.is_empty());
+        assert!(view.selected.is_none());
+    }
+}

--- a/crates/app/src/replay_view.rs
+++ b/crates/app/src/replay_view.rs
@@ -21,18 +21,30 @@ use quantick_replay::clock::SPEEDS;
 use quantick_replay::format::{self, UtcOffset};
 use quantick_replay::{Library, ParseOptions, Session, SessionEntry, SessionError, library};
 
-use crate::app::{MUTED, OVERLAY, WARN};
+use crate::app::{DIVIDER, MUTED, OVERLAY, WARN};
 use crate::feed::{ReplayControl, ReplayLink, ReplayOptions, ReplayRequest};
 
 /// The accent this feature owns: the same amber the chart already uses for the
 /// backfill/live divider, so "this is not live data" reads the same way twice.
-const REPLAY_ACCENT: egui::Color32 = egui::Color32::from_rgb(240, 185, 11);
+/// Borrowed rather than repeated, so the two can never drift apart.
+const REPLAY_ACCENT: egui::Color32 = DIVIDER;
+
+/// Background of the docked transport bar.
+const TRANSPORT_BG: egui::Color32 = egui::Color32::from_rgb(24, 27, 34);
+
+/// The unplayed part of the seek track.
+const TRACK_BG: egui::Color32 = egui::Color32::from_rgb(45, 50, 60);
 
 /// Environment variable naming the folder the browser opens on.
 pub const REPLAY_DIR_ENV: &str = "QUANTICK_REPLAY_DIR";
 
 /// Height of the seek track, in pixels.
 const TRACK_HEIGHT: f32 = 6.0;
+
+/// Radius of the seek handle, resting and hovered.
+const HANDLE_RADIUS: f32 = 4.5;
+/// See [`HANDLE_RADIUS`].
+const HANDLE_RADIUS_HOVERED: f32 = 6.0;
 
 /// What the replay interface asks the app to do.
 pub enum ReplayAction {
@@ -62,6 +74,12 @@ pub struct ReplayView {
     show_format: bool,
     speed: f32,
     autoplay: bool,
+    /// Where the seek handle is being held, while it is being held.
+    ///
+    /// Seeking rebuilds the chart from the session's history, which is work
+    /// proportional to the whole recording — so a drag shows this position and
+    /// only commits it when the handle is let go. See [`seek_track`].
+    scrub: Option<f32>,
 }
 
 impl Default for ReplayView {
@@ -85,6 +103,7 @@ impl ReplayView {
             show_format: false,
             speed: 1.0,
             autoplay: true,
+            scrub: None,
         }
     }
 
@@ -128,9 +147,10 @@ impl ReplayView {
     pub fn draw(&mut self, ctx: &egui::Context, link: Option<&ReplayLink>) -> Option<ReplayAction> {
         self.poll_picker();
         let mut action = self.poll_loading();
-        if let Some(from_browser) = self.draw_browser(ctx) {
-            action = action.or(Some(from_browser));
-        }
+        // The browser starts a load rather than returning an action: the
+        // session is parsed on a worker, and `poll_loading` turns the result
+        // into the `Open` a later frame carries.
+        self.draw_browser(ctx);
         if let Some(link) = link
             && let Some(from_transport) = self.draw_transport(ctx, link)
         {
@@ -250,9 +270,10 @@ impl ReplayView {
         library.sessions.get(self.selected?)
     }
 
-    fn draw_browser(&mut self, ctx: &egui::Context) -> Option<ReplayAction> {
+    /// Draw the session browser, starting a load if one was asked for.
+    fn draw_browser(&mut self, ctx: &egui::Context) {
         if !self.browser_open {
-            return None;
+            return;
         }
         let mut open = true;
         let mut load_clicked = false;
@@ -268,19 +289,18 @@ impl ReplayView {
                 ui.visuals_mut().override_text_color = Some(OVERLAY);
                 self.draw_folder_row(ui);
                 ui.add_space(10.0);
-                self.draw_session_list(ui);
+                load_clicked = self.draw_session_list(ui);
                 ui.add_space(8.0);
                 self.draw_problems(ui);
                 self.draw_format_help(ui);
                 ui.add_space(6.0);
-                load_clicked = self.draw_start_row(ui);
+                load_clicked |= self.draw_start_row(ui);
             });
 
         self.browser_open = open;
         if load_clicked {
             self.load_selected();
         }
-        None
     }
 
     fn draw_folder_row(&mut self, ui: &mut egui::Ui) {
@@ -316,7 +336,10 @@ impl ReplayView {
         }
     }
 
-    fn draw_session_list(&mut self, ui: &mut egui::Ui) {
+    /// Draw the session list. Returns whether one was double-clicked, which is
+    /// the same request as picking it and pressing **Play session**.
+    fn draw_session_list(&mut self, ui: &mut egui::Ui) -> bool {
+        let mut open_requested = false;
         ui.label(egui::RichText::new("Sessions").color(MUTED).small());
         let frame = egui::Frame::none()
             .fill(egui::Color32::from_black_alpha(60))
@@ -370,6 +393,7 @@ impl ReplayView {
                         }
                         if response.double_clicked() {
                             self.selected = Some(index);
+                            open_requested = true;
                         }
                         if !entry.notes.is_empty() {
                             for note in &entry.notes {
@@ -383,6 +407,7 @@ impl ReplayView {
                     }
                 });
         });
+        open_requested
     }
 
     fn draw_problems(&mut self, ui: &mut egui::Ui) {
@@ -520,7 +545,7 @@ impl ReplayView {
         egui::TopBottomPanel::bottom("replay_transport")
             .frame(
                 egui::Frame::none()
-                    .fill(egui::Color32::from_rgb(24, 27, 34))
+                    .fill(TRANSPORT_BG)
                     .inner_margin(egui::Margin::symmetric(10.0, 6.0)),
             )
             .show(ctx, |ui| {
@@ -588,7 +613,7 @@ impl ReplayView {
                 });
 
                 ui.add_space(2.0);
-                if let Some(fraction) = seek_track(ui, status.progress()) {
+                if let Some(fraction) = seek_track(ui, status.progress(), &mut self.scrub) {
                     action = Some(ReplayAction::Control(ReplayControl::SeekToFraction(
                         fraction,
                     )));
@@ -638,8 +663,14 @@ fn badge(ui: &mut egui::Ui, text: &str) {
         });
 }
 
-/// The seek track. Returns the fraction to jump to when dragged or clicked.
-fn seek_track(ui: &mut egui::Ui, progress: f32) -> Option<f32> {
+/// The seek track. Returns the fraction to jump to, once per gesture.
+///
+/// A held handle only moves `scrub`, which is what the track draws; the jump is
+/// emitted when the handle is let go, or immediately on a click. That bound is
+/// not cosmetic: every seek rebuilds the chart from the session's history, so
+/// emitting one per dragged frame would re-ingest the whole recording at frame
+/// rate — hundreds of megabytes a second on a full trading day.
+fn seek_track(ui: &mut egui::Ui, progress: f32, scrub: &mut Option<f32>) -> Option<f32> {
     let width = ui.available_width();
     let (rect, response) = ui.allocate_exact_size(
         egui::vec2(width, TRACK_HEIGHT + 8.0),
@@ -649,24 +680,40 @@ fn seek_track(ui: &mut egui::Ui, progress: f32) -> Option<f32> {
         egui::pos2(rect.left(), rect.center().y - TRACK_HEIGHT / 2.0),
         egui::vec2(width, TRACK_HEIGHT),
     );
+
+    // Keep the last position the pointer held: on the frame the button is
+    // released egui may already report no interaction position, and that frame
+    // is exactly the one carrying the seek.
+    if let Some(pointer) = response.interact_pointer_pos() {
+        *scrub = Some(((pointer.x - track.left()) / width.max(1.0)).clamp(0.0, 1.0));
+    }
+    let held = response.dragged() || response.is_pointer_button_down_on();
+    let shown = match *scrub {
+        Some(fraction) if held => fraction,
+        _ => progress.clamp(0.0, 1.0),
+    };
+
     let painter = ui.painter();
-    painter.rect_filled(track, 3.0, egui::Color32::from_rgb(45, 50, 60));
-    let filled = egui::Rect::from_min_size(
-        track.min,
-        egui::vec2(width * progress.clamp(0.0, 1.0), TRACK_HEIGHT),
-    );
+    painter.rect_filled(track, 3.0, TRACK_BG);
+    let filled = egui::Rect::from_min_size(track.min, egui::vec2(width * shown, TRACK_HEIGHT));
     painter.rect_filled(filled, 3.0, REPLAY_ACCENT);
     painter.circle_filled(
         egui::pos2(filled.right(), track.center().y),
-        if response.hovered() { 6.0 } else { 4.5 },
+        if response.hovered() || held {
+            HANDLE_RADIUS_HOVERED
+        } else {
+            HANDLE_RADIUS
+        },
         REPLAY_ACCENT,
     );
 
-    if !(response.dragged() || response.clicked()) {
-        return None;
+    if response.drag_stopped() || response.clicked() {
+        return scrub.take();
     }
-    let pointer = response.interact_pointer_pos()?;
-    Some(((pointer.x - track.left()) / width.max(1.0)).clamp(0.0, 1.0))
+    if !held {
+        *scrub = None;
+    }
+    None
 }
 
 /// `HH:MM:SS` of a replay position, read in the session's own timezone — the

--- a/crates/replay/Cargo.toml
+++ b/crates/replay/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "quantick-replay"
+description = "Recorded market-replay sessions: tick file format, library scan and deterministic playback clock"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+quantick-engine = { path = "../engine" }
+rust_decimal = "1"
+
+# Only the NDJSON importer (an example, not the library) parses JSON.
+[dev-dependencies]
+serde_json = "1"

--- a/crates/replay/examples/import_mt5_ndjson.rs
+++ b/crates/replay/examples/import_mt5_ndjson.rs
@@ -1,0 +1,649 @@
+//! Convert recorded MT5 order-flow NDJSON into quantick replay sessions.
+//!
+//! The recorders used around the desk write one JSON object per line, mixing
+//! `tick` and `book_update` events. This turns the trade prints into the folder
+//! layout the chart's Market Replay reads:
+//!
+//! ```text
+//! cargo run -p quantick-replay --example import_mt5_ndjson -- \
+//!     --in F:/src/milostrategies/runtime/mt5_orderflow_20260316.ndjson \
+//!     --out F:/replay
+//! ```
+//!
+//! Options:
+//!
+//! ```text
+//! --in <file>              recording to read; repeat for several
+//! --out <folder>           replay folder to write into (created if absent)
+//! --symbol <name>          keep only this instrument
+//! --side-source <policy>   bid_ask (default) | flags | tick_rule
+//! --spread-within-second   even out prints inside each recorded second
+//! --timezone <offset>      override the offset the rows are written in
+//! ```
+//!
+//! # What it does with an inferred aggressor
+//!
+//! MT5 tick flags are broker-dependent, so the default policy reads the side
+//! from the print's position against the recorded bid/ask and falls back to the
+//! tick rule when there is no quote. Whichever policy runs is written into the
+//! session's `# side_source=` line, and the run prints how often each rule
+//! decided — including how often it disagreed with the broker's own flags.
+//!
+//! # About the one-second timestamps
+//!
+//! These recordings stamp trades to the second. Replay therefore delivers a
+//! whole second of prints at once, which is honest but visibly stepped.
+//! `--spread-within-second` distributes the prints of each second evenly across
+//! it for smoother playback; because those sub-second times are made up, the
+//! session is marked `# time_resolution=1s_interpolated` and the chart says so.
+//!
+//! Every diagnostic line is a single JSON object with an `event_code`, so a
+//! person with `jq` — or an AI reading the log — can follow the run without
+//! scraping prose.
+
+use std::collections::BTreeMap;
+use std::io::{BufRead as _, BufWriter, Write as _};
+use std::path::{Path, PathBuf};
+use std::str::FromStr as _;
+
+use quantick_engine::{Side, Trade};
+use quantick_replay::format::{self, Quote, UtcOffset, WriteHeader};
+use rust_decimal::Decimal;
+use serde_json::Value;
+
+/// MQL5 tick flag: the print carries a `last` price (i.e. it is a trade).
+const TICK_FLAG_LAST: u64 = 8;
+/// MQL5 tick flag: a buyer-initiated trade, per the broker.
+const TICK_FLAG_BUY: u64 = 32;
+/// MQL5 tick flag: a seller-initiated trade, per the broker.
+const TICK_FLAG_SELL: u64 = 64;
+
+/// How the aggressor side is decided.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SidePolicy {
+    /// Compare the print against the recorded bid/ask; tick rule as fallback.
+    BidAsk,
+    /// Trust the broker's BUY/SELL tick flags.
+    Flags,
+    /// Uptick is a buy, downtick a sell, unchanged repeats the last decision.
+    TickRule,
+}
+
+impl SidePolicy {
+    fn parse(text: &str) -> Option<Self> {
+        match text {
+            "bid_ask" => Some(SidePolicy::BidAsk),
+            "flags" => Some(SidePolicy::Flags),
+            "tick_rule" => Some(SidePolicy::TickRule),
+            _ => None,
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            SidePolicy::BidAsk => "bid_ask",
+            SidePolicy::Flags => "flags",
+            SidePolicy::TickRule => "tick_rule",
+        }
+    }
+}
+
+/// Emit one structured diagnostic line to stderr.
+macro_rules! emit {
+    ($code:expr $(, $key:ident = $value:expr)* $(,)?) => {{
+        let mut fields = serde_json::Map::new();
+        fields.insert("event_code".to_string(), Value::from($code));
+        $( fields.insert(stringify!($key).to_string(), Value::from($value)); )*
+        eprintln!("{}", Value::Object(fields));
+    }};
+}
+
+/// One converted print, before it is written out.
+struct Row {
+    timestamp_ms: i64,
+    price: Decimal,
+    volume: Decimal,
+    side: Side,
+    quote: Option<Quote>,
+}
+
+/// The prints of one instrument-day, with the recordings they came from. The
+/// provenance is per session, not per run: a session must name the file it was
+/// actually built from, even when one command converts several recordings.
+#[derive(Default)]
+struct SessionRows {
+    rows: Vec<Row>,
+    sources: Vec<String>,
+}
+
+impl SessionRows {
+    fn note_source(&mut self, source: &str) {
+        if !self.sources.iter().any(|s| s == source) {
+            self.sources.push(source.to_string());
+        }
+    }
+}
+
+/// Counters worth reporting honestly at the end of a run.
+#[derive(Default)]
+struct Stats {
+    lines: u64,
+    ticks: u64,
+    trades: u64,
+    skipped_not_a_trade: u64,
+    skipped_other_symbol: u64,
+    skipped_unparseable: u64,
+    side_from_quote: u64,
+    side_from_flags: u64,
+    side_from_tick_rule: u64,
+    side_unknown_dropped: u64,
+    flags_disagreed: u64,
+}
+
+struct Args {
+    inputs: Vec<PathBuf>,
+    out: PathBuf,
+    symbol: Option<String>,
+    policy: SidePolicy,
+    spread_within_second: bool,
+    timezone: Option<UtcOffset>,
+}
+
+fn parse_args() -> Result<Args, String> {
+    let mut inputs = Vec::new();
+    let mut out = None;
+    let mut symbol = None;
+    let mut policy = SidePolicy::BidAsk;
+    let mut spread_within_second = false;
+    let mut timezone = None;
+
+    let mut args = std::env::args().skip(1);
+    while let Some(arg) = args.next() {
+        let mut value = || args.next().ok_or_else(|| format!("{arg} needs a value"));
+        match arg.as_str() {
+            "--in" => inputs.push(PathBuf::from(value()?)),
+            "--out" => out = Some(PathBuf::from(value()?)),
+            "--symbol" => symbol = Some(value()?),
+            "--side-source" => {
+                let text = value()?;
+                policy = SidePolicy::parse(&text).ok_or_else(|| {
+                    format!("--side-source `{text}` (expected bid_ask, flags or tick_rule)")
+                })?;
+            }
+            "--spread-within-second" => spread_within_second = true,
+            "--timezone" => {
+                let text = value()?;
+                timezone = Some(
+                    UtcOffset::parse(&text)
+                        .ok_or_else(|| format!("--timezone `{text}` is not a UTC offset"))?,
+                );
+            }
+            "--help" | "-h" => return Err("help".to_string()),
+            other => return Err(format!("unexpected argument `{other}`")),
+        }
+    }
+
+    if inputs.is_empty() {
+        return Err("--in <recording.ndjson> is required".to_string());
+    }
+    Ok(Args {
+        inputs,
+        out: out.ok_or("--out <replay folder> is required")?,
+        symbol,
+        policy,
+        spread_within_second,
+        timezone,
+    })
+}
+
+fn main() -> std::process::ExitCode {
+    let args = match parse_args() {
+        Ok(args) => args,
+        Err(message) => {
+            if message == "help" {
+                eprintln!("{}", usage());
+            } else {
+                emit!("IMPORT_BAD_ARGUMENTS", detail = message, usage = usage());
+            }
+            return std::process::ExitCode::from(2);
+        }
+    };
+
+    match run(&args) {
+        Ok(0) => {
+            emit!(
+                "IMPORT_NOTHING_WRITTEN",
+                fix = "check --symbol, or whether the recording holds trade ticks at all",
+            );
+            std::process::ExitCode::from(3)
+        }
+        Ok(_) => std::process::ExitCode::SUCCESS,
+        Err(message) => {
+            emit!("IMPORT_FAILED", detail = message);
+            std::process::ExitCode::FAILURE
+        }
+    }
+}
+
+fn usage() -> String {
+    "usage: import_mt5_ndjson --in <recording.ndjson> --out <replay folder> \
+     [--symbol NAME] [--side-source bid_ask|flags|tick_rule] [--spread-within-second] \
+     [--timezone -03:00]"
+        .to_string()
+}
+
+fn run(args: &Args) -> Result<usize, String> {
+    // Grouped by instrument, then by session day, so one recording spanning a
+    // rollover still produces one file per day.
+    let mut sessions: BTreeMap<(String, i64), SessionRows> = BTreeMap::new();
+    let mut stats = Stats::default();
+    let mut offset = args.timezone;
+
+    for input in &args.inputs {
+        let file = std::fs::File::open(input)
+            .map_err(|e| format!("cannot read {}: {e}", input.display()))?;
+        let source: String = input.file_name().map_or_else(
+            || input.display().to_string(),
+            |n| n.to_string_lossy().into(),
+        );
+        let mut reader = std::io::BufReader::with_capacity(1 << 20, file);
+        let mut last_price: BTreeMap<String, Decimal> = BTreeMap::new();
+        let mut last_side: BTreeMap<String, Side> = BTreeMap::new();
+        let mut line = String::new();
+
+        loop {
+            line.clear();
+            match reader.read_line(&mut line) {
+                Ok(0) => break,
+                Ok(_) => {}
+                Err(e) => return Err(format!("cannot read {}: {e}", input.display())),
+            }
+            stats.lines += 1;
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            let Ok(event) = serde_json::from_str::<Value>(trimmed) else {
+                stats.skipped_unparseable += 1;
+                continue;
+            };
+            if event.get("event_type").and_then(Value::as_str) != Some("tick") {
+                continue;
+            }
+            stats.ticks += 1;
+
+            let symbol = event
+                .get("symbol")
+                .and_then(Value::as_str)
+                .unwrap_or("unknown")
+                .to_string();
+            if let Some(wanted) = &args.symbol
+                && &symbol != wanted
+            {
+                stats.skipped_other_symbol += 1;
+                continue;
+            }
+
+            let flags = event.get("flags").and_then(Value::as_u64).unwrap_or(0);
+            let volume = number(event.get("volume"))
+                .or_else(|| number(event.get("volume_real")))
+                .unwrap_or_default();
+            let Some(price) = number(event.get("last")) else {
+                stats.skipped_not_a_trade += 1;
+                continue;
+            };
+            // A trade print carries a last price and a size. Quote-only ticks
+            // (bid/ask moves) are not prints and must not become candles.
+            if flags & TICK_FLAG_LAST == 0 || volume <= Decimal::ZERO || price <= Decimal::ZERO {
+                stats.skipped_not_a_trade += 1;
+                continue;
+            }
+
+            let Some((timestamp_ms, row_offset)) = event
+                .get("time")
+                .and_then(Value::as_str)
+                .and_then(parse_iso)
+            else {
+                stats.skipped_unparseable += 1;
+                continue;
+            };
+            let offset = *offset.get_or_insert(row_offset);
+
+            let bid = number(event.get("bid")).filter(|v| *v > Decimal::ZERO);
+            let ask = number(event.get("ask")).filter(|v| *v > Decimal::ZERO);
+            let quote = match (bid, ask) {
+                (Some(bid), Some(ask)) if ask >= bid => Some(Quote { bid, ask }),
+                _ => None,
+            };
+
+            let previous = last_price.get(&symbol).copied();
+            let carried = last_side.get(&symbol).copied();
+            let Some((side, decided_by)) =
+                decide_side(args.policy, price, quote, flags, previous, carried)
+            else {
+                stats.side_unknown_dropped += 1;
+                continue;
+            };
+            match decided_by {
+                SidePolicy::BidAsk => stats.side_from_quote += 1,
+                SidePolicy::Flags => stats.side_from_flags += 1,
+                SidePolicy::TickRule => stats.side_from_tick_rule += 1,
+            }
+            if let Some(flagged) = side_from_flags(flags)
+                && flagged != side
+            {
+                stats.flags_disagreed += 1;
+            }
+            last_price.insert(symbol.clone(), price);
+            last_side.insert(symbol.clone(), side);
+
+            let day = (timestamp_ms.saturating_add(offset.millis())).div_euclid(86_400_000);
+            stats.trades += 1;
+            let session = sessions.entry((symbol, day)).or_default();
+            session.note_source(&source);
+            session.rows.push(Row {
+                timestamp_ms,
+                price,
+                volume,
+                side,
+                quote,
+            });
+        }
+
+        emit!(
+            "IMPORT_FILE_READ",
+            file = input.display().to_string(),
+            lines = stats.lines,
+            ticks = stats.ticks,
+            trades = stats.trades,
+        );
+    }
+
+    let offset = offset.unwrap_or(UtcOffset::UTC);
+    let mut written = 0;
+
+    for ((symbol, day), mut session) in sessions {
+        // Stable sort: prints stamped to the same second keep the order the
+        // recorder saw them in.
+        session.rows.sort_by_key(|row| row.timestamp_ms);
+        if args.spread_within_second {
+            spread_within_second(&mut session.rows);
+        }
+        let path = session_path(&args.out, &symbol, day, offset);
+        let count = session.rows.len();
+        write_session(
+            &path,
+            &symbol,
+            offset,
+            args.policy,
+            args.spread_within_second,
+            &session.sources.join(", "),
+            &session.rows,
+        )
+        .map_err(|e| format!("cannot write {}: {e}", path.display()))?;
+        written += 1;
+        emit!(
+            "IMPORT_SESSION_WRITTEN",
+            file = path.display().to_string(),
+            symbol = symbol,
+            trades = count as u64,
+            first_ms = session.rows.first().map_or(0, |r| r.timestamp_ms),
+            last_ms = session.rows.last().map_or(0, |r| r.timestamp_ms),
+        );
+    }
+
+    emit!(
+        "IMPORT_DONE",
+        sessions_written = written as u64,
+        trades = stats.trades,
+        ticks = stats.ticks,
+        skipped_not_a_trade = stats.skipped_not_a_trade,
+        skipped_other_symbol = stats.skipped_other_symbol,
+        skipped_unparseable = stats.skipped_unparseable,
+        side_source = args.policy.label(),
+        side_from_quote = stats.side_from_quote,
+        side_from_flags = stats.side_from_flags,
+        side_from_tick_rule = stats.side_from_tick_rule,
+        side_unknown_dropped = stats.side_unknown_dropped,
+        flags_disagreed = stats.flags_disagreed,
+        time_resolution = if args.spread_within_second {
+            "1s_interpolated"
+        } else {
+            "1s"
+        },
+    );
+    if !args.spread_within_second && written > 0 {
+        emit!(
+            "IMPORT_TIME_RESOLUTION_NOTE",
+            detail = "the recording stamps trades to the second, so replay delivers a second of prints at a time",
+            fix = "re-run with --spread-within-second for smoother playback (sub-second times are then interpolated and labelled as such)",
+        );
+    }
+    Ok(written)
+}
+
+/// Decide the aggressor side, returning which rule actually decided it.
+fn decide_side(
+    policy: SidePolicy,
+    price: Decimal,
+    quote: Option<Quote>,
+    flags: u64,
+    previous_price: Option<Decimal>,
+    carried_side: Option<Side>,
+) -> Option<(Side, SidePolicy)> {
+    match policy {
+        SidePolicy::Flags => side_from_flags(flags)
+            .map(|side| (side, SidePolicy::Flags))
+            .or_else(|| {
+                side_from_tick_rule(price, previous_price, carried_side)
+                    .map(|side| (side, SidePolicy::TickRule))
+            }),
+        SidePolicy::BidAsk => quote
+            .and_then(|quote| {
+                if price >= quote.ask {
+                    Some(Side::Buy)
+                } else if price <= quote.bid {
+                    Some(Side::Sell)
+                } else {
+                    None
+                }
+            })
+            .map(|side| (side, SidePolicy::BidAsk))
+            .or_else(|| {
+                side_from_tick_rule(price, previous_price, carried_side)
+                    .map(|side| (side, SidePolicy::TickRule))
+            }),
+        SidePolicy::TickRule => side_from_tick_rule(price, previous_price, carried_side)
+            .map(|side| (side, SidePolicy::TickRule)),
+    }
+}
+
+fn side_from_flags(flags: u64) -> Option<Side> {
+    match (flags & TICK_FLAG_BUY != 0, flags & TICK_FLAG_SELL != 0) {
+        (true, false) => Some(Side::Buy),
+        (false, true) => Some(Side::Sell),
+        // Both bits or neither says nothing; guessing would invent order flow.
+        _ => None,
+    }
+}
+
+fn side_from_tick_rule(
+    price: Decimal,
+    previous: Option<Decimal>,
+    carried: Option<Side>,
+) -> Option<Side> {
+    match previous {
+        Some(previous) if price > previous => Some(Side::Buy),
+        Some(previous) if price < previous => Some(Side::Sell),
+        Some(_) => carried,
+        // The very first print of a session has nothing to compare against.
+        None => None,
+    }
+}
+
+/// Spread the prints of each recorded second evenly across it, so a chart fed
+/// from second-resolution data still moves smoothly.
+fn spread_within_second(rows: &mut [Row]) {
+    let mut start = 0;
+    while start < rows.len() {
+        let second = rows[start].timestamp_ms.div_euclid(1000);
+        let mut end = start + 1;
+        while end < rows.len() && rows[end].timestamp_ms.div_euclid(1000) == second {
+            end += 1;
+        }
+        let count = end - start;
+        if count > 1 {
+            let base = second * 1000;
+            for (offset, row) in rows[start..end].iter_mut().enumerate() {
+                row.timestamp_ms = base + (offset as i64 * 1000) / count as i64;
+            }
+        }
+        start = end;
+    }
+}
+
+/// `<out>/<SYMBOL>/<YYYYMMDD>.csv` for a day index in the session's timezone.
+fn session_path(out: &Path, symbol: &str, day: i64, offset: UtcOffset) -> PathBuf {
+    let civil = format::civil_parts(day * 86_400_000 - offset.millis(), offset);
+    out.join(sanitize(symbol)).join(format!(
+        "{:04}{:02}{:02}.csv",
+        civil.year, civil.month, civil.day
+    ))
+}
+
+/// Keep instrument names usable as folder names (`WDO$` is a real B3 symbol).
+fn sanitize(symbol: &str) -> String {
+    symbol
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | '$' | '#') {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+fn write_session(
+    path: &Path,
+    symbol: &str,
+    offset: UtcOffset,
+    policy: SidePolicy,
+    interpolated: bool,
+    source: &str,
+    rows: &[Row],
+) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let file = std::fs::File::create(path)?;
+    let mut out = BufWriter::with_capacity(1 << 20, file);
+
+    let mut header = format::write_header(&WriteHeader {
+        symbol: symbol.to_string(),
+        timezone: offset,
+        side_source: policy.label().to_string(),
+        source: Some(source.to_string()),
+    });
+    // The resolution line goes above the column header, where the reader keeps
+    // metadata; splice it in rather than re-implementing the writer.
+    let resolution = if interpolated {
+        "1s_interpolated"
+    } else {
+        "1s"
+    };
+    header = header.replace(
+        format::CANONICAL_HEADER,
+        &format!(
+            "# time_resolution={resolution}\n{}",
+            format::CANONICAL_HEADER
+        ),
+    );
+    out.write_all(header.as_bytes())?;
+
+    let mut buffer = String::with_capacity(64 * 1024);
+    for (index, row) in rows.iter().enumerate() {
+        format::write_trade(
+            &mut buffer,
+            &Trade {
+                agg_id: index as u64 + 1,
+                timestamp_ms: row.timestamp_ms,
+                price: row.price,
+                quantity: row.volume,
+                side: row.side,
+            },
+            row.quote,
+            offset,
+        );
+        if buffer.len() >= 32 * 1024 {
+            out.write_all(buffer.as_bytes())?;
+            buffer.clear();
+        }
+    }
+    out.write_all(buffer.as_bytes())?;
+    out.flush()
+}
+
+/// Read a JSON number as an exact decimal, keeping the digits the recorder
+/// wrote instead of round-tripping through a float twice.
+fn number(value: Option<&Value>) -> Option<Decimal> {
+    let value = value?;
+    // Trailing zeros carry no information here and would show up in every
+    // written row ("182035.0"), so the digits are normalised once on the way in.
+    if let Some(text) = value.as_str() {
+        return Decimal::from_str(text).ok().map(|d| d.normalize());
+    }
+    Decimal::from_str(&value.as_number()?.to_string())
+        .ok()
+        .map(|d| d.normalize())
+}
+
+/// Parse `2026-03-16T10:01:08-03:00` (optionally with fractional seconds) into
+/// an epoch-millisecond instant plus the offset it was written in.
+fn parse_iso(text: &str) -> Option<(i64, UtcOffset)> {
+    let (date, rest) = text.split_once('T')?;
+    let year: i64 = date.get(0..4)?.parse().ok()?;
+    let month: u32 = date.get(5..7)?.parse().ok()?;
+    let day: u32 = date.get(8..10)?.parse().ok()?;
+
+    // The offset is what follows the clock: `Z`, `+HH:MM` or `-HH:MM`.
+    let split = rest
+        .rfind(['+', '-'])
+        .filter(|at| *at >= 8)
+        .or_else(|| rest.find(['Z', 'z']));
+    let (clock, zone) = match split {
+        Some(at) => (&rest[..at], &rest[at..]),
+        None => (rest, ""),
+    };
+    let offset = if zone.is_empty() {
+        UtcOffset::UTC
+    } else {
+        UtcOffset::parse(zone)?
+    };
+
+    let hour: u32 = clock.get(0..2)?.parse().ok()?;
+    let minute: u32 = clock.get(3..5)?.parse().ok()?;
+    let second: u32 = clock.get(6..8)?.parse().ok()?;
+    let milli = match clock.get(9..) {
+        Some(fraction) if !fraction.is_empty() => {
+            let digits = &fraction[..fraction.len().min(3)];
+            let scale = 10u32.pow(3 - digits.len() as u32);
+            digits.parse::<u32>().ok()? * scale
+        }
+        _ => 0,
+    };
+    if month > 12 || day > 31 || hour > 23 || minute > 59 || second > 60 {
+        return None;
+    }
+    let civil = format::CivilTime {
+        year,
+        month,
+        day,
+        hour,
+        minute,
+        second: second.min(59),
+        milli,
+    };
+    Some((civil.epoch_millis(offset), offset))
+}

--- a/crates/replay/src/clock.rs
+++ b/crates/replay/src/clock.rs
@@ -126,6 +126,11 @@ impl Playhead {
             playing: false,
             config: PlaybackConfig {
                 speed: config.speed.clamp(MIN_SPEED, MAX_SPEED),
+                // A cap of zero would hand back an empty batch forever, leaving
+                // the cursor where it is: playback would stall in silence, with
+                // nothing to see and nothing to report. One print per advance is
+                // slow, but it always finishes.
+                max_batch: config.max_batch.max(1),
                 ..config
             },
         }
@@ -473,6 +478,26 @@ mod tests {
             emitted += head.advance(&trades, 16.0).len();
         }
         assert_eq!(emitted, 100, "no print is skipped by the cap");
+        assert!(head.is_finished());
+    }
+
+    #[test]
+    fn a_zero_batch_cap_cannot_stall_playback() {
+        let trades = ticks(5);
+        let mut head = Playhead::new(
+            &trades,
+            PlaybackConfig {
+                speed: 1.0,
+                max_batch: 0,
+                ..Default::default()
+            },
+        );
+        head.play();
+        let mut emitted = 0;
+        for _ in 0..trades.len() {
+            emitted += head.advance(&trades, 1_000.0).len();
+        }
+        assert_eq!(emitted, trades.len(), "every print is still delivered");
         assert!(head.is_finished());
     }
 

--- a/crates/replay/src/clock.rs
+++ b/crates/replay/src/clock.rs
@@ -1,0 +1,579 @@
+//! The playback clock: how much of a recorded session has been reached.
+//!
+//! Deterministic and clock-free — [`Playhead::advance`] is told how much real
+//! time passed, it never reads one. The same sequence of deltas always emits the
+//! same trades in the same batches, so playback is unit-tested without sleeping
+//! and a replay-driven backtest replays identically to the chart.
+//!
+//! The playhead owns no trades. Callers pass the session's trade slice into each
+//! method, which keeps this struct copyable, lifetime-free, and cheap to hand to
+//! a worker thread alongside an `Arc<[Trade]>`.
+
+use quantick_engine::Trade;
+
+/// The speeds the transport offers, in market-seconds per real second.
+pub const SPEEDS: [f32; 7] = [1.0, 2.0, 3.0, 5.0, 10.0, 20.0, 50.0];
+
+/// Slowest and fastest speed the clock accepts, so a stray value cannot stall
+/// playback or run a session out in one frame.
+pub const MIN_SPEED: f32 = 0.1;
+/// See [`MIN_SPEED`].
+pub const MAX_SPEED: f32 = 1000.0;
+
+/// Market time that may pass with no prints before the clock jumps ahead.
+///
+/// Recorded sessions have holes — the lunch lull, a halt, the gap between the
+/// close and the next morning. Waiting through them in real time is not replay,
+/// it is staring at a still chart, so every platform that ships a replay skips
+/// them. Two seconds is short enough that the rhythm of live trading survives.
+pub const DEFAULT_SKIP_IDLE_MS: i64 = 2_000;
+
+/// Most trades one [`Playhead::advance`] hands back.
+///
+/// A cap, not a filter: prints beyond it are delivered by the next call, and the
+/// clock stays with them instead of skipping ahead. Sized well above a real B3
+/// burst at 50×, so it only ever engages on pathological data.
+pub const DEFAULT_MAX_BATCH: usize = 20_000;
+
+/// How a session is played back.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct PlaybackConfig {
+    /// Market seconds per real second.
+    pub speed: f32,
+    /// Jump forward when the next print is further away than this. `None` plays
+    /// every idle gap in full.
+    pub skip_idle_over_ms: Option<i64>,
+    /// Upper bound on trades returned per advance.
+    pub max_batch: usize,
+}
+
+impl Default for PlaybackConfig {
+    fn default() -> Self {
+        Self {
+            speed: 1.0,
+            skip_idle_over_ms: Some(DEFAULT_SKIP_IDLE_MS),
+            max_batch: DEFAULT_MAX_BATCH,
+        }
+    }
+}
+
+/// A range of trades to emit, as indices into the session's trade slice.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Batch {
+    /// First trade index, inclusive.
+    pub start: usize,
+    /// Last trade index, exclusive.
+    pub end: usize,
+    /// Whether the clock jumped over an idle gap to reach this batch.
+    pub skipped_gap: bool,
+}
+
+impl Batch {
+    /// An empty batch at `at`.
+    #[must_use]
+    pub fn empty(at: usize) -> Self {
+        Self {
+            start: at,
+            end: at,
+            skipped_gap: false,
+        }
+    }
+
+    /// How many trades the batch covers.
+    #[must_use]
+    pub fn len(self) -> usize {
+        self.end.saturating_sub(self.start)
+    }
+
+    /// Whether there is nothing to emit.
+    #[must_use]
+    pub fn is_empty(self) -> bool {
+        self.end <= self.start
+    }
+
+    /// The batch as a slice range.
+    #[must_use]
+    pub fn range(self) -> std::ops::Range<usize> {
+        self.start..self.end
+    }
+}
+
+/// Where playback has reached in a session.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Playhead {
+    position_ms: i64,
+    start_ms: i64,
+    end_ms: i64,
+    cursor: usize,
+    total: usize,
+    playing: bool,
+    config: PlaybackConfig,
+}
+
+impl Playhead {
+    /// A playhead parked on the first trade of `trades`, paused.
+    ///
+    /// An empty session yields a playhead that is immediately finished.
+    #[must_use]
+    pub fn new(trades: &[Trade], config: PlaybackConfig) -> Self {
+        let start_ms = trades.first().map_or(0, |t| t.timestamp_ms);
+        Self {
+            position_ms: start_ms,
+            start_ms,
+            end_ms: trades.last().map_or(0, |t| t.timestamp_ms),
+            cursor: 0,
+            total: trades.len(),
+            playing: false,
+            config: PlaybackConfig {
+                speed: config.speed.clamp(MIN_SPEED, MAX_SPEED),
+                ..config
+            },
+        }
+    }
+
+    /// Advance by `wall_delta_ms` of real time and return the trades that fall
+    /// due, as indices into the same slice the playhead was built from.
+    ///
+    /// Returns an empty batch when paused, finished, or when no print is due
+    /// yet. Negative or non-finite deltas are treated as zero: a clock that
+    /// jumps backwards must never rewind the market.
+    pub fn advance(&mut self, trades: &[Trade], wall_delta_ms: f64) -> Batch {
+        if !self.playing || self.is_finished() {
+            return Batch::empty(self.cursor);
+        }
+        let delta = if wall_delta_ms.is_finite() && wall_delta_ms > 0.0 {
+            (wall_delta_ms * f64::from(self.config.speed)).round() as i64
+        } else {
+            0
+        };
+        let mut target = self.position_ms.saturating_add(delta);
+
+        // Nothing prints for a while: jump to the next print rather than
+        // playing an empty chart in real time.
+        let mut skipped_gap = false;
+        if let Some(limit) = self.config.skip_idle_over_ms
+            && let Some(next) = trades.get(self.cursor)
+            && next.timestamp_ms.saturating_sub(target) > limit
+        {
+            target = next.timestamp_ms;
+            skipped_gap = true;
+        }
+
+        let due = self.cursor + trades[self.cursor..].partition_point(|t| t.timestamp_ms <= target);
+        let end = due.min(self.cursor.saturating_add(self.config.max_batch));
+
+        if end < due {
+            // Capped: stay with the prints that were not delivered instead of
+            // stepping over them. The clock falls behind, honestly.
+            self.position_ms = trades[end.saturating_sub(1)].timestamp_ms;
+        } else {
+            self.position_ms = target.min(self.end_ms);
+        }
+
+        let batch = Batch {
+            start: self.cursor,
+            end,
+            skipped_gap,
+        };
+        self.cursor = end;
+        batch
+    }
+
+    /// Move to `target_ms` of market time, returning the trades between the old
+    /// and new position when seeking forward.
+    ///
+    /// Seeking backwards returns an empty batch: the caller has to rebuild its
+    /// chart from the new cursor, because bars that were already closed cannot
+    /// be un-closed. [`Playhead::cursor`] is where to restart from.
+    pub fn seek_to(&mut self, trades: &[Trade], target_ms: i64) -> Batch {
+        let target = target_ms.clamp(self.start_ms, self.end_ms);
+        let index = trades.partition_point(|t| t.timestamp_ms <= target);
+        let batch = if index >= self.cursor {
+            Batch {
+                start: self.cursor,
+                end: index,
+                skipped_gap: true,
+            }
+        } else {
+            Batch::empty(index)
+        };
+        self.position_ms = target;
+        self.cursor = index;
+        batch
+    }
+
+    /// Seek to a fraction of the session, `0.0` being the open and `1.0` the
+    /// close. See [`Playhead::seek_to`] for the backwards case.
+    pub fn seek_to_fraction(&mut self, trades: &[Trade], fraction: f32) -> Batch {
+        let span = self.end_ms.saturating_sub(self.start_ms) as f64;
+        let offset = (span * f64::from(fraction.clamp(0.0, 1.0))).round() as i64;
+        self.seek_to(trades, self.start_ms.saturating_add(offset))
+    }
+
+    /// Park back on the first trade, keeping speed and play state.
+    pub fn restart(&mut self) {
+        self.position_ms = self.start_ms;
+        self.cursor = 0;
+    }
+
+    /// Start playing. A finished session restarts from the open, which is what
+    /// pressing play at the end of a replay is asking for.
+    pub fn play(&mut self) {
+        if self.is_finished() {
+            self.restart();
+        }
+        self.playing = true;
+    }
+
+    /// Stop advancing; the position is kept.
+    pub fn pause(&mut self) {
+        self.playing = false;
+    }
+
+    /// Toggle between playing and paused.
+    pub fn toggle(&mut self) {
+        if self.playing {
+            self.pause();
+        } else {
+            self.play();
+        }
+    }
+
+    /// Change the speed, clamped to [`MIN_SPEED`]..=[`MAX_SPEED`]. The position
+    /// is untouched, so speed can be changed mid-playback without a jump.
+    pub fn set_speed(&mut self, speed: f32) {
+        self.config.speed = speed.clamp(MIN_SPEED, MAX_SPEED);
+    }
+
+    /// The current speed multiplier.
+    #[must_use]
+    pub fn speed(&self) -> f32 {
+        self.config.speed
+    }
+
+    /// Whether playback is running.
+    #[must_use]
+    pub fn is_playing(&self) -> bool {
+        self.playing
+    }
+
+    /// Whether every trade has been emitted.
+    #[must_use]
+    pub fn is_finished(&self) -> bool {
+        self.cursor >= self.total
+    }
+
+    /// Index of the next trade to emit.
+    #[must_use]
+    pub fn cursor(&self) -> usize {
+        self.cursor
+    }
+
+    /// Market time reached, in epoch milliseconds.
+    #[must_use]
+    pub fn position_ms(&self) -> i64 {
+        self.position_ms
+    }
+
+    /// Timestamp of the session's first trade.
+    #[must_use]
+    pub fn start_ms(&self) -> i64 {
+        self.start_ms
+    }
+
+    /// Timestamp of the session's last trade.
+    #[must_use]
+    pub fn end_ms(&self) -> i64 {
+        self.end_ms
+    }
+
+    /// How far through the session playback is, `0.0`..=`1.0`.
+    #[must_use]
+    pub fn progress(&self) -> f32 {
+        let span = self.end_ms.saturating_sub(self.start_ms);
+        if span <= 0 {
+            return if self.is_finished() { 1.0 } else { 0.0 };
+        }
+        let elapsed = self.position_ms.saturating_sub(self.start_ms) as f64;
+        (elapsed / span as f64).clamp(0.0, 1.0) as f32
+    }
+
+    /// How many trades the session holds.
+    #[must_use]
+    pub fn total(&self) -> usize {
+        self.total
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use quantick_engine::Side;
+    use rust_decimal::Decimal;
+
+    /// Trades one second apart, starting at epoch 10_000 ms.
+    fn ticks(count: usize) -> Vec<Trade> {
+        (0..count)
+            .map(|i| Trade {
+                agg_id: i as u64 + 1,
+                timestamp_ms: 10_000 + i as i64 * 1_000,
+                price: Decimal::from(100),
+                quantity: Decimal::ONE,
+                side: Side::Buy,
+            })
+            .collect()
+    }
+
+    fn playing(trades: &[Trade], speed: f32) -> Playhead {
+        let mut head = Playhead::new(
+            trades,
+            PlaybackConfig {
+                speed,
+                ..Default::default()
+            },
+        );
+        head.play();
+        head
+    }
+
+    #[test]
+    fn a_paused_playhead_emits_nothing() {
+        let trades = ticks(5);
+        let mut head = Playhead::new(&trades, PlaybackConfig::default());
+        assert!(head.advance(&trades, 5_000.0).is_empty());
+        assert_eq!(head.cursor(), 0);
+        assert!(!head.is_playing());
+    }
+
+    #[test]
+    fn one_times_speed_follows_market_time() {
+        let trades = ticks(5);
+        let mut head = playing(&trades, 1.0);
+        // The playhead starts on the first trade's timestamp, so it is due at once.
+        assert_eq!(head.advance(&trades, 0.0).len(), 1);
+        assert_eq!(head.advance(&trades, 999.0).len(), 0, "not due yet");
+        assert_eq!(
+            head.advance(&trades, 1.0).len(),
+            1,
+            "the next second's print"
+        );
+        assert_eq!(head.advance(&trades, 2_000.0).len(), 2);
+        assert!(!head.is_finished(), "one print still to come");
+        assert_eq!(head.advance(&trades, 1_000.0).len(), 1);
+        assert!(head.is_finished());
+    }
+
+    #[test]
+    fn speed_multiplies_market_time_per_real_second() {
+        let trades = ticks(51);
+        let mut head = playing(&trades, 50.0);
+        // One real second at 50× covers 50 s of market time: 51 prints.
+        let batch = head.advance(&trades, 1_000.0);
+        assert_eq!(batch.len(), 51);
+        assert!(head.is_finished());
+    }
+
+    #[test]
+    fn every_offered_speed_plays_a_session_out() {
+        for speed in SPEEDS {
+            let trades = ticks(120);
+            let mut head = playing(&trades, speed);
+            let mut emitted = 0;
+            // 120 s of market time, in 16 ms frames, at the speed under test.
+            let frames = (120_000.0 / (16.0 * f64::from(speed))).ceil() as usize + 2;
+            for _ in 0..frames {
+                emitted += head.advance(&trades, 16.0).len();
+            }
+            assert_eq!(emitted, trades.len(), "speed {speed}×");
+            assert!(head.is_finished(), "speed {speed}×");
+        }
+    }
+
+    #[test]
+    fn playback_is_deterministic_for_the_same_deltas() {
+        let trades = ticks(200);
+        let run = || {
+            let mut head = playing(&trades, 10.0);
+            let mut batches = Vec::new();
+            for step in 0..40 {
+                batches.push(head.advance(&trades, f64::from(step % 7) * 8.0));
+            }
+            (batches, head)
+        };
+        let (first_batches, first) = run();
+        let (second_batches, second) = run();
+        assert_eq!(first_batches, second_batches);
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn idle_gaps_are_skipped_to_the_next_print() {
+        let mut trades = ticks(2);
+        // A one-hour hole before the third print.
+        trades.push(Trade {
+            timestamp_ms: trades[1].timestamp_ms + 3_600_000,
+            ..trades[1].clone()
+        });
+        let mut head = playing(&trades, 1.0);
+        head.advance(&trades, 0.0); // first print
+        head.advance(&trades, 1_000.0); // second print
+        let batch = head.advance(&trades, 16.0);
+        assert_eq!(batch.len(), 1, "the print after the gap arrives at once");
+        assert!(batch.skipped_gap);
+        assert_eq!(head.position_ms(), trades[2].timestamp_ms);
+    }
+
+    #[test]
+    fn gap_skipping_can_be_turned_off() {
+        let mut trades = ticks(1);
+        trades.push(Trade {
+            timestamp_ms: trades[0].timestamp_ms + 3_600_000,
+            ..trades[0].clone()
+        });
+        let mut head = Playhead::new(
+            &trades,
+            PlaybackConfig {
+                speed: 1.0,
+                skip_idle_over_ms: None,
+                ..Default::default()
+            },
+        );
+        head.play();
+        head.advance(&trades, 0.0);
+        assert!(
+            head.advance(&trades, 16.0).is_empty(),
+            "the gap is played out"
+        );
+    }
+
+    #[test]
+    fn a_burst_larger_than_the_cap_is_delivered_across_calls() {
+        // 100 prints in the same millisecond.
+        let trades: Vec<Trade> = (0..100)
+            .map(|i| Trade {
+                agg_id: i + 1,
+                timestamp_ms: 10_000,
+                price: Decimal::from(100),
+                quantity: Decimal::ONE,
+                side: Side::Buy,
+            })
+            .collect();
+        let mut head = Playhead::new(
+            &trades,
+            PlaybackConfig {
+                speed: 1.0,
+                max_batch: 30,
+                ..Default::default()
+            },
+        );
+        head.play();
+        let mut emitted = 0;
+        for _ in 0..4 {
+            emitted += head.advance(&trades, 16.0).len();
+        }
+        assert_eq!(emitted, 100, "no print is skipped by the cap");
+        assert!(head.is_finished());
+    }
+
+    #[test]
+    fn seeking_forward_hands_back_everything_in_between() {
+        let trades = ticks(100);
+        let mut head = playing(&trades, 1.0);
+        head.advance(&trades, 0.0);
+        let batch = head.seek_to(&trades, trades[49].timestamp_ms);
+        assert_eq!(batch.start, 1);
+        assert_eq!(batch.end, 50);
+        assert_eq!(head.cursor(), 50);
+    }
+
+    #[test]
+    fn seeking_backwards_rewinds_the_cursor_and_emits_nothing() {
+        let trades = ticks(100);
+        let mut head = playing(&trades, 1.0);
+        head.advance(&trades, 60_000.0);
+        assert!(head.cursor() > 50);
+        let batch = head.seek_to(&trades, trades[10].timestamp_ms);
+        assert!(batch.is_empty());
+        assert_eq!(head.cursor(), 11, "restart from here");
+    }
+
+    #[test]
+    fn seeking_by_fraction_lands_inside_the_session() {
+        let trades = ticks(101);
+        let mut head = playing(&trades, 1.0);
+        head.seek_to_fraction(&trades, 0.5);
+        assert_eq!(head.position_ms(), trades[50].timestamp_ms);
+        assert!((head.progress() - 0.5).abs() < 0.001);
+        head.seek_to_fraction(&trades, 2.0);
+        assert_eq!(head.position_ms(), head.end_ms());
+        head.seek_to_fraction(&trades, -1.0);
+        assert_eq!(head.position_ms(), head.start_ms());
+    }
+
+    #[test]
+    fn play_at_the_end_starts_the_session_over() {
+        let trades = ticks(3);
+        let mut head = playing(&trades, 1.0);
+        head.advance(&trades, 10_000.0);
+        assert!(head.is_finished());
+        head.play();
+        assert!(!head.is_finished());
+        assert_eq!(head.cursor(), 0);
+        assert_eq!(head.position_ms(), head.start_ms());
+    }
+
+    #[test]
+    fn speed_changes_do_not_move_the_playhead() {
+        let trades = ticks(50);
+        let mut head = playing(&trades, 1.0);
+        head.advance(&trades, 5_000.0);
+        let before = (head.position_ms(), head.cursor());
+        head.set_speed(20.0);
+        assert_eq!((head.position_ms(), head.cursor()), before);
+        assert_eq!(head.speed(), 20.0);
+    }
+
+    #[test]
+    fn speed_is_clamped_to_a_sane_band() {
+        let trades = ticks(2);
+        let mut head = playing(&trades, 1.0);
+        head.set_speed(0.0);
+        assert_eq!(head.speed(), MIN_SPEED);
+        head.set_speed(f32::INFINITY);
+        assert_eq!(head.speed(), MAX_SPEED);
+    }
+
+    #[test]
+    fn a_backwards_or_broken_delta_never_rewinds() {
+        let trades = ticks(10);
+        let mut head = playing(&trades, 1.0);
+        head.advance(&trades, 0.0);
+        let before = head.position_ms();
+        for delta in [-1_000.0, f64::NAN, f64::INFINITY] {
+            head.advance(&trades, delta);
+        }
+        assert_eq!(head.position_ms(), before);
+        assert_eq!(head.cursor(), 1);
+    }
+
+    #[test]
+    fn an_empty_session_is_finished_immediately() {
+        let trades: Vec<Trade> = Vec::new();
+        let mut head = playing(&trades, 1.0);
+        assert!(head.is_finished());
+        assert!(head.advance(&trades, 1_000.0).is_empty());
+        assert_eq!(head.progress(), 1.0);
+    }
+
+    #[test]
+    fn progress_runs_from_open_to_close() {
+        let trades = ticks(11);
+        let mut head = playing(&trades, 1.0);
+        assert_eq!(head.progress(), 0.0);
+        head.advance(&trades, 5_000.0);
+        assert!((head.progress() - 0.5).abs() < 0.001);
+        head.advance(&trades, 60_000.0);
+        assert_eq!(head.progress(), 1.0);
+    }
+}

--- a/crates/replay/src/format.rs
+++ b/crates/replay/src/format.rs
@@ -1,0 +1,1289 @@
+//! The quantick market-replay tick file: one executed trade per line, CSV.
+//!
+//! The shape follows the tick-data export every retail platform already speaks
+//! (Sierra Chart ASCII, NinjaTrader tick import, the CSVs sold by tick-data
+//! vendors): a `Date,Time,Price,Bid,Ask,Volume,Side` row per print, in
+//! chronological order, preceded by `#` metadata lines.
+//!
+//! ```text
+//! # quantick-replay 1
+//! # symbol=WINJ26
+//! # timezone=-03:00
+//! # side_source=bid_ask
+//! Date,Time,Price,Bid,Ask,Volume,Side
+//! 2026-03-16,10:01:08.000,182035,182030,182035,12,B
+//! 2026-03-16,10:01:09.000,182025,182025,182030,4,S
+//! ```
+//!
+//! # Why the columns are read by name
+//!
+//! The header line is parsed into a [`ColumnMap`], so column *order* is free and
+//! unknown columns are ignored instead of rejected. A file that also carries an
+//! `Id` or an exchange-specific column still loads, and a future quantick can
+//! start reading a new column without invalidating a single recorded session.
+//!
+//! # Timestamps
+//!
+//! `Date`/`Time` are wall-clock in the exchange's own timezone, which is what a
+//! trader reads on a chart. The `# timezone=` metadata line declares the offset
+//! (e.g. `-03:00` for B3); everything downstream works in epoch milliseconds
+//! UTC. A file with no `timezone=` line is read as UTC — declared, not guessed.
+//!
+//! # Aggressor side
+//!
+//! `Side` is the **aggressor**: `B` when the buyer crossed the spread, `S` when
+//! the seller did. It is deliberately not `A`/`B` for "at ask"/"at bid" — that
+//! vocabulary inverts between vendors and would silently mirror the order flow.
+//! Where the side had to be inferred, the recorder says so in `# side_source=`.
+
+use std::fmt::Write as _;
+use std::str::FromStr as _;
+
+use quantick_engine::{Side, Trade};
+use rust_decimal::Decimal;
+
+/// Name written on the first metadata line, and looked for when identifying a
+/// file as a quantick replay session.
+pub const FORMAT_NAME: &str = "quantick-replay";
+
+/// Version of the layout described in this module.
+pub const FORMAT_VERSION: u32 = 1;
+
+/// The only file extension scanned as a replay session.
+pub const FILE_EXTENSION: &str = "csv";
+
+/// The header line [`write_header`] emits. Reading accepts any column order.
+pub const CANONICAL_HEADER: &str = "Date,Time,Price,Bid,Ask,Volume,Side";
+
+/// The format, explained for a person who just picked the wrong folder.
+///
+/// Shown verbatim in the UI next to whatever went wrong, so the fix never
+/// requires opening the documentation.
+pub const FORMAT_HELP: &str = "\
+Expected layout — one folder per instrument, one CSV per session day:
+
+    <replay folder>/
+        WINJ26/
+            20260316.csv
+            20260317.csv
+
+Files named SYMBOL-YYYYMMDD.csv directly in the folder are read too.
+
+Each file holds one executed trade per line, oldest first:
+
+    # quantick-replay 1
+    # symbol=WINJ26
+    # timezone=-03:00
+    Date,Time,Price,Bid,Ask,Volume,Side
+    2026-03-16,10:01:08.000,182035,182030,182035,12,B
+
+Required columns: Date, Time, Price, Volume, Side.
+Optional columns: Bid, Ask, Id. Any other column is ignored.
+Date is YYYY-MM-DD, Time is HH:MM:SS or HH:MM:SS.mmm, in the timezone declared
+by the `# timezone=` line (UTC when absent).
+Side is the aggressor: B when the buyer lifted the offer, S when the seller hit
+the bid.
+
+Recordings you already have can be converted with:
+    cargo run -p quantick-replay --example import_mt5_ndjson -- \\
+        --in <recording.ndjson> --out <replay folder>";
+
+/// A fixed offset from UTC, in minutes, as declared by `# timezone=`.
+///
+/// Fixed on purpose: a replay session is a recording of one day, and applying a
+/// DST rule to a timestamp that was already stamped by the exchange would move
+/// prints the recorder never moved.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UtcOffset(i32);
+
+impl UtcOffset {
+    /// No offset — the default when a file declares no timezone.
+    pub const UTC: Self = Self(0);
+
+    /// An offset of `minutes` east of UTC, if it is within ±24 h.
+    #[must_use]
+    pub fn from_minutes(minutes: i32) -> Option<Self> {
+        (-1440..=1440).contains(&minutes).then_some(Self(minutes))
+    }
+
+    /// Parse `UTC`, `Z`, `+HH:MM`, `-HH:MM`, `-HHMM` or `-HH`.
+    #[must_use]
+    pub fn parse(text: &str) -> Option<Self> {
+        let text = text.trim();
+        if text.eq_ignore_ascii_case("utc") || text.eq_ignore_ascii_case("z") {
+            return Some(Self::UTC);
+        }
+        let (sign, rest) = match text.as_bytes().first()? {
+            b'+' => (1, &text[1..]),
+            b'-' => (-1, &text[1..]),
+            _ => (1, text),
+        };
+        let (hh, mm) = match rest.split_once(':') {
+            Some((h, m)) => (h, m),
+            None => match rest.len() {
+                4 => rest.split_at(2),
+                1 | 2 => (rest, "0"),
+                _ => return None,
+            },
+        };
+        let hours: i32 = hh.parse().ok()?;
+        let minutes: i32 = mm.parse().ok()?;
+        if !(0..=59).contains(&minutes) {
+            return None;
+        }
+        Self::from_minutes(sign * (hours * 60 + minutes))
+    }
+
+    /// Minutes east of UTC.
+    #[must_use]
+    pub fn minutes(self) -> i32 {
+        self.0
+    }
+
+    /// Milliseconds east of UTC, for epoch conversion.
+    #[must_use]
+    pub fn millis(self) -> i64 {
+        i64::from(self.0) * 60_000
+    }
+
+    /// The canonical `±HH:MM` rendering (`UTC` for zero).
+    #[must_use]
+    pub fn label(self) -> String {
+        if self.0 == 0 {
+            return "UTC".to_string();
+        }
+        let sign = if self.0 < 0 { '-' } else { '+' };
+        let abs = self.0.abs();
+        format!("{sign}{:02}:{:02}", abs / 60, abs % 60)
+    }
+}
+
+impl Default for UtcOffset {
+    fn default() -> Self {
+        Self::UTC
+    }
+}
+
+/// What went wrong while reading a replay file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FormatErrorKind {
+    /// The file holds no data rows at all.
+    Empty,
+    /// No header line naming the columns.
+    MissingHeader,
+    /// The header omits a column the format requires.
+    MissingColumn,
+    /// The header names the same column twice.
+    DuplicateColumn,
+    /// A row has fewer fields than the header declared.
+    FieldCount,
+    /// `Date` is not `YYYY-MM-DD`, or names a day that does not exist.
+    Date,
+    /// `Time` is not `HH:MM:SS[.mmm]`.
+    Time,
+    /// `Price` or `Volume` is not a number.
+    Number,
+    /// `Side` is not a recognised aggressor token.
+    Side,
+    /// A row is stamped before the row above it.
+    OutOfOrder,
+    /// `# timezone=` does not name a fixed UTC offset.
+    Timezone,
+}
+
+impl FormatErrorKind {
+    /// A short, stable token for logs and tests.
+    #[must_use]
+    pub fn code(self) -> &'static str {
+        match self {
+            FormatErrorKind::Empty => "empty",
+            FormatErrorKind::MissingHeader => "missing_header",
+            FormatErrorKind::MissingColumn => "missing_column",
+            FormatErrorKind::DuplicateColumn => "duplicate_column",
+            FormatErrorKind::FieldCount => "field_count",
+            FormatErrorKind::Date => "bad_date",
+            FormatErrorKind::Time => "bad_time",
+            FormatErrorKind::Number => "bad_number",
+            FormatErrorKind::Side => "bad_side",
+            FormatErrorKind::OutOfOrder => "out_of_order",
+            FormatErrorKind::Timezone => "bad_timezone",
+        }
+    }
+
+    /// What to change to make the file load.
+    #[must_use]
+    pub fn advice(self) -> &'static str {
+        match self {
+            FormatErrorKind::Empty => "Add at least one trade row below the header.",
+            FormatErrorKind::MissingHeader => {
+                "Add the column header line above the rows, e.g. `Date,Time,Price,Bid,Ask,Volume,Side`."
+            }
+            FormatErrorKind::MissingColumn => {
+                "Name every required column in the header: Date, Time, Price, Volume, Side."
+            }
+            FormatErrorKind::DuplicateColumn => {
+                "Keep one column per name; rename or drop the repeated one."
+            }
+            FormatErrorKind::FieldCount => {
+                "Give every row the same number of comma-separated fields as the header."
+            }
+            FormatErrorKind::Date => "Write dates as YYYY-MM-DD, e.g. 2026-03-16.",
+            FormatErrorKind::Time => "Write times as HH:MM:SS or HH:MM:SS.mmm, e.g. 10:01:08.250.",
+            FormatErrorKind::Number => "Use a plain decimal number, e.g. 182035 or 182035.5.",
+            FormatErrorKind::Side => {
+                "Use B for a buyer-initiated trade and S for a seller-initiated one."
+            }
+            FormatErrorKind::OutOfOrder => {
+                "Sort the rows oldest first; a replay plays time forward only."
+            }
+            FormatErrorKind::Timezone => {
+                "Declare the offset as `# timezone=-03:00`, or drop the line to mean UTC."
+            }
+        }
+    }
+}
+
+/// A problem in a replay file, located at a line.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FormatError {
+    /// 1-based line number; `0` when the problem is the file as a whole.
+    pub line: usize,
+    /// The category of problem.
+    pub kind: FormatErrorKind,
+    /// What was found, in the file's own words.
+    pub detail: String,
+}
+
+impl FormatError {
+    /// Build an error at `line`.
+    #[must_use]
+    pub fn at(line: usize, kind: FormatErrorKind, detail: impl Into<String>) -> Self {
+        Self {
+            line,
+            kind,
+            detail: detail.into(),
+        }
+    }
+
+    /// What to change to make the file load.
+    #[must_use]
+    pub fn advice(&self) -> &'static str {
+        self.kind.advice()
+    }
+}
+
+impl std::fmt::Display for FormatError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.line == 0 {
+            write!(f, "{}", self.detail)
+        } else {
+            write!(f, "line {}: {}", self.line, self.detail)
+        }
+    }
+}
+
+impl std::error::Error for FormatError {}
+
+/// Where each field sits on a row, resolved once from the header line.
+///
+/// Reading by index after this is a slice lookup, so a million-row file costs
+/// one header parse instead of a million name comparisons.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ColumnMap {
+    date: usize,
+    time: usize,
+    price: usize,
+    volume: usize,
+    side: usize,
+    bid: Option<usize>,
+    ask: Option<usize>,
+    id: Option<usize>,
+    /// How many fields the header declared.
+    width: usize,
+    /// Header names that quantick does not read, kept so the UI can say what
+    /// was ignored rather than silently dropping data.
+    ignored: Vec<String>,
+}
+
+impl ColumnMap {
+    /// Resolve the header line at `line_no` into field positions.
+    ///
+    /// # Errors
+    ///
+    /// [`FormatErrorKind::MissingColumn`] when a required column is absent,
+    /// [`FormatErrorKind::DuplicateColumn`] when one is named twice.
+    pub fn parse(header: &str, line_no: usize) -> Result<Self, FormatError> {
+        let mut date = None;
+        let mut time = None;
+        let mut price = None;
+        let mut volume = None;
+        let mut side = None;
+        let mut bid = None;
+        let mut ask = None;
+        let mut id = None;
+        let mut ignored = Vec::new();
+        let mut width = 0;
+
+        for (index, raw) in header.split(',').enumerate() {
+            width = index + 1;
+            let name = raw.trim().trim_matches('"').to_ascii_lowercase();
+            let slot = match name.as_str() {
+                "date" => &mut date,
+                "time" => &mut time,
+                "price" | "last" => &mut price,
+                "volume" | "size" | "qty" | "quantity" => &mut volume,
+                "side" | "aggressor" => &mut side,
+                "bid" | "bidprice" | "bid_price" => &mut bid,
+                "ask" | "askprice" | "ask_price" | "offer" => &mut ask,
+                "id" | "trade_id" | "tradeid" => &mut id,
+                _ => {
+                    if !name.is_empty() {
+                        ignored.push(raw.trim().to_string());
+                    }
+                    continue;
+                }
+            };
+            if slot.is_some() {
+                return Err(FormatError::at(
+                    line_no,
+                    FormatErrorKind::DuplicateColumn,
+                    format!("column `{}` appears more than once", raw.trim()),
+                ));
+            }
+            *slot = Some(index);
+        }
+
+        // A file exported with a semicolon or tab separator reads as one long
+        // column, and "header has no `Date` column" would send someone looking
+        // for a column that is plainly there. Name the real problem instead.
+        if !header.contains(',')
+            && let Some(separator) = ['\t', ';', '|'].into_iter().find(|s| header.contains(*s))
+        {
+            let shown = if separator == '\t' {
+                "a tab".to_string()
+            } else {
+                format!("`{separator}`")
+            };
+            return Err(FormatError::at(
+                line_no,
+                FormatErrorKind::MissingColumn,
+                format!("this file separates columns with {shown}, not a comma"),
+            ));
+        }
+
+        let required = |slot: Option<usize>, name: &str| -> Result<usize, FormatError> {
+            slot.ok_or_else(|| {
+                FormatError::at(
+                    line_no,
+                    FormatErrorKind::MissingColumn,
+                    format!("header has no `{name}` column"),
+                )
+            })
+        };
+
+        Ok(Self {
+            date: required(date, "Date")?,
+            time: required(time, "Time")?,
+            price: required(price, "Price")?,
+            volume: required(volume, "Volume")?,
+            side: required(side, "Side")?,
+            bid,
+            ask,
+            id,
+            width,
+            ignored,
+        })
+    }
+
+    /// The highest field index the map reads, for the row-width check.
+    #[must_use]
+    fn needed_width(&self) -> usize {
+        [
+            Some(self.date),
+            Some(self.time),
+            Some(self.price),
+            Some(self.volume),
+            Some(self.side),
+            self.bid,
+            self.ask,
+            self.id,
+        ]
+        .into_iter()
+        .flatten()
+        .max()
+        .map_or(0, |max| max + 1)
+    }
+
+    /// How many fields the header declared.
+    #[must_use]
+    pub fn width(&self) -> usize {
+        self.width
+    }
+
+    /// Header names quantick does not read.
+    #[must_use]
+    pub fn ignored(&self) -> &[String] {
+        &self.ignored
+    }
+
+    /// Whether the file carries a bid/ask quote alongside each print.
+    #[must_use]
+    pub fn has_quotes(&self) -> bool {
+        self.bid.is_some() && self.ask.is_some()
+    }
+}
+
+/// The `#` metadata block plus the resolved column positions.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FileHeader {
+    /// Format version from `# quantick-replay <n>`, when present.
+    pub version: Option<u32>,
+    /// Instrument from `# symbol=`, when present.
+    pub symbol: Option<String>,
+    /// Offset the `Date`/`Time` columns are expressed in.
+    pub timezone: UtcOffset,
+    /// Whether the file actually declared the timezone (vs defaulting to UTC).
+    pub timezone_declared: bool,
+    /// How the recorder decided the aggressor side, from `# side_source=`.
+    pub side_source: Option<String>,
+    /// Where each field sits on a row.
+    pub columns: ColumnMap,
+    /// 1-based line number of the column header.
+    pub header_line: usize,
+}
+
+/// Read the metadata block and column header from the start of a file.
+///
+/// Only reads far enough to find the header line, so scanning a folder of large
+/// recordings does not parse a single trade.
+///
+/// # Errors
+///
+/// [`FormatErrorKind::MissingHeader`] when no column header is found,
+/// [`FormatErrorKind::Timezone`] on an undecodable offset, plus anything
+/// [`ColumnMap::parse`] rejects.
+pub fn parse_header(text: &str) -> Result<FileHeader, FormatError> {
+    let mut version = None;
+    let mut symbol = None;
+    let mut timezone = UtcOffset::UTC;
+    let mut timezone_declared = false;
+    let mut side_source = None;
+
+    for (index, raw) in text.lines().enumerate() {
+        let line = raw.trim();
+        let line_no = index + 1;
+        if line.is_empty() {
+            continue;
+        }
+        if let Some(comment) = line.strip_prefix('#') {
+            let comment = comment.trim();
+            if let Some(rest) = comment
+                .strip_prefix(FORMAT_NAME)
+                .map(str::trim)
+                .filter(|rest| !rest.starts_with('-'))
+            {
+                version = rest.parse().ok();
+                continue;
+            }
+            let Some((key, value)) = comment.split_once('=') else {
+                continue;
+            };
+            let value = value.trim();
+            match key.trim().to_ascii_lowercase().as_str() {
+                "symbol" | "instrument" => symbol = Some(value.to_string()),
+                "timezone" | "tz" | "utc_offset" => {
+                    timezone = UtcOffset::parse(value).ok_or_else(|| {
+                        FormatError::at(
+                            line_no,
+                            FormatErrorKind::Timezone,
+                            format!("`{value}` is not a fixed UTC offset"),
+                        )
+                    })?;
+                    timezone_declared = true;
+                }
+                "side_source" | "aggressor_source" => side_source = Some(value.to_string()),
+                _ => {}
+            }
+            continue;
+        }
+        // First non-comment line is the column header.
+        return Ok(FileHeader {
+            version,
+            symbol,
+            timezone,
+            timezone_declared,
+            side_source,
+            columns: ColumnMap::parse(line, line_no)?,
+            header_line: line_no,
+        });
+    }
+
+    Err(FormatError::at(
+        0,
+        FormatErrorKind::MissingHeader,
+        "no column header line found".to_string(),
+    ))
+}
+
+/// The bid/ask quote recorded alongside a print, when the file carries one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Quote {
+    /// Best bid at the time of the print.
+    pub bid: Decimal,
+    /// Best ask at the time of the print.
+    pub ask: Decimal,
+}
+
+/// Everything one file yielded.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedFile {
+    /// Metadata and column positions.
+    pub header: FileHeader,
+    /// Trades, in file order (oldest first).
+    pub trades: Vec<Trade>,
+    /// Quotes parallel to `trades`, when requested and available.
+    pub quotes: Vec<Quote>,
+}
+
+/// Tuning for [`parse_file`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct ParseOptions {
+    /// Also collect the `Bid`/`Ask` columns into [`ParsedFile::quotes`].
+    ///
+    /// Off by default: the chart replays trades, and keeping quotes for a
+    /// multi-million-row session costs memory nothing reads yet.
+    pub keep_quotes: bool,
+}
+
+/// Parse a whole replay file.
+///
+/// Trades come out in file order with a synthetic `agg_id` — the sequence
+/// number of the print within the file, unless the file carries an `Id` column.
+/// Rows must be chronologically non-decreasing; the first row that steps
+/// backwards is an error rather than a silently reordered print.
+///
+/// # Errors
+///
+/// The first [`FormatError`] encountered, carrying its 1-based line number.
+pub fn parse_file(text: &str, options: ParseOptions) -> Result<ParsedFile, FormatError> {
+    let header = parse_header(text)?;
+    let columns = &header.columns;
+    let needed = columns.needed_width();
+    let tz_ms = header.timezone.millis();
+    let want_quotes = options.keep_quotes && columns.has_quotes();
+
+    // One allocation sized from the file: ~60 bytes per row is the shape of a
+    // real B3 session, and over-reserving beats re-growing a 250k-row vector.
+    let estimate = text.len() / 60;
+    let mut trades = Vec::with_capacity(estimate);
+    let mut quotes = if want_quotes {
+        Vec::with_capacity(estimate)
+    } else {
+        Vec::new()
+    };
+
+    let mut fields: Vec<&str> = Vec::with_capacity(columns.width().max(needed));
+    let mut last_ms = i64::MIN;
+    let mut sequence: u64 = 0;
+
+    for (index, raw) in text.lines().enumerate().skip(header.header_line) {
+        let line = raw.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let line_no = index + 1;
+
+        fields.clear();
+        fields.extend(line.split(','));
+        if fields.len() < needed {
+            return Err(FormatError::at(
+                line_no,
+                FormatErrorKind::FieldCount,
+                format!(
+                    "row has {} field(s); the header declares {}",
+                    fields.len(),
+                    columns.width()
+                ),
+            ));
+        }
+
+        let date_ms = parse_date(fields[columns.date].trim(), line_no)?;
+        let time_ms = parse_time(fields[columns.time].trim(), line_no)?;
+        let timestamp_ms = date_ms.saturating_add(time_ms).saturating_sub(tz_ms);
+        if timestamp_ms < last_ms {
+            return Err(FormatError::at(
+                line_no,
+                FormatErrorKind::OutOfOrder,
+                format!(
+                    "{} {} is older than the row above it",
+                    fields[columns.date].trim(),
+                    fields[columns.time].trim()
+                ),
+            ));
+        }
+        last_ms = timestamp_ms;
+
+        let price = parse_decimal(fields[columns.price].trim(), "Price", line_no)?;
+        let quantity = parse_decimal(fields[columns.volume].trim(), "Volume", line_no)?;
+        let side = parse_side(fields[columns.side].trim(), line_no)?;
+
+        sequence += 1;
+        let agg_id = match columns.id {
+            Some(at) => fields[at].trim().parse::<u64>().unwrap_or(sequence),
+            None => sequence,
+        };
+
+        if want_quotes {
+            let bid = columns
+                .bid
+                .map(|at| parse_decimal(fields[at].trim(), "Bid", line_no))
+                .transpose()?;
+            let ask = columns
+                .ask
+                .map(|at| parse_decimal(fields[at].trim(), "Ask", line_no))
+                .transpose()?;
+            if let (Some(bid), Some(ask)) = (bid, ask) {
+                quotes.push(Quote { bid, ask });
+            }
+        }
+
+        trades.push(Trade {
+            agg_id,
+            timestamp_ms,
+            price,
+            quantity,
+            side,
+        });
+    }
+
+    if trades.is_empty() {
+        return Err(FormatError::at(
+            0,
+            FormatErrorKind::Empty,
+            "file has a header but no trade rows".to_string(),
+        ));
+    }
+
+    Ok(ParsedFile {
+        header,
+        trades,
+        quotes,
+    })
+}
+
+/// Milliseconds at midnight UTC of a `YYYY-MM-DD` date.
+fn parse_date(text: &str, line_no: usize) -> Result<i64, FormatError> {
+    let err = || {
+        FormatError::at(
+            line_no,
+            FormatErrorKind::Date,
+            format!("`{text}` is not a YYYY-MM-DD date"),
+        )
+    };
+    let bytes = text.as_bytes();
+    if bytes.len() != 10 || bytes[4] != b'-' || bytes[7] != b'-' {
+        return Err(err());
+    }
+    let year: i64 = text[0..4].parse().map_err(|_| err())?;
+    let month: u32 = text[5..7].parse().map_err(|_| err())?;
+    let day: u32 = text[8..10].parse().map_err(|_| err())?;
+    if !(1..=12).contains(&month) || day < 1 || day > days_in_month(year, month) {
+        return Err(err());
+    }
+    Ok(days_from_civil(year, month, day) * 86_400_000)
+}
+
+/// Milliseconds since midnight of a `HH:MM:SS[.mmm]` time.
+fn parse_time(text: &str, line_no: usize) -> Result<i64, FormatError> {
+    let err = || {
+        FormatError::at(
+            line_no,
+            FormatErrorKind::Time,
+            format!("`{text}` is not a HH:MM:SS[.mmm] time"),
+        )
+    };
+    let (clock, fraction) = match text.split_once('.') {
+        Some((clock, fraction)) => (clock, Some(fraction)),
+        None => (text, None),
+    };
+    let bytes = clock.as_bytes();
+    if bytes.len() != 8 || bytes[2] != b':' || bytes[5] != b':' {
+        return Err(err());
+    }
+    let hours: i64 = clock[0..2].parse().map_err(|_| err())?;
+    let minutes: i64 = clock[3..5].parse().map_err(|_| err())?;
+    let seconds: i64 = clock[6..8].parse().map_err(|_| err())?;
+    // 60 is accepted as a leap second and clamped, the way exchange feeds stamp
+    // them; 61 is a typo.
+    if hours > 23 || minutes > 59 || seconds > 60 {
+        return Err(err());
+    }
+    let millis = match fraction {
+        None => 0,
+        Some(fraction) => {
+            if fraction.is_empty() || !fraction.bytes().all(|b| b.is_ascii_digit()) {
+                return Err(err());
+            }
+            // Accept any precision; anything finer than a millisecond is
+            // truncated, never rounded, so a re-export cannot drift forward.
+            let digits = &fraction[..fraction.len().min(3)];
+            let scale = 10i64.pow(3 - digits.len() as u32);
+            digits.parse::<i64>().map_err(|_| err())? * scale
+        }
+    };
+    Ok(((hours * 60 + minutes) * 60 + seconds.min(59)) * 1000 + millis)
+}
+
+fn parse_decimal(text: &str, column: &str, line_no: usize) -> Result<Decimal, FormatError> {
+    Decimal::from_str(text).map_err(|e| {
+        FormatError::at(
+            line_no,
+            FormatErrorKind::Number,
+            format!("{column} `{text}`: {e}"),
+        )
+    })
+}
+
+fn parse_side(text: &str, line_no: usize) -> Result<Side, FormatError> {
+    match text {
+        "B" | "b" | "1" => return Ok(Side::Buy),
+        "S" | "s" | "-1" => return Ok(Side::Sell),
+        _ => {}
+    }
+    if text.eq_ignore_ascii_case("buy") {
+        return Ok(Side::Buy);
+    }
+    if text.eq_ignore_ascii_case("sell") {
+        return Ok(Side::Sell);
+    }
+    // `A`/`ASK` reads as "traded at the ask" in some exports and "ask-side
+    // aggressor" in others, which are opposite sides. Guessing would mirror the
+    // whole session's order flow, so it is rejected by name.
+    let detail = if text.eq_ignore_ascii_case("a")
+        || text.eq_ignore_ascii_case("ask")
+        || text.eq_ignore_ascii_case("bid")
+    {
+        format!(
+            "Side `{text}` is ambiguous — it names a price level, not the aggressor \
+             (write B for a buyer-initiated trade, S for a seller-initiated one)"
+        )
+    } else if text.is_empty() {
+        "Side is empty; every row must state the aggressor".to_string()
+    } else {
+        format!("Side `{text}` is not B or S")
+    };
+    Err(FormatError::at(line_no, FormatErrorKind::Side, detail))
+}
+
+/// Days since the Unix epoch for a proleptic-Gregorian date (Howard Hinnant's
+/// `days_from_civil`). Pure integer maths — no calendar dependency, and the
+/// same answer on every platform.
+fn days_from_civil(year: i64, month: u32, day: u32) -> i64 {
+    let year = if month <= 2 { year - 1 } else { year };
+    let era = if year >= 0 { year } else { year - 399 } / 400;
+    let year_of_era = year - era * 400;
+    let month = i64::from(month);
+    let shifted = if month > 2 { month - 3 } else { month + 9 };
+    let day_of_year = (153 * shifted + 2) / 5 + i64::from(day) - 1;
+    let day_of_era = year_of_era * 365 + year_of_era / 4 - year_of_era / 100 + day_of_year;
+    era * 146_097 + day_of_era - 719_468
+}
+
+/// The inverse of [`days_from_civil`], for writing files.
+fn civil_from_days(days: i64) -> (i64, u32, u32) {
+    let z = days + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let day_of_era = z - era * 146_097;
+    let year_of_era =
+        (day_of_era - day_of_era / 1460 + day_of_era / 36524 - day_of_era / 146_096) / 365;
+    let year = year_of_era + era * 400;
+    let day_of_year = day_of_era - (365 * year_of_era + year_of_era / 4 - year_of_era / 100);
+    let shifted = (5 * day_of_year + 2) / 153;
+    let day = (day_of_year - (153 * shifted + 2) / 5 + 1) as u32;
+    let month = if shifted < 10 {
+        shifted + 3
+    } else {
+        shifted - 9
+    } as u32;
+    (if month <= 2 { year + 1 } else { year }, month, day)
+}
+
+fn days_in_month(year: i64, month: u32) -> u32 {
+    match month {
+        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+        4 | 6 | 9 | 11 => 30,
+        2 if is_leap(year) => 29,
+        2 => 28,
+        _ => 0,
+    }
+}
+
+fn is_leap(year: i64) -> bool {
+    (year % 4 == 0 && year % 100 != 0) || year % 400 == 0
+}
+
+/// A wall-clock reading: what a `Date`/`Time` pair says, with no timezone of its
+/// own. Pair it with a [`UtcOffset`] to get an instant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CivilTime {
+    /// Four-digit year.
+    pub year: i64,
+    /// Month, 1–12.
+    pub month: u32,
+    /// Day of month, 1–31.
+    pub day: u32,
+    /// Hour, 0–23.
+    pub hour: u32,
+    /// Minute, 0–59.
+    pub minute: u32,
+    /// Second, 0–59.
+    pub second: u32,
+    /// Millisecond, 0–999.
+    pub milli: u32,
+}
+
+impl CivilTime {
+    /// The instant this reading names when read at `offset`.
+    ///
+    /// The inverse of [`civil_parts`]. Out-of-range parts are not rejected here
+    /// — callers reading untrusted text validate first (see [`parse_file`]);
+    /// this is the arithmetic, shared so recorders and readers agree to the
+    /// millisecond.
+    #[must_use]
+    pub fn epoch_millis(self, offset: UtcOffset) -> i64 {
+        let days = days_from_civil(self.year, self.month, self.day);
+        let in_day =
+            (i64::from(self.hour) * 3600 + i64::from(self.minute) * 60 + i64::from(self.second))
+                * 1000
+                + i64::from(self.milli);
+        days.saturating_mul(86_400_000)
+            .saturating_add(in_day)
+            .saturating_sub(offset.millis())
+    }
+
+    /// The `Date` field, `YYYY-MM-DD`.
+    #[must_use]
+    pub fn date_field(self) -> String {
+        format!("{:04}-{:02}-{:02}", self.year, self.month, self.day)
+    }
+
+    /// The `Time` field, `HH:MM:SS.mmm`.
+    #[must_use]
+    pub fn time_field(self) -> String {
+        format!(
+            "{:02}:{:02}:{:02}.{:03}",
+            self.hour, self.minute, self.second, self.milli
+        )
+    }
+}
+
+/// Split an epoch-millisecond instant into the wall-clock reading seen at
+/// `offset`.
+#[must_use]
+pub fn civil_parts(timestamp_ms: i64, offset: UtcOffset) -> CivilTime {
+    let local = timestamp_ms.saturating_add(offset.millis());
+    let days = local.div_euclid(86_400_000);
+    let in_day = local.rem_euclid(86_400_000);
+    let (year, month, day) = civil_from_days(days);
+    let seconds = in_day / 1000;
+    CivilTime {
+        year,
+        month,
+        day,
+        hour: (seconds / 3600) as u32,
+        minute: ((seconds % 3600) / 60) as u32,
+        second: (seconds % 60) as u32,
+        milli: (in_day % 1000) as u32,
+    }
+}
+
+/// Format the `Date` and `Time` fields for one instant.
+#[must_use]
+pub fn format_datetime(timestamp_ms: i64, offset: UtcOffset) -> (String, String) {
+    let civil = civil_parts(timestamp_ms, offset);
+    (civil.date_field(), civil.time_field())
+}
+
+/// Metadata written above the column header by [`write_header`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WriteHeader {
+    /// Instrument the session belongs to.
+    pub symbol: String,
+    /// Offset the `Date`/`Time` columns are written in.
+    pub timezone: UtcOffset,
+    /// How the aggressor side was decided, recorded honestly.
+    pub side_source: String,
+    /// Where the rows came from, e.g. the recording file name.
+    pub source: Option<String>,
+}
+
+/// Write the metadata block and column header.
+#[must_use]
+pub fn write_header(header: &WriteHeader) -> String {
+    let mut out = String::with_capacity(256);
+    let _ = writeln!(out, "# {FORMAT_NAME} {FORMAT_VERSION}");
+    let _ = writeln!(out, "# symbol={}", header.symbol);
+    let _ = writeln!(out, "# timezone={}", header.timezone.label());
+    let _ = writeln!(out, "# side_source={}", header.side_source);
+    if let Some(source) = &header.source {
+        let _ = writeln!(out, "# source={source}");
+    }
+    out.push_str(CANONICAL_HEADER);
+    out.push('\n');
+    out
+}
+
+/// Append one trade row in [`CANONICAL_HEADER`] order.
+///
+/// `quote` supplies the `Bid`/`Ask` columns; without one they are written
+/// empty, which reads back as "not recorded" rather than as a zero quote.
+pub fn write_trade(out: &mut String, trade: &Trade, quote: Option<Quote>, offset: UtcOffset) {
+    let (date, time) = format_datetime(trade.timestamp_ms, offset);
+    let (bid, ask) = match quote {
+        Some(q) => (q.bid.to_string(), q.ask.to_string()),
+        None => (String::new(), String::new()),
+    };
+    let _ = writeln!(
+        out,
+        "{date},{time},{},{bid},{ask},{},{}",
+        trade.price,
+        trade.quantity,
+        match trade.side {
+            Side::Buy => 'B',
+            Side::Sell => 'S',
+        }
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dec(text: &str) -> Decimal {
+        Decimal::from_str(text).unwrap()
+    }
+
+    const SAMPLE: &str = "\
+# quantick-replay 1
+# symbol=WINJ26
+# timezone=-03:00
+# side_source=bid_ask
+Date,Time,Price,Bid,Ask,Volume,Side
+2026-03-16,10:01:08.000,182035,182030,182035,12,B
+2026-03-16,10:01:09.250,182025,182025,182030,4,S
+";
+
+    #[test]
+    fn reads_metadata_and_columns() {
+        let header = parse_header(SAMPLE).unwrap();
+        assert_eq!(header.version, Some(1));
+        assert_eq!(header.symbol.as_deref(), Some("WINJ26"));
+        assert_eq!(header.timezone, UtcOffset::from_minutes(-180).unwrap());
+        assert!(header.timezone_declared);
+        assert_eq!(header.side_source.as_deref(), Some("bid_ask"));
+        assert_eq!(header.header_line, 5);
+        assert!(header.columns.has_quotes());
+    }
+
+    #[test]
+    fn parses_trades_into_utc_epoch_millis() {
+        let parsed = parse_file(SAMPLE, ParseOptions::default()).unwrap();
+        assert_eq!(parsed.trades.len(), 2);
+        // 2026-03-16 10:01:08 at UTC-03:00 is 13:01:08 UTC.
+        let civil = civil_parts(parsed.trades[0].timestamp_ms, UtcOffset::UTC);
+        assert_eq!(civil.date_field(), "2026-03-16");
+        assert_eq!(civil.time_field(), "13:01:08.000");
+        assert_eq!(parsed.trades[0].price, dec("182035"));
+        assert_eq!(parsed.trades[0].quantity, dec("12"));
+        assert_eq!(parsed.trades[0].side, Side::Buy);
+        assert_eq!(parsed.trades[1].side, Side::Sell);
+        assert_eq!(
+            parsed.trades[1].timestamp_ms - parsed.trades[0].timestamp_ms,
+            1250
+        );
+        // Synthetic ids number the prints in file order.
+        assert_eq!(parsed.trades[0].agg_id, 1);
+        assert_eq!(parsed.trades[1].agg_id, 2);
+        assert!(parsed.quotes.is_empty(), "quotes are opt-in");
+    }
+
+    #[test]
+    fn collects_quotes_when_asked() {
+        let parsed = parse_file(SAMPLE, ParseOptions { keep_quotes: true }).unwrap();
+        assert_eq!(parsed.quotes.len(), 2);
+        assert_eq!(parsed.quotes[0].bid, dec("182030"));
+        assert_eq!(parsed.quotes[0].ask, dec("182035"));
+    }
+
+    #[test]
+    fn column_order_is_free_and_extra_columns_are_ignored() {
+        let text = "\
+Side,Volume,Time,Date,Exchange,Price
+B,7,09:00:00,2026-03-16,BVMF,182000
+";
+        let parsed = parse_file(text, ParseOptions::default()).unwrap();
+        assert_eq!(parsed.trades[0].quantity, dec("7"));
+        assert_eq!(parsed.trades[0].price, dec("182000"));
+        assert_eq!(parsed.header.columns.ignored(), ["Exchange"]);
+        assert!(!parsed.header.columns.has_quotes());
+    }
+
+    #[test]
+    fn an_id_column_replaces_the_synthetic_sequence() {
+        let text = "\
+Id,Date,Time,Price,Volume,Side
+9001,2026-03-16,09:00:00,100,1,B
+9002,2026-03-16,09:00:01,101,1,S
+";
+        let parsed = parse_file(text, ParseOptions::default()).unwrap();
+        assert_eq!(parsed.trades[0].agg_id, 9001);
+        assert_eq!(parsed.trades[1].agg_id, 9002);
+    }
+
+    #[test]
+    fn no_timezone_line_means_utc_and_says_so() {
+        let text = "Date,Time,Price,Volume,Side\n2026-03-16,00:00:00,1,1,B\n";
+        let parsed = parse_file(text, ParseOptions::default()).unwrap();
+        assert_eq!(parsed.header.timezone, UtcOffset::UTC);
+        assert!(!parsed.header.timezone_declared);
+        assert_eq!(parsed.trades[0].timestamp_ms, 1_773_619_200_000);
+    }
+
+    #[test]
+    fn missing_required_column_names_it() {
+        let err = parse_file("Date,Time,Price,Volume\n", ParseOptions::default()).unwrap_err();
+        assert_eq!(err.kind, FormatErrorKind::MissingColumn);
+        assert!(err.detail.contains("Side"), "{}", err.detail);
+        assert!(err.advice().contains("Side"));
+    }
+
+    #[test]
+    fn a_semicolon_export_is_told_what_is_wrong_with_it() {
+        for text in [
+            "Date;Time;Price;Volume;Side\n2026-03-16;10:00:00;1;1;B\n",
+            "Date\tTime\tPrice\tVolume\tSide\n2026-03-16\t10:00:00\t1\t1\tB\n",
+        ] {
+            let err = parse_file(text, ParseOptions::default()).unwrap_err();
+            assert_eq!(err.kind, FormatErrorKind::MissingColumn);
+            assert!(
+                err.detail.contains("not a comma"),
+                "should name the separator, said: {}",
+                err.detail
+            );
+        }
+    }
+
+    #[test]
+    fn a_file_without_a_header_is_rejected() {
+        let err = parse_file("# only comments\n\n", ParseOptions::default()).unwrap_err();
+        assert_eq!(err.kind, FormatErrorKind::MissingHeader);
+        assert_eq!(err.line, 0);
+    }
+
+    #[test]
+    fn a_header_without_rows_is_rejected() {
+        let err = parse_file(CANONICAL_HEADER, ParseOptions::default()).unwrap_err();
+        assert_eq!(err.kind, FormatErrorKind::Empty);
+    }
+
+    #[test]
+    fn duplicate_columns_are_rejected() {
+        let err = parse_file(
+            "Date,Time,Price,Price,Volume,Side\n",
+            ParseOptions::default(),
+        )
+        .unwrap_err();
+        assert_eq!(err.kind, FormatErrorKind::DuplicateColumn);
+    }
+
+    #[test]
+    fn short_rows_report_the_line() {
+        let text =
+            "Date,Time,Price,Volume,Side\n2026-03-16,09:00:00,100,1,B\n2026-03-16,09:00:01\n";
+        let err = parse_file(text, ParseOptions::default()).unwrap_err();
+        assert_eq!(err.kind, FormatErrorKind::FieldCount);
+        assert_eq!(err.line, 3);
+    }
+
+    #[test]
+    fn impossible_dates_are_rejected() {
+        for date in ["2026-02-30", "2026-13-01", "16/03/2026", "2026-3-16"] {
+            let text = format!("Date,Time,Price,Volume,Side\n{date},09:00:00,1,1,B\n");
+            let err = parse_file(&text, ParseOptions::default()).unwrap_err();
+            assert_eq!(err.kind, FormatErrorKind::Date, "{date}");
+        }
+        // A real leap day still loads.
+        let text = "Date,Time,Price,Volume,Side\n2028-02-29,09:00:00,1,1,B\n";
+        assert!(parse_file(text, ParseOptions::default()).is_ok());
+    }
+
+    #[test]
+    fn malformed_times_are_rejected() {
+        for time in ["9:00:00", "09:00", "09:00:61", "24:00:00", "09:00:00."] {
+            let text = format!("Date,Time,Price,Volume,Side\n2026-03-16,{time},1,1,B\n");
+            let err = parse_file(&text, ParseOptions::default()).unwrap_err();
+            assert_eq!(err.kind, FormatErrorKind::Time, "{time}");
+        }
+    }
+
+    #[test]
+    fn sub_millisecond_precision_truncates() {
+        let text = "Date,Time,Price,Volume,Side\n2026-03-16,09:00:00.123456,1,1,B\n";
+        let parsed = parse_file(text, ParseOptions::default()).unwrap();
+        let civil = civil_parts(parsed.trades[0].timestamp_ms, UtcOffset::UTC);
+        assert_eq!(civil.milli, 123);
+    }
+
+    #[test]
+    fn ambiguous_side_tokens_are_refused_by_name() {
+        let text = "Date,Time,Price,Volume,Side\n2026-03-16,09:00:00,1,1,A\n";
+        let err = parse_file(text, ParseOptions::default()).unwrap_err();
+        assert_eq!(err.kind, FormatErrorKind::Side);
+        assert!(err.detail.contains("ambiguous"), "{}", err.detail);
+    }
+
+    #[test]
+    fn rows_must_move_forward_in_time() {
+        let text = "\
+Date,Time,Price,Volume,Side
+2026-03-16,09:00:01,1,1,B
+2026-03-16,09:00:00,1,1,B
+";
+        let err = parse_file(text, ParseOptions::default()).unwrap_err();
+        assert_eq!(err.kind, FormatErrorKind::OutOfOrder);
+        assert_eq!(err.line, 3);
+        // Equal timestamps are normal — several prints share a millisecond.
+        let same = "\
+Date,Time,Price,Volume,Side
+2026-03-16,09:00:01,1,1,B
+2026-03-16,09:00:01,1,1,S
+";
+        assert!(parse_file(same, ParseOptions::default()).is_ok());
+    }
+
+    #[test]
+    fn a_bad_timezone_line_is_an_error_not_a_guess() {
+        let text =
+            "# timezone=Brazil/East\nDate,Time,Price,Volume,Side\n2026-03-16,09:00:00,1,1,B\n";
+        let err = parse_file(text, ParseOptions::default()).unwrap_err();
+        assert_eq!(err.kind, FormatErrorKind::Timezone);
+        assert_eq!(err.line, 1);
+    }
+
+    #[test]
+    fn utc_offsets_parse_in_every_common_spelling() {
+        assert_eq!(UtcOffset::parse("UTC"), Some(UtcOffset::UTC));
+        assert_eq!(UtcOffset::parse("Z"), Some(UtcOffset::UTC));
+        assert_eq!(UtcOffset::parse("-03:00").unwrap().minutes(), -180);
+        assert_eq!(UtcOffset::parse("-0300").unwrap().minutes(), -180);
+        assert_eq!(UtcOffset::parse("-3").unwrap().minutes(), -180);
+        assert_eq!(UtcOffset::parse("+05:30").unwrap().minutes(), 330);
+        assert_eq!(UtcOffset::parse("+05:30").unwrap().label(), "+05:30");
+        assert_eq!(UtcOffset::parse("nonsense"), None);
+        assert_eq!(UtcOffset::parse("-03:99"), None);
+    }
+
+    #[test]
+    fn written_files_round_trip() {
+        let header = WriteHeader {
+            symbol: "WINJ26".to_string(),
+            timezone: UtcOffset::parse("-03:00").unwrap(),
+            side_source: "bid_ask".to_string(),
+            source: Some("mt5_orderflow_20260316.ndjson".to_string()),
+        };
+        let trades = vec![
+            Trade {
+                agg_id: 1,
+                timestamp_ms: 1_773_666_068_000,
+                price: dec("182035"),
+                quantity: dec("12"),
+                side: Side::Buy,
+            },
+            Trade {
+                agg_id: 2,
+                timestamp_ms: 1_773_666_069_250,
+                price: dec("182025"),
+                quantity: dec("4"),
+                side: Side::Sell,
+            },
+        ];
+        let quotes = [
+            Quote {
+                bid: dec("182030"),
+                ask: dec("182035"),
+            },
+            Quote {
+                bid: dec("182025"),
+                ask: dec("182030"),
+            },
+        ];
+
+        let mut text = write_header(&header);
+        for (trade, quote) in trades.iter().zip(quotes) {
+            write_trade(&mut text, trade, Some(quote), header.timezone);
+        }
+
+        let parsed = parse_file(&text, ParseOptions { keep_quotes: true }).unwrap();
+        assert_eq!(parsed.trades, trades);
+        assert_eq!(parsed.quotes, quotes);
+        assert_eq!(parsed.header.symbol.as_deref(), Some("WINJ26"));
+        assert_eq!(parsed.header.timezone, header.timezone);
+        assert_eq!(parsed.header.side_source.as_deref(), Some("bid_ask"));
+    }
+
+    #[test]
+    fn missing_quotes_are_written_empty_not_zero() {
+        let mut text = String::new();
+        write_trade(
+            &mut text,
+            &Trade {
+                agg_id: 1,
+                timestamp_ms: 0,
+                price: dec("1"),
+                quantity: dec("1"),
+                side: Side::Buy,
+            },
+            None,
+            UtcOffset::UTC,
+        );
+        assert_eq!(text, "1970-01-01,00:00:00.000,1,,,1,B\n");
+    }
+
+    #[test]
+    fn epoch_millis_is_the_inverse_of_civil_parts() {
+        let offset = UtcOffset::parse("-03:00").unwrap();
+        let civil = CivilTime {
+            year: 2026,
+            month: 3,
+            day: 16,
+            hour: 10,
+            minute: 1,
+            second: 8,
+            milli: 250,
+        };
+        let ms = civil.epoch_millis(offset);
+        assert_eq!(civil_parts(ms, offset), civil);
+        // Same instant, read in UTC, is three hours later on the clock.
+        assert_eq!(civil_parts(ms, UtcOffset::UTC).time_field(), "13:01:08.250");
+        // And it agrees with what the row parser produces.
+        let text =
+            "# timezone=-03:00\nDate,Time,Price,Volume,Side\n2026-03-16,10:01:08.250,1,1,B\n";
+        let parsed = parse_file(text, ParseOptions::default()).unwrap();
+        assert_eq!(parsed.trades[0].timestamp_ms, ms);
+    }
+
+    #[test]
+    fn civil_days_round_trip_across_boundaries() {
+        for (y, m, d) in [
+            (1970, 1, 1),
+            (1999, 12, 31),
+            (2000, 3, 1),
+            (2026, 3, 16),
+            (2028, 2, 29),
+            (2100, 3, 1),
+        ] {
+            let days = days_from_civil(y, m, d);
+            assert_eq!(civil_from_days(days), (y, m, d), "{y}-{m}-{d}");
+        }
+    }
+}

--- a/crates/replay/src/lib.rs
+++ b/crates/replay/src/lib.rs
@@ -1,0 +1,61 @@
+//! quantick-replay — recorded sessions, played back like a live feed.
+//!
+//! Market replay is how a trader rehearses: take a day that already happened and
+//! run it forward at a chosen speed, with the chart forming bars print by print
+//! exactly as it did live. This crate owns the three pieces that need no screen
+//! and no network:
+//!
+//! - [`format`] — the tick file: `Date,Time,Price,Bid,Ask,Volume,Side` rows with
+//!   a `#` metadata block. Reading, writing, and telling a person precisely why
+//!   a file was rejected.
+//! - [`library`] — scanning a chosen folder for playable sessions, and reporting
+//!   everything that is not one instead of silently skipping it.
+//! - [`clock`] — the deterministic playhead: given how much real time passed, it
+//!   says which trades fall due.
+//!
+//! Like [`quantick_engine`], this crate is headless and deterministic: no UI, no
+//! network, no async, and no wall-clock read anywhere. The playhead is *told*
+//! how much time passed. That is what lets the same session drive the chart, a
+//! backtest and a bot through one code path, and be unit-tested without sleeping.
+//!
+//! # Why this file format
+//!
+//! Two shapes are established for replay data. Platforms with a proprietary
+//! store keep a binary file per instrument-day in a folder tree — NinjaTrader's
+//! `db/replay/<Instrument>/<yyyyMMdd>.nrd`, Sierra Chart's `.scid`. Everyone who
+//! *sells* tick data ships CSV with a row per print. quantick takes the folder
+//! layout from the first and the row format from the second:
+//!
+//! ```text
+//! <replay folder>/
+//!     WINJ26/
+//!         20260316.csv
+//!         20260317.csv
+//! ```
+//!
+//! A recorded session is then something a person can open, diff, hand-edit and
+//! generate from any language, while the folder still says at a glance which
+//! instrument and which day. Loading is a single pass with the columns resolved
+//! once from the header, and playback runs entirely from memory, so the text
+//! format costs a load and never a frame.
+//!
+//! # Extending it
+//!
+//! Columns are read by name, and unknown ones are carried as notes rather than
+//! rejected — a recorder may add its own without breaking older sessions, and a
+//! future quantick may read a new one without invalidating recorded ones. Depth
+//! (the L2 book behind the heatmap) is deliberately absent from version 1: it
+//! belongs in a sibling file per session, not smuggled into the trade rows.
+
+pub mod clock;
+pub mod format;
+pub mod library;
+pub mod session;
+
+pub use clock::{Batch, PlaybackConfig, Playhead, SPEEDS};
+pub use format::{
+    FORMAT_HELP, FORMAT_NAME, FORMAT_VERSION, FormatError, FormatErrorKind, ParseOptions, Quote,
+    UtcOffset,
+};
+pub use library::{Library, Problem, ProblemKind, SessionEntry, scan};
+pub use session::{Session, SessionDate, SessionError};

--- a/crates/replay/src/library.rs
+++ b/crates/replay/src/library.rs
@@ -1,0 +1,608 @@
+//! Scanning a folder of recorded sessions, and saying plainly what does not fit.
+//!
+//! The scan is deliberately shallow — the chosen folder and one level of
+//! instrument sub-folders — so pointing quantick at a large directory can never
+//! turn into a disk-wide crawl. Each candidate file is identified from its first
+//! few kilobytes, so listing a folder of week-long recordings stays instant.
+//!
+//! Everything that is *not* a session is reported rather than skipped: a folder
+//! that looks empty because every file was quietly ignored is the worst possible
+//! answer to "why is my replay list blank?".
+
+use std::io::Read as _;
+use std::path::{Path, PathBuf};
+
+use crate::format::{self, FormatError, FormatErrorKind, UtcOffset};
+use crate::session::{self, SessionDate};
+
+/// How much of a file is read to identify it. The metadata block and column
+/// header live in the first few lines; a session's trades are never touched
+/// while scanning.
+const HEAD_BYTES: u64 = 16 * 1024;
+
+/// How deep below the chosen folder the scan looks: the folder itself, plus one
+/// level of instrument sub-folders.
+const MAX_DEPTH: usize = 1;
+
+/// A file in the folder that is not a playable session.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProblemKind {
+    /// The chosen path does not exist.
+    FolderMissing,
+    /// The chosen path exists but is a file, not a folder.
+    NotAFolder,
+    /// The folder could not be listed.
+    FolderUnreadable,
+    /// The folder holds no session files at all.
+    NoSessions,
+    /// A file that is not a `.csv`, so it was not considered.
+    NotASessionFile,
+    /// A raw MT5/order-flow recording that has to be converted first.
+    NeedsImport,
+    /// A `.csv` that could not be read from disk.
+    Unreadable,
+    /// A `.csv` whose header does not follow the replay format.
+    BadFormat(FormatErrorKind),
+}
+
+impl ProblemKind {
+    /// A short, stable token for logs and tests.
+    #[must_use]
+    pub fn code(self) -> &'static str {
+        match self {
+            ProblemKind::FolderMissing => "folder_missing",
+            ProblemKind::NotAFolder => "not_a_folder",
+            ProblemKind::FolderUnreadable => "folder_unreadable",
+            ProblemKind::NoSessions => "no_sessions",
+            ProblemKind::NotASessionFile => "not_a_session_file",
+            ProblemKind::NeedsImport => "needs_import",
+            ProblemKind::Unreadable => "unreadable",
+            ProblemKind::BadFormat(kind) => kind.code(),
+        }
+    }
+
+    /// What to change so the folder loads.
+    #[must_use]
+    pub fn advice(self) -> &'static str {
+        match self {
+            ProblemKind::FolderMissing => "Pick a folder that exists.",
+            ProblemKind::NotAFolder => "Pick the folder that holds the session files, not a file.",
+            ProblemKind::FolderUnreadable => {
+                "Check quantick may list this folder, then open it again."
+            }
+            ProblemKind::NoSessions => {
+                "Put one .csv per session day in the folder, or in a sub-folder named after the instrument."
+            }
+            ProblemKind::NotASessionFile => "Replay sessions are .csv files; this one was skipped.",
+            ProblemKind::NeedsImport => {
+                "Convert the recording first: cargo run -p quantick-replay --example import_mt5_ndjson -- --in <file> --out <replay folder>"
+            }
+            ProblemKind::Unreadable => "Check the file still exists and that quantick may read it.",
+            ProblemKind::BadFormat(kind) => kind.advice(),
+        }
+    }
+
+    /// Whether this stops the folder from being usable at all, as opposed to
+    /// one file being left out.
+    #[must_use]
+    pub fn is_fatal(self) -> bool {
+        matches!(
+            self,
+            ProblemKind::FolderMissing
+                | ProblemKind::NotAFolder
+                | ProblemKind::FolderUnreadable
+                | ProblemKind::NoSessions
+        )
+    }
+}
+
+/// Something in the chosen folder that quantick could not play, with the reason.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Problem {
+    /// The file this is about; `None` when it is about the folder itself.
+    pub path: Option<PathBuf>,
+    /// What kind of problem it is.
+    pub kind: ProblemKind,
+    /// What was found, in the folder's own words.
+    pub detail: String,
+}
+
+impl Problem {
+    /// The name to show: the file name, or the folder when there is no file.
+    #[must_use]
+    pub fn subject(&self) -> String {
+        self.path.as_ref().map_or_else(
+            || "folder".to_string(),
+            |p| {
+                p.file_name()
+                    .map_or_else(|| p.display().to_string(), |n| n.to_string_lossy().into())
+            },
+        )
+    }
+
+    /// What to change so the folder loads.
+    #[must_use]
+    pub fn advice(&self) -> &'static str {
+        self.kind.advice()
+    }
+}
+
+/// A session file found in the folder, identified without parsing its trades.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionEntry {
+    /// Full path to the file.
+    pub path: PathBuf,
+    /// Instrument, from the `# symbol=` line or the folder layout.
+    pub symbol: String,
+    /// Session day, when the file name follows the convention.
+    pub date: Option<SessionDate>,
+    /// File size, for the "this one is big" signal in the picker.
+    pub size_bytes: u64,
+    /// Offset the file's clock readings are expressed in.
+    pub timezone: UtcOffset,
+    /// Whether the file declared that offset, or defaulted to UTC.
+    pub timezone_declared: bool,
+    /// How the recorder decided the aggressor side, when it said.
+    pub side_source: Option<String>,
+    /// Whether the file carries bid/ask alongside each print.
+    pub has_quotes: bool,
+    /// Non-fatal remarks: the file loads, but something is worth knowing.
+    pub notes: Vec<String>,
+}
+
+impl SessionEntry {
+    /// Instrument and day, e.g. `WINJ26 · 2026-03-16`.
+    #[must_use]
+    pub fn label(&self) -> String {
+        match self.date {
+            Some(date) => format!("{} · {}", self.symbol, date.label()),
+            None => format!("{} · {}", self.symbol, self.file_name()),
+        }
+    }
+
+    /// Just the file name.
+    #[must_use]
+    pub fn file_name(&self) -> String {
+        self.path
+            .file_name()
+            .map_or_else(String::new, |n| n.to_string_lossy().into())
+    }
+
+    /// Size rendered for a person, e.g. `14.6 MB`.
+    #[must_use]
+    pub fn size_label(&self) -> String {
+        let bytes = self.size_bytes as f64;
+        if bytes >= 1024.0 * 1024.0 {
+            format!("{:.1} MB", bytes / (1024.0 * 1024.0))
+        } else if bytes >= 1024.0 {
+            format!("{:.0} kB", bytes / 1024.0)
+        } else {
+            format!("{} B", self.size_bytes)
+        }
+    }
+}
+
+/// Everything the chosen folder holds: what can be played, and what cannot.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Library {
+    /// The folder that was scanned.
+    pub root: PathBuf,
+    /// Playable sessions, sorted by instrument then day.
+    pub sessions: Vec<SessionEntry>,
+    /// Everything that did not fit, with the reason.
+    pub problems: Vec<Problem>,
+}
+
+impl Library {
+    /// Whether the folder yielded nothing to play.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.sessions.is_empty()
+    }
+
+    /// The instruments found, in display order, without repeats.
+    #[must_use]
+    pub fn symbols(&self) -> Vec<String> {
+        let mut out: Vec<String> = Vec::new();
+        for session in &self.sessions {
+            if !out.contains(&session.symbol) {
+                out.push(session.symbol.clone());
+            }
+        }
+        out
+    }
+}
+
+/// Scan `root` for playable sessions.
+///
+/// Never fails: a folder that cannot be listed comes back as a [`Library`] with
+/// no sessions and a [`Problem`] explaining why, which is what the UI shows.
+#[must_use]
+pub fn scan(root: &Path) -> Library {
+    let mut library = Library {
+        root: root.to_path_buf(),
+        sessions: Vec::new(),
+        problems: Vec::new(),
+    };
+
+    match std::fs::metadata(root) {
+        Err(e) => {
+            let kind = if e.kind() == std::io::ErrorKind::NotFound {
+                ProblemKind::FolderMissing
+            } else {
+                ProblemKind::FolderUnreadable
+            };
+            library.problems.push(Problem {
+                path: None,
+                kind,
+                detail: format!("{}: {e}", root.display()),
+            });
+            return library;
+        }
+        Ok(meta) if !meta.is_dir() => {
+            library.problems.push(Problem {
+                path: None,
+                kind: ProblemKind::NotAFolder,
+                detail: format!("{} is a file", root.display()),
+            });
+            return library;
+        }
+        Ok(_) => {}
+    }
+
+    visit(root, 0, &mut library);
+
+    // Deterministic order: instrument, then day, then file name. The picker
+    // must list the same sessions in the same order on every open.
+    library.sessions.sort_by(|a, b| {
+        a.symbol
+            .cmp(&b.symbol)
+            .then(a.date.cmp(&b.date))
+            .then(a.path.cmp(&b.path))
+    });
+    library.problems.sort_by(|a, b| a.path.cmp(&b.path));
+
+    // "Nothing here" only helps when nothing else was said. A folder whose files
+    // were all rejected already carries the reason, and burying that under a
+    // generic line is how a person ends up not reading either.
+    if library.sessions.is_empty() && library.problems.is_empty() {
+        library.problems.insert(
+            0,
+            Problem {
+                path: None,
+                kind: ProblemKind::NoSessions,
+                detail: format!("no replay sessions in {}", root.display()),
+            },
+        );
+    }
+    library
+}
+
+fn visit(dir: &Path, depth: usize, library: &mut Library) {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(e) => {
+            library.problems.push(Problem {
+                path: (depth > 0).then(|| dir.to_path_buf()),
+                kind: ProblemKind::FolderUnreadable,
+                detail: format!("{}: {e}", dir.display()),
+            });
+            return;
+        }
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if file_type.is_dir() {
+            if depth < MAX_DEPTH {
+                visit(&path, depth + 1, library);
+            }
+            continue;
+        }
+        if !file_type.is_file() {
+            continue;
+        }
+        let size = entry.metadata().map(|m| m.len()).unwrap_or_default();
+        classify(&path, size, library);
+    }
+}
+
+/// Decide what one file is, reading only its head.
+fn classify(path: &Path, size_bytes: u64, library: &mut Library) {
+    let extension = path
+        .extension()
+        .map(|e| e.to_string_lossy().to_ascii_lowercase())
+        .unwrap_or_default();
+
+    if extension != format::FILE_EXTENSION {
+        // Only speak up about files a person might have expected to work.
+        // Screenshots and stray notes in the folder are not the user's mistake.
+        let kind = match extension.as_str() {
+            "ndjson" | "jsonl" => Some(ProblemKind::NeedsImport),
+            "txt" | "json" | "scid" | "nrd" | "gz" | "zip" | "tsv" => {
+                Some(ProblemKind::NotASessionFile)
+            }
+            _ => None,
+        };
+        if let Some(kind) = kind {
+            library.problems.push(Problem {
+                path: Some(path.to_path_buf()),
+                kind,
+                detail: match kind {
+                    ProblemKind::NeedsImport => "raw recording, not a replay session".to_string(),
+                    _ => format!("`.{extension}` is not a replay session file"),
+                },
+            });
+        }
+        return;
+    }
+
+    let head = match read_head(path) {
+        Ok(head) => head,
+        Err(e) => {
+            library.problems.push(Problem {
+                path: Some(path.to_path_buf()),
+                kind: ProblemKind::Unreadable,
+                detail: e.to_string(),
+            });
+            return;
+        }
+    };
+
+    match format::parse_header(&head) {
+        Ok(header) => {
+            let mut notes = Vec::new();
+            if !header.timezone_declared {
+                notes.push("no `# timezone=` line — times are read as UTC".to_string());
+            }
+            if !header.columns.ignored().is_empty() {
+                notes.push(format!(
+                    "ignored column(s): {}",
+                    header.columns.ignored().join(", ")
+                ));
+            }
+            let date = session::date_from_path(path);
+            if date.is_none() {
+                notes.push("file name is not YYYYMMDD, so the session day is unknown".to_string());
+            }
+            let symbol = header
+                .symbol
+                .clone()
+                .or_else(|| session::symbol_from_path(path))
+                .unwrap_or_else(|| "unknown".to_string());
+            library.sessions.push(SessionEntry {
+                path: path.to_path_buf(),
+                symbol,
+                date,
+                size_bytes,
+                timezone: header.timezone,
+                timezone_declared: header.timezone_declared,
+                side_source: header.side_source,
+                has_quotes: header.columns.has_quotes(),
+                notes,
+            });
+        }
+        Err(FormatError { kind, detail, line }) => {
+            library.problems.push(Problem {
+                path: Some(path.to_path_buf()),
+                kind: ProblemKind::BadFormat(kind),
+                detail: if line == 0 {
+                    detail
+                } else {
+                    format!("line {line}: {detail}")
+                },
+            });
+        }
+    }
+}
+
+/// Read the first [`HEAD_BYTES`] of a file as text, cut back to the last
+/// complete line so a truncated row is never parsed as a real one.
+fn read_head(path: &Path) -> std::io::Result<String> {
+    let file = std::fs::File::open(path)?;
+    let mut buffer = Vec::with_capacity(HEAD_BYTES as usize);
+    file.take(HEAD_BYTES).read_to_end(&mut buffer)?;
+    let text = String::from_utf8_lossy(&buffer).into_owned();
+    match text.rfind('\n') {
+        Some(at) if buffer.len() as u64 == HEAD_BYTES => Ok(text[..=at].to_string()),
+        _ => Ok(text),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    /// A unique scratch folder per test, cleaned up on the way out.
+    struct Scratch(PathBuf);
+
+    impl Scratch {
+        fn new(name: &str) -> Self {
+            static COUNTER: AtomicU32 = AtomicU32::new(0);
+            let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+            let dir = std::env::temp_dir().join(format!(
+                "quantick-replay-{name}-{}-{id}",
+                std::process::id()
+            ));
+            let _ = std::fs::remove_dir_all(&dir);
+            std::fs::create_dir_all(&dir).unwrap();
+            Self(dir)
+        }
+
+        fn write(&self, relative: &str, contents: &str) -> PathBuf {
+            let path = self.0.join(relative);
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent).unwrap();
+            }
+            std::fs::write(&path, contents).unwrap();
+            path
+        }
+
+        fn path(&self) -> &Path {
+            &self.0
+        }
+    }
+
+    impl Drop for Scratch {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    const GOOD: &str = "\
+# quantick-replay 1
+# symbol=WINJ26
+# timezone=-03:00
+Date,Time,Price,Bid,Ask,Volume,Side
+2026-03-16,10:00:00.000,182035,182030,182035,12,B
+";
+
+    #[test]
+    fn finds_sessions_in_instrument_sub_folders() {
+        let scratch = Scratch::new("subfolders");
+        scratch.write("WINJ26/20260316.csv", GOOD);
+        scratch.write("WINJ26/20260317.csv", GOOD);
+
+        let library = scan(scratch.path());
+        assert_eq!(library.sessions.len(), 2);
+        assert_eq!(library.symbols(), ["WINJ26"]);
+        assert_eq!(library.sessions[0].label(), "WINJ26 · 2026-03-16");
+        assert_eq!(library.sessions[1].label(), "WINJ26 · 2026-03-17");
+        assert!(library.sessions[0].has_quotes);
+        assert!(library.problems.is_empty(), "{:?}", library.problems);
+    }
+
+    #[test]
+    fn finds_flat_files_named_symbol_date() {
+        let scratch = Scratch::new("flat");
+        scratch.write("WINJ26-20260316.csv", GOOD);
+
+        let library = scan(scratch.path());
+        assert_eq!(library.sessions.len(), 1);
+        assert_eq!(library.sessions[0].symbol, "WINJ26");
+    }
+
+    #[test]
+    fn sessions_are_listed_in_a_stable_order() {
+        let scratch = Scratch::new("order");
+        scratch.write("WDO/20260317.csv", GOOD);
+        scratch.write("WDO/20260316.csv", GOOD);
+        scratch.write("WINJ26/20260316.csv", GOOD);
+
+        let first = scan(scratch.path());
+        let second = scan(scratch.path());
+        assert_eq!(first, second);
+        let dates: Vec<String> = first
+            .sessions
+            .iter()
+            .map(|s| format!("{}/{}", s.symbol, s.date.unwrap().label()))
+            .collect();
+        // `# symbol=WINJ26` in the file wins over the folder name, so both WDO
+        // files report WINJ26 here; the point is the order is deterministic.
+        assert_eq!(dates.len(), 3);
+        assert!(dates.windows(2).all(|w| w[0] <= w[1]), "{dates:?}");
+    }
+
+    #[test]
+    fn a_missing_folder_is_reported_not_silently_empty() {
+        let library = scan(Path::new("does/not/exist/anywhere"));
+        assert!(library.is_empty());
+        assert_eq!(library.problems[0].kind, ProblemKind::FolderMissing);
+        assert!(library.problems[0].kind.is_fatal());
+    }
+
+    #[test]
+    fn an_empty_folder_says_what_it_expected() {
+        let scratch = Scratch::new("empty");
+        let library = scan(scratch.path());
+        assert_eq!(library.problems[0].kind, ProblemKind::NoSessions);
+        assert!(library.problems[0].advice().contains(".csv"));
+    }
+
+    #[test]
+    fn raw_recordings_point_at_the_importer() {
+        let scratch = Scratch::new("ndjson");
+        scratch.write(
+            "mt5_orderflow_20260316.ndjson",
+            "{\"event_type\":\"tick\"}\n",
+        );
+
+        let library = scan(scratch.path());
+        assert!(library.is_empty());
+        let problem = library
+            .problems
+            .iter()
+            .find(|p| p.kind == ProblemKind::NeedsImport)
+            .expect("needs-import problem");
+        assert!(problem.advice().contains("import_mt5_ndjson"));
+        assert_eq!(problem.subject(), "mt5_orderflow_20260316.ndjson");
+    }
+
+    #[test]
+    fn a_malformed_csv_is_reported_with_its_reason() {
+        let scratch = Scratch::new("malformed");
+        scratch.write("WINJ26/20260316.csv", "Date,Time,Price,Volume\n1,2,3,4\n");
+
+        let library = scan(scratch.path());
+        assert!(library.is_empty());
+        // The file's own reason is the whole message — no generic "nothing here"
+        // line on top of it.
+        assert_eq!(library.problems.len(), 1);
+        let problem = &library.problems[0];
+        assert_eq!(
+            problem.kind,
+            ProblemKind::BadFormat(FormatErrorKind::MissingColumn)
+        );
+        assert!(problem.detail.contains("Side"), "{}", problem.detail);
+        assert!(problem.advice().contains("Side"));
+    }
+
+    #[test]
+    fn undeclared_timezone_and_unknown_day_come_back_as_notes() {
+        let scratch = Scratch::new("notes");
+        scratch.write(
+            "WINJ26/session-one.csv",
+            "Date,Time,Price,Volume,Side,Note\n2026-03-16,10:00:00,1,1,B,x\n",
+        );
+
+        let library = scan(scratch.path());
+        let session = &library.sessions[0];
+        assert!(session.date.is_none());
+        assert_eq!(session.notes.len(), 3, "{:?}", session.notes);
+        assert!(session.notes.iter().any(|n| n.contains("UTC")));
+        assert!(session.notes.iter().any(|n| n.contains("Note")));
+        assert!(session.notes.iter().any(|n| n.contains("YYYYMMDD")));
+    }
+
+    #[test]
+    fn the_scan_does_not_descend_past_instrument_folders() {
+        let scratch = Scratch::new("depth");
+        scratch.write("WINJ26/nested/deeper/20260316.csv", GOOD);
+
+        let library = scan(scratch.path());
+        assert!(library.is_empty(), "{:?}", library.sessions);
+    }
+
+    #[test]
+    fn size_labels_scale_with_the_file() {
+        let entry = |bytes: u64| SessionEntry {
+            path: PathBuf::from("x.csv"),
+            symbol: "X".into(),
+            date: None,
+            size_bytes: bytes,
+            timezone: UtcOffset::UTC,
+            timezone_declared: false,
+            side_source: None,
+            has_quotes: false,
+            notes: Vec::new(),
+        };
+        assert_eq!(entry(512).size_label(), "512 B");
+        assert_eq!(entry(2048).size_label(), "2 kB");
+        assert_eq!(entry(15 * 1024 * 1024).size_label(), "15.0 MB");
+    }
+}

--- a/crates/replay/src/session.rs
+++ b/crates/replay/src/session.rs
@@ -1,0 +1,308 @@
+//! A loaded replay session: the trades of one instrument on one day.
+
+use std::path::{Path, PathBuf};
+
+use quantick_engine::Trade;
+
+use crate::format::{self, FileHeader, FormatError, ParseOptions, Quote, UtcOffset};
+
+/// The calendar day a session file covers, taken from its file name.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct SessionDate {
+    /// Four-digit year.
+    pub year: i32,
+    /// Month, 1–12.
+    pub month: u32,
+    /// Day of month, 1–31.
+    pub day: u32,
+}
+
+impl SessionDate {
+    /// Parse a `YYYYMMDD` or `YYYY-MM-DD` file stem.
+    #[must_use]
+    pub fn parse(stem: &str) -> Option<Self> {
+        let digits: String = stem.chars().filter(char::is_ascii_digit).collect();
+        if digits.len() != 8 || digits.len() != stem.chars().filter(|c| *c != '-').count() {
+            return None;
+        }
+        let year: i32 = digits[0..4].parse().ok()?;
+        let month: u32 = digits[4..6].parse().ok()?;
+        let day: u32 = digits[6..8].parse().ok()?;
+        if !(1..=12).contains(&month) || !(1..=31).contains(&day) {
+            return None;
+        }
+        Some(Self { year, month, day })
+    }
+
+    /// The ISO rendering, e.g. `2026-03-16`.
+    #[must_use]
+    pub fn label(self) -> String {
+        format!("{:04}-{:02}-{:02}", self.year, self.month, self.day)
+    }
+}
+
+/// Why a session file could not be loaded.
+#[derive(Debug)]
+pub enum SessionError {
+    /// The file could not be read from disk.
+    Read {
+        /// The file that failed.
+        path: PathBuf,
+        /// The operating system's message.
+        message: String,
+    },
+    /// The file was read but does not follow the replay format.
+    Format {
+        /// The file that failed.
+        path: PathBuf,
+        /// Where and what.
+        error: FormatError,
+    },
+}
+
+impl SessionError {
+    /// The file this error is about.
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        match self {
+            SessionError::Read { path, .. } | SessionError::Format { path, .. } => path,
+        }
+    }
+
+    /// What to change to make the file load.
+    #[must_use]
+    pub fn advice(&self) -> &'static str {
+        match self {
+            SessionError::Read { .. } => {
+                "Check the file still exists and that quantick may read it."
+            }
+            SessionError::Format { error, .. } => error.advice(),
+        }
+    }
+}
+
+impl std::fmt::Display for SessionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SessionError::Read { path, message } => {
+                write!(f, "cannot read {}: {message}", path.display())
+            }
+            SessionError::Format { path, error } => {
+                write!(f, "{}: {error}", file_label(path))
+            }
+        }
+    }
+}
+
+impl std::error::Error for SessionError {}
+
+/// The file name alone, for messages that already name the folder.
+fn file_label(path: &Path) -> String {
+    path.file_name().map_or_else(
+        || path.display().to_string(),
+        |n| n.to_string_lossy().into(),
+    )
+}
+
+/// One instrument's trades for one session day, ready to play.
+#[derive(Debug, Clone)]
+pub struct Session {
+    /// Where it was loaded from.
+    pub path: PathBuf,
+    /// Instrument, from the `# symbol=` line or the parent folder.
+    pub symbol: String,
+    /// Session day, from the file name, when it followed the convention.
+    pub date: Option<SessionDate>,
+    /// The metadata block and column positions the file declared.
+    pub header: FileHeader,
+    /// Trades in chronological order — the replay's whole input.
+    pub trades: Vec<Trade>,
+    /// Quotes parallel to `trades`, when the caller asked to keep them.
+    pub quotes: Vec<Quote>,
+}
+
+impl Session {
+    /// Load and parse a session file.
+    ///
+    /// # Errors
+    ///
+    /// [`SessionError::Read`] when the file cannot be read, or
+    /// [`SessionError::Format`] with the offending line when it does not follow
+    /// the format.
+    pub fn load(path: &Path, options: ParseOptions) -> Result<Self, SessionError> {
+        let text = std::fs::read_to_string(path).map_err(|e| SessionError::Read {
+            path: path.to_path_buf(),
+            message: e.to_string(),
+        })?;
+        Self::from_text(path, &text, options)
+    }
+
+    /// Parse an already-read session file. Split out so the whole load path is
+    /// testable without touching a disk.
+    ///
+    /// # Errors
+    ///
+    /// [`SessionError::Format`] with the offending line.
+    pub fn from_text(path: &Path, text: &str, options: ParseOptions) -> Result<Self, SessionError> {
+        let parsed = format::parse_file(text, options).map_err(|error| SessionError::Format {
+            path: path.to_path_buf(),
+            error,
+        })?;
+        let symbol = parsed
+            .header
+            .symbol
+            .clone()
+            .or_else(|| symbol_from_path(path))
+            .unwrap_or_else(|| "unknown".to_string());
+        Ok(Self {
+            path: path.to_path_buf(),
+            symbol,
+            date: date_from_path(path),
+            header: parsed.header,
+            trades: parsed.trades,
+            quotes: parsed.quotes,
+        })
+    }
+
+    /// Instrument and day, e.g. `WINJ26 · 2026-03-16`.
+    #[must_use]
+    pub fn label(&self) -> String {
+        match self.date {
+            Some(date) => format!("{} · {}", self.symbol, date.label()),
+            None => format!("{} · {}", self.symbol, file_label(&self.path)),
+        }
+    }
+
+    /// Timestamp of the first trade, in epoch milliseconds.
+    #[must_use]
+    pub fn start_ms(&self) -> i64 {
+        self.trades.first().map_or(0, |t| t.timestamp_ms)
+    }
+
+    /// Timestamp of the last trade, in epoch milliseconds.
+    #[must_use]
+    pub fn end_ms(&self) -> i64 {
+        self.trades.last().map_or(0, |t| t.timestamp_ms)
+    }
+
+    /// How much market time the session covers, in milliseconds.
+    #[must_use]
+    pub fn span_ms(&self) -> i64 {
+        self.end_ms().saturating_sub(self.start_ms())
+    }
+
+    /// The offset the file's clock readings are expressed in.
+    #[must_use]
+    pub fn timezone(&self) -> UtcOffset {
+        self.header.timezone
+    }
+}
+
+/// The instrument a path implies: the `SYMBOL` in `SYMBOL/20260316.csv`, or the
+/// `SYMBOL` in `SYMBOL-20260316.csv`.
+#[must_use]
+pub fn symbol_from_path(path: &Path) -> Option<String> {
+    let stem = path.file_stem()?.to_string_lossy();
+    if let Some((symbol, tail)) = stem.rsplit_once(['-', '_'])
+        && SessionDate::parse(tail).is_some()
+        && !symbol.is_empty()
+    {
+        return Some(symbol.to_string());
+    }
+    let parent = path.parent()?.file_name()?.to_string_lossy().to_string();
+    (!parent.is_empty()).then_some(parent)
+}
+
+/// The session day a file name implies, from `20260316.csv` or
+/// `SYMBOL-20260316.csv`.
+#[must_use]
+pub fn date_from_path(path: &Path) -> Option<SessionDate> {
+    let stem = path.file_stem()?.to_string_lossy();
+    SessionDate::parse(&stem).or_else(|| {
+        let (_, tail) = stem.rsplit_once(['-', '_'])?;
+        SessionDate::parse(tail)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = "\
+# quantick-replay 1
+# symbol=WINJ26
+# timezone=-03:00
+Date,Time,Price,Volume,Side
+2026-03-16,10:00:00.000,182035,12,B
+2026-03-16,10:00:02.500,182040,3,B
+";
+
+    #[test]
+    fn session_dates_parse_both_spellings() {
+        assert_eq!(
+            SessionDate::parse("20260316"),
+            Some(SessionDate {
+                year: 2026,
+                month: 3,
+                day: 16
+            })
+        );
+        assert_eq!(
+            SessionDate::parse("2026-03-16").map(SessionDate::label),
+            Some("2026-03-16".to_string())
+        );
+        assert_eq!(SessionDate::parse("2026031"), None);
+        assert_eq!(SessionDate::parse("20261316"), None);
+        assert_eq!(SessionDate::parse("session"), None);
+    }
+
+    #[test]
+    fn symbol_and_date_come_from_the_folder_layout() {
+        let path = Path::new("replay/WINJ26/20260316.csv");
+        assert_eq!(symbol_from_path(path).as_deref(), Some("WINJ26"));
+        assert_eq!(
+            date_from_path(path).map(SessionDate::label).as_deref(),
+            Some("2026-03-16")
+        );
+    }
+
+    #[test]
+    fn symbol_and_date_come_from_a_flat_file_name() {
+        let path = Path::new("replay/WINJ26-20260316.csv");
+        assert_eq!(symbol_from_path(path).as_deref(), Some("WINJ26"));
+        assert_eq!(
+            date_from_path(path).map(SessionDate::label).as_deref(),
+            Some("2026-03-16")
+        );
+        let underscore = Path::new("replay/WDO$-20260317.csv");
+        assert_eq!(symbol_from_path(underscore).as_deref(), Some("WDO$"));
+    }
+
+    #[test]
+    fn a_session_exposes_its_span_and_label() {
+        let path = Path::new("replay/WINJ26/20260316.csv");
+        let session = Session::from_text(path, SAMPLE, ParseOptions::default()).unwrap();
+        assert_eq!(session.symbol, "WINJ26");
+        assert_eq!(session.trades.len(), 2);
+        assert_eq!(session.span_ms(), 2_500);
+        assert_eq!(session.label(), "WINJ26 · 2026-03-16");
+        assert_eq!(session.timezone().minutes(), -180);
+    }
+
+    #[test]
+    fn the_metadata_symbol_wins_over_the_folder_name() {
+        let path = Path::new("replay/renamed-folder/20260316.csv");
+        let session = Session::from_text(path, SAMPLE, ParseOptions::default()).unwrap();
+        assert_eq!(session.symbol, "WINJ26");
+    }
+
+    #[test]
+    fn a_format_error_keeps_the_file_and_the_line() {
+        let path = Path::new("replay/WINJ26/20260316.csv");
+        let err =
+            Session::from_text(path, "Date,Time,Price\n", ParseOptions::default()).unwrap_err();
+        assert_eq!(err.path(), path);
+        assert!(err.to_string().contains("20260316.csv"), "{err}");
+        assert!(!err.advice().is_empty());
+    }
+}


### PR DESCRIPTION
Market replay is a **source, not a chart mode**. A recorded session is released down the same `FeedEvent` channel a live venue uses, so bars, navigation and metrics run one code path — and nothing is ever labelled "live" while a recording plays.

## What lands

- **`quantick-replay`** — a new pure domain crate (no network, no async, told how much time passed rather than reading a clock). It holds the CSV tick-file format (read, write, and explain *why* a file was rejected), the folder scan behind the session browser, and the playback clock.
- **`app/src/feed/replay.rs`** — the playback source, selected through the new `FeedSource` dispatch alongside the live providers. `feed::spawn_live` is the shorthand live callers use.
- **`app/src/replay_view.rs`** — the session browser and the transport bar, shown only while a recording is the source.
- **`FeedEvent::LiveBatch`** so a 50× replay does not pay a channel message per print; **`FeedEvent::Reset`** so seeking backwards rebuilds the series instead of patching bars that already closed.
- **Importer example** — MT5 order-flow NDJSON to sessions, reporting how often each rule decided the aggressor side (including disagreements with the broker's flags) and writing the policy into the session's `# side_source=` line.
- **`chore(skills)`** — the `arch-review` skill, in a separate commit.

## Design rules honoured

- **One engine, one path** — playback reuses the whole chart untouched; no replay-specific bar logic.
- **Data honesty** — inferred sub-second timestamps are marked `1s_interpolated`; `A`/`ASK`/`BID` side spellings are rejected by name rather than guessed, since they mean opposite sides at different vendors.
- **Capabilities, not modes** — UI affordances gate on `FeedCapabilities`. A recording reports no depth and no history paging, so the heatmap toggle disables itself from that alone.

## Verification

All four checks pass on this branch, rebased on current `main` (includes #69):

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo build --workspace`
- `cargo test --workspace` — 209 engine + 56 replay, 0 failures

README documents the file format, the folder layout, the importer options and the `QUANTICK_REPLAY_*` variables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MquWcZMBfhWjbDM1QsdSvh