### PR TITLE
feat(app): histogram-only live strip, separator rings, bubbles autostart

### DIFF
--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -311,6 +311,11 @@ impl QuantickApp {
         if std::env::var("QUANTICK_LIVE_STRIP_AUTOSTART").is_ok_and(|value| value == "1") {
             app.live_strip_visible = true;
         }
+        // Same convenience for the aggression layer (bubbles + the live
+        // column's footprint). Same code path as the toolbar toggle.
+        if std::env::var("QUANTICK_BUBBLES_AUTOSTART").is_ok_and(|value| value == "1") {
+            app.orderflow.set_bubbles_enabled(true);
+        }
         // Same convenience for Market Replay: open the folder named by
         // QUANTICK_REPLAY_DIR and play its first session. One env var, the same
         // code path a click takes, so a scripted run and a person get the same

--- a/crates/app/src/live_strip.rs
+++ b/crates/app/src/live_strip.rs
@@ -102,6 +102,15 @@ pub(crate) fn fallback_reference(rows: &[DepthRow]) -> Decimal {
 /// Opacity of the histogram bars over the depth background.
 pub(crate) const HISTOGRAM_ALPHA: f32 = 0.8;
 
+/// Width of the dark outline around each histogram bar, so a green bar never
+/// melts into a green depth cell behind it — same job as the bubbles'
+/// separator ring.
+pub(crate) const HISTOGRAM_OUTLINE_PX: f32 = 1.0;
+
+/// Alpha of that outline: translucent black, darkening whatever depth colour
+/// sits behind the bar's edge.
+pub(crate) const HISTOGRAM_OUTLINE_ALPHA: u8 = 200;
+
 /// Widest histogram bar, as a fraction of the strip's half width, leaving a
 /// sliver of background visible even at full scale.
 pub(crate) const HISTOGRAM_MAX_HALF_FRAC: f32 = 0.94;

--- a/crates/app/src/live_strip.rs
+++ b/crates/app/src/live_strip.rs
@@ -1,33 +1,28 @@
 //! The live strip: a narrow column between the chart body and the price
-//! gutter showing the book's resting depth *right now* (Live Edge proposal,
-//! phase 4). Rows are bucketed at the same effective grouping as the heatmap
-//! and coloured through the heatmap's own ramp, so a wall on the strip lines
-//! up 1:1 with that wall's history to its left; the real spread reads as an
-//! empty gap between the marked best bid and best ask.
+//! gutter showing the forming bar's aggression histogram (Live Edge,
+//! phases 4–5; depth silhouette retired after live use — it only repeated
+//! the heatmap's right edge and buried the histogram).
 //!
-//! Phase 5 lays the forming bar's aggression histogram over that background:
-//! buys grow rightward from the strip's centre, sells leftward, each bar's
+//! Buys grow rightward from the strip's centre, sells leftward, each bar's
 //! width on the same square-root area rule the bubbles use, normalized by the
 //! forming bar's own biggest bucket. The rows come from the projection's
 //! aggression clusters — the one engine code path — filtered to the forming
 //! bar, so the histogram resets on bar close simply because the new bar has
-//! no clusters yet. Without book data the strip degrades to this histogram
-//! alone, which is why it works on any source that streams trades (replay
-//! included).
+//! no clusters yet. It works on any source that streams trades (replay
+//! included); with book capture on, the best bid/ask touch lines mark the
+//! real spread over it.
 //!
 //! This module owns the pure, testable math (bucketing, references, the
 //! histogram); painting lives in `OrderflowView::draw_live_strip`, which
-//! reads the published [`BookLadder`] and frame.
+//! reads the published ladder's best bid/ask and the frame.
 
 use quantick_engine::Side;
-use quantick_orderbook::{BookLevel, BookSide};
 use rust_decimal::Decimal;
 
 use crate::orderflow::projection::AggressionPrimitive;
-use crate::orderflow_engine::BookLadder;
 
 /// Width of the strip, in pixels. The proposal band is 72–96 px: wide enough
-/// for the depth silhouette to read, narrow enough to never crowd the chart.
+/// for the histogram to read, narrow enough to never crowd the chart.
 pub(crate) const LIVE_STRIP_WIDTH_PX: f32 = 84.0;
 
 /// Stroke of the best bid/ask touch markers, in pixels.
@@ -36,80 +31,11 @@ pub(crate) const TOUCH_MARKER_STROKE_PX: f32 = 1.5;
 /// Alpha of the strip's left border line, against the chart body.
 pub(crate) const STRIP_BORDER_ALPHA: f32 = 0.3;
 
-/// Left inset of the depth rows, in pixels, so the border stays visible.
+/// Left inset of the strip's content, in pixels, so the border stays visible.
 pub(crate) const STRIP_ROW_INSET_PX: f32 = 1.0;
 
-/// One depth row: an aggregated price bucket of the current book.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct DepthRow {
-    pub side: BookSide,
-    /// Inclusive lower price edge of the bucket, in the heatmap's bucket
-    /// space: `floor(price / width) * width`.
-    pub price_bucket: Decimal,
-    /// Summed resting quantity of the ladder levels inside the bucket.
-    pub quantity: Decimal,
-}
-
-/// Aggregate the ladder into heatmap-aligned buckets: asks first (ascending),
-/// then bids (descending) — each side walking away from the spread, so the
-/// order is deterministic and mirrors the ladder's own.
-pub(crate) fn depth_rows(ladder: &BookLadder, bucket_width: Decimal) -> Vec<DepthRow> {
-    if bucket_width <= Decimal::ZERO {
-        return Vec::new();
-    }
-    let mut rows = Vec::new();
-    bucket_side(&ladder.asks, BookSide::Ask, bucket_width, &mut rows);
-    bucket_side(&ladder.bids, BookSide::Bid, bucket_width, &mut rows);
-    rows
-}
-
-fn bucket_side(levels: &[BookLevel], side: BookSide, width: Decimal, rows: &mut Vec<DepthRow>) {
-    // Ladder levels arrive best-first and strictly ordered, so equal buckets
-    // are always adjacent: one running row per bucket, no map needed.
-    let mut current: Option<DepthRow> = None;
-    for level in levels {
-        let bucket = (level.price() / width).trunc() * width;
-        match &mut current {
-            Some(row) if row.price_bucket == bucket => row.quantity += level.quantity(),
-            _ => {
-                if let Some(done) = current.take() {
-                    rows.push(done);
-                }
-                current = Some(DepthRow {
-                    side,
-                    price_bucket: bucket,
-                    quantity: level.quantity(),
-                });
-            }
-        }
-    }
-    if let Some(done) = current {
-        rows.push(done);
-    }
-}
-
-/// Full-intensity reference when no heatmap frame supplies one: the largest
-/// visible bucket. Honest for a lone column — the biggest wall in view is
-/// the hottest — though it re-normalizes as walls come and go, unlike the
-/// frame's stickier visible-P99 reference.
-pub(crate) fn fallback_reference(rows: &[DepthRow]) -> Decimal {
-    rows.iter()
-        .map(|row| row.quantity)
-        .max()
-        .unwrap_or(Decimal::ZERO)
-}
-
-/// Opacity of the histogram bars over the depth background.
+/// Opacity of the histogram bars.
 pub(crate) const HISTOGRAM_ALPHA: f32 = 0.8;
-
-/// Width of the dark outline around each histogram bar, so a green bar never
-/// melts into a green depth cell behind it — same job as the bubbles'
-/// separator ring.
-pub(crate) const HISTOGRAM_OUTLINE_PX: f32 = 1.0;
-
-/// Alpha of that outline: translucent black, darkening whatever depth colour
-/// sits behind the bar's edge.
-pub(crate) const HISTOGRAM_OUTLINE_ALPHA: u8 = 200;
 
 /// Widest histogram bar, as a fraction of the strip's half width, leaving a
 /// sliver of background visible even at full scale.
@@ -176,72 +102,6 @@ mod tests {
 
     fn dec(value: &str) -> Decimal {
         Decimal::from_str(value).unwrap()
-    }
-
-    fn level(price: &str, quantity: &str) -> BookLevel {
-        BookLevel::new(dec(price), dec(quantity)).unwrap()
-    }
-
-    fn ladder(bids: Vec<BookLevel>, asks: Vec<BookLevel>) -> BookLadder {
-        BookLadder {
-            best_bid: bids.first().copied(),
-            best_ask: asks.first().copied(),
-            bids,
-            asks,
-        }
-    }
-
-    #[test]
-    fn rows_bucket_like_the_heatmap_and_merge_neighbours() {
-        // Asks best-first ascending, bids best-first descending, bucket 2:
-        // levels sharing a bucket sum into one row.
-        let ladder = ladder(
-            vec![level("999", "1"), level("998", "2"), level("997", "4")],
-            vec![level("1001", "1"), level("1002", "2"), level("1003", "4")],
-        );
-        let rows = depth_rows(&ladder, dec("2"));
-        assert_eq!(
-            rows,
-            vec![
-                DepthRow {
-                    side: BookSide::Ask,
-                    price_bucket: dec("1000"),
-                    quantity: dec("1"),
-                },
-                DepthRow {
-                    side: BookSide::Ask,
-                    price_bucket: dec("1002"),
-                    quantity: dec("6"),
-                },
-                DepthRow {
-                    side: BookSide::Bid,
-                    price_bucket: dec("998"),
-                    quantity: dec("3"),
-                },
-                DepthRow {
-                    side: BookSide::Bid,
-                    price_bucket: dec("996"),
-                    quantity: dec("4"),
-                },
-            ]
-        );
-    }
-
-    #[test]
-    fn a_degenerate_bucket_width_yields_no_rows() {
-        let ladder = ladder(vec![level("999", "1")], vec![level("1001", "1")]);
-        assert!(depth_rows(&ladder, Decimal::ZERO).is_empty());
-    }
-
-    #[test]
-    fn the_fallback_reference_is_the_biggest_visible_bucket() {
-        let ladder = ladder(
-            vec![level("999", "5"), level("998", "9")],
-            vec![level("1001", "3")],
-        );
-        let rows = depth_rows(&ladder, Decimal::ONE);
-        assert_eq!(fallback_reference(&rows), dec("9"));
-        assert_eq!(fallback_reference(&[]), Decimal::ZERO);
     }
 
     /// A minimal cluster: only the fields the histogram reads carry data.

--- a/crates/app/src/orderflow_render.rs
+++ b/crates/app/src/orderflow_render.rs
@@ -2432,6 +2432,39 @@ mod tests {
         format!("{:?}", output.shapes)
     }
 
+    /// The cheap-dot path is the fps contract on a dense tape: below the
+    /// dressing radius a solid print stays exactly one filled circle — no
+    /// halo, no rim, and no separator ring may sneak onto it.
+    #[test]
+    fn a_cheap_dot_stays_a_single_circle() {
+        let bubbles = BubbleStyle {
+            min_radius: 2.0,
+            detail_min_radius: 6.0,
+            hollow_small_buys: false,
+            ..BubbleStyle::default()
+        };
+        let colors = BubbleColors::resolve(&Palette::for_theme(HeatmapTheme::Bookmap), &bubbles);
+        let shapes = painted(|painter| {
+            draw_bubble(
+                painter,
+                BubbleMark {
+                    center: egui::pos2(50.0, 50.0),
+                    radius: 3.0,
+                    side: Side::Sell,
+                    size: 0.1,
+                    matched: None,
+                },
+                &bubbles,
+                &colors,
+            )
+        });
+        assert_eq!(
+            shapes.matches("CircleShape").count(),
+            1,
+            "a cheap dot must stay one circle: {shapes}"
+        );
+    }
+
     #[test]
     fn the_preview_draws_a_bubble_exactly_the_way_the_chart_does() {
         // The preview is the instrument the user tunes the sliders against, so

--- a/crates/app/src/orderflow_render.rs
+++ b/crates/app/src/orderflow_render.rs
@@ -2125,17 +2125,6 @@ fn heat_fill_parts(
     Some((resting_rgb(style.theme, side, intensity), alpha))
 }
 
-/// [`heat_fill_parts`] as a ready egui colour, for callers that need no
-/// separate glow pass.
-pub(crate) fn heat_fill(
-    style: &OrderflowRenderStyle,
-    side: BookSide,
-    raw_intensity: f32,
-    base_alpha: f32,
-) -> Option<egui::Color32> {
-    heat_fill_parts(style, side, raw_intensity, base_alpha).map(|(rgb, alpha)| rgba(rgb, alpha))
-}
-
 fn mix_rgb(from: [u8; 3], to: [u8; 3], amount: f32) -> [u8; 3] {
     let amount = finite_unit(amount);
     [

--- a/crates/app/src/orderflow_render.rs
+++ b/crates/app/src/orderflow_render.rs
@@ -246,6 +246,15 @@ fn hollow_ring_width(radius: f32) -> f32 {
     (radius * HOLLOW_RING_SCALE).clamp(HOLLOW_MIN_RING_PX, HOLLOW_MAX_RING_PX)
 }
 
+/// Width of the dark separator ring drawn just outside a bubble's rim. The
+/// heat ramp passes through greens the buy side almost matches, so without a
+/// dark hair between them "aggression" and "liquidity" melt into one layer
+/// wherever a bubble sits on warm heat — the ring is what keeps them two.
+const SEPARATOR_RING_PX: f32 = 1.2;
+/// Alpha of that ring: translucent black, so it darkens whatever heat is
+/// behind it instead of assuming one canvas colour.
+const SEPARATOR_RING_ALPHA: u8 = 200;
+
 /// Gap, in pixels, between a bubble's rim and the halo drawn behind it.
 const HALO_PADDING_PX: f32 = 2.5;
 /// Gap, in pixels, between a bubble's rim and its impact ring.
@@ -476,6 +485,18 @@ fn draw_bubble(
             center,
             radius + HALO_PADDING_PX,
             color.gamma_multiply(halo_alpha(size, bubbles)),
+        );
+    }
+    // The dark hair between the mark and the heat behind it. Skipped on the
+    // cheap-dot path, which stays a single circle per print.
+    if dressed || hollow {
+        painter.circle_stroke(
+            center,
+            radius + SEPARATOR_RING_PX / 2.0,
+            egui::Stroke::new(
+                SEPARATOR_RING_PX,
+                egui::Color32::from_black_alpha(SEPARATOR_RING_ALPHA),
+            ),
         );
     }
     if hollow {

--- a/crates/app/src/orderflow_view.rs
+++ b/crates/app/src/orderflow_view.rs
@@ -20,7 +20,7 @@ use rust_decimal::prelude::{FromPrimitive as _, ToPrimitive as _};
 use crate::bubble_presets::{self, BubblePreset, BubblePresetFile, PresetSource};
 use crate::chart::PriceScale;
 use crate::live_strip;
-use crate::orderflow::projection::{normalized_area_size, normalized_log_intensity};
+use crate::orderflow::projection::normalized_area_size;
 use crate::orderflow::{
     BubbleRenderMode, BubbleSizeReference, DisplayGrouping, HeatmapConfig, HeatmapTheme,
     IntensityMode, MAX_BUBBLE_MAX_RADIUS, MAX_BUBBLE_MIN_RADIUS, MIN_BUBBLE_MAX_RADIUS,
@@ -31,7 +31,7 @@ use crate::orderflow_engine::{
 };
 use crate::orderflow_render::{
     OrderflowRenderStyle, ProjectedLayout, RenderContext, draw_aggression_bubbles,
-    draw_compact_legend, draw_heatmap_background, draw_liquidity_events, draw_preview, heat_fill,
+    draw_compact_legend, draw_heatmap_background, draw_liquidity_events, draw_preview,
     theme_bubble_rgb,
 };
 use crate::orderflow_worker::{BookCommand, BookWorker};
@@ -399,14 +399,13 @@ impl OrderflowView {
         painter.galley(pos, galley, color);
     }
 
-    /// Draw the live strip. Background: the current book's depth silhouette,
-    /// bucketed and coloured exactly like the heatmap (same buckets, same
-    /// ramp, same full-intensity reference when a frame exists), with the
-    /// real spread as an empty gap between the marked best bid and best ask.
-    /// Foreground: the forming bar's aggression histogram, buys growing
-    /// rightward from the centre and sells leftward, on the bubbles'
+    /// Draw the live strip: the forming bar's aggression histogram, buys
+    /// growing rightward from the centre and sells leftward, on the bubbles'
     /// square-root area rule normalized by the bar itself — it resets on bar
-    /// close because the new bar has no clusters yet. `bar_open_ms` is the
+    /// close because the new bar has no clusters yet. The published ladder
+    /// contributes only the best bid/ask touch lines (the real spread); the
+    /// depth silhouette was retired after live use — it repeated the
+    /// heatmap's right edge and buried the histogram. `bar_open_ms` is the
     /// forming bar's open time (`None` hides the histogram); `scale` is the
     /// chart's own price scale, so everything lines up 1:1 with the chart.
     pub fn draw_live_strip(
@@ -429,77 +428,13 @@ impl OrderflowView {
 
         let ladder = self.published.ladder.clone();
         let frame = self.published.frame.clone();
-        let style = OrderflowRenderStyle::from_config(&self.config, canvas_background).sanitized();
         let colors = theme_bubble_rgb(self.config.theme);
         let clip = painter.with_clip_rect(strip);
         let rows_left = strip.left() + live_strip::STRIP_ROW_INSET_PX;
 
-        // Background: the depth silhouette. Same bucket and same
-        // full-intensity reference as the heatmap frame when one exists, so
-        // one wall wears one colour across the chart edge; without a frame
-        // (heat layer off) the strip normalizes against its own biggest
-        // visible bucket.
-        if let Some(ladder) = &ladder {
-            let (bucket_width, frame_reference) = match frame.as_deref() {
-                Some(frame) => (
-                    frame.projection.effective_grouping.bucket_width,
-                    Some(frame.projection.liquidity_reference),
-                ),
-                None => (self.published.base_price_grouping, None),
-            };
-            let rows = live_strip::depth_rows(ladder, bucket_width);
-            let reference = frame_reference
-                .filter(|reference| *reference > Decimal::ZERO)
-                .unwrap_or_else(|| live_strip::fallback_reference(&rows));
-
-            for row in &rows {
-                let intensity =
-                    normalized_log_intensity(row.quantity, reference, self.config.gamma);
-                // Same alpha recipe as a projected heat cell: the projection
-                // sets `alpha = intensity * opacity`, then `heat_fill` layers
-                // the style's own multiplier on top.
-                let base_alpha = intensity * self.config.opacity;
-                let Some(fill) = heat_fill(&style, row.side, intensity, base_alpha) else {
-                    continue;
-                };
-                let top = scale.y((row.price_bucket + bucket_width)
-                    .to_f64()
-                    .unwrap_or(f64::NAN));
-                let bottom = scale.y(row.price_bucket.to_f64().unwrap_or(f64::NAN));
-                if !top.is_finite() || !bottom.is_finite() {
-                    continue;
-                }
-                let rect = egui::Rect::from_min_max(
-                    egui::pos2(rows_left, top),
-                    egui::pos2(strip.right(), bottom),
-                )
-                .intersect(strip);
-                if rect.is_positive() {
-                    clip.rect_filled(rect, egui::Rounding::ZERO, fill);
-                }
-            }
-
-            // The real spread: cleared back to canvas so it reads as the one
-            // empty band.
-            if let (Some(bid), Some(ask)) = (ladder.best_bid, ladder.best_ask) {
-                let ask_y = scale.y(ask.price().to_f64().unwrap_or(f64::NAN));
-                let bid_y = scale.y(bid.price().to_f64().unwrap_or(f64::NAN));
-                if ask_y.is_finite() && bid_y.is_finite() {
-                    let gap = egui::Rect::from_min_max(
-                        egui::pos2(rows_left, ask_y),
-                        egui::pos2(strip.right(), bid_y),
-                    )
-                    .intersect(strip);
-                    if gap.is_positive() {
-                        clip.rect_filled(gap, egui::Rounding::ZERO, canvas_background);
-                    }
-                }
-            }
-        }
-
-        // Foreground: the forming bar's mirrored aggression histogram, from
-        // the same projection clusters the bubbles draw — one engine, one
-        // aggregation path. Empty whenever those layers publish nothing.
+        // The forming bar's mirrored aggression histogram, from the same
+        // projection clusters the bubbles draw — one engine, one aggregation
+        // path. Empty whenever those layers publish nothing.
         let histogram = match (frame.as_deref(), bar_open_ms) {
             (Some(frame), Some(open_ms)) => {
                 live_strip::aggression_rows(&frame.projection.aggressions, open_ms)
@@ -519,12 +454,6 @@ impl OrderflowView {
                 .gamma_multiply(live_strip::HISTOGRAM_ALPHA);
             let sell_fill = egui::Color32::from_rgb(colors.sell[0], colors.sell[1], colors.sell[2])
                 .gamma_multiply(live_strip::HISTOGRAM_ALPHA);
-            // A dark hair around each bar keeps a green bar readable over a
-            // green depth cell — the strip's version of the bubbles' ring.
-            let outline = egui::Stroke::new(
-                live_strip::HISTOGRAM_OUTLINE_PX,
-                egui::Color32::from_black_alpha(live_strip::HISTOGRAM_OUTLINE_ALPHA),
-            );
             for row in &histogram {
                 let top = scale.y((row.price_bucket + bucket_width)
                     .to_f64()
@@ -542,7 +471,6 @@ impl OrderflowView {
                     .intersect(strip);
                     if rect.is_positive() {
                         clip.rect_filled(rect, egui::Rounding::ZERO, buy_fill);
-                        clip.rect_stroke(rect, egui::Rounding::ZERO, outline);
                     }
                 }
                 let sell_extent = normalized_area_size(row.sell, reference) * half_width;
@@ -554,7 +482,6 @@ impl OrderflowView {
                     .intersect(strip);
                     if rect.is_positive() {
                         clip.rect_filled(rect, egui::Rounding::ZERO, sell_fill);
-                        clip.rect_stroke(rect, egui::Rounding::ZERO, outline);
                     }
                 }
             }

--- a/crates/app/src/orderflow_view.rs
+++ b/crates/app/src/orderflow_view.rs
@@ -519,6 +519,12 @@ impl OrderflowView {
                 .gamma_multiply(live_strip::HISTOGRAM_ALPHA);
             let sell_fill = egui::Color32::from_rgb(colors.sell[0], colors.sell[1], colors.sell[2])
                 .gamma_multiply(live_strip::HISTOGRAM_ALPHA);
+            // A dark hair around each bar keeps a green bar readable over a
+            // green depth cell — the strip's version of the bubbles' ring.
+            let outline = egui::Stroke::new(
+                live_strip::HISTOGRAM_OUTLINE_PX,
+                egui::Color32::from_black_alpha(live_strip::HISTOGRAM_OUTLINE_ALPHA),
+            );
             for row in &histogram {
                 let top = scale.y((row.price_bucket + bucket_width)
                     .to_f64()
@@ -536,6 +542,7 @@ impl OrderflowView {
                     .intersect(strip);
                     if rect.is_positive() {
                         clip.rect_filled(rect, egui::Rounding::ZERO, buy_fill);
+                        clip.rect_stroke(rect, egui::Rounding::ZERO, outline);
                     }
                 }
                 let sell_extent = normalized_area_size(row.sell, reference) * half_width;
@@ -547,6 +554,7 @@ impl OrderflowView {
                     .intersect(strip);
                     if rect.is_positive() {
                         clip.rect_filled(rect, egui::Rounding::ZERO, sell_fill);
+                        clip.rect_stroke(rect, egui::Rounding::ZERO, outline);
                     }
                 }
             }


### PR DESCRIPTION
## What

The salvage from the compact-live-tail experiment (PR #84, closed unmerged after live validation) — the three pieces the owner kept:

1. **Live strip shows the histogram alone.** The depth silhouette and spread-gap clearing are retired: in live use they only repeated the heatmap's right edge and buried the histogram the strip exists for. The published ladder now contributes just the best bid/ask touch lines. `depth_rows`, `fallback_reference` and `heat_fill` lost their last readers and are deleted with their tests (−246 lines).
2. **Dark separator ring** (1.2 px translucent black) outside every dressed/hollow bubble rim: the heat ramp passes through greens the buy side almost matches, and without the ring aggression and liquidity melted into one layer. The cheap-dot path stays a single circle per print — now pinned by `a_cheap_dot_stays_a_single_circle`.
3. **`QUANTICK_BUBBLES_AUTOSTART=1`** completes the autostart family (book, strip) so scripted runs can exercise the aggression layer without a click.

The forming bar keeps main's wall-clock live tail: the motion of the bubbles is the owner's felt signal that the flow is alive — recorded as the standing verdict on any future attempt to freeze the live region.

## Arch-review

Run over `git diff main...HEAD`. No Blockers. One test-coverage gap (the ring's perf contract on the cheap-dot path) fixed in-branch. Performance: the ring adds one stroked circle per **dressed** bubble at ~60 Hz (dense-tape validation earlier tonight held 60 fps with frame CPU under 5 ms); the strip loses a whole per-frame aggregation and its row fills — strictly faster.

## Verification

`cargo fmt --all -- --check` ✓ · `cargo clippy --workspace --all-targets -- -D warnings` ✓ · `cargo build --workspace` ✓ · `cargo test --workspace` ✓ (all 24 suites green)

Validated live on Binance/BTCUSDT ("dense tape btc", Binance-only scratchpad config): bubbles rolling on the timeline again, strip clean with the mirrored histogram + bid/ask lines, rings keeping marks readable over warm heat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkY8ocUoB2TszfTErAqNVt