### PR TITLE
fix(config): restore embedded/tracked bubble preset order parity

### DIFF
--- a/crates/app/config/bubbles.toml
+++ b/crates/app/config/bubbles.toml
@@ -99,6 +99,36 @@ show_quantity_labels = true
 show_trade_count = true
 label_min_radius = 14.0
 
+# For studying who is eating whom: the bubble shrinks and the consumption mark
+# takes over — a wide, bright front and a long trail into the consumed side.
+[[presets]]
+name = "consumption focus"
+cluster_ms = 200
+
+[presets.bubbles]
+min_radius = 2.0
+max_radius = 12.0
+opacity = 0.55
+outline_width = 0.0
+halo_strength = 0.06
+detail_min_radius = 3.0
+size_reference = "visible_max"
+size_reference_quantity = 100.0
+min_quantity = 0.0
+side_offset = 6.0
+show_consumption_front = true
+front_width = 5.0
+front_length_scale = 3.2
+show_impact_ring = true
+impact_ring_width = 3.0
+trail_length = 40.0
+trail_opacity = 0.85
+show_quantity_labels = false
+show_trade_count = false
+label_min_radius = 16.0
+front_color = [255, 246, 205]
+trail_color = [255, 190, 90]
+
 # Bookmap-style shaded spheres. The darkened rim on every bubble keeps
 # overlapping prints readable as separate bubbles on a dense tape, so the
 # detail floor is low: even small prints get the shading.
@@ -130,36 +160,6 @@ trail_opacity = 0.62
 show_quantity_labels = true
 show_trade_count = true
 label_min_radius = 16.0
-
-# For studying who is eating whom: the bubble shrinks and the consumption mark
-# takes over — a wide, bright front and a long trail into the consumed side.
-[[presets]]
-name = "consumption focus"
-cluster_ms = 200
-
-[presets.bubbles]
-min_radius = 2.0
-max_radius = 12.0
-opacity = 0.55
-outline_width = 0.0
-halo_strength = 0.06
-detail_min_radius = 3.0
-size_reference = "visible_max"
-size_reference_quantity = 100.0
-min_quantity = 0.0
-side_offset = 6.0
-show_consumption_front = true
-front_width = 5.0
-front_length_scale = 3.2
-show_impact_ring = true
-impact_ring_width = 3.0
-trail_length = 40.0
-trail_opacity = 0.85
-show_quantity_labels = false
-show_trade_count = false
-label_min_radius = 16.0
-front_color = [255, 246, 205]
-trail_color = [255, 190, 90]
 
 # The project's default open: a BTC-tuned dense tape saved from the panel.
 # Small quiet dots hugging the tape, thin fronts, near-black consumption marks.


### PR DESCRIPTION
## What

Reorder the `3d spheres` preset block in the embedded `crates/app/config/bubbles.toml` to match the tracked `config/bubbles.toml` (after `consumption focus`). No values change — only block position.

## Why

Main CI is red: #72 (3d spheres) and #73 (dense tape btc) inserted their presets at different positions in the two files. Each PR was green on its branch, but the merged combination fails `the_embedded_fallback_matches_the_tracked_presets_file`, which asserts the parsed files are identical.

## Verification

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo build --workspace`
- [x] `cargo test --workspace` — the sync test fails without this change, passes with it

## Arch-review

Clean, zero findings: config-only reorder restoring a test-asserted invariant; no code touched, no values changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)