### PR TITLE
feat(app): 3D sphere render mode for aggression bubbles

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -36,6 +36,9 @@ cluster_ms = 200          # merge compatible prints inside this window
 
 [presets.bubbles]         # everything visual; every key is optional
 max_radius = 15.0
+render_mode = "sphere"    # "flat" (classic disc) or "sphere" (shaded 3D ball);
+sphere_shading = 0.6      # spheres keep overlapping prints readable as separate
+sphere_highlight = 0.4    # bubbles on a dense tape
 side_offset = 3.5         # buys nudged up, sells down, so both sides are readable
 front_width = 3.0         # the vertical consumption mark ("risco")
 trail_length = 18.0       # the glow into the consumed side ("rastro")

--- a/config/bubbles.toml
+++ b/config/bubbles.toml
@@ -114,6 +114,38 @@ label_min_radius = 16.0
 front_color = [255, 246, 205]
 trail_color = [255, 190, 90]
 
+# Bookmap-style shaded spheres. The darkened rim on every bubble keeps
+# overlapping prints readable as separate bubbles on a dense tape, so the
+# detail floor is low: even small prints get the shading.
+[[presets]]
+name = "3d spheres"
+cluster_ms = 200
+
+[presets.bubbles]
+min_radius = 2.0
+max_radius = 16.0
+opacity = 0.85
+outline_width = 1.0
+halo_strength = 0.05
+detail_min_radius = 2.0
+render_mode = "sphere"
+sphere_shading = 0.6
+sphere_highlight = 0.4
+size_reference = "visible_p99"
+size_reference_quantity = 100.0
+min_quantity = 0.0
+side_offset = 3.5
+show_consumption_front = true
+front_width = 3.0
+front_length_scale = 2.1
+show_impact_ring = true
+impact_ring_width = 2.2
+trail_length = 18.0
+trail_opacity = 0.62
+show_quantity_labels = true
+show_trade_count = true
+label_min_radius = 16.0
+
 [[presets]]
 name = "dense tape btc"
 cluster_ms = 500

--- a/crates/app/config/bubbles.toml
+++ b/crates/app/config/bubbles.toml
@@ -99,6 +99,38 @@ show_quantity_labels = true
 show_trade_count = true
 label_min_radius = 14.0
 
+# Bookmap-style shaded spheres. The darkened rim on every bubble keeps
+# overlapping prints readable as separate bubbles on a dense tape, so the
+# detail floor is low: even small prints get the shading.
+[[presets]]
+name = "3d spheres"
+cluster_ms = 200
+
+[presets.bubbles]
+min_radius = 2.0
+max_radius = 16.0
+opacity = 0.85
+outline_width = 1.0
+halo_strength = 0.05
+detail_min_radius = 2.0
+render_mode = "sphere"
+sphere_shading = 0.6
+sphere_highlight = 0.4
+size_reference = "visible_p99"
+size_reference_quantity = 100.0
+min_quantity = 0.0
+side_offset = 3.5
+show_consumption_front = true
+front_width = 3.0
+front_length_scale = 2.1
+show_impact_ring = true
+impact_ring_width = 2.2
+trail_length = 18.0
+trail_opacity = 0.62
+show_quantity_labels = true
+show_trade_count = true
+label_min_radius = 16.0
+
 # For studying who is eating whom: the bubble shrinks and the consumption mark
 # takes over — a wide, bright front and a long trail into the consumed side.
 [[presets]]

--- a/crates/app/src/orderflow/config.rs
+++ b/crates/app/src/orderflow/config.rs
@@ -43,6 +43,10 @@ pub const MIN_BUBBLE_MAX_RADIUS: f32 = 4.0;
 pub const MAX_BUBBLE_MAX_RADIUS: f32 = 48.0;
 /// Largest accepted radius for the smallest drawn bubble.
 pub const MAX_BUBBLE_MIN_RADIUS: f32 = 12.0;
+/// Default edge darkening of a sphere-rendered bubble.
+pub const DEFAULT_SPHERE_SHADING: f32 = 0.55;
+/// Default highlight strength of a sphere-rendered bubble.
+pub const DEFAULT_SPHERE_HIGHLIGHT: f32 = 0.35;
 
 /// Renderer-only price grouping layered over the exact capture buckets.
 ///
@@ -136,6 +140,23 @@ pub enum BubbleSizeReference {
     Fixed,
 }
 
+/// How a bubble's fill is painted.
+///
+/// `Flat` is the classic solid disc. `Sphere` shades each bubble like a ball
+/// lit from the upper left — an offset highlight over a darkened rim — so
+/// overlapping prints on a dense tape keep a visible boundary instead of
+/// merging into one solid blob. Purely visual: geometry, clustering and
+/// liquidity association are identical in both modes.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BubbleRenderMode {
+    /// Solid 2D disc.
+    #[default]
+    Flat,
+    /// Shaded 3D-looking sphere.
+    Sphere,
+}
+
 /// Decimal places kept when a bubble float is written to the presets file.
 ///
 /// Four is past the precision any pixel radius or alpha carries, and well
@@ -190,6 +211,15 @@ pub struct BubbleStyle {
     /// impact ring). Raising it trades detail for frame time on a fast tape.
     #[serde(serialize_with = "serialize_short_f32")]
     pub detail_min_radius: f32,
+    /// Whether the fill is a flat disc or a shaded sphere.
+    pub render_mode: BubbleRenderMode,
+    /// How much a sphere-rendered bubble darkens toward its rim. Zero shades
+    /// nothing (the fill reads flat again); one pushes the rim to black.
+    #[serde(serialize_with = "serialize_short_f32")]
+    pub sphere_shading: f32,
+    /// Strength of the off-center light spot on a sphere-rendered bubble.
+    #[serde(serialize_with = "serialize_short_f32")]
+    pub sphere_highlight: f32,
     /// How the full-size reference quantity is chosen.
     pub size_reference: BubbleSizeReference,
     /// Quantity mapped to [`max_radius`](Self::max_radius) when the reference
@@ -265,6 +295,10 @@ impl Default for BubbleStyle {
             outline_width: 1.0,
             halo_strength: 0.12,
             detail_min_radius: 4.0,
+            // Flat, so merely gaining the sphere option changes no pixels.
+            render_mode: BubbleRenderMode::Flat,
+            sphere_shading: DEFAULT_SPHERE_SHADING,
+            sphere_highlight: DEFAULT_SPHERE_HIGHLIGHT,
             size_reference: BubbleSizeReference::VisibleP99,
             size_reference_quantity: 100.0,
             min_quantity: 0.0,
@@ -303,6 +337,9 @@ impl BubbleStyle {
         self.outline_width = finite_clamp(self.outline_width, 0.0, 6.0, 1.0);
         self.halo_strength = finite_clamp(self.halo_strength, 0.0, 1.0, 0.12);
         self.detail_min_radius = finite_clamp(self.detail_min_radius, 0.0, 32.0, 4.0);
+        self.sphere_shading = finite_clamp(self.sphere_shading, 0.0, 1.0, DEFAULT_SPHERE_SHADING);
+        self.sphere_highlight =
+            finite_clamp(self.sphere_highlight, 0.0, 1.0, DEFAULT_SPHERE_HIGHLIGHT);
         if !self.size_reference_quantity.is_finite() || self.size_reference_quantity <= 0.0 {
             self.size_reference_quantity = 100.0;
         }
@@ -647,6 +684,36 @@ mod tests {
         assert_eq!(bubbles.size_reference, BubbleSizeReference::VisibleP99);
         assert_eq!(bubbles.min_quantity, 0.0, "nothing is hidden by default");
         assert_eq!(bubbles.min_quantity_decimal(), None);
+        assert_eq!(
+            bubbles.render_mode,
+            BubbleRenderMode::Flat,
+            "gaining the sphere option must not change existing charts"
+        );
+        assert!((0.0..=1.0).contains(&bubbles.sphere_shading));
+        assert!((0.0..=1.0).contains(&bubbles.sphere_highlight));
+    }
+
+    #[test]
+    fn sphere_fields_sanitize_and_round_trip_through_toml() {
+        let mut style = BubbleStyle {
+            render_mode: BubbleRenderMode::Sphere,
+            sphere_shading: f32::NAN,
+            sphere_highlight: 7.0,
+            ..BubbleStyle::default()
+        };
+        style.sanitize();
+        assert_eq!(style.render_mode, BubbleRenderMode::Sphere);
+        assert_eq!(style.sphere_shading, DEFAULT_SPHERE_SHADING);
+        assert_eq!(style.sphere_highlight, 1.0);
+
+        let text = toml::to_string(&style).expect("serialize");
+        assert!(text.contains("render_mode = \"sphere\""));
+        let parsed: BubbleStyle = toml::from_str(&text).expect("parse");
+        assert_eq!(parsed, style);
+
+        // A presets file written before the mode existed keeps rendering flat.
+        let old: BubbleStyle = toml::from_str("max_radius = 30.0").expect("parse old file");
+        assert_eq!(old.render_mode, BubbleRenderMode::Flat);
     }
 
     #[test]

--- a/crates/app/src/orderflow/mod.rs
+++ b/crates/app/src/orderflow/mod.rs
@@ -16,8 +16,9 @@ pub mod timeline;
 // the public DTOs here gives later renderers one stable import surface.
 #[allow(unused_imports)]
 pub use config::{
-    BubbleSizeReference, BubbleStyle, DisplayGrouping, HeatmapConfig, HeatmapTheme, IntensityMode,
-    MAX_BUBBLE_MAX_RADIUS, MAX_BUBBLE_MIN_RADIUS, MIN_BUBBLE_MAX_RADIUS,
+    BubbleRenderMode, BubbleSizeReference, BubbleStyle, DisplayGrouping, HeatmapConfig,
+    HeatmapTheme, IntensityMode, MAX_BUBBLE_MAX_RADIUS, MAX_BUBBLE_MIN_RADIUS,
+    MIN_BUBBLE_MAX_RADIUS,
 };
 #[allow(unused_imports)]
 pub use grouping::{

--- a/crates/app/src/orderflow_render.rs
+++ b/crates/app/src/orderflow_render.rs
@@ -234,11 +234,20 @@ const SPHERE_LIGHT_OFFSET: f32 = 0.35;
 /// it and side colour → darkened rim outside it; that gradient is the whole
 /// shading model.
 const SPHERE_CORE_RADIUS: f32 = 0.62;
-/// Tessellation bounds for a sphere-shaded bubble, scaled with the radius so
-/// a small dressed bubble stays cheap and a full-size sweep stays round.
+/// Ring segments per pixel of radius on a sphere-shaded bubble, bounded by
+/// [`SPHERE_MIN_SEGMENTS`] and [`SPHERE_MAX_SEGMENTS`]: a small dressed
+/// bubble stays cheap, a full-size sweep stays round.
+const SPHERE_SEGMENTS_PER_RADIUS_PX: f32 = 2.0;
+/// See [`SPHERE_SEGMENTS_PER_RADIUS_PX`].
 const SPHERE_MIN_SEGMENTS: usize = 12;
-/// See [`SPHERE_MIN_SEGMENTS`].
+/// See [`SPHERE_SEGMENTS_PER_RADIUS_PX`].
 const SPHERE_MAX_SEGMENTS: usize = 32;
+
+/// Tessellation of a sphere-shaded bubble of this radius.
+fn sphere_segments(radius: f32) -> usize {
+    ((radius * SPHERE_SEGMENTS_PER_RADIUS_PX) as usize)
+        .clamp(SPHERE_MIN_SEGMENTS, SPHERE_MAX_SEGMENTS)
+}
 
 /// Label font size as a fraction of the bubble radius, and the range it is
 /// held to: too small to read is pointless, too large stops fitting inside.
@@ -336,18 +345,17 @@ fn add_sphere_disc(
     if !radius.is_finite() || radius <= 0.0 || !center.is_finite() {
         return;
     }
-    let segments = ((radius * 2.0) as usize).clamp(SPHERE_MIN_SEGMENTS, SPHERE_MAX_SEGMENTS);
+    let segments = sphere_segments(radius);
     let offset = egui::vec2(-radius, -radius) * SPHERE_LIGHT_OFFSET;
     // The core ring keeps a scaled-down share of the highlight offset, which
     // holds the whole lit zone inside the rim at any radius.
     let core_center = center + offset * (1.0 - SPHERE_CORE_RADIUS);
     let base = mesh.vertices.len() as u32;
     mesh.colored_vertex(center + offset, core);
-    for ring in [
+    for (ring_center, ring_radius, color) in [
         (core_center, radius * SPHERE_CORE_RADIUS, body),
         (center, radius, edge),
     ] {
-        let (ring_center, ring_radius, color) = ring;
         for index in 0..segments {
             let angle = index as f32 / segments as f32 * std::f32::consts::TAU;
             let direction = egui::vec2(angle.cos(), angle.sin());
@@ -2354,7 +2362,7 @@ mod tests {
             egui::Color32::GRAY,
             egui::Color32::BLACK,
         );
-        let segments = ((radius * 2.0) as usize).clamp(SPHERE_MIN_SEGMENTS, SPHERE_MAX_SEGMENTS);
+        let segments = sphere_segments(radius);
         assert_eq!(mesh.vertices.len(), 1 + 2 * segments);
         assert_eq!(mesh.indices.len(), segments * 9);
         for vertex in &mesh.vertices {

--- a/crates/app/src/orderflow_render.rs
+++ b/crates/app/src/orderflow_render.rs
@@ -13,8 +13,8 @@ use rust_decimal::Decimal;
 use rust_decimal::prelude::ToPrimitive as _;
 
 use crate::orderflow::{
-    AggressionPrimitive, BubbleStyle, HeatmapConfig, HeatmapProjection, HeatmapTheme,
-    LiquidityEvidence,
+    AggressionPrimitive, BubbleRenderMode, BubbleStyle, HeatmapConfig, HeatmapProjection,
+    HeatmapTheme, LiquidityEvidence,
 };
 use crate::viewport::Viewport;
 
@@ -225,6 +225,21 @@ const IMPACT_RING_MATCH_ALPHA: f32 = 0.25;
 /// still ate something, so it still leaves a visible mark.
 const MIN_MATCH_STRENGTH: f32 = 0.25;
 
+/// Fraction of the radius the sphere's lit core is offset toward the upper
+/// left. One fixed light direction keeps every bubble shaded identically, so
+/// the eye reads the gradient as volume instead of as data.
+const SPHERE_LIGHT_OFFSET: f32 = 0.35;
+/// Radius of the sphere's full-brightness core ring, as a fraction of the
+/// bubble radius. Vertex colours interpolate highlight → side colour inside
+/// it and side colour → darkened rim outside it; that gradient is the whole
+/// shading model.
+const SPHERE_CORE_RADIUS: f32 = 0.62;
+/// Tessellation bounds for a sphere-shaded bubble, scaled with the radius so
+/// a small dressed bubble stays cheap and a full-size sweep stays round.
+const SPHERE_MIN_SEGMENTS: usize = 12;
+/// See [`SPHERE_MIN_SEGMENTS`].
+const SPHERE_MAX_SEGMENTS: usize = 32;
+
 /// Label font size as a fraction of the bubble radius, and the range it is
 /// held to: too small to read is pointless, too large stops fitting inside.
 const LABEL_FONT_SCALE: f32 = 0.68;
@@ -287,6 +302,72 @@ fn trail_rect(
     )
 }
 
+/// The side colour pushed toward white for a sphere's lit core.
+fn sphere_core_color(color: egui::Color32, highlight: f32) -> egui::Color32 {
+    opaque_rgb(mix_rgb(
+        [color.r(), color.g(), color.b()],
+        [255, 255, 255],
+        highlight,
+    ))
+}
+
+/// The side colour pushed toward black for a sphere's rim.
+fn sphere_edge_color(color: egui::Color32, shading: f32) -> egui::Color32 {
+    opaque_rgb(mix_rgb(
+        [color.r(), color.g(), color.b()],
+        [0, 0, 0],
+        shading,
+    ))
+}
+
+/// Append one sphere-shaded disc to `mesh`: a triangle fan from the offset lit
+/// core through a full-brightness ring to the darkened rim. Vertex colours do
+/// all the shading, so the 3D look costs one small mesh — no texture, no
+/// per-pixel work — and overlapping bubbles keep a visible boundary because
+/// each rim is darker than its neighbour's body.
+fn add_sphere_disc(
+    mesh: &mut egui::Mesh,
+    center: egui::Pos2,
+    radius: f32,
+    core: egui::Color32,
+    body: egui::Color32,
+    edge: egui::Color32,
+) {
+    if !radius.is_finite() || radius <= 0.0 || !center.is_finite() {
+        return;
+    }
+    let segments = ((radius * 2.0) as usize).clamp(SPHERE_MIN_SEGMENTS, SPHERE_MAX_SEGMENTS);
+    let offset = egui::vec2(-radius, -radius) * SPHERE_LIGHT_OFFSET;
+    // The core ring keeps a scaled-down share of the highlight offset, which
+    // holds the whole lit zone inside the rim at any radius.
+    let core_center = center + offset * (1.0 - SPHERE_CORE_RADIUS);
+    let base = mesh.vertices.len() as u32;
+    mesh.colored_vertex(center + offset, core);
+    for ring in [
+        (core_center, radius * SPHERE_CORE_RADIUS, body),
+        (center, radius, edge),
+    ] {
+        let (ring_center, ring_radius, color) = ring;
+        for index in 0..segments {
+            let angle = index as f32 / segments as f32 * std::f32::consts::TAU;
+            let direction = egui::vec2(angle.cos(), angle.sin());
+            mesh.colored_vertex(ring_center + direction * ring_radius, color);
+        }
+    }
+    let count = segments as u32;
+    let core_ring = base + 1;
+    let rim_ring = core_ring + count;
+    for index in 0..count {
+        let next = (index + 1) % count;
+        mesh.indices
+            .extend_from_slice(&[base, core_ring + index, core_ring + next]);
+        mesh.indices
+            .extend_from_slice(&[core_ring + index, rim_ring + index, rim_ring + next]);
+        mesh.indices
+            .extend_from_slice(&[core_ring + index, rim_ring + next, core_ring + next]);
+    }
+}
+
 /// One aggression bubble, already placed in screen space.
 #[derive(Debug, Clone, Copy)]
 struct BubbleMark {
@@ -324,10 +405,12 @@ fn draw_bubble(
     let color = colors.for_side(side);
 
     // Small prints are the common case on a busy tape: one cheap dot each.
-    // The full dressing (halo, rim, impact ring) is reserved for bubbles
-    // big enough to read it, which also keeps the per-frame tessellation
-    // budget flat no matter how fast the tape runs.
+    // The full dressing (halo, rim, impact ring — and sphere shading, which
+    // is unreadable at dot size anyway) is reserved for bubbles big enough to
+    // read it, which also keeps the per-frame tessellation budget flat no
+    // matter how fast the tape runs.
     let dressed = radius >= bubbles.detail_min_radius;
+    let sphere = dressed && bubbles.render_mode == BubbleRenderMode::Sphere;
     if dressed && bubbles.halo_strength > 0.0 {
         painter.circle_filled(
             center,
@@ -335,12 +418,32 @@ fn draw_bubble(
             color.gamma_multiply(halo_alpha(size, bubbles)),
         );
     }
-    painter.circle_filled(center, radius, color.gamma_multiply(bubbles.opacity));
+    if sphere {
+        let mut mesh = egui::Mesh::default();
+        add_sphere_disc(
+            &mut mesh,
+            center,
+            radius,
+            sphere_core_color(color, bubbles.sphere_highlight).gamma_multiply(bubbles.opacity),
+            color.gamma_multiply(bubbles.opacity),
+            sphere_edge_color(color, bubbles.sphere_shading).gamma_multiply(bubbles.opacity),
+        );
+        painter.add(egui::Shape::mesh(mesh));
+    } else {
+        painter.circle_filled(center, radius, color.gamma_multiply(bubbles.opacity));
+    }
     if dressed && bubbles.outline_width > 0.0 {
+        // A sphere's rim adopts the darkened edge colour: the dark separator
+        // is what keeps two overlapping same-side bubbles readable as two.
+        let rim = if sphere {
+            sphere_edge_color(color, bubbles.sphere_shading)
+        } else {
+            color
+        };
         painter.circle_stroke(
             center,
             radius,
-            egui::Stroke::new(bubbles.outline_width, color.gamma_multiply(RIM_ALPHA)),
+            egui::Stroke::new(bubbles.outline_width, rim.gamma_multiply(RIM_ALPHA)),
         );
     }
 
@@ -2223,6 +2326,152 @@ mod tests {
             egui::Color32::from_rgb(9, 9, 9),
             "the trail follows the front colour unless overridden itself"
         );
+    }
+
+    #[test]
+    fn sphere_colours_brighten_the_core_and_darken_the_rim() {
+        let color = egui::Color32::from_rgb(40, 200, 120);
+        let rgb = |c: egui::Color32| [c.r(), c.g(), c.b()];
+        assert!(luminance(rgb(sphere_core_color(color, 0.35))) > luminance(rgb(color)));
+        assert!(luminance(rgb(sphere_edge_color(color, 0.55))) < luminance(rgb(color)));
+        // Zero strength is the identity, so "sphere with no shading" degrades
+        // honestly into the flat colour instead of some third look.
+        assert_eq!(sphere_core_color(color, 0.0), color);
+        assert_eq!(sphere_edge_color(color, 0.0), color);
+        assert_eq!(sphere_edge_color(color, 1.0), egui::Color32::BLACK);
+    }
+
+    #[test]
+    fn a_sphere_disc_is_a_bounded_two_ring_fan() {
+        let mut mesh = egui::Mesh::default();
+        let center = egui::pos2(50.0, 50.0);
+        let radius = 10.0;
+        add_sphere_disc(
+            &mut mesh,
+            center,
+            radius,
+            egui::Color32::WHITE,
+            egui::Color32::GRAY,
+            egui::Color32::BLACK,
+        );
+        let segments = ((radius * 2.0) as usize).clamp(SPHERE_MIN_SEGMENTS, SPHERE_MAX_SEGMENTS);
+        assert_eq!(mesh.vertices.len(), 1 + 2 * segments);
+        assert_eq!(mesh.indices.len(), segments * 9);
+        for vertex in &mesh.vertices {
+            assert!(
+                (vertex.pos - center).length() <= radius + 0.001,
+                "shading must stay inside the bubble: {:?}",
+                vertex.pos
+            );
+        }
+
+        // Degenerate geometry appends nothing rather than poisoning the mesh.
+        let before = mesh.vertices.len();
+        add_sphere_disc(
+            &mut mesh,
+            egui::pos2(f32::NAN, 0.0),
+            radius,
+            egui::Color32::WHITE,
+            egui::Color32::GRAY,
+            egui::Color32::BLACK,
+        );
+        add_sphere_disc(
+            &mut mesh,
+            center,
+            0.0,
+            egui::Color32::WHITE,
+            egui::Color32::GRAY,
+            egui::Color32::BLACK,
+        );
+        assert_eq!(mesh.vertices.len(), before);
+    }
+
+    #[test]
+    fn sphere_mode_swaps_the_flat_fill_for_a_shaded_mesh() {
+        let mark = BubbleMark {
+            center: egui::pos2(120.0, 80.0),
+            radius: 12.0,
+            side: Side::Buy,
+            size: 0.8,
+            matched: None,
+        };
+        let palette = Palette::for_theme(HeatmapTheme::Bookmap);
+        let flat_style = BubbleStyle::default();
+        let sphere_style = BubbleStyle {
+            render_mode: BubbleRenderMode::Sphere,
+            ..BubbleStyle::default()
+        };
+        let colors = BubbleColors::resolve(&palette, &flat_style);
+
+        let flat = painted(|painter| draw_bubble(painter, mark, &flat_style, &colors));
+        let sphere = painted(|painter| draw_bubble(painter, mark, &sphere_style, &colors));
+        assert_ne!(flat, sphere, "the mode must change what is painted");
+        assert!(
+            sphere.contains("Mesh"),
+            "sphere mode paints a vertex-shaded mesh: {sphere}"
+        );
+
+        // Below the detail floor both modes paint the same cheap dot, keeping
+        // the tessellation budget flat on a fast tape.
+        let dot = BubbleMark {
+            radius: flat_style.detail_min_radius - 1.0,
+            ..mark
+        };
+        let flat_dot = painted(|painter| draw_bubble(painter, dot, &flat_style, &colors));
+        let sphere_dot = painted(|painter| draw_bubble(painter, dot, &sphere_style, &colors));
+        assert_eq!(flat_dot, sphere_dot);
+    }
+
+    #[test]
+    fn the_preview_draws_a_sphere_bubble_exactly_the_way_the_chart_does() {
+        // Same contract as the flat parity test: the preview must not render
+        // its own approximation of the sphere look.
+        let bubbles = BubbleStyle {
+            render_mode: BubbleRenderMode::Sphere,
+            trail_length: 0.0,
+            ..BubbleStyle::default()
+        };
+        let colors = BubbleColors::resolve(&Palette::for_theme(HeatmapTheme::Bookmap), &bubbles);
+        let at = egui::pos2(120.0, 80.0);
+        let radius = bubble_radius(
+            PREVIEW_LARGE_PRINT_SIZE,
+            bubbles.min_radius,
+            bubbles.max_radius,
+        );
+
+        let live = painted(|painter| {
+            draw_bubble(
+                painter,
+                BubbleMark {
+                    center: at + egui::vec2(0.0, side_offset_y(Side::Buy, bubbles.side_offset)),
+                    radius,
+                    side: Side::Buy,
+                    size: PREVIEW_LARGE_PRINT_SIZE,
+                    matched: Some(PREVIEW_MATCHED_FRACTION),
+                },
+                &bubbles,
+                &colors,
+            );
+        });
+        let preview = painted(|painter| {
+            draw_preview_bubble(
+                painter,
+                PreviewBubble {
+                    center: at,
+                    size: PREVIEW_LARGE_PRINT_SIZE,
+                    side: Side::Buy,
+                    linked_reduction: true,
+                },
+                f32::INFINITY,
+                &bubbles,
+                &colors,
+            );
+        });
+        assert!(
+            live.contains("Mesh"),
+            "the sample must shade a sphere: {live}"
+        );
+        assert_eq!(live, preview);
     }
 
     #[test]

--- a/crates/app/src/orderflow_view.rs
+++ b/crates/app/src/orderflow_view.rs
@@ -18,8 +18,8 @@ use rust_decimal::prelude::{FromPrimitive as _, ToPrimitive as _};
 
 use crate::bubble_presets::{self, BubblePreset, BubblePresetFile, PresetSource};
 use crate::orderflow::{
-    BubbleSizeReference, DisplayGrouping, HeatmapConfig, HeatmapTheme, IntensityMode,
-    MAX_BUBBLE_MAX_RADIUS, MAX_BUBBLE_MIN_RADIUS, MIN_BUBBLE_MAX_RADIUS,
+    BubbleRenderMode, BubbleSizeReference, DisplayGrouping, HeatmapConfig, HeatmapTheme,
+    IntensityMode, MAX_BUBBLE_MAX_RADIUS, MAX_BUBBLE_MIN_RADIUS, MIN_BUBBLE_MAX_RADIUS,
 };
 use crate::orderflow_engine::{
     BookPublished, CaptureStatus, OrderflowHealth, PROJECTION_INTERVAL, ProjectionLayout,
@@ -593,6 +593,50 @@ impl OrderflowView {
             .id_salt("bubble_size_section")
             .default_open(true)
             .show(ui, |ui| {
+                ui.horizontal(|ui| {
+                    ui.label("render style");
+                    egui::ComboBox::from_id_salt("bubble_render_mode")
+                        .selected_text(render_mode_label(bubbles.render_mode))
+                        .show_ui(ui, |ui| {
+                            ui.selectable_value(
+                                &mut bubbles.render_mode,
+                                BubbleRenderMode::Flat,
+                                "Flat · 2D disc",
+                            );
+                            ui.selectable_value(
+                                &mut bubbles.render_mode,
+                                BubbleRenderMode::Sphere,
+                                "Sphere · 3D shaded",
+                            );
+                        })
+                        .response
+                        .on_hover_text(
+                            "flat is the classic solid disc. Sphere shades every bubble like a \
+                             ball lit from the upper left (the Bookmap look): on a dense tape \
+                             each darkened rim keeps overlapping prints readable as separate \
+                             bubbles instead of one merged blob. Purely visual — clustering and \
+                             liquidity association do not change.",
+                        );
+                });
+                if bubbles.render_mode == BubbleRenderMode::Sphere {
+                    ui.add(
+                        egui::Slider::new(&mut bubbles.sphere_shading, 0.0..=1.0)
+                            .text("depth shading"),
+                    )
+                    .on_hover_text(
+                        "how much the rim darkens toward the edge; higher separates \
+                         overlapping bubbles harder, zero reads flat again",
+                    );
+                    ui.add(
+                        egui::Slider::new(&mut bubbles.sphere_highlight, 0.0..=1.0)
+                            .text("highlight"),
+                    )
+                    .on_hover_text("strength of the light spot that gives the ball its volume");
+                    ui.small(
+                        "Sphere shading applies from the 'detail from px' radius up; smaller \
+                         prints stay cheap dots.",
+                    );
+                }
                 ui.add(
                     egui::Slider::new(&mut bubbles.min_radius, 0.5..=MAX_BUBBLE_MIN_RADIUS)
                         .text("smallest print px"),
@@ -1202,6 +1246,13 @@ const fn size_reference_label(reference: BubbleSizeReference) -> &'static str {
         BubbleSizeReference::VisibleP99 => "Auto · visible P99",
         BubbleSizeReference::VisibleMax => "Auto · largest visible",
         BubbleSizeReference::Fixed => "Fixed quantity",
+    }
+}
+
+const fn render_mode_label(mode: BubbleRenderMode) -> &'static str {
+    match mode {
+        BubbleRenderMode::Flat => "Flat · 2D disc",
+        BubbleRenderMode::Sphere => "Sphere · 3D shaded",
     }
 }
 


### PR DESCRIPTION
## What

Adds a **render style** option to the aggression-bubbles panel: **Flat · 2D disc** (the existing look, still the default) or **Sphere · 3D shaded** — Bookmap-style shaded balls with an offset highlight and a darkened rim, plus `depth shading` and `highlight` sliders.

## Why

On a dense tape, flat discs of the same colour merge into one unreadable blob. A sphere's darkened rim gives every bubble its own visible boundary, so overlapping prints stay readable as separate bubbles — more bubbles per pixel.

## How

- `BubbleRenderMode` + `sphere_shading` / `sphere_highlight` are `BubbleStyle` fields: presets capture, save and replay the look, and preset files written before the mode existed parse as `Flat` (proven by test).
- The shading is one small vertex-coloured mesh per dressed bubble (two rings + lit core, 12–32 segments scaled with radius) built in `draw_bubble`, the single path the live chart **and** the settings preview share — parity is proven by test.
- Below `detail_min_radius` both modes paint the same cheap dot, keeping the tessellation budget flat on a fast tape.
- New `3d spheres` preset in `config/bubbles.toml` and the embedded fallback.

## Performance

Flat mode (default) is byte-identical to before. Sphere mode is opt-in: ≤65 vertices per dressed bubble, bounded by `max_aggression_primitives` (700). Per-bubble meshes are deliberate — batching would change draw order (the most recent print must read in front).

## Arch-review

Run over `git diff main...HEAD`; both actionable findings fixed in `6e32163` (named the tessellation-density constant, destructured in the for-pattern). Two considered-and-kept trades: per-bubble mesh allocation (draw-order fidelity, bounded) and the closed two-variant enum (matches the `BubbleSizeReference` precedent).

## Verification

`cargo fmt --check` ✓ · `cargo clippy -D warnings` ✓ · `cargo build --workspace` ✓ · `cargo test --workspace` ✓ (216 app tests, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)