### PR TITLE
docs(ux): UI design model — shell zones, toolbar, tool rail, dock, status bar

### DIFF
--- a/docs/ux/img/01-current-audit.svg
+++ b/docs/ux/img/01-current-audit.svg
@@ -1,0 +1,212 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 1000" font-family="Segoe UI, system-ui, sans-serif">
+  <defs>
+    <style>
+      .t  { fill: #D2DAE2; }
+      .m  { fill: #96A0AF; }
+      .f  { fill: #6E7887; }
+      .amb{ fill: #F0B90B; }
+      .mono { font-family: Consolas, monospace; }
+    </style>
+  </defs>
+
+  <rect width="1440" height="1000" fill="#0B0D12"/>
+  <text x="40" y="38" font-size="20" font-weight="600" class="t">quantick — today's UI (audit)</text>
+  <text x="40" y="58" font-size="12" class="m">every control the app has in 2026-07, drawn where it lives today · numbered chips mark the findings listed below</text>
+
+  <!-- ======== window frame ======== -->
+  <rect x="40" y="80" width="1360" height="640" rx="6" fill="#131722" stroke="#2E3648"/>
+
+  <!-- menu bar -->
+  <rect x="40" y="80" width="1360" height="26" fill="#171B26"/>
+  <text x="56" y="97" font-size="12" class="t">File</text>
+  <text x="92" y="97" font-size="12" class="t">Help</text>
+  <line x1="40" y1="106" x2="1400" y2="106" stroke="#232936"/>
+
+  <!-- controls row (single wrapped row) -->
+  <rect x="40" y="106" width="1360" height="36" fill="#171B26"/>
+  <text x="56" y="128" font-size="11" class="m">feed:</text>
+  <rect x="86" y="113" width="86" height="20" rx="3" fill="#232936"/>
+  <text x="94" y="127" font-size="11" class="t">Binance ▾</text>
+  <text x="184" y="128" font-size="11" class="m">symbol:</text>
+  <rect x="228" y="113" width="86" height="20" rx="3" fill="#232936"/>
+  <text x="236" y="127" font-size="11" class="t">BTCUSDT ▾</text>
+  <line x1="326" y1="112" x2="326" y2="136" stroke="#232936"/>
+  <text x="336" y="128" font-size="11" class="m">bar type:</text>
+  <rect x="388" y="113" width="56" height="20" rx="3" fill="#232936"/>
+  <text x="396" y="127" font-size="11" class="t">tick ▾</text>
+  <text x="452" y="128" font-size="11" class="m">N trades</text>
+  <rect x="502" y="113" width="40" height="20" rx="3" fill="#232936"/>
+  <text x="510" y="127" font-size="11" class="t mono">50</text>
+  <line x1="552" y1="112" x2="552" y2="136" stroke="#232936"/>
+  <text x="562" y="128" font-size="11" class="m">history +</text>
+  <rect x="614" y="113" width="46" height="20" rx="3" fill="#232936"/>
+  <text x="620" y="127" font-size="11" class="t mono">2000</text>
+  <rect x="666" y="113" width="72" height="20" rx="3" fill="#232936"/>
+  <text x="673" y="127" font-size="11" class="t">load older</text>
+  <text x="744" y="128" font-size="11" class="f mono">(12,483 trades)</text>
+  <line x1="838" y1="112" x2="838" y2="136" stroke="#232936"/>
+  <rect x="848" y="113" width="58" height="20" rx="3" fill="#232936"/>
+  <text x="855" y="127" font-size="11" class="t">candle</text>
+  <line x1="914" y1="112" x2="914" y2="136" stroke="#232936"/>
+  <rect x="924" y="115" width="12" height="12" rx="2" fill="#26A69A"/>
+  <text x="942" y="127" font-size="11" class="t">book heatmap</text>
+  <rect x="1020" y="113" width="66" height="20" rx="3" fill="#232936"/>
+  <text x="1027" y="127" font-size="11" class="t">L2 panel</text>
+  <line x1="1094" y1="112" x2="1094" y2="136" stroke="#232936"/>
+  <rect x="1104" y="115" width="12" height="12" rx="2" fill="none" stroke="#96A0AF"/>
+  <text x="1122" y="127" font-size="11" class="t">bubbles</text>
+  <rect x="1174" y="113" width="86" height="20" rx="3" fill="#232936"/>
+  <text x="1181" y="127" font-size="11" class="t">bubbles panel</text>
+  <line x1="1268" y1="112" x2="1268" y2="136" stroke="#232936"/>
+  <rect x="1278" y="115" width="12" height="12" rx="2" fill="#26A69A"/>
+  <text x="1296" y="127" font-size="11" class="t">perf</text>
+  <line x1="40" y1="142" x2="1400" y2="142" stroke="#232936"/>
+
+  <!-- left side panels, stacked side by side -->
+  <rect x="40" y="142" width="180" height="546" fill="#161A24" stroke="#232936"/>
+  <text x="54" y="164" font-size="12" font-weight="600" class="t">L2 heatmap</text>
+  <rect x="54" y="176" width="152" height="16" rx="3" fill="#232936"/>
+  <rect x="54" y="200" width="152" height="16" rx="3" fill="#232936"/>
+  <rect x="54" y="224" width="110" height="16" rx="3" fill="#232936"/>
+  <rect x="54" y="256" width="152" height="10" rx="3" fill="#232936"/>
+  <rect x="54" y="274" width="152" height="10" rx="3" fill="#232936"/>
+  <text x="54" y="310" font-size="10" class="f">palette · ranges · liquidity</text>
+  <rect x="220" y="142" width="180" height="546" fill="#161A24" stroke="#232936"/>
+  <text x="234" y="164" font-size="12" font-weight="600" class="t">aggression bubbles</text>
+  <rect x="234" y="176" width="152" height="16" rx="3" fill="#232936"/>
+  <rect x="234" y="200" width="152" height="16" rx="3" fill="#232936"/>
+  <rect x="234" y="224" width="110" height="16" rx="3" fill="#232936"/>
+  <rect x="234" y="256" width="152" height="10" rx="3" fill="#232936"/>
+  <text x="234" y="292" font-size="10" class="f">presets · size · colours</text>
+
+  <!-- chart area -->
+  <rect x="400" y="142" width="936" height="546" fill="#131722"/>
+  <!-- header text painted over chart -->
+  <text x="416" y="162" font-size="11" class="m mono">BTCUSDT · tick(50) · 240 backfilled + 61 live bars · ● live</text>
+  <!-- loading indicator top-center -->
+  <text x="850" y="162" font-size="10" class="f">◌ loading history…</text>
+
+  <!-- grid -->
+  <g stroke="#232936" stroke-width="1">
+    <line x1="400" y1="240" x2="1336" y2="240"/>
+    <line x1="400" y1="330" x2="1336" y2="330"/>
+    <line x1="400" y1="420" x2="1336" y2="420"/>
+    <line x1="400" y1="510" x2="1336" y2="510"/>
+    <line x1="400" y1="600" x2="1336" y2="600"/>
+  </g>
+
+  <!-- amber backfill divider -->
+  <line x1="880" y1="142" x2="880" y2="666" stroke="#F0B90B" stroke-width="1.5"/>
+  <text x="874" y="660" font-size="10" text-anchor="end" class="m">backfill</text>
+  <text x="886" y="660" font-size="10" class="amb">live</text>
+
+  <!-- candles -->
+  <g>
+    <line x1="470" y1="300" x2="470" y2="420" stroke="#A0A9B8"/>
+    <rect x="458" y="330" width="24" height="60" fill="#26A69A"/>
+    <line x1="530" y1="320" x2="530" y2="440" stroke="#A0A9B8"/>
+    <rect x="518" y="350" width="24" height="70" fill="#EF5350"/>
+    <line x1="590" y1="280" x2="590" y2="400" stroke="#A0A9B8"/>
+    <rect x="578" y="300" width="24" height="80" fill="#26A69A"/>
+    <line x1="650" y1="250" x2="650" y2="360" stroke="#A0A9B8"/>
+    <rect x="638" y="270" width="24" height="60" fill="#26A69A"/>
+    <line x1="710" y1="260" x2="710" y2="380" stroke="#A0A9B8"/>
+    <rect x="698" y="290" width="24" height="70" fill="#EF5350"/>
+    <line x1="770" y1="290" x2="770" y2="410" stroke="#A0A9B8"/>
+    <rect x="758" y="310" width="24" height="70" fill="#EF5350"/>
+    <line x1="830" y1="270" x2="830" y2="390" stroke="#A0A9B8"/>
+    <rect x="818" y="290" width="24" height="70" fill="#26A69A"/>
+    <line x1="910" y1="240" x2="910" y2="350" stroke="#A0A9B8"/>
+    <rect x="898" y="260" width="24" height="60" fill="#26A69A"/>
+    <line x1="970" y1="220" x2="970" y2="330" stroke="#A0A9B8"/>
+    <rect x="958" y="240" width="24" height="60" fill="#26A69A"/>
+    <line x1="1030" y1="240" x2="1030" y2="360" stroke="#A0A9B8"/>
+    <rect x="1018" y="270" width="24" height="60" fill="#EF5350"/>
+    <line x1="1090" y1="230" x2="1090" y2="340" stroke="#A0A9B8"/>
+    <rect x="1078" y="250" width="24" height="60" fill="#26A69A"/>
+  </g>
+
+  <!-- perf overlay bottom-left of chart -->
+  <rect x="416" y="580" width="170" height="76" rx="4" fill="#000000" opacity="0.6"/>
+  <text x="428" y="600" font-size="11" class="t mono">  60 fps    6.2 ms</text>
+  <text x="428" y="618" font-size="11" class="t mono">cpu 3.1 ms worst 9.8</text>
+  <text x="428" y="636" font-size="11" class="t mono">feed lag 42 ms</text>
+  <text x="428" y="652" font-size="11" class="t mono">24,183 live trades</text>
+
+  <!-- price axis gutter -->
+  <line x1="1336" y1="142" x2="1336" y2="666" stroke="#232936"/>
+  <g font-size="11" class="m mono">
+    <text x="1344" y="244">64,420</text>
+    <text x="1344" y="334">64,380</text>
+    <text x="1344" y="424">64,340</text>
+    <text x="1344" y="514">64,300</text>
+    <text x="1344" y="604">64,260</text>
+  </g>
+
+  <!-- time strip -->
+  <line x1="400" y1="666" x2="1336" y2="666" stroke="#232936"/>
+  <g font-size="10" class="m mono">
+    <text x="470" y="682" text-anchor="middle">10:41:02</text>
+    <text x="650" y="682" text-anchor="middle">10:41:17</text>
+    <text x="830" y="682" text-anchor="middle">10:41:35</text>
+    <text x="1010" y="682" text-anchor="middle">10:41:58</text>
+    <text x="1190" y="682" text-anchor="middle">10:42:20</text>
+  </g>
+
+  <!-- tz selector floating bottom-right -->
+  <rect x="1250" y="640" width="120" height="24" rx="4" fill="#000000" opacity="0.6"/>
+  <text x="1262" y="656" font-size="11" class="t">UTC−03:00 ▾</text>
+
+  <!-- replay transport bottom panel -->
+  <rect x="40" y="688" width="1360" height="32" fill="#171B26"/>
+  <line x1="40" y1="688" x2="1400" y2="688" stroke="#232936"/>
+  <text x="56" y="708" font-size="12" class="amb">▶</text>
+  <text x="76" y="708" font-size="11" class="t">WINJ26 2026-03-10</text>
+  <rect x="220" y="698" width="900" height="10" rx="5" fill="#232936"/>
+  <rect x="220" y="698" width="390" height="10" rx="5" fill="#F0B90B" opacity="0.85"/>
+  <text x="1136" y="708" font-size="11" class="m mono">1× · 43%</text>
+
+  <!-- floating windows, drawn beside the frame -->
+  <rect x="612" y="380" width="240" height="160" rx="6" fill="#171B26" stroke="#2E3648"/>
+  <text x="628" y="402" font-size="12" font-weight="600" class="t">candle style</text>
+  <rect x="628" y="416" width="208" height="12" rx="3" fill="#232936"/>
+  <rect x="628" y="436" width="208" height="12" rx="3" fill="#232936"/>
+  <rect x="628" y="456" width="160" height="12" rx="3" fill="#232936"/>
+  <text x="628" y="490" font-size="10" class="f">floating egui window</text>
+  <rect x="900" y="420" width="260" height="150" rx="6" fill="#171B26" stroke="#2E3648"/>
+  <text x="916" y="442" font-size="12" font-weight="600" class="t">Market Replay</text>
+  <rect x="916" y="456" width="228" height="12" rx="3" fill="#232936"/>
+  <rect x="916" y="476" width="228" height="12" rx="3" fill="#232936"/>
+  <rect x="916" y="496" width="170" height="12" rx="3" fill="#232936"/>
+  <text x="916" y="530" font-size="10" class="f">floating egui window (Ctrl+R)</text>
+
+  <!-- ======== finding chips ======== -->
+  <g font-size="13" font-weight="700">
+    <circle cx="700" cy="124" r="12" fill="#F0B90B"/><text x="700" y="129" text-anchor="middle" fill="#131722">1</text>
+    <circle cx="230" cy="470" r="12" fill="#F0B90B"/><text x="230" y="475" text-anchor="middle" fill="#131722">2</text>
+    <circle cx="855" cy="392" r="12" fill="#F0B90B"/><text x="855" y="397" text-anchor="middle" fill="#131722">3</text>
+    <circle cx="870" cy="124" r="12" fill="#F0B90B"/><text x="870" y="129" text-anchor="middle" fill="#131722">4</text>
+    <circle cx="600" cy="592" r="12" fill="#F0B90B"/><text x="600" y="597" text-anchor="middle" fill="#131722">5</text>
+    <circle cx="1320" cy="124" r="12" fill="#F0B90B"/><text x="1320" y="129" text-anchor="middle" fill="#131722">6</text>
+    <circle cx="180" cy="704" r="12" fill="#F0B90B"/><text x="180" y="709" text-anchor="middle" fill="#131722">7</text>
+  </g>
+
+  <!-- ======== findings legend ======== -->
+  <g font-size="12">
+    <text x="40" y="760" font-size="14" font-weight="600" class="t">Findings</text>
+    <circle cx="52" cy="782" r="10" fill="#F0B90B"/><text x="52" y="786" text-anchor="middle" font-weight="700" font-size="11" fill="#131722">1</text>
+    <text x="72" y="786" class="t">One row mixes six concerns — source, bar spec, history, appearance, layers, diagnostics. It wraps on narrow windows and grows by one control per feature.</text>
+    <circle cx="52" cy="812" r="10" fill="#F0B90B"/><text x="52" y="816" text-anchor="middle" font-weight="700" font-size="11" fill="#131722">2</text>
+    <text x="72" y="816" class="t">Each settings panel is its own left SidePanel. Two open at once cost the chart ~400 px; there are no tabs and no collapse.</text>
+    <circle cx="52" cy="842" r="10" fill="#F0B90B"/><text x="52" y="846" text-anchor="middle" font-weight="700" font-size="11" fill="#131722">3</text>
+    <text x="72" y="846" class="t">Inconsistent surfaces: candle style and the replay browser float, L2/bubbles dock left, the timezone picker pins bottom-right.</text>
+    <circle cx="52" cy="872" r="10" fill="#F0B90B"/><text x="52" y="876" text-anchor="middle" font-weight="700" font-size="11" fill="#131722">4</text>
+    <text x="72" y="876" class="t">Three ad-hoc emoji glyphs stand in for an icon system; no shared sizes, strokes or interaction states.</text>
+    <circle cx="52" cy="902" r="10" fill="#F0B90B"/><text x="52" y="906" text-anchor="middle" font-weight="700" font-size="11" fill="#131722">5</text>
+    <text x="72" y="906" class="t">Status is painted over the candles in four corners: header line, perf box, history loader, timezone pill. There is no single glance line.</text>
+    <circle cx="52" cy="932" r="10" fill="#F0B90B"/><text x="52" y="936" text-anchor="middle" font-weight="700" font-size="11" fill="#131722">6</text>
+    <text x="72" y="936" class="t">No reserved zone for what is coming — indicators, drawing tools, alerts would each add yet another checkbox to the row.</text>
+    <circle cx="52" cy="962" r="10" fill="#F0B90B"/><text x="52" y="966" text-anchor="middle" font-weight="700" font-size="11" fill="#131722">7</text>
+    <text x="72" y="966" class="t">The replay transport is a style island: its own bottom panel with its own conventions, unrelated to any status line.</text>
+  </g>
+</svg>

--- a/docs/ux/img/02-shell-zones.svg
+++ b/docs/ux/img/02-shell-zones.svg
@@ -1,0 +1,163 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 960" font-family="Segoe UI, system-ui, sans-serif">
+  <defs>
+    <style>
+      .t  { fill: #D2DAE2; }
+      .m  { fill: #96A0AF; }
+      .f  { fill: #6E7887; }
+      .mono { font-family: Consolas, monospace; }
+      .zone { font-size: 12px; font-weight: 600; }
+    </style>
+  </defs>
+
+  <rect width="1440" height="960" fill="#0B0D12"/>
+  <text x="40" y="38" font-size="20" font-weight="600" class="t">quantick — proposed shell (zone model)</text>
+  <text x="40" y="58" font-size="12" class="m">nine fixed zones · the chart is the only elastic one · everything future docks into an existing zone, never into a new one</text>
+
+  <!-- ======== window ======== -->
+  <rect x="40" y="80" width="1360" height="744" rx="6" fill="#131722" stroke="#2E3648"/>
+
+  <!-- Z1 menu bar -->
+  <rect x="40" y="80" width="1360" height="28" fill="#8AB4F8" opacity="0.14"/>
+  <rect x="40" y="80" width="1360" height="28" fill="none" stroke="#8AB4F8" stroke-dasharray="4 3"/>
+  <g font-size="12" class="t">
+    <text x="58" y="99">File</text>
+    <text x="94" y="99">View</text>
+    <text x="138" y="99">Insert</text>
+    <text x="188" y="99">Tools</text>
+    <text x="234" y="99">Help</text>
+  </g>
+  <text x="1310" y="99" class="zone" fill="#8AB4F8">1 · menu bar</text>
+
+  <!-- Z2 context toolbar -->
+  <rect x="40" y="108" width="1360" height="44" fill="#4A90D9" opacity="0.12"/>
+  <rect x="40" y="108" width="1360" height="44" fill="none" stroke="#4A90D9" stroke-dasharray="4 3"/>
+  <rect x="56" y="118" width="96" height="24" rx="4" fill="#232936"/>
+  <text x="66" y="134" font-size="11" class="t">Binance ▾</text>
+  <rect x="158" y="118" width="104" height="24" rx="4" fill="#232936"/>
+  <text x="168" y="134" font-size="11" font-weight="600" class="t">BTCUSDT ▾</text>
+  <line x1="276" y1="114" x2="276" y2="146" stroke="#2E3648"/>
+  <rect x="290" y="118" width="76" height="24" rx="4" fill="#232936"/>
+  <text x="300" y="134" font-size="11" class="t">Tick ▾</text>
+  <rect x="372" y="118" width="52" height="24" rx="4" fill="#232936"/>
+  <text x="382" y="134" font-size="11" class="t mono">50</text>
+  <g>
+    <rect x="1076" y="118" width="28" height="24" rx="4" fill="#26A69A" opacity="0.25"/>
+    <rect x="1076" y="118" width="28" height="24" rx="4" fill="none" stroke="#26A69A"/>
+    <rect x="1110" y="118" width="28" height="24" rx="4" fill="#232936"/>
+    <rect x="1144" y="118" width="28" height="24" rx="4" fill="#232936"/>
+    <line x1="1184" y1="114" x2="1184" y2="146" stroke="#2E3648"/>
+    <rect x="1194" y="118" width="28" height="24" rx="4" fill="#232936"/>
+    <rect x="1228" y="118" width="28" height="24" rx="4" fill="#232936"/>
+    <text x="1272" y="134" font-size="14" class="m">⋯</text>
+  </g>
+  <text x="1300" y="136" class="zone" fill="#4A90D9">2 · toolbar</text>
+
+  <!-- Z3 tool rail -->
+  <rect x="40" y="152" width="44" height="560" fill="#B07CF0" opacity="0.12"/>
+  <rect x="40" y="152" width="44" height="560" fill="none" stroke="#B07CF0" stroke-dasharray="4 3"/>
+  <g fill="#96A0AF">
+    <rect x="52" y="168" width="20" height="20" rx="4" fill="#B07CF0" opacity="0.35"/>
+    <rect x="52" y="196" width="20" height="20" rx="4" fill="#232936"/>
+    <rect x="52" y="224" width="20" height="20" rx="4" fill="#232936"/>
+    <rect x="52" y="252" width="20" height="20" rx="4" fill="#232936"/>
+    <rect x="52" y="280" width="20" height="20" rx="4" fill="#232936"/>
+    <rect x="52" y="308" width="20" height="20" rx="4" fill="#232936"/>
+    <rect x="52" y="648" width="20" height="20" rx="4" fill="#232936"/>
+    <rect x="52" y="676" width="20" height="20" rx="4" fill="#232936"/>
+  </g>
+  <text x="62" y="740" class="zone" fill="#B07CF0" transform="rotate(-90 62 740)">3 · tool rail</text>
+
+  <!-- Z4 chart canvas -->
+  <rect x="84" y="152" width="988" height="380" fill="none" stroke="#D2DAE2" stroke-dasharray="5 4" opacity="0.6"/>
+  <text x="100" y="176" font-size="11" class="m mono">BTCUSDT · tick 50 · ● live</text>
+  <text x="100" y="194" font-size="11" class="m mono">EMA 21 · VWAP</text>
+  <g stroke="#232936"><line x1="84" y1="250" x2="1072" y2="250"/><line x1="84" y1="340" x2="1072" y2="340"/><line x1="84" y1="430" x2="1072" y2="430"/></g>
+  <g>
+    <line x1="300" y1="280" x2="300" y2="400" stroke="#A0A9B8"/><rect x="288" y="300" width="24" height="70" fill="#26A69A"/>
+    <line x1="380" y1="260" x2="380" y2="390" stroke="#A0A9B8"/><rect x="368" y="290" width="24" height="70" fill="#EF5350"/>
+    <line x1="460" y1="240" x2="460" y2="360" stroke="#A0A9B8"/><rect x="448" y="260" width="24" height="70" fill="#26A69A"/>
+    <line x1="540" y1="220" x2="540" y2="340" stroke="#A0A9B8"/><rect x="528" y="240" width="24" height="70" fill="#26A69A"/>
+    <line x1="620" y1="240" x2="620" y2="370" stroke="#A0A9B8"/><rect x="608" y="270" width="24" height="70" fill="#EF5350"/>
+    <line x1="700" y1="260" x2="700" y2="380" stroke="#A0A9B8"/><rect x="688" y="280" width="24" height="70" fill="#26A69A"/>
+    <line x1="780" y1="230" x2="780" y2="350" stroke="#A0A9B8"/><rect x="768" y="250" width="24" height="70" fill="#26A69A"/>
+  </g>
+  <path d="M 250 360 C 400 330, 520 290, 660 300 S 900 280, 1040 260" fill="none" stroke="#8AB4F8" stroke-width="1.6" opacity="0.9"/>
+  <text x="560" y="520" class="zone" fill="#D2DAE2">4 · chart canvas (elastic — the only zone that grows)</text>
+
+  <!-- Z5 sub-panes -->
+  <rect x="84" y="532" width="988" height="150" fill="#26A69A" opacity="0.10"/>
+  <rect x="84" y="532" width="988" height="150" fill="none" stroke="#26A69A" stroke-dasharray="4 3"/>
+  <line x1="84" y1="612" x2="1072" y2="612" stroke="#2E3648"/>
+  <text x="100" y="552" font-size="11" class="m mono">CVD</text>
+  <path d="M 100 596 C 260 560, 420 588, 580 566 S 900 540, 1040 556" fill="none" stroke="#26A69A" stroke-width="1.5"/>
+  <text x="100" y="632" font-size="11" class="m mono">Delta</text>
+  <g>
+    <rect x="240" y="640" width="10" height="28" fill="#26A69A"/>
+    <rect x="270" y="654" width="10" height="14" fill="#EF5350"/>
+    <rect x="300" y="636" width="10" height="32" fill="#26A69A"/>
+    <rect x="330" y="650" width="10" height="18" fill="#EF5350"/>
+    <rect x="360" y="644" width="10" height="24" fill="#26A69A"/>
+    <rect x="390" y="658" width="10" height="10" fill="#EF5350"/>
+    <rect x="420" y="640" width="10" height="28" fill="#26A69A"/>
+  </g>
+  <text x="880" y="552" class="zone" fill="#26A69A">5 · indicator sub-panes</text>
+
+  <!-- Z6 time axis -->
+  <rect x="84" y="682" width="988" height="24" fill="#96A0AF" opacity="0.10"/>
+  <rect x="84" y="682" width="988" height="24" fill="none" stroke="#96A0AF" stroke-dasharray="4 3"/>
+  <g font-size="10" class="m mono">
+    <text x="240" y="698" text-anchor="middle">10:41:02</text>
+    <text x="480" y="698" text-anchor="middle">10:41:35</text>
+    <text x="720" y="698" text-anchor="middle">10:42:20</text>
+  </g>
+  <text x="960" y="699" class="zone" fill="#96A0AF">6 · time axis</text>
+
+  <!-- Z9 price axis -->
+  <rect x="1072" y="152" width="64" height="554" fill="#96A0AF" opacity="0.10"/>
+  <rect x="1072" y="152" width="64" height="554" fill="none" stroke="#96A0AF" stroke-dasharray="4 3"/>
+  <g font-size="10" class="m mono">
+    <text x="1080" y="254">64,420</text>
+    <text x="1080" y="344">64,340</text>
+    <text x="1080" y="434">64,260</text>
+  </g>
+  <text x="1092" y="600" class="zone" fill="#96A0AF" transform="rotate(-90 1092 600)">9 · price axis</text>
+
+  <!-- Z8 right dock -->
+  <rect x="1136" y="152" width="264" height="554" fill="#E8845A" opacity="0.10"/>
+  <rect x="1136" y="152" width="264" height="554" fill="none" stroke="#E8845A" stroke-dasharray="4 3"/>
+  <g>
+    <rect x="1136" y="152" width="36" height="554" fill="#171B26"/>
+    <rect x="1142" y="164" width="24" height="24" rx="4" fill="#E8845A" opacity="0.35"/>
+    <rect x="1142" y="196" width="24" height="24" rx="4" fill="#232936"/>
+    <rect x="1142" y="228" width="24" height="24" rx="4" fill="#232936"/>
+    <rect x="1142" y="260" width="24" height="24" rx="4" fill="#232936"/>
+  </g>
+  <text x="1184" y="180" font-size="12" font-weight="600" class="t">L2 heatmap</text>
+  <rect x="1184" y="194" width="196" height="14" rx="3" fill="#232936"/>
+  <rect x="1184" y="216" width="196" height="14" rx="3" fill="#232936"/>
+  <rect x="1184" y="238" width="150" height="14" rx="3" fill="#232936"/>
+  <rect x="1184" y="268" width="196" height="10" rx="3" fill="#232936"/>
+  <text x="1210" y="690" class="zone" fill="#E8845A">8 · dock (tabbed)</text>
+
+  <!-- Z7 status bar with transport slot -->
+  <rect x="40" y="762" width="1360" height="28" fill="#F0B90B" opacity="0.10"/>
+  <rect x="40" y="762" width="1360" height="28" fill="none" stroke="#F0B90B" stroke-dasharray="4 3"/>
+  <circle cx="62" cy="776" r="4" fill="#26A69A"/>
+  <text x="74" y="781" font-size="11" class="t">live · Binance · BTCUSDT</text>
+  <text x="240" y="781" font-size="11" class="m mono">lag 42 ms</text>
+  <text x="1080" y="781" font-size="11" class="m mono">24,183 trades · 60 fps</text>
+  <text x="1270" y="781" font-size="11" class="m">UTC−03:00 ▾</text>
+  <text x="640" y="781" class="zone" fill="#F0B90B">7 · status bar (owns the replay transport)</text>
+
+  <!-- transport slot, dashed, above status bar -->
+  <rect x="40" y="712" width="1360" height="30" fill="none" stroke="#F0B90B" stroke-dasharray="2 3" opacity="0.6"/>
+  <text x="56" y="731" font-size="10" fill="#F0B90B" opacity="0.9">7b · transport strip — appears only while a recording plays, amber like every not-live surface</text>
+
+  <!-- ======== budgets footer ======== -->
+  <g font-size="12">
+    <text x="40" y="856" font-size="14" font-weight="600" class="t">Fixed chrome budget</text>
+    <text x="40" y="880" class="m">menu 28 px · toolbar 44 px · tool rail 44 px · price axis 64 px · time axis 24 px · status bar 28 px · transport 30 px (replay only)</text>
+    <text x="40" y="900" class="m">dock 280–360 px, collapsible to its 36 px tab strip · sub-panes ≤ 40% of chart height, max 3 · vertical chrome while live: 124 px — 4 px more than today</text>
+    <text x="40" y="930" class="t">Rule: a new feature must claim a slot inside zones 1–9. If it cannot, the shell — not the feature — is what gets redesigned.</text>
+  </g>
+</svg>

--- a/docs/ux/img/03-toolbar-model.svg
+++ b/docs/ux/img/03-toolbar-model.svg
@@ -1,0 +1,164 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 860" font-family="Segoe UI, system-ui, sans-serif">
+  <defs>
+    <style>
+      .t  { fill: #D2DAE2; }
+      .m  { fill: #96A0AF; }
+      .f  { fill: #6E7887; }
+      .mono { font-family: Consolas, monospace; }
+      .cap { font-size: 11px; fill: #6E7887; letter-spacing: 1px; }
+    </style>
+  </defs>
+
+  <rect width="1440" height="860" fill="#0B0D12"/>
+  <text x="40" y="38" font-size="20" font-weight="600" class="t">Toolbar — grouped by question, not by feature</text>
+  <text x="40" y="58" font-size="12" class="m">left answers “what am I looking at?” · right answers “how is it drawn?” · diagnostics leave the toolbar for the status bar</text>
+
+  <!-- ======== full toolbar ======== -->
+  <rect x="40" y="90" width="1360" height="48" rx="6" fill="#171B26" stroke="#2E3648"/>
+
+  <!-- SOURCE group -->
+  <text x="56" y="82" class="cap">SOURCE</text>
+  <rect x="56" y="100" width="100" height="28" rx="4" fill="#232936"/>
+  <text x="68" y="118" font-size="12" class="t">Binance ▾</text>
+  <rect x="162" y="100" width="112" height="28" rx="4" fill="#232936"/>
+  <text x="174" y="118" font-size="12" font-weight="600" class="t">BTCUSDT ▾</text>
+  <line x1="288" y1="96" x2="288" y2="132" stroke="#2E3648"/>
+
+  <!-- BARS group -->
+  <text x="302" y="82" class="cap">BARS</text>
+  <rect x="302" y="100" width="80" height="28" rx="4" fill="#232936"/>
+  <text x="314" y="118" font-size="12" class="t">Tick ▾</text>
+  <rect x="388" y="100" width="56" height="28" rx="4" fill="#232936"/>
+  <text x="400" y="118" font-size="12" class="t mono">50</text>
+  <line x1="458" y1="96" x2="458" y2="132" stroke="#2E3648"/>
+
+  <!-- HISTORY group -->
+  <text x="472" y="82" class="cap">HISTORY</text>
+  <rect x="472" y="100" width="90" height="28" rx="4" fill="#232936"/>
+  <text x="484" y="118" font-size="12" class="t">+ older ▾</text>
+
+  <!-- spacer note -->
+  <text x="640" y="118" font-size="11" class="f" font-style="italic">← flexible space — groups never wrap, they collapse into ⋯ →</text>
+
+  <!-- LAYERS group -->
+  <text x="1024" y="82" class="cap">LAYERS</text>
+  <g>
+    <rect x="1024" y="100" width="30" height="28" rx="4" fill="#26A69A" opacity="0.22"/>
+    <rect x="1024" y="100" width="30" height="28" rx="4" fill="none" stroke="#26A69A"/>
+    <g stroke="#26A69A" stroke-width="1.6"><line x1="1031" y1="122" x2="1031" y2="112"/><line x1="1037" y1="122" x2="1037" y2="107"/><line x1="1043" y1="122" x2="1043" y2="116"/><line x1="1049" y1="122" x2="1049" y2="110"/></g>
+    <rect x="1060" y="100" width="30" height="28" rx="4" fill="#232936"/>
+    <g fill="none" stroke="#96A0AF" stroke-width="1.4"><circle cx="1070" cy="118" r="4"/><circle cx="1080" cy="110" r="3"/><circle cx="1079" cy="121" r="2.2"/></g>
+    <rect x="1096" y="100" width="30" height="28" rx="4" fill="#232936"/>
+    <path d="M 1102 122 L 1108 112 L 1114 117 L 1121 106" fill="none" stroke="#96A0AF" stroke-width="1.6"/>
+  </g>
+  <line x1="1140" y1="96" x2="1140" y2="132" stroke="#2E3648"/>
+
+  <!-- LOOK group -->
+  <text x="1154" y="82" class="cap">LOOK</text>
+  <rect x="1154" y="100" width="30" height="28" rx="4" fill="#232936"/>
+  <g fill="none" stroke="#96A0AF" stroke-width="1.4">
+    <rect x="1162" y="106" width="6" height="10"/><line x1="1165" y1="103" x2="1165" y2="119"/>
+    <rect x="1172" y="110" width="6" height="8"/><line x1="1175" y1="107" x2="1175" y2="121"/>
+  </g>
+  <line x1="1198" y1="96" x2="1198" y2="132" stroke="#2E3648"/>
+
+  <!-- PANELS group -->
+  <text x="1212" y="82" class="cap">PANELS</text>
+  <rect x="1212" y="100" width="30" height="28" rx="4" fill="#232936"/>
+  <g fill="none" stroke="#96A0AF" stroke-width="1.4"><rect x="1219" y="107" width="16" height="14" rx="2"/><line x1="1229" y1="107" x2="1229" y2="121"/></g>
+
+  <!-- overflow -->
+  <text x="1262" y="121" font-size="16" class="m">⋯</text>
+  <text x="1300" y="118" font-size="11" class="f">overflow</text>
+
+  <!-- group annotations -->
+  <g font-size="12" class="m">
+    <text x="56" y="168">SOURCE — feed and symbol, from config. During replay the two combos are replaced by the amber session label: the source is the recording.</text>
+    <text x="56" y="188">BARS — bar kind + its one parameter. HISTORY — “+ older ▾” button with the page size inside its menu, gated by the paging capability.</text>
+    <text x="56" y="208">LAYERS — one icon toggle per visual layer: heatmap, bubbles, indicators. Right-click (or caret) opens that layer's dock tab. Adding a layer adds one icon, not one checkbox row.</text>
+    <text x="56" y="228">LOOK — appearance dialog (candles, canvas, grid). PANELS — show/hide the dock. Perf display moves to the status bar; it is a reading, not a control.</text>
+  </g>
+
+  <!-- ======== states strip ======== -->
+  <text x="40" y="292" font-size="16" font-weight="600" class="t">One icon button, five states</text>
+  <g>
+    <rect x="40" y="310" width="34" height="30" rx="4" fill="#232936"/>
+    <g stroke="#96A0AF" stroke-width="1.6"><line x1="49" y1="333" x2="49" y2="323"/><line x1="55" y1="333" x2="55" y2="318"/><line x1="61" y1="333" x2="61" y2="327"/><line x1="67" y1="333" x2="67" y2="321"/></g>
+    <text x="57" y="360" font-size="11" text-anchor="middle" class="m">idle</text>
+
+    <rect x="140" y="310" width="34" height="30" rx="4" fill="#2E3648"/>
+    <g stroke="#D2DAE2" stroke-width="1.6"><line x1="149" y1="333" x2="149" y2="323"/><line x1="155" y1="333" x2="155" y2="318"/><line x1="161" y1="333" x2="161" y2="327"/><line x1="167" y1="333" x2="167" y2="321"/></g>
+    <text x="157" y="360" font-size="11" text-anchor="middle" class="m">hover + tooltip</text>
+
+    <rect x="240" y="310" width="34" height="30" rx="4" fill="#26A69A" opacity="0.22"/>
+    <rect x="240" y="310" width="34" height="30" rx="4" fill="none" stroke="#26A69A"/>
+    <g stroke="#26A69A" stroke-width="1.6"><line x1="249" y1="333" x2="249" y2="323"/><line x1="255" y1="333" x2="255" y2="318"/><line x1="261" y1="333" x2="261" y2="327"/><line x1="267" y1="333" x2="267" y2="321"/></g>
+    <text x="257" y="360" font-size="11" text-anchor="middle" class="m">active</text>
+
+    <rect x="340" y="310" width="34" height="30" rx="4" fill="#232936" opacity="0.45"/>
+    <g stroke="#96A0AF" stroke-width="1.6" opacity="0.4"><line x1="349" y1="333" x2="349" y2="323"/><line x1="355" y1="333" x2="355" y2="318"/><line x1="361" y1="333" x2="361" y2="327"/><line x1="367" y1="333" x2="367" y2="321"/></g>
+    <text x="357" y="360" font-size="11" text-anchor="middle" class="m">disabled</text>
+
+    <rect x="440" y="310" width="34" height="30" rx="4" fill="#232936" opacity="0.45"/>
+    <g stroke="#96A0AF" stroke-width="1.6" opacity="0.4"><line x1="449" y1="333" x2="449" y2="323"/><line x1="455" y1="333" x2="455" y2="318"/><line x1="461" y1="333" x2="461" y2="327"/><line x1="467" y1="333" x2="467" y2="321"/></g>
+    <rect x="484" y="300" width="330" height="26" rx="4" fill="#373F50"/>
+    <path d="M 484 316 L 476 322 L 484 328 Z" fill="#373F50"/>
+    <text x="496" y="317" font-size="11" class="t">this feed has no order-book depth — capability, not error</text>
+    <text x="500" y="360" font-size="11" class="m">disabled explains itself on hover</text>
+  </g>
+  <text x="40" y="396" font-size="12" class="m">Disabled ≠ hidden: an affordance the venue cannot serve stays visible at 40% and says why. Only a mode change (replay) may swap chrome.</text>
+
+  <!-- ======== responsive collapse ======== -->
+  <text x="40" y="452" font-size="16" font-weight="600" class="t">Width discipline — the row never wraps</text>
+
+  <text x="40" y="480" font-size="11" class="cap">WIDE ≥ 1280 px</text>
+  <rect x="40" y="490" width="1360" height="40" rx="6" fill="#171B26" stroke="#2E3648"/>
+  <g font-size="11" class="t">
+    <rect x="52" y="498" width="88" height="24" rx="4" fill="#232936"/><text x="62" y="514">Binance ▾</text>
+    <rect x="146" y="498" width="96" height="24" rx="4" fill="#232936"/><text x="156" y="514" font-weight="600">BTCUSDT ▾</text>
+    <line x1="252" y1="494" x2="252" y2="526" stroke="#2E3648"/>
+    <rect x="262" y="498" width="70" height="24" rx="4" fill="#232936"/><text x="272" y="514">Tick ▾</text>
+    <rect x="338" y="498" width="48" height="24" rx="4" fill="#232936"/><text x="348" y="514" class="mono">50</text>
+    <line x1="396" y1="494" x2="396" y2="526" stroke="#2E3648"/>
+    <rect x="406" y="498" width="82" height="24" rx="4" fill="#232936"/><text x="416" y="514">+ older ▾</text>
+    <rect x="1112" y="498" width="26" height="24" rx="4" fill="#26A69A" opacity="0.25"/>
+    <rect x="1142" y="498" width="26" height="24" rx="4" fill="#232936"/>
+    <rect x="1172" y="498" width="26" height="24" rx="4" fill="#232936"/>
+    <line x1="1208" y1="494" x2="1208" y2="526" stroke="#2E3648"/>
+    <rect x="1218" y="498" width="26" height="24" rx="4" fill="#232936"/>
+    <rect x="1248" y="498" width="26" height="24" rx="4" fill="#232936"/>
+    <text x="1288" y="516" font-size="14" class="m">⋯</text>
+  </g>
+
+  <text x="40" y="566" font-size="11" class="cap">NARROW &lt; 1280 px — LOOK and PANELS fold into ⋯, symbol keeps its name</text>
+  <rect x="40" y="576" width="880" height="40" rx="6" fill="#171B26" stroke="#2E3648"/>
+  <g font-size="11" class="t">
+    <rect x="52" y="584" width="30" height="24" rx="4" fill="#232936"/><text x="60" y="600" class="m">B</text>
+    <rect x="88" y="584" width="96" height="24" rx="4" fill="#232936"/><text x="98" y="600" font-weight="600">BTCUSDT ▾</text>
+    <line x1="194" y1="580" x2="194" y2="612" stroke="#2E3648"/>
+    <rect x="204" y="584" width="96" height="24" rx="4" fill="#232936"/><text x="214" y="600" class="mono">Tick · 50 ▾</text>
+    <line x1="310" y1="580" x2="310" y2="612" stroke="#2E3648"/>
+    <rect x="662" y="584" width="26" height="24" rx="4" fill="#26A69A" opacity="0.25"/>
+    <rect x="692" y="584" width="26" height="24" rx="4" fill="#232936"/>
+    <rect x="722" y="584" width="26" height="24" rx="4" fill="#232936"/>
+    <text x="762" y="602" font-size="14" class="m">⋯</text>
+  </g>
+
+  <text x="40" y="652" font-size="11" class="cap">REPLAY MODE — the source group becomes the honest amber label; capabilities disable the rest</text>
+  <rect x="40" y="662" width="1360" height="40" rx="6" fill="#171B26" stroke="#2E3648"/>
+  <g font-size="11">
+    <text x="52" y="686" fill="#F0B90B" font-weight="600">▶ WINJ26 · 2026-03-10 session</text>
+    <line x1="262" y1="666" x2="262" y2="698" stroke="#2E3648"/>
+    <rect x="272" y="670" width="70" height="24" rx="4" fill="#232936"/><text x="282" y="686" class="t">Tick ▾</text>
+    <rect x="348" y="670" width="48" height="24" rx="4" fill="#232936"/><text x="358" y="686" class="t mono">50</text>
+    <rect x="416" y="670" width="82" height="24" rx="4" fill="#232936" opacity="0.45"/><text x="426" y="686" class="m" opacity="0.5">+ older ▾</text>
+    <rect x="1112" y="670" width="26" height="24" rx="4" fill="#232936" opacity="0.45"/>
+    <rect x="1142" y="670" width="26" height="24" rx="4" fill="#232936"/>
+    <rect x="1172" y="670" width="26" height="24" rx="4" fill="#232936"/>
+  </g>
+
+  <g font-size="12" class="m">
+    <text x="40" y="746">Collapse order (first to fold): LOOK → PANELS → HISTORY → bar parameter merges into the kind combo → feed name shrinks to its initial.</text>
+    <text x="40" y="766">Never folded: the symbol and the LAYERS toggles — they are the two things a trader glances at mid-session.</text>
+  </g>
+</svg>

--- a/docs/ux/img/04-tool-rail-dock.svg
+++ b/docs/ux/img/04-tool-rail-dock.svg
@@ -1,0 +1,178 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 900" font-family="Segoe UI, system-ui, sans-serif">
+  <defs>
+    <style>
+      .t  { fill: #D2DAE2; }
+      .m  { fill: #96A0AF; }
+      .f  { fill: #6E7887; }
+      .mono { font-family: Consolas, monospace; }
+      .cap { font-size: 11px; fill: #6E7887; letter-spacing: 1px; }
+      .key { font-family: Consolas, monospace; font-size: 10px; fill: #6E7887; }
+    </style>
+  </defs>
+
+  <rect width="1440" height="900" fill="#0B0D12"/>
+  <text x="40" y="38" font-size="20" font-weight="600" class="t">Tool rail (left) and dock (right)</text>
+  <text x="40" y="58" font-size="12" class="m">the rail holds tools that act on the chart · the dock holds settings that describe layers · one is 44 px forever, the other is one panel at a time</text>
+
+  <!-- ================= LEFT: tool rail ================= -->
+  <text x="40" y="100" font-size="16" font-weight="600" class="t">Tool rail — 44 px, drawing tools land here</text>
+  <text x="40" y="120" font-size="12" class="m">exclusive selection: exactly one tool armed; Esc always returns to Pointer</text>
+
+  <rect x="40" y="140" width="44" height="600" fill="#171B26" stroke="#2E3648"/>
+
+  <!-- pointer (active) -->
+  <rect x="47" y="152" width="30" height="30" rx="4" fill="#4A90D9" opacity="0.25"/>
+  <rect x="47" y="152" width="30" height="30" rx="4" fill="none" stroke="#4A90D9"/>
+  <path d="M 57 159 L 57 175 L 61 171 L 64 177 L 66 176 L 63 170 L 68 170 Z" fill="#D2DAE2"/>
+  <text x="96" y="171" font-size="12" class="t">Pointer — pan, zoom, select</text>
+  <text x="330" y="171" class="key">Esc / 1</text>
+
+  <!-- crosshair -->
+  <rect x="47" y="190" width="30" height="30" rx="4" fill="#232936"/>
+  <g stroke="#96A0AF" stroke-width="1.4"><line x1="62" y1="196" x2="62" y2="214"/><line x1="53" y1="205" x2="71" y2="205"/></g>
+  <text x="96" y="209" font-size="12" class="t">Crosshair — precise read, price tag on axis</text>
+  <text x="330" y="209" class="key">2</text>
+
+  <!-- separator -->
+  <line x1="48" y1="232" x2="76" y2="232" stroke="#2E3648"/>
+
+  <!-- trend line -->
+  <rect x="47" y="242" width="30" height="30" rx="4" fill="#232936"/>
+  <g stroke="#96A0AF" stroke-width="1.4"><line x1="53" y1="266" x2="71" y2="248"/><circle cx="53" cy="266" r="2" fill="#96A0AF"/><circle cx="71" cy="248" r="2" fill="#96A0AF"/></g>
+  <text x="96" y="261" font-size="12" class="t">Trend line — two anchors, bar-index coordinates</text>
+  <text x="330" y="261" class="key">T</text>
+
+  <!-- horizontal line -->
+  <rect x="47" y="280" width="30" height="30" rx="4" fill="#232936"/>
+  <g stroke="#96A0AF" stroke-width="1.4"><line x1="52" y1="295" x2="72" y2="295"/><circle cx="62" cy="295" r="2" fill="#96A0AF"/></g>
+  <text x="96" y="299" font-size="12" class="t">Horizontal level — one price, extends both ways</text>
+  <text x="330" y="299" class="key">H</text>
+
+  <!-- rectangle zone -->
+  <rect x="47" y="318" width="30" height="30" rx="4" fill="#232936"/>
+  <rect x="53" y="325" width="18" height="14" fill="none" stroke="#96A0AF" stroke-width="1.4"/>
+  <text x="96" y="337" font-size="12" class="t">Zone — price-time rectangle (supply/demand)</text>
+  <text x="330" y="337" class="key">R</text>
+
+  <!-- measure -->
+  <rect x="47" y="356" width="30" height="30" rx="4" fill="#232936"/>
+  <g stroke="#96A0AF" stroke-width="1.4"><line x1="53" y1="378" x2="71" y2="362"/><line x1="53" y1="374" x2="53" y2="382"/><line x1="67" y1="360" x2="75" y2="366"/></g>
+  <text x="96" y="375" font-size="12" class="t">Measure — Δprice, Δbars, Δdelta between two points</text>
+  <text x="330" y="375" class="key">M</text>
+
+  <!-- text note -->
+  <rect x="47" y="394" width="30" height="30" rx="4" fill="#232936"/>
+  <text x="56" y="415" font-size="14" class="m" font-weight="600">A</text>
+  <text x="96" y="413" font-size="12" class="t">Note — text label pinned to a bar and price</text>
+  <text x="330" y="413" class="key">N</text>
+
+  <!-- future slot -->
+  <rect x="47" y="432" width="30" height="30" rx="4" fill="none" stroke="#2E3648" stroke-dasharray="3 3"/>
+  <text x="96" y="451" font-size="12" class="f" font-style="italic">reserved — fib, ray, path… one slot per tool, same grammar</text>
+
+  <!-- footer group -->
+  <line x1="48" y1="642" x2="76" y2="642" stroke="#2E3648"/>
+  <rect x="47" y="652" width="30" height="30" rx="4" fill="#232936"/>
+  <g stroke="#96A0AF" stroke-width="1.4" fill="none"><path d="M 55 674 C 55 664, 69 664, 69 674"/><circle cx="62" cy="662" r="3"/></g>
+  <text x="96" y="671" font-size="12" class="t">Magnet — snap anchors to OHLC of the nearest bar</text>
+
+  <rect x="47" y="690" width="30" height="30" rx="4" fill="#232936"/>
+  <g fill="none" stroke="#96A0AF" stroke-width="1.4"><rect x="55" y="703" width="14" height="10" rx="2"/><path d="M 58 703 v-3 a4 4 0 0 1 8 0 v3"/></g>
+  <text x="96" y="709" font-size="12" class="t">Lock drawings — objects stay, edits refuse politely</text>
+
+  <text x="40" y="778" font-size="12" class="m">Footer = modifiers (toggle state), body = tools (exclusive). Object delete lives on the object:</text>
+  <text x="40" y="796" font-size="12" class="m">select → Del, or the object's own context row — never a global “clear all” icon within reach of a fat finger.</text>
+
+  <!-- ================= RIGHT: dock ================= -->
+  <text x="560" y="100" font-size="16" font-weight="600" class="t">Dock — one home for every settings panel</text>
+  <text x="560" y="120" font-size="12" class="m">tab strip 36 px, always visible when the dock is open · exactly one panel expanded · collapses to the strip</text>
+
+  <!-- dock frame -->
+  <rect x="560" y="140" width="340" height="600" fill="#161A24" stroke="#2E3648"/>
+  <!-- tab strip -->
+  <rect x="560" y="140" width="36" height="600" fill="#171B26"/>
+  <!-- tabs -->
+  <rect x="565" y="152" width="26" height="26" rx="4" fill="#E8845A" opacity="0.30"/>
+  <rect x="565" y="152" width="26" height="26" rx="4" fill="none" stroke="#E8845A"/>
+  <g stroke="#E8845A" stroke-width="1.5"><line x1="571" y1="172" x2="571" y2="164"/><line x1="577" y1="172" x2="577" y2="158"/><line x1="583" y1="172" x2="583" y2="167"/></g>
+  <rect x="565" y="186" width="26" height="26" rx="4" fill="#232936"/>
+  <g fill="none" stroke="#96A0AF" stroke-width="1.3"><circle cx="574" cy="200" r="3.5"/><circle cx="583" cy="194" r="2.5"/></g>
+  <rect x="565" y="220" width="26" height="26" rx="4" fill="#232936"/>
+  <path d="M 570 240 L 576 230 L 581 235 L 587 226" fill="none" stroke="#96A0AF" stroke-width="1.5"/>
+  <rect x="565" y="254" width="26" height="26" rx="4" fill="#232936"/>
+  <g fill="none" stroke="#96A0AF" stroke-width="1.3"><circle cx="578" cy="267" r="7"/><path d="M 578 262 v5 l4 2"/></g>
+
+  <g font-size="10" class="f">
+    <text x="604" y="169">L2</text>
+    <text x="604" y="203">Bubbles</text>
+    <text x="604" y="237">Indicators</text>
+    <text x="604" y="271">Session</text>
+  </g>
+
+  <!-- open panel: L2 -->
+  <text x="620" y="170" font-size="13" font-weight="600" class="t">L2 heatmap</text>
+  <text x="878" y="170" font-size="12" text-anchor="end" class="m">⟨⟨</text>
+
+  <text x="620" y="200" font-size="11" class="cap">PALETTE</text>
+  <rect x="620" y="210" width="258" height="26" rx="4" fill="#232936"/>
+  <text x="632" y="227" font-size="12" class="t">thermal ▾</text>
+
+  <text x="620" y="262" font-size="11" class="cap">PRICE GROUPING</text>
+  <rect x="620" y="272" width="120" height="26" rx="4" fill="#232936"/>
+  <text x="632" y="289" font-size="12" class="t mono">0.05 ▾</text>
+  <text x="750" y="289" font-size="11" class="f">non-destructive</text>
+
+  <text x="620" y="324" font-size="11" class="cap">INTENSITY</text>
+  <rect x="620" y="336" width="258" height="6" rx="3" fill="#232936"/>
+  <rect x="620" y="336" width="170" height="6" rx="3" fill="#E8845A" opacity="0.8"/>
+  <circle cx="790" cy="339" r="7" fill="#D2DAE2"/>
+  <rect x="620" y="354" width="16" height="16" rx="3" fill="#26A69A"/>
+  <text x="644" y="366" font-size="12" class="t">auto intensity (visible P99)</text>
+
+  <text x="620" y="404" font-size="11" class="cap">LEGEND</text>
+  <rect x="620" y="414" width="16" height="16" rx="3" fill="#26A69A"/>
+  <text x="644" y="426" font-size="12" class="t">show chart legend</text>
+
+  <line x1="620" y1="452" x2="878" y2="452" stroke="#232936"/>
+  <rect x="620" y="466" width="130" height="26" rx="4" fill="#232936"/>
+  <text x="632" y="483" font-size="12" class="t">reset L2 visuals</text>
+
+  <text x="620" y="530" font-size="11" class="f" font-style="italic">same content as today's left panel —</text>
+  <text x="620" y="546" font-size="11" class="f" font-style="italic">only its home changes</text>
+
+  <!-- collapsed variant -->
+  <text x="960" y="100" font-size="16" font-weight="600" class="t">Collapsed</text>
+  <text x="960" y="120" font-size="12" class="m">36 px — layers stay one click away</text>
+  <rect x="960" y="140" width="36" height="380" fill="#171B26" stroke="#2E3648"/>
+  <rect x="965" y="152" width="26" height="26" rx="4" fill="#232936"/>
+  <g stroke="#96A0AF" stroke-width="1.5"><line x1="971" y1="172" x2="971" y2="164"/><line x1="977" y1="172" x2="977" y2="158"/><line x1="983" y1="172" x2="983" y2="167"/></g>
+  <rect x="965" y="186" width="26" height="26" rx="4" fill="#232936"/>
+  <g fill="none" stroke="#96A0AF" stroke-width="1.3"><circle cx="974" cy="200" r="3.5"/><circle cx="983" cy="194" r="2.5"/></g>
+  <rect x="965" y="220" width="26" height="26" rx="4" fill="#232936"/>
+  <path d="M 970 240 L 976 230 L 981 235 L 987 226" fill="none" stroke="#96A0AF" stroke-width="1.5"/>
+  <rect x="965" y="254" width="26" height="26" rx="4" fill="#232936"/>
+  <g fill="none" stroke="#96A0AF" stroke-width="1.3"><circle cx="978" cy="267" r="7"/><path d="M 978 262 v5 l4 2"/></g>
+
+  <!-- rules column -->
+  <g font-size="12">
+    <text x="1060" y="170" font-size="14" font-weight="600" class="t">Dock rules</text>
+    <text x="1060" y="196" class="m">· A layer toggle lives in the toolbar;</text>
+    <text x="1072" y="212" class="m">its settings live in its dock tab.</text>
+    <text x="1060" y="238" class="m">· Opening a tab never toggles the layer —</text>
+    <text x="1072" y="254" class="m">looking is not enabling.</text>
+    <text x="1060" y="280" class="m">· New feature = new tab. The chart pays</text>
+    <text x="1072" y="296" class="m">280 px once, not per panel.</text>
+    <text x="1060" y="322" class="m">· Dock width is user-draggable</text>
+    <text x="1072" y="338" class="m">280–360 px, remembered per tab.</text>
+    <text x="1060" y="364" class="m">· Floating windows remain only for</text>
+    <text x="1072" y="380" class="m">transient tasks: session browser,</text>
+    <text x="1072" y="396" class="m">appearance dialog, script errors.</text>
+  </g>
+
+  <!-- migration note -->
+  <g font-size="12">
+    <text x="560" y="790" font-size="14" font-weight="600" class="t">What moves where</text>
+    <text x="560" y="814" class="m">L2 panel (left SidePanel) → dock tab “L2” · bubbles panel (left SidePanel) → dock tab “Bubbles” · replay browser window → tab “Session”</text>
+    <text x="560" y="834" class="m">indicator manager (planned) → tab “Indicators” · candle style window → stays floating (LOOK), it is a pick-and-close task</text>
+  </g>
+</svg>

--- a/docs/ux/img/05-indicators-panes.svg
+++ b/docs/ux/img/05-indicators-panes.svg
@@ -1,0 +1,149 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 900" font-family="Segoe UI, system-ui, sans-serif">
+  <defs>
+    <style>
+      .t  { fill: #D2DAE2; }
+      .m  { fill: #96A0AF; }
+      .f  { fill: #6E7887; }
+      .amb{ fill: #F0B90B; }
+      .mono { font-family: Consolas, monospace; }
+    </style>
+  </defs>
+
+  <rect width="1440" height="900" fill="#0B0D12"/>
+  <text x="40" y="38" font-size="20" font-weight="600" class="t">Indicators — legend, sub-panes and honest gaps</text>
+  <text x="40" y="58" font-size="12" class="m">overlay scripts join the price chart and its legend · pane scripts stack below, sharing the x-axis · every surface tells the truth about its data</text>
+
+  <!-- ======== chart mock ======== -->
+  <rect x="40" y="80" width="1180" height="700" fill="#131722" stroke="#2E3648"/>
+
+  <!-- price chart region -->
+  <g stroke="#232936"><line x1="40" y1="180" x2="1140" y2="180"/><line x1="40" y1="280" x2="1140" y2="280"/><line x1="40" y1="380" x2="1140" y2="380"/></g>
+
+  <!-- legend block -->
+  <text x="56" y="106" font-size="12" class="t mono">WINQ26 · tick 50 · ● live</text>
+  <!-- indicator legend row: normal -->
+  <circle cx="62" cy="126" r="4" fill="#8AB4F8"/>
+  <text x="74" y="130" font-size="11" class="t mono">EMA 21 close</text>
+  <text x="172" y="130" font-size="11" class="mono" fill="#8AB4F8">64,318.4</text>
+  <!-- indicator legend row: hovered, controls visible -->
+  <rect x="52" y="138" width="330" height="20" rx="3" fill="#1B2030"/>
+  <circle cx="62" cy="148" r="4" fill="#26A69A"/>
+  <text x="74" y="152" font-size="11" class="t mono">CVD (pane)</text>
+  <text x="168" y="152" font-size="11" class="mono" fill="#26A69A">+12,408</text>
+  <g font-size="11" class="m">
+    <text x="296" y="152">👁</text>
+    <text x="318" y="152">⚙</text>
+    <text x="340" y="152">✕</text>
+  </g>
+  <text x="368" y="152" font-size="10" class="f">← on hover</text>
+  <!-- indicator legend row: error state -->
+  <circle cx="62" cy="170" r="4" fill="#FF6347"/>
+  <text x="74" y="174" font-size="11" class="mono" fill="#FF6347">zigzag.pine — error at 12:8 (PINE_STATEFUL_IN_LOOP)</text>
+  <!-- stale row -->
+  <circle cx="62" cy="192" r="4" fill="#F0B90B"/>
+  <text x="74" y="196" font-size="11" class="t mono">range_box.pine</text>
+  <rect x="196" y="184" width="150" height="16" rx="8" fill="#F0B90B" opacity="0.18"/>
+  <text x="204" y="196" font-size="10" class="amb">stale — edit has errors</text>
+
+  <!-- candles -->
+  <g>
+    <line x1="240" y1="230" x2="240" y2="350" stroke="#A0A9B8"/><rect x="228" y="250" width="24" height="70" fill="#26A69A"/>
+    <line x1="320" y1="210" x2="320" y2="340" stroke="#A0A9B8"/><rect x="308" y="240" width="24" height="70" fill="#EF5350"/>
+    <line x1="400" y1="190" x2="400" y2="310" stroke="#A0A9B8"/><rect x="388" y="210" width="24" height="70" fill="#26A69A"/>
+    <line x1="480" y1="170" x2="480" y2="290" stroke="#A0A9B8"/><rect x="468" y="190" width="24" height="70" fill="#26A69A"/>
+    <line x1="560" y1="190" x2="560" y2="320" stroke="#A0A9B8"/><rect x="548" y="220" width="24" height="70" fill="#EF5350"/>
+    <line x1="640" y1="210" x2="640" y2="330" stroke="#A0A9B8"/><rect x="628" y="230" width="24" height="70" fill="#26A69A"/>
+    <line x1="720" y1="180" x2="720" y2="300" stroke="#A0A9B8"/><rect x="708" y="200" width="24" height="70" fill="#26A69A"/>
+    <line x1="800" y1="160" x2="800" y2="280" stroke="#A0A9B8"/><rect x="788" y="180" width="24" height="70" fill="#EF5350"/>
+    <line x1="880" y1="180" x2="880" y2="300" stroke="#A0A9B8"/><rect x="868" y="200" width="24" height="70" fill="#26A69A"/>
+    <line x1="960" y1="160" x2="960" y2="270" stroke="#A0A9B8"/><rect x="948" y="180" width="24" height="60" fill="#26A69A"/>
+    <line x1="1040" y1="150" x2="1040" y2="260" stroke="#A0A9B8"/><rect x="1028" y="170" width="24" height="60" fill="#EF5350"/>
+  </g>
+
+  <!-- EMA with warmup gap -->
+  <path d="M 400 300 C 480 270, 560 280, 640 272 S 800 240, 880 244 S 1000 218, 1080 210" fill="none" stroke="#8AB4F8" stroke-width="1.8"/>
+  <g stroke="#6E7887" stroke-dasharray="3 3" fill="none"><path d="M 240 320 C 290 312, 340 308, 396 301"/></g>
+  <rect x="196" y="330" width="188" height="20" rx="4" fill="#171B26" stroke="#2E3648"/>
+  <text x="206" y="344" font-size="10" class="m">warmup: NaN plots as a gap, never a fake value</text>
+
+  <!-- zone object from a script -->
+  <rect x="620" y="150" width="260" height="46" fill="#F0B90B" opacity="0.10"/>
+  <rect x="620" y="150" width="260" height="46" fill="none" stroke="#F0B90B" stroke-dasharray="4 3" opacity="0.7"/>
+  <text x="628" y="166" font-size="10" class="amb">box.new — range_box.pine</text>
+
+  <!-- pane divider + grip -->
+  <line x1="40" y1="420" x2="1220" y2="420" stroke="#2E3648" stroke-width="2"/>
+  <g fill="#6E7887"><circle cx="620" cy="420" r="1.8"/><circle cx="630" cy="420" r="1.8"/><circle cx="640" cy="420" r="1.8"/></g>
+  <text x="1120" y="414" font-size="10" class="f">drag to resize</text>
+
+  <!-- ======== pane 1: CVD ======== -->
+  <rect x="40" y="420" width="1180" height="140" fill="#10141D"/>
+  <text x="56" y="440" font-size="11" font-weight="600" class="t mono">CVD</text>
+  <text x="96" y="440" font-size="11" class="mono" fill="#26A69A">+12,408</text>
+  <text x="170" y="440" font-size="10" class="f">▾ collapse</text>
+  <g stroke="#232936"><line x1="40" y1="490" x2="1140" y2="490"/></g>
+  <path d="M 60 530 C 200 500, 340 520, 480 496 S 760 462, 900 470 S 1060 448, 1140 452" fill="none" stroke="#26A69A" stroke-width="1.6"/>
+  <g font-size="10" class="m mono"><text x="1148" y="472">12.4k</text><text x="1148" y="530">11.9k</text></g>
+
+  <!-- pane divider -->
+  <line x1="40" y1="560" x2="1220" y2="560" stroke="#2E3648" stroke-width="2"/>
+  <g fill="#6E7887"><circle cx="620" cy="560" r="1.8"/><circle cx="630" cy="560" r="1.8"/><circle cx="640" cy="560" r="1.8"/></g>
+
+  <!-- ======== pane 2: Delta histogram ======== -->
+  <rect x="40" y="560" width="1180" height="130" fill="#10141D"/>
+  <text x="56" y="580" font-size="11" font-weight="600" class="t mono">Delta</text>
+  <text x="106" y="580" font-size="11" class="mono" fill="#EF5350">−184</text>
+  <line x1="40" y1="630" x2="1140" y2="630" stroke="#232936"/>
+  <g>
+    <rect x="234" y="602" width="12" height="28" fill="#26A69A"/>
+    <rect x="314" y="630" width="12" height="20" fill="#EF5350"/>
+    <rect x="394" y="596" width="12" height="34" fill="#26A69A"/>
+    <rect x="474" y="606" width="12" height="24" fill="#26A69A"/>
+    <rect x="554" y="630" width="12" height="30" fill="#EF5350"/>
+    <rect x="634" y="616" width="12" height="14" fill="#26A69A"/>
+    <rect x="714" y="608" width="12" height="22" fill="#26A69A"/>
+    <rect x="794" y="630" width="12" height="26" fill="#EF5350"/>
+    <rect x="874" y="612" width="12" height="18" fill="#26A69A"/>
+    <rect x="954" y="600" width="12" height="30" fill="#26A69A"/>
+    <rect x="1034" y="630" width="12" height="16" fill="#EF5350"/>
+  </g>
+  <g font-size="10" class="m mono"><text x="1148" y="606">+400</text><text x="1148" y="634">0</text><text x="1148" y="662">−400</text></g>
+
+  <!-- shared crosshair across panes -->
+  <line x1="800" y1="80" x2="800" y2="690" stroke="#6E7887" stroke-dasharray="4 3" opacity="0.8"/>
+  <text x="808" y="700" font-size="10" class="f">one crosshair, every pane</text>
+
+  <!-- time axis -->
+  <line x1="40" y1="690" x2="1220" y2="690" stroke="#232936"/>
+  <g font-size="10" class="m mono">
+    <text x="240" y="708" text-anchor="middle">10:41:02</text>
+    <text x="480" y="708" text-anchor="middle">10:41:35</text>
+    <text x="720" y="708" text-anchor="middle">10:41:58</text>
+    <text x="960" y="708" text-anchor="middle">10:42:20</text>
+  </g>
+  <text x="56" y="750" font-size="11" class="f">price axis omitted for clarity — panes keep their own auto-fit scale, x-axis is shared</text>
+
+  <!-- ======== side rules ======== -->
+  <g font-size="12">
+    <text x="1250" y="106" font-size="14" font-weight="600" class="t">Rules</text>
+    <text x="1250" y="132" class="m">· Legend is the manager's</text>
+    <text x="1262" y="148" class="m">fast path: eye, gear, remove</text>
+    <text x="1262" y="164" class="m">on hover. The full manager</text>
+    <text x="1262" y="180" class="m">is the Indicators dock tab.</text>
+    <text x="1250" y="210" class="m">· Overlay scripts share the</text>
+    <text x="1262" y="226" class="m">price scale and auto-fit.</text>
+    <text x="1250" y="256" class="m">· Pane scripts stack below,</text>
+    <text x="1262" y="272" class="m">max 3 panes, resizable,</text>
+    <text x="1262" y="288" class="m">collapsible to their header.</text>
+    <text x="1250" y="318" class="m">· Errors name file, line and</text>
+    <text x="1262" y="334" class="m">code in the legend row —</text>
+    <text x="1262" y="350" class="m">red is broken, amber is</text>
+    <text x="1262" y="366" class="m">stale-but-running.</text>
+    <text x="1250" y="396" class="m">· A recompute shows progress</text>
+    <text x="1262" y="412" class="m">in the status bar; the chart</text>
+    <text x="1262" y="428" class="m">never freezes.</text>
+    <text x="1250" y="458" class="m">· Script drawings (line, box,</text>
+    <text x="1262" y="474" class="m">label) render under user</text>
+    <text x="1262" y="490" class="m">drawings; both under bubbles.</text>
+  </g>
+</svg>

--- a/docs/ux/img/06-status-bar.svg
+++ b/docs/ux/img/06-status-bar.svg
@@ -1,0 +1,89 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 640" font-family="Segoe UI, system-ui, sans-serif">
+  <defs>
+    <style>
+      .t  { fill: #D2DAE2; }
+      .m  { fill: #96A0AF; }
+      .f  { fill: #6E7887; }
+      .amb{ fill: #F0B90B; }
+      .mono { font-family: Consolas, monospace; }
+      .cap { font-size: 11px; fill: #6E7887; letter-spacing: 1px; }
+    </style>
+  </defs>
+
+  <rect width="1440" height="640" fill="#0B0D12"/>
+  <text x="40" y="38" font-size="20" font-weight="600" class="t">Status bar — one glance line, three states</text>
+  <text x="40" y="58" font-size="12" class="m">replaces the perf overlay, the floating timezone pill and the mode text painted over candles · readings live here, controls stay above</text>
+
+  <!-- ======== LIVE ======== -->
+  <text x="40" y="110" class="cap">LIVE — green dot, quiet chrome</text>
+  <rect x="40" y="120" width="1360" height="30" rx="4" fill="#171B26" stroke="#2E3648"/>
+  <circle cx="62" cy="135" r="4" fill="#26A69A"/>
+  <text x="76" y="140" font-size="12" class="t">live · Binance · BTCUSDT</text>
+  <line x1="248" y1="126" x2="248" y2="144" stroke="#2E3648"/>
+  <text x="260" y="140" font-size="12" class="m mono">lag 42 ms</text>
+  <line x1="348" y1="126" x2="348" y2="144" stroke="#2E3648"/>
+  <text x="360" y="140" font-size="12" class="m mono">tick 50 · 240+61 bars</text>
+  <text x="1010" y="140" font-size="12" class="m mono">24,183 trades</text>
+  <line x1="1128" y1="126" x2="1128" y2="144" stroke="#2E3648"/>
+  <text x="1140" y="140" font-size="12" class="m mono">60 fps · 6.1 ms</text>
+  <line x1="1268" y1="126" x2="1268" y2="144" stroke="#2E3648"/>
+  <text x="1280" y="140" font-size="12" class="m">UTC−03:00 ▾</text>
+
+  <!-- ======== WARNING ======== -->
+  <text x="40" y="200" class="cap">DEGRADED — the reading that breached its threshold turns warn-red; nothing else changes</text>
+  <rect x="40" y="210" width="1360" height="30" rx="4" fill="#171B26" stroke="#2E3648"/>
+  <circle cx="62" cy="225" r="4" fill="#26A69A"/>
+  <text x="76" y="230" font-size="12" class="t">live · MetaTrader 5 · WINQ26</text>
+  <line x1="270" y1="216" x2="270" y2="234" stroke="#2E3648"/>
+  <text x="282" y="230" font-size="12" font-weight="600" class="mono" fill="#FF6347">lag 3,208 ms</text>
+  <line x1="400" y1="216" x2="400" y2="234" stroke="#2E3648"/>
+  <text x="412" y="230" font-size="12" class="m mono">tick 50 · 240+61 bars</text>
+  <text x="1010" y="230" font-size="12" class="m mono">24,183 trades</text>
+  <line x1="1128" y1="216" x2="1128" y2="234" stroke="#2E3648"/>
+  <text x="1140" y="230" font-size="12" font-weight="600" class="mono" fill="#FF6347">31 fps · 21.4 ms</text>
+  <line x1="1268" y1="216" x2="1268" y2="234" stroke="#2E3648"/>
+  <text x="1280" y="230" font-size="12" class="m">UTC−03:00 ▾</text>
+
+  <!-- ======== REPLAY ======== -->
+  <text x="40" y="290" class="cap">REPLAY — amber thread: the transport strip appears above the status line, both marked not-live</text>
+  <!-- transport strip -->
+  <rect x="40" y="300" width="1360" height="32" rx="4" fill="#171B26" stroke="#F0B90B" stroke-opacity="0.45"/>
+  <g fill="#F0B90B">
+    <path d="M 60 309 L 60 323 L 66 316 Z"/>
+    <rect x="72" y="309" width="4" height="14"/>
+    <rect x="79" y="309" width="4" height="14"/>
+  </g>
+  <text x="98" y="321" font-size="12" class="amb" font-weight="600">WINJ26 · 2026-03-10</text>
+  <rect x="270" y="311" width="56" height="18" rx="3" fill="#232936"/>
+  <text x="280" y="324" font-size="11" class="t mono">2× ▾</text>
+  <rect x="344" y="313" width="880" height="8" rx="4" fill="#232936"/>
+  <rect x="344" y="313" width="378" height="8" rx="4" fill="#F0B90B" opacity="0.9"/>
+  <circle cx="722" cy="317" r="6" fill="#D2DAE2"/>
+  <text x="1240" y="322" font-size="11" class="mono amb">43% · 10:41:58</text>
+  <text x="1352" y="322" font-size="11" class="m">close ✕</text>
+  <!-- status line under it -->
+  <rect x="40" y="332" width="1360" height="30" rx="4" fill="#171B26" stroke="#2E3648"/>
+  <text x="56" y="352" font-size="12" class="amb">▶ replay · WINJ26</text>
+  <line x1="196" y1="338" x2="196" y2="356" stroke="#2E3648"/>
+  <text x="208" y="352" font-size="12" class="m mono">side: inferred (tick rule)</text>
+  <line x1="404" y1="338" x2="404" y2="356" stroke="#2E3648"/>
+  <text x="416" y="352" font-size="12" class="m mono">tick 50 · 512 bars</text>
+  <text x="1010" y="352" font-size="12" class="m mono">88,412 trades</text>
+  <line x1="1128" y1="338" x2="1128" y2="356" stroke="#2E3648"/>
+  <text x="1140" y="352" font-size="12" class="m mono">60 fps · 5.8 ms</text>
+  <line x1="1268" y1="338" x2="1268" y2="356" stroke="#2E3648"/>
+  <text x="1280" y="352" font-size="12" class="m">UTC−03:00 ▾</text>
+
+  <!-- ======== anatomy ======== -->
+  <g font-size="12">
+    <text x="40" y="430" font-size="16" font-weight="600" class="t">Anatomy</text>
+    <text x="40" y="458" class="t" font-weight="600">left — provenance:</text>
+    <text x="196" y="458" class="m">where the data comes from and how healthy the pipe is: state dot (green live · amber replay · red stalled), venue, symbol, lag.</text>
+    <text x="40" y="482" class="t" font-weight="600">middle — content:</text>
+    <text x="196" y="482" class="m">what the chart is made of: bar spec, bar counts, and honesty labels such as “side: inferred (tick rule)” for feeds without true aggressor sides.</text>
+    <text x="40" y="506" class="t" font-weight="600">right — machinery:</text>
+    <text x="196" y="506" class="m">trades ingested, fps and frame time (the old perf overlay), timezone picker — the bar's only control, kept at the far edge.</text>
+    <text x="40" y="540" class="t">Recompute progress (indicators) borrows the middle section: “computing zigzag.pine · 62%” with a thin progress underline, then yields it back.</text>
+    <text x="40" y="568" class="amb">Amber is reserved: it may only mark data that is not live ground truth — replay, backfill boundary, inferred sides, stale scripts. Never decoration.</text>
+  </g>
+</svg>

--- a/docs/ux/ui-design-model.md
+++ b/docs/ux/ui-design-model.md
@@ -1,0 +1,359 @@
+# quantick UI Design Model
+
+Status: **proposed model, not yet implemented**
+Scope: the desktop app's chrome — where buttons, menus, icons, panels and tools
+live today, and where they will live as the app grows into indicators, drawing
+tools and beyond. This document is the reference for every future UI change:
+a new feature first finds its home here, then gets built.
+
+The companion images in [`img/`](img/) are part of the spec, not decoration.
+Everything in `CLAUDE.md` applies unchanged; this model adds UI placement rules
+on top of it.
+
+---
+
+## 1. Why now
+
+The app's UI grew feature by feature: each capability added one more control to
+a single toolbar row, one more side panel, or one more floating box painted
+over the candles. That was the right cost/benefit while the app was proving
+its engine. Two upcoming features break the pattern:
+
+- **Indicators** (`docs/indicator-system-plan.md`) need a manager panel,
+  per-indicator settings, overlay legends, sub-panes and error surfaces.
+- **Drawing tools** need an exclusive-selection tool palette and object
+  editing conventions.
+
+Bolted onto the current chrome, each would add checkboxes to an already
+overloaded row and panels to an already crowded left edge. The model below
+reorganizes the shell **once**, so that everything after it docks into a
+reserved zone instead of inventing a new surface.
+
+## 2. Today's UI — audit
+
+![Today's UI, annotated](img/01-current-audit.svg)
+
+Inventory, from code:
+
+| Surface | Kind | Code |
+|---|---|---|
+| Menu bar (`File`, `Help`) | top panel | `app.rs::draw_menu_bar` |
+| Controls row (feed, symbol, bar type + param, history paging, candle style button, heatmap toggle + L2 panel button, bubbles toggle + panel button, perf toggle) | top panel, one wrapped row | `app.rs::draw_controls` |
+| L2 heatmap settings | **left** side panel | `orderflow_view.rs::draw_l2_panel` |
+| Aggression bubbles settings | **left** side panel | `orderflow_view.rs::draw_bubbles_panel` |
+| Candle style editor | floating window | `candle_view.rs::draw_style_window` |
+| Market Replay browser | floating window (Ctrl+R) | `replay_view.rs::draw_browser` |
+| Replay transport | bottom panel (while replaying) | `replay_view.rs::draw_transport` |
+| Timezone picker | floating area, pinned bottom-right | `app.rs::draw_timezone_selector` |
+| Header line (symbol · spec · bar counts · mode) | text painted on chart | `app.rs::draw_header` |
+| Perf overlay (fps, frame ms, lag, trades) | box painted on chart | `app.rs::draw_overlay` |
+| History loader | spinner painted on chart | `app.rs::draw_history_loader` |
+| Backfill/live divider | amber line on chart | `app.rs::draw_backfill_divider` |
+
+Findings (numbered in the image):
+
+1. **The row answers six unrelated questions.** Source, bar spec, history,
+   appearance, layers and diagnostics share one `horizontal_wrapped` row. It
+   wraps unpredictably and grows linearly with features.
+2. **Panels multiply leftward.** Every settings panel is its own
+   `SidePanel::left`; two open at once cost the chart ~400 px.
+3. **Four surface conventions coexist.** Docked panels, floating windows, a
+   pinned area and painted overlays — with no rule for which a new feature
+   should pick.
+4. **No icon system.** Three ad-hoc emoji glyphs (`⟲`, `🎨`, `📈`) with no
+   shared geometry or states.
+5. **Status is scattered across four corners** of the canvas, occluding
+   candles — there is no single line to glance at.
+6. **Nothing is reserved for what is coming.** Indicators, drawings and
+   alerts have no zone; each would extend findings 1–5.
+7. **The transport is an island** with its own bottom-panel conventions.
+
+What today's UI gets **right**, and the model keeps:
+
+- Affordances gate on `FeedCapabilities`, never on provider names.
+- Amber consistently marks "not live" (backfill divider, replay).
+- Data text is monospace; chrome text is proportional.
+- The chart owns almost the whole window; chrome is thin.
+
+## 3. Principles
+
+1. **The chart buys every pixel.** Fixed chrome has a budget (§5); any new
+   chrome must fit an existing zone or displace something inside it.
+2. **Group by question, not by feature.** *What am I looking at?* (source,
+   bars) · *what is drawn on it?* (layers) · *how do I act on it?* (tools) ·
+   *how healthy is it?* (status). A feature splits across groups rather than
+   forming its own cluster.
+3. **The amber thread.** `#F0B90B` is reserved for provenance honesty: replay,
+   backfill boundary, inferred data, stale scripts. It is never decoration.
+   This is the UI expression of the project's data-honesty rule — and the one
+   deliberate visual signature of the app.
+4. **Disabled ≠ hidden.** A capability the venue lacks renders at 40% opacity
+   and explains itself on hover. Only a mode change (replay) may swap chrome.
+5. **Docked is persistent, floating is transient.** Anything a trader keeps
+   open while trading docks (settings, managers). Anything opened, used and
+   closed floats (browsers, pickers, error details).
+
+## 4. Design tokens
+
+Palette — extracted from `app.rs` / `style.rs`, now named:
+
+| Token | Value | Role |
+|---|---|---|
+| `bg/canvas` | `#131722` | chart canvas (user-configurable) |
+| `bg/chrome` | `#171B26` | menu, toolbar, dock, status bar |
+| `bg/inset` | `#10141D` | sub-panes, wells |
+| `bg/control` | `#232936` | buttons, combos, inputs (also grid lines) |
+| `border` | `#2E3648` | panel and control borders |
+| `text/primary` | `#D2DAE2` | labels, values (today's `OVERLAY`) |
+| `text/muted` | `#96A0AF` | secondary labels (today's `MUTED`) |
+| `text/faint` | `#6E7887` | hints, disabled (today's `CROSSHAIR`) |
+| `buy` | `#26A69A` | bull candles, buy flow, healthy/live dot |
+| `sell` | `#EF5350` | bear candles, sell flow |
+| `accent/overlay` | `#8AB4F8` | indicator overlay default (first plot) |
+| `honest/amber` | `#F0B90B` | not-live provenance only (§3.3) |
+| `warn` | `#FF6347` | threshold breaches, script errors |
+| `tag/bg` | `#373F50` | tooltips, axis price tag |
+
+Type:
+
+- **Data is monospace** (`Consolas`/platform mono): prices, counts, times,
+  lag, speeds. Sizes 10–12 px.
+- **Chrome is proportional** (egui default): labels, menus, buttons. Sizes
+  11–13 px.
+- No third family; weight (400/600) is the only emphasis tool.
+
+Icons (§6–§7 use them):
+
+- 16 px glyph on a 28×28 px hit target (rail: 20 px on 30×30).
+- Stroke 1.5 px, outline style; **filled/tinted = active**, outline = idle.
+- States: idle `text/muted` → hover `text/primary` on `border` fill → active
+  glyph in layer accent on 22% tint → disabled 40% opacity + hover
+  explanation.
+- Source: a vetted icon font (e.g. Phosphor via `egui-phosphor`) or in-house
+  tessellated set — **no more ad-hoc emoji in chrome**. Emoji remain fine
+  inside free text (menus, tooltips).
+
+## 5. The shell — nine zones
+
+![Zone model](img/02-shell-zones.svg)
+
+| # | Zone | Size | Owns |
+|---|---|---|---|
+| 1 | Menu bar | 28 px | rare actions, discoverability, shortcuts (§10) |
+| 2 | Context toolbar | 44 px | source · bars · history · layers · look · panels (§6) |
+| 3 | Tool rail | 44 px | chart-acting tools: cursor, crosshair, drawings (§7) |
+| 4 | Chart canvas | elastic | candles, flow layers, overlay legends, drawings |
+| 5 | Sub-panes | ≤ 40% of 4, max 3 | pane indicators: CVD, delta… (§9) |
+| 6 | Time axis | 24 px | time labels, x-zoom drag |
+| 7 | Status bar | 28 px (+30 transport) | provenance · content · machinery (§8) |
+| 8 | Dock | 280–360 px, collapsible to 36 | tabbed settings panels (§7) |
+| 9 | Price axis | 64 px | price labels, y-zoom drag |
+
+Vertical chrome while live: 28+44+24+28 = **124 px** — 4 px more than today's
+120 px (menu 26 + controls 36 + time 22 + header/overlays ≈ 36 painted over
+candles). In exchange, nothing is painted over the candles anymore except the
+legend and honest markers.
+
+**The rule that keeps this stable:** a new feature must claim a slot inside
+zones 1–9. If it genuinely cannot, the shell — not the feature — is what gets
+redesigned, in this document first.
+
+## 6. Toolbar
+
+![Toolbar model](img/03-toolbar-model.svg)
+
+Left, *what am I looking at*:
+
+- **SOURCE** — feed combo, symbol combo (from config, as today). During
+  replay the group is replaced by the amber session label; you cannot pick a
+  venue without closing the recording first (existing behaviour, kept).
+- **BARS** — bar-kind combo + its one parameter drag (as today).
+- **HISTORY** — one `+ older ▾` split button; the page size moves into its
+  menu. Gated by the `history_paging` capability.
+
+Right, *what is drawn on it*:
+
+- **LAYERS** — one icon toggle per visual layer: heatmap, bubbles,
+  indicators (future). Left-click toggles the layer; a small caret (or
+  right-click) opens the layer's dock tab. **Adding a layer adds one icon**,
+  not a checkbox + button pair as today.
+- **LOOK** — opens the appearance dialog (candles, canvas, grid).
+- **PANELS** — shows/hides the dock.
+- **⋯ overflow** — collapse target; the toolbar never wraps. Collapse order:
+  LOOK → PANELS → HISTORY → bar parameter merges into the kind combo → feed
+  name shrinks to its initial. Never folded: the symbol and LAYERS.
+
+Leaving the toolbar: the perf checkbox (a *reading*, moves to the status
+bar §8) and both panel-opening buttons (the dock's tab strip replaces them).
+
+## 7. Tool rail and dock
+
+![Tool rail and dock](img/04-tool-rail-dock.svg)
+
+**Tool rail (left, 44 px).** Exclusive selection; exactly one tool armed;
+`Esc` always returns to Pointer. Ships now with Pointer and Crosshair —
+2 slots that already earn their place — and gives drawing tools their
+permanent home the day they land:
+
+| Tool | Key | Notes |
+|---|---|---|
+| Pointer | `Esc`/`1` | pan/zoom/select — today's default interaction |
+| Crosshair | `2` | today's hover crosshair becomes a mode |
+| Trend line | `T` | two anchors, **bar-index coordinates** (Pine-compatible) |
+| Horizontal level | `H` | one price, extends both ways |
+| Zone (rectangle) | `R` | supply/demand boxes |
+| Measure | `M` | Δprice, Δbars — and Δdelta: an order-flow-native measure |
+| Note | `N` | text pinned to bar + price |
+| *(footer)* Magnet | | snap anchors to nearest bar OHLC |
+| *(footer)* Lock | | drawings ignore edits until unlocked |
+
+Footer slots are toggling *modifiers*, body slots are exclusive *tools*.
+Object deletion happens on the selected object (`Del` / context row) — no
+global "clear all" icon within reach of a slip.
+
+User drawings persist per symbol; coordinates are bar-index + price, the same
+x-model the indicator plan locks for scripts, so replay seeks and history
+prepends shift them correctly (`viewport.shift_right_edge` already models
+this).
+
+**Dock (right, 280–360 px).** One tabbed panel replaces today's stack of
+left `SidePanel`s: tabs **L2**, **Bubbles**, **Indicators**, **Session**.
+Tab strip (36 px) stays visible when collapsed. Rules:
+
+- A layer's *toggle* lives in the toolbar; its *settings* live in its tab.
+  Opening a tab never toggles the layer — looking is not enabling.
+- One tab open at a time; the chart pays the dock width once, not per panel.
+- Width draggable, remembered per tab.
+- Panel contents migrate as-is (palette, grouping, intensity…); only their
+  home changes.
+- Floating windows remain for transient tasks only: session browser (from
+  the Session tab / Ctrl+R), appearance dialog, script error details.
+
+Why right, when today's panels are left: the rail claims the left edge
+(tools want to be near the pointer's resting side), settings are read-mostly,
+and the dock sits beyond the price axis where the eye rarely travels
+mid-trade.
+
+## 8. Status bar and transport
+
+![Status bar](img/06-status-bar.svg)
+
+One 28 px line, three sections, replacing the perf overlay, the floating
+timezone pill and the mode text painted over candles:
+
+- **Left — provenance:** state dot (green live · amber replay · red stalled),
+  venue, symbol, feed lag.
+- **Middle — content:** bar spec, bar counts (`240+61 bars` keeps today's
+  backfilled+live split), honesty labels such as `side: inferred (tick rule)`
+  for feeds without true aggressor sides (the MT5/B3 case). Indicator
+  recompute progress borrows this section, then yields it back.
+- **Right — machinery:** trades ingested, fps + frame time, timezone picker
+  (the bar's only control, kept at the far edge).
+
+A reading that breaches its threshold turns `warn` — the layout never moves.
+While a recording plays, the **transport strip** (30 px) appears directly
+above the status line: play/pause, speed, seek bar, session label, close —
+all amber-marked. The transport is thus part of the status system, not an
+island.
+
+The chart canvas keeps only: overlay legend (§9), the amber backfill divider,
+the history-loading spinner, and the L2 connection badge — things that mark
+*positions or data on the chart itself*.
+
+## 9. Indicator surfaces
+
+![Indicators](img/05-indicators-panes.svg)
+
+Where the indicator plan (`docs/indicator-system-plan.md` §4) meets the
+shell:
+
+- **Legend (chart overlay, top-left)** — one row per active indicator:
+  colour dot, short title, last value; eye / gear / remove appear on hover.
+  Red row = script error (file:line + code, click for details); amber row =
+  `stale — edit has errors` (last good version still running). The legend is
+  the *fast path*; the full manager is the **Indicators dock tab** (add,
+  reorder, library browser, input settings generated from `InputSpec`).
+- **Sub-panes** — pane indicators stack between chart and time axis: own
+  auto-fit y-scale, shared x-axis, shared crosshair. Max 3; draggable
+  dividers; a pane collapses to its header. Pane headers carry name + live
+  value + collapse chevron.
+- **Honest gaps** — warmup NaN renders as a gap in the plot, never a
+  fabricated value. This is a rendering *rule*, stated here so no future
+  "fix" interpolates it away.
+- **Insert menu** — `Insert → Indicator…` (opens the dock tab),
+  `Insert → EMA / CVD / …` for natives. Drawing tools also list under
+  `Insert` with their shortcuts, mirroring the rail.
+- **Paint order** (extends the contract in `candle_view.rs`): heatmap →
+  grid → script draw-objects → candles → overlay plots → user drawings →
+  bubbles → legend/badges. Scripts draw under user drawings; both under
+  bubbles — execution evidence always wins.
+
+## 10. Menus and shortcuts
+
+Menus stay shallow; they exist for discoverability and shortcuts, never as
+the only path:
+
+- **File** — Market Replay… (`Ctrl+R`), Close Replay, Exit.
+- **View** — dock show/hide (`Ctrl+B`), each dock tab, sub-pane
+  collapse-all, perf readings on/off, timezone.
+- **Insert** — indicators (natives + library), drawing tools (§9).
+- **Tools** — appearance dialog, future: script library folder, alerts.
+- **Help** — replay file format…, future: Pine dialect reference,
+  shortcut list.
+
+Shortcut map (reserved now so nothing collides later):
+`Esc/1` pointer · `2` crosshair · `T/H/R/M/N` drawing tools · `Del` delete
+selected drawing · `Ctrl+R` replay browser · `Ctrl+B` dock · `Space`
+play/pause while replaying · `+`/`−` replay speed. Single letters stay free
+of modifiers (no text inputs live on the chart).
+
+## 11. Growth map
+
+Where future features land — decided now, so they never claim new chrome:
+
+| Future feature | Toggle/entry | Settings | Canvas presence | Status |
+|---|---|---|---|---|
+| Indicators (M1–M5) | LAYERS icon + Insert menu | dock tab Indicators | legend rows, overlays, sub-panes | recompute progress |
+| Drawing tools | tool rail + Insert menu | selected-object popover | drawings layer | object count (View) |
+| Alerts | on indicator/level context | dock tab Alerts | triggered marker on bar | armed count + last fired |
+| Bot / strategy monitor | LAYERS icon | dock tab | order/position markers | connection + P&L cell |
+| Second chart / layouts | File → Layout | — | split canvas (zones 4–6 duplicate per chart; zones 1–3, 7–9 stay singular) | per-chart provenance |
+| Watchlist | — | dock tab | — | — |
+
+## 12. Migration plan
+
+Each phase is one small PR, passing the four checks, shippable alone, no
+engine changes anywhere. Suggested order — cheapest confidence first:
+
+1. **Status bar** (`app/src/statusbar.rs`) — move perf readings, timezone,
+   mode/counts line off the canvas; delete `draw_overlay`,
+   `draw_timezone_selector`, and the header's status half. Transport strip
+   restyles into it (`replay_view.rs` keeps ownership).
+2. **Toolbar regroup** (`app/src/toolbar.rs`) — extract `draw_controls`,
+   regroup per §6 with the overflow rule; history becomes a split button.
+   No behaviour change, only placement; capability gating untouched.
+3. **Icon set** — adopt the icon font/set, replace emoji glyphs, implement
+   the four button states as a small widget helper (`app/src/widgets.rs`).
+4. **Dock** (`app/src/dock.rs`) — tabbed right dock; migrate L2 + bubbles
+   panel bodies unchanged; retire the two `SidePanel::left`s; Session tab
+   hosts the replay browser entry.
+5. **Tool rail skeleton** (`app/src/toolrail.rs`) — Pointer + Crosshair as
+   real modes with the exclusive-selection + `Esc` grammar, reserving the
+   geometry drawing tools will fill.
+6. **Indicator surfaces** — land with indicator milestones M1/M4 (worker,
+   legend, panes, dock tab), already knowing their home.
+
+Phases 1–3 are pure relocation and can precede indicator M1; phase 4 should
+land before the Indicators tab is needed; phase 5 anytime; phase 6 rides the
+indicator plan.
+
+## 13. Open questions
+
+- **Persistence of chrome state** (dock width, active tab, rail tool,
+  sub-pane heights): piggyback on the indicator plan's
+  `indicators-state.toml` or a sibling `ui-state.toml`. Decide at phase 4.
+- **Multi-chart** (§11) doubles zones 4–6 per chart; the model supports it,
+  but splitter behaviour and per-chart toolbars are deliberately unspecified
+  until a real need exists.
+- **Themes**: tokens (§4) make a light theme *possible*; it is a non-goal
+  until someone asks for one.


### PR DESCRIPTION
## What

A professional UI design model for the app's chrome, in `docs/ux/`: one reference document plus six SVG spec images. Docs only — no code changes.

- `ui-design-model.md` — audit of today's UI (from code), design principles, named design tokens, the nine-zone shell model, toolbar/tool-rail/dock/status-bar specs, indicator surfaces, menu + shortcut map, growth map and a six-phase migration plan.
- `img/01-current-audit.svg` — today's UI annotated with 7 findings
- `img/02-shell-zones.svg` — the proposed nine-zone shell (master diagram)
- `img/03-toolbar-model.svg` — toolbar groups, icon states, width discipline, replay mode
- `img/04-tool-rail-dock.svg` — left drawing-tool rail + right tabbed dock
- `img/05-indicators-panes.svg` — legend, sub-panes, honest NaN gaps, error states
- `img/06-status-bar.svg` — live / degraded / replay states, transport strip

## Why

Indicators (`docs/indicator-system-plan.md`) and drawing tools are coming. Bolted onto today's chrome they would each add more checkboxes to an overloaded toolbar row and more stacking side panels. This model reorganizes the shell once, on paper, so every future feature docks into a reserved zone.

Note: the doc mentions `docs/indicator-system-plan.md`, which is not committed yet (it exists locally as the approved indicator plan). The mention is inline text, not a hyperlink, so nothing renders broken; the name is the plan's canonical future path.

## Verification

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo build --workspace`
- [x] `cargo test --workspace`
- [x] arch-review: clean, zero findings (docs-only, zero existing files touched; code references and colour tokens verified against `app.rs`/`style.rs`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)