### PR TITLE
feat(app): modular loading indicators for every slow path

### DIFF
--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -20,6 +20,7 @@ use crate::candle_view::{draw_candle, draw_style_window};
 use crate::chart::PriceScale;
 use crate::config::{AppConfig, FeedCapabilities, ProviderKind};
 use crate::feed::{self, FeedCommand, FeedEvent, FeedHandle, ReplayLink};
+use crate::loading::{self, LoadingTask, LoadingTracker};
 use crate::metrics::{self, FrameStats};
 use crate::orderflow_view::OrderflowView;
 use crate::price_view::PriceView;
@@ -132,16 +133,20 @@ pub struct QuantickApp {
     // trades have been backfilled in total (for the readout).
     history_step: usize,
     history_trades: usize,
-    // How many history loads (initial backfill + queued "load older"
-    // requests) are still unanswered; the loading indicator shows while > 0.
-    // A count, not a flag: several requests can be queued (the command
-    // channel holds 16), and the first reply must not hide the indicator
-    // while others are still in flight. The feed answers every request with
-    // exactly one event, so the count always drains back to zero.
-    pending_history_loads: usize,
+    // Every wait currently in flight, drawn by one overlay (see
+    // crate::loading). History loads are counted — several can be queued and
+    // the first reply must not hide the indicator while others are still out;
+    // the feed answers every request with exactly one event, so the count
+    // always drains back to zero. Replay parsing and book synchronization are
+    // level-triggered mirrors of their owners' state.
+    loading: LoadingTracker,
 
     // Bar-type selector state (one parameter retained per kind).
     kind: BarKind,
+    // The spec the selectors ask for, applied one frame after they settle so
+    // the frame carrying the change paints the loading overlay before the
+    // synchronous rebuild holds this thread. See apply_spec_change.
+    pending_spec: Option<BarSpec>,
     tick_n: u64,
     volume_units: f64,
     dollar_notional: f64,
@@ -215,6 +220,11 @@ impl QuantickApp {
             BarSpec::Imbalance(target) => imbalance_target = *target,
         }
 
+        let mut loading = LoadingTracker::new();
+        // The feed starts backfilling the moment it is spawned, so the chart
+        // opens with that one load already in flight.
+        loading.begin(LoadingTask::History);
+
         let mut app = Self {
             kind: spec.kind(),
             state: ChartState::new(spec),
@@ -232,9 +242,8 @@ impl QuantickApp {
             symbol,
             history_step: 2000,
             history_trades: 0,
-            // The feed starts backfilling the moment it is spawned, so the
-            // chart opens with that one load already in flight.
-            pending_history_loads: 1,
+            loading,
+            pending_spec: None,
             tick_n,
             volume_units,
             dollar_notional,
@@ -557,7 +566,7 @@ impl QuantickApp {
             count: self.history_step.max(1),
         }) {
             Ok(()) => {
-                self.pending_history_loads += 1;
+                self.loading.begin(LoadingTask::History);
                 tracing::info!(
                     target: "quantick::app",
                     count = self.history_step,
@@ -722,13 +731,50 @@ impl QuantickApp {
         self.last_auto_range = None;
         self.hover_pos = None;
         self.history_trades = 0;
-        self.pending_history_loads = 1;
+        // The old feed's unanswered loads died with its channel; the new feed
+        // opens with exactly one backfill in flight.
+        self.loading.restart(LoadingTask::History);
         self.latest_trade_ms = None;
         self.orderflow.reset_for_symbol(self.symbol.clone());
 
         self.active = (self.feed_id.clone(), self.symbol.clone());
         if resume_book_capture {
             self.request_book_capture(true);
+        }
+    }
+
+    /// Apply a bar-type/parameter change one frame after the selectors settle.
+    ///
+    /// Switching the spec replays every retained trade synchronously, which
+    /// can hold this thread long enough to notice on a deep history. Deferring
+    /// the rebuild by one frame lets the frame that carries the change paint
+    /// the loading overlay first, so the wait reads as the chart working
+    /// rather than the app hanging. A selector still moving (a dragged
+    /// parameter) keeps pushing the pending spec forward, which also debounces
+    /// the rebuild to one per gesture.
+    fn apply_spec_change(&mut self) {
+        let desired = self.current_spec();
+        if desired == *self.state.spec() {
+            // Selection and chart agree — nothing is pending any more (a feed
+            // switch or reset may have rebuilt the state under a pending spec).
+            if self.pending_spec.take().is_some() {
+                self.loading.set_active(LoadingTask::BarRebuild, false);
+            }
+            return;
+        }
+        match self.pending_spec.take() {
+            // The frame that changed the selector: arm the indicator, paint.
+            None => {
+                self.pending_spec = Some(desired);
+                self.loading.set_active(LoadingTask::BarRebuild, true);
+            }
+            // Still moving: wait for the selector to settle for a frame.
+            Some(pending) if pending != desired => self.pending_spec = Some(desired),
+            // Settled since last frame: do the rebuild.
+            Some(_) => {
+                self.state.set_spec(desired);
+                self.loading.set_active(LoadingTask::BarRebuild, false);
+            }
         }
     }
 
@@ -834,7 +880,7 @@ impl QuantickApp {
         loop {
             match self.events.try_recv() {
                 Ok(FeedEvent::Backfilled(trades)) => {
-                    self.pending_history_loads = self.pending_history_loads.saturating_sub(1);
+                    self.loading.end(LoadingTask::History);
                     if let Some(last) = trades.last() {
                         self.latest_trade_ms = Some(last.timestamp_ms);
                     }
@@ -844,7 +890,7 @@ impl QuantickApp {
                 Ok(FeedEvent::HistoryPrepended(trades)) => {
                     // The reply — even an empty one — answers exactly one
                     // pending load; the indicator survives until the last one.
-                    self.pending_history_loads = self.pending_history_loads.saturating_sub(1);
+                    self.loading.end(LoadingTask::History);
                     // Older bars shift every index up; keep the view steady.
                     self.history_trades += trades.len();
                     let added = self.state.prepend_history(&trades);
@@ -889,8 +935,9 @@ impl QuantickApp {
         self.live_tail_hold = 0.0;
         self.last_total_bars = 0;
         // The refill arrives as one backfill batch; keep the loading indicator
-        // up until it lands.
-        self.pending_history_loads = 1;
+        // up until it lands. Requests sent to the source before the reset will
+        // never be answered, so the count restarts rather than accumulates.
+        self.loading.restart(LoadingTask::History);
         self.orderflow.reset_for_symbol(self.symbol.clone());
     }
 
@@ -1614,31 +1661,6 @@ impl QuantickApp {
             y += line_h;
         }
     }
-
-    /// A discreet "history is loading" indicator centred at the chart's top: a
-    /// small spinner plus a tiny label, shown while the initial backfill or an
-    /// on-demand "load older" request is in flight. Centred so it never covers
-    /// the symbol tag at the top-left or the perf overlay at the top-right.
-    fn draw_history_loader(&self, ui: &mut egui::Ui, area: egui::Rect) {
-        if self.pending_history_loads == 0 {
-            return;
-        }
-        let size = 12.0;
-        let gap = 6.0;
-        let galley = ui.painter().layout_no_wrap(
-            "loading history…".to_owned(),
-            egui::FontId::proportional(10.0),
-            MUTED,
-        );
-        // Centre spinner + gap + label as one group on the chart's mid-line.
-        let total_w = size + gap + galley.size().x;
-        let left = area.center().x - total_w / 2.0;
-        let top = area.top() + 8.0;
-        let spinner_rect = egui::Rect::from_min_size(egui::pos2(left, top), egui::vec2(size, size));
-        ui.put(spinner_rect, egui::Spinner::new().size(size).color(MUTED));
-        let text_pos = egui::pos2(left + size + gap, top + (size - galley.size().y) / 2.0);
-        ui.painter().galley(text_pos, galley, MUTED);
-    }
 }
 
 /// Opens the Market Replay browser. The one shortcut this feature claims.
@@ -1811,13 +1833,19 @@ impl eframe::App for QuantickApp {
         // Respawn the feed if the feed/symbol selection changed (resets the
         // chart), then apply any bar-type change (no-op if unchanged).
         self.maybe_switch_feed();
-        self.state.set_spec(self.current_spec());
+        self.apply_spec_change();
         self.draw_style_panel(ctx, now);
         // Docked before the central panel so the chart keeps the remaining
         // width instead of being covered by a floating window.
         if self.orderflow.draw_panels(ctx) {
             self.restart_book_capture();
         }
+        // Waits owned by other components, mirrored level-style each frame so
+        // the overlay needs no push notifications from either.
+        self.loading
+            .set_active(LoadingTask::ReplaySession, self.replay_view.is_loading());
+        self.loading
+            .set_active(LoadingTask::BookSync, self.orderflow.is_syncing());
 
         egui::CentralPanel::default()
             .frame(egui::Frame::none().fill(bg))
@@ -1826,7 +1854,7 @@ impl eframe::App for QuantickApp {
                 self.handle_navigation(ui, area);
                 self.draw_chart(ui.painter(), area);
                 self.draw_overlay(ui.painter(), area);
-                self.draw_history_loader(ui, area);
+                loading::overlay(ui, area, &self.loading);
             });
         self.draw_timezone_selector(ctx);
         // Live feed: keep polling the channel ~60×/s without busy-spinning.
@@ -1920,27 +1948,43 @@ mod tests {
         // flight: three loads pending. The first reply must NOT hide the
         // indicator - only the last one may.
         let (mut app, evt_tx, _cmd_rx, _book_tx) = test_app();
-        assert_eq!(app.pending_history_loads, 1, "backfill in flight at start");
+        assert_eq!(
+            app.loading.count(LoadingTask::History),
+            1,
+            "backfill in flight at start"
+        );
 
         app.request_older_history();
         app.request_older_history();
-        assert_eq!(app.pending_history_loads, 3);
+        assert_eq!(app.loading.count(LoadingTask::History), 3);
 
         evt_tx.try_send(FeedEvent::Backfilled(Vec::new())).unwrap();
         app.drain_feed();
-        assert_eq!(app.pending_history_loads, 2, "older loads still pending");
+        assert_eq!(
+            app.loading.count(LoadingTask::History),
+            2,
+            "older loads still pending"
+        );
 
         evt_tx
             .try_send(FeedEvent::HistoryPrepended(Vec::new()))
             .unwrap();
         app.drain_feed();
-        assert_eq!(app.pending_history_loads, 1, "one reply answers one load");
+        assert_eq!(
+            app.loading.count(LoadingTask::History),
+            1,
+            "one reply answers one load"
+        );
 
         evt_tx
             .try_send(FeedEvent::HistoryPrepended(Vec::new()))
             .unwrap();
         app.drain_feed();
-        assert_eq!(app.pending_history_loads, 0, "last reply hides the loader");
+        assert_eq!(
+            app.loading.count(LoadingTask::History),
+            0,
+            "last reply hides the loader"
+        );
     }
 
     #[test]
@@ -1950,7 +1994,70 @@ mod tests {
         let (mut app, _evt_tx, cmd_rx, _book_tx) = test_app();
         drop(cmd_rx);
         app.request_older_history();
-        assert_eq!(app.pending_history_loads, 1, "only the initial backfill");
+        assert_eq!(
+            app.loading.count(LoadingTask::History),
+            1,
+            "only the initial backfill"
+        );
+    }
+
+    #[test]
+    fn a_source_reset_restarts_the_history_wait() {
+        // Loads queued before a reset will never be answered; the refill after
+        // the reset is the one load left in flight.
+        let (mut app, evt_tx, _cmd_rx, _book_tx) = test_app();
+        app.request_older_history();
+        app.request_older_history();
+        assert_eq!(app.loading.count(LoadingTask::History), 3);
+
+        evt_tx.try_send(FeedEvent::Reset).unwrap();
+        app.drain_feed();
+        assert_eq!(app.loading.count(LoadingTask::History), 1);
+    }
+
+    #[test]
+    fn bar_spec_change_defers_one_frame_and_shows_the_rebuild() {
+        let (mut app, _evt_tx, _cmd_rx, _book_tx) = test_app();
+        app.tick_n = 100;
+
+        app.apply_spec_change();
+        assert!(app.loading.is_active(LoadingTask::BarRebuild));
+        assert_eq!(
+            app.state.spec(),
+            &BarSpec::Tick(50),
+            "the arming frame must paint the overlay before the rebuild runs"
+        );
+
+        app.apply_spec_change();
+        assert_eq!(app.state.spec(), &BarSpec::Tick(100));
+        assert!(!app.loading.is_active(LoadingTask::BarRebuild));
+    }
+
+    #[test]
+    fn a_still_moving_selector_keeps_deferring_the_rebuild() {
+        let (mut app, _evt_tx, _cmd_rx, _book_tx) = test_app();
+        app.tick_n = 100;
+        app.apply_spec_change();
+        app.tick_n = 200; // the drag continues
+        app.apply_spec_change();
+        assert_eq!(
+            app.state.spec(),
+            &BarSpec::Tick(50),
+            "no rebuild mid-gesture"
+        );
+        assert!(app.loading.is_active(LoadingTask::BarRebuild));
+
+        app.apply_spec_change();
+        assert_eq!(app.state.spec(), &BarSpec::Tick(200));
+        assert!(!app.loading.is_active(LoadingTask::BarRebuild));
+    }
+
+    #[test]
+    fn an_unchanged_spec_never_arms_the_rebuild_indicator() {
+        let (mut app, _evt_tx, _cmd_rx, _book_tx) = test_app();
+        app.apply_spec_change();
+        assert!(!app.loading.is_active(LoadingTask::BarRebuild));
+        assert!(app.pending_spec.is_none());
     }
 
     #[test]

--- a/crates/app/src/loading.rs
+++ b/crates/app/src/loading.rs
@@ -1,0 +1,283 @@
+//! One reusable "something is loading" affordance for the whole app.
+//!
+//! Every operation that can take noticeable time — pulling history, rebuilding
+//! bars after a spec change, synchronizing the order book, parsing a replay
+//! session — registers itself in the app's [`LoadingTracker`] under its
+//! [`LoadingTask`]. One overlay ([`overlay`]) then draws every active wait as
+//! a spinner + label row at the top of the chart, so "the app is working"
+//! always looks the same, and making a new slow path visible is one
+//! `begin`/`end` (or [`LoadingTracker::set_active`]) away. [`inline`] is the
+//! same spinner + label pair for embedding inside windows and toolbars.
+
+use eframe::egui;
+
+use crate::app::{DIVIDER, OVERLAY};
+
+/// Spinner diameter, in pixels — shared by the overlay and the inline row so
+/// loading looks the same everywhere it appears.
+const SPINNER_SIZE: f32 = 14.0;
+/// Gap between the spinner and its label, in pixels.
+const GAP: f32 = 6.0;
+/// Horizontal padding inside the overlay backdrop, in pixels.
+const PAD: f32 = 8.0;
+/// Height of one overlay row, in pixels.
+const ROW_HEIGHT: f32 = 20.0;
+
+/// Something slow the interface may be waiting on. One variant per kind of
+/// wait; the label is what the user reads next to the spinner.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum LoadingTask {
+    /// The initial backfill, an on-demand "load older" request, or the refill
+    /// after a source reset.
+    History,
+    /// Bars are being rebuilt from the retained trades after a bar-type or
+    /// parameter change.
+    BarRebuild,
+    /// Order-book capture is connecting, buffering, fetching its snapshot or
+    /// resyncing after a gap.
+    BookSync,
+    /// A recorded session is being parsed on a worker thread.
+    ReplaySession,
+}
+
+impl LoadingTask {
+    /// Every task, in the order the overlay stacks their rows.
+    pub const ALL: [Self; 4] = [
+        Self::History,
+        Self::BarRebuild,
+        Self::BookSync,
+        Self::ReplaySession,
+    ];
+
+    /// What the row says, without the trailing ellipsis.
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::History => "loading history",
+            Self::BarRebuild => "rebuilding bars",
+            Self::BookSync => "syncing order book",
+            Self::ReplaySession => "loading replay session",
+        }
+    }
+
+    /// This task's position in [`Self::ALL`] — the tracker's array index.
+    fn index(self) -> usize {
+        match self {
+            Self::History => 0,
+            Self::BarRebuild => 1,
+            Self::BookSync => 2,
+            Self::ReplaySession => 3,
+        }
+    }
+}
+
+/// How many operations of each kind are currently in flight.
+///
+/// Counted rather than boolean because several requests of one kind can
+/// overlap (the feed command channel queues history loads) and the first
+/// reply must not hide the indicator while others are still out. Waits owned
+/// by someone else's state machine are mirrored level-style through
+/// [`Self::set_active`] instead.
+#[derive(Default)]
+pub struct LoadingTracker {
+    counts: [usize; LoadingTask::ALL.len()],
+}
+
+impl LoadingTracker {
+    /// A tracker with nothing in flight.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// One more operation of this kind is in flight.
+    pub fn begin(&mut self, task: LoadingTask) {
+        let count = &mut self.counts[task.index()];
+        *count = count.saturating_add(1);
+    }
+
+    /// One operation of this kind was answered. Saturates at zero so a stray
+    /// reply can never underflow into "loading forever".
+    pub fn end(&mut self, task: LoadingTask) {
+        let count = &mut self.counts[task.index()];
+        *count = count.saturating_sub(1);
+    }
+
+    /// Forget every operation of this kind and leave exactly one in flight —
+    /// what a respawned or reset source needs, whose earlier requests will
+    /// never be answered.
+    pub fn restart(&mut self, task: LoadingTask) {
+        self.counts[task.index()] = 1;
+    }
+
+    /// Level-triggered form for waits mirrored from state owned elsewhere:
+    /// active or not, with no count to balance.
+    pub fn set_active(&mut self, task: LoadingTask, active: bool) {
+        self.counts[task.index()] = usize::from(active);
+    }
+
+    /// How many operations of this kind are in flight.
+    #[must_use]
+    pub fn count(&self, task: LoadingTask) -> usize {
+        self.counts[task.index()]
+    }
+
+    /// Whether at least one operation of this kind is in flight.
+    #[must_use]
+    pub fn is_active(&self, task: LoadingTask) -> bool {
+        self.count(task) > 0
+    }
+
+    /// Whether anything at all is in flight.
+    #[must_use]
+    pub fn any_active(&self) -> bool {
+        self.counts.iter().any(|&count| count > 0)
+    }
+
+    /// The active tasks, in the order the overlay stacks them.
+    pub fn active(&self) -> impl Iterator<Item = LoadingTask> + '_ {
+        LoadingTask::ALL
+            .into_iter()
+            .filter(|task| self.is_active(*task))
+    }
+}
+
+/// A spinner + `label…` pair added to the current layout, for embedding in
+/// windows and toolbars. Adds two widgets rather than opening its own row, so
+/// the caller's layout (including right-to-left rows) keeps deciding where
+/// they land.
+pub fn inline(ui: &mut egui::Ui, label: &str) {
+    ui.add(egui::Spinner::new().size(SPINNER_SIZE).color(DIVIDER));
+    ui.label(egui::RichText::new(format!("{label}…")).color(OVERLAY));
+}
+
+/// The one loading overlay: every active task as a spinner + label row on a
+/// shared backdrop, centred at the top of `area` so it never covers the
+/// symbol header on the left or the book status badge on the right.
+pub fn overlay(ui: &mut egui::Ui, area: egui::Rect, tracker: &LoadingTracker) {
+    if !tracker.any_active() {
+        return;
+    }
+    let font = egui::FontId::proportional(12.0);
+    let painter = ui.painter().clone();
+    let galleys: Vec<_> = tracker
+        .active()
+        .map(|task| painter.layout_no_wrap(format!("{}…", task.label()), font.clone(), OVERLAY))
+        .collect();
+
+    let widest = galleys
+        .iter()
+        .map(|galley| galley.size().x)
+        .fold(0.0_f32, f32::max);
+    let box_w = PAD + SPINNER_SIZE + GAP + widest + PAD;
+    let box_h = galleys.len() as f32 * ROW_HEIGHT + PAD;
+    let backdrop = egui::Rect::from_min_size(
+        egui::pos2(area.center().x - box_w / 2.0, area.top() + 8.0),
+        egui::vec2(box_w, box_h),
+    );
+    painter.rect_filled(
+        backdrop,
+        egui::Rounding::same(4.0),
+        egui::Color32::from_black_alpha(150),
+    );
+
+    let mut y = backdrop.top() + PAD / 2.0;
+    for galley in galleys {
+        let spinner = egui::Rect::from_min_size(
+            egui::pos2(backdrop.left() + PAD, y + (ROW_HEIGHT - SPINNER_SIZE) / 2.0),
+            egui::vec2(SPINNER_SIZE, SPINNER_SIZE),
+        );
+        ui.put(
+            spinner,
+            egui::Spinner::new().size(SPINNER_SIZE).color(DIVIDER),
+        );
+        let text_pos = egui::pos2(
+            spinner.right() + GAP,
+            y + (ROW_HEIGHT - galley.size().y) / 2.0,
+        );
+        painter.galley(text_pos, galley, OVERLAY);
+        y += ROW_HEIGHT;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn counts_overlapping_operations_and_drains_to_zero() {
+        let mut tracker = LoadingTracker::new();
+        assert!(!tracker.any_active());
+
+        tracker.begin(LoadingTask::History);
+        tracker.begin(LoadingTask::History);
+        assert_eq!(tracker.count(LoadingTask::History), 2);
+        assert!(tracker.is_active(LoadingTask::History));
+
+        tracker.end(LoadingTask::History);
+        assert!(
+            tracker.is_active(LoadingTask::History),
+            "one reply, one load"
+        );
+        tracker.end(LoadingTask::History);
+        assert!(!tracker.any_active());
+    }
+
+    #[test]
+    fn ending_more_than_began_saturates_at_zero() {
+        let mut tracker = LoadingTracker::new();
+        tracker.end(LoadingTask::History);
+        assert_eq!(tracker.count(LoadingTask::History), 0);
+    }
+
+    #[test]
+    fn restart_leaves_exactly_one_in_flight() {
+        let mut tracker = LoadingTracker::new();
+        tracker.begin(LoadingTask::History);
+        tracker.begin(LoadingTask::History);
+        tracker.begin(LoadingTask::History);
+        tracker.restart(LoadingTask::History);
+        assert_eq!(tracker.count(LoadingTask::History), 1);
+    }
+
+    #[test]
+    fn set_active_is_level_triggered() {
+        let mut tracker = LoadingTracker::new();
+        tracker.set_active(LoadingTask::BookSync, true);
+        tracker.set_active(LoadingTask::BookSync, true);
+        assert_eq!(tracker.count(LoadingTask::BookSync), 1, "no accumulation");
+        tracker.set_active(LoadingTask::BookSync, false);
+        assert!(!tracker.is_active(LoadingTask::BookSync));
+    }
+
+    #[test]
+    fn tasks_are_independent() {
+        let mut tracker = LoadingTracker::new();
+        tracker.begin(LoadingTask::History);
+        tracker.set_active(LoadingTask::ReplaySession, true);
+        tracker.end(LoadingTask::History);
+        assert!(!tracker.is_active(LoadingTask::History));
+        assert!(tracker.is_active(LoadingTask::ReplaySession));
+    }
+
+    #[test]
+    fn active_tasks_come_out_in_overlay_order() {
+        let mut tracker = LoadingTracker::new();
+        tracker.set_active(LoadingTask::ReplaySession, true);
+        tracker.begin(LoadingTask::History);
+        let active: Vec<_> = tracker.active().collect();
+        assert_eq!(
+            active,
+            vec![LoadingTask::History, LoadingTask::ReplaySession],
+            "declaration order, not activation order"
+        );
+    }
+
+    #[test]
+    fn every_task_indexes_its_own_slot_and_has_a_label() {
+        for (position, task) in LoadingTask::ALL.into_iter().enumerate() {
+            assert_eq!(task.index(), position, "ALL and index() must agree");
+            assert!(!task.label().is_empty());
+        }
+    }
+}

--- a/crates/app/src/loading.rs
+++ b/crates/app/src/loading.rs
@@ -22,6 +22,15 @@ const GAP: f32 = 6.0;
 const PAD: f32 = 8.0;
 /// Height of one overlay row, in pixels.
 const ROW_HEIGHT: f32 = 20.0;
+/// Font size of an overlay row label, in points.
+const LABEL_FONT_SIZE: f32 = 12.0;
+/// Distance from the top of the chart area to the backdrop, in pixels.
+const TOP_OFFSET_PX: f32 = 8.0;
+/// Backdrop opacity (0–255): dark enough to read over candles, light enough
+/// to keep the chart visible behind it. Matches the perf overlay's backdrop.
+const BACKDROP_ALPHA: u8 = 150;
+/// Backdrop corner radius, in pixels.
+const CORNER_RADIUS_PX: f32 = 4.0;
 
 /// Something slow the interface may be waiting on. One variant per kind of
 /// wait; the label is what the user reads next to the spinner.
@@ -61,13 +70,9 @@ impl LoadingTask {
     }
 
     /// This task's position in [`Self::ALL`] — the tracker's array index.
+    /// Declaration order *is* the index, so adding a variant cannot drift.
     fn index(self) -> usize {
-        match self {
-            Self::History => 0,
-            Self::BarRebuild => 1,
-            Self::BookSync => 2,
-            Self::ReplaySession => 3,
-        }
+        self as usize
     }
 }
 
@@ -158,7 +163,7 @@ pub fn overlay(ui: &mut egui::Ui, area: egui::Rect, tracker: &LoadingTracker) {
     if !tracker.any_active() {
         return;
     }
-    let font = egui::FontId::proportional(12.0);
+    let font = egui::FontId::proportional(LABEL_FONT_SIZE);
     let painter = ui.painter().clone();
     let galleys: Vec<_> = tracker
         .active()
@@ -172,13 +177,13 @@ pub fn overlay(ui: &mut egui::Ui, area: egui::Rect, tracker: &LoadingTracker) {
     let box_w = PAD + SPINNER_SIZE + GAP + widest + PAD;
     let box_h = galleys.len() as f32 * ROW_HEIGHT + PAD;
     let backdrop = egui::Rect::from_min_size(
-        egui::pos2(area.center().x - box_w / 2.0, area.top() + 8.0),
+        egui::pos2(area.center().x - box_w / 2.0, area.top() + TOP_OFFSET_PX),
         egui::vec2(box_w, box_h),
     );
     painter.rect_filled(
         backdrop,
-        egui::Rounding::same(4.0),
-        egui::Color32::from_black_alpha(150),
+        egui::Rounding::same(CORNER_RADIUS_PX),
+        egui::Color32::from_black_alpha(BACKDROP_ALPHA),
     );
 
     let mut y = backdrop.top() + PAD / 2.0;

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -17,6 +17,7 @@ mod candle_view;
 mod chart;
 mod config;
 mod feed;
+mod loading;
 mod metrics;
 mod orderflow;
 mod orderflow_engine;

--- a/crates/app/src/orderflow_engine.rs
+++ b/crates/app/src/orderflow_engine.rs
@@ -285,6 +285,19 @@ impl CaptureStatus {
             Self::Error => "error",
         }
     }
+
+    /// Whether capture is working towards a live book — the states the app's
+    /// loading overlay shows as a wait. Exhaustive so a new status must decide
+    /// whether it reads as "loading" instead of silently defaulting to "no".
+    pub fn is_syncing(&self) -> bool {
+        match self {
+            Self::Connecting
+            | Self::Buffering
+            | Self::SnapshotFetching
+            | Self::Resyncing { .. } => true,
+            Self::Disabled | Self::Live { .. } | Self::Disconnected { .. } | Self::Error => false,
+        }
+    }
 }
 
 /// One immutable snapshot of everything the UI reads between frames.
@@ -946,6 +959,31 @@ mod tests {
     use super::*;
     use quantick_engine::Side;
     use quantick_orderbook::{BookCoverage, BookDelta, BookLevel, BookSnapshot};
+
+    #[test]
+    fn only_states_working_towards_a_live_book_read_as_syncing() {
+        assert!(CaptureStatus::Connecting.is_syncing());
+        assert!(CaptureStatus::Buffering.is_syncing());
+        assert!(CaptureStatus::SnapshotFetching.is_syncing());
+        assert!(CaptureStatus::Resyncing { reason: "gap" }.is_syncing());
+
+        assert!(!CaptureStatus::Disabled.is_syncing());
+        assert!(
+            !CaptureStatus::Live {
+                generation: 1,
+                last_update_id: 1,
+            }
+            .is_syncing()
+        );
+        assert!(
+            !CaptureStatus::Disconnected {
+                error_class: "read",
+            }
+            .is_syncing(),
+            "a dead connection is a warning, not a wait"
+        );
+        assert!(!CaptureStatus::Error.is_syncing());
+    }
 
     #[test]
     fn adaptive_base_scales_with_price_and_stays_round() {

--- a/crates/app/src/orderflow_view.rs
+++ b/crates/app/src/orderflow_view.rs
@@ -432,19 +432,12 @@ impl OrderflowView {
     }
 
     /// Whether capture is turned on but not yet (or no longer) delivering a
-    /// live book — connecting, buffering, fetching its snapshot or resyncing
-    /// after a gap. What the app's loading overlay mirrors. Reads the frame's
-    /// mirror, refreshed by the panel/projection calls the frame already made.
+    /// live book. What the app's loading overlay mirrors. Reads the frame's
+    /// mirror, refreshed by the panel/projection calls the frame already made;
+    /// which statuses count as a wait is [`CaptureStatus::is_syncing`]'s call.
     #[must_use]
     pub fn is_syncing(&self) -> bool {
-        self.config.enabled
-            && matches!(
-                self.published.status,
-                CaptureStatus::Connecting
-                    | CaptureStatus::Buffering
-                    | CaptureStatus::SnapshotFetching
-                    | CaptureStatus::Resyncing { .. }
-            )
+        self.config.enabled && self.published.status.is_syncing()
     }
 
     pub fn reset_summary_counters(&mut self) {
@@ -1351,6 +1344,20 @@ mod tests {
             sell_volume: Decimal::ONE,
             trade_count: 2,
         }
+    }
+
+    #[test]
+    fn capture_reads_as_syncing_only_while_enabled_and_settling() {
+        let mut view = OrderflowView::new("BTCUSDT");
+        assert!(!view.is_syncing(), "disabled capture is not a wait");
+
+        view.set_enabled(true, 10);
+        view.flush_for_test();
+        assert!(view.is_syncing(), "connecting reads as a wait");
+
+        view.set_enabled(false, 20);
+        view.flush_for_test();
+        assert!(!view.is_syncing(), "turning capture off ends the wait");
     }
 
     #[test]

--- a/crates/app/src/orderflow_view.rs
+++ b/crates/app/src/orderflow_view.rs
@@ -431,6 +431,22 @@ impl OrderflowView {
         self.published.health.clone()
     }
 
+    /// Whether capture is turned on but not yet (or no longer) delivering a
+    /// live book — connecting, buffering, fetching its snapshot or resyncing
+    /// after a gap. What the app's loading overlay mirrors. Reads the frame's
+    /// mirror, refreshed by the panel/projection calls the frame already made.
+    #[must_use]
+    pub fn is_syncing(&self) -> bool {
+        self.config.enabled
+            && matches!(
+                self.published.status,
+                CaptureStatus::Connecting
+                    | CaptureStatus::Buffering
+                    | CaptureStatus::SnapshotFetching
+                    | CaptureStatus::Resyncing { .. }
+            )
+    }
+
     pub fn reset_summary_counters(&mut self) {
         self.worker.send(BookCommand::ResetSummaryCounters);
     }

--- a/crates/app/src/replay_view.rs
+++ b/crates/app/src/replay_view.rs
@@ -121,6 +121,13 @@ impl ReplayView {
         self.show_format = true;
     }
 
+    /// Whether a session is being parsed on a worker right now — what the
+    /// app's loading overlay mirrors.
+    #[must_use]
+    pub fn is_loading(&self) -> bool {
+        self.loading.is_some()
+    }
+
     /// Scan the configured folder and start its first session, without opening
     /// the browser.
     ///
@@ -328,11 +335,9 @@ impl ReplayView {
             }
         });
         if self.picker.is_some() {
-            ui.label(
-                egui::RichText::new("Waiting for the folder dialog…")
-                    .color(MUTED)
-                    .small(),
-            );
+            ui.horizontal(|ui| {
+                crate::loading::inline(ui, "waiting for the folder dialog");
+            });
         }
     }
 
@@ -511,12 +516,7 @@ impl ReplayView {
 
             ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                 if let Some(loading) = &self.loading {
-                    ui.add(egui::Spinner::new().size(14.0).color(MUTED));
-                    ui.label(
-                        egui::RichText::new(format!("Loading {}…", loading.label))
-                            .color(MUTED)
-                            .small(),
-                    );
+                    crate::loading::inline(ui, &format!("loading {}", loading.label));
                     return;
                 }
                 let ready = self.selected_entry().is_some();

--- a/crates/app/src/replay_view.rs
+++ b/crates/app/src/replay_view.rs
@@ -769,6 +769,7 @@ mod tests {
         assert_eq!(view.speed, 1.0);
         assert!(view.autoplay);
         assert!(view.library.is_none());
+        assert!(!view.is_loading(), "nothing is being parsed yet");
     }
 
     #[test]


### PR DESCRIPTION
## What

One reusable "(spinner) loading…" structure for every operation that can take noticeable time, so it is always visible on screen when the app is working:

- **New `crates/app/src/loading.rs`** — `LoadingTask` (what can wait) + `LoadingTracker` (counted for overlapping requests, level-triggered for waits mirrored from other components), one `overlay` drawing every active wait as amber spinner + label rows at the top of the chart, and one `inline` widget for windows/toolbars. Adding a new slow path to the overlay is one enum variant + one `begin`/`end` or `set_active` call.
- **History** — initial backfill, "load older" and post-reset refills keep the counted semantics the old `pending_history_loads` had, now through the shared tracker.
- **Bar type / parameter changes** — the rebuild replays every retained trade synchronously, so it now applies one frame after the selectors settle: the frame carrying the change paints "rebuilding bars…" before the rebuild holds the thread. Side effect: a dragged parameter debounces to **one rebuild per gesture** instead of one per frame.
- **Order book** — `CaptureStatus::is_syncing()` (exhaustive match) decides which statuses read as a wait; enabling capture or restarting it after a grouping change shows "syncing order book…" until the book is live.
- **Replay** — session parsing shows in the overlay and in the browser through the same inline widget; the folder-dialog wait reuses it too.

## Arch-review

Ran per workflow; no Blockers. Four Should-fix/Consider findings (non-exhaustive status classification, untested mirrors, unnamed overlay constants, hand-kept enum index) — all fixed in the second commit, none deferred.

## Verification

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (224 app tests, incl. new coverage for the tracker, the deferred rebuild and both mirrors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)