### PR TITLE
feat(app): implement the UI design model shell (phases 1-5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,7 +104,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
  "x11rb",
 ]
 
@@ -764,6 +764,15 @@ dependencies = [
  "epaint",
  "log",
  "nohash-hasher",
+]
+
+[[package]]
+name = "egui-phosphor"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74744068685d20e004d1a4326c48403b6759e325c7fce8c5eeeab93f0a9f67ca"
+dependencies = [
+ "egui",
 ]
 
 [[package]]
@@ -2452,6 +2461,7 @@ name = "quantick-app"
 version = "0.1.0"
 dependencies = [
  "eframe",
+ "egui-phosphor",
  "quantick-engine",
  "quantick-feed-binance",
  "quantick-feed-mt5",
@@ -2915,7 +2925,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -26,6 +26,7 @@ eframe = { version = "0.29", default-features = false, features = [
     "x11",
     "default_fonts",
 ] }
+egui-phosphor = "0.7"
 
 [target.'cfg(windows)'.build-dependencies]
 winresource = "0.1"

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -406,8 +406,13 @@ impl QuantickApp {
             appearance_open: self.show_style,
         };
         let actions = toolbar::draw(ctx, &mut model);
-        // A newly picked feed may not offer the current symbol.
-        self.ensure_symbol_valid();
+        // A newly picked feed may not offer the current symbol. Never during
+        // a replay: the recorded instrument belongs to no live feed's menu,
+        // and snapping it away would relabel the whole session — the status
+        // bar and the logs must keep naming what is actually playing.
+        if self.replay.is_none() {
+            self.ensure_symbol_valid();
+        }
         for action in actions {
             self.apply_toolbar_action(action);
         }
@@ -1440,6 +1445,7 @@ impl QuantickApp {
             live_trades: self.live_trades,
             fps: self.frames.fps(),
             frame_avg_ms: self.frames.avg_ms(),
+            frame_cpu_ms: self.cpu_frames.avg_ms(),
             show_perf: self.show_perf,
         }
     }
@@ -2162,6 +2168,49 @@ mod tests {
         assert!(
             app.book_channel_closed_reported,
             "subsequent frames keep the one-shot diagnostic latched"
+        );
+    }
+
+    #[test]
+    fn replay_keeps_the_recorded_symbol_out_of_the_live_feed_snap() {
+        // A recorded instrument no configured live feed offers must survive
+        // the toolbar frame untouched — snapping it away would relabel the
+        // whole session on the status bar and in the logs. The live path,
+        // drawn through the very same frame, must keep snapping an invalid
+        // selection back to the feed's list.
+        let (mut app, _evt_tx, _cmd_rx, _book_tx) = test_app();
+        let text = "# quantick,csv,1\n# symbol=WINJ26\n# timezone=-03:00\n\
+                    Date,Time,Price,Volume,Side\n\
+                    2026-03-16,10:01:08.000,182035,12,B\n";
+        let session = quantick_replay::Session::from_text(
+            std::path::Path::new("WINJ26_2026-03-16.csv"),
+            text,
+            quantick_replay::ParseOptions::default(),
+        )
+        .expect("fixture session parses");
+        app.open_replay(crate::feed::ReplayRequest {
+            session: std::sync::Arc::new(session),
+            options: crate::feed::ReplayOptions {
+                autoplay: false,
+                ..Default::default()
+            },
+        });
+        assert_eq!(app.symbol, "WINJ26");
+
+        let ctx = egui::Context::default();
+        let _ = ctx.run(egui::RawInput::default(), |ctx| app.draw_toolbar(ctx));
+        assert_eq!(
+            app.symbol, "WINJ26",
+            "a toolbar frame during replay must not relabel the session"
+        );
+
+        // The same frame path with the replay closed: validation still works.
+        app.replay = None;
+        app.symbol = "NOT-A-SYMBOL".to_owned();
+        let _ = ctx.run(egui::RawInput::default(), |ctx| app.draw_toolbar(ctx));
+        assert_eq!(
+            app.symbol, "TESTUSDT",
+            "live selections keep snapping to the feed's symbol list"
         );
     }
 

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -19,6 +19,7 @@ use quantick_feed_binance::depth::DepthEvent;
 use crate::candle_view::{draw_candle, draw_style_window};
 use crate::chart::PriceScale;
 use crate::config::{AppConfig, FeedCapabilities, ProviderKind};
+use crate::dock::{Dock, DockEnv, DockTab};
 use crate::feed::{self, FeedCommand, FeedEvent, FeedHandle, ReplayLink};
 use crate::loading::{self, LoadingTask, LoadingTracker};
 use crate::metrics::{self, FrameStats};
@@ -26,8 +27,12 @@ use crate::orderflow_view::OrderflowView;
 use crate::price_view::PriceView;
 use crate::replay_view::{ReplayAction, ReplayView};
 use crate::state::{BarKind, BarSpec, ChartState};
+use crate::statusbar;
 use crate::style::{CandlePreset, ChartStyle};
+use crate::theme;
 use crate::timezone::TzOffset;
+use crate::toolbar::{self, ToolbarAction};
+use crate::toolrail::{Tool, ToolRail};
 use crate::viewport::Viewport;
 
 /// Convert an explicit unmultiplied RGBA style colour to egui.
@@ -35,22 +40,10 @@ fn color32([r, g, b, a]: [u8; 4]) -> egui::Color32 {
     egui::Color32::from_rgba_unmultiplied(r, g, b, a)
 }
 
-/// The amber that marks "this is not live data": the backfill/live divider on
-/// the chart, and the market-replay transport.
-pub(crate) const DIVIDER: egui::Color32 = egui::Color32::from_rgb(240, 185, 11);
-/// Secondary text: labels, hints, anything that must not compete with data.
-pub(crate) const MUTED: egui::Color32 = egui::Color32::from_rgb(150, 160, 175);
-/// Primary text over the chart and the chrome.
-pub(crate) const OVERLAY: egui::Color32 = egui::Color32::from_rgb(210, 218, 226);
-/// Something needs attention.
-pub(crate) const WARN: egui::Color32 = egui::Color32::from_rgb(255, 99, 71);
-const CROSSHAIR: egui::Color32 = egui::Color32::from_rgb(110, 120, 135);
-const TAG_BG: egui::Color32 = egui::Color32::from_rgb(55, 63, 80);
-
-/// Width of the right-hand price-axis gutter, in pixels.
-const AXIS_GUTTER: f32 = 60.0;
-/// Height of the bottom time-axis strip, in pixels.
-const TIME_STRIP: f32 = 22.0;
+/// Width of the right-hand price-axis gutter, in pixels (§5 zone 9).
+const AXIS_GUTTER: f32 = 64.0;
+/// Height of the bottom time-axis strip, in pixels (§5 zone 6).
+const TIME_STRIP: f32 = 24.0;
 
 /// How often the perf summary is logged (not every frame).
 const SUMMARY_INTERVAL: Duration = Duration::from_secs(2);
@@ -129,6 +122,11 @@ pub struct QuantickApp {
     replay: Option<ReplayLink>,
     replay_view: ReplayView,
 
+    // The two chrome zones the design model reserves beside the chart: the
+    // tabbed right dock (settings) and the left tool rail (chart tools).
+    dock: Dock,
+    toolrail: ToolRail,
+
     // How many older trades to pull per "load older" click, and how many
     // trades have been backfilled in total (for the readout).
     history_step: usize,
@@ -176,8 +174,8 @@ pub struct QuantickApp {
     style_revision: u64,
     style_log_pending: bool,
     last_style_change: Option<Instant>,
-    // Whether the perf overlay (fps / frame time / feed lag) is drawn.
-    show_overlay: bool,
+    // Whether the status bar shows the perf readings (View → perf readings).
+    show_perf: bool,
 
     // Fixed UTC offset the time axis is displayed in (default UTC−03:00).
     tz: TzOffset,
@@ -237,6 +235,8 @@ impl QuantickApp {
             active: (feed_id.clone(), symbol.clone()),
             replay: feed.replay,
             replay_view: ReplayView::new(),
+            dock: Dock::new(),
+            toolrail: ToolRail::new(),
             config,
             feed_id,
             symbol,
@@ -261,7 +261,7 @@ impl QuantickApp {
             style_revision: 0,
             style_log_pending: false,
             last_style_change: None,
-            show_overlay: true,
+            show_perf: true,
             tz: TzOffset::default(),
             frames: FrameStats::new(120),
             cpu_frames: FrameStats::new(120),
@@ -338,31 +338,14 @@ impl QuantickApp {
         }
     }
 
-    /// The feed + symbol selectors, both populated from the configuration.
-    ///
-    /// During a replay the selectors give way to what is actually playing: a
-    /// live venue cannot be picked without leaving the recording first, and a
-    /// combo that silently did so would throw away the session mid-run.
-    fn draw_feed_selectors(&mut self, ui: &mut egui::Ui) {
-        if let Some(link) = &self.replay {
-            ui.label(egui::RichText::new("source:").color(MUTED));
-            ui.label(egui::RichText::new(link.label()).color(DIVIDER).strong())
-                .on_hover_text(format!(
-                    "Replaying {}\nSide source: {}",
-                    link.session.path.display(),
-                    link.session
-                        .header
-                        .side_source
-                        .as_deref()
-                        .unwrap_or("not recorded"),
-                ));
-            return;
-        }
-
-        // Pre-collect owned option lists so the combo closures don't borrow
+    /// Build the toolbar's model from the app's state, draw it, and carry
+    /// out whatever it asked (§6 — the toolbar module owns grouping and the
+    /// overflow rule; this method owns the side effects).
+    fn draw_toolbar(&mut self, ctx: &egui::Context) {
+        // Pre-collect owned option lists so the toolbar's combos don't borrow
         // `self.config` while they mutate `self.feed_id` / `self.symbol`.
-        // Providers that aren't streaming yet are labelled "(soon)" so the menu
-        // is honest about what actually connects.
+        // Providers that aren't streaming yet are labelled "(soon)" so the
+        // menu is honest about what actually connects.
         let feeds: Vec<(String, String)> = self
             .config
             .feeds
@@ -376,167 +359,72 @@ impl QuantickApp {
                 (f.id.clone(), label)
             })
             .collect();
-        ui.label("feed:");
-        egui::ComboBox::from_id_salt("feed_sel")
-            .selected_text(self.feed_display_name())
-            .show_ui(ui, |ui| {
-                for (id, name) in &feeds {
-                    ui.selectable_value(&mut self.feed_id, id.clone(), name);
-                }
-            });
-        // A newly picked feed may not offer the current symbol.
-        self.ensure_symbol_valid();
-
         let symbols: Vec<String> = self
             .config
             .feed(&self.feed_id)
             .map(|f| f.symbols.clone())
             .unwrap_or_default();
-        ui.label("symbol:");
-        egui::ComboBox::from_id_salt("symbol_sel")
-            .selected_text(&self.symbol)
-            .show_ui(ui, |ui| {
-                for s in &symbols {
-                    ui.selectable_value(&mut self.symbol, s.clone(), s);
-                }
-            });
+        // During a replay the SOURCE group gives way to what is actually
+        // playing: a live venue cannot be picked without leaving the
+        // recording first, and a combo that silently did so would throw away
+        // the session mid-run.
+        let replay = self.replay.as_ref().map(|link| toolbar::ReplaySource {
+            label: link.label(),
+            hover: format!(
+                "Replaying {}\nSide source: {}",
+                link.session.path.display(),
+                link.session
+                    .header
+                    .side_source
+                    .as_deref()
+                    .unwrap_or("not recorded"),
+            ),
+        });
+        let capabilities = self.capabilities();
+        let feed_display_name = self.feed_display_name();
+        let heatmap_on = self.orderflow.enabled();
+        let bubbles_on = self.orderflow.bubbles_enabled();
+        let mut model = toolbar::ToolbarModel {
+            feeds,
+            feed_id: &mut self.feed_id,
+            feed_display_name,
+            symbols,
+            symbol: &mut self.symbol,
+            replay,
+            kind: &mut self.kind,
+            tick_n: &mut self.tick_n,
+            volume_units: &mut self.volume_units,
+            dollar_notional: &mut self.dollar_notional,
+            time_interval_ms: &mut self.time_interval_ms,
+            imbalance_target: &mut self.imbalance_target,
+            history_step: &mut self.history_step,
+            history_trades: self.history_trades,
+            capabilities,
+            heatmap_on,
+            bubbles_on,
+            dock_visible: self.dock.visible(),
+            appearance_open: self.show_style,
+        };
+        let actions = toolbar::draw(ctx, &mut model);
+        // A newly picked feed may not offer the current symbol.
+        self.ensure_symbol_valid();
+        for action in actions {
+            self.apply_toolbar_action(action);
+        }
     }
 
-    /// The bar-type selector: a combo for the kind and a drag for its parameter.
-    fn draw_controls(&mut self, ui: &mut egui::Ui) {
-        ui.horizontal_wrapped(|ui| {
-            self.draw_feed_selectors(ui);
-            ui.separator();
-            ui.label("bar type:");
-            egui::ComboBox::from_id_salt("bar_kind")
-                .selected_text(self.kind.label())
-                .show_ui(ui, |ui| {
-                    for kind in BarKind::ALL {
-                        ui.selectable_value(&mut self.kind, kind, kind.label());
-                    }
-                });
-            ui.separator();
-            match self.kind {
-                BarKind::Tick => {
-                    ui.label("N trades");
-                    ui.add(egui::DragValue::new(&mut self.tick_n).range(1.0..=5000.0));
-                }
-                BarKind::Volume => {
-                    ui.label("units");
-                    ui.add(
-                        egui::DragValue::new(&mut self.volume_units)
-                            .range(0.1..=1000.0)
-                            .speed(0.1),
-                    );
-                }
-                BarKind::Dollar => {
-                    ui.label("notional");
-                    ui.add(
-                        egui::DragValue::new(&mut self.dollar_notional)
-                            .range(1000.0..=1_000_000_000.0)
-                            .speed(1000.0),
-                    );
-                }
-                BarKind::Time => {
-                    ui.label("interval ms");
-                    ui.add(
-                        egui::DragValue::new(&mut self.time_interval_ms)
-                            .range(100.0..=600_000.0)
-                            .speed(100.0),
-                    );
-                }
-                BarKind::Imbalance => {
-                    ui.label("target trades");
-                    ui.add(egui::DragValue::new(&mut self.imbalance_target).range(2.0..=5000.0))
-                        .on_hover_text(
-                            "expected trades per bar in balanced flow; \
-                             one-sided aggression closes bars sooner",
-                        );
-                }
-            }
-            ui.separator();
-            // History: pull older trades on demand, N per click.
-            ui.label("history +");
-            ui.add(
-                egui::DragValue::new(&mut self.history_step)
-                    .range(500.0..=50_000.0)
-                    .speed(100.0),
-            );
-            let capabilities = self.capabilities();
-            if ui
-                .add_enabled(
-                    capabilities.history_paging,
-                    egui::Button::new("⟲ load older"),
-                )
-                .on_hover_text(if capabilities.history_paging {
-                    "fetch older trades and prepend them"
-                } else {
-                    "this feed only streams forward; it cannot page older trades"
-                })
-                .clicked()
-            {
-                self.request_older_history();
-            }
-            ui.label(format!("({} trades)", self.history_trades));
-            ui.separator();
-            if ui
-                .button("🎨 candle")
-                .on_hover_text("candle transparency, outlines, colours and presets")
-                .clicked()
-            {
-                self.show_style = !self.show_style;
-            }
-            ui.separator();
-            let supports_book = capabilities.book_capture;
-            let mut book_enabled = self.orderflow.enabled();
-            let toggle = ui.add_enabled(
-                supports_book,
-                egui::Checkbox::new(&mut book_enabled, "book heatmap"),
-            );
-            if toggle
-                .on_hover_text(if supports_book {
-                    "capture synchronized live L2 depth; history starts when enabled"
-                } else {
-                    "order-book capture is not available for this provider"
-                })
-                .changed()
-            {
-                self.request_book_capture(book_enabled);
-            }
-            if ui
-                .add_enabled(
-                    supports_book,
-                    egui::Button::new(self.orderflow.l2_button_label()),
-                )
-                .on_hover_text(
-                    "dock the L2 panel: palette, non-destructive price ranges and liquidity response",
-                )
-                .clicked()
-            {
-                self.orderflow.toggle_l2_panel();
-            }
-            ui.separator();
-            // The aggression layer reads the trade stream the chart already
-            // consumes, so it needs no depth pipeline and no provider support.
-            let mut bubbles_enabled = self.orderflow.bubbles_enabled();
-            if ui
-                .checkbox(&mut bubbles_enabled, "bubbles")
-                .on_hover_text("confirmed executions as bubbles; independent of the book heatmap")
-                .changed()
-            {
-                self.orderflow.set_bubbles_enabled(bubbles_enabled);
-            }
-            if ui
-                .button(self.orderflow.bubbles_button_label())
-                .on_hover_text("dock the aggression-bubble panel: clustering, opacity and size")
-                .clicked()
-            {
-                self.orderflow.toggle_bubbles_panel();
-            }
-            ui.separator();
-            ui.checkbox(&mut self.show_overlay, "📈 perf")
-                .on_hover_text("show fps / frame time / feed lag (bottom-left)");
-        });
+    /// One toolbar side effect. Layer toggles reuse the same code paths the
+    /// old checkboxes took, so provider gating and command acknowledgement
+    /// rules are unchanged.
+    fn apply_toolbar_action(&mut self, action: ToolbarAction) {
+        match action {
+            ToolbarAction::LoadOlder => self.request_older_history(),
+            ToolbarAction::SetHeatmap(enabled) => self.request_book_capture(enabled),
+            ToolbarAction::SetBubbles(enabled) => self.orderflow.set_bubbles_enabled(enabled),
+            ToolbarAction::OpenDockTab(tab) => self.dock.open_tab(tab),
+            ToolbarAction::ToggleDock => self.dock.toggle_visible(),
+            ToolbarAction::ToggleAppearance => self.show_style = !self.show_style,
+        }
     }
 
     /// What the selected feed's backend can do.
@@ -783,13 +671,6 @@ impl QuantickApp {
         color32(self.style.canvas.background_rgba())
     }
 
-    /// Window chrome stays opaque even when the plot canvas is transparent;
-    /// otherwise toolbar labels would depend on the platform clear colour.
-    fn chrome_bg(&self) -> egui::Color32 {
-        let [r, g, b] = self.style.canvas.background;
-        egui::Color32::from_rgb(r, g, b)
-    }
-
     /// The current chart-grid colour. `TRANSPARENT` disables grid painting
     /// without branching throughout the axis code.
     fn grid(&self) -> egui::Color32 {
@@ -841,37 +722,6 @@ impl QuantickApp {
             "candle appearance changed"
         );
         self.style_log_pending = false;
-    }
-
-    /// A floating timezone picker anchored to the bottom-right corner. The time
-    /// axis relabels immediately on selection; the engine is untouched.
-    fn draw_timezone_selector(&mut self, ctx: &egui::Context) {
-        // Panels shrink the context's available rect, so the picker rides above
-        // whatever claimed the bottom of the window — the replay transport, and
-        // anything docked there later — instead of sitting on top of it.
-        let bottom_inset = (ctx.screen_rect().bottom() - ctx.available_rect().bottom()).max(0.0);
-        egui::Area::new(egui::Id::new("tz_selector"))
-            .anchor(
-                egui::Align2::RIGHT_BOTTOM,
-                egui::vec2(-10.0, -8.0 - bottom_inset),
-            )
-            .show(ctx, |ui| {
-                egui::Frame::popup(ui.style())
-                    .fill(egui::Color32::from_black_alpha(150))
-                    .show(ui, |ui| {
-                        ui.visuals_mut().override_text_color = Some(OVERLAY);
-                        ui.horizontal(|ui| {
-                            ui.label("🕑");
-                            egui::ComboBox::from_id_salt("tz_combo")
-                                .selected_text(self.tz.label())
-                                .show_ui(ui, |ui| {
-                                    for tz in TzOffset::ALL {
-                                        ui.selectable_value(&mut self.tz, tz, tz.label());
-                                    }
-                                });
-                        });
-                    });
-            });
     }
 
     /// Drain every feed event available this frame into the engine, tracking the
@@ -1222,7 +1072,7 @@ impl QuantickApp {
                 egui::Align2::CENTER_CENTER,
                 format!("connecting to {} …", self.symbol),
                 egui::FontId::proportional(16.0),
-                MUTED,
+                theme::TEXT_MUTED,
             );
             self.orderflow.draw_status_badge(painter, chart_rect);
             return;
@@ -1372,7 +1222,6 @@ impl QuantickApp {
         self.draw_backfill_divider(painter, chart_rect, total, cw);
         self.draw_time_strip(painter, areas.time_strip, closed, start, end, total);
         self.draw_crosshair(painter, chart_rect, &scale);
-        self.draw_header(painter, chart_rect);
         self.orderflow.draw_status_badge(painter, chart_rect);
 
         // Cache the auto range + height for next frame's input handler, which
@@ -1417,7 +1266,7 @@ impl QuantickApp {
                         egui::Align2::CENTER_CENTER,
                         fmt_time(bar.open_time, self.tz),
                         font.clone(),
-                        MUTED,
+                        theme::TEXT_MUTED,
                     );
                 }
             }
@@ -1446,7 +1295,7 @@ impl QuantickApp {
                 egui::Align2::LEFT_CENTER,
                 format!("{tick:.2}"),
                 font.clone(),
-                MUTED,
+                theme::TEXT_MUTED,
             );
         }
         // The axis dividing line.
@@ -1460,14 +1309,19 @@ impl QuantickApp {
     }
 
     /// Crosshair following the pointer, with the price shown on the axis.
+    /// Drawn only while the Crosshair tool is armed on the rail (§7 — the
+    /// hover crosshair is a mode, not an always-on layer).
     fn draw_crosshair(&self, painter: &egui::Painter, chart_rect: egui::Rect, scale: &PriceScale) {
+        if self.toolrail.tool() != Tool::Crosshair {
+            return;
+        }
         let Some(pos) = self.hover_pos else {
             return;
         };
         if !chart_rect.contains(pos) {
             return;
         }
-        let stroke = egui::Stroke::new(1.0_f32, CROSSHAIR);
+        let stroke = egui::Stroke::new(1.0_f32, theme::TEXT_FAINT);
         painter.line_segment(
             [
                 egui::pos2(pos.x, chart_rect.top()),
@@ -1495,7 +1349,7 @@ impl QuantickApp {
             text_pos - egui::vec2(3.0, 1.0),
             galley.size() + egui::vec2(6.0, 2.0),
         );
-        painter.rect_filled(bg, egui::Rounding::same(2.0), TAG_BG);
+        painter.rect_filled(bg, egui::Rounding::same(2.0), theme::TAG_BG);
         painter.galley(text_pos, galley, egui::Color32::WHITE);
     }
 
@@ -1524,7 +1378,7 @@ impl QuantickApp {
                 egui::pos2(x, chart_rect.top()),
                 egui::pos2(x, chart_rect.bottom()),
             ],
-            egui::Stroke::new(1.0_f32, DIVIDER),
+            egui::Stroke::new(1.0_f32, theme::AMBER),
         );
         let font = egui::FontId::proportional(11.0);
         painter.text(
@@ -1532,157 +1386,93 @@ impl QuantickApp {
             egui::Align2::RIGHT_BOTTOM,
             "backfill",
             font.clone(),
-            MUTED,
+            theme::TEXT_MUTED,
         );
         painter.text(
             egui::pos2(x + 4.0, chart_rect.bottom() - 4.0),
             egui::Align2::LEFT_BOTTOM,
             "live",
             font,
-            DIVIDER,
+            theme::AMBER,
         );
     }
 
-    fn draw_header(&self, painter: &egui::Painter, plot: egui::Rect) {
+    /// Data-honesty label for how the aggressor side of each trade is known,
+    /// or `None` when the venue reports true sides (§8 — the status bar's
+    /// middle section).
+    fn side_note(&self) -> Option<String> {
+        if let Some(link) = &self.replay {
+            Some(match link.session.header.side_source.as_deref() {
+                Some(source) => format!("side: {source}"),
+                None => "side: not recorded".to_owned(),
+            })
+        } else {
+            // The running feed, not the still-uncommitted selection.
+            self.config.side_note(&self.active.0).map(str::to_owned)
+        }
+    }
+
+    /// Everything the status bar reports this frame.
+    fn status_model(&self) -> statusbar::StatusModel {
         let bars = self.state.bars();
         let (backfilled, live) = match self.state.backfill_boundary() {
-            Some(b) => (b, bars.len().saturating_sub(b)),
+            Some(boundary) => (boundary, bars.len().saturating_sub(boundary)),
             None => (0, bars.len()),
         };
-        let mode = match (self.viewport.follows_live(), self.replay.is_some()) {
-            // Never label a recording "live", however current the chart looks.
-            // `▶` rather than `●`: the bundled fonts carry the transport glyph.
-            (true, true) => "▶ replay",
-            (true, false) => "● live",
-            (false, _) => "history · double-click for live",
-        };
-        let price_mode = if self.price_view.is_auto() {
-            ""
-        } else {
-            " · price: manual (double-click to auto-fit)"
-        };
-        let header = format!(
-            "{} · {} · {} backfilled + {} live bars · {}{}",
-            self.symbol,
-            self.state.spec().summary(),
-            backfilled,
-            live,
-            mode,
-            price_mode
-        );
-        painter.text(
-            egui::pos2(plot.left(), plot.top()),
-            egui::Align2::LEFT_TOP,
-            header,
-            egui::FontId::proportional(13.0),
-            MUTED,
-        );
-    }
-
-    /// A bottom-left overlay with FPS, frame time and feed lag; values that
-    /// breach a threshold are drawn in the warning colour. Sits in the empty
-    /// lower-left of the chart so it doesn't cover the candles, and is toggled by
-    /// the "perf" checkbox in the controls bar.
-    fn draw_overlay(&self, painter: &egui::Painter, area: egui::Rect) {
-        if !self.show_overlay {
-            return;
-        }
-        let avg = self.frames.avg_ms();
-        let lag = self.trade_lag_ms();
-
-        let fps_color = if avg.is_some_and(|a| a > metrics::SLOW_FRAME_MS) {
-            WARN
-        } else {
-            OVERLAY
-        };
-        let lag_color = if lag.is_some_and(|l| l > metrics::HIGH_LAG_MS) {
-            WARN
-        } else {
-            OVERLAY
-        };
-        // A recording has no lag to report — its prints are months old by
-        // design. The line says what is actually driving the chart instead.
-        let lag_text = match (&self.replay, lag) {
-            (Some(link), _) => format!(
-                "replay {:.0}×  {:.0}%",
-                link.status.speed(),
-                link.status.progress() * 100.0
-            ),
-            (None, Some(l)) => format!("feed lag {l} ms"),
-            (None, None) => "feed lag —".to_string(),
-        };
-
-        let lines: [(String, egui::Color32); 4] = [
-            (
-                format!(
-                    "{:>4.0} fps  {:>5.1} ms",
-                    self.frames.fps().unwrap_or(0.0),
-                    avg.unwrap_or(0.0)
-                ),
-                fps_color,
-            ),
-            (
-                format!(
-                    "cpu {:>5.1} ms  worst {:>5.1} ms",
-                    self.cpu_frames.avg_ms().unwrap_or(0.0),
-                    self.frames.worst_ms().unwrap_or(0.0)
-                ),
-                OVERLAY,
-            ),
-            (lag_text, lag_color),
-            (format!("{} live trades", self.live_trades), OVERLAY),
-        ];
-
-        let font = egui::FontId::monospace(12.0);
-        let pad = 8.0;
-        let line_h = 16.0;
-        let box_w = 180.0;
-        let box_h = lines.len() as f32 * line_h + pad;
-        // Anchor to the empty lower-left of the chart body, above the time strip.
-        let chart = plot_split(area).chart;
-        let bottom_left = egui::pos2(chart.left() + 8.0, chart.bottom() - 8.0 - box_h);
-        let backdrop = egui::Rect::from_min_size(bottom_left, egui::vec2(box_w, box_h));
-        painter.rect_filled(
-            backdrop,
-            egui::Rounding::same(4.0),
-            egui::Color32::from_black_alpha(150),
-        );
-
-        let mut y = backdrop.top() + pad / 2.0;
-        let left = backdrop.left() + pad;
-        for (text, color) in &lines {
-            painter.text(
-                egui::pos2(left, y),
-                egui::Align2::LEFT_TOP,
-                text,
-                font.clone(),
-                *color,
-            );
-            y += line_h;
+        statusbar::StatusModel {
+            venue: if self.replay.is_some() {
+                "recording".to_owned()
+            } else {
+                self.feed_display_name()
+            },
+            symbol: self.symbol.clone(),
+            replay: self.replay.as_ref().map(|link| statusbar::ReplayFigures {
+                speed: link.status.speed(),
+                progress: link.status.progress(),
+            }),
+            feed_lag_ms: self.trade_lag_ms(),
+            spec_summary: self.state.spec().summary(),
+            backfilled_bars: backfilled,
+            live_bars: live,
+            side_note: self.side_note(),
+            follows_live: self.viewport.follows_live(),
+            price_auto: self.price_view.is_auto(),
+            live_trades: self.live_trades,
+            fps: self.frames.fps(),
+            frame_avg_ms: self.frames.avg_ms(),
+            show_perf: self.show_perf,
         }
     }
 }
 
-/// Opens the Market Replay browser. The one shortcut this feature claims.
+/// Opens the Market Replay browser (§10).
 const REPLAY_SHORTCUT: egui::KeyboardShortcut =
     egui::KeyboardShortcut::new(egui::Modifiers::CTRL, egui::Key::R);
+/// Shows/hides the panels dock (§10).
+const DOCK_SHORTCUT: egui::KeyboardShortcut =
+    egui::KeyboardShortcut::new(egui::Modifiers::CTRL, egui::Key::B);
+/// Height of the menu bar, in pixels (§5 zone 1).
+const MENU_BAR_HEIGHT: f32 = 28.0;
 
 impl QuantickApp {
-    /// The window's menu bar: one line, two menus, nothing that duplicates a
-    /// control already on the toolbar below it.
+    /// The window's menu bar (§10): shallow menus for discoverability and
+    /// shortcuts, never the only path to anything.
     fn draw_menu_bar(&mut self, ctx: &egui::Context) {
         if ctx.input_mut(|i| i.consume_shortcut(&REPLAY_SHORTCUT)) {
             self.replay_view.open_browser();
         }
+        if ctx.input_mut(|i| i.consume_shortcut(&DOCK_SHORTCUT)) {
+            self.dock.toggle_visible();
+        }
 
         egui::TopBottomPanel::top("menu_bar")
+            .exact_height(MENU_BAR_HEIGHT)
             .frame(
                 egui::Frame::none()
-                    .fill(self.chrome_bg())
-                    .inner_margin(egui::Margin::symmetric(6.0, 2.0)),
+                    .fill(theme::CHROME)
+                    .inner_margin(egui::Margin::symmetric(6.0, 4.0)),
             )
             .show(ctx, |ui| {
-                ui.visuals_mut().override_text_color = Some(OVERLAY);
                 egui::menu::bar(ui, |ui| {
                     ui.menu_button("File", |ui| {
                         if ui
@@ -1702,6 +1492,56 @@ impl QuantickApp {
                         ui.separator();
                         if ui.button("Exit").clicked() {
                             ui.ctx().send_viewport_cmd(egui::ViewportCommand::Close);
+                        }
+                    });
+                    ui.menu_button("View", |ui| {
+                        let panels_label = if self.dock.visible() {
+                            "Hide panels"
+                        } else {
+                            "Show panels"
+                        };
+                        if ui
+                            .add(
+                                egui::Button::new(panels_label)
+                                    .shortcut_text(ui.ctx().format_shortcut(&DOCK_SHORTCUT)),
+                            )
+                            .clicked()
+                        {
+                            self.dock.toggle_visible();
+                            ui.close_menu();
+                        }
+                        for (tab, label) in [
+                            (DockTab::L2, "L2 settings"),
+                            (DockTab::Bubbles, "Bubble settings"),
+                            (DockTab::Session, "Session"),
+                        ] {
+                            if ui.button(label).clicked() {
+                                self.dock.open_tab(tab);
+                                ui.close_menu();
+                            }
+                        }
+                        ui.separator();
+                        ui.checkbox(&mut self.show_perf, "Perf readings")
+                            .on_hover_text("fps, frame time and trade count on the status bar");
+                        ui.separator();
+                        ui.menu_button("Timezone", |ui| {
+                            egui::ScrollArea::vertical()
+                                .max_height(280.0)
+                                .show(ui, |ui| {
+                                    for tz in TzOffset::ALL {
+                                        if ui.selectable_label(self.tz == tz, tz.label()).clicked()
+                                        {
+                                            self.tz = tz;
+                                            ui.close_menu();
+                                        }
+                                    }
+                                });
+                        });
+                    });
+                    ui.menu_button("Tools", |ui| {
+                        if ui.button("Appearance…").clicked() {
+                            self.show_style = true;
+                            ui.close_menu();
                         }
                     });
                     ui.menu_button("Help", |ui| {
@@ -1818,16 +1658,43 @@ impl eframe::App for QuantickApp {
         self.maybe_emit_summary(now);
 
         let bg = self.bg();
+        // Rail shortcuts first: Esc/1/2 must be read before any widget can
+        // claim the keyboard this frame.
+        self.toolrail.handle_keys(ctx);
+        // Chrome panels claim their zones outside-in (§5): menu and toolbar
+        // on top, the status line at the very bottom with the replay
+        // transport directly above it, then the tool rail and the dock on the
+        // sides. The chart keeps whatever remains.
         self.draw_menu_bar(ctx);
-        egui::TopBottomPanel::top("controls")
-            .frame(egui::Frame::none().fill(self.chrome_bg()).inner_margin(8.0))
-            .show(ctx, |ui| {
-                ui.visuals_mut().override_text_color = Some(OVERLAY);
-                self.draw_controls(ui);
-            });
+        self.draw_toolbar(ctx);
+        let status = self.status_model();
+        statusbar::draw(ctx, &status, &mut self.tz);
         // The browser window and, while a session plays, the transport bar.
-        // Drawn before the chart so the bottom panel claims its strip first.
         if let Some(action) = self.replay_view.draw(ctx, self.replay.as_ref()) {
+            self.apply_replay_action(action);
+        }
+        self.toolrail.draw(ctx);
+        let dock_response = {
+            let Self {
+                dock,
+                orderflow,
+                replay_view,
+                replay,
+                ..
+            } = self;
+            dock.draw(
+                ctx,
+                &mut DockEnv {
+                    orderflow,
+                    replay_view,
+                    replay: replay.as_ref(),
+                },
+            )
+        };
+        if dock_response.restart_book_capture {
+            self.restart_book_capture();
+        }
+        if let Some(action) = dock_response.replay_action {
             self.apply_replay_action(action);
         }
         // Respawn the feed if the feed/symbol selection changed (resets the
@@ -1835,11 +1702,6 @@ impl eframe::App for QuantickApp {
         self.maybe_switch_feed();
         self.apply_spec_change();
         self.draw_style_panel(ctx, now);
-        // Docked before the central panel so the chart keeps the remaining
-        // width instead of being covered by a floating window.
-        if self.orderflow.draw_panels(ctx) {
-            self.restart_book_capture();
-        }
         // Waits owned by other components, mirrored level-style each frame so
         // the overlay needs no push notifications from either.
         self.loading
@@ -1853,10 +1715,8 @@ impl eframe::App for QuantickApp {
                 let area = ui.available_rect_before_wrap();
                 self.handle_navigation(ui, area);
                 self.draw_chart(ui.painter(), area);
-                self.draw_overlay(ui.painter(), area);
                 loading::overlay(ui, area, &self.loading);
             });
-        self.draw_timezone_selector(ctx);
         // Live feed: keep polling the channel ~60×/s without busy-spinning.
         ctx.request_repaint_after(Duration::from_millis(16));
     }

--- a/crates/app/src/config.rs
+++ b/crates/app/src/config.rs
@@ -205,6 +205,21 @@ impl AppConfig {
         self.feed(id).map(|f| f.provider)
     }
 
+    /// Data-honesty label for how feed `id` decides the aggressor side of a
+    /// trade, or `None` when the venue reports true sides. Shown verbatim on
+    /// the status bar; this sits next to the provider → code-path map because
+    /// it is provider knowledge, not a UI affordance gate.
+    #[must_use]
+    pub fn side_note(&self, id: &str) -> Option<&'static str> {
+        match self.provider_of(id)? {
+            ProviderKind::Binance => None,
+            ProviderKind::MetaTrader => Some(match self.metatrader.side_source {
+                Mt5SideSource::TickRule => "side: inferred (tick rule)",
+                Mt5SideSource::Flags => "side: broker flags",
+            }),
+        }
+    }
+
     /// Validate internal consistency: at least one feed, unique ids, non-empty
     /// symbol lists, and a default selection that actually resolves.
     ///
@@ -372,6 +387,32 @@ mod tests {
         let (config, _) = sample();
         assert_eq!(config.provider_of("binance"), Some(ProviderKind::Binance));
         assert_eq!(config.provider_of("nope"), None);
+    }
+
+    #[test]
+    fn side_note_labels_inferred_sides_and_stays_silent_on_venue_truth() {
+        let (config, _) = sample();
+        // Binance reports true aggressor sides — nothing to disclaim.
+        assert_eq!(config.side_note("binance"), None);
+        assert_eq!(config.side_note("nope"), None);
+
+        let text = r#"
+            default_feed = "mt"
+            default_symbol = "WINQ26"
+            [[feeds]]
+            id = "mt"
+            name = "MetaTrader 5"
+            provider = "metatrader"
+            symbols = ["WINQ26"]
+        "#;
+        let mut config = parse(text, ConfigSource::Embedded).unwrap();
+        assert_eq!(
+            config.side_note("mt"),
+            Some("side: inferred (tick rule)"),
+            "the tick-rule default must be disclosed"
+        );
+        config.metatrader.side_source = Mt5SideSource::Flags;
+        assert_eq!(config.side_note("mt"), Some("side: broker flags"));
     }
 
     #[test]

--- a/crates/app/src/dock.rs
+++ b/crates/app/src/dock.rs
@@ -1,0 +1,382 @@
+//! The right dock: one tabbed panel for everything a trader keeps open while
+//! trading (`docs/ux/ui-design-model.md` §7).
+//!
+//! Tabs — L2, Bubbles, Session (Indicators docks here when it lands) —
+//! replace the stack of left `SidePanel`s: the chart pays the dock width
+//! once, not per panel. The 36 px tab strip stays visible when the dock is
+//! collapsed; clicking the active tab collapses, clicking any other switches.
+//! A layer's *toggle* lives in the toolbar; opening a tab never toggles the
+//! layer — looking is not enabling.
+
+use eframe::egui;
+use egui_phosphor::regular as icons;
+
+use crate::feed::ReplayLink;
+use crate::orderflow_view::OrderflowView;
+use crate::replay_view::{ReplayAction, ReplayView};
+use crate::theme;
+use crate::widgets::{IconButton, RAIL_ICON};
+
+/// Width of the always-visible tab strip, in pixels.
+pub const TAB_STRIP_WIDTH: f32 = 36.0;
+/// Narrowest dock body the model allows.
+pub const DOCK_MIN_WIDTH: f32 = 280.0;
+/// Widest dock body the model allows.
+pub const DOCK_MAX_WIDTH: f32 = 360.0;
+
+/// One dock tab.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DockTab {
+    /// L2 liquidity-map settings (migrated from the left panel).
+    L2,
+    /// Aggression-bubble settings (migrated from the left panel).
+    Bubbles,
+    /// The replay session: what is playing, and the browser entry.
+    Session,
+}
+
+impl DockTab {
+    /// Every tab, in strip order.
+    pub const ALL: [Self; 3] = [Self::L2, Self::Bubbles, Self::Session];
+
+    /// The Phosphor glyph on the strip.
+    #[must_use]
+    pub fn icon(self) -> &'static str {
+        match self {
+            Self::L2 => icons::STACK,
+            Self::Bubbles => icons::CIRCLES_THREE,
+            Self::Session => icons::FILM_STRIP,
+        }
+    }
+
+    /// Header title inside the body.
+    #[must_use]
+    pub fn title(self) -> &'static str {
+        match self {
+            Self::L2 => "L2 · LIQUIDITY MAP",
+            Self::Bubbles => "AGGRESSION BUBBLES",
+            Self::Session => "SESSION",
+        }
+    }
+
+    /// Strip tooltip.
+    #[must_use]
+    pub fn hover_text(self) -> &'static str {
+        match self {
+            Self::L2 => "L2 settings — the heatmap toggle stays in the toolbar",
+            Self::Bubbles => "Bubble settings — the layer toggle stays in the toolbar",
+            Self::Session => "Market replay session",
+        }
+    }
+
+    /// This tab's slot in the per-tab width memory.
+    fn index(self) -> usize {
+        self as usize
+    }
+}
+
+/// What the dock's tabs need from the app, split by field so the dock can be
+/// borrowed mutably alongside them.
+pub struct DockEnv<'a> {
+    /// The order-flow facade whose settings the L2/Bubbles tabs edit.
+    pub orderflow: &'a mut OrderflowView,
+    /// The replay browser the Session tab opens.
+    pub replay_view: &'a mut ReplayView,
+    /// The playing session, if any.
+    pub replay: Option<&'a ReplayLink>,
+}
+
+/// What drawing the dock asked the app to do.
+#[derive(Default)]
+pub struct DockResponse {
+    /// The L2 tab changed the base capture resolution; capture must restart.
+    pub restart_book_capture: bool,
+    /// The Session tab asked to close the replay.
+    pub replay_action: Option<ReplayAction>,
+}
+
+/// The dock's chrome state. Hidden, collapsed to the strip, or open on one
+/// tab; body width is remembered per tab.
+#[derive(Debug)]
+pub struct Dock {
+    visible: bool,
+    active: Option<DockTab>,
+    widths: [f32; DockTab::ALL.len()],
+}
+
+impl Default for Dock {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Dock {
+    /// A visible dock, collapsed to its tab strip.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            visible: true,
+            active: None,
+            // Opening widths per tab, ordered as [`DockTab::ALL`]: the L2 tab
+            // carries the densest controls, the Session tab the fewest.
+            widths: [340.0, 320.0, 300.0],
+        }
+    }
+
+    /// Whether any part of the dock (strip included) is on screen.
+    #[must_use]
+    pub fn visible(&self) -> bool {
+        self.visible
+    }
+
+    /// Show/hide the whole dock — the toolbar PANELS button and `Ctrl+B`.
+    pub fn toggle_visible(&mut self) {
+        self.visible = !self.visible;
+    }
+
+    /// Open `tab`, revealing the dock if it was hidden. Never touches the
+    /// layer the tab configures.
+    pub fn open_tab(&mut self, tab: DockTab) {
+        self.visible = true;
+        self.active = Some(tab);
+    }
+
+    /// A strip click: the active tab collapses the body, any other opens it.
+    pub fn select(&mut self, tab: DockTab) {
+        self.active = if self.active == Some(tab) {
+            None
+        } else {
+            Some(tab)
+        };
+    }
+
+    /// Remember `width` for the active tab, clamped to the model's range.
+    fn remember_width(&mut self, tab: DockTab, width: f32) {
+        self.widths[tab.index()] = width.clamp(DOCK_MIN_WIDTH, DOCK_MAX_WIDTH);
+    }
+
+    /// Draw the strip and, when a tab is open, its body panel.
+    pub fn draw(&mut self, ctx: &egui::Context, env: &mut DockEnv) -> DockResponse {
+        let mut response = DockResponse::default();
+        if !self.visible {
+            return response;
+        }
+
+        egui::SidePanel::right("dock_strip")
+            .exact_width(TAB_STRIP_WIDTH)
+            .resizable(false)
+            .frame(
+                egui::Frame::none()
+                    .fill(theme::CHROME)
+                    .inner_margin(egui::Margin::symmetric(3.0, 8.0)),
+            )
+            .show(ctx, |ui| {
+                ui.spacing_mut().item_spacing.y = 6.0;
+                for tab in DockTab::ALL {
+                    let button = IconButton::new(tab.icon(), RAIL_ICON)
+                        .active(self.active == Some(tab))
+                        .hover_text(tab.hover_text())
+                        .show(ui);
+                    if button.clicked() {
+                        self.select(tab);
+                    }
+                }
+            });
+
+        if let Some(tab) = self.active {
+            let panel = egui::SidePanel::right(egui::Id::new(("dock_body", tab.index())))
+                .resizable(true)
+                .default_width(self.widths[tab.index()])
+                .width_range(DOCK_MIN_WIDTH..=DOCK_MAX_WIDTH)
+                .frame(
+                    egui::Frame::none()
+                        .fill(theme::CHROME)
+                        .inner_margin(egui::Margin::symmetric(10.0, 8.0)),
+                )
+                .show(ctx, |ui| {
+                    draw_tab_header(ui, tab, &mut self.active);
+                    match tab {
+                        DockTab::L2 => {
+                            response.restart_book_capture |= env.orderflow.draw_l2_tab(ui);
+                        }
+                        DockTab::Bubbles => {
+                            response.restart_book_capture |= env.orderflow.draw_bubbles_tab(ui);
+                        }
+                        DockTab::Session => {
+                            response.replay_action = draw_session_tab(ui, env);
+                        }
+                    }
+                });
+            self.remember_width(tab, panel.response.rect.width());
+        }
+        response
+    }
+}
+
+/// Title row shared by every tab, with the collapse affordance.
+fn draw_tab_header(ui: &mut egui::Ui, tab: DockTab, active: &mut Option<DockTab>) {
+    ui.horizontal(|ui| {
+        ui.label(
+            egui::RichText::new(tab.title())
+                .strong()
+                .color(theme::TEXT_PRIMARY),
+        );
+        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+            // `×` is Latin-1, so it renders in egui's default proportional
+            // font without borrowing an icon that means "delete".
+            if ui
+                .small_button("×")
+                .on_hover_text("collapse the dock to its tab strip")
+                .clicked()
+            {
+                *active = None;
+            }
+        });
+    });
+    ui.separator();
+}
+
+/// The Session tab: what is playing (amber, like everything not live) and
+/// the entry to the transient browser window.
+fn draw_session_tab(ui: &mut egui::Ui, env: &mut DockEnv) -> Option<ReplayAction> {
+    let mut action = None;
+    match env.replay {
+        Some(link) => {
+            ui.label(
+                egui::RichText::new(link.label())
+                    .color(theme::AMBER)
+                    .strong(),
+            );
+            ui.small(format!("file: {}", link.session.path.display()));
+            ui.small(format!(
+                "side source: {}",
+                link.session
+                    .header
+                    .side_source
+                    .as_deref()
+                    .unwrap_or("not recorded")
+            ));
+            ui.add_space(6.0);
+            if ui
+                .button("Close replay")
+                .on_hover_text("go back to the live feed")
+                .clicked()
+            {
+                action = Some(ReplayAction::Close);
+            }
+        }
+        None => {
+            ui.label(egui::RichText::new("No recording is playing.").color(theme::TEXT_MUTED));
+        }
+    }
+    ui.add_space(6.0);
+    if ui
+        .button(format!("{} Open session browser…", icons::FOLDER_OPEN))
+        .on_hover_text("browse recorded sessions (Ctrl+R)")
+        .clicked()
+    {
+        env.replay_view.open_browser();
+    }
+    action
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_new_dock_shows_the_strip_with_no_tab_open() {
+        let dock = Dock::new();
+        assert!(dock.visible());
+        assert_eq!(dock.active, None);
+    }
+
+    #[test]
+    fn selecting_toggles_between_open_and_collapsed() {
+        let mut dock = Dock::new();
+        dock.select(DockTab::L2);
+        assert_eq!(dock.active, Some(DockTab::L2));
+        // A second click on the open tab collapses; nothing else opens.
+        dock.select(DockTab::L2);
+        assert_eq!(dock.active, None);
+        // Switching tabs is one click, not collapse-then-open.
+        dock.select(DockTab::L2);
+        dock.select(DockTab::Bubbles);
+        assert_eq!(dock.active, Some(DockTab::Bubbles));
+    }
+
+    #[test]
+    fn open_tab_reveals_a_hidden_dock() {
+        let mut dock = Dock::new();
+        dock.toggle_visible();
+        assert!(!dock.visible());
+        dock.open_tab(DockTab::Session);
+        assert!(dock.visible());
+        assert_eq!(dock.active, Some(DockTab::Session));
+    }
+
+    #[test]
+    fn widths_are_remembered_per_tab_within_the_model_range() {
+        let mut dock = Dock::new();
+        dock.remember_width(DockTab::L2, 500.0);
+        assert_eq!(dock.widths[DockTab::L2.index()], DOCK_MAX_WIDTH);
+        dock.remember_width(DockTab::Bubbles, 10.0);
+        assert_eq!(dock.widths[DockTab::Bubbles.index()], DOCK_MIN_WIDTH);
+        dock.remember_width(DockTab::Session, 300.0);
+        assert_eq!(dock.widths[DockTab::Session.index()], 300.0);
+    }
+
+    #[test]
+    fn every_tab_has_strip_metadata() {
+        for tab in DockTab::ALL {
+            assert!(!tab.icon().is_empty());
+            assert!(!tab.title().is_empty());
+            assert!(!tab.hover_text().is_empty());
+        }
+    }
+
+    /// Lay the whole dock out for real, off-screen, on every tab — a broken
+    /// nested layout, a duplicated panel id or a body that panics fails here
+    /// instead of on the chart. Two frames per tab so the second one re-uses
+    /// the ids the first allocated.
+    #[test]
+    fn the_dock_draws_every_tab_against_a_real_context() {
+        let ctx = egui::Context::default();
+        let mut dock = Dock::new();
+        let mut orderflow = OrderflowView::new("TESTUSDT");
+        let mut replay_view = ReplayView::new();
+        for tab in DockTab::ALL {
+            dock.open_tab(tab);
+            for _ in 0..2 {
+                let _ = ctx.run(egui::RawInput::default(), |ctx| {
+                    let response = dock.draw(
+                        ctx,
+                        &mut DockEnv {
+                            orderflow: &mut orderflow,
+                            replay_view: &mut replay_view,
+                            replay: None,
+                        },
+                    );
+                    assert!(
+                        !response.restart_book_capture,
+                        "drawing settings must never restart capture by itself"
+                    );
+                    assert!(response.replay_action.is_none());
+                });
+            }
+        }
+        // Hidden dock: drawing is a no-op that asks nothing of the app.
+        dock.toggle_visible();
+        let _ = ctx.run(egui::RawInput::default(), |ctx| {
+            let response = dock.draw(
+                ctx,
+                &mut DockEnv {
+                    orderflow: &mut orderflow,
+                    replay_view: &mut replay_view,
+                    replay: None,
+                },
+            );
+            assert!(!response.restart_book_capture);
+        });
+    }
+}

--- a/crates/app/src/loading.rs
+++ b/crates/app/src/loading.rs
@@ -11,7 +11,7 @@
 
 use eframe::egui;
 
-use crate::app::{DIVIDER, OVERLAY};
+use crate::theme::{AMBER, TEXT_PRIMARY};
 
 /// Spinner diameter, in pixels — shared by the overlay and the inline row so
 /// loading looks the same everywhere it appears.
@@ -27,7 +27,7 @@ const LABEL_FONT_SIZE: f32 = 12.0;
 /// Distance from the top of the chart area to the backdrop, in pixels.
 const TOP_OFFSET_PX: f32 = 8.0;
 /// Backdrop opacity (0–255): dark enough to read over candles, light enough
-/// to keep the chart visible behind it. Matches the perf overlay's backdrop.
+/// to keep the chart visible behind it.
 const BACKDROP_ALPHA: u8 = 150;
 /// Backdrop corner radius, in pixels.
 const CORNER_RADIUS_PX: f32 = 4.0;
@@ -152,8 +152,8 @@ impl LoadingTracker {
 /// the caller's layout (including right-to-left rows) keeps deciding where
 /// they land.
 pub fn inline(ui: &mut egui::Ui, label: &str) {
-    ui.add(egui::Spinner::new().size(SPINNER_SIZE).color(DIVIDER));
-    ui.label(egui::RichText::new(format!("{label}…")).color(OVERLAY));
+    ui.add(egui::Spinner::new().size(SPINNER_SIZE).color(AMBER));
+    ui.label(egui::RichText::new(format!("{label}…")).color(TEXT_PRIMARY));
 }
 
 /// The one loading overlay: every active task as a spinner + label row on a
@@ -167,7 +167,9 @@ pub fn overlay(ui: &mut egui::Ui, area: egui::Rect, tracker: &LoadingTracker) {
     let painter = ui.painter().clone();
     let galleys: Vec<_> = tracker
         .active()
-        .map(|task| painter.layout_no_wrap(format!("{}…", task.label()), font.clone(), OVERLAY))
+        .map(|task| {
+            painter.layout_no_wrap(format!("{}…", task.label()), font.clone(), TEXT_PRIMARY)
+        })
         .collect();
 
     let widest = galleys
@@ -194,13 +196,13 @@ pub fn overlay(ui: &mut egui::Ui, area: egui::Rect, tracker: &LoadingTracker) {
         );
         ui.put(
             spinner,
-            egui::Spinner::new().size(SPINNER_SIZE).color(DIVIDER),
+            egui::Spinner::new().size(SPINNER_SIZE).color(AMBER),
         );
         let text_pos = egui::pos2(
             spinner.right() + GAP,
             y + (ROW_HEIGHT - galley.size().y) / 2.0,
         );
-        painter.galley(text_pos, galley, OVERLAY);
+        painter.galley(text_pos, galley, TEXT_PRIMARY);
         y += ROW_HEIGHT;
     }
 }

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -16,6 +16,7 @@ mod bubble_presets;
 mod candle_view;
 mod chart;
 mod config;
+mod dock;
 mod feed;
 mod loading;
 mod metrics;
@@ -27,9 +28,14 @@ mod orderflow_worker;
 mod price_view;
 mod replay_view;
 mod state;
+mod statusbar;
 mod style;
+mod theme;
 mod timezone;
+mod toolbar;
+mod toolrail;
 mod viewport;
+mod widgets;
 
 /// The bar type the chart opens on. The type and its parameter are tunable live
 /// from the controls bar; the feed and symbol come from the configuration.
@@ -118,7 +124,14 @@ fn main() -> eframe::Result {
     eframe::run_native(
         "quantick",
         options,
-        Box::new(move |_cc| {
+        Box::new(move |cc| {
+            // Chrome glyphs come from the bundled Phosphor icon font; the
+            // design tokens point egui's own widgets at the chrome palette.
+            // Both are installed once, before the first frame.
+            let mut fonts = egui::FontDefinitions::default();
+            egui_phosphor::add_to_fonts(&mut fonts, egui_phosphor::Variant::Regular);
+            cc.egui_ctx.set_fonts(fonts);
+            theme::apply(&cc.egui_ctx);
             Ok(Box::new(app::QuantickApp::new(
                 config,
                 feed_id,

--- a/crates/app/src/orderflow_view.rs
+++ b/crates/app/src/orderflow_view.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use eframe::egui;
+use egui_phosphor::regular as icons;
 use quantick_engine::{Bar, Trade};
 use quantick_orderbook::DepthEvent;
 use rust_decimal::Decimal;
@@ -35,14 +36,14 @@ use crate::viewport::Viewport;
 
 fn status_color(status: &CaptureStatus) -> egui::Color32 {
     match status {
-        CaptureStatus::Live { .. } => egui::Color32::from_rgb(45, 205, 145),
+        CaptureStatus::Live { .. } => crate::theme::BUY,
         CaptureStatus::Connecting | CaptureStatus::Buffering | CaptureStatus::SnapshotFetching => {
-            egui::Color32::from_rgb(240, 185, 11)
+            crate::theme::AMBER
         }
-        CaptureStatus::Disabled => egui::Color32::from_rgb(145, 155, 170),
+        CaptureStatus::Disabled => crate::theme::TEXT_MUTED,
         CaptureStatus::Resyncing { .. }
         | CaptureStatus::Disconnected { .. }
-        | CaptureStatus::Error => egui::Color32::from_rgb(255, 99, 71),
+        | CaptureStatus::Error => crate::theme::WARN,
     }
 }
 
@@ -57,10 +58,6 @@ pub struct OrderflowView {
     published: BookPublished,
     /// Engine bucket last adopted into the mirror, to detect auto-base moves.
     last_seen_base: Decimal,
-    /// Whether the docked L2 (liquidity map) settings panel is open.
-    show_l2_panel: bool,
-    /// Whether the docked aggression-bubble settings panel is open.
-    show_bubbles_panel: bool,
     capture_grouping_draft: f64,
     pending_capture_grouping_previous: Option<Decimal>,
     last_requested_layout: Option<ProjectionLayout>,
@@ -115,8 +112,6 @@ impl OrderflowView {
             config,
             published: BookPublished::initial(),
             last_seen_base: base_grouping,
-            show_l2_panel: false,
-            show_bubbles_panel: false,
             capture_grouping_draft: base_grouping.to_f64().unwrap_or(0.01),
             pending_capture_grouping_previous: None,
             last_requested_layout: None,
@@ -177,31 +172,6 @@ impl OrderflowView {
         }
         self.sync_published();
         self.published.live_end_ms
-    }
-
-    pub fn toggle_l2_panel(&mut self) {
-        self.show_l2_panel = !self.show_l2_panel;
-    }
-
-    pub fn toggle_bubbles_panel(&mut self) {
-        self.show_bubbles_panel = !self.show_bubbles_panel;
-    }
-
-    #[must_use]
-    pub fn l2_button_label(&self) -> String {
-        match self.config.display_grouping {
-            DisplayGrouping::Adaptive { .. } => "⚙ L2 · auto".to_owned(),
-            DisplayGrouping::Native => "⚙ L2 · 1×".to_owned(),
-            DisplayGrouping::Multiple(multiple) => format!("⚙ L2 · {multiple}×"),
-        }
-    }
-
-    #[must_use]
-    pub fn bubbles_button_label(&self) -> String {
-        format!(
-            "⚙ bubbles · {}",
-            cluster_label(self.config.bubble_cluster_ms)
-        )
     }
 
     #[cfg(test)]
@@ -474,7 +444,7 @@ impl OrderflowView {
                     }
                 });
             if ui
-                .small_button("↻")
+                .small_button(icons::ARROW_CLOCKWISE)
                 .on_hover_text("reload the presets file from disk, discarding unsaved tweaks")
                 .clicked()
             {
@@ -818,38 +788,19 @@ impl OrderflowView {
             });
     }
 
-    /// Draw the docked order-flow panels and return whether capture must
-    /// restart because the base capture resolution changed.
+    /// The L2 dock tab's body: everything the depth map owns. Returns
+    /// whether capture must restart because the base capture resolution
+    /// changed.
     ///
-    /// The L2 map and the aggression bubbles get one panel each, so neither
-    /// configuration hides behind the other's switch.
-    pub fn draw_panels(&mut self, ctx: &egui::Context) -> bool {
-        if !self.show_l2_panel && !self.show_bubbles_panel {
-            return false;
-        }
+    /// The layer's *toggle* lives in the toolbar; this tab is settings only —
+    /// opening it never starts capture (looking is not enabling).
+    pub fn draw_l2_tab(&mut self, ui: &mut egui::Ui) -> bool {
         self.sync_published();
         let before = self.config.clone();
-        self.draw_l2_panel(ctx);
-        self.draw_bubbles_panel(ctx);
-        self.commit_config_changes(before)
-    }
-
-    /// Left dock for everything the depth map owns.
-    fn draw_l2_panel(&mut self, ctx: &egui::Context) {
-        if !self.show_l2_panel {
-            return;
-        }
-        let mut open = true;
-        egui::SidePanel::left("orderflow_l2_panel")
-            .resizable(true)
-            .default_width(340.0)
-            .width_range(300.0..=620.0)
-            .show(ctx, |ui| {
-                panel_header(ui, "L2 · LIQUIDITY MAP", &mut open);
-                egui::ScrollArea::vertical()
-                    .id_salt("orderflow_l2_scroll")
-                    .auto_shrink([false, false])
-                    .show(ui, |ui| {
+        egui::ScrollArea::vertical()
+            .id_salt("orderflow_l2_scroll")
+            .auto_shrink([false, false])
+            .show(ui, |ui| {
                 ui.label(
                     egui::RichText::new(self.published.status.label())
                         .small()
@@ -1074,28 +1025,21 @@ impl OrderflowView {
                         ..HeatmapConfig::default()
                     };
                 }
-                    });
             });
-        self.show_l2_panel = open;
+        self.commit_config_changes(before)
     }
 
-    /// Left dock for the aggression layer. Everything here is independent of
-    /// L2 capture: bubbles are built from the aggregate-trade stream.
-    fn draw_bubbles_panel(&mut self, ctx: &egui::Context) {
-        if !self.show_bubbles_panel {
-            return;
-        }
-        let mut open = true;
-        egui::SidePanel::left("orderflow_bubbles_panel")
-            .resizable(true)
-            .default_width(300.0)
-            .width_range(260.0..=520.0)
-            .show(ctx, |ui| {
-                panel_header(ui, "AGGRESSION BUBBLES", &mut open);
-                egui::ScrollArea::vertical()
-                    .id_salt("orderflow_bubbles_scroll")
-                    .auto_shrink([false, false])
-                    .show(ui, |ui| {
+    /// The Bubbles dock tab's body: the aggression layer's settings.
+    /// Everything here is independent of L2 capture — bubbles are built from
+    /// the aggregate-trade stream. Same return contract as
+    /// [`Self::draw_l2_tab`].
+    pub fn draw_bubbles_tab(&mut self, ui: &mut egui::Ui) -> bool {
+        self.sync_published();
+        let before = self.config.clone();
+        egui::ScrollArea::vertical()
+            .id_salt("orderflow_bubbles_scroll")
+            .auto_shrink([false, false])
+            .show(ui, |ui| {
                         ui.small(
                             "Confirmed executions from the trade stream. Colour is the aggressor side; area is quantity.",
                         );
@@ -1158,7 +1102,7 @@ impl OrderflowView {
                         }
                         if ui
                             .button("reset bubble visuals")
-                            .on_hover_text("only this panel; L2 and history settings stay as they are")
+                            .on_hover_text("only this tab; L2 and history settings stay as they are")
                             .clicked()
                         {
                             let defaults = HeatmapConfig::default();
@@ -1171,8 +1115,7 @@ impl OrderflowView {
                                 Some("bubble defaults restored (not saved)".to_owned());
                         }
                     });
-            });
-        self.show_bubbles_panel = open;
+        self.commit_config_changes(before)
     }
 
     fn commit_config_changes(&mut self, before: HeatmapConfig) -> bool {
@@ -1200,30 +1143,6 @@ impl OrderflowView {
         }
         restart_required
     }
-}
-
-/// Title row shared by the docked panels, with the close affordance a floating
-/// window used to provide.
-fn panel_header(ui: &mut egui::Ui, title: &str, open: &mut bool) {
-    ui.horizontal(|ui| {
-        ui.label(
-            egui::RichText::new(title)
-                .strong()
-                .color(egui::Color32::from_rgb(255, 222, 92)),
-        );
-        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-            // `×` is Latin-1, so it renders in egui's default proportional
-            // font — the fancier ✕/✖ glyphs fall back to an empty box.
-            if ui
-                .small_button("×")
-                .on_hover_text("close this panel")
-                .clicked()
-            {
-                *open = false;
-            }
-        });
-    });
-    ui.separator();
 }
 
 fn theme_label(theme: HeatmapTheme) -> &'static str {
@@ -1294,19 +1213,19 @@ mod tests {
     use crate::orderflow::{BubbleSizeReference, BubbleStyle};
     use quantick_orderbook::{BookCoverage, BookDelta, BookLevel, BookSnapshot};
 
-    /// Lay the docked panels out for real, off-screen, so a broken nested
-    /// layout or a duplicated widget id fails here instead of on the chart.
-    /// Both panels are open at once: they share the left dock and the bubble
-    /// controls must not collide with the L2 ones.
+    /// Lay the dock tabs out for real, off-screen, so a broken nested layout
+    /// or a duplicated widget id fails here instead of on the chart. Both tabs
+    /// are drawn in the same frame: their widget ids must not collide.
     #[test]
-    fn the_bubble_panel_lays_out_every_control() {
+    fn the_bubble_tab_lays_out_every_control() {
         let ctx = egui::Context::default();
         let mut view = OrderflowView::new("BTCUSDT");
-        view.toggle_bubbles_panel();
-        view.toggle_l2_panel();
         let frame = |view: &mut OrderflowView| {
             ctx.run(egui::RawInput::default(), |ctx| {
-                view.draw_panels(ctx);
+                egui::CentralPanel::default().show(ctx, |ui| {
+                    view.draw_bubbles_tab(ui);
+                    view.draw_l2_tab(ui);
+                });
             })
         };
         // Two frames: the second one re-uses the ids the first allocated.
@@ -1328,9 +1247,8 @@ mod tests {
         let output = frame(&mut view);
         assert!(
             !output.shapes.is_empty(),
-            "the panel must still paint when bubbles are hidden"
+            "the tab must still paint when bubbles are hidden"
         );
-        assert!(view.show_bubbles_panel);
     }
 
     #[test]

--- a/crates/app/src/replay_view.rs
+++ b/crates/app/src/replay_view.rs
@@ -16,24 +16,23 @@ use std::sync::Arc;
 use std::sync::mpsc::{Receiver, TryRecvError};
 
 use eframe::egui;
+use egui_phosphor::regular as icons;
 
 use quantick_replay::clock::SPEEDS;
 use quantick_replay::format::{self, UtcOffset};
 use quantick_replay::{Library, ParseOptions, Session, SessionEntry, SessionError, library};
 
-use crate::app::{DIVIDER, MUTED, OVERLAY, WARN};
 use crate::feed::{ReplayControl, ReplayLink, ReplayOptions, ReplayRequest};
+use crate::theme::{AMBER, CHROME, CONTROL, TEXT_MUTED, TEXT_PRIMARY, WARN};
 
 /// The accent this feature owns: the same amber the chart already uses for the
 /// backfill/live divider, so "this is not live data" reads the same way twice.
 /// Borrowed rather than repeated, so the two can never drift apart.
-const REPLAY_ACCENT: egui::Color32 = DIVIDER;
+const REPLAY_ACCENT: egui::Color32 = AMBER;
 
-/// Background of the docked transport bar.
-const TRANSPORT_BG: egui::Color32 = egui::Color32::from_rgb(24, 27, 34);
-
-/// The unplayed part of the seek track.
-const TRACK_BG: egui::Color32 = egui::Color32::from_rgb(45, 50, 60);
+/// Height of the transport strip, in pixels — part of the status system, one
+/// line directly above the status bar (`docs/ux/ui-design-model.md` §8).
+pub const TRANSPORT_HEIGHT: f32 = 30.0;
 
 /// Environment variable naming the folder the browser opens on.
 pub const REPLAY_DIR_ENV: &str = "QUANTICK_REPLAY_DIR";
@@ -293,7 +292,7 @@ impl ReplayView {
             .default_height(460.0)
             .anchor(egui::Align2::CENTER_CENTER, egui::vec2(0.0, 0.0))
             .show(ctx, |ui| {
-                ui.visuals_mut().override_text_color = Some(OVERLAY);
+                ui.visuals_mut().override_text_color = Some(TEXT_PRIMARY);
                 self.draw_folder_row(ui);
                 ui.add_space(10.0);
                 load_clicked = self.draw_session_list(ui);
@@ -311,7 +310,11 @@ impl ReplayView {
     }
 
     fn draw_folder_row(&mut self, ui: &mut egui::Ui) {
-        ui.label(egui::RichText::new("Replay folder").color(MUTED).small());
+        ui.label(
+            egui::RichText::new("Replay folder")
+                .color(TEXT_MUTED)
+                .small(),
+        );
         ui.horizontal(|ui| {
             let width = (ui.available_width() - 110.0).max(120.0);
             let response = ui.add_sized(
@@ -327,7 +330,7 @@ impl ReplayView {
                 self.browse();
             }
             if ui
-                .button("↻")
+                .button(icons::ARROW_CLOCKWISE)
                 .on_hover_text("Scan this folder again")
                 .clicked()
             {
@@ -345,7 +348,7 @@ impl ReplayView {
     /// the same request as picking it and pressing **Play session**.
     fn draw_session_list(&mut self, ui: &mut egui::Ui) -> bool {
         let mut open_requested = false;
-        ui.label(egui::RichText::new("Sessions").color(MUTED).small());
+        ui.label(egui::RichText::new("Sessions").color(TEXT_MUTED).small());
         let frame = egui::Frame::none()
             .fill(egui::Color32::from_black_alpha(60))
             .inner_margin(8.0)
@@ -358,7 +361,7 @@ impl ReplayView {
                 ui.vertical_centered(|ui| {
                     ui.label(
                         egui::RichText::new("Choose the folder holding your recorded sessions.")
-                            .color(MUTED),
+                            .color(TEXT_MUTED),
                     );
                 });
                 return;
@@ -372,7 +375,7 @@ impl ReplayView {
                         egui::RichText::new(
                             "quantick reads one CSV per session day, in a folder per instrument.",
                         )
-                        .color(MUTED)
+                        .color(TEXT_MUTED)
                         .small(),
                     );
                 });
@@ -404,7 +407,7 @@ impl ReplayView {
                             for note in &entry.notes {
                                 ui.label(
                                     egui::RichText::new(format!("    {note}"))
-                                        .color(MUTED)
+                                        .color(TEXT_MUTED)
                                         .small(),
                                 );
                             }
@@ -438,14 +441,14 @@ impl ReplayView {
                     ui.horizontal_wrapped(|ui| {
                         ui.label(
                             egui::RichText::new(problem.subject())
-                                .color(OVERLAY)
+                                .color(TEXT_PRIMARY)
                                 .monospace(),
                         );
-                        ui.label(egui::RichText::new(&problem.detail).color(MUTED));
+                        ui.label(egui::RichText::new(&problem.detail).color(TEXT_MUTED));
                     });
                     ui.label(
                         egui::RichText::new(format!("    {}", problem.advice()))
-                            .color(MUTED)
+                            .color(TEXT_MUTED)
                             .small(),
                     );
                     ui.add_space(4.0);
@@ -460,7 +463,7 @@ impl ReplayView {
             "Show the file format"
         };
         if ui
-            .link(egui::RichText::new(label).color(MUTED).small())
+            .link(egui::RichText::new(label).color(TEXT_MUTED).small())
             .clicked()
         {
             self.show_format = !self.show_format;
@@ -481,7 +484,7 @@ impl ReplayView {
                             egui::RichText::new(format::FORMAT_HELP)
                                 .monospace()
                                 .small()
-                                .color(MUTED),
+                                .color(TEXT_MUTED),
                         );
                     });
             });
@@ -503,7 +506,7 @@ impl ReplayView {
 
         let mut clicked = false;
         ui.horizontal(|ui| {
-            ui.label(egui::RichText::new("Start at").color(MUTED).small());
+            ui.label(egui::RichText::new("Start at").color(TEXT_MUTED).small());
             for speed in SPEEDS {
                 let selected = (self.speed - speed).abs() < f32::EPSILON;
                 if speed_chip(ui, speed, selected).clicked() {
@@ -536,23 +539,26 @@ impl ReplayView {
         clicked
     }
 
-    /// The transport bar, docked at the bottom while a session is playing.
+    /// The transport strip: one 30 px row directly above the status bar while
+    /// a session is playing — part of the status system, not an island (§8).
     fn draw_transport(&mut self, ctx: &egui::Context, link: &ReplayLink) -> Option<ReplayAction> {
         let mut action = None;
         let status = &link.status;
         let timezone = link.session.timezone();
 
         egui::TopBottomPanel::bottom("replay_transport")
+            .exact_height(TRANSPORT_HEIGHT)
             .frame(
                 egui::Frame::none()
-                    .fill(TRANSPORT_BG)
-                    .inner_margin(egui::Margin::symmetric(10.0, 6.0)),
+                    .fill(CHROME)
+                    .inner_margin(egui::Margin::symmetric(10.0, 3.0)),
             )
             .show(ctx, |ui| {
-                ui.visuals_mut().override_text_color = Some(OVERLAY);
-                ui.horizontal(|ui| {
+                ui.visuals_mut().override_text_color = Some(TEXT_PRIMARY);
+                ui.horizontal_centered(|ui| {
+                    ui.spacing_mut().item_spacing.x = 6.0;
                     if ui
-                        .button("⏮")
+                        .button(icons::SKIP_BACK)
                         .on_hover_text("Back to the first print")
                         .clicked()
                     {
@@ -563,9 +569,9 @@ impl ReplayView {
                     // cannot invert a state that changed between frames.
                     let playing = status.is_playing() && !status.is_finished();
                     let (label, hint, control) = if playing {
-                        ("⏸", "Pause (Space)", ReplayControl::Pause)
+                        (icons::PAUSE, "Pause (Space)", ReplayControl::Pause)
                     } else {
-                        ("▶", "Play (Space)", ReplayControl::Play)
+                        (icons::PLAY, "Play (Space)", ReplayControl::Play)
                     };
                     if ui
                         .button(egui::RichText::new(label).color(REPLAY_ACCENT))
@@ -575,16 +581,14 @@ impl ReplayView {
                         action = Some(ReplayAction::Control(control));
                     }
 
-                    ui.add_space(6.0);
                     badge(ui, "REPLAY");
-                    ui.label(egui::RichText::new(link.label()).color(OVERLAY));
+                    ui.label(egui::RichText::new(link.label()).color(TEXT_PRIMARY));
                     ui.label(
                         egui::RichText::new(clock_text(status.position_ms(), timezone))
                             .monospace()
                             .color(REPLAY_ACCENT),
                     );
 
-                    ui.add_space(6.0);
                     for speed in SPEEDS {
                         let selected = (status.speed() - speed).abs() < f32::EPSILON;
                         if speed_chip(ui, speed, selected).clicked() {
@@ -594,7 +598,7 @@ impl ReplayView {
 
                     ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                         if ui
-                            .button("✖")
+                            .button(icons::X)
                             .on_hover_text("Close the replay and go back to the live feed")
                             .clicked()
                         {
@@ -606,18 +610,18 @@ impl ReplayView {
                                 thousands(status.played()),
                                 thousands(status.total())
                             ))
-                            .color(MUTED)
+                            .color(TEXT_MUTED)
                             .small(),
                         );
+                        // The seek track takes every pixel left between the
+                        // speed chips and the counts.
+                        if let Some(fraction) = seek_track(ui, status.progress(), &mut self.scrub) {
+                            action = Some(ReplayAction::Control(ReplayControl::SeekToFraction(
+                                fraction,
+                            )));
+                        }
                     });
                 });
-
-                ui.add_space(2.0);
-                if let Some(fraction) = seek_track(ui, status.progress(), &mut self.scrub) {
-                    action = Some(ReplayAction::Control(ReplayControl::SeekToFraction(
-                        fraction,
-                    )));
-                }
             });
 
         // Space toggles playback, the way every media transport behaves. Only
@@ -694,7 +698,7 @@ fn seek_track(ui: &mut egui::Ui, progress: f32, scrub: &mut Option<f32>) -> Opti
     };
 
     let painter = ui.painter();
-    painter.rect_filled(track, 3.0, TRACK_BG);
+    painter.rect_filled(track, 3.0, CONTROL);
     let filled = egui::Rect::from_min_size(track.min, egui::vec2(width * shown, TRACK_HEIGHT));
     painter.rect_filled(filled, 3.0, REPLAY_ACCENT);
     painter.circle_filled(

--- a/crates/app/src/statusbar.rs
+++ b/crates/app/src/statusbar.rs
@@ -115,6 +115,9 @@ pub struct StatusModel {
     pub fps: Option<f32>,
     /// Rolling mean frame time, in milliseconds.
     pub frame_avg_ms: Option<f32>,
+    /// Rolling mean CPU cost per frame (update + tessellation + paint, no
+    /// vsync wait), in milliseconds.
+    pub frame_cpu_ms: Option<f32>,
     /// Whether the perf readings (fps, frame time, trades) are shown
     /// (View → perf readings).
     pub show_perf: bool,
@@ -248,11 +251,15 @@ fn draw_machinery(ui: &mut egui::Ui, model: &StatusModel, tz: &mut TzOffset) {
         .frame_avg_ms
         .is_some_and(|avg| avg > metrics::SLOW_FRAME_MS);
     let fps_color = if slow { theme::WARN } else { theme::TEXT_MUTED };
+    // The cpu cost rides along because frame time alone hides behind vsync:
+    // a real incident needed exactly this split to tell "we are slow" from
+    // "we are waiting for the display".
     ui.label(
         egui::RichText::new(format!(
-            "{:>4.0} fps · {:>5.1} ms",
+            "{:>4.0} fps · {:>5.1} ms · cpu {:>4.1} ms",
             model.fps.unwrap_or(0.0),
-            model.frame_avg_ms.unwrap_or(0.0)
+            model.frame_avg_ms.unwrap_or(0.0),
+            model.frame_cpu_ms.unwrap_or(0.0)
         ))
         .monospace()
         .color(fps_color),
@@ -339,7 +346,8 @@ mod tests {
                 price_auto: false,
                 live_trades: 12_345,
                 fps: Some(60.0),
-                frame_avg_ms: Some(4.2),
+                frame_avg_ms: Some(16.7),
+                frame_cpu_ms: Some(4.2),
                 show_perf: true,
             };
             for _ in 0..2 {

--- a/crates/app/src/statusbar.rs
+++ b/crates/app/src/statusbar.rs
@@ -1,0 +1,355 @@
+//! The status bar: one 28 px line answering "how healthy is it?"
+//! (`docs/ux/ui-design-model.md` §8).
+//!
+//! Three sections replace the perf overlay, the floating timezone pill and
+//! the mode text that used to be painted over candles: provenance on the
+//! left (state dot, venue, symbol, lag), content in the middle (bar spec,
+//! counts, honesty labels), machinery on the right (trades, fps, and the
+//! bar's only control — the timezone picker). A reading that breaches its
+//! threshold turns [`theme::WARN`]; the layout never moves.
+//!
+//! The section values are computed by the app and handed in as a plain
+//! [`StatusModel`], so every text and colour decision here stays pure and
+//! unit-testable.
+
+use eframe::egui;
+use egui_phosphor::regular as icons;
+
+use crate::metrics;
+use crate::theme;
+use crate::timezone::TzOffset;
+
+/// Height of the status line, in pixels (§5 zone 7).
+pub const STATUS_BAR_HEIGHT: f32 = 28.0;
+/// Diameter of the provenance state dot, in pixels.
+const STATE_DOT_DIAMETER_PX: f32 = 8.0;
+/// Gap between neighbouring cells on the line, in pixels.
+const CELL_SPACING_PX: f32 = 8.0;
+
+/// What the provenance dot reports.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FeedState {
+    /// No trade has arrived yet.
+    Connecting,
+    /// Live and within the lag threshold.
+    Live,
+    /// Live but the newest trade is older than [`metrics::HIGH_LAG_MS`].
+    Stalled,
+    /// A recorded session is the source.
+    Replay,
+}
+
+impl FeedState {
+    /// Dot colour: green live, amber replay, red stalled, faint connecting.
+    #[must_use]
+    pub fn color(self) -> egui::Color32 {
+        match self {
+            Self::Connecting => theme::TEXT_FAINT,
+            Self::Live => theme::BUY,
+            Self::Stalled => theme::WARN,
+            Self::Replay => theme::AMBER,
+        }
+    }
+
+    /// The word next to the dot.
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Connecting => "connecting",
+            Self::Live => "live",
+            Self::Stalled => "stalled",
+            Self::Replay => "replay",
+        }
+    }
+}
+
+/// Classify the feed for the provenance dot.
+#[must_use]
+pub fn feed_state(replaying: bool, lag_ms: Option<i64>) -> FeedState {
+    if replaying {
+        return FeedState::Replay;
+    }
+    match lag_ms {
+        None => FeedState::Connecting,
+        Some(lag) if lag > metrics::HIGH_LAG_MS => FeedState::Stalled,
+        Some(_) => FeedState::Live,
+    }
+}
+
+/// Replay figures for the provenance section, read from the transport link.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ReplayFigures {
+    /// Playback speed multiplier.
+    pub speed: f32,
+    /// Played fraction in `[0, 1]`.
+    pub progress: f32,
+}
+
+/// Everything the bar shows this frame, precomputed by the app.
+pub struct StatusModel {
+    /// Display name of the venue (or the session, while replaying).
+    pub venue: String,
+    /// The streamed symbol.
+    pub symbol: String,
+    /// Replay speed/progress while a recording plays, `None` when live.
+    pub replay: Option<ReplayFigures>,
+    /// Exchange-to-screen lag of the newest trade; `None` before the first
+    /// trade or while replaying (a recording has no lag to report).
+    pub feed_lag_ms: Option<i64>,
+    /// The bar spec, e.g. `tick(50)`.
+    pub spec_summary: String,
+    /// Closed bars built from backfilled history.
+    pub backfilled_bars: usize,
+    /// Closed bars built live.
+    pub live_bars: usize,
+    /// Data-honesty label such as `side: inferred (tick rule)`, when the
+    /// aggressor side is not venue truth.
+    pub side_note: Option<String>,
+    /// Whether the viewport follows the live edge.
+    pub follows_live: bool,
+    /// Whether the price axis is auto-fitting.
+    pub price_auto: bool,
+    /// Live trades ingested since the feed started.
+    pub live_trades: u64,
+    /// Rolling frames per second.
+    pub fps: Option<f32>,
+    /// Rolling mean frame time, in milliseconds.
+    pub frame_avg_ms: Option<f32>,
+    /// Whether the perf readings (fps, frame time, trades) are shown
+    /// (View → perf readings).
+    pub show_perf: bool,
+}
+
+/// The lag/progress cell: `lag 123 ms` live, `10× 45%` while replaying,
+/// `lag —` before the first trade.
+#[must_use]
+pub fn lag_text(replay: Option<ReplayFigures>, lag_ms: Option<i64>) -> String {
+    match (replay, lag_ms) {
+        (Some(figures), _) => format!(
+            "{:.0}× {:>3.0}%",
+            figures.speed,
+            figures.progress.clamp(0.0, 1.0) * 100.0
+        ),
+        (None, Some(lag)) => format!("lag {lag} ms"),
+        (None, None) => "lag —".to_owned(),
+    }
+}
+
+/// The bar-count cell, keeping the backfilled+live split: `240+61 bars`.
+#[must_use]
+pub fn bars_text(backfilled: usize, live: usize) -> String {
+    format!("{backfilled}+{live} bars")
+}
+
+/// Draw the status bar as the window's bottom panel. `tz` is the bar's only
+/// control; picking an offset relabels the time axis immediately.
+pub fn draw(ctx: &egui::Context, model: &StatusModel, tz: &mut TzOffset) {
+    egui::TopBottomPanel::bottom("status_bar")
+        .exact_height(STATUS_BAR_HEIGHT)
+        .frame(
+            egui::Frame::none()
+                .fill(theme::CHROME)
+                .inner_margin(egui::Margin::symmetric(10.0, 4.0)),
+        )
+        .show(ctx, |ui| {
+            ui.horizontal_centered(|ui| {
+                ui.spacing_mut().item_spacing.x = CELL_SPACING_PX;
+                draw_provenance(ui, model);
+                ui.separator();
+                draw_content(ui, model);
+                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                    draw_machinery(ui, model, tz)
+                });
+            });
+        });
+}
+
+/// Left section: state dot, venue, symbol, lag.
+fn draw_provenance(ui: &mut egui::Ui, model: &StatusModel) {
+    let state = feed_state(model.replay.is_some(), model.feed_lag_ms);
+    let (rect, _) = ui.allocate_exact_size(
+        egui::vec2(STATE_DOT_DIAMETER_PX, STATE_DOT_DIAMETER_PX),
+        egui::Sense::hover(),
+    );
+    ui.painter()
+        .circle_filled(rect.center(), STATE_DOT_DIAMETER_PX / 2.0, state.color());
+    ui.label(
+        egui::RichText::new(state.label())
+            .small()
+            .color(state.color()),
+    );
+    ui.label(egui::RichText::new(&model.venue).color(theme::TEXT_MUTED));
+    ui.label(
+        egui::RichText::new(&model.symbol)
+            .monospace()
+            .color(theme::TEXT_PRIMARY),
+    );
+    let lag_color = match state {
+        FeedState::Stalled => theme::WARN,
+        FeedState::Replay => theme::AMBER,
+        FeedState::Live | FeedState::Connecting => theme::TEXT_MUTED,
+    };
+    ui.label(
+        egui::RichText::new(lag_text(model.replay, model.feed_lag_ms))
+            .monospace()
+            .color(lag_color),
+    );
+}
+
+/// Middle section: bar spec, counts, honesty labels and navigation hints.
+fn draw_content(ui: &mut egui::Ui, model: &StatusModel) {
+    ui.label(
+        egui::RichText::new(&model.spec_summary)
+            .monospace()
+            .color(theme::TEXT_PRIMARY),
+    );
+    ui.label(
+        egui::RichText::new(bars_text(model.backfilled_bars, model.live_bars))
+            .monospace()
+            .color(theme::TEXT_MUTED),
+    );
+    if let Some(note) = &model.side_note {
+        // Inferred data wears the amber thread, like every not-quite-venue
+        // truth on this chart.
+        ui.label(egui::RichText::new(note).small().color(theme::AMBER));
+    }
+    if !model.follows_live {
+        ui.label(
+            egui::RichText::new("history · double-click for live")
+                .small()
+                .color(theme::TEXT_FAINT),
+        );
+    }
+    if !model.price_auto {
+        ui.label(
+            egui::RichText::new("price: manual · double-click the axis to auto-fit")
+                .small()
+                .color(theme::TEXT_FAINT),
+        );
+    }
+}
+
+/// Right section, laid out right-to-left: timezone picker at the far edge,
+/// then the perf readings.
+fn draw_machinery(ui: &mut egui::Ui, model: &StatusModel, tz: &mut TzOffset) {
+    egui::ComboBox::from_id_salt("tz_combo")
+        .selected_text(tz.label())
+        .show_ui(ui, |ui| {
+            for offset in TzOffset::ALL {
+                ui.selectable_value(tz, offset, offset.label());
+            }
+        });
+    ui.label(egui::RichText::new(icons::CLOCK).color(theme::TEXT_MUTED));
+    if !model.show_perf {
+        return;
+    }
+    ui.separator();
+    let slow = model
+        .frame_avg_ms
+        .is_some_and(|avg| avg > metrics::SLOW_FRAME_MS);
+    let fps_color = if slow { theme::WARN } else { theme::TEXT_MUTED };
+    ui.label(
+        egui::RichText::new(format!(
+            "{:>4.0} fps · {:>5.1} ms",
+            model.fps.unwrap_or(0.0),
+            model.frame_avg_ms.unwrap_or(0.0)
+        ))
+        .monospace()
+        .color(fps_color),
+    );
+    ui.separator();
+    ui.label(
+        egui::RichText::new(format!("{} trades", model.live_trades))
+            .monospace()
+            .color(theme::TEXT_MUTED),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_dot_reads_the_feed_honestly() {
+        assert_eq!(feed_state(false, None), FeedState::Connecting);
+        assert_eq!(feed_state(false, Some(120)), FeedState::Live);
+        assert_eq!(
+            feed_state(false, Some(metrics::HIGH_LAG_MS + 1)),
+            FeedState::Stalled
+        );
+        // A recording is replay, whatever its (meaningless) lag would be.
+        assert_eq!(feed_state(true, None), FeedState::Replay);
+        assert_eq!(feed_state(true, Some(999_999)), FeedState::Replay);
+    }
+
+    #[test]
+    fn dot_colours_follow_the_tokens() {
+        assert_eq!(FeedState::Live.color(), theme::BUY);
+        assert_eq!(FeedState::Replay.color(), theme::AMBER);
+        assert_eq!(FeedState::Stalled.color(), theme::WARN);
+        assert_eq!(FeedState::Connecting.color(), theme::TEXT_FAINT);
+    }
+
+    #[test]
+    fn lag_cell_reports_replay_live_and_waiting() {
+        let replay = Some(ReplayFigures {
+            speed: 10.0,
+            progress: 0.45,
+        });
+        assert_eq!(lag_text(replay, None), "10×  45%");
+        assert_eq!(lag_text(None, Some(230)), "lag 230 ms");
+        assert_eq!(lag_text(None, None), "lag —");
+    }
+
+    #[test]
+    fn replay_progress_is_clamped_to_a_percentage() {
+        let over = Some(ReplayFigures {
+            speed: 1.0,
+            progress: 1.7,
+        });
+        assert_eq!(lag_text(over, None), "1× 100%");
+    }
+
+    #[test]
+    fn bar_counts_keep_the_backfilled_live_split() {
+        assert_eq!(bars_text(240, 61), "240+61 bars");
+        assert_eq!(bars_text(0, 0), "0+0 bars");
+    }
+
+    /// Lay the bar out for real, off-screen, in its live and replay shapes —
+    /// every section drawn, no duplicated widget id, no panicking widget.
+    #[test]
+    fn the_status_bar_lays_out_against_a_real_context() {
+        let ctx = egui::Context::default();
+        let mut tz = TzOffset::default();
+        for replaying in [false, true] {
+            let model = StatusModel {
+                venue: "Binance".to_owned(),
+                symbol: "BTCUSDT".to_owned(),
+                replay: replaying.then_some(ReplayFigures {
+                    speed: 10.0,
+                    progress: 0.4,
+                }),
+                feed_lag_ms: (!replaying).then_some(120),
+                spec_summary: "tick(50)".to_owned(),
+                backfilled_bars: 240,
+                live_bars: 61,
+                side_note: replaying.then(|| "side: inferred (tick rule)".to_owned()),
+                follows_live: false,
+                price_auto: false,
+                live_trades: 12_345,
+                fps: Some(60.0),
+                frame_avg_ms: Some(4.2),
+                show_perf: true,
+            };
+            for _ in 0..2 {
+                let _ = ctx.run(egui::RawInput::default(), |ctx| draw(ctx, &model, &mut tz));
+            }
+        }
+        assert_eq!(
+            tz,
+            TzOffset::default(),
+            "an un-clicked frame changes nothing"
+        );
+    }
+}

--- a/crates/app/src/theme.rs
+++ b/crates/app/src/theme.rs
@@ -1,0 +1,146 @@
+//! The chrome's design tokens, named after `docs/ux/ui-design-model.md` §4.
+//!
+//! One module answers "which colour is this?" for every fixed surface — menu,
+//! toolbar, tool rail, dock, status bar — so a new control never invents its
+//! own grey. The chart canvas itself stays user-configurable through
+//! [`crate::style::CanvasStyle`]; only the chrome is pinned here.
+//!
+//! [`AMBER`] is reserved for provenance honesty — replay, the backfill
+//! divider, inferred data — and is never decoration. This is the UI
+//! expression of the project's data-honesty rule.
+
+use eframe::egui;
+use eframe::egui::Color32;
+
+/// `bg/canvas` — default chart canvas (user-configurable in the appearance
+/// dialog; [`crate::style::CanvasStyle`] holds the editable copy, and the
+/// parity test below keeps the two in agreement — the reason this token
+/// exists without a chrome consumer).
+#[allow(dead_code)]
+pub const CANVAS: Color32 = Color32::from_rgb(0x13, 0x17, 0x22);
+/// `bg/chrome` — menu bar, toolbar, tool rail, dock and status bar.
+pub const CHROME: Color32 = Color32::from_rgb(0x17, 0x1B, 0x26);
+/// `bg/inset` — sub-panes and wells sunk into the chrome.
+pub const INSET: Color32 = Color32::from_rgb(0x10, 0x14, 0x1D);
+/// `bg/control` — buttons, combos and inputs (also the default grid colour).
+pub const CONTROL: Color32 = Color32::from_rgb(0x23, 0x29, 0x36);
+/// `border` — panel and control borders.
+pub const BORDER: Color32 = Color32::from_rgb(0x2E, 0x36, 0x48);
+/// `text/primary` — labels and values.
+pub const TEXT_PRIMARY: Color32 = Color32::from_rgb(0xD2, 0xDA, 0xE2);
+/// `text/muted` — secondary labels.
+pub const TEXT_MUTED: Color32 = Color32::from_rgb(0x96, 0xA0, 0xAF);
+/// `text/faint` — hints, disabled text and the crosshair.
+pub const TEXT_FAINT: Color32 = Color32::from_rgb(0x6E, 0x78, 0x87);
+/// `buy` — bull candles, buy flow and the healthy/live status dot.
+pub const BUY: Color32 = Color32::from_rgb(0x26, 0xA6, 0x9A);
+/// `sell` — bear candles and sell flow. Candles read their editable copy
+/// from [`crate::style`]; the parity test below pins the two together, which
+/// is this token's only consumer until a chrome surface needs sell red.
+#[allow(dead_code)]
+pub const SELL: Color32 = Color32::from_rgb(0xEF, 0x53, 0x50);
+/// `accent/overlay` — selection accent and the future first indicator plot.
+pub const ACCENT: Color32 = Color32::from_rgb(0x8A, 0xB4, 0xF8);
+/// `honest/amber` — not-live provenance only: replay, backfill, inferred data.
+pub const AMBER: Color32 = Color32::from_rgb(0xF0, 0xB9, 0x0B);
+/// `warn` — threshold breaches and errors.
+pub const WARN: Color32 = Color32::from_rgb(0xFF, 0x63, 0x47);
+/// `tag/bg` — tooltips and the axis price tag.
+pub const TAG_BG: Color32 = Color32::from_rgb(0x37, 0x3F, 0x50);
+
+/// Alpha of an "active" tint: a layer accent at 22% over the chrome.
+const ACTIVE_TINT_ALPHA: u8 = 56; // ≈ 22% of 255
+
+/// `accent` reduced to the 22% tint used behind an active icon.
+#[must_use]
+pub fn active_tint(accent: Color32) -> Color32 {
+    Color32::from_rgba_unmultiplied(accent.r(), accent.g(), accent.b(), ACTIVE_TINT_ALPHA)
+}
+
+/// Point egui's own widgets at the tokens, so combos, sliders and windows
+/// drawn anywhere in the app match the chrome without per-call overrides.
+pub fn apply(ctx: &egui::Context) {
+    let mut style = (*ctx.style()).clone();
+    let visuals = &mut style.visuals;
+    *visuals = egui::Visuals::dark();
+    visuals.panel_fill = CHROME;
+    visuals.window_fill = CHROME;
+    visuals.window_stroke = egui::Stroke::new(1.0_f32, BORDER);
+    visuals.extreme_bg_color = INSET;
+    visuals.faint_bg_color = INSET;
+    visuals.widgets.noninteractive.bg_fill = CHROME;
+    visuals.widgets.noninteractive.bg_stroke = egui::Stroke::new(1.0_f32, BORDER);
+    visuals.widgets.noninteractive.fg_stroke.color = TEXT_MUTED;
+    visuals.widgets.inactive.bg_fill = CONTROL;
+    visuals.widgets.inactive.weak_bg_fill = CONTROL;
+    visuals.widgets.inactive.fg_stroke.color = TEXT_PRIMARY;
+    visuals.widgets.hovered.bg_fill = BORDER;
+    visuals.widgets.hovered.weak_bg_fill = BORDER;
+    visuals.widgets.hovered.bg_stroke = egui::Stroke::new(1.0_f32, BORDER);
+    visuals.widgets.hovered.fg_stroke.color = TEXT_PRIMARY;
+    visuals.widgets.active.bg_fill = active_tint(ACCENT);
+    visuals.widgets.active.weak_bg_fill = active_tint(ACCENT);
+    visuals.widgets.active.fg_stroke.color = TEXT_PRIMARY;
+    visuals.widgets.open.bg_fill = CONTROL;
+    visuals.widgets.open.weak_bg_fill = CONTROL;
+    visuals.widgets.open.fg_stroke.color = TEXT_PRIMARY;
+    visuals.selection.bg_fill = active_tint(ACCENT);
+    visuals.selection.stroke = egui::Stroke::new(1.0_f32, ACCENT);
+    visuals.hyperlink_color = ACCENT;
+    ctx.set_style(style);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tokens_match_the_design_model() {
+        // The values documented in docs/ux/ui-design-model.md §4, verbatim.
+        assert_eq!(CANVAS, Color32::from_rgb(19, 23, 34));
+        assert_eq!(CHROME, Color32::from_rgb(23, 27, 38));
+        assert_eq!(INSET, Color32::from_rgb(16, 20, 29));
+        assert_eq!(CONTROL, Color32::from_rgb(35, 41, 54));
+        assert_eq!(BORDER, Color32::from_rgb(46, 54, 72));
+        assert_eq!(TEXT_PRIMARY, Color32::from_rgb(210, 218, 226));
+        assert_eq!(TEXT_MUTED, Color32::from_rgb(150, 160, 175));
+        assert_eq!(TEXT_FAINT, Color32::from_rgb(110, 120, 135));
+        assert_eq!(BUY, Color32::from_rgb(38, 166, 154));
+        assert_eq!(SELL, Color32::from_rgb(239, 83, 80));
+        assert_eq!(ACCENT, Color32::from_rgb(138, 180, 248));
+        assert_eq!(AMBER, Color32::from_rgb(240, 185, 11));
+        assert_eq!(WARN, Color32::from_rgb(255, 99, 71));
+        assert_eq!(TAG_BG, Color32::from_rgb(55, 63, 80));
+    }
+
+    #[test]
+    fn canvas_default_and_grid_agree_with_the_style_module() {
+        // The user-editable canvas defaults must start on the tokens, or the
+        // first paint would disagree with this palette.
+        let canvas = crate::style::CanvasStyle::default();
+        assert_eq!(
+            canvas.background_rgba(),
+            [CANVAS.r(), CANVAS.g(), CANVAS.b(), 255]
+        );
+        let grid = canvas.grid_rgba().expect("grid on by default");
+        assert_eq!(&grid[..3], &[CONTROL.r(), CONTROL.g(), CONTROL.b()]);
+    }
+
+    #[test]
+    fn default_candles_agree_with_the_buy_sell_tokens() {
+        // The Order-flow preset's fills are the token pair; a drifted preset
+        // would break the "one deliberate visual signature" rule quietly.
+        let candles = crate::style::CandlePreset::OrderFlow.style();
+        assert_eq!(candles.bull_fill, [BUY.r(), BUY.g(), BUY.b()]);
+        assert_eq!(candles.bear_fill, [SELL.r(), SELL.g(), SELL.b()]);
+    }
+
+    #[test]
+    fn active_tint_is_the_accent_at_22_percent() {
+        // Compare through the same constructor: egui stores premultiplied
+        // colour, so the raw channel accessors do not round-trip the input.
+        let tint = active_tint(ACCENT);
+        assert_eq!(tint, Color32::from_rgba_unmultiplied(0x8A, 0xB4, 0xF8, 56));
+        assert_eq!(tint.a(), 56);
+    }
+}

--- a/crates/app/src/toolbar.rs
+++ b/crates/app/src/toolbar.rs
@@ -1,0 +1,613 @@
+//! The context toolbar: *what am I looking at* on the left, *what is drawn
+//! on it* on the right (`docs/ux/ui-design-model.md` §6).
+//!
+//! Left: SOURCE (feed + symbol, or the amber session label while replaying),
+//! BARS (kind + one parameter), HISTORY (a `+ older ▾` split button whose
+//! menu holds the page size). Right: LAYERS (one icon toggle per visual
+//! layer; right-click opens its dock tab), LOOK (appearance dialog), PANELS
+//! (dock show/hide). The toolbar never wraps: [`collapse_plan`] folds groups
+//! into the `⋯` overflow menu in the §6 order — LOOK → PANELS → HISTORY →
+//! bar parameter merges into the kind combo → the feed name shrinks to its
+//! initial. The symbol and LAYERS never fold.
+//!
+//! The widgets edit the app's state through [`ToolbarModel`]'s borrows;
+//! anything with a side effect beyond a field write comes back as a
+//! [`ToolbarAction`] for the app to carry out.
+
+use eframe::egui;
+use egui_phosphor::regular as icons;
+
+use crate::config::FeedCapabilities;
+use crate::dock::DockTab;
+use crate::state::BarKind;
+use crate::theme;
+use crate::widgets::{IconButton, TOOLBAR_ICON};
+
+/// Height of the toolbar, in pixels (§5 zone 2).
+pub const TOOLBAR_HEIGHT: f32 = 44.0;
+
+// Width estimates for the overflow rule, in pixels. egui sizes widgets while
+// drawing them, so the plan is decided up front from these; they only need to
+// be right enough that folding starts before clipping does.
+/// Margins, separators and inter-group spacing.
+const W_SLACK: f32 = 90.0;
+/// SOURCE with the full feed name.
+const W_SOURCE_FULL: f32 = 350.0;
+/// SOURCE with the feed shrunk to its initial.
+const W_SOURCE_SHRUNK: f32 = 260.0;
+/// BARS without the parameter widget.
+const W_BARS: f32 = 160.0;
+/// The bar-parameter label + drag value.
+const W_BAR_PARAM: f32 = 150.0;
+/// The `+ older ▾` split button.
+const W_HISTORY: f32 = 100.0;
+/// The LAYERS icon pair.
+const W_LAYERS: f32 = 64.0;
+/// One 28 px icon button (LOOK, PANELS, or the overflow `⋯`).
+const W_ICON: f32 = 28.0;
+
+/// Which groups stay inline at the current width. Everything folded is
+/// reachable through the `⋯` overflow menu instead — never hidden.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CollapsePlan {
+    /// LOOK renders as its own icon.
+    pub look_inline: bool,
+    /// PANELS renders as its own icon.
+    pub panels_inline: bool,
+    /// HISTORY renders as the split button.
+    pub history_inline: bool,
+    /// The bar parameter renders next to the kind combo.
+    pub param_inline: bool,
+    /// The feed combo shows its full display name.
+    pub feed_full_name: bool,
+}
+
+impl CollapsePlan {
+    /// Nothing folded.
+    const FULL: Self = Self {
+        look_inline: true,
+        panels_inline: true,
+        history_inline: true,
+        param_inline: true,
+        feed_full_name: true,
+    };
+
+    /// Whether the `⋯` menu is needed to reach a folded group. A shrunk feed
+    /// name loses no affordance, so it alone needs no overflow.
+    #[must_use]
+    pub fn overflow_needed(self) -> bool {
+        !(self.look_inline && self.panels_inline && self.history_inline && self.param_inline)
+    }
+
+    /// Estimated width of the toolbar under this plan. The `⋯` slot is
+    /// always reserved: it appears exactly when something folds, so counting
+    /// it conditionally would make the first fold width-neutral and leave
+    /// the planner skipping straight past it.
+    fn width(self) -> f32 {
+        let mut width = W_SLACK + W_ICON + W_BARS + W_LAYERS;
+        width += if self.feed_full_name {
+            W_SOURCE_FULL
+        } else {
+            W_SOURCE_SHRUNK
+        };
+        if self.param_inline {
+            width += W_BAR_PARAM;
+        }
+        if self.history_inline {
+            width += W_HISTORY;
+        }
+        if self.look_inline {
+            width += W_ICON;
+        }
+        if self.panels_inline {
+            width += W_ICON;
+        }
+        width
+    }
+}
+
+/// Decide what folds at `available` width, following the §6 collapse order.
+/// The last plan is accepted even when it still overflows — there is nothing
+/// left to fold, and the symbol and LAYERS are never candidates.
+#[must_use]
+pub fn collapse_plan(available: f32) -> CollapsePlan {
+    let mut plan = CollapsePlan::FULL;
+    let steps: [fn(&mut CollapsePlan); 5] = [
+        |plan| plan.look_inline = false,
+        |plan| plan.panels_inline = false,
+        |plan| plan.history_inline = false,
+        |plan| plan.param_inline = false,
+        |plan| plan.feed_full_name = false,
+    ];
+    for fold in steps {
+        if plan.width() <= available {
+            return plan;
+        }
+        fold(&mut plan);
+    }
+    plan
+}
+
+/// The amber label that replaces SOURCE while a recording plays.
+pub struct ReplaySource {
+    /// What the label says.
+    pub label: String,
+    /// The hover detail (file, side source).
+    pub hover: String,
+}
+
+/// The toolbar's view of the app: fields it edits directly, and read-only
+/// context for gating and display.
+pub struct ToolbarModel<'a> {
+    /// `(id, display label)` for every configured feed.
+    pub feeds: Vec<(String, String)>,
+    /// The selected feed id.
+    pub feed_id: &'a mut String,
+    /// Display name of the selected feed.
+    pub feed_display_name: String,
+    /// Symbols offered by the selected feed.
+    pub symbols: Vec<String>,
+    /// The selected symbol.
+    pub symbol: &'a mut String,
+    /// Present while a recording is the source; replaces the SOURCE combos.
+    pub replay: Option<ReplaySource>,
+    /// The selected bar kind.
+    pub kind: &'a mut BarKind,
+    /// Parameter for [`BarKind::Tick`].
+    pub tick_n: &'a mut u64,
+    /// Parameter for [`BarKind::Volume`].
+    pub volume_units: &'a mut f64,
+    /// Parameter for [`BarKind::Dollar`].
+    pub dollar_notional: &'a mut f64,
+    /// Parameter for [`BarKind::Time`].
+    pub time_interval_ms: &'a mut i64,
+    /// Parameter for [`BarKind::Imbalance`].
+    pub imbalance_target: &'a mut u64,
+    /// Trades pulled per "+ older" click.
+    pub history_step: &'a mut usize,
+    /// Trades backfilled so far, for the history menu readout.
+    pub history_trades: usize,
+    /// What the active source's backend can do.
+    pub capabilities: FeedCapabilities,
+    /// Whether L2 capture is running.
+    pub heatmap_on: bool,
+    /// Whether the aggression layer is on.
+    pub bubbles_on: bool,
+    /// Whether the dock (strip included) is shown.
+    pub dock_visible: bool,
+    /// Whether the appearance dialog is open.
+    pub appearance_open: bool,
+}
+
+/// A side effect the toolbar asks the app to perform.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolbarAction {
+    /// Fetch and prepend one page of older trades.
+    LoadOlder,
+    /// Start or stop L2 depth capture.
+    SetHeatmap(bool),
+    /// Turn the aggression layer on or off.
+    SetBubbles(bool),
+    /// Open a dock tab (a layer's settings; never toggles the layer).
+    OpenDockTab(DockTab),
+    /// Show or hide the dock.
+    ToggleDock,
+    /// Open or close the appearance dialog.
+    ToggleAppearance,
+}
+
+/// Draw the toolbar as the 44 px top panel and return what was asked of the
+/// app this frame. One pointer produces at most one click per frame, so the
+/// list carries zero or one action in practice; a `Vec` only spares every
+/// widget the "was something already clicked" bookkeeping.
+pub fn draw(ctx: &egui::Context, model: &mut ToolbarModel) -> Vec<ToolbarAction> {
+    let mut actions = Vec::new();
+    egui::TopBottomPanel::top("toolbar")
+        .exact_height(TOOLBAR_HEIGHT)
+        .frame(
+            egui::Frame::none()
+                .fill(theme::CHROME)
+                .inner_margin(egui::Margin::symmetric(8.0, 0.0)),
+        )
+        .show(ctx, |ui| {
+            let plan = collapse_plan(ui.available_width());
+            ui.horizontal_centered(|ui| {
+                ui.spacing_mut().item_spacing.x = 6.0;
+                draw_source(ui, model, plan);
+                ui.separator();
+                draw_bars(ui, model, plan);
+                if plan.history_inline {
+                    ui.separator();
+                    draw_history(ui, model, &mut actions);
+                }
+                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                    if plan.overflow_needed() {
+                        draw_overflow(ui, model, plan, &mut actions);
+                    }
+                    if plan.panels_inline {
+                        let panels = IconButton::new(icons::SIDEBAR_SIMPLE, TOOLBAR_ICON)
+                            .active(model.dock_visible)
+                            .hover_text("show or hide the panels dock (Ctrl+B)")
+                            .show(ui);
+                        if panels.clicked() {
+                            actions.push(ToolbarAction::ToggleDock);
+                        }
+                    }
+                    if plan.look_inline {
+                        let look = IconButton::new(icons::PAINT_BRUSH, TOOLBAR_ICON)
+                            .active(model.appearance_open)
+                            .hover_text("appearance: candles, canvas, grid")
+                            .show(ui);
+                        if look.clicked() {
+                            actions.push(ToolbarAction::ToggleAppearance);
+                        }
+                    }
+                    ui.separator();
+                    draw_layers(ui, model, &mut actions);
+                });
+            });
+        });
+    actions
+}
+
+/// SOURCE: feed + symbol combos, or the amber session label during replay.
+fn draw_source(ui: &mut egui::Ui, model: &mut ToolbarModel, plan: CollapsePlan) {
+    if let Some(replay) = &model.replay {
+        ui.label(egui::RichText::new("source:").color(theme::TEXT_MUTED));
+        ui.label(
+            egui::RichText::new(&replay.label)
+                .color(theme::AMBER)
+                .strong(),
+        )
+        .on_hover_text(&replay.hover);
+        return;
+    }
+
+    let feed_text = if plan.feed_full_name {
+        model.feed_display_name.clone()
+    } else {
+        model
+            .feed_display_name
+            .chars()
+            .next()
+            .map(String::from)
+            .unwrap_or_default()
+    };
+    ui.label(egui::RichText::new("feed").color(theme::TEXT_MUTED));
+    egui::ComboBox::from_id_salt("feed_sel")
+        .selected_text(feed_text)
+        .show_ui(ui, |ui| {
+            for (id, name) in &model.feeds {
+                ui.selectable_value(model.feed_id, id.clone(), name);
+            }
+        });
+    ui.label(egui::RichText::new("symbol").color(theme::TEXT_MUTED));
+    egui::ComboBox::from_id_salt("symbol_sel")
+        .selected_text(model.symbol.clone())
+        .show_ui(ui, |ui| {
+            for symbol in &model.symbols {
+                ui.selectable_value(model.symbol, symbol.clone(), symbol);
+            }
+        });
+}
+
+/// BARS: the kind combo, with the parameter beside it or merged into its
+/// selected text when folded.
+fn draw_bars(ui: &mut egui::Ui, model: &mut ToolbarModel, plan: CollapsePlan) {
+    ui.label(egui::RichText::new("bars").color(theme::TEXT_MUTED));
+    let selected = if plan.param_inline {
+        model.kind.label().to_owned()
+    } else {
+        format!("{} · {}", model.kind.label(), param_summary(model))
+    };
+    egui::ComboBox::from_id_salt("bar_kind")
+        .selected_text(selected)
+        .show_ui(ui, |ui| {
+            for kind in BarKind::ALL {
+                ui.selectable_value(model.kind, kind, kind.label());
+            }
+        });
+    if plan.param_inline {
+        draw_bar_param(ui, model);
+    }
+}
+
+/// The one parameter of the selected bar kind. Lives beside the combo, or in
+/// the overflow menu when the plan folded it.
+fn draw_bar_param(ui: &mut egui::Ui, model: &mut ToolbarModel) {
+    match model.kind {
+        BarKind::Tick => {
+            ui.label("N trades");
+            ui.add(egui::DragValue::new(model.tick_n).range(1.0..=5000.0));
+        }
+        BarKind::Volume => {
+            ui.label("units");
+            ui.add(
+                egui::DragValue::new(model.volume_units)
+                    .range(0.1..=1000.0)
+                    .speed(0.1),
+            );
+        }
+        BarKind::Dollar => {
+            ui.label("notional");
+            ui.add(
+                egui::DragValue::new(model.dollar_notional)
+                    .range(1000.0..=1_000_000_000.0)
+                    .speed(1000.0),
+            );
+        }
+        BarKind::Time => {
+            ui.label("interval ms");
+            ui.add(
+                egui::DragValue::new(model.time_interval_ms)
+                    .range(100.0..=600_000.0)
+                    .speed(100.0),
+            );
+        }
+        BarKind::Imbalance => {
+            ui.label("target trades");
+            ui.add(egui::DragValue::new(model.imbalance_target).range(2.0..=5000.0))
+                .on_hover_text(
+                    "expected trades per bar in balanced flow; \
+                     one-sided aggression closes bars sooner",
+                );
+        }
+    }
+}
+
+/// Short parameter readout for the merged kind combo, e.g. `tick · 50`.
+fn param_summary(model: &ToolbarModel) -> String {
+    match model.kind {
+        BarKind::Tick => model.tick_n.to_string(),
+        BarKind::Volume => format!("{:.1}", model.volume_units),
+        BarKind::Dollar => format!("{:.0}", model.dollar_notional),
+        BarKind::Time => format!("{} ms", model.time_interval_ms),
+        BarKind::Imbalance => model.imbalance_target.to_string(),
+    }
+}
+
+/// HISTORY: the `+ older ▾` split button. The page size lives in the caret
+/// menu; the whole group gates on the `history_paging` capability.
+fn draw_history(ui: &mut egui::Ui, model: &mut ToolbarModel, actions: &mut Vec<ToolbarAction>) {
+    let paging = model.capabilities.history_paging;
+    let load = ui
+        .add_enabled(paging, egui::Button::new(format!("{} older", icons::PLUS)))
+        .on_hover_text("fetch older trades and prepend them")
+        .on_disabled_hover_text("this feed only streams forward; it cannot page older trades");
+    if load.clicked() {
+        actions.push(ToolbarAction::LoadOlder);
+    }
+    ui.add_enabled_ui(paging, |ui| {
+        ui.menu_button(icons::CARET_DOWN, |ui| {
+            draw_history_menu(ui, model);
+        });
+    });
+}
+
+/// The history caret/overflow menu body: page size and the running total.
+fn draw_history_menu(ui: &mut egui::Ui, model: &mut ToolbarModel) {
+    ui.label("page size (trades per load)");
+    ui.add(
+        egui::DragValue::new(model.history_step)
+            .range(500.0..=50_000.0)
+            .speed(100.0),
+    );
+    ui.small(format!("{} trades backfilled so far", model.history_trades));
+}
+
+/// LAYERS: one icon toggle per visual layer. Left-click toggles the layer;
+/// right-click opens its dock tab — looking is not enabling. Drawn inside the
+/// right-to-left layout, so the call order is the reverse of what is seen.
+fn draw_layers(ui: &mut egui::Ui, model: &ToolbarModel, actions: &mut Vec<ToolbarAction>) {
+    let bubbles = IconButton::new(icons::CIRCLES_THREE, TOOLBAR_ICON)
+        .active(model.bubbles_on)
+        .accent(theme::BUY)
+        .hover_text(
+            "aggression bubbles: confirmed executions from the trade stream — \
+             right-click for settings",
+        )
+        .show(ui);
+    if bubbles.clicked() {
+        actions.push(ToolbarAction::SetBubbles(!model.bubbles_on));
+    }
+    if bubbles.secondary_clicked() {
+        actions.push(ToolbarAction::OpenDockTab(DockTab::Bubbles));
+    }
+
+    let heatmap = IconButton::new(icons::FIRE, TOOLBAR_ICON)
+        .active(model.heatmap_on)
+        .accent(theme::ACCENT)
+        .enabled(model.capabilities.book_capture)
+        .hover_text("L2 heatmap: capture synchronized live depth — right-click for settings")
+        .disabled_explanation("order-book capture is not available for this source")
+        .show(ui);
+    if heatmap.clicked() {
+        actions.push(ToolbarAction::SetHeatmap(!model.heatmap_on));
+    }
+    if heatmap.secondary_clicked() {
+        actions.push(ToolbarAction::OpenDockTab(DockTab::L2));
+    }
+}
+
+/// The `⋯` menu holding every folded group, in a fixed order so muscle
+/// memory survives resizes.
+fn draw_overflow(
+    ui: &mut egui::Ui,
+    model: &mut ToolbarModel,
+    plan: CollapsePlan,
+    actions: &mut Vec<ToolbarAction>,
+) {
+    ui.menu_button(egui::RichText::new(icons::DOTS_THREE).size(16.0), |ui| {
+        if !plan.look_inline
+            && ui
+                .button(format!("{} Appearance…", icons::PAINT_BRUSH))
+                .clicked()
+        {
+            actions.push(ToolbarAction::ToggleAppearance);
+            ui.close_menu();
+        }
+        if !plan.panels_inline
+            && ui
+                .button(format!("{} Show/hide panels", icons::SIDEBAR_SIMPLE))
+                .clicked()
+        {
+            actions.push(ToolbarAction::ToggleDock);
+            ui.close_menu();
+        }
+        if !plan.history_inline {
+            ui.separator();
+            let paging = model.capabilities.history_paging;
+            let load = ui
+                .add_enabled(
+                    paging,
+                    egui::Button::new(format!("{} Load older", icons::PLUS)),
+                )
+                .on_disabled_hover_text(
+                    "this feed only streams forward; it cannot page older trades",
+                );
+            if load.clicked() {
+                actions.push(ToolbarAction::LoadOlder);
+                ui.close_menu();
+            }
+            if paging {
+                draw_history_menu(ui, model);
+            }
+        }
+        if !plan.param_inline {
+            ui.separator();
+            ui.label(egui::RichText::new("bar parameter").color(theme::TEXT_MUTED));
+            draw_bar_param(ui, model);
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// How many §6 collapse steps a plan has taken. `None` when the plan is
+    /// not one of the six canonical states — folding out of order.
+    fn stage(plan: CollapsePlan) -> Option<usize> {
+        let states = [
+            (true, true, true, true, true),
+            (false, true, true, true, true),
+            (false, false, true, true, true),
+            (false, false, false, true, true),
+            (false, false, false, false, true),
+            (false, false, false, false, false),
+        ];
+        states.iter().position(|&state| {
+            state
+                == (
+                    plan.look_inline,
+                    plan.panels_inline,
+                    plan.history_inline,
+                    plan.param_inline,
+                    plan.feed_full_name,
+                )
+        })
+    }
+
+    #[test]
+    fn a_wide_toolbar_folds_nothing() {
+        let plan = collapse_plan(10_000.0);
+        assert_eq!(stage(plan), Some(0));
+        assert!(!plan.overflow_needed());
+    }
+
+    #[test]
+    fn a_hopeless_width_ends_fully_folded() {
+        let plan = collapse_plan(0.0);
+        assert_eq!(stage(plan), Some(5));
+        assert!(plan.overflow_needed());
+    }
+
+    #[test]
+    fn folding_follows_the_documented_order_and_never_skips() {
+        let mut last_stage = 5;
+        // Sweep from narrow to wide: the collapse stage must only decrease,
+        // and every plan must be one of the canonical §6 states.
+        let mut width = 100.0;
+        while width <= 2000.0 {
+            let plan = collapse_plan(width);
+            let stage = stage(plan).expect("plans fold strictly in the §6 order");
+            assert!(
+                stage <= last_stage,
+                "widening from {width} px must never fold more"
+            );
+            last_stage = stage;
+            width += 10.0;
+        }
+        assert_eq!(last_stage, 0, "the sweep must reach the unfolded plan");
+    }
+
+    #[test]
+    fn look_folds_first_and_alone_at_a_mildly_tight_width() {
+        // One pixel short of the full plan: exactly LOOK moves to overflow.
+        let full_width = CollapsePlan::FULL.width();
+        let plan = collapse_plan(full_width - 1.0);
+        assert_eq!(stage(plan), Some(1));
+        assert!(plan.overflow_needed());
+    }
+
+    #[test]
+    fn a_shrunk_feed_name_alone_never_requires_the_overflow_menu() {
+        let plan = CollapsePlan {
+            feed_full_name: false,
+            ..CollapsePlan::FULL
+        };
+        assert!(!plan.overflow_needed());
+    }
+
+    /// Lay the toolbar out for real, off-screen, live and replaying — a
+    /// duplicated widget id or a panicking widget fails here instead of on
+    /// the chart, and an un-clicked frame must ask nothing of the app.
+    #[test]
+    fn the_toolbar_lays_out_against_a_real_context() {
+        let ctx = egui::Context::default();
+        let mut feed_id = "binance".to_owned();
+        let mut symbol = "BTCUSDT".to_owned();
+        let mut kind = BarKind::Tick;
+        let mut tick_n = 50_u64;
+        let mut volume_units = 5.0_f64;
+        let mut dollar_notional = 500_000.0_f64;
+        let mut time_interval_ms = 1_000_i64;
+        let mut imbalance_target = 100_u64;
+        let mut history_step = 2_000_usize;
+        for replaying in [false, true] {
+            for _ in 0..2 {
+                let _ = ctx.run(egui::RawInput::default(), |ctx| {
+                    let mut model = ToolbarModel {
+                        feeds: vec![("binance".to_owned(), "Binance".to_owned())],
+                        feed_id: &mut feed_id,
+                        feed_display_name: "Binance".to_owned(),
+                        symbols: vec!["BTCUSDT".to_owned()],
+                        symbol: &mut symbol,
+                        replay: replaying.then(|| ReplaySource {
+                            label: "BTCUSDT · 2026-03-16".to_owned(),
+                            hover: "Replaying a recorded session".to_owned(),
+                        }),
+                        kind: &mut kind,
+                        tick_n: &mut tick_n,
+                        volume_units: &mut volume_units,
+                        dollar_notional: &mut dollar_notional,
+                        time_interval_ms: &mut time_interval_ms,
+                        imbalance_target: &mut imbalance_target,
+                        history_step: &mut history_step,
+                        history_trades: 1_000,
+                        capabilities: FeedCapabilities {
+                            book_capture: !replaying,
+                            history_paging: !replaying,
+                        },
+                        heatmap_on: false,
+                        bubbles_on: true,
+                        dock_visible: true,
+                        appearance_open: false,
+                    };
+                    let actions = draw(ctx, &mut model);
+                    assert!(actions.is_empty(), "no clicks, no actions");
+                });
+            }
+        }
+    }
+}

--- a/crates/app/src/toolrail.rs
+++ b/crates/app/src/toolrail.rs
@@ -1,0 +1,158 @@
+//! The tool rail: chart-acting tools on the left edge
+//! (`docs/ux/ui-design-model.md` §7).
+//!
+//! Exclusive selection — exactly one tool is armed, `Esc` always returns to
+//! Pointer. It ships with Pointer and Crosshair and reserves the geometry the
+//! drawing tools will fill; the selection state machine lives here, pure and
+//! tested, while the chart reads [`ToolRail::tool`] to decide what the pointer
+//! does.
+
+use eframe::egui;
+use egui_phosphor::regular as icons;
+
+use crate::theme;
+use crate::widgets::{IconButton, RAIL_ICON};
+
+/// Width of the rail, in pixels (§5 zone 3).
+pub const RAIL_WIDTH: f32 = 44.0;
+
+/// A chart-acting tool. Body slots are exclusive; footer modifiers (magnet,
+/// lock) arrive with the drawing tools.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Tool {
+    /// Pan, zoom and select — the default interaction.
+    #[default]
+    Pointer,
+    /// The hover crosshair, as an armed mode instead of an always-on layer.
+    Crosshair,
+}
+
+impl Tool {
+    /// Every tool, in rail order.
+    pub const ALL: [Self; 2] = [Self::Pointer, Self::Crosshair];
+
+    /// The Phosphor glyph on the rail slot.
+    #[must_use]
+    pub fn icon(self) -> &'static str {
+        match self {
+            Self::Pointer => icons::CURSOR,
+            Self::Crosshair => icons::CROSSHAIR,
+        }
+    }
+
+    /// Tooltip, shortcut included.
+    #[must_use]
+    pub fn hover_text(self) -> &'static str {
+        match self {
+            Self::Pointer => "Pointer — pan, zoom, select (1, Esc)",
+            Self::Crosshair => "Crosshair (2)",
+        }
+    }
+}
+
+/// The rail's state: which tool is armed.
+#[derive(Debug, Default)]
+pub struct ToolRail {
+    tool: Tool,
+}
+
+impl ToolRail {
+    /// A rail with the Pointer armed.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The armed tool.
+    #[must_use]
+    pub fn tool(&self) -> Tool {
+        self.tool
+    }
+
+    /// Arm `tool`, replacing whatever was armed — the exclusive-selection
+    /// rule.
+    pub fn arm(&mut self, tool: Tool) {
+        self.tool = tool;
+    }
+
+    /// Apply the rail shortcuts: `Esc`/`1` arm the Pointer, `2` the
+    /// Crosshair. Single letters stay modifier-free, so they are ignored
+    /// whenever a widget owns the keyboard (typing in a field must not switch
+    /// tools).
+    pub fn handle_keys(&mut self, ctx: &egui::Context) {
+        if ctx.memory(|memory| memory.focused().is_some()) {
+            return;
+        }
+        ctx.input(|input| {
+            if input.key_pressed(egui::Key::Escape) || input.key_pressed(egui::Key::Num1) {
+                self.arm(Tool::Pointer);
+            }
+            if input.key_pressed(egui::Key::Num2) {
+                self.arm(Tool::Crosshair);
+            }
+        });
+    }
+
+    /// Draw the rail as the left 44 px panel.
+    pub fn draw(&mut self, ctx: &egui::Context) {
+        egui::SidePanel::left("tool_rail")
+            .exact_width(RAIL_WIDTH)
+            .resizable(false)
+            .frame(
+                egui::Frame::none()
+                    .fill(theme::CHROME)
+                    .inner_margin(egui::Margin::symmetric(7.0, 8.0)),
+            )
+            .show(ctx, |ui| {
+                ui.spacing_mut().item_spacing.y = 6.0;
+                for tool in Tool::ALL {
+                    let response = IconButton::new(tool.icon(), RAIL_ICON)
+                        .active(self.tool == tool)
+                        .hover_text(tool.hover_text())
+                        .show(ui);
+                    if response.clicked() {
+                        self.arm(tool);
+                    }
+                }
+            });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_rail_opens_on_the_pointer() {
+        assert_eq!(ToolRail::new().tool(), Tool::Pointer);
+    }
+
+    #[test]
+    fn arming_is_exclusive() {
+        let mut rail = ToolRail::new();
+        rail.arm(Tool::Crosshair);
+        assert_eq!(rail.tool(), Tool::Crosshair);
+        rail.arm(Tool::Pointer);
+        assert_eq!(rail.tool(), Tool::Pointer);
+    }
+
+    #[test]
+    fn every_tool_has_a_glyph_and_a_tooltip() {
+        for tool in Tool::ALL {
+            assert!(!tool.icon().is_empty());
+            assert!(!tool.hover_text().is_empty());
+        }
+    }
+
+    /// Lay the rail out for real, off-screen: an un-clicked frame must leave
+    /// the armed tool alone.
+    #[test]
+    fn the_rail_lays_out_against_a_real_context() {
+        let ctx = egui::Context::default();
+        let mut rail = ToolRail::new();
+        for _ in 0..2 {
+            let _ = ctx.run(egui::RawInput::default(), |ctx| rail.draw(ctx));
+        }
+        assert_eq!(rail.tool(), Tool::Pointer);
+    }
+}

--- a/crates/app/src/widgets.rs
+++ b/crates/app/src/widgets.rs
@@ -1,0 +1,223 @@
+//! Shared chrome widgets, starting with the four-state icon button of
+//! `docs/ux/ui-design-model.md` §4.
+//!
+//! One widget owns the icon-state grammar — idle, hover, active (tinted in
+//! the layer's accent), disabled (40% opacity that explains itself on hover)
+//! — so the toolbar, the tool rail and the dock's tab strip cannot drift
+//! apart. Glyphs come from the bundled Phosphor icon font; ad-hoc emoji are
+//! no longer welcome in chrome.
+
+use eframe::egui;
+
+use crate::theme;
+
+/// Toolbar geometry: a 16 px glyph centred on a 28×28 px hit target.
+pub const TOOLBAR_ICON: IconSize = IconSize {
+    glyph: 16.0,
+    hit: 28.0,
+};
+
+/// Rail/tab-strip geometry: a 20 px glyph on a 30×30 px hit target.
+pub const RAIL_ICON: IconSize = IconSize {
+    glyph: 20.0,
+    hit: 30.0,
+};
+
+/// Opacity of a disabled glyph.
+const DISABLED_OPACITY: f32 = 0.4;
+/// Corner radius of the hover/active backdrop.
+const CORNER_RADIUS: f32 = 4.0;
+
+/// Glyph and hit-target sizes for one icon-button family.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct IconSize {
+    /// Font size of the glyph, in pixels.
+    pub glyph: f32,
+    /// Side of the square hit target, in pixels.
+    pub hit: f32,
+}
+
+/// How one icon button should be painted this frame — the §4 state table,
+/// resolved before any egui call so it stays unit-testable.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct IconPaint {
+    /// Backdrop fill, or `None` for the bare chrome.
+    pub fill: Option<egui::Color32>,
+    /// Glyph colour, opacity already applied.
+    pub glyph: egui::Color32,
+}
+
+/// Resolve the §4 state table: disabled beats everything, active tints in the
+/// layer accent, hover lifts an idle glyph, idle stays muted.
+#[must_use]
+pub fn icon_paint(enabled: bool, active: bool, hovered: bool, accent: egui::Color32) -> IconPaint {
+    if !enabled {
+        return IconPaint {
+            fill: None,
+            glyph: theme::TEXT_MUTED.gamma_multiply(DISABLED_OPACITY),
+        };
+    }
+    if active {
+        return IconPaint {
+            fill: Some(theme::active_tint(accent)),
+            glyph: accent,
+        };
+    }
+    if hovered {
+        return IconPaint {
+            fill: Some(theme::BORDER),
+            glyph: theme::TEXT_PRIMARY,
+        };
+    }
+    IconPaint {
+        fill: None,
+        glyph: theme::TEXT_MUTED,
+    }
+}
+
+/// A chrome icon button: one Phosphor glyph, four states, fixed hit target.
+pub struct IconButton<'a> {
+    glyph: &'a str,
+    size: IconSize,
+    active: bool,
+    enabled: bool,
+    accent: egui::Color32,
+    hover_text: &'a str,
+    disabled_text: &'a str,
+}
+
+impl<'a> IconButton<'a> {
+    /// A button showing `glyph` at the given geometry, idle and enabled.
+    #[must_use]
+    pub fn new(glyph: &'a str, size: IconSize) -> Self {
+        Self {
+            glyph,
+            size,
+            active: false,
+            enabled: true,
+            accent: theme::ACCENT,
+            hover_text: "",
+            disabled_text: "",
+        }
+    }
+
+    /// Whether the button renders in its active (tinted) state.
+    #[must_use]
+    pub fn active(mut self, active: bool) -> Self {
+        self.active = active;
+        self
+    }
+
+    /// The accent that tints the active state — the owning layer's colour.
+    #[must_use]
+    pub fn accent(mut self, accent: egui::Color32) -> Self {
+        self.accent = accent;
+        self
+    }
+
+    /// Enable or disable the button. Disabled ≠ hidden: the glyph stays at
+    /// 40% opacity and [`Self::disabled_explanation`] says why on hover.
+    #[must_use]
+    pub fn enabled(mut self, enabled: bool) -> Self {
+        self.enabled = enabled;
+        self
+    }
+
+    /// Tooltip while the button is enabled.
+    #[must_use]
+    pub fn hover_text(mut self, text: &'a str) -> Self {
+        self.hover_text = text;
+        self
+    }
+
+    /// Tooltip while the button is disabled — the explanation §3.4 requires.
+    #[must_use]
+    pub fn disabled_explanation(mut self, text: &'a str) -> Self {
+        self.disabled_text = text;
+        self
+    }
+
+    /// Draw the button and return its response. Clicks only register while
+    /// enabled; the disabled state still hovers so it can explain itself.
+    pub fn show(self, ui: &mut egui::Ui) -> egui::Response {
+        let sense = if self.enabled {
+            egui::Sense::click()
+        } else {
+            egui::Sense::hover()
+        };
+        let (rect, response) =
+            ui.allocate_exact_size(egui::vec2(self.size.hit, self.size.hit), sense);
+        if ui.is_rect_visible(rect) {
+            let paint = icon_paint(self.enabled, self.active, response.hovered(), self.accent);
+            let painter = ui.painter();
+            if let Some(fill) = paint.fill {
+                painter.rect_filled(rect, egui::Rounding::same(CORNER_RADIUS), fill);
+            }
+            painter.text(
+                rect.center(),
+                egui::Align2::CENTER_CENTER,
+                self.glyph,
+                egui::FontId::proportional(self.size.glyph),
+                paint.glyph,
+            );
+        }
+        let hover = if self.enabled {
+            self.hover_text
+        } else {
+            self.disabled_text
+        };
+        if hover.is_empty() {
+            response
+        } else {
+            response.on_hover_text(hover)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn idle_is_muted_on_bare_chrome() {
+        let paint = icon_paint(true, false, false, theme::ACCENT);
+        assert_eq!(paint.fill, None);
+        assert_eq!(paint.glyph, theme::TEXT_MUTED);
+    }
+
+    #[test]
+    fn hover_lifts_the_glyph_on_a_border_fill() {
+        let paint = icon_paint(true, false, true, theme::ACCENT);
+        assert_eq!(paint.fill, Some(theme::BORDER));
+        assert_eq!(paint.glyph, theme::TEXT_PRIMARY);
+    }
+
+    #[test]
+    fn active_tints_in_the_layer_accent_even_under_hover() {
+        for hovered in [false, true] {
+            let paint = icon_paint(true, true, hovered, theme::BUY);
+            assert_eq!(paint.fill, Some(theme::active_tint(theme::BUY)));
+            assert_eq!(paint.glyph, theme::BUY);
+        }
+    }
+
+    #[test]
+    fn disabled_beats_every_other_state_and_dims_the_glyph() {
+        for (active, hovered) in [(false, false), (true, false), (false, true), (true, true)] {
+            let paint = icon_paint(false, active, hovered, theme::ACCENT);
+            assert_eq!(paint.fill, None);
+            assert!(
+                paint.glyph.a() < theme::TEXT_MUTED.a(),
+                "disabled glyph must be dimmer than idle"
+            );
+        }
+    }
+
+    #[test]
+    fn icon_geometries_match_the_model() {
+        assert_eq!(TOOLBAR_ICON.glyph, 16.0);
+        assert_eq!(TOOLBAR_ICON.hit, 28.0);
+        assert_eq!(RAIL_ICON.glyph, 20.0);
+        assert_eq!(RAIL_ICON.hit, 30.0);
+    }
+}

--- a/docs/ux/ui-design-model.md
+++ b/docs/ux/ui-design-model.md
@@ -1,6 +1,8 @@
 # quantick UI Design Model
 
-Status: **proposed model, not yet implemented**
+Status: **implemented — migration phases 1–5** (status bar, toolbar regroup,
+icon set, right dock, tool rail); phase 6 lands with the indicator milestones.
+§2 documents the UI as it was *before* this model, kept as the audit record.
 Scope: the desktop app's chrome — where buttons, menus, icons, panels and tools
 live today, and where they will live as the app grows into indicators, drawing
 tools and beyond. This document is the reference for every future UI change:


### PR DESCRIPTION
## Summary

Implements `docs/ux/ui-design-model.md` migration phases 1–5 — the new visual shell. UI-only: the engine, feeds and every hot path are untouched.

- **Design tokens + theme** (`theme.rs`): the §4 palette as named constants, applied to egui's widgets once at startup. Amber stays reserved for provenance honesty. Parity tests pin `style.rs` defaults to the tokens.
- **Icon system** (`widgets.rs`, phase 3): Phosphor icon font; one four-state icon button (idle / hover / active-tinted / disabled at 40% opacity that explains itself on hover). Emoji leave the chrome.
- **Status bar** (`statusbar.rs`, phase 1): one 28 px line — provenance (state dot green live / amber replay / red stalled, venue, symbol, lag), content (bar spec, `240+61 bars` split, `side: inferred (tick rule)` honesty label for MT5/replay), machinery (trades, fps + frame time gated by View → perf readings, timezone picker). Replaces the perf overlay, the floating timezone pill and the header painted over candles. The transport restyles into a single 30 px row directly above it.
- **Toolbar** (`toolbar.rs`, phase 2): SOURCE · BARS · HISTORY left, LAYERS · LOOK · PANELS right. Heatmap/bubbles become icon toggles (right-click opens the dock tab); history is a `+ older ▾` split button with the page size in its menu. The row never wraps: `collapse_plan` folds groups into `⋯` in the §6 order (unit-tested for order and monotonicity). Capability gating unchanged.
- **Dock** (`dock.rs`, phase 4): tabbed right dock (L2 / Bubbles / Session), collapsible to a 36 px strip, width remembered per tab, `Ctrl+B`. Panel bodies migrated as-is; both left `SidePanel`s retired. Opening a tab never toggles a layer.
- **Tool rail** (`toolrail.rs`, phase 5): Pointer / Crosshair as exclusive tools (`Esc`/`1`, `2`); the hover crosshair is now a mode.
- Menus per §10 (View: panels, dock tabs, perf readings, timezone; Tools: appearance); zone sizes per §5 (menu 28, toolbar 44, status 28, transport 30, time axis 24, price axis 64).
- `config.rs` gains `side_note()` so the status bar can disclose tick-rule side inference — the one place a provider maps to a provenance statement.

## Verification

- `cargo fmt --check`, `clippy -D warnings`, `build`, `test --workspace` all green (258 app tests + workspace).
- Smoke-run on Windows: connects to Binance, opens on BTCUSDT with the "dense tape btc" preset, streams live trades, no panics.
- arch-review run over the diff; all findings fixed in-branch (off-screen layout tests for every new chrome surface, named constants on the status bar, documented action convention). Phase 6 (indicator surfaces) deliberately deferred — it rides the indicator plan per §12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)