### PR TITLE
feat(app): live strip complete — mirrored aggression histogram (phase 5)

### DIFF
--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -468,12 +468,12 @@ impl QuantickApp {
         }
     }
 
-    /// Width reserved for the live strip this frame. Capability-driven like
-    /// every affordance: on a source without book capture there is nothing
-    /// the strip could show yet, so it yields its pixels back to the chart
-    /// even while the user's toggle stays on.
+    /// Width reserved for the live strip this frame. No capability gate any
+    /// more: the aggression histogram runs on the trade stream, which every
+    /// source provides (replay included), and without book data the strip
+    /// honestly degrades to that histogram alone.
     fn live_strip_width(&self) -> f32 {
-        if self.live_strip_visible && self.capabilities().book_capture {
+        if self.live_strip_visible {
             crate::live_strip::LIVE_STRIP_WIDTH_PX
         } else {
             0.0
@@ -1274,11 +1274,19 @@ impl QuantickApp {
             );
         }
 
-        // The live strip: the book right now, beside the axis the price
-        // labels live on. Its own rect, so chart layers never bleed into it.
+        // The live strip: the book right now plus the forming bar's
+        // aggression histogram, beside the axis the price labels live on.
+        // Its own rect, so chart layers never bleed into it. The histogram
+        // follows `partial` (not its visible filter): the strip reports the
+        // bar forming now even while the user pans through history.
         if let Some(strip) = areas.live_strip {
-            self.orderflow
-                .draw_live_strip(painter, strip, &scale, canvas_background);
+            self.orderflow.draw_live_strip(
+                painter,
+                strip,
+                &scale,
+                canvas_background,
+                partial.map(|bar| bar.open_time),
+            );
         }
 
         // Above the flow layers: everything else on the canvas is read against

--- a/crates/app/src/live_strip.rs
+++ b/crates/app/src/live_strip.rs
@@ -5,13 +5,25 @@
 //! up 1:1 with that wall's history to its left; the real spread reads as an
 //! empty gap between the marked best bid and best ask.
 //!
-//! This module owns the pure, testable math (bucketing, the fallback
-//! reference); painting lives in `OrderflowView::draw_live_strip`, which
-//! reads the published [`BookLadder`].
+//! Phase 5 lays the forming bar's aggression histogram over that background:
+//! buys grow rightward from the strip's centre, sells leftward, each bar's
+//! width on the same square-root area rule the bubbles use, normalized by the
+//! forming bar's own biggest bucket. The rows come from the projection's
+//! aggression clusters — the one engine code path — filtered to the forming
+//! bar, so the histogram resets on bar close simply because the new bar has
+//! no clusters yet. Without book data the strip degrades to this histogram
+//! alone, which is why it works on any source that streams trades (replay
+//! included).
+//!
+//! This module owns the pure, testable math (bucketing, references, the
+//! histogram); painting lives in `OrderflowView::draw_live_strip`, which
+//! reads the published [`BookLadder`] and frame.
 
+use quantick_engine::Side;
 use quantick_orderbook::{BookLevel, BookSide};
 use rust_decimal::Decimal;
 
+use crate::orderflow::projection::AggressionPrimitive;
 use crate::orderflow_engine::BookLadder;
 
 /// Width of the strip, in pixels. The proposal band is 72–96 px: wide enough
@@ -83,6 +95,67 @@ fn bucket_side(levels: &[BookLevel], side: BookSide, width: Decimal, rows: &mut 
 pub(crate) fn fallback_reference(rows: &[DepthRow]) -> Decimal {
     rows.iter()
         .map(|row| row.quantity)
+        .max()
+        .unwrap_or(Decimal::ZERO)
+}
+
+/// Opacity of the histogram bars over the depth background.
+pub(crate) const HISTOGRAM_ALPHA: f32 = 0.8;
+
+/// Widest histogram bar, as a fraction of the strip's half width, leaving a
+/// sliver of background visible even at full scale.
+pub(crate) const HISTOGRAM_MAX_HALF_FRAC: f32 = 0.94;
+
+/// One histogram row: the forming bar's aggression at one price bucket,
+/// both sides together because the drawing mirrors them around one centre.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct HistogramRow {
+    /// Inclusive lower price edge, in the projection's own bucket space.
+    pub price_bucket: Decimal,
+    /// Summed buy-aggression quantity in the bucket.
+    pub buy: Decimal,
+    /// Summed sell-aggression quantity in the bucket.
+    pub sell: Decimal,
+}
+
+/// Sum the forming bar's aggression clusters per price bucket. `bar_open_ms`
+/// is the forming bar's open time: clusters that ended before it belong to
+/// closed bars and are dropped, which is the whole "resets on close" rule.
+/// Ascending bucket order, deterministic.
+pub(crate) fn aggression_rows(
+    aggressions: &[AggressionPrimitive],
+    bar_open_ms: i64,
+) -> Vec<HistogramRow> {
+    let mut buckets: std::collections::BTreeMap<Decimal, (Decimal, Decimal)> =
+        std::collections::BTreeMap::new();
+    for cluster in aggressions {
+        if cluster.last_timestamp_ms < bar_open_ms {
+            continue;
+        }
+        let entry = buckets
+            .entry(cluster.price_bucket)
+            .or_insert((Decimal::ZERO, Decimal::ZERO));
+        match cluster.side {
+            Side::Buy => entry.0 += cluster.quantity,
+            Side::Sell => entry.1 += cluster.quantity,
+        }
+    }
+    buckets
+        .into_iter()
+        .map(|(price_bucket, (buy, sell))| HistogramRow {
+            price_bucket,
+            buy,
+            sell,
+        })
+        .collect()
+}
+
+/// Full-width reference for the histogram: the forming bar's own biggest
+/// single-side bucket, per the "normalized by the bar" rule — the bar's
+/// heaviest price level always reaches full width, whatever its size.
+pub(crate) fn histogram_reference(rows: &[HistogramRow]) -> Decimal {
+    rows.iter()
+        .map(|row| row.buy.max(row.sell))
         .max()
         .unwrap_or(Decimal::ZERO)
 }
@@ -160,5 +233,61 @@ mod tests {
         let rows = depth_rows(&ladder, Decimal::ONE);
         assert_eq!(fallback_reference(&rows), dec("9"));
         assert_eq!(fallback_reference(&[]), Decimal::ZERO);
+    }
+
+    /// A minimal cluster: only the fields the histogram reads carry data.
+    fn cluster(side: Side, bucket: &str, quantity: &str, last_ms: i64) -> AggressionPrimitive {
+        AggressionPrimitive {
+            agg_id: 1,
+            agg_ids: vec![1],
+            generation: None,
+            side,
+            consumed_side: match side {
+                Side::Buy => quantick_orderbook::BookSide::Ask,
+                Side::Sell => quantick_orderbook::BookSide::Bid,
+            },
+            quantity: dec(quantity),
+            price_bucket: dec(bucket),
+            trade_count: 1,
+            first_timestamp_ms: last_ms,
+            last_timestamp_ms: last_ms,
+            matched_quantity: Decimal::ZERO,
+            matched_fraction: 0.0,
+            liquidity_event_ids: Vec::new(),
+            x: 0.5,
+            y: 0.5,
+            size: 0.5,
+        }
+    }
+
+    #[test]
+    fn the_histogram_keeps_only_the_forming_bar_and_sums_per_bucket() {
+        let clusters = vec![
+            // Closed-bar cluster: ended before the forming bar opened.
+            cluster(Side::Buy, "100", "50", 900),
+            // Forming bar: two buys in one bucket, one sell in another.
+            cluster(Side::Buy, "100", "2", 1_100),
+            cluster(Side::Buy, "100", "3", 1_200),
+            cluster(Side::Sell, "99", "4", 1_150),
+        ];
+        let rows = aggression_rows(&clusters, 1_000);
+        assert_eq!(
+            rows,
+            vec![
+                HistogramRow {
+                    price_bucket: dec("99"),
+                    buy: Decimal::ZERO,
+                    sell: dec("4"),
+                },
+                HistogramRow {
+                    price_bucket: dec("100"),
+                    buy: dec("5"),
+                    sell: Decimal::ZERO,
+                },
+            ]
+        );
+        // The bar's heaviest single-side bucket sets full width.
+        assert_eq!(histogram_reference(&rows), dec("5"));
+        assert_eq!(histogram_reference(&[]), Decimal::ZERO);
     }
 }

--- a/crates/app/src/orderflow/projection.rs
+++ b/crates/app/src/orderflow/projection.rs
@@ -642,7 +642,10 @@ pub(crate) fn normalized_log_intensity(quantity: Decimal, reference: Decimal, ga
     logarithmic.powf(f64::from(gamma)) as f32
 }
 
-fn normalized_area_size(quantity: Decimal, reference: Decimal) -> f32 {
+/// Shared with the live strip's aggression histogram, which sizes its bars by
+/// the same square-root area rule the bubbles use — twice the quantity reads
+/// as twice the ink, on both.
+pub(crate) fn normalized_area_size(quantity: Decimal, reference: Decimal) -> f32 {
     if quantity <= Decimal::ZERO || reference <= Decimal::ZERO {
         return 0.0;
     }

--- a/crates/app/src/orderflow_view.rs
+++ b/crates/app/src/orderflow_view.rs
@@ -20,7 +20,7 @@ use rust_decimal::prelude::{FromPrimitive as _, ToPrimitive as _};
 use crate::bubble_presets::{self, BubblePreset, BubblePresetFile, PresetSource};
 use crate::chart::PriceScale;
 use crate::live_strip;
-use crate::orderflow::projection::normalized_log_intensity;
+use crate::orderflow::projection::{normalized_area_size, normalized_log_intensity};
 use crate::orderflow::{
     BubbleRenderMode, BubbleSizeReference, DisplayGrouping, HeatmapConfig, HeatmapTheme,
     IntensityMode, MAX_BUBBLE_MAX_RADIUS, MAX_BUBBLE_MIN_RADIUS, MIN_BUBBLE_MAX_RADIUS,
@@ -399,17 +399,23 @@ impl OrderflowView {
         painter.galley(pos, galley, color);
     }
 
-    /// Draw the live strip: the current book's depth silhouette, bucketed and
-    /// coloured exactly like the heatmap (same buckets, same ramp, same
-    /// full-intensity reference when a frame exists), with the real spread as
-    /// an empty gap between the marked best bid and best ask. `scale` is the
-    /// chart's own price scale, so rows line up 1:1 with the heatmap rows.
+    /// Draw the live strip. Background: the current book's depth silhouette,
+    /// bucketed and coloured exactly like the heatmap (same buckets, same
+    /// ramp, same full-intensity reference when a frame exists), with the
+    /// real spread as an empty gap between the marked best bid and best ask.
+    /// Foreground: the forming bar's aggression histogram, buys growing
+    /// rightward from the centre and sells leftward, on the bubbles'
+    /// square-root area rule normalized by the bar itself — it resets on bar
+    /// close because the new bar has no clusters yet. `bar_open_ms` is the
+    /// forming bar's open time (`None` hides the histogram); `scale` is the
+    /// chart's own price scale, so everything lines up 1:1 with the chart.
     pub fn draw_live_strip(
         &mut self,
         painter: &egui::Painter,
         strip: egui::Rect,
         scale: &PriceScale,
         canvas_background: egui::Color32,
+        bar_open_ms: Option<i64>,
     ) {
         self.sync_published();
         painter.rect_filled(strip, egui::Rounding::ZERO, canvas_background);
@@ -420,9 +426,157 @@ impl OrderflowView {
                 crate::theme::TEXT_MUTED.gamma_multiply(live_strip::STRIP_BORDER_ALPHA),
             ),
         );
-        let Some(ladder) = self.published.ladder.clone() else {
-            // Honest empty state: the strip is on, the data is not (capture
-            // off, or no snapshot yet).
+
+        let ladder = self.published.ladder.clone();
+        let frame = self.published.frame.clone();
+        let style = OrderflowRenderStyle::from_config(&self.config, canvas_background).sanitized();
+        let colors = theme_bubble_rgb(self.config.theme);
+        let clip = painter.with_clip_rect(strip);
+        let rows_left = strip.left() + live_strip::STRIP_ROW_INSET_PX;
+
+        // Background: the depth silhouette. Same bucket and same
+        // full-intensity reference as the heatmap frame when one exists, so
+        // one wall wears one colour across the chart edge; without a frame
+        // (heat layer off) the strip normalizes against its own biggest
+        // visible bucket.
+        if let Some(ladder) = &ladder {
+            let (bucket_width, frame_reference) = match frame.as_deref() {
+                Some(frame) => (
+                    frame.projection.effective_grouping.bucket_width,
+                    Some(frame.projection.liquidity_reference),
+                ),
+                None => (self.published.base_price_grouping, None),
+            };
+            let rows = live_strip::depth_rows(ladder, bucket_width);
+            let reference = frame_reference
+                .filter(|reference| *reference > Decimal::ZERO)
+                .unwrap_or_else(|| live_strip::fallback_reference(&rows));
+
+            for row in &rows {
+                let intensity =
+                    normalized_log_intensity(row.quantity, reference, self.config.gamma);
+                // Same alpha recipe as a projected heat cell: the projection
+                // sets `alpha = intensity * opacity`, then `heat_fill` layers
+                // the style's own multiplier on top.
+                let base_alpha = intensity * self.config.opacity;
+                let Some(fill) = heat_fill(&style, row.side, intensity, base_alpha) else {
+                    continue;
+                };
+                let top = scale.y((row.price_bucket + bucket_width)
+                    .to_f64()
+                    .unwrap_or(f64::NAN));
+                let bottom = scale.y(row.price_bucket.to_f64().unwrap_or(f64::NAN));
+                if !top.is_finite() || !bottom.is_finite() {
+                    continue;
+                }
+                let rect = egui::Rect::from_min_max(
+                    egui::pos2(rows_left, top),
+                    egui::pos2(strip.right(), bottom),
+                )
+                .intersect(strip);
+                if rect.is_positive() {
+                    clip.rect_filled(rect, egui::Rounding::ZERO, fill);
+                }
+            }
+
+            // The real spread: cleared back to canvas so it reads as the one
+            // empty band.
+            if let (Some(bid), Some(ask)) = (ladder.best_bid, ladder.best_ask) {
+                let ask_y = scale.y(ask.price().to_f64().unwrap_or(f64::NAN));
+                let bid_y = scale.y(bid.price().to_f64().unwrap_or(f64::NAN));
+                if ask_y.is_finite() && bid_y.is_finite() {
+                    let gap = egui::Rect::from_min_max(
+                        egui::pos2(rows_left, ask_y),
+                        egui::pos2(strip.right(), bid_y),
+                    )
+                    .intersect(strip);
+                    if gap.is_positive() {
+                        clip.rect_filled(gap, egui::Rounding::ZERO, canvas_background);
+                    }
+                }
+            }
+        }
+
+        // Foreground: the forming bar's mirrored aggression histogram, from
+        // the same projection clusters the bubbles draw — one engine, one
+        // aggregation path. Empty whenever those layers publish nothing.
+        let histogram = match (frame.as_deref(), bar_open_ms) {
+            (Some(frame), Some(open_ms)) => {
+                live_strip::aggression_rows(&frame.projection.aggressions, open_ms)
+            }
+            _ => Vec::new(),
+        };
+        if !histogram.is_empty() {
+            let bucket_width = frame
+                .as_deref()
+                .map(|frame| frame.projection.effective_grouping.bucket_width)
+                .unwrap_or(self.published.base_price_grouping);
+            let reference = live_strip::histogram_reference(&histogram);
+            let centre_x = f32::midpoint(rows_left, strip.right());
+            let half_width =
+                (strip.right() - rows_left) / 2.0 * live_strip::HISTOGRAM_MAX_HALF_FRAC;
+            let buy_fill = egui::Color32::from_rgb(colors.buy[0], colors.buy[1], colors.buy[2])
+                .gamma_multiply(live_strip::HISTOGRAM_ALPHA);
+            let sell_fill = egui::Color32::from_rgb(colors.sell[0], colors.sell[1], colors.sell[2])
+                .gamma_multiply(live_strip::HISTOGRAM_ALPHA);
+            for row in &histogram {
+                let top = scale.y((row.price_bucket + bucket_width)
+                    .to_f64()
+                    .unwrap_or(f64::NAN));
+                let bottom = scale.y(row.price_bucket.to_f64().unwrap_or(f64::NAN));
+                if !top.is_finite() || !bottom.is_finite() {
+                    continue;
+                }
+                let buy_extent = normalized_area_size(row.buy, reference) * half_width;
+                if buy_extent > 0.0 {
+                    let rect = egui::Rect::from_min_max(
+                        egui::pos2(centre_x, top),
+                        egui::pos2(centre_x + buy_extent, bottom),
+                    )
+                    .intersect(strip);
+                    if rect.is_positive() {
+                        clip.rect_filled(rect, egui::Rounding::ZERO, buy_fill);
+                    }
+                }
+                let sell_extent = normalized_area_size(row.sell, reference) * half_width;
+                if sell_extent > 0.0 {
+                    let rect = egui::Rect::from_min_max(
+                        egui::pos2(centre_x - sell_extent, top),
+                        egui::pos2(centre_x, bottom),
+                    )
+                    .intersect(strip);
+                    if rect.is_positive() {
+                        clip.rect_filled(rect, egui::Rounding::ZERO, sell_fill);
+                    }
+                }
+            }
+        }
+
+        // Touch markers last, readable over both layers.
+        if let Some(ladder) = &ladder {
+            let mark = |price: Option<Decimal>, rgb: [u8; 3]| {
+                let Some(price) = price.and_then(|price| price.to_f64()) else {
+                    return;
+                };
+                let y = scale.y(price);
+                if !y.is_finite() {
+                    return;
+                }
+                clip.line_segment(
+                    [egui::pos2(rows_left, y), egui::pos2(strip.right(), y)],
+                    egui::Stroke::new(
+                        live_strip::TOUCH_MARKER_STROKE_PX,
+                        egui::Color32::from_rgb(rgb[0], rgb[1], rgb[2]),
+                    ),
+                );
+            };
+            mark(ladder.best_ask.map(BookLevel::price), colors.sell);
+            mark(ladder.best_bid.map(BookLevel::price), colors.buy);
+        }
+
+        // Honest empty state: the strip is on, no data source has anything —
+        // no book (capture off or no snapshot) and no forming-bar aggression.
+        if ladder.is_none() && histogram.is_empty() {
             painter.text(
                 egui::pos2(strip.center().x, strip.top() + 10.0),
                 egui::Align2::CENTER_CENTER,
@@ -430,81 +584,6 @@ impl OrderflowView {
                 egui::FontId::proportional(10.0),
                 crate::theme::TEXT_MUTED,
             );
-            return;
-        };
-
-        let style = OrderflowRenderStyle::from_config(&self.config, canvas_background).sanitized();
-        // Same bucket and same full-intensity reference as the heatmap frame
-        // when one exists, so one wall wears one colour across the chart
-        // edge; without a frame (heat layer off) the strip normalizes against
-        // its own biggest visible bucket.
-        let (bucket_width, frame_reference) = match self.published.frame.as_deref() {
-            Some(frame) => (
-                frame.projection.effective_grouping.bucket_width,
-                Some(frame.projection.liquidity_reference),
-            ),
-            None => (self.published.base_price_grouping, None),
-        };
-        let rows = live_strip::depth_rows(&ladder, bucket_width);
-        let reference = frame_reference
-            .filter(|reference| *reference > Decimal::ZERO)
-            .unwrap_or_else(|| live_strip::fallback_reference(&rows));
-
-        let clip = painter.with_clip_rect(strip);
-        let rows_left = strip.left() + live_strip::STRIP_ROW_INSET_PX;
-        for row in &rows {
-            let intensity = normalized_log_intensity(row.quantity, reference, self.config.gamma);
-            // Same alpha recipe as a projected heat cell: the projection sets
-            // `alpha = intensity * opacity`, then `heat_fill` layers the
-            // style's own multiplier on top.
-            let base_alpha = intensity * self.config.opacity;
-            let Some(fill) = heat_fill(&style, row.side, intensity, base_alpha) else {
-                continue;
-            };
-            let top = scale.y((row.price_bucket + bucket_width)
-                .to_f64()
-                .unwrap_or(f64::NAN));
-            let bottom = scale.y(row.price_bucket.to_f64().unwrap_or(f64::NAN));
-            if !top.is_finite() || !bottom.is_finite() {
-                continue;
-            }
-            let rect = egui::Rect::from_min_max(
-                egui::pos2(rows_left, top),
-                egui::pos2(strip.right(), bottom),
-            )
-            .intersect(strip);
-            if rect.is_positive() {
-                clip.rect_filled(rect, egui::Rounding::ZERO, fill);
-            }
-        }
-
-        // The real spread: cleared back to canvas so it reads as the one empty
-        // band, with the touch marked on both edges.
-        if let (Some(bid), Some(ask)) = (ladder.best_bid, ladder.best_ask) {
-            let ask_y = scale.y(ask.price().to_f64().unwrap_or(f64::NAN));
-            let bid_y = scale.y(bid.price().to_f64().unwrap_or(f64::NAN));
-            if ask_y.is_finite() && bid_y.is_finite() {
-                let gap = egui::Rect::from_min_max(
-                    egui::pos2(rows_left, ask_y),
-                    egui::pos2(strip.right(), bid_y),
-                )
-                .intersect(strip);
-                if gap.is_positive() {
-                    clip.rect_filled(gap, egui::Rounding::ZERO, canvas_background);
-                }
-                let colors = theme_bubble_rgb(self.config.theme);
-                let mark = |y: f32, rgb: [u8; 3]| {
-                    clip.line_segment(
-                        [egui::pos2(rows_left, y), egui::pos2(strip.right(), y)],
-                        egui::Stroke::new(
-                            live_strip::TOUCH_MARKER_STROKE_PX,
-                            egui::Color32::from_rgb(rgb[0], rgb[1], rgb[2]),
-                        ),
-                    );
-                };
-                mark(ask_y, colors.sell);
-                mark(bid_y, colors.buy);
-            }
         }
     }
 
@@ -1629,7 +1708,13 @@ mod tests {
         let paint = |view: &mut OrderflowView| {
             ctx.run(egui::RawInput::default(), |ctx| {
                 egui::CentralPanel::default().show(ctx, |ui| {
-                    view.draw_live_strip(ui.painter(), strip, &scale, egui::Color32::BLACK);
+                    view.draw_live_strip(
+                        ui.painter(),
+                        strip,
+                        &scale,
+                        egui::Color32::BLACK,
+                        Some(0),
+                    );
                 });
             })
         };

--- a/crates/app/src/toolbar.rs
+++ b/crates/app/src/toolbar.rs
@@ -433,15 +433,16 @@ fn draw_layers(ui: &mut egui::Ui, model: &ToolbarModel, actions: &mut Vec<Toolba
         actions.push(ToolbarAction::OpenDockTab(DockTab::L2));
     }
 
+    // Never capability-gated: the aggression histogram runs on the trade
+    // stream every source provides (replay included), and without book data
+    // the strip honestly degrades to it.
     let strip = IconButton::new(icons::WALL, TOOLBAR_ICON)
         .active(model.live_strip_on)
         .accent(theme::ACCENT)
-        .enabled(model.capabilities.book_capture)
         .hover_text(
-            "live strip: the book's resting depth right now, beside the price axis — \
-             right-click for settings",
+            "live strip: the book's resting depth and the forming bar's aggression, \
+             beside the price axis — right-click for settings",
         )
-        .disabled_explanation("order-book capture is not available for this source")
         .show(ui);
     if strip.clicked() {
         actions.push(ToolbarAction::SetLiveStrip(!model.live_strip_on));


### PR DESCRIPTION
## Summary

Phase 5 — the last phase — of the Live Edge goal ([proposal](https://claude.ai/code/artifact/7c24c517-c05a-4a42-b9b9-77b55fa4c8d2)): the forming bar's aggression histogram on the live strip.

- Mirrored around the strip's centre: buys grow rightward, sells leftward, over the depth background from phase 4.
- Bar widths use the bubbles' own square-root area rule (`normalized_area_size`, now shared) normalized by the forming bar's heaviest single-side bucket — the "sqrt scale normalized by the bar" rule from the goal.
- Rows come from the projection's aggression clusters (one engine, one aggregation path — dust merge and side toggles apply consistently), filtered to clusters ending at or after the forming bar's open time. **Reset on close falls out for free**: the new bar has no clusters yet.
- Degradation delivered: the trade stream flows on every source (replay included), so the strip toggle loses its `book_capture` gate — without book data the strip is the histogram alone, and "no book" shows only when neither source has anything.
- Touch markers moved above both layers so the spread stays readable over the histogram.

This completes the Live Edge goal's five phases.

## Review

Self arch-review over `git diff main...HEAD`: no new data plumbing (reads the already-published frame), per-frame cost is one linear pass over the frame's bounded cluster list plus a `BTreeMap` over the forming bar's clusters; constants named; deterministic ordering.

## Verification

- `cargo fmt --all -- --check` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo build --workspace` ✅
- `cargo test --workspace` ✅ (291 tests in quantick-app)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkY8ocUoB2TszfTErAqNVt