### PR TITLE
feat(app): live strip MVP — the book right now beside the price axis (phase 4)

### DIFF
--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -1219,8 +1219,10 @@ impl QuantickApp {
             );
         }
 
-        // Grid + price labels first, behind the candles.
-        self.draw_price_axis(painter, chart_rect, &scale);
+        // Grid + price labels first, behind the candles. Labels anchor on the
+        // gutter's edge, past the live strip when one is shown.
+        let axis_x = areas.price_gutter.left();
+        self.draw_price_axis(painter, chart_rect, axis_x, &scale);
 
         // Candles, clipped to the chart body so they don't spill into the axes.
         let clip = painter.with_clip_rect(chart_rect);
@@ -1282,11 +1284,11 @@ impl QuantickApp {
         // Above the flow layers: everything else on the canvas is read against
         // it. Drawn on the unclipped painter so the chip reaches the gutter.
         if let Some(bar) = partial.or_else(|| closed.last()) {
-            self.draw_last_price(painter, chart_rect, &scale, bar);
+            self.draw_last_price(painter, chart_rect, axis_x, &scale, bar);
         }
         self.draw_backfill_divider(painter, chart_rect, total, cw);
         self.draw_time_strip(painter, areas.time_strip, closed, start, end, total);
-        self.draw_crosshair(painter, chart_rect, &scale);
+        self.draw_crosshair(painter, chart_rect, axis_x, &scale);
         self.orderflow.draw_status_badge(painter, chart_rect);
 
         // Cache the auto range + height for next frame's input handler, which
@@ -1339,8 +1341,16 @@ impl QuantickApp {
         }
     }
 
-    /// Right-hand price axis: round-number gridlines and labels.
-    fn draw_price_axis(&self, painter: &egui::Painter, chart_rect: egui::Rect, scale: &PriceScale) {
+    /// Right-hand price axis: round-number gridlines and labels. `axis_x` is
+    /// the gutter's left edge — the chart's right edge normally, the live
+    /// strip's right edge while the strip sits between them.
+    fn draw_price_axis(
+        &self,
+        painter: &egui::Painter,
+        chart_rect: egui::Rect,
+        axis_x: f32,
+        scale: &PriceScale,
+    ) {
         let (lo, hi) = scale.range();
         let font = egui::FontId::monospace(11.0);
         for tick in crate::chart::nice_ticks(lo, hi, 8) {
@@ -1356,7 +1366,7 @@ impl QuantickApp {
                 egui::Stroke::new(1.0_f32, self.grid()),
             );
             painter.text(
-                egui::pos2(chart_rect.right() + 6.0, y),
+                egui::pos2(axis_x + 6.0, y),
                 egui::Align2::LEFT_CENTER,
                 format!("{tick:.2}"),
                 font.clone(),
@@ -1366,8 +1376,8 @@ impl QuantickApp {
         // The axis dividing line.
         painter.line_segment(
             [
-                egui::pos2(chart_rect.right(), chart_rect.top()),
-                egui::pos2(chart_rect.right(), chart_rect.bottom()),
+                egui::pos2(axis_x, chart_rect.top()),
+                egui::pos2(axis_x, chart_rect.bottom()),
             ],
             egui::Stroke::new(1.0_f32, self.grid()),
         );
@@ -1383,6 +1393,7 @@ impl QuantickApp {
         &self,
         painter: &egui::Painter,
         chart_rect: egui::Rect,
+        axis_x: f32,
         scale: &PriceScale,
         bar: &quantick_engine::Bar,
     ) {
@@ -1402,11 +1413,10 @@ impl QuantickApp {
         };
         let color = egui::Color32::from_rgb(rgb[0], rgb[1], rgb[2]);
 
+        // Runs through the live strip when one is shown (`axis_x` then sits
+        // past it): the depth silhouette is read against this exact line.
         painter.extend(egui::Shape::dashed_line(
-            &[
-                egui::pos2(chart_rect.left(), y),
-                egui::pos2(chart_rect.right(), y),
-            ],
+            &[egui::pos2(chart_rect.left(), y), egui::pos2(axis_x, y)],
             egui::Stroke::new(1.0_f32, color.gamma_multiply(LAST_PRICE_LINE_ALPHA)),
             LAST_PRICE_DASH_PX,
             LAST_PRICE_GAP_PX,
@@ -1419,7 +1429,7 @@ impl QuantickApp {
             egui::FontId::monospace(11.0),
             LAST_PRICE_CHIP_TEXT,
         );
-        let text_pos = egui::pos2(chart_rect.right() + 6.0, y - galley.size().y / 2.0);
+        let text_pos = egui::pos2(axis_x + 6.0, y - galley.size().y / 2.0);
         let bg = egui::Rect::from_min_size(
             text_pos - egui::vec2(3.0, 1.0),
             galley.size() + egui::vec2(6.0, 2.0),
@@ -1431,7 +1441,13 @@ impl QuantickApp {
     /// Crosshair following the pointer, with the price shown on the axis.
     /// Drawn only while the Crosshair tool is armed on the rail (§7 — the
     /// hover crosshair is a mode, not an always-on layer).
-    fn draw_crosshair(&self, painter: &egui::Painter, chart_rect: egui::Rect, scale: &PriceScale) {
+    fn draw_crosshair(
+        &self,
+        painter: &egui::Painter,
+        chart_rect: egui::Rect,
+        axis_x: f32,
+        scale: &PriceScale,
+    ) {
         if self.toolrail.tool() != Tool::Crosshair {
             return;
         }
@@ -1449,10 +1465,12 @@ impl QuantickApp {
             ],
             stroke,
         );
+        // Reaches the axis through the live strip when one is shown, so the
+        // cursor height can be read against the depth silhouette too.
         painter.line_segment(
             [
                 egui::pos2(chart_rect.left(), pos.y),
-                egui::pos2(chart_rect.right(), pos.y),
+                egui::pos2(axis_x, pos.y),
             ],
             stroke,
         );
@@ -1464,7 +1482,7 @@ impl QuantickApp {
             egui::FontId::monospace(11.0),
             egui::Color32::WHITE,
         );
-        let text_pos = egui::pos2(chart_rect.right() + 6.0, pos.y - galley.size().y / 2.0);
+        let text_pos = egui::pos2(axis_x + 6.0, pos.y - galley.size().y / 2.0);
         let bg = egui::Rect::from_min_size(
             text_pos - egui::vec2(3.0, 1.0),
             galley.size() + egui::vec2(6.0, 2.0),

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -72,17 +72,27 @@ fn dec_from_f64(x: f64) -> Decimal {
     Decimal::from_f64(x.max(1e-8)).unwrap_or(Decimal::ONE)
 }
 
-/// Split the padded plot area into the candle chart, the right price gutter and
-/// the bottom time strip, so the input handler and the renderer agree on the
-/// boundaries.
-fn plot_split(area: egui::Rect) -> PlotAreas {
+/// Split the padded plot area into the candle chart, the optional live strip,
+/// the right price gutter and the bottom time strip, so the input handler and
+/// the renderer agree on the boundaries. `live_strip_width` of zero means the
+/// strip is off and the chart runs straight into the gutter, exactly as it
+/// did before the strip existed.
+fn plot_split(area: egui::Rect, live_strip_width: f32) -> PlotAreas {
     let plot = area.shrink(16.0);
-    let split_x = (plot.right() - AXIS_GUTTER).max(plot.left() + 20.0);
+    let strip_width = live_strip_width.max(0.0);
+    let gutter_x = (plot.right() - AXIS_GUTTER).max(plot.left() + 20.0);
+    let split_x = (gutter_x - strip_width).max(plot.left() + 20.0);
     let split_y = (plot.bottom() - TIME_STRIP).max(plot.top() + 20.0);
     PlotAreas {
         chart: egui::Rect::from_min_max(plot.min, egui::pos2(split_x, split_y)),
+        live_strip: (strip_width > 0.0).then(|| {
+            egui::Rect::from_min_max(
+                egui::pos2(split_x, plot.top()),
+                egui::pos2(gutter_x, split_y),
+            )
+        }),
         price_gutter: egui::Rect::from_min_max(
-            egui::pos2(split_x, plot.top()),
+            egui::pos2(gutter_x, plot.top()),
             egui::pos2(plot.right(), split_y),
         ),
         time_strip: egui::Rect::from_min_max(
@@ -92,9 +102,12 @@ fn plot_split(area: egui::Rect) -> PlotAreas {
     }
 }
 
-/// The three interactive regions of the plot.
+/// The interactive regions of the plot, plus the optional live strip.
 struct PlotAreas {
     chart: egui::Rect,
+    /// Present only while the strip is shown; sits between `chart` and
+    /// `price_gutter` and is not an input region.
+    live_strip: Option<egui::Rect>,
     price_gutter: egui::Rect,
     time_strip: egui::Rect,
 }
@@ -117,6 +130,9 @@ pub struct QuantickApp {
     orderflow: OrderflowView,
     book_capture_epoch: u64,
     book_channel_closed_reported: bool,
+    /// Whether the user wants the live strip shown. The pixels it actually
+    /// gets are still capability-gated — see [`Self::live_strip_width`].
+    live_strip_visible: bool,
 
     // Feed & asset selection, driven by the configuration. `feed_id`/`symbol`
     // are what the selectors show (the desired selection); `active` is what the
@@ -244,6 +260,7 @@ impl QuantickApp {
             orderflow: OrderflowView::new(symbol.clone()),
             book_capture_epoch: 0,
             book_channel_closed_reported: false,
+            live_strip_visible: false,
             active: (feed_id.clone(), symbol.clone()),
             replay: feed.replay,
             replay_view: ReplayView::new(),
@@ -414,6 +431,7 @@ impl QuantickApp {
             capabilities,
             heatmap_on,
             bubbles_on,
+            live_strip_on: self.live_strip_visible,
             dock_visible: self.dock.visible(),
             appearance_open: self.show_style,
         };
@@ -438,9 +456,22 @@ impl QuantickApp {
             ToolbarAction::LoadOlder => self.request_older_history(),
             ToolbarAction::SetHeatmap(enabled) => self.request_book_capture(enabled),
             ToolbarAction::SetBubbles(enabled) => self.orderflow.set_bubbles_enabled(enabled),
+            ToolbarAction::SetLiveStrip(shown) => self.live_strip_visible = shown,
             ToolbarAction::OpenDockTab(tab) => self.dock.open_tab(tab),
             ToolbarAction::ToggleDock => self.dock.toggle_visible(),
             ToolbarAction::ToggleAppearance => self.show_style = !self.show_style,
+        }
+    }
+
+    /// Width reserved for the live strip this frame. Capability-driven like
+    /// every affordance: on a source without book capture there is nothing
+    /// the strip could show yet, so it yields its pixels back to the chart
+    /// even while the user's toggle stays on.
+    fn live_strip_width(&self) -> f32 {
+        if self.live_strip_visible && self.capabilities().book_capture {
+            crate::live_strip::LIVE_STRIP_WIDTH_PX
+        } else {
+            0.0
         }
     }
 
@@ -998,7 +1029,7 @@ impl QuantickApp {
     /// - scroll over either axis → zoom that axis;
     /// - double-click → reset to the live edge and auto-fit price.
     fn handle_navigation(&mut self, ui: &egui::Ui, area: egui::Rect) {
-        let areas = plot_split(area);
+        let areas = plot_split(area, self.live_strip_width());
         let auto = self.last_auto_range;
         let height = self.last_chart_height;
         let total = self.state.bars().len() + usize::from(self.state.partial().is_some());
@@ -1081,7 +1112,7 @@ impl QuantickApp {
         let closed = self.state.bars();
         let partial = self.state.partial();
         let total = closed.len() + usize::from(partial.is_some());
-        let areas = plot_split(area);
+        let areas = plot_split(area, self.live_strip_width());
         let chart_rect = areas.chart;
         if total == 0 {
             painter.text(
@@ -1234,6 +1265,13 @@ impl QuantickApp {
                 canvas_background,
                 live_span,
             );
+        }
+
+        // The live strip: the book right now, beside the axis the price
+        // labels live on. Its own rect, so chart layers never bleed into it.
+        if let Some(strip) = areas.live_strip {
+            self.orderflow
+                .draw_live_strip(painter, strip, &scale, canvas_background);
         }
 
         // Above the flow layers: everything else on the canvas is read against
@@ -1805,6 +1843,29 @@ mod tests {
     use super::*;
 
     use crate::config::{FeedConfig, ProviderKind};
+
+    #[test]
+    fn the_live_strip_carves_between_chart_and_gutter_only_when_shown() {
+        let area = egui::Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(1000.0, 600.0));
+
+        let off = plot_split(area, 0.0);
+        assert!(off.live_strip.is_none());
+        assert_eq!(off.chart.right(), off.price_gutter.left());
+
+        let on = plot_split(area, crate::live_strip::LIVE_STRIP_WIDTH_PX);
+        let strip = on.live_strip.expect("strip rect");
+        assert_eq!(on.chart.right(), strip.left());
+        assert_eq!(strip.right(), on.price_gutter.left());
+        assert_eq!(strip.width(), crate::live_strip::LIVE_STRIP_WIDTH_PX);
+        // The strip pays with the chart's pixels: the gutter stays put, and
+        // the time axis keeps spanning exactly the chart body.
+        assert_eq!(on.price_gutter, off.price_gutter);
+        assert_eq!(
+            on.chart.width(),
+            off.chart.width() - crate::live_strip::LIVE_STRIP_WIDTH_PX
+        );
+        assert_eq!(on.time_strip.right(), on.chart.right());
+    }
 
     /// A minimal one-feed, two-symbol config for the app tests.
     fn test_config() -> AppConfig {

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -306,6 +306,11 @@ impl QuantickApp {
         if std::env::var("QUANTICK_BOOK_AUTOSTART").is_ok_and(|value| value == "1") {
             app.request_book_capture(true);
         }
+        // Same convenience for the live strip; its pixels stay
+        // capability-gated either way (see live_strip_width).
+        if std::env::var("QUANTICK_LIVE_STRIP_AUTOSTART").is_ok_and(|value| value == "1") {
+            app.live_strip_visible = true;
+        }
         // Same convenience for Market Replay: open the folder named by
         // QUANTICK_REPLAY_DIR and play its first session. One env var, the same
         // code path a click takes, so a scripted run and a person get the same

--- a/crates/app/src/live_strip.rs
+++ b/crates/app/src/live_strip.rs
@@ -1,0 +1,164 @@
+//! The live strip: a narrow column between the chart body and the price
+//! gutter showing the book's resting depth *right now* (Live Edge proposal,
+//! phase 4). Rows are bucketed at the same effective grouping as the heatmap
+//! and coloured through the heatmap's own ramp, so a wall on the strip lines
+//! up 1:1 with that wall's history to its left; the real spread reads as an
+//! empty gap between the marked best bid and best ask.
+//!
+//! This module owns the pure, testable math (bucketing, the fallback
+//! reference); painting lives in `OrderflowView::draw_live_strip`, which
+//! reads the published [`BookLadder`].
+
+use quantick_orderbook::{BookLevel, BookSide};
+use rust_decimal::Decimal;
+
+use crate::orderflow_engine::BookLadder;
+
+/// Width of the strip, in pixels. The proposal band is 72–96 px: wide enough
+/// for the depth silhouette to read, narrow enough to never crowd the chart.
+pub(crate) const LIVE_STRIP_WIDTH_PX: f32 = 84.0;
+
+/// Stroke of the best bid/ask touch markers, in pixels.
+pub(crate) const TOUCH_MARKER_STROKE_PX: f32 = 1.5;
+
+/// Alpha of the strip's left border line, against the chart body.
+pub(crate) const STRIP_BORDER_ALPHA: f32 = 0.3;
+
+/// Left inset of the depth rows, in pixels, so the border stays visible.
+pub(crate) const STRIP_ROW_INSET_PX: f32 = 1.0;
+
+/// One depth row: an aggregated price bucket of the current book.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DepthRow {
+    pub side: BookSide,
+    /// Inclusive lower price edge of the bucket, in the heatmap's bucket
+    /// space: `floor(price / width) * width`.
+    pub price_bucket: Decimal,
+    /// Summed resting quantity of the ladder levels inside the bucket.
+    pub quantity: Decimal,
+}
+
+/// Aggregate the ladder into heatmap-aligned buckets: asks first (ascending),
+/// then bids (descending) — each side walking away from the spread, so the
+/// order is deterministic and mirrors the ladder's own.
+pub(crate) fn depth_rows(ladder: &BookLadder, bucket_width: Decimal) -> Vec<DepthRow> {
+    if bucket_width <= Decimal::ZERO {
+        return Vec::new();
+    }
+    let mut rows = Vec::new();
+    bucket_side(&ladder.asks, BookSide::Ask, bucket_width, &mut rows);
+    bucket_side(&ladder.bids, BookSide::Bid, bucket_width, &mut rows);
+    rows
+}
+
+fn bucket_side(levels: &[BookLevel], side: BookSide, width: Decimal, rows: &mut Vec<DepthRow>) {
+    // Ladder levels arrive best-first and strictly ordered, so equal buckets
+    // are always adjacent: one running row per bucket, no map needed.
+    let mut current: Option<DepthRow> = None;
+    for level in levels {
+        let bucket = (level.price() / width).trunc() * width;
+        match &mut current {
+            Some(row) if row.price_bucket == bucket => row.quantity += level.quantity(),
+            _ => {
+                if let Some(done) = current.take() {
+                    rows.push(done);
+                }
+                current = Some(DepthRow {
+                    side,
+                    price_bucket: bucket,
+                    quantity: level.quantity(),
+                });
+            }
+        }
+    }
+    if let Some(done) = current {
+        rows.push(done);
+    }
+}
+
+/// Full-intensity reference when no heatmap frame supplies one: the largest
+/// visible bucket. Honest for a lone column — the biggest wall in view is
+/// the hottest — though it re-normalizes as walls come and go, unlike the
+/// frame's stickier visible-P99 reference.
+pub(crate) fn fallback_reference(rows: &[DepthRow]) -> Decimal {
+    rows.iter()
+        .map(|row| row.quantity)
+        .max()
+        .unwrap_or(Decimal::ZERO)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr as _;
+
+    fn dec(value: &str) -> Decimal {
+        Decimal::from_str(value).unwrap()
+    }
+
+    fn level(price: &str, quantity: &str) -> BookLevel {
+        BookLevel::new(dec(price), dec(quantity)).unwrap()
+    }
+
+    fn ladder(bids: Vec<BookLevel>, asks: Vec<BookLevel>) -> BookLadder {
+        BookLadder {
+            best_bid: bids.first().copied(),
+            best_ask: asks.first().copied(),
+            bids,
+            asks,
+        }
+    }
+
+    #[test]
+    fn rows_bucket_like_the_heatmap_and_merge_neighbours() {
+        // Asks best-first ascending, bids best-first descending, bucket 2:
+        // levels sharing a bucket sum into one row.
+        let ladder = ladder(
+            vec![level("999", "1"), level("998", "2"), level("997", "4")],
+            vec![level("1001", "1"), level("1002", "2"), level("1003", "4")],
+        );
+        let rows = depth_rows(&ladder, dec("2"));
+        assert_eq!(
+            rows,
+            vec![
+                DepthRow {
+                    side: BookSide::Ask,
+                    price_bucket: dec("1000"),
+                    quantity: dec("1"),
+                },
+                DepthRow {
+                    side: BookSide::Ask,
+                    price_bucket: dec("1002"),
+                    quantity: dec("6"),
+                },
+                DepthRow {
+                    side: BookSide::Bid,
+                    price_bucket: dec("998"),
+                    quantity: dec("3"),
+                },
+                DepthRow {
+                    side: BookSide::Bid,
+                    price_bucket: dec("996"),
+                    quantity: dec("4"),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn a_degenerate_bucket_width_yields_no_rows() {
+        let ladder = ladder(vec![level("999", "1")], vec![level("1001", "1")]);
+        assert!(depth_rows(&ladder, Decimal::ZERO).is_empty());
+    }
+
+    #[test]
+    fn the_fallback_reference_is_the_biggest_visible_bucket() {
+        let ladder = ladder(
+            vec![level("999", "5"), level("998", "9")],
+            vec![level("1001", "3")],
+        );
+        let rows = depth_rows(&ladder, Decimal::ONE);
+        assert_eq!(fallback_reference(&rows), dec("9"));
+        assert_eq!(fallback_reference(&[]), Decimal::ZERO);
+    }
+}

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -18,6 +18,7 @@ mod chart;
 mod config;
 mod dock;
 mod feed;
+mod live_strip;
 mod loading;
 mod metrics;
 mod orderflow;

--- a/crates/app/src/orderflow/projection.rs
+++ b/crates/app/src/orderflow/projection.rs
@@ -630,7 +630,10 @@ fn percentile_99(values: impl Iterator<Item = Decimal>) -> Decimal {
     positive[rank.saturating_sub(1)]
 }
 
-fn normalized_log_intensity(quantity: Decimal, reference: Decimal, gamma: f32) -> f32 {
+/// Shared with the live strip (`crate::live_strip`), which normalizes its
+/// depth rows against the same reference the heatmap cells used, so one wall
+/// reads with one colour on both sides of the chart edge.
+pub(crate) fn normalized_log_intensity(quantity: Decimal, reference: Decimal, gamma: f32) -> f32 {
     if quantity <= Decimal::ZERO || reference <= Decimal::ZERO {
         return 0.0;
     }

--- a/crates/app/src/orderflow_render.rs
+++ b/crates/app/src/orderflow_render.rs
@@ -145,7 +145,7 @@ impl OrderflowRenderStyle {
     }
 
     #[must_use]
-    fn sanitized(&self) -> Self {
+    pub(crate) fn sanitized(&self) -> Self {
         let mut style = self.clone();
         style.heat_opacity = finite_clamp(style.heat_opacity, 0.0, 1.0, 1.0);
         style.min_cell_height = finite_clamp(style.min_cell_height, 0.5, 12.0, 1.5);
@@ -697,28 +697,14 @@ pub(crate) fn draw_heatmap_background(painter: &egui::Painter, context: &RenderC
             continue;
         }
 
-        let raw_intensity = finite_unit(cell.intensity);
-        let base_alpha = finite_unit(cell.alpha);
-        if raw_intensity <= 0.0 || base_alpha <= 0.0 {
+        let Some((rgb, alpha)) = heat_fill_parts(&style, cell.side, cell.intensity, cell.alpha)
+        else {
             continue;
-        }
-        // Quantize magnitude into a few bands so the book's per-update jitter
-        // maps to the SAME colour: adjacent runs merge into one crisp, stable
-        // band instead of a flickering gradient that reads as "meteors". The
-        // faintest noise (rounding to zero) drops out entirely.
-        let intensity = quantize_heat(raw_intensity);
-        if intensity <= 0.0 {
-            continue;
-        }
-        let alpha = finite_unit(base_alpha * (intensity / raw_intensity) * style.heat_opacity);
-        if alpha <= 0.0 {
-            continue;
-        }
-        let rgb = resting_rgb(style.theme, cell.side, intensity);
+        };
         let fill = rgba(rgb, alpha);
 
         if style.edge_glow > 0.0 {
-            let spread = 0.55 + intensity * 0.85;
+            let spread = 0.55 + quantize_heat(finite_unit(cell.intensity)) * 0.85;
             let glow_rect = egui::Rect::from_min_max(
                 egui::pos2(rect.left(), rect.top() - spread),
                 egui::pos2(rect.right(), rect.bottom() + spread),
@@ -2086,6 +2072,47 @@ fn rgba(rgb: [u8; 3], alpha: f32) -> egui::Color32 {
         rgb[2],
         (finite_unit(alpha) * 255.0).round() as u8,
     )
+}
+
+/// Colour and opacity of one resting-liquidity block — the heatmap's exact
+/// pipeline (quantized magnitude bands, thermal ramp, side tint), factored out
+/// so the live strip reads on the very same ramp by construction. `None`
+/// means the block is too faint to draw at all.
+fn heat_fill_parts(
+    style: &OrderflowRenderStyle,
+    side: BookSide,
+    raw_intensity: f32,
+    base_alpha: f32,
+) -> Option<([u8; 3], f32)> {
+    let raw_intensity = finite_unit(raw_intensity);
+    let base_alpha = finite_unit(base_alpha);
+    if raw_intensity <= 0.0 || base_alpha <= 0.0 {
+        return None;
+    }
+    // Quantize magnitude into a few bands so the book's per-update jitter
+    // maps to the SAME colour: adjacent runs merge into one crisp, stable
+    // band instead of a flickering gradient that reads as "meteors". The
+    // faintest noise (rounding to zero) drops out entirely.
+    let intensity = quantize_heat(raw_intensity);
+    if intensity <= 0.0 {
+        return None;
+    }
+    let alpha = finite_unit(base_alpha * (intensity / raw_intensity) * style.heat_opacity);
+    if alpha <= 0.0 {
+        return None;
+    }
+    Some((resting_rgb(style.theme, side, intensity), alpha))
+}
+
+/// [`heat_fill_parts`] as a ready egui colour, for callers that need no
+/// separate glow pass.
+pub(crate) fn heat_fill(
+    style: &OrderflowRenderStyle,
+    side: BookSide,
+    raw_intensity: f32,
+    base_alpha: f32,
+) -> Option<egui::Color32> {
+    heat_fill_parts(style, side, raw_intensity, base_alpha).map(|(rgb, alpha)| rgba(rgb, alpha))
 }
 
 fn mix_rgb(from: [u8; 3], to: [u8; 3], amount: f32) -> [u8; 3] {

--- a/crates/app/src/orderflow_view.rs
+++ b/crates/app/src/orderflow_view.rs
@@ -18,6 +18,9 @@ use rust_decimal::Decimal;
 use rust_decimal::prelude::{FromPrimitive as _, ToPrimitive as _};
 
 use crate::bubble_presets::{self, BubblePreset, BubblePresetFile, PresetSource};
+use crate::chart::PriceScale;
+use crate::live_strip;
+use crate::orderflow::projection::normalized_log_intensity;
 use crate::orderflow::{
     BubbleRenderMode, BubbleSizeReference, DisplayGrouping, HeatmapConfig, HeatmapTheme,
     IntensityMode, MAX_BUBBLE_MAX_RADIUS, MAX_BUBBLE_MIN_RADIUS, MIN_BUBBLE_MAX_RADIUS,
@@ -28,7 +31,7 @@ use crate::orderflow_engine::{
 };
 use crate::orderflow_render::{
     OrderflowRenderStyle, ProjectedLayout, RenderContext, draw_aggression_bubbles,
-    draw_compact_legend, draw_heatmap_background, draw_liquidity_events, draw_preview,
+    draw_compact_legend, draw_heatmap_background, draw_liquidity_events, draw_preview, heat_fill,
     theme_bubble_rgb,
 };
 use crate::orderflow_worker::{BookCommand, BookWorker};
@@ -394,6 +397,115 @@ impl OrderflowView {
             egui::Color32::from_black_alpha(165),
         );
         painter.galley(pos, galley, color);
+    }
+
+    /// Draw the live strip: the current book's depth silhouette, bucketed and
+    /// coloured exactly like the heatmap (same buckets, same ramp, same
+    /// full-intensity reference when a frame exists), with the real spread as
+    /// an empty gap between the marked best bid and best ask. `scale` is the
+    /// chart's own price scale, so rows line up 1:1 with the heatmap rows.
+    pub fn draw_live_strip(
+        &mut self,
+        painter: &egui::Painter,
+        strip: egui::Rect,
+        scale: &PriceScale,
+        canvas_background: egui::Color32,
+    ) {
+        self.sync_published();
+        painter.rect_filled(strip, egui::Rounding::ZERO, canvas_background);
+        painter.line_segment(
+            [strip.left_top(), strip.left_bottom()],
+            egui::Stroke::new(
+                1.0_f32,
+                crate::theme::TEXT_MUTED.gamma_multiply(live_strip::STRIP_BORDER_ALPHA),
+            ),
+        );
+        let Some(ladder) = self.published.ladder.clone() else {
+            // Honest empty state: the strip is on, the data is not (capture
+            // off, or no snapshot yet).
+            painter.text(
+                egui::pos2(strip.center().x, strip.top() + 10.0),
+                egui::Align2::CENTER_CENTER,
+                "no book",
+                egui::FontId::proportional(10.0),
+                crate::theme::TEXT_MUTED,
+            );
+            return;
+        };
+
+        let style = OrderflowRenderStyle::from_config(&self.config, canvas_background).sanitized();
+        // Same bucket and same full-intensity reference as the heatmap frame
+        // when one exists, so one wall wears one colour across the chart
+        // edge; without a frame (heat layer off) the strip normalizes against
+        // its own biggest visible bucket.
+        let (bucket_width, frame_reference) = match self.published.frame.as_deref() {
+            Some(frame) => (
+                frame.projection.effective_grouping.bucket_width,
+                Some(frame.projection.liquidity_reference),
+            ),
+            None => (self.published.base_price_grouping, None),
+        };
+        let rows = live_strip::depth_rows(&ladder, bucket_width);
+        let reference = frame_reference
+            .filter(|reference| *reference > Decimal::ZERO)
+            .unwrap_or_else(|| live_strip::fallback_reference(&rows));
+
+        let clip = painter.with_clip_rect(strip);
+        let rows_left = strip.left() + live_strip::STRIP_ROW_INSET_PX;
+        for row in &rows {
+            let intensity = normalized_log_intensity(row.quantity, reference, self.config.gamma);
+            // Same alpha recipe as a projected heat cell: the projection sets
+            // `alpha = intensity * opacity`, then `heat_fill` layers the
+            // style's own multiplier on top.
+            let base_alpha = intensity * self.config.opacity;
+            let Some(fill) = heat_fill(&style, row.side, intensity, base_alpha) else {
+                continue;
+            };
+            let top = scale.y((row.price_bucket + bucket_width)
+                .to_f64()
+                .unwrap_or(f64::NAN));
+            let bottom = scale.y(row.price_bucket.to_f64().unwrap_or(f64::NAN));
+            if !top.is_finite() || !bottom.is_finite() {
+                continue;
+            }
+            let rect = egui::Rect::from_min_max(
+                egui::pos2(rows_left, top),
+                egui::pos2(strip.right(), bottom),
+            )
+            .intersect(strip);
+            if rect.is_positive() {
+                clip.rect_filled(rect, egui::Rounding::ZERO, fill);
+            }
+        }
+
+        // The real spread: cleared back to canvas so it reads as the one empty
+        // band, with the touch marked on both edges.
+        if let (Some(bid), Some(ask)) = (ladder.best_bid, ladder.best_ask) {
+            let ask_y = scale.y(ask.price().to_f64().unwrap_or(f64::NAN));
+            let bid_y = scale.y(bid.price().to_f64().unwrap_or(f64::NAN));
+            if ask_y.is_finite() && bid_y.is_finite() {
+                let gap = egui::Rect::from_min_max(
+                    egui::pos2(rows_left, ask_y),
+                    egui::pos2(strip.right(), bid_y),
+                )
+                .intersect(strip);
+                if gap.is_positive() {
+                    clip.rect_filled(gap, egui::Rounding::ZERO, canvas_background);
+                }
+                let colors = theme_bubble_rgb(self.config.theme);
+                let mark = |y: f32, rgb: [u8; 3]| {
+                    clip.line_segment(
+                        [egui::pos2(rows_left, y), egui::pos2(strip.right(), y)],
+                        egui::Stroke::new(
+                            live_strip::TOUCH_MARKER_STROKE_PX,
+                            egui::Color32::from_rgb(rgb[0], rgb[1], rgb[2]),
+                        ),
+                    );
+                };
+                mark(ask_y, colors.sell);
+                mark(bid_y, colors.buy);
+            }
+        }
     }
 
     pub fn health(&mut self) -> OrderflowHealth {
@@ -1501,6 +1613,37 @@ mod tests {
 
     fn prices_of(levels: &[BookLevel]) -> Vec<Decimal> {
         levels.iter().map(|level| level.price()).collect()
+    }
+
+    /// Paint the strip for real, off-screen, on both of its paths: with a
+    /// published ladder (depth rows + spread gap) and without one (the honest
+    /// "no book" state). A panicking painter or a broken price mapping fails
+    /// here instead of on the chart.
+    #[test]
+    fn the_live_strip_paints_on_both_of_its_paths() {
+        let ctx = egui::Context::default();
+        let mut view = OrderflowView::new("BTCUSDT");
+        let strip = egui::Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(84.0, 400.0));
+        let scale = PriceScale::from_range(95.0, 105.0, strip.top(), strip.bottom());
+
+        let paint = |view: &mut OrderflowView| {
+            ctx.run(egui::RawInput::default(), |ctx| {
+                egui::CentralPanel::default().show(ctx, |ui| {
+                    view.draw_live_strip(ui.painter(), strip, &scale, egui::Color32::BLACK);
+                });
+            })
+        };
+
+        // Capture off: no ladder, the strip must say so rather than draw an
+        // empty column that could be mistaken for "no liquidity".
+        let empty = paint(&mut view);
+        assert!(!empty.shapes.is_empty());
+
+        view.set_enabled(true, 10);
+        view.handle_depth_event(snapshot_event(10));
+        view.flush_for_test();
+        let live = paint(&mut view);
+        assert!(!live.shapes.is_empty());
     }
 
     #[test]

--- a/crates/app/src/toolbar.rs
+++ b/crates/app/src/toolbar.rs
@@ -41,8 +41,8 @@ const W_BARS: f32 = 160.0;
 const W_BAR_PARAM: f32 = 150.0;
 /// The `+ older ▾` split button.
 const W_HISTORY: f32 = 100.0;
-/// The LAYERS icon pair.
-const W_LAYERS: f32 = 64.0;
+/// The LAYERS icon trio (bubbles, heatmap, live strip).
+const W_LAYERS: f32 = 96.0;
 /// One 28 px icon button (LOOK, PANELS, or the overflow `⋯`).
 const W_ICON: f32 = 28.0;
 
@@ -173,6 +173,8 @@ pub struct ToolbarModel<'a> {
     pub heatmap_on: bool,
     /// Whether the aggression layer is on.
     pub bubbles_on: bool,
+    /// Whether the live strip is shown.
+    pub live_strip_on: bool,
     /// Whether the dock (strip included) is shown.
     pub dock_visible: bool,
     /// Whether the appearance dialog is open.
@@ -188,6 +190,9 @@ pub enum ToolbarAction {
     SetHeatmap(bool),
     /// Turn the aggression layer on or off.
     SetBubbles(bool),
+    /// Show or hide the live strip (the book's current depth beside the
+    /// price axis). Display-only: capture is untouched.
+    SetLiveStrip(bool),
     /// Open a dock tab (a layer's settings; never toggles the layer).
     OpenDockTab(DockTab),
     /// Show or hide the dock.
@@ -427,6 +432,23 @@ fn draw_layers(ui: &mut egui::Ui, model: &ToolbarModel, actions: &mut Vec<Toolba
     if heatmap.secondary_clicked() {
         actions.push(ToolbarAction::OpenDockTab(DockTab::L2));
     }
+
+    let strip = IconButton::new(icons::WALL, TOOLBAR_ICON)
+        .active(model.live_strip_on)
+        .accent(theme::ACCENT)
+        .enabled(model.capabilities.book_capture)
+        .hover_text(
+            "live strip: the book's resting depth right now, beside the price axis — \
+             right-click for settings",
+        )
+        .disabled_explanation("order-book capture is not available for this source")
+        .show(ui);
+    if strip.clicked() {
+        actions.push(ToolbarAction::SetLiveStrip(!model.live_strip_on));
+    }
+    if strip.secondary_clicked() {
+        actions.push(ToolbarAction::OpenDockTab(DockTab::L2));
+    }
 }
 
 /// The `⋯` menu holding every folded group, in a fixed order so muscle
@@ -601,6 +623,7 @@ mod tests {
                         },
                         heatmap_on: false,
                         bubbles_on: true,
+                        live_strip_on: false,
                         dock_visible: true,
                         appearance_open: false,
                     };


### PR DESCRIPTION
## Summary

Phase 4 of the Live Edge goal ([proposal](https://claude.ai/code/artifact/7c24c517-c05a-4a42-b9b9-77b55fa4c8d2)): the Live Strip MVP.

- New 84 px column (`live_strip.rs`) between the chart body and the price gutter, drawn from the ladder published in phase 3 (#80).
- Depth rows bucket at the heatmap frame's **effective grouping** and colour through the heatmap's **own pipeline**: `heat_fill` is extracted from the cell loop, so strip and heatmap share one ramp by construction, and rows normalize against the frame's `liquidity_reference` — one wall wears one colour on both sides of the chart edge, rows align 1:1.
- The **real spread** reads as an empty gap with the best bid (buy colour) and best ask (sell colour) marked.
- Toolbar gains a third LAYERS toggle (wall icon), gated on `FeedCapabilities.book_capture` exactly like the heatmap toggle; on a capability-less source the strip yields its pixels back to the chart even while the toggle stays on.
- Honesty: no ladder (capture off / no snapshot) → the strip says "no book" instead of drawing an empty column that could read as zero liquidity; without a frame it normalizes against its own biggest visible bucket (documented fallback).

Out of scope here (phase 5): the mirrored aggression histogram and its bar-close reset.

## Review

Self arch-review over `git diff main...HEAD`: additive (`plot_split` at width zero reproduces the old geometry exactly, pinned by test); per-frame strip cost is bounded (≤ 256 ladder levels bucketed adjacently, no maps, no allocations beyond the row Vec); constants named with units; capability-driven gating, never source-typed.

## Verification

- `cargo fmt --all -- --check` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo build --workspace` ✅
- `cargo test --workspace` ✅ (290 tests in quantick-app, incl. 5 new: bucketing, fallback reference, split geometry, both paint paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkY8ocUoB2TszfTErAqNVt