### PR TITLE
feat(app): make the forming bar's order flow readable (live edge, phase 1)

### DIFF
--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -1350,7 +1350,9 @@ impl QuantickApp {
         if y < chart_rect.top() || y > chart_rect.bottom() {
             return;
         }
-        let rgb = if bar.close >= bar.open {
+        // Same predicate and same two colours the candle wears, so the chip
+        // and the bar it reports can never disagree about direction.
+        let rgb = if crate::candle_view::is_bullish(bar) {
             self.style.candles.bull_outline
         } else {
             self.style.candles.bear_outline

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -45,6 +45,18 @@ const AXIS_GUTTER: f32 = 64.0;
 /// Height of the bottom time-axis strip, in pixels (§5 zone 6).
 const TIME_STRIP: f32 = 24.0;
 
+/// Alpha of the last-price line: legible at a glance without competing with a
+/// candle or a bubble for attention.
+const LAST_PRICE_LINE_ALPHA: f32 = 0.55;
+/// Dash length, in pixels, of the last-price line. Dashed so it never reads as
+/// a level someone drew.
+const LAST_PRICE_DASH_PX: f32 = 4.0;
+/// See [`LAST_PRICE_DASH_PX`].
+const LAST_PRICE_GAP_PX: f32 = 4.0;
+/// Ink on the last-price chip. The chip is filled with a saturated candle
+/// colour, so its text is the one place on the chrome that goes dark.
+const LAST_PRICE_CHIP_TEXT: egui::Color32 = egui::Color32::from_rgb(0x0E, 0x12, 0x1A);
+
 /// How often the perf summary is logged (not every frame).
 const SUMMARY_INTERVAL: Duration = Duration::from_secs(2);
 /// Coalesce slider drags into one diagnostic event after the value settles.
@@ -1224,6 +1236,11 @@ impl QuantickApp {
             );
         }
 
+        // Above the flow layers: everything else on the canvas is read against
+        // it. Drawn on the unclipped painter so the chip reaches the gutter.
+        if let Some(bar) = partial.or_else(|| closed.last()) {
+            self.draw_last_price(painter, chart_rect, &scale, bar);
+        }
         self.draw_backfill_divider(painter, chart_rect, total, cw);
         self.draw_time_strip(painter, areas.time_strip, closed, start, end, total);
         self.draw_crosshair(painter, chart_rect, &scale);
@@ -1311,6 +1328,59 @@ impl QuantickApp {
             ],
             egui::Stroke::new(1.0_f32, self.grid()),
         );
+    }
+
+    /// The current price: a dashed line across the chart and a solid chip on
+    /// the price axis, coloured by the direction of the bar carrying it.
+    ///
+    /// This is the always-on answer to "am I above or below?" — the question
+    /// every other mark on the canvas is read against, and the one a wall of
+    /// resting liquidity cannot answer on its own.
+    fn draw_last_price(
+        &self,
+        painter: &egui::Painter,
+        chart_rect: egui::Rect,
+        scale: &PriceScale,
+        bar: &quantick_engine::Bar,
+    ) {
+        let Some(price) = bar.close.to_f64() else {
+            return;
+        };
+        let y = scale.y(price);
+        if y < chart_rect.top() || y > chart_rect.bottom() {
+            return;
+        }
+        let rgb = if bar.close >= bar.open {
+            self.style.candles.bull_outline
+        } else {
+            self.style.candles.bear_outline
+        };
+        let color = egui::Color32::from_rgb(rgb[0], rgb[1], rgb[2]);
+
+        painter.extend(egui::Shape::dashed_line(
+            &[
+                egui::pos2(chart_rect.left(), y),
+                egui::pos2(chart_rect.right(), y),
+            ],
+            egui::Stroke::new(1.0_f32, color.gamma_multiply(LAST_PRICE_LINE_ALPHA)),
+            LAST_PRICE_DASH_PX,
+            LAST_PRICE_GAP_PX,
+        ));
+
+        // Same geometry as the crosshair tag, so the two never disagree about
+        // where a price sits on the axis.
+        let galley = painter.layout_no_wrap(
+            format!("{price:.2}"),
+            egui::FontId::monospace(11.0),
+            LAST_PRICE_CHIP_TEXT,
+        );
+        let text_pos = egui::pos2(chart_rect.right() + 6.0, y - galley.size().y / 2.0);
+        let bg = egui::Rect::from_min_size(
+            text_pos - egui::vec2(3.0, 1.0),
+            galley.size() + egui::vec2(6.0, 2.0),
+        );
+        painter.rect_filled(bg, egui::Rounding::same(2.0), color);
+        painter.galley(text_pos, galley, LAST_PRICE_CHIP_TEXT);
     }
 
     /// Crosshair following the pointer, with the price shown on the axis.

--- a/crates/app/src/bubble_presets.rs
+++ b/crates/app/src/bubble_presets.rs
@@ -20,7 +20,10 @@ use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
-use crate::orderflow::{BubbleStyle, HeatmapConfig, config::DEFAULT_BUBBLE_CLUSTER_MS};
+use crate::orderflow::{
+    BubbleStyle, HeatmapConfig,
+    config::{DEFAULT_BUBBLE_CLUSTER_MS, DEFAULT_BUBBLE_DUST_MERGE_MS},
+};
 
 /// Environment variable naming an explicit presets file.
 pub const PRESETS_ENV: &str = "QUANTICK_BUBBLES";
@@ -38,6 +41,10 @@ const fn default_cluster_ms() -> i64 {
     DEFAULT_BUBBLE_CLUSTER_MS
 }
 
+const fn default_dust_merge_ms() -> i64 {
+    DEFAULT_BUBBLE_DUST_MERGE_MS
+}
+
 /// One named snapshot of the aggression-bubble panel's *appearance*.
 ///
 /// Deliberately not a switch: whether the layer draws at all stays a live
@@ -53,6 +60,10 @@ pub struct BubblePreset {
     /// Temporal window used to cluster compatible prints, in milliseconds.
     #[serde(default = "default_cluster_ms")]
     pub cluster_ms: i64,
+    /// Window over which prints too small to read fold together, in
+    /// milliseconds. Part of the look: how crowded the tape is allowed to get.
+    #[serde(default = "default_dust_merge_ms")]
+    pub dust_merge_ms: i64,
     /// Every visual choice for the bubbles themselves.
     #[serde(default)]
     pub bubbles: BubbleStyle,
@@ -65,6 +76,7 @@ impl BubblePreset {
         Self {
             name: name.into(),
             cluster_ms: config.bubble_cluster_ms,
+            dust_merge_ms: config.bubble_dust_merge_ms,
             bubbles: config.bubbles.clone(),
         }
     }
@@ -73,6 +85,7 @@ impl BubblePreset {
     /// and never the layer's own switch.
     pub fn apply_to(&self, config: &mut HeatmapConfig) {
         config.bubble_cluster_ms = self.cluster_ms;
+        config.bubble_dust_merge_ms = self.dust_merge_ms;
         config.bubbles = self.bubbles.clone();
     }
 }
@@ -399,6 +412,7 @@ mod tests {
         file.upsert(BubblePreset {
             name: "default".to_owned(),
             cluster_ms: DEFAULT_BUBBLE_CLUSTER_MS,
+            dust_merge_ms: DEFAULT_BUBBLE_DUST_MERGE_MS,
             bubbles: BubbleStyle {
                 front_color: Some([255, 246, 205]),
                 ..BubbleStyle::default()

--- a/crates/app/src/candle_view.rs
+++ b/crates/app/src/candle_view.rs
@@ -21,6 +21,21 @@ pub struct StylePanelResponse {
     pub applied_preset: Option<CandlePreset>,
 }
 
+/// Whether a bar reads as bullish, and so which of the two candle colours it
+/// wears.
+///
+/// A bar that closed exactly where it opened counts as bullish, which also
+/// makes a freshly opened forming bar — where close still equals open — start
+/// on the up colour rather than flickering.
+///
+/// Shared so that everything colouring by direction agrees by construction:
+/// the candle and the last-price chip sit on the same canvas at the same
+/// price, and a reader would take any disagreement between them as data.
+#[must_use]
+pub fn is_bullish(bar: &Bar) -> bool {
+    bar.close >= bar.open
+}
+
 /// Draw one candle from pure geometry and a resolved paint description.
 ///
 /// The heatmap is painted before this function and aggression bubbles after it.
@@ -35,7 +50,7 @@ pub fn draw_candle(
     forming: bool,
     style: &CandleStyle,
 ) {
-    let paint = style.resolved(bar.close >= bar.open, forming);
+    let paint = style.resolved(is_bullish(bar), forming);
     let geometry = candle_geometry(scale, bar, xc, half_width, paint.min_body_height);
     let body = egui::Rect::from_min_max(
         egui::pos2(geometry.body.left, geometry.body.top),
@@ -451,5 +466,59 @@ fn draw_preview_candle(
             rounding,
             egui::Stroke::new(paint.outline_width, color32(paint.outline)),
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::style::CandleStyle;
+    use rust_decimal::Decimal;
+    use std::str::FromStr as _;
+
+    fn bar(open: &str, close: &str) -> Bar {
+        let open = Decimal::from_str(open).unwrap();
+        let close = Decimal::from_str(close).unwrap();
+        Bar {
+            open_time: 0,
+            close_time: 0,
+            open,
+            high: open.max(close),
+            low: open.min(close),
+            close,
+            buy_volume: Decimal::ZERO,
+            sell_volume: Decimal::ZERO,
+            trade_count: 1,
+        }
+    }
+
+    #[test]
+    fn direction_reads_a_flat_bar_as_bullish() {
+        assert!(is_bullish(&bar("100", "101")));
+        assert!(is_bullish(&bar("100", "100")));
+        assert!(!is_bullish(&bar("100", "99")));
+    }
+
+    /// The last-price chip picks its colour straight from the candle palette
+    /// using this predicate. Both are on the same canvas at the same price, so
+    /// a reader would take any disagreement as information — this pins them
+    /// to one another.
+    #[test]
+    fn the_candle_outline_follows_the_same_direction_the_chip_would_use() {
+        let style = CandleStyle::default();
+        for (open, close) in [("100", "101"), ("100", "100"), ("100", "99")] {
+            let bar = bar(open, close);
+            let chip = if is_bullish(&bar) {
+                style.bull_outline
+            } else {
+                style.bear_outline
+            };
+            let candle = style.resolved(is_bullish(&bar), false);
+            assert_eq!(
+                [candle.outline[0], candle.outline[1], candle.outline[2]],
+                chip,
+                "{open}->{close} painted a candle and a chip of different colours"
+            );
+        }
     }
 }

--- a/crates/app/src/orderflow/config.rs
+++ b/crates/app/src/orderflow/config.rs
@@ -1,6 +1,7 @@
 //! Sanitized runtime configuration for the order-book heatmap.
 
 use rust_decimal::Decimal;
+use rust_decimal::prelude::FromPrimitive as _;
 use serde::{Deserialize, Serialize};
 
 /// Shortest history window accepted by the UI.
@@ -29,6 +30,12 @@ pub const MAX_DISPLAY_GROUP_MULTIPLE: u32 = 1_000_000;
 pub const DEFAULT_BUBBLE_CLUSTER_MS: i64 = 200;
 /// Largest temporal window used to cluster aggressive prints.
 pub const MAX_BUBBLE_CLUSTER_MS: i64 = 2_000;
+/// Default window over which prints too small to read are folded together.
+/// Long enough to gather the dust of a quiet price range, short enough that
+/// the merged bubble still points at a moment rather than at the whole bar.
+pub const DEFAULT_BUBBLE_DUST_MERGE_MS: i64 = 1_500;
+/// Largest window accepted for folding unreadable prints together.
+pub const MAX_BUBBLE_DUST_MERGE_MS: i64 = 30_000;
 /// Default distance accepted when correlating a depth reduction and aggression.
 pub const DEFAULT_LIQUIDITY_CORRELATION_MS: i64 = 250;
 /// Safe upper bound for depth/aggression correlation.
@@ -211,6 +218,15 @@ pub struct BubbleStyle {
     /// impact ring). Raising it trades detail for frame time on a fast tape.
     #[serde(serialize_with = "serialize_short_f32")]
     pub detail_min_radius: f32,
+    /// Whether buy prints too small to be dressed are drawn as an open ring
+    /// instead of a solid dot.
+    ///
+    /// Shape survives where colour does not: at the small end of the radius
+    /// range a green speck and a red speck are the same speck, but a ring and
+    /// a disc still read as two different things. Bubbles large enough to
+    /// carry a halo, a rim and their sphere shading already state their side
+    /// clearly, so this leaves them alone.
+    pub hollow_small_buys: bool,
     /// Whether the fill is a flat disc or a shaded sphere.
     pub render_mode: BubbleRenderMode,
     /// How much a sphere-rendered bubble darkens toward its rim. Zero shades
@@ -295,6 +311,7 @@ impl Default for BubbleStyle {
             outline_width: 1.0,
             halo_strength: 0.12,
             detail_min_radius: 4.0,
+            hollow_small_buys: true,
             // Flat, so merely gaining the sphere option changes no pixels.
             render_mode: BubbleRenderMode::Flat,
             sphere_shading: DEFAULT_SPHERE_SHADING,
@@ -353,6 +370,29 @@ impl BubbleStyle {
         self.trail_length = finite_clamp(self.trail_length, 0.0, 120.0, 18.0);
         self.trail_opacity = finite_clamp(self.trail_opacity, 0.0, 1.0, 0.62);
         self.label_min_radius = finite_clamp(self.label_min_radius, 4.0, 64.0, 16.0);
+    }
+
+    /// Quantity at which a print stops being dust: the exact quantity whose
+    /// bubble lands on [`detail_min_radius`](Self::detail_min_radius), the
+    /// radius below which the renderer drops the halo, rim and impact ring and
+    /// leaves a bare dot.
+    ///
+    /// Inverts the renderer's area mapping — `radius = sqrt(min² + size² ·
+    /// (max² − min²))` at `size² = quantity / reference` — so the threshold
+    /// follows whatever radius range is configured instead of pinning a second
+    /// magic number beside it. `None` means nothing can be dust: no reference
+    /// to size against, or a detail radius already at the minimum.
+    #[must_use]
+    pub fn dust_quantity(&self, reference: Decimal) -> Option<Decimal> {
+        if reference <= Decimal::ZERO || self.detail_min_radius <= self.min_radius {
+            return None;
+        }
+        let span = self.max_radius.powi(2) - self.min_radius.powi(2);
+        if span <= 0.0 {
+            return None;
+        }
+        let size_sq = (self.detail_min_radius.powi(2) - self.min_radius.powi(2)) / span;
+        Decimal::from_f32(size_sq.clamp(0.0, 1.0)).map(|share| reference * share)
     }
 
     /// Exact quantity below which a print is not drawn, if any.
@@ -418,6 +458,14 @@ pub struct HeatmapConfig {
     ///
     /// Zero keeps raw, one-trade-per-bubble projection.
     pub bubble_cluster_ms: i64,
+    /// Temporal window over which prints too small to read are folded into one
+    /// bubble per visual price range.
+    ///
+    /// Zero draws every cluster, however small. The threshold itself is not a
+    /// setting: it is whatever quantity lands on
+    /// [`BubbleStyle::detail_min_radius`], so widening the radius range moves
+    /// the floor with it.
+    pub bubble_dust_merge_ms: i64,
     /// Everything else the aggression-bubble panel owns: geometry (including
     /// the alpha and largest radius this used to carry as two flat fields),
     /// colour, consumption marks and labels.
@@ -470,6 +518,7 @@ impl Default for HeatmapConfig {
             gamma: 1.8,
             show_aggressions: false,
             bubble_cluster_ms: DEFAULT_BUBBLE_CLUSTER_MS,
+            bubble_dust_merge_ms: DEFAULT_BUBBLE_DUST_MERGE_MS,
             bubbles: BubbleStyle::default(),
             show_liquidity_events: true,
             min_unattributed_reduction: 0.5,
@@ -529,6 +578,7 @@ impl HeatmapConfig {
         }
         self.min_unattributed_pull_share = self.min_unattributed_pull_share.clamp(0.0, 1.0);
         self.bubble_cluster_ms = self.bubble_cluster_ms.clamp(0, MAX_BUBBLE_CLUSTER_MS);
+        self.bubble_dust_merge_ms = self.bubble_dust_merge_ms.clamp(0, MAX_BUBBLE_DUST_MERGE_MS);
         self.bubbles.sanitize();
         self.liquidity_correlation_ms = self
             .liquidity_correlation_ms
@@ -564,6 +614,8 @@ mod tests {
         assert!(!config.show_aggressions);
         assert!(!config.any_layer_enabled());
         assert_eq!(config.bubble_cluster_ms, DEFAULT_BUBBLE_CLUSTER_MS);
+        assert_eq!(config.bubble_dust_merge_ms, DEFAULT_BUBBLE_DUST_MERGE_MS);
+        assert!(config.bubbles.hollow_small_buys);
         assert_eq!(config.bubbles.opacity, DEFAULT_BUBBLE_OPACITY);
         assert_eq!(config.bubbles.max_radius, DEFAULT_BUBBLE_MAX_RADIUS);
         assert!(config.show_liquidity_events);
@@ -587,6 +639,7 @@ mod tests {
             opacity: f32::NAN,
             gamma: -1.0,
             bubble_cluster_ms: i64::MAX,
+            bubble_dust_merge_ms: i64::MAX,
             bubbles: BubbleStyle {
                 opacity: f32::NAN,
                 max_radius: 900.0,
@@ -610,6 +663,7 @@ mod tests {
         assert_eq!(config.opacity, 0.9);
         assert_eq!(config.gamma, 1.0);
         assert_eq!(config.bubble_cluster_ms, MAX_BUBBLE_CLUSTER_MS);
+        assert_eq!(config.bubble_dust_merge_ms, MAX_BUBBLE_DUST_MERGE_MS);
         assert_eq!(config.bubbles.opacity, DEFAULT_BUBBLE_OPACITY);
         assert_eq!(config.bubbles.max_radius, MAX_BUBBLE_MAX_RADIUS);
         assert_eq!(config.liquidity_correlation_ms, 0);
@@ -779,12 +833,14 @@ mod tests {
         let zero_rows = HeatmapConfig {
             display_grouping: DisplayGrouping::Adaptive { target_rows: 0 },
             bubble_cluster_ms: -5,
+            bubble_dust_merge_ms: -1,
             liquidity_correlation_ms: i64::MAX,
             ..HeatmapConfig::default()
         }
         .sanitized();
         assert_eq!(zero_rows.display_grouping, DisplayGrouping::default());
         assert_eq!(zero_rows.bubble_cluster_ms, 0);
+        assert_eq!(zero_rows.bubble_dust_merge_ms, 0);
         assert_eq!(
             zero_rows.liquidity_correlation_ms,
             MAX_LIQUIDITY_CORRELATION_MS

--- a/crates/app/src/orderflow/config.rs
+++ b/crates/app/src/orderflow/config.rs
@@ -50,6 +50,12 @@ pub const MIN_BUBBLE_MAX_RADIUS: f32 = 4.0;
 pub const MAX_BUBBLE_MAX_RADIUS: f32 = 48.0;
 /// Largest accepted radius for the smallest drawn bubble.
 pub const MAX_BUBBLE_MIN_RADIUS: f32 = 12.0;
+/// Default radius, in pixels, below which a bubble is treated as unreadable
+/// on its own: small enough to be a routine print, large enough that side
+/// colour and the side nudge actually register at a glance.
+pub const DEFAULT_READABLE_MIN_RADIUS: f32 = 6.0;
+/// Largest accepted readability floor.
+pub const MAX_READABLE_MIN_RADIUS: f32 = 32.0;
 /// Default edge darkening of a sphere-rendered bubble.
 pub const DEFAULT_SPHERE_SHADING: f32 = 0.55;
 /// Default highlight strength of a sphere-rendered bubble.
@@ -218,14 +224,22 @@ pub struct BubbleStyle {
     /// impact ring). Raising it trades detail for frame time on a fast tape.
     #[serde(serialize_with = "serialize_short_f32")]
     pub detail_min_radius: f32,
-    /// Whether buy prints too small to be dressed are drawn as an open ring
-    /// instead of a solid dot.
+    /// Radius, in pixels, below which a bubble cannot be read on its own.
     ///
-    /// Shape survives where colour does not: at the small end of the radius
-    /// range a green speck and a red speck are the same speck, but a ring and
-    /// a disc still read as two different things. Bubbles large enough to
-    /// carry a halo, a rim and their sphere shading already state their side
-    /// clearly, so this leaves them alone.
+    /// The readability floor both the dust merge and
+    /// [`hollow_small_buys`](Self::hollow_small_buys) gate on. Deliberately
+    /// *not* [`detail_min_radius`](Self::detail_min_radius): that one decides
+    /// how much dressing a bubble can afford, and a sphere-heavy look sets it
+    /// low on purpose — the "3d spheres" and "dense tape btc" presets put it
+    /// at or below `min_radius`, which would leave nothing to fold.
+    pub readable_min_radius: f32,
+    /// Whether buy prints below [`readable_min_radius`](Self::readable_min_radius)
+    /// are drawn as an open ring instead of a solid dot.
+    ///
+    /// Shape survives where colour does not: at that size a green speck and a
+    /// red speck are the same speck, but a ring and a disc still read as two
+    /// different things. Bubbles above the floor keep their fill, so a sphere
+    /// look is untouched.
     pub hollow_small_buys: bool,
     /// Whether the fill is a flat disc or a shaded sphere.
     pub render_mode: BubbleRenderMode,
@@ -311,6 +325,7 @@ impl Default for BubbleStyle {
             outline_width: 1.0,
             halo_strength: 0.12,
             detail_min_radius: 4.0,
+            readable_min_radius: DEFAULT_READABLE_MIN_RADIUS,
             hollow_small_buys: true,
             // Flat, so merely gaining the sphere option changes no pixels.
             render_mode: BubbleRenderMode::Flat,
@@ -354,6 +369,12 @@ impl BubbleStyle {
         self.outline_width = finite_clamp(self.outline_width, 0.0, 6.0, 1.0);
         self.halo_strength = finite_clamp(self.halo_strength, 0.0, 1.0, 0.12);
         self.detail_min_radius = finite_clamp(self.detail_min_radius, 0.0, 32.0, 4.0);
+        self.readable_min_radius = finite_clamp(
+            self.readable_min_radius,
+            0.0,
+            MAX_READABLE_MIN_RADIUS,
+            DEFAULT_READABLE_MIN_RADIUS,
+        );
         self.sphere_shading = finite_clamp(self.sphere_shading, 0.0, 1.0, DEFAULT_SPHERE_SHADING);
         self.sphere_highlight =
             finite_clamp(self.sphere_highlight, 0.0, 1.0, DEFAULT_SPHERE_HIGHLIGHT);
@@ -373,25 +394,23 @@ impl BubbleStyle {
     }
 
     /// Quantity at which a print stops being dust: the exact quantity whose
-    /// bubble lands on [`detail_min_radius`](Self::detail_min_radius), the
-    /// radius below which the renderer drops the halo, rim and impact ring and
-    /// leaves a bare dot.
+    /// bubble lands on [`readable_min_radius`](Self::readable_min_radius).
     ///
     /// Inverts the renderer's area mapping — `radius = sqrt(min² + size² ·
     /// (max² − min²))` at `size² = quantity / reference` — so the threshold
     /// follows whatever radius range is configured instead of pinning a second
     /// magic number beside it. `None` means nothing can be dust: no reference
-    /// to size against, or a detail radius already at the minimum.
+    /// to size against, or a floor already at the smallest drawn radius.
     #[must_use]
     pub fn dust_quantity(&self, reference: Decimal) -> Option<Decimal> {
-        if reference <= Decimal::ZERO || self.detail_min_radius <= self.min_radius {
+        if reference <= Decimal::ZERO || self.readable_min_radius <= self.min_radius {
             return None;
         }
         let span = self.max_radius.powi(2) - self.min_radius.powi(2);
         if span <= 0.0 {
             return None;
         }
-        let size_sq = (self.detail_min_radius.powi(2) - self.min_radius.powi(2)) / span;
+        let size_sq = (self.readable_min_radius.powi(2) - self.min_radius.powi(2)) / span;
         Decimal::from_f32(size_sq.clamp(0.0, 1.0)).map(|share| reference * share)
     }
 

--- a/crates/app/src/orderflow/config.rs
+++ b/crates/app/src/orderflow/config.rs
@@ -232,6 +232,7 @@ pub struct BubbleStyle {
     /// how much dressing a bubble can afford, and a sphere-heavy look sets it
     /// low on purpose — the "3d spheres" and "dense tape btc" presets put it
     /// at or below `min_radius`, which would leave nothing to fold.
+    #[serde(serialize_with = "serialize_short_f32")]
     pub readable_min_radius: f32,
     /// Whether buy prints below [`readable_min_radius`](Self::readable_min_radius)
     /// are drawn as an open ring instead of a solid dot.

--- a/crates/app/src/orderflow/interaction.rs
+++ b/crates/app/src/orderflow/interaction.rs
@@ -266,6 +266,158 @@ pub fn cluster_aggressions<'a>(
     clusters
 }
 
+/// Accumulator folding consecutive dust clusters into one bubble.
+#[derive(Debug)]
+struct DustMerge {
+    key: ClusterKey,
+    cluster: AggressionCluster,
+    price_quantity: Decimal,
+    count: usize,
+}
+
+impl DustMerge {
+    fn new(key: ClusterKey, cluster: AggressionCluster) -> DustMerge {
+        let price_quantity = cluster.price * cluster.quantity;
+        DustMerge {
+            key,
+            cluster,
+            price_quantity,
+            count: 1,
+        }
+    }
+
+    /// Whether `cluster` extends this merge without spanning more than
+    /// `window_ms` from the anchor's first print.
+    fn accepts(&self, key: ClusterKey, cluster: &AggressionCluster, window_ms: i64) -> bool {
+        self.key == key
+            && cluster
+                .last_timestamp_ms
+                .saturating_sub(self.cluster.first_timestamp_ms)
+                <= window_ms
+    }
+
+    fn push(&mut self, other: AggressionCluster) {
+        self.price_quantity += other.price * other.quantity;
+        self.cluster.quantity += other.quantity;
+        self.cluster.matched_quantity += other.matched_quantity;
+        self.cluster.agg_ids.extend(other.agg_ids);
+        self.cluster
+            .liquidity_event_ids
+            .extend(other.liquidity_event_ids);
+        self.cluster.first_timestamp_ms = self
+            .cluster
+            .first_timestamp_ms
+            .min(other.first_timestamp_ms);
+        self.cluster.last_timestamp_ms =
+            self.cluster.last_timestamp_ms.max(other.last_timestamp_ms);
+        self.count += 1;
+    }
+
+    fn finish(mut self) -> AggressionCluster {
+        // A lone cluster is returned exactly as it arrived: merging must be
+        // invisible where there was nothing to merge.
+        if self.count == 1 {
+            return self.cluster;
+        }
+        if self.cluster.quantity > Decimal::ZERO {
+            self.cluster.price = self.price_quantity / self.cluster.quantity;
+        }
+        self.cluster.timestamp_ms = self.cluster.first_timestamp_ms.saturating_add(
+            self.cluster
+                .last_timestamp_ms
+                .saturating_sub(self.cluster.first_timestamp_ms)
+                / 2,
+        );
+        self.cluster.agg_ids.sort_unstable();
+        self.cluster.agg_ids.dedup();
+        self.cluster.liquidity_event_ids.sort_unstable();
+        self.cluster.liquidity_event_ids.dedup();
+        self.cluster.trade_count = self.cluster.agg_ids.len();
+        if let Some(first) = self.cluster.agg_ids.first() {
+            self.cluster.agg_id = *first;
+        }
+        self.cluster
+    }
+}
+
+/// Fold prints too small to draw as anything but a dot into one bubble per
+/// visual price range.
+///
+/// The bulk of a busy tape is dust: clusters whose quantity puts them at the
+/// minimum radius, where neither the fill colour nor the side nudge survives.
+/// Drawn one by one they are a rash of identical specks that says only "trades
+/// happened here"; folded together they become a single mark carrying the same
+/// exact quantity, which is the part worth reading.
+///
+/// A merge is anchored at its first cluster and never spans more than
+/// `window_ms`, so a quiet price range cannot pull unrelated prints together
+/// across the whole visible history, and a cluster above `dust_quantity` both
+/// passes through untouched and closes any open merge — a merged bubble is
+/// always contiguous in time. Quantities, ids and matched evidence are summed:
+/// nothing is dropped, and `trade_count` still reports every aggregate trade
+/// standing behind the mark.
+#[must_use]
+pub fn merge_dust_clusters(
+    clusters: Vec<AggressionCluster>,
+    dust_quantity: Decimal,
+    window_ms: i64,
+) -> Vec<AggressionCluster> {
+    if dust_quantity <= Decimal::ZERO || window_ms <= 0 {
+        return clusters;
+    }
+
+    let mut keyed: Vec<(ClusterKey, AggressionCluster)> = clusters
+        .into_iter()
+        .map(|cluster| {
+            let key = ClusterKey {
+                generation: cluster.generation,
+                side: aggressor_side_key(cluster.side),
+                price_bucket: cluster.price_bucket,
+            };
+            (key, cluster)
+        })
+        .collect();
+    keyed.sort_by(|(a_key, a), (b_key, b)| {
+        a_key
+            .cmp(b_key)
+            .then_with(|| a.first_timestamp_ms.cmp(&b.first_timestamp_ms))
+            .then_with(|| a.agg_id.cmp(&b.agg_id))
+    });
+
+    let mut merged: Vec<AggressionCluster> = Vec::with_capacity(keyed.len());
+    let mut open: Option<DustMerge> = None;
+    for (key, cluster) in keyed {
+        if cluster.quantity >= dust_quantity {
+            if let Some(pending) = open.take() {
+                merged.push(pending.finish());
+            }
+            merged.push(cluster);
+            continue;
+        }
+        match open.as_mut() {
+            Some(pending) if pending.accepts(key, &cluster, window_ms) => pending.push(cluster),
+            _ => {
+                if let Some(pending) = open.replace(DustMerge::new(key, cluster)) {
+                    merged.push(pending.finish());
+                }
+            }
+        }
+    }
+    if let Some(pending) = open {
+        merged.push(pending.finish());
+    }
+
+    merged.sort_by(|a, b| {
+        a.first_timestamp_ms
+            .cmp(&b.first_timestamp_ms)
+            .then_with(|| a.last_timestamp_ms.cmp(&b.last_timestamp_ms))
+            .then_with(|| aggressor_side_key(a.side).cmp(&aggressor_side_key(b.side)))
+            .then_with(|| a.price_bucket.cmp(&b.price_bucket))
+            .then_with(|| a.agg_id.cmp(&b.agg_id))
+    });
+    merged
+}
+
 /// Convert factual grouped transitions into reduction events.
 #[must_use]
 pub fn liquidity_events(transitions: &[LiquidityTransition]) -> Vec<LiquidityEvent> {
@@ -551,6 +703,101 @@ mod tests {
                 .sum::<Decimal>(),
             dec("5")
         );
+    }
+
+    /// One raw cluster per print, which is what the dust merge is handed once
+    /// the temporal clustering has already run.
+    fn raw_clusters(prints: &[Aggression]) -> Vec<AggressionCluster> {
+        cluster_aggressions(prints.iter(), &[coverage(0, None)], grouping(), 0)
+    }
+
+    #[test]
+    fn dust_folds_into_one_bubble_and_conserves_quantity_ids_and_span() {
+        let prints = [
+            aggression(1, 100, "100", "1", Side::Buy, Some(3)),
+            aggression(2, 300, "101", "2", Side::Buy, Some(3)),
+            aggression(3, 500, "100", "1", Side::Buy, Some(3)),
+        ];
+        let clusters = raw_clusters(&prints);
+        assert_eq!(clusters.len(), 3);
+
+        let merged = merge_dust_clusters(clusters, dec("10"), 1_000);
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].quantity, dec("4"));
+        assert_eq!(merged[0].agg_ids, [1, 2, 3]);
+        assert_eq!(merged[0].trade_count, 3);
+        assert_eq!(merged[0].first_timestamp_ms, 100);
+        assert_eq!(merged[0].last_timestamp_ms, 500);
+        assert_eq!(merged[0].timestamp_ms, 300);
+        // Quantity-weighted: (100·1 + 101·2 + 100·1) / 4.
+        assert_eq!(merged[0].price, dec("100.5"));
+    }
+
+    #[test]
+    fn a_dust_merge_never_spans_more_than_its_window() {
+        let prints = [
+            aggression(1, 0, "100", "1", Side::Buy, Some(3)),
+            aggression(2, 200, "100", "1", Side::Buy, Some(3)),
+            aggression(3, 900, "100", "1", Side::Buy, Some(3)),
+        ];
+        let merged = merge_dust_clusters(raw_clusters(&prints), dec("10"), 500);
+        assert_eq!(merged.len(), 2);
+        assert_eq!(merged[0].agg_ids, [1, 2]);
+        assert_eq!(merged[1].agg_ids, [3]);
+    }
+
+    #[test]
+    fn a_readable_print_passes_through_untouched_and_splits_the_merge() {
+        let prints = [
+            aggression(1, 0, "100", "1", Side::Buy, Some(3)),
+            aggression(2, 100, "100", "50", Side::Buy, Some(3)),
+            aggression(3, 200, "100", "1", Side::Buy, Some(3)),
+        ];
+        let merged = merge_dust_clusters(raw_clusters(&prints), dec("10"), 5_000);
+        assert_eq!(merged.len(), 3);
+        assert_eq!(merged[1].agg_ids, [2]);
+        assert_eq!(merged[1].quantity, dec("50"));
+    }
+
+    #[test]
+    fn dust_never_merges_across_side_or_price_range() {
+        let prints = [
+            aggression(1, 0, "100", "1", Side::Buy, Some(3)),
+            aggression(2, 10, "100", "1", Side::Sell, Some(3)),
+            aggression(3, 20, "110", "1", Side::Buy, Some(3)),
+        ];
+        let merged = merge_dust_clusters(raw_clusters(&prints), dec("10"), 5_000);
+        assert_eq!(merged.len(), 3);
+    }
+
+    #[test]
+    fn a_zero_window_or_threshold_draws_every_print() {
+        let prints = [
+            aggression(1, 0, "100", "1", Side::Buy, Some(3)),
+            aggression(2, 10, "100", "1", Side::Buy, Some(3)),
+        ];
+        let clusters = raw_clusters(&prints);
+        assert_eq!(merge_dust_clusters(clusters.clone(), dec("10"), 0).len(), 2);
+        assert_eq!(merge_dust_clusters(clusters, Decimal::ZERO, 5_000).len(), 2);
+    }
+
+    #[test]
+    fn merging_dust_carries_its_matched_evidence_along() {
+        let prints = [
+            aggression(1, 0, "100", "1", Side::Buy, Some(3)),
+            aggression(2, 100, "100", "1", Side::Buy, Some(3)),
+        ];
+        let mut clusters = raw_clusters(&prints);
+        clusters[0].matched_quantity = dec("0.5");
+        clusters[0].liquidity_event_ids = vec![7];
+        clusters[1].matched_quantity = dec("1");
+        clusters[1].liquidity_event_ids = vec![7, 9];
+
+        let merged = merge_dust_clusters(clusters, dec("10"), 5_000);
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].matched_quantity, dec("1.5"));
+        assert_eq!(merged[0].liquidity_event_ids, [7, 9]);
+        assert_eq!(merged[0].matched_fraction(), 0.75);
     }
 
     #[test]

--- a/crates/app/src/orderflow/projection.rs
+++ b/crates/app/src/orderflow/projection.rs
@@ -9,6 +9,7 @@ use super::history::{AggressorSide, LiquidityHistory, RestingSide};
 pub use super::interaction::LiquidityEvidence;
 use super::interaction::{
     AggressionCluster, cluster_aggressions, correlate_liquidity, liquidity_events,
+    merge_dust_clusters,
 };
 use super::timeline::BarTimeline;
 
@@ -421,6 +422,17 @@ pub fn project(
         aggression_clusters.retain(|cluster| cluster.quantity >= floor);
     }
 
+    // Readability floor. Association already happened, so folding the dust
+    // together moves no evidence: a merged bubble carries the summed quantity
+    // and the union of the event ids its parts pointed at. Sized against the
+    // reference computed above, which is deliberately *not* recomputed —
+    // merging is a drawing decision and must not rescale the bubbles that were
+    // already readable.
+    if let Some(dust) = config.bubbles.dust_quantity(aggression_reference) {
+        aggression_clusters =
+            merge_dust_clusters(aggression_clusters, dust, config.bubble_dust_merge_ms);
+    }
+
     let dropped_aggressions = if config.show_aggressions {
         aggression_clusters
             .len()
@@ -712,10 +724,18 @@ mod tests {
     }
 
     /// Four prints an order of magnitude apart, so the size ladder is visible.
-    /// Clustering is off: these must stay four distinct bubbles.
+    /// Both readability passes are off — temporal clustering and the dust
+    /// merge — so these stay four distinct bubbles and the test measures the
+    /// size mapping alone.
     fn history_with_a_size_ladder(config: HeatmapConfig) -> LiquidityHistory {
+        size_ladder(config, 0)
+    }
+
+    /// The ladder above with the dust merge armed at `dust_merge_ms`.
+    fn size_ladder(config: HeatmapConfig, dust_merge_ms: i64) -> LiquidityHistory {
         let mut history = LiquidityHistory::new(HeatmapConfig {
             bubble_cluster_ms: 0,
+            bubble_dust_merge_ms: dust_merge_ms,
             ..config
         });
         history.install_snapshot(100, 1, snapshot(10)).unwrap();
@@ -749,6 +769,49 @@ mod tests {
             .collect();
         sizes.sort_by_key(|pair| pair.0);
         sizes
+    }
+
+    #[test]
+    fn the_dust_merge_folds_unreadable_prints_without_losing_quantity() {
+        // The same ladder with the dust merge armed. Against a reference of
+        // 200 the two smallest prints (1 and 10) fall below the radius where
+        // the renderer stops dressing a bubble, so they arrive as one mark
+        // carrying both — while the two readable prints are left alone.
+        let history = size_ladder(
+            HeatmapConfig {
+                bubbles: BubbleStyle {
+                    size_reference: BubbleSizeReference::VisibleMax,
+                    ..BubbleStyle::default()
+                },
+                ..config()
+            },
+            5_000,
+        );
+        let projection = project(
+            &history,
+            &BarTimeline::from_bars(0, &[bar(0, 1_000)], None, None),
+            PriceWindow::new(dec("98"), dec("103")).unwrap(),
+        );
+
+        let mut quantities: Vec<Decimal> = projection
+            .aggressions
+            .iter()
+            .map(|aggression| aggression.quantity)
+            .collect();
+        quantities.sort();
+        assert_eq!(quantities, [dec("11"), dec("50"), dec("200")]);
+        assert_eq!(
+            quantities.iter().sum::<Decimal>(),
+            dec("261"),
+            "merging is a drawing decision and never loses quantity"
+        );
+        let folded = projection
+            .aggressions
+            .iter()
+            .find(|aggression| aggression.quantity == dec("11"))
+            .expect("the two dust prints fold into one bubble");
+        assert_eq!(folded.trade_count, 2);
+        assert_eq!(folded.agg_ids, [1, 2]);
     }
 
     #[test]

--- a/crates/app/src/orderflow_render.rs
+++ b/crates/app/src/orderflow_render.rs
@@ -202,6 +202,24 @@ const fn side_offset_y(side: Side, offset: f32) -> f32 {
     }
 }
 
+/// Interior alpha of a hollow bubble, as a fraction of the configured fill
+/// alpha: enough tint to keep the disc's area readable, light enough that the
+/// ring is what the eye catches.
+const HOLLOW_FILL_ALPHA: f32 = 0.22;
+/// Ring thickness of a hollow bubble as a fraction of its radius, and the
+/// pixel range it is held to — thin enough to stay a ring on a full-size
+/// sweep, thick enough to survive at dot size.
+const HOLLOW_RING_SCALE: f32 = 0.42;
+/// See [`HOLLOW_RING_SCALE`].
+const HOLLOW_MIN_RING_PX: f32 = 1.2;
+/// See [`HOLLOW_RING_SCALE`].
+const HOLLOW_MAX_RING_PX: f32 = 3.0;
+
+/// Ring thickness of a hollow bubble of this radius.
+fn hollow_ring_width(radius: f32) -> f32 {
+    (radius * HOLLOW_RING_SCALE).clamp(HOLLOW_MIN_RING_PX, HOLLOW_MAX_RING_PX)
+}
+
 /// Gap, in pixels, between a bubble's rim and the halo drawn behind it.
 const HALO_PADDING_PX: f32 = 2.5;
 /// Gap, in pixels, between a bubble's rim and its impact ring.
@@ -418,6 +436,12 @@ fn draw_bubble(
     // read it, which also keeps the per-frame tessellation budget flat no
     // matter how fast the tape runs.
     let dressed = radius >= bubbles.detail_min_radius;
+    // Shape carries the side exactly where colour stops doing it: an undressed
+    // buy is a green speck and an undressed sell a red one, and at that size
+    // the two are the same speck. An open ring is not. Dressed bubbles keep
+    // their fill — halo, rim and sphere shading already say which side they
+    // are, and punching a hole would only undo the shading.
+    let hollow = !dressed && bubbles.hollow_small_buys && matches!(side, Side::Buy);
     let sphere = dressed && bubbles.render_mode == BubbleRenderMode::Sphere;
     if dressed && bubbles.halo_strength > 0.0 {
         painter.circle_filled(
@@ -426,7 +450,21 @@ fn draw_bubble(
             color.gamma_multiply(halo_alpha(size, bubbles)),
         );
     }
-    if sphere {
+    if hollow {
+        let ring = hollow_ring_width(radius);
+        painter.circle_filled(
+            center,
+            radius,
+            color.gamma_multiply(bubbles.opacity * HOLLOW_FILL_ALPHA),
+        );
+        // Stroked on the inside of the radius, so a hollow bubble occupies
+        // exactly the area its quantity earned.
+        painter.circle_stroke(
+            center,
+            (radius - ring / 2.0).max(0.5),
+            egui::Stroke::new(ring, color.gamma_multiply(bubbles.opacity)),
+        );
+    } else if sphere {
         let mut mesh = egui::Mesh::default();
         add_sphere_disc(
             &mut mesh,
@@ -2061,6 +2099,46 @@ fn finite_clamp(value: f32, low: f32, high: f32, fallback: f32) -> f32 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The dust threshold is defined by inverting this module's radius
+    /// mapping, but lives in `config` beside the style it reads. This pins the
+    /// two together: a print at the threshold must land exactly on the radius
+    /// where the renderer stops dressing a bubble.
+    #[test]
+    fn the_dust_threshold_lands_on_the_detail_radius() {
+        use rust_decimal::prelude::ToPrimitive as _;
+
+        let bubbles = BubbleStyle::default();
+        let reference = rust_decimal::Decimal::from(400);
+        let dust = bubbles
+            .dust_quantity(reference)
+            .expect("the default style has a detail radius above its minimum");
+        let size = (dust / reference)
+            .to_f32()
+            .expect("the threshold share converts")
+            .sqrt();
+        let radius = bubble_radius(size, bubbles.min_radius, bubbles.max_radius);
+        assert!(
+            (radius - bubbles.detail_min_radius).abs() < 1e-3,
+            "a dust print rendered at {radius}, not {}",
+            bubbles.detail_min_radius
+        );
+    }
+
+    #[test]
+    fn nothing_is_dust_without_a_reference_or_a_detail_radius() {
+        let bubbles = BubbleStyle::default();
+        assert!(bubbles.dust_quantity(rust_decimal::Decimal::ZERO).is_none());
+
+        let flat = BubbleStyle {
+            detail_min_radius: 0.0,
+            ..BubbleStyle::default()
+        };
+        assert!(
+            flat.dust_quantity(rust_decimal::Decimal::from(400))
+                .is_none()
+        );
+    }
 
     fn luminance(rgb: [u8; 3]) -> f32 {
         0.2126 * f32::from(rgb[0]) + 0.7152 * f32::from(rgb[1]) + 0.0722 * f32::from(rgb[2])

--- a/crates/app/src/orderflow_render.rs
+++ b/crates/app/src/orderflow_render.rs
@@ -2561,6 +2561,46 @@ mod tests {
     }
 
     #[test]
+    fn hollow_small_buys_opens_the_dot_and_leaves_dressed_bubbles_alone() {
+        let hollow = BubbleStyle {
+            trail_length: 0.0,
+            ..BubbleStyle::default()
+        };
+        assert!(hollow.hollow_small_buys);
+        let solid = BubbleStyle {
+            hollow_small_buys: false,
+            ..hollow.clone()
+        };
+        let colors = BubbleColors::resolve(&Palette::for_theme(HeatmapTheme::Bookmap), &hollow);
+        let mark = |radius| BubbleMark {
+            center: egui::pos2(40.0, 40.0),
+            radius,
+            side: Side::Buy,
+            size: 0.05,
+            matched: None,
+        };
+
+        // Below the detail radius — where colour alone stops working — the
+        // setting must change what is painted.
+        let small = hollow.min_radius;
+        assert!(small < hollow.detail_min_radius);
+        assert_ne!(
+            painted(|painter| draw_bubble(painter, mark(small), &hollow, &colors)),
+            painted(|painter| draw_bubble(painter, mark(small), &solid, &colors)),
+            "an undressed buy must not paint the same with the ring off"
+        );
+
+        // Above it the setting must change nothing: dressing and sphere
+        // shading already say which side the bubble is.
+        let big = hollow.detail_min_radius + 1.0;
+        assert_eq!(
+            painted(|painter| draw_bubble(painter, mark(big), &hollow, &colors)),
+            painted(|painter| draw_bubble(painter, mark(big), &solid, &colors)),
+            "a dressed buy must be untouched by the ring setting"
+        );
+    }
+
+    #[test]
     fn live_span_grows_with_time_and_clamps() {
         assert_eq!(live_span_for(0, 1000, 8.0), 1.0);
         assert_eq!(live_span_for(500, 0, 8.0), 1.0);

--- a/crates/app/src/orderflow_render.rs
+++ b/crates/app/src/orderflow_render.rs
@@ -436,14 +436,16 @@ fn draw_bubble(
     // read it, which also keeps the per-frame tessellation budget flat no
     // matter how fast the tape runs.
     let dressed = radius >= bubbles.detail_min_radius;
-    // Shape carries the side exactly where colour stops doing it: an undressed
-    // buy is a green speck and an undressed sell a red one, and at that size
-    // the two are the same speck. An open ring is not. Dressed bubbles keep
-    // their fill — halo, rim and sphere shading already say which side they
-    // are, and punching a hole would only undo the shading.
-    let hollow = !dressed && bubbles.hollow_small_buys && matches!(side, Side::Buy);
-    let sphere = dressed && bubbles.render_mode == BubbleRenderMode::Sphere;
-    if dressed && bubbles.halo_strength > 0.0 {
+    // Shape carries the side exactly where colour stops doing it: below the
+    // readability floor a green speck and a red speck are the same speck, and
+    // an open ring is not. Gated on that floor rather than on `dressed`,
+    // because a sphere-heavy look sets the dressing radius low on purpose and
+    // would otherwise leave every bubble solid.
+    let hollow = bubbles.hollow_small_buys
+        && matches!(side, Side::Buy)
+        && radius < bubbles.readable_min_radius;
+    let sphere = !hollow && dressed && bubbles.render_mode == BubbleRenderMode::Sphere;
+    if !hollow && dressed && bubbles.halo_strength > 0.0 {
         painter.circle_filled(
             center,
             radius + HALO_PADDING_PX,
@@ -478,7 +480,7 @@ fn draw_bubble(
     } else {
         painter.circle_filled(center, radius, color.gamma_multiply(bubbles.opacity));
     }
-    if dressed && bubbles.outline_width > 0.0 {
+    if !hollow && dressed && bubbles.outline_width > 0.0 {
         // A sphere's rim adopts the darkened edge colour: the dark separator
         // is what keeps two overlapping same-side bubbles readable as two.
         let rim = if sphere {
@@ -2102,36 +2104,77 @@ mod tests {
 
     /// The dust threshold is defined by inverting this module's radius
     /// mapping, but lives in `config` beside the style it reads. This pins the
-    /// two together: a print at the threshold must land exactly on the radius
-    /// where the renderer stops dressing a bubble.
+    /// two together: a print at the threshold must land exactly on the
+    /// readability floor.
     #[test]
-    fn the_dust_threshold_lands_on_the_detail_radius() {
+    fn the_dust_threshold_lands_on_the_readability_floor() {
         use rust_decimal::prelude::ToPrimitive as _;
 
         let bubbles = BubbleStyle::default();
         let reference = rust_decimal::Decimal::from(400);
         let dust = bubbles
             .dust_quantity(reference)
-            .expect("the default style has a detail radius above its minimum");
+            .expect("the default style has a readability floor above its minimum");
         let size = (dust / reference)
             .to_f32()
             .expect("the threshold share converts")
             .sqrt();
         let radius = bubble_radius(size, bubbles.min_radius, bubbles.max_radius);
         assert!(
-            (radius - bubbles.detail_min_radius).abs() < 1e-3,
+            (radius - bubbles.readable_min_radius).abs() < 1e-3,
             "a dust print rendered at {radius}, not {}",
-            bubbles.detail_min_radius
+            bubbles.readable_min_radius
+        );
+    }
+
+    /// The shipped presets tune `detail_min_radius` down to buy sphere shading
+    /// on small prints — "dense tape btc" (the default open) sets it *below*
+    /// `min_radius`. Anchoring the readability floor there made both the dust
+    /// merge and the hollow ring inert on exactly the look the project opens
+    /// with, which is the regression this guards.
+    #[test]
+    fn a_low_detail_radius_does_not_disarm_the_readability_floor() {
+        let dense_tape_btc = BubbleStyle {
+            min_radius: 2.2,
+            max_radius: 14.0,
+            detail_min_radius: 2.0,
+            ..BubbleStyle::default()
+        };
+        assert!(dense_tape_btc.detail_min_radius < dense_tape_btc.min_radius);
+        assert!(
+            dense_tape_btc
+                .dust_quantity(rust_decimal::Decimal::from(400))
+                .is_some(),
+            "prints must still be foldable when the dressing radius is low"
+        );
+
+        let colors =
+            BubbleColors::resolve(&Palette::for_theme(HeatmapTheme::Bookmap), &dense_tape_btc);
+        let mark = BubbleMark {
+            center: egui::pos2(40.0, 40.0),
+            radius: dense_tape_btc.min_radius,
+            side: Side::Buy,
+            size: 0.02,
+            matched: None,
+        };
+        let solid = BubbleStyle {
+            hollow_small_buys: false,
+            ..dense_tape_btc.clone()
+        };
+        assert_ne!(
+            painted(|painter| draw_bubble(painter, mark, &dense_tape_btc, &colors)),
+            painted(|painter| draw_bubble(painter, mark, &solid, &colors)),
+            "the ring must still fire when the dressing radius is below the minimum"
         );
     }
 
     #[test]
-    fn nothing_is_dust_without_a_reference_or_a_detail_radius() {
+    fn nothing_is_dust_without_a_reference_or_a_readability_floor() {
         let bubbles = BubbleStyle::default();
         assert!(bubbles.dust_quantity(rust_decimal::Decimal::ZERO).is_none());
 
         let flat = BubbleStyle {
-            detail_min_radius: 0.0,
+            readable_min_radius: 0.0,
             ..BubbleStyle::default()
         };
         assert!(
@@ -2580,23 +2623,23 @@ mod tests {
             matched: None,
         };
 
-        // Below the detail radius — where colour alone stops working — the
-        // setting must change what is painted.
+        // Below the readability floor — where colour alone stops working —
+        // the setting must change what is painted.
         let small = hollow.min_radius;
-        assert!(small < hollow.detail_min_radius);
+        assert!(small < hollow.readable_min_radius);
         assert_ne!(
             painted(|painter| draw_bubble(painter, mark(small), &hollow, &colors)),
             painted(|painter| draw_bubble(painter, mark(small), &solid, &colors)),
-            "an undressed buy must not paint the same with the ring off"
+            "a buy below the floor must not paint the same with the ring off"
         );
 
-        // Above it the setting must change nothing: dressing and sphere
-        // shading already say which side the bubble is.
-        let big = hollow.detail_min_radius + 1.0;
+        // Above it the setting must change nothing: at that size the fill and
+        // its sphere shading already say which side the bubble is.
+        let big = hollow.readable_min_radius + 1.0;
         assert_eq!(
             painted(|painter| draw_bubble(painter, mark(big), &hollow, &colors)),
             painted(|painter| draw_bubble(painter, mark(big), &solid, &colors)),
-            "a dressed buy must be untouched by the ring setting"
+            "a buy above the floor must be untouched by the ring setting"
         );
     }
 

--- a/crates/app/src/orderflow_view.rs
+++ b/crates/app/src/orderflow_view.rs
@@ -1295,6 +1295,7 @@ mod tests {
         view.presets.upsert(BubblePreset {
             name: "wide".to_owned(),
             cluster_ms: 100,
+            dust_merge_ms: 3_000,
             bubbles: BubbleStyle {
                 max_radius: 42.0,
                 side_offset: 8.0,
@@ -1304,6 +1305,7 @@ mod tests {
         view.apply_preset("wide");
         assert_eq!(view.config.bubbles.max_radius, 42.0);
         assert_eq!(view.config.bubble_cluster_ms, 100);
+        assert_eq!(view.config.bubble_dust_merge_ms, 3_000);
         assert_eq!(view.presets.active, "wide");
         assert_eq!(view.preset_name_draft, "wide");
         // Untouched: the layer switch, retention, grouping, gamma, capture bucket.

--- a/crates/app/src/orderflow_view.rs
+++ b/crates/app/src/orderflow_view.rs
@@ -707,14 +707,22 @@ impl OrderflowView {
                 )
                 .on_hover_text(
                     "bubbles smaller than this are plain dots (no halo, rim or impact ring). \
-                     Raising it buys frame time on a fast tape, and moves the quantity below \
-                     which prints are folded together.",
+                     Raising it buys frame time on a fast tape.",
+                );
+                ui.add(
+                    egui::Slider::new(&mut bubbles.readable_min_radius, 0.0..=24.0)
+                        .text("readable from px"),
+                )
+                .on_hover_text(
+                    "the size at which a bubble stops being readable on its own. Prints below \
+                     it are what \"fold dust\" merges, and what the ring below marks. Raise it \
+                     for fewer, larger bubbles; zero disables both.",
                 );
                 ui.checkbox(&mut bubbles.hollow_small_buys, "hollow small buys")
                     .on_hover_text(
-                        "draw undressed buy prints as an open ring instead of a solid dot. At \
-                         that size a green speck and a red speck read the same; a ring and a \
-                         disc do not. Dressed bubbles keep their fill.",
+                        "draw buy prints below the readable radius as an open ring instead of \
+                         a solid dot. At that size a green speck and a red speck read the same; \
+                         a ring and a disc do not. Larger bubbles keep their fill.",
                     );
             });
 
@@ -1109,7 +1117,7 @@ impl OrderflowView {
                             })
                             .response
                             .on_hover_text(
-                                "a second pass over the prints too small to draw as anything but a dot: inside this window they fold into one bubble per price range. The threshold follows \"detail from px\" — quantities and trade counts are summed exactly",
+                                "a second pass over the prints too small to read on their own: inside this window they fold into one bubble per price range. The threshold follows \"readable from px\" — quantities and trade counts are summed exactly",
                             );
                             self.draw_bubble_controls(ui);
                         });

--- a/crates/app/src/orderflow_view.rs
+++ b/crates/app/src/orderflow_view.rs
@@ -707,8 +707,15 @@ impl OrderflowView {
                 )
                 .on_hover_text(
                     "bubbles smaller than this are plain dots (no halo, rim or impact ring). \
-                     Raising it buys frame time on a fast tape.",
+                     Raising it buys frame time on a fast tape, and moves the quantity below \
+                     which prints are folded together.",
                 );
+                ui.checkbox(&mut bubbles.hollow_small_buys, "hollow small buys")
+                    .on_hover_text(
+                        "draw undressed buy prints as an open ring instead of a solid dot. At \
+                         that size a green speck and a red speck read the same; a ring and a \
+                         disc do not. Dressed bubbles keep their fill.",
+                    );
             });
 
         egui::CollapsingHeader::new("consumption marks")
@@ -1021,6 +1028,7 @@ impl OrderflowView {
                         // so its whole look (and the preset it came from) stays.
                         show_aggressions: self.config.show_aggressions,
                         bubble_cluster_ms: self.config.bubble_cluster_ms,
+                        bubble_dust_merge_ms: self.config.bubble_dust_merge_ms,
                         bubbles: self.config.bubbles.clone(),
                         ..HeatmapConfig::default()
                     };
@@ -1085,6 +1093,24 @@ impl OrderflowView {
                             .on_hover_text(
                                 "merge compatible prints (same side, same price range) inside this window into one bubble; quantities are summed exactly",
                             );
+                            ui.horizontal(|ui| {
+                                ui.label("fold dust");
+                                egui::ComboBox::from_id_salt("heatmap_bubble_dust")
+                                    .selected_text(dust_label(self.config.bubble_dust_merge_ms))
+                                    .show_ui(ui, |ui| {
+                                        for milliseconds in [0, 500, 1_500, 3_000, 10_000] {
+                                            ui.selectable_value(
+                                                &mut self.config.bubble_dust_merge_ms,
+                                                milliseconds,
+                                                dust_label(milliseconds),
+                                            );
+                                        }
+                                    });
+                            })
+                            .response
+                            .on_hover_text(
+                                "a second pass over the prints too small to draw as anything but a dot: inside this window they fold into one bubble per price range. The threshold follows \"detail from px\" — quantities and trade counts are summed exactly",
+                            );
                             self.draw_bubble_controls(ui);
                         });
 
@@ -1107,6 +1133,7 @@ impl OrderflowView {
                         {
                             let defaults = HeatmapConfig::default();
                             self.config.bubble_cluster_ms = defaults.bubble_cluster_ms;
+                            self.config.bubble_dust_merge_ms = defaults.bubble_dust_merge_ms;
                             self.config.bubbles = defaults.bubbles;
                             // No stored preset is on screen any more, so the
                             // picker must not keep claiming one.
@@ -1164,6 +1191,16 @@ fn display_grouping_label(grouping: DisplayGrouping) -> String {
 fn cluster_label(milliseconds: i64) -> String {
     if milliseconds == 0 {
         "Raw".to_owned()
+    } else {
+        format!("{milliseconds} ms")
+    }
+}
+
+fn dust_label(milliseconds: i64) -> String {
+    if milliseconds == 0 {
+        "Off · draw every print".to_owned()
+    } else if milliseconds % 1_000 == 0 {
+        format!("{} s", milliseconds / 1_000)
     } else {
         format!("{milliseconds} ms")
     }


### PR DESCRIPTION
Phase 1 of the Live Edge plan (proposal: https://claude.ai/code/artifact/7c24c517-c05a-4a42-b9b9-77b55fa4c8d2): three readability passes over the aggression layer, none needing data the UI does not already have.

## What

- **Last-price line + axis chip** — a dashed line across the chart and a solid chip on the price gutter, coloured by the forming bar's direction through the same `is_bullish()` predicate the candle uses. The always-on answer to "am I above or below?".
- **Dust merge (pure layer)** — prints whose bubble would land below the new `readable_min_radius` are folded into one mark per side and visual price range, bounded by a `bubble_dust_merge_ms` window. The threshold inverts the renderer's area mapping, so it follows the configured radius range. Runs after liquidity association; quantities, ids and matched evidence are summed — nothing dropped.
- **Hollow small buys** — buys below the readability floor draw as an open ring, sells stay solid discs. Shape carries the side exactly where 2px of colour cannot. Dressed bubbles keep their fill, so the 3D sphere look is untouched.
- Both knobs exposed in the Bubbles tab (`fold dust`, `readable from px`, `hollow small buys`), included in the tab's reset, and carried by saved presets (defaulted on read for older files).

## Review notes

`arch-review` ran over the branch; both findings fixed (missing test for the hollow ring; presets not carrying the dust window). One live-validation regression found and fixed: anchoring the floor on `detail_min_radius` disarmed both features on the shipped "dense tape btc" and "3d spheres" presets, which tune that radius below `min_radius` — `readable_min_radius` now states the threshold directly, with regression cover reconstructing the shipped preset's radii.

## Verification

- `cargo fmt --all -- --check` / `cargo clippy --workspace --all-targets -- -D warnings` / `cargo build --workspace` / `cargo test --workspace` all green (276 tests in `quantick-app`).
- Validated live on Binance BTCUSDT with the default "dense tape btc" preset: screenshots in the session confirm the ring/disc distinction at dot size and the merged marks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkY8ocUoB2TszfTErAqNVt