### PR TITLE
fix(config): sync embedded bubble presets with the tracked file

### DIFF
--- a/crates/app/config/bubbles.toml
+++ b/crates/app/config/bubbles.toml
@@ -14,7 +14,7 @@
 # A preset only describes how bubbles LOOK. Turning the layer on stays a live
 # decision in the panel, so having this file can never start capture by itself.
 
-active = "default"
+active = "dense tape btc"
 
 [[presets]]
 name = "default"
@@ -128,3 +128,34 @@ show_trade_count = false
 label_min_radius = 16.0
 front_color = [255, 246, 205]
 trail_color = [255, 190, 90]
+
+# The project's default open: a BTC-tuned dense tape saved from the panel.
+# Small quiet dots hugging the tape, thin fronts, near-black consumption marks.
+# Built for Binance BTCUSDT. Kept in sync with `config/bubbles.toml`.
+[[presets]]
+name = "dense tape btc"
+cluster_ms = 500
+
+[presets.bubbles]
+min_radius = 2.2
+max_radius = 14.0
+opacity = 0.75
+outline_width = 0.2
+halo_strength = 0.25
+detail_min_radius = 2.0
+size_reference = "visible_p99"
+size_reference_quantity = 100.0
+min_quantity = 0.0
+side_offset = 1.0
+show_consumption_front = true
+front_width = 0.5
+front_length_scale = 1.1
+show_impact_ring = true
+impact_ring_width = 0.5
+trail_length = 7.0
+trail_opacity = 0.77
+show_quantity_labels = false
+show_trade_count = true
+label_min_radius = 20.0
+front_color = [2, 2, 0]
+trail_color = [0, 0, 0]

--- a/crates/app/src/bubble_presets.rs
+++ b/crates/app/src/bubble_presets.rs
@@ -282,6 +282,20 @@ mod tests {
     }
 
     #[test]
+    fn the_embedded_fallback_matches_the_tracked_presets_file() {
+        // The panel reads and writes `config/bubbles.toml` at the repository
+        // root; the embedded copy is what a user gets running from anywhere
+        // else. They drifted apart once — the tracked file gained a preset the
+        // binary never saw — so the sync is asserted, not assumed. Comments
+        // may differ between the two files; meaning may not.
+        let tracked = include_str!("../../../config/bubbles.toml");
+        assert_eq!(
+            parse(tracked).expect("tracked presets file"),
+            parse(EMBEDDED_DEFAULT).expect("embedded presets"),
+        );
+    }
+
+    #[test]
     fn a_preset_round_trips_through_the_panel_state() {
         let mut config = HeatmapConfig {
             bubble_cluster_ms: 50,


### PR DESCRIPTION
## Why

`config/bubbles.toml` (the tracked file the panel reads and writes) gained the **dense tape btc** preset and made it active in 3ca1573 — but the fallback compiled into the binary (`crates/app/config/bubbles.toml`) never saw it. A fresh clone running outside the repository root still opened on `default`.

## What

- Copy the "dense tape btc" preset into the embedded fallback and set `active = "dense tape btc"`, so a clone opens on the project's default look regardless of working directory.
- Add `the_embedded_fallback_matches_the_tracked_presets_file`: the two files must parse identically (comments may differ, meaning may not), so the drift cannot recur silently.

## Verification

- `cargo fmt --all -- --check` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo build --workspace` ✓
- `cargo test --workspace` ✓ (443 passed, 0 failed)

Arch-review ran; its one Should-fix (missing regression cover for the embedded/tracked sync) is fixed by the new test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)