### PR TITLE
feat(app): tell the user what the MetaTrader bridge is doing

### DIFF
--- a/bridge/mt5/README.md
+++ b/bridge/mt5/README.md
@@ -21,6 +21,22 @@ chart, is used instead of being fought. All it needs is the official package
 `bridge_autostart = false`, or point `bridge_command` somewhere else, under
 `[metatrader]` in your config.
 
+Two things make that work outside a developer's checkout:
+
+- **The script is found, not assumed.** A relative `bridge_command` path is
+  resolved against the working directory *and* against the folder holding the
+  quantick executable and its ancestors, so a build launched from a shortcut
+  still finds the `bridge/` folder shipped beside it.
+- **`python` is a first guess, not a requirement.** With no `python` on PATH,
+  the Windows `py` launcher is tried next. A `bridge_command` you configured
+  yourself is never second-guessed — it is an instruction, not a hint.
+
+**You should not have to read this file to fix a broken setup.** Whatever stops
+the bridge is reported on the chart, with the one next step: terminal closed,
+package missing, contract not in Market Watch, server clock unmeasurable, no
+Depth of Market for that symbol. The log keeps the full detail; the chart
+carries the part you have to act on.
+
 To run it by hand anyway — to see its log lines up close, or to feed a quantick
 that is not yours:
 

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -2019,6 +2019,73 @@ mod tests {
         (app, evt_tx, cmd_rx, book_tx)
     }
 
+    /// The same app, plus the notice sender its feed would hold. The other
+    /// ends come back so the caller keeps the channels open, exactly as a live
+    /// feed thread would.
+    #[allow(clippy::type_complexity)]
+    fn test_app_with_notices() -> (
+        QuantickApp,
+        mpsc::Sender<FeedNotice>,
+        (mpsc::Sender<FeedEvent>, mpsc::Sender<DepthEvent>),
+    ) {
+        let (evt_tx, evt_rx) = mpsc::channel(64);
+        let (book_tx, book_rx) = mpsc::channel(64);
+        let (cmd_tx, _cmd_rx) = mpsc::channel(16);
+        let (notice_tx, notice_rx) = mpsc::channel(8);
+        let app = QuantickApp::new(
+            test_config(),
+            "binance",
+            "TESTUSDT",
+            BarSpec::Tick(50),
+            FeedHandle {
+                events: evt_rx,
+                book_events: book_rx,
+                notices: notice_rx,
+                commands: cmd_tx,
+                replay: None,
+            },
+        );
+        (app, notice_tx, (evt_tx, book_tx))
+    }
+
+    #[test]
+    fn the_newest_notice_wins_and_clear_puts_the_chart_back() {
+        let (mut app, notices, _feed_ends) = test_app_with_notices();
+        assert_eq!(app.notice, FeedNotice::Clear, "nothing to report at birth");
+
+        // A burst arriving between two frames must leave the latest state, not
+        // a queue of cards to page through.
+        notices
+            .blocking_send(FeedNotice::working("starting the MetaTrader bridge"))
+            .unwrap();
+        notices
+            .blocking_send(FeedNotice::attention(
+                "MetaTrader 5 is not running",
+                "Open the terminal and log in.",
+            ))
+            .unwrap();
+        app.drain_notices();
+        assert!(
+            matches!(app.notice, FeedNotice::Attention { .. }),
+            "the newest notice is what the user sees, got {:?}",
+            app.notice
+        );
+
+        // And a feed that recovers takes its own instruction back down.
+        notices.blocking_send(FeedNotice::Clear).unwrap();
+        app.drain_notices();
+        assert_eq!(app.notice, FeedNotice::Clear);
+    }
+
+    #[test]
+    fn a_feed_with_nothing_to_report_leaves_the_chart_alone() {
+        // Binance and replay hand over a closed channel; draining it must be a
+        // no-op rather than an error the app has to special-case.
+        let (mut app, _evt_tx, _cmd_rx, _book_tx) = test_app();
+        app.drain_notices();
+        assert_eq!(app.notice, FeedNotice::Clear);
+    }
+
     fn enable_heatmap_with_snapshot(
         app: &mut QuantickApp,
         commands: &mut mpsc::Receiver<FeedCommand>,

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -20,9 +20,10 @@ use crate::candle_view::{draw_candle, draw_style_window};
 use crate::chart::PriceScale;
 use crate::config::{AppConfig, FeedCapabilities, ProviderKind};
 use crate::dock::{Dock, DockEnv, DockTab};
-use crate::feed::{self, FeedCommand, FeedEvent, FeedHandle, ReplayLink};
+use crate::feed::{self, FeedCommand, FeedEvent, FeedHandle, FeedNotice, ReplayLink};
 use crate::loading::{self, LoadingTask, LoadingTracker};
 use crate::metrics::{self, FrameStats};
+use crate::notice_card;
 use crate::orderflow_view::OrderflowView;
 use crate::price_view::PriceView;
 use crate::replay_view::{ReplayAction, ReplayView};
@@ -126,6 +127,12 @@ pub struct QuantickApp {
     state: ChartState,
     events: mpsc::Receiver<FeedEvent>,
     book_events: mpsc::Receiver<DepthEvent>,
+    /// Connection trouble the feed wants the user to know about.
+    notices: mpsc::Receiver<FeedNotice>,
+    /// The newest notice, held until the feed says it is over. A feed that
+    /// blocks once and then goes quiet has to keep saying so — the chart it
+    /// left empty will not.
+    notice: FeedNotice,
     commands: mpsc::Sender<FeedCommand>,
     orderflow: OrderflowView,
     book_capture_epoch: u64,
@@ -256,6 +263,8 @@ impl QuantickApp {
             state: ChartState::new(spec),
             events: feed.events,
             book_events: feed.book_events,
+            notices: feed.notices,
+            notice: FeedNotice::Clear,
             commands: feed.commands,
             orderflow: OrderflowView::new(symbol.clone()),
             book_capture_epoch: 0,
@@ -665,6 +674,10 @@ impl QuantickApp {
         let handle = feed::spawn_live(provider, &self.symbol, &self.config);
         self.events = handle.events;
         self.book_events = handle.book_events;
+        self.notices = handle.notices;
+        // The old feed's trouble is not the new feed's: switching away from a
+        // blocked source must not leave its instruction on screen.
+        self.notice = FeedNotice::Clear;
         self.commands = handle.commands;
         self.replay = handle.replay;
         self.book_channel_closed_reported = false;
@@ -815,6 +828,17 @@ impl QuantickApp {
                 Ok(FeedEvent::Reset) => self.reset_market_state(),
                 Err(_) => break,
             }
+        }
+    }
+
+    /// Take the newest feed notice, if the feed sent any this frame.
+    ///
+    /// Level-triggered rather than queued: only the latest state matters, and
+    /// a burst of bridge output must not queue up cards to show one by one.
+    /// A closed channel (a feed with nothing to report) simply yields nothing.
+    fn drain_notices(&mut self) {
+        while let Ok(notice) = self.notices.try_recv() {
+            self.notice = notice;
         }
     }
 
@@ -1746,6 +1770,10 @@ impl QuantickApp {
         let handle = feed::spawn(feed::FeedSource::Replay(Box::new(request)), &self.config);
         self.events = handle.events;
         self.book_events = handle.book_events;
+        self.notices = handle.notices;
+        // The old feed's trouble is not the new feed's: switching away from a
+        // blocked source must not leave its instruction on screen.
+        self.notice = FeedNotice::Clear;
         self.commands = handle.commands;
         self.replay = handle.replay;
         self.book_channel_closed_reported = false;
@@ -1787,6 +1815,44 @@ impl QuantickApp {
         let handle = feed::spawn_live(provider, &self.symbol, &self.config);
         self.events = handle.events;
         self.book_events = handle.book_events;
+        self.notices = handle.notices;
+        // The old feed's trouble is not the new feed's: switching away from a
+        // blocked source must not leave its instruction on screen.
+        self.notice = FeedNotice::Clear;
+        self.commands = handle.commands;
+        self.replay = handle.replay;
+        self.book_channel_closed_reported = false;
+        self.reset_market_state();
+    }
+
+    /// Start the current feed over, from the card that asked the user to fix
+    /// something.
+    ///
+    /// The same respawn a feed switch performs, minus the switch: after the
+    /// terminal is opened or the package installed, the way back has to be one
+    /// click, not a restart of quantick. A replay owns the chart while it
+    /// plays and has nothing to retry.
+    fn restart_feed(&mut self) {
+        if self.replay.is_some() {
+            return;
+        }
+        let Some(provider) = self.config.provider_of(&self.feed_id) else {
+            return;
+        };
+        tracing::info!(
+            target: "quantick::app",
+            schema_version = 1_u8,
+            event_code = "FEED_RESTARTED_BY_USER",
+            feed = %self.feed_id,
+            symbol = %self.symbol,
+            action = "respawn_feed",
+            "restarting the feed from the notice card"
+        );
+        let handle = feed::spawn_live(provider, &self.symbol, &self.config);
+        self.events = handle.events;
+        self.book_events = handle.book_events;
+        self.notices = handle.notices;
+        self.notice = FeedNotice::Clear;
         self.commands = handle.commands;
         self.replay = handle.replay;
         self.book_channel_closed_reported = false;
@@ -1807,6 +1873,7 @@ impl eframe::App for QuantickApp {
 
         self.drain_feed();
         self.drain_book_feed();
+        self.drain_notices();
         self.maybe_emit_summary(now);
 
         let bg = self.bg();
@@ -1861,6 +1928,7 @@ impl eframe::App for QuantickApp {
         self.loading
             .set_active(LoadingTask::BookSync, self.orderflow.is_syncing());
 
+        let mut notice_action = notice_card::NoticeAction::None;
         egui::CentralPanel::default()
             .frame(egui::Frame::none().fill(bg))
             .show(ctx, |ui| {
@@ -1868,7 +1936,13 @@ impl eframe::App for QuantickApp {
                 self.handle_navigation(ui, area);
                 self.draw_chart(ui.painter(), area);
                 loading::overlay(ui, area, &self.loading);
+                if notice_card::should_draw(&self.notice, self.state.bars().len()) {
+                    notice_action = notice_card::draw(ui, area, &self.notice);
+                }
             });
+        if notice_action == notice_card::NoticeAction::Retry {
+            self.restart_feed();
+        }
         // Live feed: keep polling the channel ~60×/s without busy-spinning.
         ctx.request_repaint_after(Duration::from_millis(16));
     }
@@ -1937,6 +2011,7 @@ mod tests {
             FeedHandle {
                 events: evt_rx,
                 book_events: book_rx,
+                notices: feed::silent_notices(),
                 commands: cmd_tx,
                 replay: None,
             },
@@ -2129,6 +2204,7 @@ mod tests {
             FeedHandle {
                 events: evt_rx,
                 book_events: book_rx,
+                notices: feed::silent_notices(),
                 commands: cmd_tx,
                 replay: None,
             },

--- a/crates/app/src/feed/binance.rs
+++ b/crates/app/src/feed/binance.rs
@@ -46,6 +46,10 @@ pub fn spawn(symbol: &str) -> FeedHandle {
     FeedHandle {
         events: rx,
         book_events: book_rx,
+        // A public venue needs no local setup, so it has nothing to walk the
+        // user through: its trouble is network trouble, and that already shows
+        // as a stalled feed on the status bar.
+        notices: super::silent_notices(),
         commands: cmd_tx,
         replay: None,
     }

--- a/crates/app/src/feed/metatrader.rs
+++ b/crates/app/src/feed/metatrader.rs
@@ -169,9 +169,18 @@ async fn feed_task(
                             Mt5Status::Waiting { .. } => FeedNotice::working(
                                 "waiting for the MetaTrader bridge to connect",
                             ),
-                            Mt5Status::Lost { .. } => FeedNotice::working(
-                                "the MetaTrader bridge disconnected — reconnecting",
-                            ),
+                            // Losing the bridge clears the flag as well as
+                            // reporting it. The supervisor reads the flag as
+                            // "is one feeding us *now*", so a terminal that
+                            // restarts mid-session gets picked back up —
+                            // without this, "reconnecting" is a promise
+                            // nobody keeps.
+                            Mt5Status::Lost { .. } => {
+                                bridge_connected.store(false, Ordering::Relaxed);
+                                FeedNotice::working(
+                                    "the MetaTrader bridge disconnected — reconnecting",
+                                )
+                            }
                         };
                         let _ = notice_tx.send(notice).await;
                         log_status(&symbol, &status);

--- a/crates/app/src/feed/metatrader.rs
+++ b/crates/app/src/feed/metatrader.rs
@@ -37,12 +37,9 @@
 //! from trade order, not ids, so the chart is unaffected; anything keying on
 //! `agg_id` across sessions must not, and this is the place that documents it.
 
-use std::process::Stdio;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::Duration;
 
-use tokio::process::Command;
 use tokio::sync::mpsc;
 use tracing::{error, info, warn};
 
@@ -52,27 +49,18 @@ use quantick_feed_mt5::{
 
 use crate::config::{MetaTraderSettings, Mt5SideSource};
 
-use super::{DepthEvent, FeedCommand, FeedEvent, FeedHandle};
+use super::mt5_bridge::{Supervision, supervise};
+use super::{DepthEvent, FeedCommand, FeedEvent, FeedHandle, FeedNotice};
 
 /// Depth events are independent from the established trade channel. Sized like
 /// the Binance backend's: a B3 book republishes far faster than the UI drains,
 /// and this absorbs bursts without either dropping deltas or stalling trades.
 const BOOK_EVENT_CHANNEL_CAPACITY: usize = 8_192;
 
-/// How long the autostart waits for a bridge that is already running before
-/// launching its own. Long enough for an attached Expert Advisor's reconnect
-/// cycle to notice the port, short enough that a cold start feels immediate.
-const BRIDGE_AUTOSTART_GRACE: Duration = Duration::from_secs(3);
-
-/// Gap between autostart attempts. The common failure is a terminal still
-/// starting up, which resolves in seconds.
-const BRIDGE_AUTOSTART_RETRY: Duration = Duration::from_secs(5);
-
-/// How many times the autostart relaunches an exiting bridge before leaving it
-/// alone. Every remaining failure (terminal closed, unknown symbol, unknown
-/// server offset) needs a human, and retrying it forever only buries the log
-/// line that says so.
-const BRIDGE_AUTOSTART_ATTEMPTS: u32 = 5;
+/// Capacity of the notice channel. Notices are rare (one per connection
+/// transition) and the UI drains every frame; this only has to outlast a
+/// burst of bridge output arriving while the chart is busy.
+const NOTICE_CHANNEL_CAPACITY: usize = 32;
 
 /// Start the MetaTrader feed for `symbol`: listen for the bridge on the
 /// configured address and translate its stream into [`FeedEvent`]s.
@@ -80,6 +68,7 @@ const BRIDGE_AUTOSTART_ATTEMPTS: u32 = 5;
 pub fn spawn(symbol: &str, settings: &MetaTraderSettings) -> FeedHandle {
     let (tx, rx) = mpsc::channel(4096);
     let (book_tx, book_rx) = mpsc::channel::<DepthEvent>(BOOK_EVENT_CHANNEL_CAPACITY);
+    let (notice_tx, notice_rx) = mpsc::channel::<FeedNotice>(NOTICE_CHANNEL_CAPACITY);
     let (cmd_tx, cmd_rx) = mpsc::channel(16);
     let symbol = symbol.to_string();
     let settings = settings.clone();
@@ -91,12 +80,13 @@ pub fn spawn(symbol: &str, settings: &MetaTraderSettings) -> FeedHandle {
                 .enable_all()
                 .build()
                 .expect("build feed runtime");
-            runtime.block_on(feed_task(symbol, settings, tx, book_tx, cmd_rx));
+            runtime.block_on(feed_task(symbol, settings, tx, book_tx, notice_tx, cmd_rx));
         })
         .expect("spawn mt5 feed thread");
     FeedHandle {
         events: rx,
         book_events: book_rx,
+        notices: notice_rx,
         commands: cmd_tx,
         replay: None,
     }
@@ -107,6 +97,7 @@ async fn feed_task(
     settings: MetaTraderSettings,
     tx: mpsc::Sender<FeedEvent>,
     book_tx: mpsc::Sender<DepthEvent>,
+    notice_tx: mpsc::Sender<FeedNotice>,
     mut cmd_rx: mpsc::Receiver<FeedCommand>,
 ) {
     // Resolve the UI's initial history load immediately: there is no
@@ -127,12 +118,25 @@ async fn feed_task(
     // until it is sure nobody else is already feeding us.
     let bridge_connected = Arc::new(AtomicBool::new(false));
     let autostart = settings.bridge_autostart.then(|| {
-        tokio::spawn(supervise_bridge(
-            symbol.clone(),
+        tokio::spawn(supervise(
             settings.clone(),
-            Arc::clone(&bridge_connected),
+            Supervision {
+                symbol: symbol.clone(),
+                connected: Arc::clone(&bridge_connected),
+                notices: notice_tx.clone(),
+            },
         ))
     });
+    if !settings.bridge_autostart {
+        // Nothing is coming unless the user brings it: say so rather than
+        // leaving an empty chart to be interpreted.
+        let _ = notice_tx
+            .send(FeedNotice::working(format!(
+                "waiting for a MetaTrader bridge on {}",
+                settings.listen_addr
+            )))
+            .await;
+    }
 
     // The switch lives on this side of the server task so UI commands can flip
     // depth capture without disturbing the bridge session or the trade stream.
@@ -154,9 +158,22 @@ async fn feed_task(
             maybe_event = mt5_rx.recv() => {
                 match maybe_event {
                     Some(Mt5Event::Status(status)) => {
-                        if matches!(status, Mt5Status::Connected { .. }) {
-                            bridge_connected.store(true, Ordering::Relaxed);
-                        }
+                        // The connection's own story, told where the user is
+                        // looking. A connected bridge clears whatever the
+                        // startup reported; a lost one replaces it.
+                        let notice = match &status {
+                            Mt5Status::Connected { .. } => {
+                                bridge_connected.store(true, Ordering::Relaxed);
+                                FeedNotice::Clear
+                            }
+                            Mt5Status::Waiting { .. } => FeedNotice::working(
+                                "waiting for the MetaTrader bridge to connect",
+                            ),
+                            Mt5Status::Lost { .. } => FeedNotice::working(
+                                "the MetaTrader bridge disconnected — reconnecting",
+                            ),
+                        };
+                        let _ = notice_tx.send(notice).await;
                         log_status(&symbol, &status);
                     }
                     Some(Mt5Event::Backfilled(batch)) => {
@@ -273,123 +290,6 @@ async fn feed_task(
     if let Some(autostart) = autostart {
         autostart.abort();
     }
-}
-
-/// Launch a bridge when nothing else is feeding us, and keep it alive.
-///
-/// Deliberately passive at the start: a bridge that is already running, or an
-/// Expert Advisor attached to a chart, gets the grace period to dial in. Only
-/// silence triggers a launch.
-async fn supervise_bridge(
-    symbol: String,
-    settings: MetaTraderSettings,
-    connected: Arc<AtomicBool>,
-) {
-    let Some((host, port)) = settings.bridge_endpoint() else {
-        warn!(
-            target: "quantick::app",
-            schema_version = 1_u8,
-            event_code = "MT5_BRIDGE_AUTOSTART_SKIPPED",
-            symbol = %symbol,
-            listen_addr = %settings.listen_addr,
-            action = "wait_for_manual_bridge",
-            "cannot derive a dial address from listen_addr; not starting a bridge"
-        );
-        return;
-    };
-    let Some((program, extra)) = settings.bridge_command.split_first() else {
-        warn!(
-            target: "quantick::app",
-            schema_version = 1_u8,
-            event_code = "MT5_BRIDGE_AUTOSTART_SKIPPED",
-            symbol = %symbol,
-            action = "wait_for_manual_bridge",
-            "bridge_command is empty; not starting a bridge"
-        );
-        return;
-    };
-
-    tokio::time::sleep(BRIDGE_AUTOSTART_GRACE).await;
-    for attempt in 1..=BRIDGE_AUTOSTART_ATTEMPTS {
-        if connected.load(Ordering::Relaxed) {
-            info!(
-                target: "quantick::app",
-                schema_version = 1_u8,
-                event_code = "MT5_BRIDGE_AUTOSTART_NOT_NEEDED",
-                symbol = %symbol,
-                action = "leave_running_bridge_alone",
-                "a bridge is already connected; quantick started none of its own"
-            );
-            return;
-        }
-
-        let mut command = Command::new(program);
-        command
-            .args(extra)
-            .arg("--symbol")
-            .arg(&symbol)
-            .arg("--host")
-            .arg(host)
-            .arg("--port")
-            .arg(port)
-            // The bridge speaks the same structured-log vocabulary, so letting
-            // it write to our streams keeps one story in one place.
-            .stdin(Stdio::null())
-            .kill_on_drop(true);
-
-        match command.spawn() {
-            Ok(mut child) => {
-                info!(
-                    target: "quantick::app",
-                    schema_version = 1_u8,
-                    event_code = "MT5_BRIDGE_SPAWNED",
-                    symbol = %symbol,
-                    program = %program,
-                    pid = child.id(),
-                    attempt,
-                    host,
-                    port,
-                    "started a bridge for this feed"
-                );
-                let status = child.wait().await;
-                warn!(
-                    target: "quantick::app",
-                    schema_version = 1_u8,
-                    event_code = "MT5_BRIDGE_EXITED",
-                    symbol = %symbol,
-                    attempt,
-                    max_attempts = BRIDGE_AUTOSTART_ATTEMPTS,
-                    status = ?status.map(|s| s.code()),
-                    action = "retry_after_backoff",
-                    "the bridge quantick started has exited"
-                );
-            }
-            Err(error) => {
-                warn!(
-                    target: "quantick::app",
-                    schema_version = 1_u8,
-                    event_code = "MT5_BRIDGE_SPAWN_FAILED",
-                    symbol = %symbol,
-                    program = %program,
-                    attempt,
-                    %error,
-                    action = "retry_after_backoff",
-                    "could not start the bridge (is it on PATH? is the working directory the repo?)"
-                );
-            }
-        }
-        tokio::time::sleep(BRIDGE_AUTOSTART_RETRY).await;
-    }
-
-    warn!(
-        target: "quantick::app",
-        schema_version = 1_u8,
-        event_code = "MT5_BRIDGE_AUTOSTART_GAVE_UP",
-        symbol = %symbol,
-        attempts = BRIDGE_AUTOSTART_ATTEMPTS,
-        action = "wait_for_manual_bridge",
-        "the bridge would not stay up; read its own log lines above for the reason"
-    );
 }
 
 /// After a fatal listener error, keep answering UI commands honestly (empty

--- a/crates/app/src/feed/mod.rs
+++ b/crates/app/src/feed/mod.rs
@@ -14,6 +14,7 @@
 
 pub mod binance;
 pub mod metatrader;
+pub mod mt5_bridge;
 pub mod replay;
 
 use tokio::sync::mpsc;
@@ -90,6 +91,64 @@ pub enum FeedSource {
     Replay(Box<replay::ReplayRequest>),
 }
 
+/// What a feed wants the person watching the chart to know.
+///
+/// A feed that cannot deliver trades knows *why* — the terminal is closed, a
+/// package is missing, the contract does not exist. Before this channel that
+/// reason only ever reached a log file, and the chart stayed blank with a
+/// faint "connecting" dot: honest, but useless to anyone not reading stderr.
+///
+/// The distinction the UI acts on is **who has to do something next**.
+/// [`Working`](Self::Working) is the feed's own business, still in progress;
+/// [`Attention`](Self::Attention) needs a human, and always carries the one
+/// next step in plain words. Feeds that never get stuck simply never send
+/// anything.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FeedNotice {
+    /// Whatever was being reported is over; the chart speaks for itself now.
+    Clear,
+    /// A step is under way and needs nobody: connecting, waiting, retrying.
+    Working {
+        /// One line, e.g. `starting the MetaTrader bridge`.
+        headline: String,
+    },
+    /// Something needs the person watching — a closed terminal, a missing
+    /// package, a contract this account cannot see.
+    Attention {
+        /// What went wrong, in the user's terms.
+        headline: String,
+        /// The single next step to fix it.
+        next_step: String,
+    },
+}
+
+/// The notice channel of a feed that has nothing to say: closed at birth, so
+/// the UI reads it exactly like a feed that simply never reported trouble.
+#[must_use]
+pub fn silent_notices() -> mpsc::Receiver<FeedNotice> {
+    let (_tx, rx) = mpsc::channel(1);
+    rx
+}
+
+impl FeedNotice {
+    /// Shorthand for a step in progress.
+    #[must_use]
+    pub fn working(headline: impl Into<String>) -> Self {
+        Self::Working {
+            headline: headline.into(),
+        }
+    }
+
+    /// Shorthand for something that needs a human.
+    #[must_use]
+    pub fn attention(headline: impl Into<String>, next_step: impl Into<String>) -> Self {
+        Self::Attention {
+            headline: headline.into(),
+            next_step: next_step.into(),
+        }
+    }
+}
+
 /// The UI's handle on a running feed: events to drain, commands to send.
 pub struct FeedHandle {
     /// Feed → UI: backfill, prepended history and live trades.
@@ -99,6 +158,12 @@ pub struct FeedHandle {
     /// Depth is isolated from the established trade/bar channel so it can be
     /// stopped, restarted or backpressured independently.
     pub book_events: mpsc::Receiver<DepthEvent>,
+    /// Feed → UI: what the person watching should know about the connection.
+    ///
+    /// Its own channel rather than a [`FeedEvent`] variant: connection trouble
+    /// is not market data, and a blocked feed must be able to say so while the
+    /// trade channel sits silent — which is exactly when it matters.
+    pub notices: mpsc::Receiver<FeedNotice>,
     /// UI → feed: on-demand history loading.
     pub commands: mpsc::Sender<FeedCommand>,
     /// Present only while a recorded session is playing: what the transport bar

--- a/crates/app/src/feed/mt5_bridge.rs
+++ b/crates/app/src/feed/mt5_bridge.rs
@@ -31,7 +31,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use quantick_feed_mt5::bridge_log::{BridgeSeverity, report_for_line};
-use tokio::io::{AsyncBufReadExt, BufReader};
+use quantick_feed_mt5::{BoundedLine, BoundedLineReader, MAX_LINE_BYTES};
 use tokio::process::Command;
 use tokio::sync::mpsc;
 use tracing::{info, warn};
@@ -227,7 +227,6 @@ pub async fn supervise(settings: MetaTraderSettings, sup: Supervision) {
         }
     }
 
-    tokio::time::sleep(AUTOSTART_GRACE).await;
     let candidates = interpreter_candidates(program);
     // Which interpreter worked, so a retry does not re-probe the ones that are
     // not installed on this machine.
@@ -238,6 +237,12 @@ pub async fn supervise(settings: MetaTraderSettings, sup: Supervision) {
     // the chart should come back on its own.
     let mut failures = 0_u32;
     let mut watching_logged = false;
+    // The grace period belongs to every *episode* of silence, not just the
+    // first. Someone else's bridge — an Expert Advisor on a chart — reconnects
+    // on its own schedule (five seconds, in the one this repo ships), and
+    // racing it with our own process is what the grace exists to avoid. Losing
+    // a session arms it again.
+    let mut grace_pending = true;
     while failures < AUTOSTART_ATTEMPTS {
         let attempt = failures + 1;
         if sup.connected.load(Ordering::Relaxed) {
@@ -256,10 +261,21 @@ pub async fn supervise(settings: MetaTraderSettings, sup: Supervision) {
                 watching_logged = true;
             }
             failures = 0;
+            grace_pending = true;
             tokio::time::sleep(WATCH_INTERVAL).await;
             continue;
         }
         watching_logged = false;
+
+        if grace_pending {
+            grace_pending = false;
+            tokio::time::sleep(AUTOSTART_GRACE).await;
+            // Whoever we were waiting for may have arrived while we waited —
+            // which is the point of waiting.
+            if sup.connected.load(Ordering::Relaxed) {
+                continue;
+            }
+        }
 
         let _ = sup
             .notices
@@ -362,10 +378,54 @@ pub async fn supervise(settings: MetaTraderSettings, sup: Supervision) {
         // exit needs no second message: the reason is already on screen.
         let mut explained = false;
         if let Some(stderr) = child.stderr.take() {
-            let mut lines = BufReader::new(stderr).lines();
-            while let Ok(Some(line)) = lines.next_line().await {
-                if forward_bridge_line(&line, symbol, &sup.notices).await {
-                    explained = true;
+            // Bounded rather than `AsyncBufReadExt::lines`, which buffers a
+            // line with no newline in it forever. The same reader guards the
+            // socket path for the same reason (PR #59); a bridge is a local
+            // process, but `bridge_command` is configuration, and a runaway
+            // one must not be able to grow the chart's memory without limit.
+            let mut lines = BoundedLineReader::new(stderr);
+            loop {
+                match lines.next_line().await {
+                    Ok(BoundedLine::Line(line)) => {
+                        if forward_bridge_line(&line, symbol, &sup.notices).await {
+                            explained = true;
+                        }
+                    }
+                    Ok(BoundedLine::Eof) => break,
+                    // Neither of these ends the reading: the bridge is alive
+                    // and its next line may be the one that matters. They are
+                    // logged rather than dropped, because "every line reaches
+                    // the log" is only true if the unreadable ones say so too.
+                    Ok(BoundedLine::TooLong) => warn!(
+                        target: "quantick::app",
+                        schema_version = 1_u8,
+                        event_code = "MT5_BRIDGE_LINE_TOO_LONG",
+                        symbol = %symbol,
+                        max_bytes = MAX_LINE_BYTES as u64,
+                        action = "skip_line_keep_reading",
+                        "a bridge log line exceeded the cap and was skipped"
+                    ),
+                    Ok(BoundedLine::NotUtf8 { len }) => warn!(
+                        target: "quantick::app",
+                        schema_version = 1_u8,
+                        event_code = "MT5_BRIDGE_LINE_NOT_UTF8",
+                        symbol = %symbol,
+                        bytes = len,
+                        action = "skip_line_keep_reading",
+                        "a bridge log line was not valid UTF-8 and was skipped"
+                    ),
+                    Err(error) => {
+                        warn!(
+                            target: "quantick::app",
+                            schema_version = 1_u8,
+                            event_code = "MT5_BRIDGE_STDERR_READ_FAILED",
+                            symbol = %symbol,
+                            %error,
+                            action = "stop_reading_wait_for_exit",
+                            "could not read the bridge's output"
+                        );
+                        break;
+                    }
                 }
             }
         }
@@ -404,7 +464,7 @@ pub async fn supervise(settings: MetaTraderSettings, sup: Supervision) {
         .send(FeedNotice::attention(
             "the MetaTrader bridge would not stay running",
             "quantick stopped retrying after several attempts. Fix what the last \
-             message reported, then switch feeds to try again.",
+             message reported, then press Try again.",
         ))
         .await;
 }
@@ -435,7 +495,8 @@ fn exit_notice(explained: bool, code: Option<i32>) -> Option<FeedNotice> {
 }
 
 /// Log one bridge stderr line and, when it means something to a person, send
-/// it on as a notice. Returns whether it produced a user-facing report.
+/// it on as a notice. Returns whether the line is one the bridge stops after —
+/// i.e. whether it explains an exit that follows.
 async fn forward_bridge_line(line: &str, symbol: &str, notices: &mpsc::Sender<FeedNotice>) -> bool {
     let trimmed = line.trim();
     if trimmed.is_empty() {
@@ -454,6 +515,7 @@ async fn forward_bridge_line(line: &str, symbol: &str, notices: &mpsc::Sender<Fe
     let Some(report) = report_for_line(trimmed) else {
         return false;
     };
+    let ends_session = report.ends_session;
     let notice = match report.severity {
         BridgeSeverity::Progress => FeedNotice::working(report.headline),
         BridgeSeverity::Attention => FeedNotice::attention(
@@ -463,9 +525,11 @@ async fn forward_bridge_line(line: &str, symbol: &str, notices: &mpsc::Sender<Fe
                 .unwrap_or_else(|| "See bridge/mt5/README.md for this bridge's setup.".to_owned()),
         ),
     };
-    let needs_user = matches!(notice, FeedNotice::Attention { .. });
     let _ = notices.send(notice).await;
-    needs_user
+    // Not "did this need the user" — a symbol without a book needs the user
+    // and keeps streaming. Only a line the bridge stops after can explain the
+    // exit that follows it.
+    ends_session
 }
 
 #[cfg(test)]
@@ -602,6 +666,37 @@ mod tests {
         };
         assert!(headline.contains("MetaTrader 5"), "headline: {headline}");
         assert!(!next_step.is_empty(), "an attention always says what to do");
+    }
+
+    #[tokio::test]
+    async fn a_survivable_warning_does_not_excuse_a_later_crash() {
+        // The DOM warning needs the user and the bridge keeps running. If it
+        // counted as "explained", a bridge that later died in silence would
+        // take the chart down without a word — the exact hole this closes.
+        let (tx, mut rx) = mpsc::channel(4);
+        let explains = forward_bridge_line(
+            r#"{"event_code":"BRIDGE_BOOK_SUBSCRIBE_FAILED","symbol":"WDO$"}"#,
+            "WDO$",
+            &tx,
+        )
+        .await;
+        assert!(!explains, "it needs the user, but it explains no exit");
+        // It still reaches the chart: the heatmap will be empty and the user
+        // is told why.
+        assert!(matches!(
+            rx.recv().await,
+            Some(FeedNotice::Attention { .. })
+        ));
+
+        // A fatal one does explain the exit that follows it.
+        assert!(
+            forward_bridge_line(
+                r#"{"event_code":"BRIDGE_SYMBOL_NOT_FOUND","symbol":"WINZ99"}"#,
+                "WINZ99",
+                &tx,
+            )
+            .await
+        );
     }
 
     #[tokio::test]

--- a/crates/app/src/feed/mt5_bridge.rs
+++ b/crates/app/src/feed/mt5_bridge.rs
@@ -1,0 +1,627 @@
+//! Starting the MetaTrader bridge for the user, and saying so out loud.
+//!
+//! Selecting a MetaTrader feed should be one action. The pieces that make it
+//! one live here, apart from the feed itself, because they are a different
+//! job: the feed translates a *connected* bridge into trades, while this
+//! module is about the minutes before that — finding the script, finding an
+//! interpreter, launching it, and reporting what happened in words that mean
+//! something to someone who has never opened a terminal.
+//!
+//! Three failures were only ever visible in a log file, and all three are
+//! ordinary:
+//!
+//! - **quantick was not started from the repository.** `bridge_command`
+//!   carries a relative path, and a double-clicked binary resolves it against
+//!   whatever directory the shortcut chose. [`resolve_script`] therefore looks
+//!   beside the executable and up its ancestors as well as in the working
+//!   directory, so the same configuration works from either.
+//! - **`python` is not what the interpreter is called.** Windows installs a
+//!   `py` launcher and, on a machine with no Python at all, a stub `python.exe`
+//!   that opens the Microsoft Store. [`interpreter_candidates`] tries the
+//!   plausible names in order — but only for the default command, since a
+//!   configured one is an instruction, not a guess.
+//! - **The bridge started and then stopped.** Its exit is not the interesting
+//!   part; the JSON line it printed first is. Those lines are read, logged, and
+//!   turned into [`FeedNotice`]s through [`quantick_feed_mt5::bridge_log`].
+
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use quantick_feed_mt5::bridge_log::{BridgeSeverity, report_for_line};
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::Command;
+use tokio::sync::mpsc;
+use tracing::{info, warn};
+
+use crate::config::MetaTraderSettings;
+
+use super::FeedNotice;
+
+/// How long the autostart waits for a bridge that is already running before
+/// launching its own. Long enough for an attached Expert Advisor's reconnect
+/// cycle to notice the port, short enough that a cold start feels immediate.
+const AUTOSTART_GRACE: Duration = Duration::from_secs(3);
+
+/// Gap between autostart attempts. The common failure is a terminal still
+/// starting up, which resolves in seconds.
+const AUTOSTART_RETRY: Duration = Duration::from_secs(5);
+
+/// How many times the autostart relaunches an exiting bridge before leaving it
+/// alone. Every remaining failure (terminal closed, unknown symbol, unknown
+/// server offset) needs a human, and retrying it forever only buries the log
+/// line that says so.
+const AUTOSTART_ATTEMPTS: u32 = 5;
+
+/// The program name that means "the bridge quantick ships with", and so the
+/// only one whose interpreter quantick is allowed to second-guess.
+const DEFAULT_INTERPRETER: &str = "python";
+
+/// Interpreter names tried, in order, for the default command.
+///
+/// `py` is the launcher a standard Windows install puts on PATH, and it
+/// resolves a real interpreter even when `python` is the Store stub.
+const INTERPRETER_FALLBACKS: [&str; 2] = ["python", "py"];
+
+/// How deep to climb from the executable looking for the repository layout.
+/// `target/release/quantick-app.exe` needs three; one more absorbs a wrapper
+/// directory without turning the search into a filesystem crawl.
+const ANCESTOR_SEARCH_DEPTH: usize = 4;
+
+/// The interpreters to try for `program`, most likely first.
+///
+/// Only the shipped default gets alternatives: someone who configured
+/// `bridge_command` told quantick exactly what to run, and silently running
+/// something else would be a worse failure than the honest one.
+#[must_use]
+pub fn interpreter_candidates(program: &str) -> Vec<String> {
+    if program == DEFAULT_INTERPRETER {
+        INTERPRETER_FALLBACKS
+            .iter()
+            .map(|p| (*p).to_string())
+            .collect()
+    } else {
+        vec![program.to_string()]
+    }
+}
+
+/// Find the bridge script named by `arg`, looking in `roots` in order.
+///
+/// An absolute path is taken as given (present or not — reporting "not found"
+/// for the path someone explicitly wrote is clearer than searching elsewhere
+/// and running a different file). A relative one is resolved against each root
+/// and, for every root, against its ancestors: a binary in `target/release`
+/// is three levels below the `bridge/` folder it ships with.
+#[must_use]
+pub fn resolve_script(arg: &str, roots: &[PathBuf]) -> Option<PathBuf> {
+    let relative = Path::new(arg);
+    if relative.is_absolute() {
+        return relative.exists().then(|| relative.to_path_buf());
+    }
+    for root in roots {
+        for base in root.ancestors().take(ANCESTOR_SEARCH_DEPTH) {
+            let candidate = base.join(relative);
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+    }
+    None
+}
+
+/// The directories a bridge script is looked for under, most specific first:
+/// the working directory (how the repo runs it), then the directory holding
+/// the executable (how a shortcut or a copied build runs it).
+#[must_use]
+pub fn default_search_roots() -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+    if let Ok(cwd) = std::env::current_dir() {
+        roots.push(cwd);
+    }
+    if let Some(exe_dir) = std::env::current_exe()
+        .ok()
+        .and_then(|exe| exe.parent().map(Path::to_path_buf))
+        .filter(|exe_dir| !roots.contains(exe_dir))
+    {
+        roots.push(exe_dir);
+    }
+    roots
+}
+
+/// Everything the supervisor needs that is not configuration.
+pub struct Supervision {
+    /// The instrument the bridge is asked to stream.
+    pub symbol: String,
+    /// Flipped by the feed when any bridge says hello, so an already-running
+    /// bridge (or an attached Expert Advisor) is never fought.
+    pub connected: Arc<AtomicBool>,
+    /// Where user-facing reports go.
+    pub notices: mpsc::Sender<FeedNotice>,
+}
+
+/// Launch a bridge when nothing else is feeding us, and keep it alive.
+///
+/// Deliberately passive at the start: a bridge that is already running, or an
+/// Expert Advisor attached to a chart, gets the grace period to dial in. Only
+/// silence triggers a launch.
+pub async fn supervise(settings: MetaTraderSettings, sup: Supervision) {
+    let symbol = sup.symbol.as_str();
+    let Some((host, port)) = settings.bridge_endpoint() else {
+        warn!(
+            target: "quantick::app",
+            schema_version = 1_u8,
+            event_code = "MT5_BRIDGE_AUTOSTART_SKIPPED",
+            symbol = %symbol,
+            listen_addr = %settings.listen_addr,
+            action = "wait_for_manual_bridge",
+            "cannot derive a dial address from listen_addr; not starting a bridge"
+        );
+        return;
+    };
+    let Some((program, extra)) = settings.bridge_command.split_first() else {
+        warn!(
+            target: "quantick::app",
+            schema_version = 1_u8,
+            event_code = "MT5_BRIDGE_AUTOSTART_SKIPPED",
+            symbol = %symbol,
+            action = "wait_for_manual_bridge",
+            "bridge_command is empty; not starting a bridge"
+        );
+        return;
+    };
+
+    // The script argument is resolved once, up front: a path that does not
+    // exist is a setup problem to report, not something five launch attempts
+    // will fix.
+    let roots = default_search_roots();
+    let mut args: Vec<String> = extra.to_vec();
+    if let Some(first) = args.first_mut() {
+        match resolve_script(first, &roots) {
+            Some(found) => *first = found.to_string_lossy().into_owned(),
+            None => {
+                let looked_in = roots
+                    .iter()
+                    .map(|root| root.display().to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                warn!(
+                    target: "quantick::app",
+                    schema_version = 1_u8,
+                    event_code = "MT5_BRIDGE_SCRIPT_NOT_FOUND",
+                    symbol = %symbol,
+                    script = %first,
+                    looked_in = %looked_in,
+                    action = "wait_for_manual_bridge",
+                    "cannot find the bridge script; not starting a bridge"
+                );
+                let _ = sup
+                    .notices
+                    .send(FeedNotice::attention(
+                        "quantick cannot find the MetaTrader bridge script",
+                        format!(
+                            "Looked for {first} under: {looked_in}. Run quantick from its \
+                             folder, or set bridge_command in your configuration."
+                        ),
+                    ))
+                    .await;
+                return;
+            }
+        }
+    }
+
+    tokio::time::sleep(AUTOSTART_GRACE).await;
+    let candidates = interpreter_candidates(program);
+    // Which interpreter worked, so a retry does not re-probe the ones that are
+    // not installed on this machine.
+    let mut chosen: Option<String> = None;
+
+    for attempt in 1..=AUTOSTART_ATTEMPTS {
+        if sup.connected.load(Ordering::Relaxed) {
+            info!(
+                target: "quantick::app",
+                schema_version = 1_u8,
+                event_code = "MT5_BRIDGE_AUTOSTART_NOT_NEEDED",
+                symbol = %symbol,
+                action = "leave_running_bridge_alone",
+                "a bridge is already connected; quantick started none of its own"
+            );
+            return;
+        }
+
+        let _ = sup
+            .notices
+            .send(FeedNotice::working("starting the MetaTrader bridge"))
+            .await;
+
+        let try_now: Vec<String> = match &chosen {
+            Some(program) => vec![program.clone()],
+            None => candidates.clone(),
+        };
+        let mut child = None;
+        for program in try_now {
+            let mut command = Command::new(&program);
+            command
+                .args(&args)
+                .arg("--symbol")
+                .arg(symbol)
+                .arg("--host")
+                .arg(host)
+                .arg("--port")
+                .arg(port)
+                .stdin(Stdio::null())
+                // Read rather than inherit: the same lines still reach the log
+                // (one story, one place), and they also become something the
+                // chart can show.
+                .stderr(Stdio::piped())
+                .kill_on_drop(true);
+            match command.spawn() {
+                Ok(spawned) => {
+                    info!(
+                        target: "quantick::app",
+                        schema_version = 1_u8,
+                        event_code = "MT5_BRIDGE_SPAWNED",
+                        symbol = %symbol,
+                        program = %program,
+                        pid = spawned.id(),
+                        attempt,
+                        host,
+                        port,
+                        "started a bridge for this feed"
+                    );
+                    chosen = Some(program);
+                    child = Some(spawned);
+                    break;
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                    info!(
+                        target: "quantick::app",
+                        schema_version = 1_u8,
+                        event_code = "MT5_BRIDGE_INTERPRETER_ABSENT",
+                        symbol = %symbol,
+                        program = %program,
+                        action = "try_next_candidate",
+                        "no such interpreter on PATH"
+                    );
+                }
+                Err(error) => {
+                    warn!(
+                        target: "quantick::app",
+                        schema_version = 1_u8,
+                        event_code = "MT5_BRIDGE_SPAWN_FAILED",
+                        symbol = %symbol,
+                        program = %program,
+                        attempt,
+                        %error,
+                        action = "try_next_candidate",
+                        "could not start the bridge"
+                    );
+                }
+            }
+        }
+
+        let Some(mut child) = child else {
+            let tried = candidates.join(" or ");
+            let _ = sup
+                .notices
+                .send(FeedNotice::attention(
+                    "quantick could not start the MetaTrader bridge",
+                    format!(
+                        "No Python interpreter was found (tried {tried}). Install Python \
+                         and the MetaTrader5 package, then reconnect."
+                    ),
+                ))
+                .await;
+            warn!(
+                target: "quantick::app",
+                schema_version = 1_u8,
+                event_code = "MT5_BRIDGE_NO_INTERPRETER",
+                symbol = %symbol,
+                tried = %tried,
+                action = "retry_after_backoff",
+                "no interpreter could be started"
+            );
+            tokio::time::sleep(AUTOSTART_RETRY).await;
+            continue;
+        };
+
+        // Whether the bridge explained itself before exiting. When it did, the
+        // exit needs no second message: the reason is already on screen.
+        let mut explained = false;
+        if let Some(stderr) = child.stderr.take() {
+            let mut lines = BufReader::new(stderr).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                if forward_bridge_line(&line, symbol, &sup.notices).await {
+                    explained = true;
+                }
+            }
+        }
+
+        let status = child.wait().await;
+        warn!(
+            target: "quantick::app",
+            schema_version = 1_u8,
+            event_code = "MT5_BRIDGE_EXITED",
+            symbol = %symbol,
+            attempt,
+            max_attempts = AUTOSTART_ATTEMPTS,
+            status = ?status.as_ref().map(|s| s.code()),
+            explained,
+            action = "retry_after_backoff",
+            "the bridge quantick started has exited"
+        );
+        if !explained && !sup.connected.load(Ordering::Relaxed) {
+            let code = status.ok().and_then(|s| s.code());
+            let _ = sup
+                .notices
+                .send(FeedNotice::attention(
+                    "the MetaTrader bridge stopped",
+                    match code {
+                        Some(code) => format!(
+                            "It exited with code {code} without saying why. Check that \
+                             MetaTrader 5 is running and logged in."
+                        ),
+                        None => "It stopped without saying why. Check that MetaTrader 5 \
+                                 is running and logged in."
+                            .to_owned(),
+                    },
+                ))
+                .await;
+        }
+        tokio::time::sleep(AUTOSTART_RETRY).await;
+    }
+
+    warn!(
+        target: "quantick::app",
+        schema_version = 1_u8,
+        event_code = "MT5_BRIDGE_AUTOSTART_GAVE_UP",
+        symbol = %symbol,
+        attempts = AUTOSTART_ATTEMPTS,
+        action = "wait_for_manual_bridge",
+        "the bridge would not stay up; read its own log lines above for the reason"
+    );
+    let _ = sup
+        .notices
+        .send(FeedNotice::attention(
+            "the MetaTrader bridge would not stay running",
+            "quantick stopped retrying after several attempts. Fix what the last \
+             message reported, then switch feeds to try again.",
+        ))
+        .await;
+}
+
+/// Log one bridge stderr line and, when it means something to a person, send
+/// it on as a notice. Returns whether it produced a user-facing report.
+async fn forward_bridge_line(line: &str, symbol: &str, notices: &mpsc::Sender<FeedNotice>) -> bool {
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+    // Every line reaches the log verbatim, recognized or not: a Python
+    // traceback is exactly the case where hiding the unknown would hurt.
+    info!(
+        target: "quantick::app",
+        schema_version = 1_u8,
+        event_code = "MT5_BRIDGE_SAID",
+        symbol = %symbol,
+        line = %trimmed,
+        "bridge output"
+    );
+    let Some(report) = report_for_line(trimmed) else {
+        return false;
+    };
+    let notice = match report.severity {
+        BridgeSeverity::Progress => FeedNotice::working(report.headline),
+        BridgeSeverity::Attention => FeedNotice::attention(
+            report.headline,
+            report
+                .next_step
+                .unwrap_or_else(|| "See bridge/mt5/README.md for this bridge's setup.".to_owned()),
+        ),
+    };
+    let needs_user = matches!(notice, FeedNotice::Attention { .. });
+    let _ = notices.send(notice).await;
+    needs_user
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A throwaway directory tree, cleaned up when the test ends.
+    struct TempTree(PathBuf);
+
+    impl TempTree {
+        fn new(tag: &str) -> Self {
+            // Unique per test without a temp-file crate: the process id keeps
+            // parallel runs apart, the tag keeps tests within one run apart.
+            let path =
+                std::env::temp_dir().join(format!("quantick-bridge-{}-{tag}", std::process::id()));
+            let _ = std::fs::remove_dir_all(&path);
+            std::fs::create_dir_all(&path).expect("create temp tree");
+            Self(path)
+        }
+
+        fn file(&self, relative: &str) -> PathBuf {
+            let path = self.0.join(relative);
+            std::fs::create_dir_all(path.parent().expect("parent")).expect("create dirs");
+            std::fs::write(&path, b"# bridge").expect("write file");
+            path
+        }
+    }
+
+    impl Drop for TempTree {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn the_script_is_found_in_the_working_directory() {
+        let tree = TempTree::new("cwd");
+        let script = tree.file("bridge/mt5/quantick_bridge.py");
+        assert_eq!(
+            resolve_script(
+                "bridge/mt5/quantick_bridge.py",
+                std::slice::from_ref(&tree.0)
+            ),
+            Some(script)
+        );
+    }
+
+    #[test]
+    fn the_script_is_found_from_a_binary_deep_in_target() {
+        // The case a double-clicked build hits: the executable sits three
+        // levels below the folder that ships the bridge.
+        let tree = TempTree::new("target");
+        let script = tree.file("bridge/mt5/quantick_bridge.py");
+        std::fs::create_dir_all(tree.0.join("target/release")).expect("create target");
+        let exe_dir = tree.0.join("target/release");
+        assert_eq!(
+            resolve_script("bridge/mt5/quantick_bridge.py", &[exe_dir]),
+            Some(script)
+        );
+    }
+
+    #[test]
+    fn a_script_that_is_nowhere_is_reported_as_missing() {
+        let tree = TempTree::new("missing");
+        assert_eq!(
+            resolve_script(
+                "bridge/mt5/quantick_bridge.py",
+                std::slice::from_ref(&tree.0)
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn an_absolute_path_is_taken_as_written() {
+        let tree = TempTree::new("absolute");
+        let script = tree.file("elsewhere/bridge.py");
+        // Found without consulting any root...
+        assert_eq!(
+            resolve_script(&script.to_string_lossy(), &[]),
+            Some(script.clone())
+        );
+        // ...and a wrong absolute path is a miss, not a search elsewhere.
+        let wrong = tree.0.join("elsewhere/absent.py");
+        assert_eq!(
+            resolve_script(&wrong.to_string_lossy(), std::slice::from_ref(&tree.0)),
+            None
+        );
+    }
+
+    #[test]
+    fn a_directory_never_passes_for_a_script() {
+        let tree = TempTree::new("dir");
+        std::fs::create_dir_all(tree.0.join("bridge/mt5")).expect("create dirs");
+        assert_eq!(
+            resolve_script("bridge/mt5", std::slice::from_ref(&tree.0)),
+            None
+        );
+    }
+
+    #[test]
+    fn only_the_default_interpreter_gets_alternatives() {
+        assert_eq!(interpreter_candidates("python"), ["python", "py"]);
+        // A configured command is an instruction, not a starting point.
+        assert_eq!(interpreter_candidates("python3.12"), ["python3.12"]);
+        assert_eq!(interpreter_candidates("py"), ["py"]);
+    }
+
+    #[test]
+    fn the_search_roots_are_real_directories_without_duplicates() {
+        let roots = default_search_roots();
+        assert!(!roots.is_empty(), "at least the working directory");
+        let mut unique = roots.clone();
+        unique.dedup();
+        assert_eq!(unique.len(), roots.len(), "no root is searched twice");
+    }
+
+    #[tokio::test]
+    async fn a_fatal_bridge_line_becomes_an_actionable_notice() {
+        let (tx, mut rx) = mpsc::channel(4);
+        let produced = forward_bridge_line(
+            r#"{"event_code":"BRIDGE_TERMINAL_ATTACH_FAILED","mt5_error":"(-10005)"}"#,
+            "WINQ26",
+            &tx,
+        )
+        .await;
+        assert!(produced, "a fatal line needs the user");
+        let Some(FeedNotice::Attention {
+            headline,
+            next_step,
+        }) = rx.recv().await
+        else {
+            panic!("expected an attention notice");
+        };
+        assert!(headline.contains("MetaTrader 5"), "headline: {headline}");
+        assert!(!next_step.is_empty(), "an attention always says what to do");
+    }
+
+    #[tokio::test]
+    async fn progress_lines_do_not_count_as_an_explanation() {
+        let (tx, mut rx) = mpsc::channel(4);
+        let produced =
+            forward_bridge_line(r#"{"event_code":"BRIDGE_STARTING"}"#, "WINQ26", &tx).await;
+        assert!(!produced, "progress is not the reason a bridge died");
+        assert!(matches!(rx.recv().await, Some(FeedNotice::Working { .. })));
+    }
+
+    #[tokio::test]
+    async fn a_missing_script_is_reported_before_anything_is_launched() {
+        // The setup failure that needs no Python, no terminal and no port: the
+        // supervisor must name what it looked for and stop, rather than spend
+        // five attempts spawning an interpreter against a path that is not
+        // there.
+        let (tx, mut rx) = mpsc::channel(4);
+        let settings = MetaTraderSettings {
+            listen_addr: "127.0.0.1:9100".to_string(),
+            bridge_autostart: true,
+            bridge_command: vec![
+                "python".to_string(),
+                "definitely/not/here/quantick_bridge.py".to_string(),
+            ],
+            ..MetaTraderSettings::default()
+        };
+        supervise(
+            settings,
+            Supervision {
+                symbol: "WINQ26".to_string(),
+                connected: Arc::new(AtomicBool::new(false)),
+                notices: tx,
+            },
+        )
+        .await;
+
+        let Some(FeedNotice::Attention {
+            headline,
+            next_step,
+        }) = rx.recv().await
+        else {
+            panic!("expected an attention notice");
+        };
+        assert!(headline.contains("cannot find"), "headline: {headline}");
+        assert!(
+            next_step.contains("definitely/not/here/quantick_bridge.py"),
+            "the step must name what was looked for: {next_step}"
+        );
+    }
+
+    #[tokio::test]
+    async fn unrecognized_output_is_logged_but_says_nothing_to_the_user() {
+        let (tx, mut rx) = mpsc::channel(4);
+        for line in ["", "   ", "Traceback (most recent call last):", "{}"] {
+            assert!(
+                !forward_bridge_line(line, "WINQ26", &tx).await,
+                "line: {line}"
+            );
+        }
+        assert!(
+            rx.try_recv().is_err(),
+            "noise must not reach the chart as a notice"
+        );
+    }
+}

--- a/crates/app/src/feed/mt5_bridge.rs
+++ b/crates/app/src/feed/mt5_bridge.rs
@@ -49,11 +49,16 @@ const AUTOSTART_GRACE: Duration = Duration::from_secs(3);
 /// starting up, which resolves in seconds.
 const AUTOSTART_RETRY: Duration = Duration::from_secs(5);
 
-/// How many times the autostart relaunches an exiting bridge before leaving it
-/// alone. Every remaining failure (terminal closed, unknown symbol, unknown
-/// server offset) needs a human, and retrying it forever only buries the log
-/// line that says so.
+/// How many times in a row the autostart may fail to keep a bridge up before
+/// it stops trying. Every remaining failure (terminal closed, unknown symbol,
+/// unknown server offset) needs a human, and retrying forever only buries the
+/// line that says so. A bridge that connects resets the count, so this is a
+/// budget for *consecutive* failures, not for the session.
 const AUTOSTART_ATTEMPTS: u32 = 5;
+
+/// How often the supervisor re-checks a bridge that is connected and healthy.
+/// Only cost is one relaxed atomic load per interval.
+const WATCH_INTERVAL: Duration = Duration::from_secs(2);
 
 /// The program name that means "the bridge quantick ships with", and so the
 /// only one whose interpreter quantick is allowed to second-guess.
@@ -134,8 +139,12 @@ pub fn default_search_roots() -> Vec<PathBuf> {
 pub struct Supervision {
     /// The instrument the bridge is asked to stream.
     pub symbol: String,
-    /// Flipped by the feed when any bridge says hello, so an already-running
-    /// bridge (or an attached Expert Advisor) is never fought.
+    /// Whether a bridge is feeding us **right now** — set by the feed on
+    /// hello, cleared when the session is lost.
+    ///
+    /// "Right now" rather than "ever": an already-running bridge (or an
+    /// attached Expert Advisor) is never fought, and a terminal that restarts
+    /// mid-session is picked back up instead of leaving the chart frozen.
     pub connected: Arc<AtomicBool>,
     /// Where user-facing reports go.
     pub notices: mpsc::Sender<FeedNotice>,
@@ -146,6 +155,13 @@ pub struct Supervision {
 /// Deliberately passive at the start: a bridge that is already running, or an
 /// Expert Advisor attached to a chart, gets the grace period to dial in. Only
 /// silence triggers a launch.
+///
+/// Then it stays. The supervisor outlives any single bridge, because the
+/// terminal underneath can restart in the middle of a session — watching a
+/// healthy bridge costs one atomic load every [`WATCH_INTERVAL`], and it is
+/// what brings the chart back without the user noticing. It gives up only
+/// after [`AUTOSTART_ATTEMPTS`] *consecutive* failures, which means the setup
+/// is wrong rather than the terminal briefly away, and says so.
 pub async fn supervise(settings: MetaTraderSettings, sup: Supervision) {
     let symbol = sup.symbol.as_str();
     let Some((host, port)) = settings.bridge_endpoint() else {
@@ -217,18 +233,33 @@ pub async fn supervise(settings: MetaTraderSettings, sup: Supervision) {
     // not installed on this machine.
     let mut chosen: Option<String> = None;
 
-    for attempt in 1..=AUTOSTART_ATTEMPTS {
+    // Consecutive failures, not attempts: the supervisor outlives any single
+    // bridge, because the terminal it depends on can restart at lunchtime and
+    // the chart should come back on its own.
+    let mut failures = 0_u32;
+    let mut watching_logged = false;
+    while failures < AUTOSTART_ATTEMPTS {
+        let attempt = failures + 1;
         if sup.connected.load(Ordering::Relaxed) {
-            info!(
-                target: "quantick::app",
-                schema_version = 1_u8,
-                event_code = "MT5_BRIDGE_AUTOSTART_NOT_NEEDED",
-                symbol = %symbol,
-                action = "leave_running_bridge_alone",
-                "a bridge is already connected; quantick started none of its own"
-            );
-            return;
+            // Somebody is feeding us — our own bridge, one started by hand, or
+            // an Expert Advisor. Watch rather than return: when that one goes
+            // away, this is what brings the chart back.
+            if !watching_logged {
+                info!(
+                    target: "quantick::app",
+                    schema_version = 1_u8,
+                    event_code = "MT5_BRIDGE_AUTOSTART_NOT_NEEDED",
+                    symbol = %symbol,
+                    action = "watch_running_bridge",
+                    "a bridge is connected; quantick leaves it alone and watches"
+                );
+                watching_logged = true;
+            }
+            failures = 0;
+            tokio::time::sleep(WATCH_INTERVAL).await;
+            continue;
         }
+        watching_logged = false;
 
         let _ = sup
             .notices
@@ -322,6 +353,7 @@ pub async fn supervise(settings: MetaTraderSettings, sup: Supervision) {
                 action = "retry_after_backoff",
                 "no interpreter could be started"
             );
+            failures += 1;
             tokio::time::sleep(AUTOSTART_RETRY).await;
             continue;
         };
@@ -351,24 +383,10 @@ pub async fn supervise(settings: MetaTraderSettings, sup: Supervision) {
             action = "retry_after_backoff",
             "the bridge quantick started has exited"
         );
-        if !explained && !sup.connected.load(Ordering::Relaxed) {
-            let code = status.ok().and_then(|s| s.code());
-            let _ = sup
-                .notices
-                .send(FeedNotice::attention(
-                    "the MetaTrader bridge stopped",
-                    match code {
-                        Some(code) => format!(
-                            "It exited with code {code} without saying why. Check that \
-                             MetaTrader 5 is running and logged in."
-                        ),
-                        None => "It stopped without saying why. Check that MetaTrader 5 \
-                                 is running and logged in."
-                            .to_owned(),
-                    },
-                ))
-                .await;
+        if let Some(notice) = exit_notice(explained, status.ok().and_then(|s| s.code())) {
+            let _ = sup.notices.send(notice).await;
         }
+        failures += 1;
         tokio::time::sleep(AUTOSTART_RETRY).await;
     }
 
@@ -389,6 +407,31 @@ pub async fn supervise(settings: MetaTraderSettings, sup: Supervision) {
              message reported, then switch feeds to try again.",
         ))
         .await;
+}
+
+/// What to tell the user about a bridge that exited, given whether it already
+/// explained itself and the exit code it left behind.
+///
+/// A bridge that named its own problem needs no second message — the reason is
+/// already on screen, and replacing it with a generic one would *lose*
+/// information. Only silence needs covering.
+#[must_use]
+fn exit_notice(explained: bool, code: Option<i32>) -> Option<FeedNotice> {
+    if explained {
+        return None;
+    }
+    Some(FeedNotice::attention(
+        "the MetaTrader bridge stopped",
+        match code {
+            Some(code) => format!(
+                "It exited with code {code} without saying why. Check that MetaTrader 5 \
+                 is running and logged in."
+            ),
+            None => "It stopped without saying why. Check that MetaTrader 5 is running \
+                     and logged in."
+                .to_owned(),
+        },
+    ))
 }
 
 /// Log one bridge stderr line and, when it means something to a person, send
@@ -568,6 +611,38 @@ mod tests {
             forward_bridge_line(r#"{"event_code":"BRIDGE_STARTING"}"#, "WINQ26", &tx).await;
         assert!(!produced, "progress is not the reason a bridge died");
         assert!(matches!(rx.recv().await, Some(FeedNotice::Working { .. })));
+    }
+
+    #[test]
+    fn a_bridge_that_explained_itself_is_not_talked_over() {
+        // The reason is already on screen; replacing "MetaTrader does not list
+        // WINZ99" with "it stopped without saying why" would lose it.
+        assert_eq!(exit_notice(true, Some(2)), None);
+        assert_eq!(exit_notice(true, None), None);
+    }
+
+    #[test]
+    fn a_silent_exit_still_gets_a_reason_and_a_step() {
+        let Some(FeedNotice::Attention {
+            headline,
+            next_step,
+        }) = exit_notice(false, Some(9))
+        else {
+            panic!("a silent exit must still say something");
+        };
+        assert!(headline.contains("stopped"), "headline: {headline}");
+        assert!(
+            next_step.contains("code 9"),
+            "the code is evidence: {next_step}"
+        );
+        assert!(next_step.contains("MetaTrader 5"), "step: {next_step}");
+
+        // Killed by a signal: no code to quote, same instruction.
+        let Some(FeedNotice::Attention { next_step, .. }) = exit_notice(false, None) else {
+            panic!("a signalled exit must still say something");
+        };
+        assert!(!next_step.contains("code"), "nothing to quote: {next_step}");
+        assert!(next_step.contains("MetaTrader 5"), "step: {next_step}");
     }
 
     #[tokio::test]

--- a/crates/app/src/feed/replay.rs
+++ b/crates/app/src/feed/replay.rs
@@ -258,6 +258,9 @@ pub fn spawn(request: ReplayRequest) -> FeedHandle {
     FeedHandle {
         events: rx,
         book_events: book_rx,
+        // A file on disk needs nothing started, and a session that failed to
+        // parse never reaches this point: the browser that opened it reports.
+        notices: super::silent_notices(),
         commands: cmd_tx,
         replay: Some(link),
     }

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -21,6 +21,7 @@ mod feed;
 mod live_strip;
 mod loading;
 mod metrics;
+mod notice_card;
 mod orderflow;
 mod orderflow_engine;
 mod orderflow_render;

--- a/crates/app/src/notice_card.rs
+++ b/crates/app/src/notice_card.rs
@@ -1,0 +1,367 @@
+//! The card that tells the user what the feed is doing, and what to do about
+//! it (`docs/ux/ui-design-model.md` §8 — provenance, told at chart scale).
+//!
+//! An empty chart is ambiguous. It looks the same whether the market is quiet,
+//! MetaTrader is closed, the Python package was never installed, or the
+//! contract does not exist for this account. The status bar's faint
+//! "connecting" dot is honest about *that* it is not connected and silent
+//! about *why*, which is fine when the answer is "wait a second" and useless
+//! when the answer is "open your terminal".
+//!
+//! So the card exists to carry a [`FeedNotice`] at a size a person notices,
+//! and to obey one rule: **never cover a working chart**. It draws when the
+//! chart has nothing to show, or when the notice needs the user; a
+//! [`FeedNotice::Working`] over a live chart is what the status bar is for.
+
+use eframe::egui;
+
+use crate::feed::FeedNotice;
+use crate::theme;
+
+/// Width of the card, in pixels — wide enough for a sentence of instruction
+/// without spanning a wide monitor.
+const CARD_WIDTH_PX: f32 = 420.0;
+/// Padding inside the card, in pixels.
+const PAD_PX: f32 = 14.0;
+/// Gap between the headline and the next step, in pixels.
+const LINE_GAP_PX: f32 = 6.0;
+/// Diameter of the leading state dot, in pixels.
+const DOT_DIAMETER_PX: f32 = 8.0;
+/// Gap between the dot and the headline, in pixels.
+const DOT_GAP_PX: f32 = 8.0;
+/// Headline font size, in points.
+const HEADLINE_PT: f32 = 14.0;
+/// Next-step font size, in points.
+const STEP_PT: f32 = 12.0;
+/// Card corner radius, in pixels.
+const CORNER_RADIUS_PX: f32 = 6.0;
+/// Size of the retry button, in pixels.
+const BUTTON_SIZE_PX: egui::Vec2 = egui::vec2(96.0, 24.0);
+/// Gap between the next step and the retry button, in pixels.
+const BUTTON_GAP_PX: f32 = 10.0;
+/// How far above the chart's vertical centre the card sits, as a fraction of
+/// the chart height. Slightly high reads as an overlay rather than content.
+const VERTICAL_BIAS: f32 = 0.12;
+
+/// What the person watching asked of the card this frame.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum NoticeAction {
+    /// Nothing was clicked.
+    #[default]
+    None,
+    /// Start the feed over.
+    ///
+    /// The way out of a bridge that stopped retrying: once the reason is fixed
+    /// — terminal opened, package installed — there has to be something to
+    /// press that is not "restart quantick".
+    Retry,
+}
+
+/// Whether `notice` should be drawn over a chart holding `bars` bars.
+///
+/// Anything needing the user is always shown — a feed that died after an hour
+/// of trading is exactly when the reason matters. Progress is shown only while
+/// there is nothing else to look at.
+#[must_use]
+pub fn should_draw(notice: &FeedNotice, bars: usize) -> bool {
+    match notice {
+        FeedNotice::Clear => false,
+        FeedNotice::Attention { .. } => true,
+        FeedNotice::Working { .. } => bars == 0,
+    }
+}
+
+/// Where every piece of the card lands, measured once so drawing and hit
+/// testing can never disagree about it.
+struct Geometry {
+    /// The card's outline.
+    card: egui::Rect,
+    /// Colour carrying the severity: the dot, the border.
+    accent: egui::Color32,
+    /// The headline, already wrapped.
+    headline: std::sync::Arc<egui::Galley>,
+    /// The next step, already wrapped; absent on a progress card.
+    step: Option<std::sync::Arc<egui::Galley>>,
+    /// The retry button, present exactly when there is a step to act on.
+    button: Option<egui::Rect>,
+}
+
+/// Measure the card for `notice` inside `area`.
+///
+/// Text height depends on the fonts, so this needs a painter — but it takes
+/// no other state, and both the drawing and the tests go through it.
+fn geometry(painter: &egui::Painter, area: egui::Rect, notice: &FeedNotice) -> Option<Geometry> {
+    let (accent, headline, next_step) = match notice {
+        FeedNotice::Clear => return None,
+        FeedNotice::Working { headline } => (theme::TEXT_MUTED, headline.as_str(), None),
+        FeedNotice::Attention {
+            headline,
+            next_step,
+        } => (theme::AMBER, headline.as_str(), Some(next_step.as_str())),
+    };
+
+    let text_width = CARD_WIDTH_PX - 2.0 * PAD_PX - DOT_DIAMETER_PX - DOT_GAP_PX;
+    let headline_galley = painter.layout(
+        headline.to_owned(),
+        egui::FontId::proportional(HEADLINE_PT),
+        theme::TEXT_PRIMARY,
+        text_width,
+    );
+    let step_galley = next_step.map(|step| {
+        painter.layout(
+            step.to_owned(),
+            egui::FontId::proportional(STEP_PT),
+            theme::TEXT_MUTED,
+            text_width,
+        )
+    });
+
+    let mut height = 2.0 * PAD_PX + headline_galley.size().y;
+    if let Some(step) = &step_galley {
+        height += LINE_GAP_PX + step.size().y;
+    }
+    // Only something that needs the user gets something to press.
+    if step_galley.is_some() {
+        height += BUTTON_GAP_PX + BUTTON_SIZE_PX.y;
+    }
+    let card = egui::Rect::from_center_size(
+        egui::pos2(
+            area.center().x,
+            area.center().y - area.height() * VERTICAL_BIAS,
+        ),
+        egui::vec2(CARD_WIDTH_PX.min(area.width()), height),
+    );
+
+    let text_left = card.left() + PAD_PX + DOT_DIAMETER_PX + DOT_GAP_PX;
+    let button = step_galley.as_ref().map(|step| {
+        let top = card.top() + PAD_PX + headline_galley.size().y + LINE_GAP_PX + step.size().y;
+        egui::Rect::from_min_size(egui::pos2(text_left, top + BUTTON_GAP_PX), BUTTON_SIZE_PX)
+    });
+
+    Some(Geometry {
+        card,
+        accent,
+        headline: headline_galley,
+        step: step_galley,
+        button,
+    })
+}
+
+/// Draw the card centred in `area`. Call only when [`should_draw`] agrees.
+#[must_use]
+pub fn draw(ui: &mut egui::Ui, area: egui::Rect, notice: &FeedNotice) -> NoticeAction {
+    let painter = ui.painter().clone();
+    let Some(geometry) = geometry(&painter, area, notice) else {
+        return NoticeAction::None;
+    };
+    let Geometry {
+        card,
+        accent,
+        headline,
+        step,
+        button,
+    } = geometry;
+
+    // Chrome, not canvas: the card belongs to the interface reporting on the
+    // chart rather than to the chart. Opaque, because an instruction someone
+    // has to follow should not be read through candles; the accent carries
+    // the severity.
+    painter.rect_filled(card, egui::Rounding::same(CORNER_RADIUS_PX), theme::CHROME);
+    painter.rect_stroke(
+        card,
+        egui::Rounding::same(CORNER_RADIUS_PX),
+        egui::Stroke::new(1.0_f32, accent),
+    );
+
+    let text_left = card.left() + PAD_PX + DOT_DIAMETER_PX + DOT_GAP_PX;
+    let headline_top = card.top() + PAD_PX;
+    painter.circle_filled(
+        egui::pos2(
+            card.left() + PAD_PX + DOT_DIAMETER_PX / 2.0,
+            headline_top + HEADLINE_PT / 2.0,
+        ),
+        DOT_DIAMETER_PX / 2.0,
+        accent,
+    );
+    let headline_height = headline.size().y;
+    painter.galley(
+        egui::pos2(text_left, headline_top),
+        headline,
+        theme::TEXT_PRIMARY,
+    );
+    if let Some(step) = step {
+        painter.galley(
+            egui::pos2(text_left, headline_top + headline_height + LINE_GAP_PX),
+            step,
+            theme::TEXT_MUTED,
+        );
+    }
+    let Some(button) = button else {
+        return NoticeAction::None;
+    };
+    if ui.put(button, egui::Button::new("Try again")).clicked() {
+        NoticeAction::Retry
+    } else {
+        NoticeAction::None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Where the retry button lands for `notice`, or `None` when it has none.
+    /// Goes through [`geometry`] exactly as [`draw`] does, so a test that
+    /// clicks here clicks what the user clicks.
+    fn retry_button_rect(
+        ui: &egui::Ui,
+        area: egui::Rect,
+        notice: &FeedNotice,
+    ) -> Option<egui::Rect> {
+        geometry(ui.painter(), area, notice).and_then(|geometry| geometry.button)
+    }
+
+    #[test]
+    fn a_clear_notice_draws_nothing() {
+        assert!(!should_draw(&FeedNotice::Clear, 0));
+        assert!(!should_draw(&FeedNotice::Clear, 500));
+    }
+
+    #[test]
+    fn progress_never_covers_a_chart_that_has_bars() {
+        let working = FeedNotice::working("starting the MetaTrader bridge");
+        assert!(should_draw(&working, 0), "an empty chart explains itself");
+        assert!(
+            !should_draw(&working, 1),
+            "one bar is enough to prefer the chart"
+        );
+    }
+
+    #[test]
+    fn anything_needing_the_user_is_shown_whatever_is_on_screen() {
+        let attention = FeedNotice::attention("MetaTrader 5 is not running", "Open the terminal.");
+        assert!(should_draw(&attention, 0));
+        assert!(
+            should_draw(&attention, 10_000),
+            "a feed that died mid-session still has to say so"
+        );
+    }
+
+    /// Lay the card out for real, off-screen, in both shapes — no panicking
+    /// widget, no duplicated id, and a long instruction that must wrap.
+    #[test]
+    fn the_card_lays_out_against_a_real_context() {
+        let ctx = egui::Context::default();
+        let notices = [
+            FeedNotice::working("starting the MetaTrader bridge"),
+            FeedNotice::attention(
+                "MetaTrader does not list WINQ26",
+                "Add the contract to Market Watch, or pick the exact name your broker \
+                 uses (front-month contracts look like WINQ26). This sentence is \
+                 deliberately long so the wrap path is exercised too.",
+            ),
+        ];
+        for notice in &notices {
+            for _ in 0..2 {
+                let _ = ctx.run(egui::RawInput::default(), |ctx| {
+                    egui::CentralPanel::default().show(ctx, |ui| {
+                        let area = egui::Rect::from_min_max(
+                            egui::pos2(0.0, 0.0),
+                            egui::pos2(900.0, 600.0),
+                        );
+                        assert_eq!(
+                            draw(ui, area, notice),
+                            NoticeAction::None,
+                            "an un-clicked frame asks for nothing"
+                        );
+                    });
+                });
+            }
+        }
+    }
+
+    /// Clicking the button is the whole point of it, so the test clicks it —
+    /// laying the card out once to learn where it landed, then pressing there.
+    #[test]
+    fn the_retry_button_reports_a_real_click() {
+        let ctx = egui::Context::default();
+        let area = egui::Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(900.0, 600.0));
+        let notice = FeedNotice::attention(
+            "MetaTrader 5 is not running",
+            "Open the terminal and log in.",
+        );
+
+        // Frame 1: draw, and capture where the button was put.
+        let mut button = egui::Rect::NOTHING;
+        let _ = ctx.run(egui::RawInput::default(), |ctx| {
+            egui::CentralPanel::default().show(ctx, |ui| {
+                let action = draw(ui, area, &notice);
+                assert_eq!(action, NoticeAction::None, "nothing was pressed yet");
+                button = retry_button_rect(ui, area, &notice).expect("attention has a button");
+            });
+        });
+        assert!(
+            area.contains(button.center()),
+            "button {button:?} escaped the chart"
+        );
+
+        // Frame 2: press and release inside it.
+        let click_at = button.center();
+        let input = egui::RawInput {
+            events: vec![
+                egui::Event::PointerMoved(click_at),
+                egui::Event::PointerButton {
+                    pos: click_at,
+                    button: egui::PointerButton::Primary,
+                    pressed: true,
+                    modifiers: egui::Modifiers::default(),
+                },
+                egui::Event::PointerButton {
+                    pos: click_at,
+                    button: egui::PointerButton::Primary,
+                    pressed: false,
+                    modifiers: egui::Modifiers::default(),
+                },
+            ],
+            ..Default::default()
+        };
+        let mut action = NoticeAction::None;
+        let _ = ctx.run(input, |ctx| {
+            egui::CentralPanel::default().show(ctx, |ui| {
+                action = draw(ui, area, &notice);
+            });
+        });
+        assert_eq!(action, NoticeAction::Retry, "a click on it must mean retry");
+    }
+
+    #[test]
+    fn a_progress_card_has_no_button_to_click() {
+        let ctx = egui::Context::default();
+        let area = egui::Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(900.0, 600.0));
+        let notice = FeedNotice::working("starting the MetaTrader bridge");
+        let _ = ctx.run(egui::RawInput::default(), |ctx| {
+            egui::CentralPanel::default().show(ctx, |ui| {
+                assert_eq!(retry_button_rect(ui, area, &notice), None);
+            });
+        });
+    }
+
+    /// A chart narrower than the card must still produce a card inside it.
+    #[test]
+    fn a_narrow_chart_does_not_overflow_the_card() {
+        let ctx = egui::Context::default();
+        let notice = FeedNotice::attention("headline", "step");
+        let _ = ctx.run(egui::RawInput::default(), |ctx| {
+            egui::CentralPanel::default().show(ctx, |ui| {
+                let area = egui::Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(200.0, 150.0));
+                assert_eq!(draw(ui, area, &notice), NoticeAction::None);
+                // The card is clamped to the chart, and its button with it.
+                let button = retry_button_rect(ui, area, &notice).expect("a button");
+                assert!(
+                    button.width() <= area.width(),
+                    "button {button:?} is wider than the chart"
+                );
+            });
+        });
+    }
+}

--- a/crates/app/src/notice_card.rs
+++ b/crates/app/src/notice_card.rs
@@ -19,8 +19,13 @@ use crate::feed::FeedNotice;
 use crate::theme;
 
 /// Width of the card, in pixels — wide enough for a sentence of instruction
-/// without spanning a wide monitor.
+/// without spanning a wide monitor. Clamped to the chart when it is narrower.
 const CARD_WIDTH_PX: f32 = 420.0;
+/// Floor for the text column, in pixels. A chart narrow enough to drive this
+/// negative would otherwise wrap every word onto its own line, or panic the
+/// layout; the card is unreadable at that size either way, and this keeps it
+/// merely cramped.
+const MIN_TEXT_WIDTH_PX: f32 = 40.0;
 /// Padding inside the card, in pixels.
 const PAD_PX: f32 = 14.0;
 /// Gap between the headline and the next step, in pixels.
@@ -100,7 +105,11 @@ fn geometry(painter: &egui::Painter, area: egui::Rect, notice: &FeedNotice) -> O
         } => (theme::AMBER, headline.as_str(), Some(next_step.as_str())),
     };
 
-    let text_width = CARD_WIDTH_PX - 2.0 * PAD_PX - DOT_DIAMETER_PX - DOT_GAP_PX;
+    // Wrap against the width the card will actually have, not the width it
+    // would like: on a narrow chart the card is clamped, and text wrapped to
+    // the unclamped width spills past its own border.
+    let width = CARD_WIDTH_PX.min(area.width());
+    let text_width = (width - 2.0 * PAD_PX - DOT_DIAMETER_PX - DOT_GAP_PX).max(MIN_TEXT_WIDTH_PX);
     let headline_galley = painter.layout(
         headline.to_owned(),
         egui::FontId::proportional(HEADLINE_PT),
@@ -129,7 +138,7 @@ fn geometry(painter: &egui::Painter, area: egui::Rect, notice: &FeedNotice) -> O
             area.center().x,
             area.center().y - area.height() * VERTICAL_BIAS,
         ),
-        egui::vec2(CARD_WIDTH_PX.min(area.width()), height),
+        egui::vec2(width, height),
     );
 
     let text_left = card.left() + PAD_PX + DOT_DIAMETER_PX + DOT_GAP_PX;
@@ -344,6 +353,54 @@ mod tests {
                 assert_eq!(retry_button_rect(ui, area, &notice), None);
             });
         });
+    }
+
+    /// Wrapped text must stay inside the card, including when the chart is
+    /// narrower than the card wants to be. The instruction is deliberately
+    /// long: short strings never wrap, so they cannot catch this.
+    #[test]
+    fn a_long_instruction_stays_inside_a_narrow_card() {
+        let ctx = egui::Context::default();
+        let notice = FeedNotice::attention(
+            "MetaTrader does not list WINZ99",
+            "Add the contract to Market Watch, or pick the exact name your broker uses \
+             (front-month contracts look like WINQ26).",
+        );
+        for chart_width in [900.0_f32, 420.0, 300.0, 180.0] {
+            let _ = ctx.run(egui::RawInput::default(), |ctx| {
+                egui::CentralPanel::default().show(ctx, |ui| {
+                    let area = egui::Rect::from_min_max(
+                        egui::pos2(0.0, 0.0),
+                        egui::pos2(chart_width, 600.0),
+                    );
+                    let geometry = geometry(ui.painter(), area, &notice).expect("a card");
+                    assert!(
+                        geometry.card.width() <= area.width() + f32::EPSILON,
+                        "card {} wider than chart {chart_width}",
+                        geometry.card.width()
+                    );
+                    // The text column plus its padding is what actually has to
+                    // fit — the bug this guards let it wrap to 376 px inside a
+                    // 180 px card.
+                    let text_right_edge =
+                        PAD_PX + DOT_DIAMETER_PX + DOT_GAP_PX + geometry.headline.size().x + PAD_PX;
+                    assert!(
+                        text_right_edge <= geometry.card.width() + 1.0,
+                        "headline needs {text_right_edge} px inside a {} px card (chart {chart_width})",
+                        geometry.card.width()
+                    );
+                    if let Some(step) = &geometry.step {
+                        let step_right_edge =
+                            PAD_PX + DOT_DIAMETER_PX + DOT_GAP_PX + step.size().x + PAD_PX;
+                        assert!(
+                            step_right_edge <= geometry.card.width() + 1.0,
+                            "step needs {step_right_edge} px inside a {} px card (chart {chart_width})",
+                            geometry.card.width()
+                        );
+                    }
+                });
+            });
+        }
     }
 
     /// A chart narrower than the card must still produce a card inside it.

--- a/crates/feed-mt5/src/bridge_log.rs
+++ b/crates/feed-mt5/src/bridge_log.rs
@@ -1,0 +1,268 @@
+//! What a bridge says about itself on stderr, read as something a person can
+//! act on.
+//!
+//! Both bridges (`bridge/mt5/quantick_bridge.py` and the `QuantickBridge.mq5`
+//! Expert Advisor) print one JSON object per line, each carrying an
+//! `event_code` from a fixed vocabulary — the same vocabulary this crate uses
+//! for its own `MT5_*` logs. That was already enough to *diagnose* a broken
+//! setup by reading a log file. It was not enough to *tell* someone, in the
+//! chart they are staring at, that MetaTrader is closed.
+//!
+//! This module is the translation: bridge line in, [`BridgeReport`] out, with
+//! the one next step spelled out for the codes a normal user can actually hit.
+//! It stays here rather than in the app because the vocabulary is the bridge's,
+//! and this crate is where the bridge protocol already lives — a second copy of
+//! these strings next to the UI would drift the first time a code is renamed.
+//!
+//! Unrecognized and non-JSON lines report nothing. A bridge is allowed to log
+//! whatever it likes (a Python traceback is not JSON); silence here means "keep
+//! this in the log", not "swallow it", and the caller still logs the raw line.
+
+use serde_json::Value;
+
+/// How much a bridge line matters to the person watching the chart.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BridgeSeverity {
+    /// Something is under way and needs nobody: starting, retrying, waiting.
+    Progress,
+    /// Nothing more will happen until a human does something.
+    Attention,
+}
+
+/// One bridge line, translated for a reader who is not reading logs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BridgeReport {
+    /// The `event_code` this came from, so logs and UI can be correlated.
+    pub event_code: String,
+    /// Whether this needs the user.
+    pub severity: BridgeSeverity,
+    /// What happened, in the user's terms — no event codes, no jargon.
+    pub headline: String,
+    /// The single next step. Always present for [`BridgeSeverity::Attention`];
+    /// progress reports have nothing to ask for.
+    pub next_step: Option<String>,
+}
+
+impl BridgeReport {
+    fn progress(code: &str, headline: impl Into<String>) -> Self {
+        Self {
+            event_code: code.to_owned(),
+            severity: BridgeSeverity::Progress,
+            headline: headline.into(),
+            next_step: None,
+        }
+    }
+
+    fn attention(code: &str, headline: impl Into<String>, next_step: impl Into<String>) -> Self {
+        Self {
+            event_code: code.to_owned(),
+            severity: BridgeSeverity::Attention,
+            headline: headline.into(),
+            next_step: Some(next_step.into()),
+        }
+    }
+}
+
+/// The `event_code` of one bridge stderr line, if it has one.
+///
+/// Useful on its own for callers that log every line but only react to some.
+#[must_use]
+pub fn event_code_of(line: &str) -> Option<String> {
+    let value: Value = serde_json::from_str(line.trim()).ok()?;
+    Some(value.get("event_code")?.as_str()?.to_owned())
+}
+
+/// Translate one bridge stderr line, or `None` when it says nothing a user
+/// needs (unknown code, routine statistics, or not JSON at all).
+#[must_use]
+pub fn report_for_line(line: &str) -> Option<BridgeReport> {
+    let value: Value = serde_json::from_str(line.trim()).ok()?;
+    let code = value.get("event_code")?.as_str()?;
+    let field = |name: &str| {
+        value
+            .get(name)
+            .and_then(Value::as_str)
+            .map(str::to_owned)
+            .filter(|text| !text.is_empty())
+    };
+    let symbol = field("symbol").unwrap_or_else(|| "that contract".to_owned());
+
+    let report = match code {
+        // -- fatal, and every one of them has a fix the user can perform ----
+        "BRIDGE_NO_MT5_PACKAGE" => BridgeReport::attention(
+            code,
+            "The MetaTrader 5 Python package is missing",
+            "Install it once, then reconnect: pip install MetaTrader5",
+        ),
+        "BRIDGE_TERMINAL_ATTACH_FAILED" => BridgeReport::attention(
+            code,
+            "MetaTrader 5 is not running, or is not logged in",
+            "Open the MetaTrader 5 terminal and log in — quantick keeps retrying.",
+        ),
+        "BRIDGE_SYMBOL_NOT_FOUND" => BridgeReport::attention(
+            code,
+            format!("MetaTrader does not list {symbol}"),
+            "Add the contract to Market Watch, or pick the exact name your \
+             broker uses (front-month contracts look like WINQ26).",
+        ),
+        "BRIDGE_SYMBOL_SELECT_FAILED" => BridgeReport::attention(
+            code,
+            format!("MetaTrader would not open {symbol}"),
+            "Right-click it in Market Watch and choose Show, then reconnect.",
+        ),
+        "BRIDGE_UTC_OFFSET_UNKNOWN" => BridgeReport::attention(
+            code,
+            "The market is quiet, so the server clock could not be measured",
+            "Connect once while the market trades — quantick then remembers the \
+             offset. Timestamps are never guessed.",
+        ),
+        // -- under way, nothing to do --------------------------------------
+        "BRIDGE_STARTING" => BridgeReport::progress(code, "starting the MetaTrader bridge"),
+        "BRIDGE_UTC_OFFSET_MARKET_QUIET" => BridgeReport::progress(
+            code,
+            "market is quiet — reading the server clock from the last session",
+        ),
+        "BRIDGE_SESSION_STARTED" => {
+            BridgeReport::progress(code, format!("loading {symbol} history from MetaTrader"))
+        }
+        "BRIDGE_BACKFILL_FAILED" => BridgeReport::progress(
+            code,
+            "MetaTrader returned no history; the chart starts from live trades",
+        ),
+        "BRIDGE_DISCONNECTED" => {
+            BridgeReport::progress(code, "the bridge lost its connection — reconnecting")
+        }
+        // -- streaming, but with less than the full picture ------------------
+        "BRIDGE_BOOK_SUBSCRIBE_FAILED" => BridgeReport::attention(
+            code,
+            format!("{symbol} has no Depth of Market in this terminal"),
+            "Trades keep streaming; the book heatmap stays empty. Ask your \
+             broker to enable DOM for this contract.",
+        ),
+        _ => return None,
+    };
+    Some(report)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_missing_package_names_the_command_that_fixes_it() {
+        let report = report_for_line(
+            r#"{"event_code":"BRIDGE_NO_MT5_PACKAGE","hint":"pip install MetaTrader5"}"#,
+        )
+        .expect("a user-visible report");
+        assert_eq!(report.severity, BridgeSeverity::Attention);
+        let step = report.next_step.expect("attention always has a next step");
+        assert!(step.contains("pip install MetaTrader5"), "step was: {step}");
+    }
+
+    #[test]
+    fn an_unknown_contract_is_named_in_the_headline() {
+        let report = report_for_line(
+            r#"{"event_code":"BRIDGE_SYMBOL_NOT_FOUND","symbol":"WINZ99","hint":"check"}"#,
+        )
+        .expect("a user-visible report");
+        assert!(
+            report.headline.contains("WINZ99"),
+            "headline was: {}",
+            report.headline
+        );
+    }
+
+    #[test]
+    fn a_symbol_less_line_still_reads_as_a_sentence() {
+        // The field is optional in the protocol; the report must not print an
+        // empty gap where the contract name would go.
+        let report = report_for_line(r#"{"event_code":"BRIDGE_SYMBOL_NOT_FOUND"}"#)
+            .expect("a user-visible report");
+        assert!(report.headline.contains("that contract"));
+        // An empty string counts as absent, not as a contract called "".
+        let empty = report_for_line(r#"{"event_code":"BRIDGE_SYMBOL_NOT_FOUND","symbol":""}"#)
+            .expect("a user-visible report");
+        assert_eq!(empty.headline, report.headline);
+    }
+
+    #[test]
+    fn progress_lines_ask_for_nothing() {
+        for line in [
+            r#"{"event_code":"BRIDGE_STARTING","symbol":"WINQ26"}"#,
+            r#"{"event_code":"BRIDGE_SESSION_STARTED","symbol":"WINQ26","book":true}"#,
+            r#"{"event_code":"BRIDGE_DISCONNECTED","reason":"eof"}"#,
+        ] {
+            let report = report_for_line(line).expect("a user-visible report");
+            assert_eq!(report.severity, BridgeSeverity::Progress, "line: {line}");
+            assert!(report.next_step.is_none(), "line: {line}");
+        }
+    }
+
+    #[test]
+    fn a_book_less_symbol_says_what_is_lost_and_what_still_works() {
+        let report = report_for_line(
+            r#"{"event_code":"BRIDGE_BOOK_SUBSCRIBE_FAILED","symbol":"WDO$","mt5_error":"(0)"}"#,
+        )
+        .expect("a user-visible report");
+        assert_eq!(report.severity, BridgeSeverity::Attention);
+        let step = report.next_step.expect("attention always has a next step");
+        assert!(step.contains("Trades keep streaming"), "step was: {step}");
+    }
+
+    #[test]
+    fn noise_reports_nothing_and_never_panics() {
+        for line in [
+            "",
+            "   ",
+            "Traceback (most recent call last):",
+            "  File \"quantick_bridge.py\", line 1, in <module>",
+            "{not json",
+            "[]",
+            "{}",
+            r#"{"event_code":42}"#,
+            r#"{"event_code":"BRIDGE_BOOK_STATS","images_sent":10}"#,
+        ] {
+            assert!(report_for_line(line).is_none(), "line: {line}");
+        }
+    }
+
+    #[test]
+    fn the_event_code_is_readable_on_its_own() {
+        assert_eq!(
+            event_code_of(r#"{"event_code":"BRIDGE_BOOK_STATS","images_sent":1}"#).as_deref(),
+            Some("BRIDGE_BOOK_STATS")
+        );
+        assert_eq!(event_code_of("not json"), None);
+    }
+
+    #[test]
+    fn every_attention_carries_a_step_and_every_progress_does_not() {
+        // The invariant the UI leans on: an amber card always has something to
+        // do under it. Checked across the whole table rather than per case.
+        const LINES: [&str; 10] = [
+            r#"{"event_code":"BRIDGE_NO_MT5_PACKAGE"}"#,
+            r#"{"event_code":"BRIDGE_TERMINAL_ATTACH_FAILED"}"#,
+            r#"{"event_code":"BRIDGE_SYMBOL_NOT_FOUND","symbol":"WINQ26"}"#,
+            r#"{"event_code":"BRIDGE_SYMBOL_SELECT_FAILED","symbol":"WINQ26"}"#,
+            r#"{"event_code":"BRIDGE_UTC_OFFSET_UNKNOWN"}"#,
+            r#"{"event_code":"BRIDGE_BOOK_SUBSCRIBE_FAILED","symbol":"WINQ26"}"#,
+            r#"{"event_code":"BRIDGE_STARTING"}"#,
+            r#"{"event_code":"BRIDGE_UTC_OFFSET_MARKET_QUIET"}"#,
+            r#"{"event_code":"BRIDGE_SESSION_STARTED","symbol":"WINQ26"}"#,
+            r#"{"event_code":"BRIDGE_BACKFILL_FAILED"}"#,
+        ];
+        for line in LINES {
+            let report = report_for_line(line).expect("a user-visible report");
+            assert!(!report.headline.is_empty(), "line: {line}");
+            match report.severity {
+                BridgeSeverity::Attention => {
+                    let step = report.next_step.unwrap_or_default();
+                    assert!(!step.is_empty(), "no next step for: {line}");
+                }
+                BridgeSeverity::Progress => {
+                    assert!(report.next_step.is_none(), "line: {line}");
+                }
+            }
+        }
+    }
+}

--- a/crates/feed-mt5/src/bridge_log.rs
+++ b/crates/feed-mt5/src/bridge_log.rs
@@ -41,6 +41,14 @@ pub struct BridgeReport {
     /// The single next step. Always present for [`BridgeSeverity::Attention`];
     /// progress reports have nothing to ask for.
     pub next_step: Option<String>,
+    /// Whether the bridge stops after printing this.
+    ///
+    /// Separate from [`severity`](Self::severity) because the two really do
+    /// come apart: a symbol with no Depth of Market needs the user *and* keeps
+    /// streaming trades. A caller watching for "did it explain why it died?"
+    /// must ask this, not whether something needed attention at some point —
+    /// otherwise one survivable warning silences every later crash.
+    pub ends_session: bool,
 }
 
 impl BridgeReport {
@@ -50,15 +58,30 @@ impl BridgeReport {
             severity: BridgeSeverity::Progress,
             headline: headline.into(),
             next_step: None,
+            ends_session: false,
         }
     }
 
-    fn attention(code: &str, headline: impl Into<String>, next_step: impl Into<String>) -> Self {
+    /// Needs the user, and the bridge exits after saying it.
+    fn fatal(code: &str, headline: impl Into<String>, next_step: impl Into<String>) -> Self {
         Self {
             event_code: code.to_owned(),
             severity: BridgeSeverity::Attention,
             headline: headline.into(),
             next_step: Some(next_step.into()),
+            ends_session: true,
+        }
+    }
+
+    /// Needs the user, but the bridge carries on with less than the full
+    /// picture.
+    fn survivable(code: &str, headline: impl Into<String>, next_step: impl Into<String>) -> Self {
+        Self {
+            event_code: code.to_owned(),
+            severity: BridgeSeverity::Attention,
+            headline: headline.into(),
+            next_step: Some(next_step.into()),
+            ends_session: false,
         }
     }
 }
@@ -89,28 +112,28 @@ pub fn report_for_line(line: &str) -> Option<BridgeReport> {
 
     let report = match code {
         // -- fatal, and every one of them has a fix the user can perform ----
-        "BRIDGE_NO_MT5_PACKAGE" => BridgeReport::attention(
+        "BRIDGE_NO_MT5_PACKAGE" => BridgeReport::fatal(
             code,
             "The MetaTrader 5 Python package is missing",
             "Install it once, then reconnect: pip install MetaTrader5",
         ),
-        "BRIDGE_TERMINAL_ATTACH_FAILED" => BridgeReport::attention(
+        "BRIDGE_TERMINAL_ATTACH_FAILED" => BridgeReport::fatal(
             code,
             "MetaTrader 5 is not running, or is not logged in",
             "Open the MetaTrader 5 terminal and log in — quantick keeps retrying.",
         ),
-        "BRIDGE_SYMBOL_NOT_FOUND" => BridgeReport::attention(
+        "BRIDGE_SYMBOL_NOT_FOUND" => BridgeReport::fatal(
             code,
             format!("MetaTrader does not list {symbol}"),
             "Add the contract to Market Watch, or pick the exact name your \
              broker uses (front-month contracts look like WINQ26).",
         ),
-        "BRIDGE_SYMBOL_SELECT_FAILED" => BridgeReport::attention(
+        "BRIDGE_SYMBOL_SELECT_FAILED" => BridgeReport::fatal(
             code,
             format!("MetaTrader would not open {symbol}"),
             "Right-click it in Market Watch and choose Show, then reconnect.",
         ),
-        "BRIDGE_UTC_OFFSET_UNKNOWN" => BridgeReport::attention(
+        "BRIDGE_UTC_OFFSET_UNKNOWN" => BridgeReport::fatal(
             code,
             "The market is quiet, so the server clock could not be measured",
             "Connect once while the market trades — quantick then remembers the \
@@ -133,7 +156,7 @@ pub fn report_for_line(line: &str) -> Option<BridgeReport> {
             BridgeReport::progress(code, "the bridge lost its connection — reconnecting")
         }
         // -- streaming, but with less than the full picture ------------------
-        "BRIDGE_BOOK_SUBSCRIBE_FAILED" => BridgeReport::attention(
+        "BRIDGE_BOOK_SUBSCRIBE_FAILED" => BridgeReport::survivable(
             code,
             format!("{symbol} has no Depth of Market in this terminal"),
             "Trades keep streaming; the book heatmap stays empty. Ask your \
@@ -195,6 +218,42 @@ mod tests {
             let report = report_for_line(line).expect("a user-visible report");
             assert_eq!(report.severity, BridgeSeverity::Progress, "line: {line}");
             assert!(report.next_step.is_none(), "line: {line}");
+        }
+    }
+
+    /// The distinction a caller leans on to decide whether a bridge that died
+    /// already said why. Mirrors `bridge/mt5/quantick_bridge.py`: everything
+    /// that raises `BridgeExit` ends the session; the DOM warning does not.
+    #[test]
+    fn only_the_codes_that_stop_the_bridge_end_the_session() {
+        let ends = |line: &str| {
+            report_for_line(line)
+                .expect("a user-visible report")
+                .ends_session
+        };
+        for line in [
+            r#"{"event_code":"BRIDGE_NO_MT5_PACKAGE"}"#,
+            r#"{"event_code":"BRIDGE_TERMINAL_ATTACH_FAILED"}"#,
+            r#"{"event_code":"BRIDGE_SYMBOL_NOT_FOUND","symbol":"WINQ26"}"#,
+            r#"{"event_code":"BRIDGE_SYMBOL_SELECT_FAILED","symbol":"WINQ26"}"#,
+            r#"{"event_code":"BRIDGE_UTC_OFFSET_UNKNOWN"}"#,
+        ] {
+            assert!(ends(line), "this one exits the process: {line}");
+        }
+        // Needs the user *and* keeps streaming: the heatmap stays empty while
+        // trades carry on. Treating it as "explained itself" would silence
+        // every later crash of the same bridge.
+        assert!(!ends(
+            r#"{"event_code":"BRIDGE_BOOK_SUBSCRIBE_FAILED","symbol":"WDO$"}"#
+        ));
+        for line in [
+            r#"{"event_code":"BRIDGE_STARTING"}"#,
+            r#"{"event_code":"BRIDGE_SESSION_STARTED","symbol":"WINQ26"}"#,
+            r#"{"event_code":"BRIDGE_DISCONNECTED"}"#,
+            r#"{"event_code":"BRIDGE_BACKFILL_FAILED"}"#,
+            r#"{"event_code":"BRIDGE_UTC_OFFSET_MARKET_QUIET"}"#,
+        ] {
+            assert!(!ends(line), "progress never ends the session: {line}");
         }
     }
 

--- a/crates/feed-mt5/src/lib.rs
+++ b/crates/feed-mt5/src/lib.rs
@@ -90,6 +90,6 @@ pub use map::{DropReason, MapOutcome, MapStats, SideMode, SideSource, TickMapper
 pub use protocol::{BridgeMsg, Hello, ParseError, SCHEMA_VERSION, Tick, parse_line};
 pub use session::{SeqAnomaly, SeqTracker};
 pub use stream::{
-    BookCaptureSwitch, DEFAULT_LISTEN_ADDR, Mt5Error, Mt5Event, Mt5Status, ServerConfig,
-    run_bridge_server,
+    BookCaptureSwitch, BoundedLine, BoundedLineReader, DEFAULT_LISTEN_ADDR, MAX_LINE_BYTES,
+    Mt5Error, Mt5Event, Mt5Status, ServerConfig, run_bridge_server,
 };

--- a/crates/feed-mt5/src/lib.rs
+++ b/crates/feed-mt5/src/lib.rs
@@ -77,12 +77,14 @@
 //! empirically on B3 `WIN$N`, 2026-07-23: every tick flagged BUY, `flags =
 //! 1080`). Re-verify any broker with `tools/mt5/record_ticks.py`.
 
+pub mod bridge_log;
 pub mod depth;
 pub mod map;
 pub mod protocol;
 pub mod session;
 pub mod stream;
 
+pub use bridge_log::{BridgeReport, BridgeSeverity, report_for_line};
 pub use depth::{BookMapper, BookStats};
 pub use map::{DropReason, MapOutcome, MapStats, SideMode, SideSource, TickMapper};
 pub use protocol::{BridgeMsg, Hello, ParseError, SCHEMA_VERSION, Tick, parse_line};

--- a/crates/feed-mt5/src/stream.rs
+++ b/crates/feed-mt5/src/stream.rs
@@ -33,7 +33,7 @@ pub const DEFAULT_LISTEN_ADDR: &str = "127.0.0.1:9100";
 /// Longest line the server will buffer. Protocol lines are a few hundred
 /// bytes; anything larger is not the bridge, and an unbounded buffer would let
 /// any local process exhaust memory by streaming bytes without a newline.
-const MAX_LINE_BYTES: usize = 64 * 1024;
+pub const MAX_LINE_BYTES: usize = 64 * 1024;
 
 /// Runtime switch controlling whether DOM images are published.
 ///
@@ -839,8 +839,69 @@ fn snippet(line: &str) -> &str {
     }
 }
 
-/// One read from the bounded line reader.
-enum BoundedLine {
+#[cfg(test)]
+mod bounded_reader_tests {
+    use super::{BoundedLine, BoundedLineReader, MAX_LINE_BYTES};
+
+    /// The reader is generic so the app can point it at a launched bridge's
+    /// stderr, not just a socket. A cursor stands in for both.
+    #[tokio::test]
+    async fn it_reads_lines_from_any_source_not_just_a_socket() {
+        let source = std::io::Cursor::new(b"first\nsecond\r\n".to_vec());
+        let mut reader = BoundedLineReader::new(source);
+        assert_eq!(
+            reader.next_line().await.unwrap(),
+            BoundedLine::Line("first".to_owned())
+        );
+        // A CRLF terminator loses the carriage return, like the socket path.
+        assert_eq!(
+            reader.next_line().await.unwrap(),
+            BoundedLine::Line("second".to_owned())
+        );
+        assert_eq!(reader.next_line().await.unwrap(), BoundedLine::Eof);
+    }
+
+    #[tokio::test]
+    async fn an_endless_line_is_capped_and_reading_continues() {
+        // The failure this bound exists for: output with no newline in it.
+        // The oversized line is dropped, and the line after it still arrives.
+        let mut bytes = vec![b'x'; MAX_LINE_BYTES + 10];
+        bytes.push(b'\n');
+        bytes.extend_from_slice(b"survivor\n");
+        let mut reader = BoundedLineReader::new(std::io::Cursor::new(bytes));
+        assert_eq!(reader.next_line().await.unwrap(), BoundedLine::TooLong);
+        assert_eq!(
+            reader.next_line().await.unwrap(),
+            BoundedLine::Line("survivor".to_owned())
+        );
+    }
+
+    #[tokio::test]
+    async fn invalid_utf8_is_reported_and_skipped_not_fatal() {
+        // A Windows-encoded path inside a Python traceback is exactly this.
+        let mut bytes = b"before\n".to_vec();
+        bytes.extend_from_slice(&[0xFF, 0xFE, b'\n']);
+        bytes.extend_from_slice(b"after\n");
+        let mut reader = BoundedLineReader::new(std::io::Cursor::new(bytes));
+        assert_eq!(
+            reader.next_line().await.unwrap(),
+            BoundedLine::Line("before".to_owned())
+        );
+        assert_eq!(
+            reader.next_line().await.unwrap(),
+            BoundedLine::NotUtf8 { len: 2 }
+        );
+        assert_eq!(
+            reader.next_line().await.unwrap(),
+            BoundedLine::Line("after".to_owned()),
+            "one unreadable line must not end the stream"
+        );
+    }
+}
+
+/// One read from a [`BoundedLineReader`].
+#[derive(Debug, PartialEq, Eq)]
+pub enum BoundedLine {
     /// A complete UTF-8 line (terminator stripped).
     Line(String),
     /// A complete line that was not valid UTF-8; skippable, per PROTOCOL.md.
@@ -865,22 +926,30 @@ enum ReadStep {
 
 /// A newline-delimited reader that never buffers more than
 /// [`MAX_LINE_BYTES`], unlike `AsyncBufReadExt::lines`. Cancel-safe: the only
-/// await is `fill_buf`, and bytes move out of the socket buffer and into the
+/// await is `fill_buf`, and bytes move out of the source buffer and into the
 /// line buffer within a single poll.
-struct BoundedLineReader {
-    reader: BufReader<TcpStream>,
+///
+/// Generic over the source because the bridge speaks the same line-delimited
+/// shape over two transports: a socket, and the stderr of a bridge quantick
+/// launched itself. Both need the same bound — an unterminated line is a
+/// memory leak wherever it comes from — and one implementation is what keeps
+/// the two honest about it.
+pub struct BoundedLineReader<R> {
+    reader: BufReader<R>,
     buf: Vec<u8>,
 }
 
-impl BoundedLineReader {
-    fn new(stream: TcpStream) -> Self {
+impl<R: tokio::io::AsyncRead + Unpin> BoundedLineReader<R> {
+    /// Wrap `source`, reading at most [`MAX_LINE_BYTES`] per line.
+    pub fn new(source: R) -> Self {
         Self {
-            reader: BufReader::new(stream),
+            reader: BufReader::new(source),
             buf: Vec::new(),
         }
     }
 
-    async fn next_line(&mut self) -> std::io::Result<BoundedLine> {
+    /// The next line, or what went wrong with it.
+    pub async fn next_line(&mut self) -> std::io::Result<BoundedLine> {
         loop {
             let step = {
                 let available = self.reader.fill_buf().await?;


### PR DESCRIPTION
Running the B3 mini index with the book heatmap already worked — selecting the
MetaTrader feed starts the Python bridge on its own. What did not work was
*finding out why it hadn't*: terminal closed, package missing, contract not in
Market Watch, server clock unmeasurable were all reported only as a JSON line
on stderr, behind a chart that showed an empty canvas and a faint "connecting"
dot. Honest about *that* it was not connected, silent about *why*.

## What changed

- **`quantick-feed-mt5::bridge_log`** — translates a bridge's stderr vocabulary
  into a headline plus the one next step. It sits beside the protocol it reads,
  so renaming an `event_code` cannot leave a stale copy of these strings next
  to the UI.
- **`app::feed::mt5_bridge`** — owns launching and supervising, out of the feed
  module. Reads the bridge's stderr (every line reaches the log verbatim,
  recognized or not — a Python traceback is exactly when hiding the unknown
  hurts), resolves a relative script path against the executable's folder as
  well as the working directory, and falls back from `python` to the Windows
  `py` launcher for the shipped default only; a configured `bridge_command` is
  an instruction, not a guess.
- **`app::notice_card`** — draws the result over the chart under one rule:
  never cover a working chart. Progress shows only while there is nothing to
  look at; anything needing the user always shows, with a **Try again** button
  so the way back is a click rather than a restart of quantick.

Notices travel on their own channel rather than as a `FeedEvent`: connection
trouble is not market data, and a blocked feed has to speak while the trade
channel is silent — which is exactly when it matters. Feeds with nothing to
report (Binance, replay) hand over a channel closed at birth.

## Found by arch-review, fixed here

`bridge_connected` only ever went to `true`. The supervisor therefore returned
the first time it saw a connected bridge, so a terminal restarting mid-session
was never picked back up — while the card promised "reconnecting". The flag now
means *is one feeding us right now*, the supervisor watches instead of
returning (one relaxed atomic load every 2 s), and its budget is five
**consecutive** failures, so a wrong contract still stops and says so.

## Verified live — B3 WINQ26 through the XP terminal, 2026-07-27

- Bars and the book heatmap stream with the app launched from **outside** the
  repository (`-WorkingDirectory C:\Users\Camillo`): 60 fps, 10+10 DOM levels,
  coverage labelled `Limited`, `side: inferred (tick rule)`.
- A non-existent contract (`WINZ99`) produces the amber card — "MetaTrader does
  not list WINZ99" + "Add the contract to Market Watch…" + Try again — instead
  of a blank chart.
- Killing the bridge mid-session: relaunched 5 s later, streaming 1 s after
  that, with no user action.
- Closing the window leaves no orphan bridge process.

Four checks green: `fmt --check`, `clippy -D warnings`, `build`, `test`
(24 test binaries, 0 failures). `arch-review` run over `git diff main...HEAD`;
its one Blocker and two Should-fix findings are resolved in 94573be. The
remaining Consider (two short `String` allocations per frame while the card is
visible) is accepted and documented: the card only draws when nothing else is
being rendered, measured at 59-60 fps with it on screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
