### PR TITLE
feat(app): record the book always, mark the pre-capture span with one line

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,8 +222,9 @@ evenly across each second for smoother playback and marks the session
 ## Optional L2 liquidity map
 
 The chart can capture Binance Spot level-2 order-book depth and render a
-Bookmap-inspired liquidity map. It is **disabled by default** and must be
-enabled from the chart controls. The **⚙ L2** button docks a settings panel to
+Bookmap-inspired liquidity map. Capture starts with any feed that can stream
+depth; the map itself is **hidden by default** and shown from the chart
+controls. The **⚙ L2** button docks a settings panel to
 the left of the chart — the chart keeps the remaining width instead of being
 covered — including a deterministic preview of every visual state, so themes
 and grouping can be tuned without waiting for a rare live-book event.
@@ -236,15 +237,23 @@ switch and its own docked panel:
 - **bubbles** (**⚙ bubbles**) — confirmed aggressive executions, built from the
   aggregate-trade stream the chart already consumes.
 
-Neither switch touches the other. Bubbles render with L2 capture off (and for
-providers without a depth pipeline at all), and stopping the book leaves the
-bubbles running. Turning L2 capture off hides the map without discarding
-retained L2 history.
+Neither switch touches the other. Bubbles render with the map hidden (and for
+providers without a depth pipeline at all), and hiding the book leaves the
+bubbles running.
+
+Both switches are display-only. Recording and drawing are separate concerns:
+the depth recorder runs from the moment a depth-capable feed starts, so hiding
+the map never punches a hole in the recorded book — reopen it and the whole
+retained window is there, without the gap that stopping capture would leave.
+While the map is hidden no projection is built and no depth geometry is drawn,
+so the only cost it carries is the recording itself, bounded by the same
+retention budget documented below. Capture stops only when the market changes:
+a feed or symbol switch, or a replay taking the chart over.
 
 The visualization follows a few data-honesty rules:
 
-- History begins at the first successfully synchronized live snapshot/update sequence. Binance does not provide historical L2 backfill through this feed, so candles before that point are marked as unavailable instead of being reconstructed.
-- Depth update IDs are checked continuously. A disconnect, sequence gap or resynchronization closes the current liquidity runs, marks the affected interval with subtle shading and dashed vertical boundaries, and starts again from a fresh snapshot. Stale book state is never stretched across a gap.
+- History begins at the first successfully synchronized live snapshot/update sequence. Binance does not provide historical L2 backfill through this feed, so candles before that point are marked as unavailable instead of being reconstructed. That stretch is marked by a single dashed line where the book begins, plus a label: it can span most of the chart, and tinting it would bury candles and bubbles that are perfectly real there.
+- Depth update IDs are checked continuously. A disconnect, sequence gap or resynchronization closes the current liquidity runs, marks the affected interval with a faint fill between dashed vertical boundaries, and starts again from a fresh snapshot. Stale book state is never stretched across a gap. Interior gaps keep their fill precisely because they are narrow — an untinted sliver would read as "no resting liquidity" rather than "no data".
 - Heatmap quantities are resting bid/ask amounts from the snapshot plus absolute depth updates, limited to the configured number of price levels on each side. Liquidity outside that coverage is unknown.
 - A displayed band records the bucket total observed when its run opened; changes smaller than ~10% merge into the open run instead of cutting a new one. This churn-merge tolerance is a disclosed granularity choice — larger moves, appearances and full removals always cut a new run at their exact value.
 - `aggTrade` bubbles are confirmed market aggression. Their area is quantity-proportional and nearby prints can be clustered without changing total volume.
@@ -257,7 +266,7 @@ The chart exposes these settings:
 
 | Setting | Default | Range / behavior |
 | --- | ---: | --- |
-| L2 heatmap | Off | Starts live capture when enabled |
+| L2 heatmap | Hidden | Display-only; the recorder runs whenever the feed can stream depth, so reopening the map shows the whole retained window |
 | Retention | 30 minutes | 1–1,440 minutes |
 | Display range | Auto / 128 rows | Native, `2×`, `5×`, `10×`, `25×`, `50×`, custom multiple or adaptive-to-zoom; changing it reprojects immediately without resetting history |
 | Base capture bucket | auto from price | Sized to ~`price / 65000` (1/2/5·10^k) on the first snapshot; any positive value can be set by hand. Changing the base resolution requires a fresh snapshot and resets retained L2 history |
@@ -279,7 +288,7 @@ The in-memory safety budgets are 500,000 liquidity runs (approximately 64 MiB), 
 | Variable | Default | Behavior |
 | --- | --- | --- |
 | `QUANTICK_BOOK_DEPTH` | `1000` | Binance snapshot depth per side. Numeric values are clamped to `1`–`5000`; a missing or invalid value uses the default. Higher values increase initial REST payload, synchronization work and memory use. |
-| `QUANTICK_BOOK_AUTOSTART` | unset | Set to `1` to enable L2 capture on startup without clicking the chart toggle (development/ops convenience; same code path as the toggle). |
+| `QUANTICK_BOOK_AUTOSTART` | unset | Set to `1` to show the L2 map on startup without clicking the chart toggle (development/ops convenience; same code path as the toggle). Capture itself needs no flag — it runs for every depth-capable feed. |
 | `QUANTICK_LOG_FORMAT` | `text` | Set to `json` for newline-delimited JSON diagnostic logs on stderr. |
 | `RUST_LOG` | `quantick=info` | Standard tracing filter; for example, use `quantick=debug` for deeper diagnostics. |
 

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -549,6 +549,10 @@ impl QuantickApp {
     /// heatmap already had — `retention_ms` (30 min by default) bounded by
     /// `max_history_runs` / `max_history_bytes` — so the ceiling is the same
     /// one an open map pays for, not a new one.
+    ///
+    /// Idempotent and cheap, so the frame loop can call it as a heartbeat on
+    /// top of the lifecycle calls: already recording costs one bool read, and
+    /// a replay costs one more `Option` check.
     fn ensure_book_capture(&mut self) {
         if self.orderflow.enabled() || !self.capabilities().book_capture {
             return;
@@ -587,7 +591,7 @@ impl QuantickApp {
                 symbol = self.symbol.as_str(),
                 enabled,
                 generation,
-                action = "retry_on_next_user_action",
+                action = "retry_on_next_frame",
                 "book capture command channel is full"
             ),
             Err(mpsc::error::TrySendError::Closed(_)) => tracing::warn!(
@@ -1832,6 +1836,13 @@ impl eframe::App for QuantickApp {
 
         self.drain_feed();
         self.drain_book_feed();
+        // Heartbeat for the recorder. The lifecycle calls below already start
+        // it at every point that knows the market changed; this one makes
+        // "always recording" true by construction, so a start command lost to
+        // a momentarily full channel heals on the next frame instead of
+        // leaving the session silently unrecorded. Free while it is running:
+        // one bool read and an early return.
+        self.ensure_book_capture();
         self.maybe_emit_summary(now);
 
         let bg = self.bg();

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -300,12 +300,14 @@ impl QuantickApp {
             trades_since_summary: 0,
             last_summary: Instant::now(),
         };
-        // Dev/ops convenience: start L2 capture without a click. Same code
-        // path as the UI toggle, so provider support and command
-        // acknowledgement rules stay identical.
-        if std::env::var("QUANTICK_BOOK_AUTOSTART").is_ok_and(|value| value == "1") {
-            app.request_book_capture(true);
-        }
+        // Recording is not a display choice: it starts with the feed, so
+        // hiding the map later never leaves a hole in what was captured.
+        app.ensure_book_capture();
+        // The map itself stays hidden until asked for — a layer nobody
+        // requested must cost no projection. Dev/ops can open it without a
+        // click; capture is already running either way.
+        app.orderflow
+            .set_depth_visible(std::env::var("QUANTICK_BOOK_AUTOSTART").is_ok_and(|v| v == "1"));
         // Same convenience for the live strip; its pixels stay
         // capability-gated either way (see live_strip_width).
         if std::env::var("QUANTICK_LIVE_STRIP_AUTOSTART").is_ok_and(|value| value == "1") {
@@ -421,7 +423,7 @@ impl QuantickApp {
         });
         let capabilities = self.capabilities();
         let feed_display_name = self.feed_display_name();
-        let heatmap_on = self.orderflow.enabled();
+        let heatmap_on = self.orderflow.depth_visible();
         let bubbles_on = self.orderflow.bubbles_enabled();
         let mut model = toolbar::ToolbarModel {
             feeds,
@@ -464,7 +466,7 @@ impl QuantickApp {
     fn apply_toolbar_action(&mut self, action: ToolbarAction) {
         match action {
             ToolbarAction::LoadOlder => self.request_older_history(),
-            ToolbarAction::SetHeatmap(enabled) => self.request_book_capture(enabled),
+            ToolbarAction::SetHeatmap(shown) => self.orderflow.set_depth_visible(shown),
             ToolbarAction::SetBubbles(enabled) => self.orderflow.set_bubbles_enabled(enabled),
             ToolbarAction::SetLiveStrip(shown) => self.live_strip_visible = shown,
             ToolbarAction::OpenDockTab(tab) => self.dock.open_tab(tab),
@@ -534,6 +536,24 @@ impl QuantickApp {
         self.book_capture_epoch = self.book_capture_epoch.saturating_add(1);
         self.book_capture_epoch
             .saturating_mul(BOOK_GENERATION_STRIDE)
+    }
+
+    /// Keep the recorder running for any feed that can stream depth.
+    ///
+    /// Capture is a data concern: it starts with the feed and stops only when
+    /// the market itself changes (feed/symbol switch, or a replay taking the
+    /// chart over). Showing and hiding the map never reaches this far, which is
+    /// what lets a hidden heatmap come back with its history intact.
+    ///
+    /// Recording with nobody watching stays inside the retention budget the
+    /// heatmap already had — `retention_ms` (30 min by default) bounded by
+    /// `max_history_runs` / `max_history_bytes` — so the ceiling is the same
+    /// one an open map pays for, not a new one.
+    fn ensure_book_capture(&mut self) {
+        if self.orderflow.enabled() || !self.capabilities().book_capture {
+            return;
+        }
+        self.request_book_capture(true);
     }
 
     /// Start or stop the independent depth pipeline without touching aggTrades
@@ -646,7 +666,11 @@ impl QuantickApp {
             (self.feed_id, self.symbol) = self.active.clone();
             return;
         };
-        let resume_book_capture = self.orderflow.enabled() && provider.capabilities().book_capture;
+        // The recorder follows the feed, not the toggle: a market that can
+        // stream depth is recorded from the moment it starts streaming. Kept
+        // for the log line below; the start itself goes through
+        // [`Self::ensure_book_capture`], the one place that decides it.
+        let resume_book_capture = provider.capabilities().book_capture;
 
         tracing::info!(
             target: "quantick::app",
@@ -684,9 +708,7 @@ impl QuantickApp {
         self.orderflow.reset_for_symbol(self.symbol.clone());
 
         self.active = (self.feed_id.clone(), self.symbol.clone());
-        if resume_book_capture {
-            self.request_book_capture(true);
-        }
+        self.ensure_book_capture();
     }
 
     /// Apply a bar-type/parameter change one frame after the selectors settle.
@@ -1235,7 +1257,7 @@ impl QuantickApp {
         // candle stays a clean divider — no liquidity band shows through it.
         // Where the price swept, the wall reads as consumed; bands survive only
         // in the gaps between candles and above/below each bar.
-        if orderflow_frame.is_some() && self.orderflow.enabled() {
+        if orderflow_frame.is_some() && self.orderflow.depth_visible() {
             let clear_bar = |xc: f32, bar: &quantick_engine::Bar| {
                 let top = scale.y(bar.high.to_f64().unwrap_or(0.0));
                 let bottom = scale.y(bar.low.to_f64().unwrap_or(0.0));
@@ -1791,6 +1813,9 @@ impl QuantickApp {
         self.replay = handle.replay;
         self.book_channel_closed_reported = false;
         self.reset_market_state();
+        // The live market is back and it can stream depth again; start
+        // recording immediately rather than waiting for the map to be opened.
+        self.ensure_book_capture();
     }
 }
 
@@ -1944,20 +1969,30 @@ mod tests {
         (app, evt_tx, cmd_rx, book_tx)
     }
 
+    /// Take the `SetBookCapture` command every test app queues at
+    /// construction and return its generation. Capture follows the feed, so
+    /// there is exactly one of these in flight before any test acts.
+    fn take_capture_start(commands: &mut mpsc::Receiver<FeedCommand>) -> u64 {
+        match commands
+            .try_recv()
+            .expect("capture starts with the feed, not with the toggle")
+        {
+            FeedCommand::SetBookCapture {
+                enabled: true,
+                initial_generation,
+            } => initial_generation,
+            _ => panic!("unexpected command"),
+        }
+    }
+
     fn enable_heatmap_with_snapshot(
         app: &mut QuantickApp,
         commands: &mut mpsc::Receiver<FeedCommand>,
     ) {
         use quantick_orderbook::{BookCoverage, BookLevel, BookSnapshot};
 
-        app.request_book_capture(true);
-        let generation = match commands.try_recv().expect("capture command") {
-            FeedCommand::SetBookCapture {
-                enabled: true,
-                initial_generation,
-            } => initial_generation,
-            _ => panic!("unexpected command"),
-        };
+        let generation = take_capture_start(commands);
+        app.orderflow.set_depth_visible(true);
         app.orderflow.handle_depth_event(DepthEvent::Snapshot {
             symbol: "TESTUSDT".to_owned(),
             generation,
@@ -2145,21 +2180,18 @@ mod tests {
     }
 
     #[test]
-    fn capture_toggle_commits_only_after_command_is_queued() {
+    fn capture_starts_with_the_feed_and_commits_only_after_the_command_is_queued() {
         let (mut app, _evt_tx, mut cmd_rx, _book_tx) = test_app();
-        assert!(!app.orderflow.enabled());
 
-        app.request_book_capture(true);
-        let command = cmd_rx.try_recv().expect("capture command");
-        let generation = match command {
-            FeedCommand::SetBookCapture {
-                enabled: true,
-                initial_generation,
-            } => initial_generation,
-            _ => panic!("unexpected command"),
-        };
-        assert_eq!(generation, BOOK_GENERATION_STRIDE);
+        // Construction already asked the feed to record: capture follows the
+        // market, not the toolbar.
+        assert_eq!(take_capture_start(&mut cmd_rx), BOOK_GENERATION_STRIDE);
         assert!(app.orderflow.enabled());
+        app.ensure_book_capture();
+        assert!(
+            cmd_rx.try_recv().is_err(),
+            "a recorder already running needs no second command"
+        );
 
         drop(cmd_rx);
         app.request_book_capture(false);
@@ -2169,30 +2201,74 @@ mod tests {
         );
     }
 
+    /// The user's complaint made executable: hiding the map is pixels only.
+    /// The recorder keeps running, so reopening it finds the history whole
+    /// instead of a hole where the map was closed.
+    #[test]
+    fn hiding_the_heatmap_never_stops_the_recorder() {
+        let (mut app, _evt_tx, mut cmd_rx, _book_tx) = test_app();
+        take_capture_start(&mut cmd_rx);
+        let gaps_before = app.orderflow.health().gaps;
+
+        app.apply_toolbar_action(ToolbarAction::SetHeatmap(true));
+        assert!(app.orderflow.depth_visible());
+
+        app.apply_toolbar_action(ToolbarAction::SetHeatmap(false));
+        assert!(!app.orderflow.depth_visible(), "the map is hidden");
+        assert!(app.orderflow.enabled(), "the recorder is untouched");
+        assert!(
+            cmd_rx.try_recv().is_err(),
+            "showing or hiding the map sends no feed command"
+        );
+
+        app.apply_toolbar_action(ToolbarAction::SetHeatmap(true));
+        app.orderflow.flush_for_test();
+        assert!(app.orderflow.depth_visible());
+        assert_eq!(
+            app.orderflow.health().gaps,
+            gaps_before,
+            "the toggle must not punch a coverage gap into the recording"
+        );
+    }
+
+    /// The guard that keeps an always-on recorder honest: a source with no
+    /// depth pipeline — a replay, or a feed missing from the config — gets no
+    /// recorder and no command, however often the app asks.
+    #[test]
+    fn a_source_without_depth_starts_no_recorder() {
+        let (mut app, _evt_tx, mut cmd_rx, _book_tx) = test_app();
+        take_capture_start(&mut cmd_rx);
+
+        let generation = app.next_book_generation();
+        app.orderflow.set_enabled(false, generation);
+        app.feed_id = "not-in-the-config".to_owned();
+        assert!(!app.capabilities().book_capture);
+
+        app.ensure_book_capture();
+        assert!(!app.orderflow.enabled());
+        assert!(
+            cmd_rx.try_recv().is_err(),
+            "a source with no book is never asked to record"
+        );
+    }
+
     #[test]
     fn bubble_toggle_needs_no_feed_command_and_leaves_capture_alone() {
         let (mut app, _evt_tx, mut cmd_rx, _book_tx) = test_app();
-        assert!(!app.orderflow.enabled());
+        take_capture_start(&mut cmd_rx);
         assert!(!app.orderflow.bubbles_enabled());
 
         app.orderflow.set_bubbles_enabled(true);
         assert!(app.orderflow.bubbles_enabled());
         assert!(
-            !app.orderflow.enabled(),
-            "the bubble layer must not start L2 capture"
-        );
-        assert!(
             cmd_rx.try_recv().is_err(),
             "aggregate trades already flow; no feed command is needed"
         );
 
-        app.request_book_capture(true);
-        cmd_rx.try_recv().expect("capture command");
-        app.request_book_capture(false);
-        cmd_rx.try_recv().expect("capture command");
+        app.apply_toolbar_action(ToolbarAction::SetHeatmap(false));
         assert!(
             app.orderflow.bubbles_enabled(),
-            "stopping the book must not stop the bubbles"
+            "hiding the book must not stop the bubbles"
         );
     }
 
@@ -2262,14 +2338,7 @@ mod tests {
         use quantick_orderbook::{BookCoverage, BookLevel, BookSnapshot};
 
         let (mut app, _evt_tx, mut cmd_rx, book_tx) = test_app();
-        app.request_book_capture(true);
-        let generation = match cmd_rx.try_recv().unwrap() {
-            FeedCommand::SetBookCapture {
-                enabled: true,
-                initial_generation,
-            } => initial_generation,
-            _ => panic!("unexpected command"),
-        };
+        let generation = take_capture_start(&mut cmd_rx);
         let bars_before = app.state.bars().len();
         book_tx
             .try_send(DepthEvent::Snapshot {
@@ -2300,11 +2369,7 @@ mod tests {
     #[test]
     fn candle_appearance_change_is_render_only() {
         let (mut app, _evt_tx, mut cmd_rx, _book_tx) = test_app();
-        app.request_book_capture(true);
-        assert!(matches!(
-            cmd_rx.try_recv(),
-            Ok(FeedCommand::SetBookCapture { enabled: true, .. })
-        ));
+        take_capture_start(&mut cmd_rx);
         let capture_epoch = app.book_capture_epoch;
         let bar_spec = app.state.spec().clone();
 
@@ -2324,11 +2389,7 @@ mod tests {
     #[test]
     fn closed_depth_channel_is_reported_once_per_feed_handle() {
         let (mut app, _evt_tx, mut cmd_rx, book_tx) = test_app();
-        app.request_book_capture(true);
-        assert!(matches!(
-            cmd_rx.try_recv(),
-            Ok(FeedCommand::SetBookCapture { enabled: true, .. })
-        ));
+        take_capture_start(&mut cmd_rx);
         drop(book_tx);
 
         app.drain_book_feed();

--- a/crates/app/src/orderflow/config.rs
+++ b/crates/app/src/orderflow/config.rs
@@ -441,19 +441,24 @@ fn finite_clamp(value: f32, low: f32, high: f32, fallback: f32) -> f32 {
 
 /// Settings shared by history retention and the pure projection layer.
 ///
-/// The two visual layers are independent switches: [`enabled`](Self::enabled)
-/// owns the L2 depth map, [`show_aggressions`](Self::show_aggressions) owns the
-/// aggression bubbles. Bubbles are built from the aggregate-trade stream the
-/// chart already consumes, so they never need the depth pipeline.
+/// The two visual layers are independent switches:
+/// [`show_depth`](Self::show_depth) owns the L2 depth map,
+/// [`show_aggressions`](Self::show_aggressions) owns the aggression bubbles.
+/// Bubbles are built from the aggregate-trade stream the chart already
+/// consumes, so they never need the depth pipeline.
 ///
-/// Both default to disabled: merely adding the feature cannot change feed load,
-/// memory use or rendering behaviour of the existing chart.
+/// Recording and drawing are separate concerns. [`enabled`](Self::enabled) is
+/// the recorder and defaults to disabled — merely adding the feature cannot
+/// change feed load or memory use. `show_depth` is the display switch, and the
+/// projection only builds depth primitives when both are on.
 #[derive(Debug, Clone, PartialEq)]
 pub struct HeatmapConfig {
-    /// Whether L2 depth capture/projection is enabled.
+    /// Whether L2 depth capture is running.
     ///
-    /// Only the depth map depends on this: the aggression layer keeps working
-    /// with capture off.
+    /// This is a data concern, not a visual one: the app keeps it on for every
+    /// feed that can stream depth, so hiding the map never punches a hole in
+    /// the recording. Only the depth map depends on it — the aggression layer
+    /// keeps working with capture off.
     pub enabled: bool,
     /// Maximum age retained in memory, measured in exchange milliseconds.
     pub retention_ms: i64,
@@ -490,7 +495,19 @@ pub struct HeatmapConfig {
     /// the alpha and largest radius this used to carry as two flat fields),
     /// colour, consumption marks and labels.
     pub bubbles: BubbleStyle,
-    /// Whether the resting-liquidity heat cells are drawn.
+    /// Whether the depth map is drawn at all — the toolbar's book-heatmap
+    /// switch, and the master of the `show_*` flags under it.
+    ///
+    /// Display-only, like every `show_*` flag in this block: L2 capture keeps
+    /// running and retained history keeps accumulating, so switching the map
+    /// back on repaints the past it kept recording instead of opening a new
+    /// hole. With it off the projection builds no depth primitives at all, so
+    /// a hidden map costs nothing beyond the capture the recorder was doing
+    /// anyway.
+    pub show_depth: bool,
+    /// Whether the resting-liquidity heat cells are drawn. Refines
+    /// [`show_depth`](Self::show_depth), which stays the depth layer's master
+    /// switch.
     ///
     /// Display-only, like every `show_*` flag in this block: L2 capture keeps
     /// running and retained history keeps accumulating, so switching a layer
@@ -510,7 +527,7 @@ pub struct HeatmapConfig {
     /// Whether depth-only (unattributed) reductions draw their markers and
     /// fading withdrawal tails.
     pub show_unattributed_reductions: bool,
-    /// Whether L2 coverage gaps draw their hatching.
+    /// Whether L2 coverage gaps draw their boundary marks.
     pub show_gaps: bool,
     /// Smallest reduction fraction whose *unattributed* (depth-only) marker is
     /// displayed. A busy book shrinks buckets by >10% constantly; drawing every
@@ -560,6 +577,7 @@ impl Default for HeatmapConfig {
             bubble_cluster_ms: DEFAULT_BUBBLE_CLUSTER_MS,
             bubble_dust_merge_ms: DEFAULT_BUBBLE_DUST_MERGE_MS,
             bubbles: BubbleStyle::default(),
+            show_depth: true,
             show_liquidity: true,
             show_buy_aggressions: true,
             show_sell_aggressions: true,
@@ -582,13 +600,22 @@ impl Default for HeatmapConfig {
 }
 
 impl HeatmapConfig {
-    /// Whether any order-flow layer asks for capture and projection.
+    /// Whether the depth map has both something recorded and permission to
+    /// draw it. Everything the depth layer projects hangs off this.
+    #[must_use]
+    pub fn depth_visible(&self) -> bool {
+        self.enabled && self.show_depth
+    }
+
+    /// Whether any order-flow layer asks for a projection.
     ///
     /// The depth map and the aggression bubbles are independent: either one
     /// alone keeps the pipeline alive, and neither can switch the other off.
+    /// Capture is not part of this question — the recorder runs on its own, so
+    /// a hidden map stops costing projections without stopping the recording.
     #[must_use]
     pub fn any_layer_enabled(&self) -> bool {
-        self.enabled || self.show_aggressions
+        self.depth_visible() || self.show_aggressions
     }
 
     /// Whether displayed-liquidity reductions need to be computed at all.
@@ -674,7 +701,11 @@ mod tests {
         assert_eq!(config.bubbles.opacity, DEFAULT_BUBBLE_OPACITY);
         assert_eq!(config.bubbles.max_radius, DEFAULT_BUBBLE_MAX_RADIUS);
         // Every visual layer defaults to on: gaining per-layer switches must
-        // change no pixels until someone actually flips one.
+        // change no pixels until someone actually flips one. The depth map
+        // still draws nothing here, because nothing is being recorded yet —
+        // recording and drawing are separate questions.
+        assert!(config.show_depth);
+        assert!(!config.depth_visible());
         assert!(config.show_liquidity);
         assert!(config.show_buy_aggressions);
         assert!(config.show_sell_aggressions);

--- a/crates/app/src/orderflow/mod.rs
+++ b/crates/app/src/orderflow/mod.rs
@@ -37,8 +37,8 @@ pub use interaction::{
 };
 #[allow(unused_imports)]
 pub use projection::{
-    AggressionPrimitive, GapPrimitive, HeatmapCell, HeatmapProjection, LiquidityEventPrimitive,
-    LiquidityEvidence, PriceWindow, project,
+    AggressionPrimitive, BEFORE_CAPTURE, GapPrimitive, HeatmapCell, HeatmapProjection,
+    LiquidityEventPrimitive, LiquidityEvidence, PriceWindow, project,
 };
 #[allow(unused_imports)]
 pub use timeline::{BarTimeline, TimelinePosition};

--- a/crates/app/src/orderflow/projection.rs
+++ b/crates/app/src/orderflow/projection.rs
@@ -138,6 +138,15 @@ pub struct LiquidityEventPrimitive {
     pub y1: f64,
 }
 
+/// Reason recorded for the stretch of chart older than the first snapshot this
+/// session captured. It is the only gap that can span most of the viewport, so
+/// renderers mark it differently from an interior discontinuity.
+///
+/// Exported so the renderer's label table matches on this constant instead of
+/// repeating the literal: a reason renamed here would otherwise fall through
+/// to the generic label without a single test noticing.
+pub const BEFORE_CAPTURE: &str = "book_unavailable_before_capture";
+
 /// A visible interval that must not be filled or connected.
 #[derive(Debug, Clone, PartialEq)]
 pub struct GapPrimitive {
@@ -151,6 +160,15 @@ pub struct GapPrimitive {
     pub x1: f64,
     /// Diagnostic reason copied from history.
     pub reason: String,
+}
+
+impl GapPrimitive {
+    /// Whether this is the leading stretch that predates local capture, as
+    /// opposed to a discontinuity inside covered time.
+    #[must_use]
+    pub fn precedes_capture(&self) -> bool {
+        self.reason == BEFORE_CAPTURE
+    }
 }
 
 /// Complete pure output for one chart frame.
@@ -233,10 +251,11 @@ pub fn project(
         return HeatmapProjection::empty(true, effective_grouping);
     };
 
-    // The depth layer is projected only while L2 capture is on. Retained runs
-    // survive a capture toggle untouched — they simply stop being drawn, so the
-    // aggression layer can keep rendering without the map behind it.
-    let depth_enabled = config.enabled;
+    // The depth layer is projected only while the map is both recording and on
+    // screen. Retained runs survive hiding it untouched — they simply stop
+    // being drawn and keep accumulating, so the aggression layer can render
+    // without the map behind it and reopening repaints the whole retained past.
+    let depth_enabled = config.depth_visible();
     let retained_start = history
         .retention_start_ms()
         .map_or(time_start, |start| start.max(time_start));
@@ -516,8 +535,8 @@ pub fn project(
         .collect();
 
     // Coverage primitives describe the depth layer. With L2 capture off there
-    // is no map whose absence needs explaining, so a bubbles-only frame stays
-    // free of gap hatching.
+    // is no map whose absence needs explaining, so a bubbles-only frame emits
+    // no gap marks at all.
     let mut gaps: Vec<GapPrimitive> = if depth_enabled && config.show_gaps {
         history
             .coverage_gaps()
@@ -544,8 +563,8 @@ pub fn project(
     // Historical trades can precede the first locally captured L2 snapshot.
     // Make that absence an explicit primitive instead of a transparent region
     // that could be mistaken for zero resting liquidity. The gap switch covers
-    // this hatch too: it is one legend entry, and half-hiding it would leave
-    // the legend describing marks the viewer cannot see.
+    // this leading span too: it is one legend entry, and half-hiding it would
+    // leave the legend describing marks the viewer cannot see.
     if depth_enabled && config.show_gaps {
         match history.coverage_segments().next() {
             Some(first_coverage) if first_coverage.start_ms > time_start => {
@@ -560,7 +579,7 @@ pub fn project(
                         to_generation: Some(first_coverage.generation),
                         x0: x0.normalized,
                         x1: x1.normalized,
-                        reason: "book_unavailable_before_capture".to_owned(),
+                        reason: BEFORE_CAPTURE.to_owned(),
                     });
                 }
             }
@@ -1710,7 +1729,7 @@ mod tests {
     }
 
     #[test]
-    fn hidden_gaps_remove_the_hatching() {
+    fn hidden_gaps_emit_no_coverage_primitives() {
         let mut history = LiquidityHistory::new(HeatmapConfig {
             show_gaps: false,
             ..config()
@@ -1725,7 +1744,38 @@ mod tests {
             PriceWindow::new(dec("98"), dec("103")).unwrap(),
         );
         // The same fixture with the flag on yields the
-        // "book_unavailable_before_capture" hatch (see the test above).
+        // "book_unavailable_before_capture" span (see the test above).
         assert!(projection.gaps.is_empty());
+    }
+
+    /// Hiding the map is display-only, so the projection must stop producing
+    /// depth work while the recorded history stays exactly where it was.
+    #[test]
+    fn a_hidden_depth_map_projects_no_depth_primitives() {
+        let mut history = LiquidityHistory::new(config());
+        history.install_snapshot(400, 1, snapshot(10)).unwrap();
+        history
+            .apply_delta(900, &BookDelta::new(10, 10, vec![], vec![]))
+            .unwrap();
+        let timeline = BarTimeline::from_bars(0, &[bar(0, 1_000)], None, None);
+        let prices = PriceWindow::new(dec("98"), dec("103")).unwrap();
+
+        let shown = project(&history, &timeline, prices);
+        assert!(!shown.cells.is_empty(), "the visible map has heat cells");
+        assert!(!shown.gaps.is_empty(), "and its pre-capture boundary");
+
+        history
+            .update_config(HeatmapConfig {
+                show_depth: false,
+                ..config()
+            })
+            .unwrap();
+        let hidden = project(&history, &timeline, prices);
+        assert!(hidden.cells.is_empty());
+        assert!(hidden.gaps.is_empty());
+        assert!(
+            hidden.liquidity_events.is_empty(),
+            "no depth primitive survives a hidden map"
+        );
     }
 }

--- a/crates/app/src/orderflow_engine.rs
+++ b/crates/app/src/orderflow_engine.rs
@@ -429,6 +429,12 @@ impl BookEngine {
         self.config.enabled
     }
 
+    /// Whether the depth map is both recording and allowed to draw.
+    #[cfg(test)]
+    pub(crate) fn depth_visible(&self) -> bool {
+        self.config.depth_visible()
+    }
+
     /// Whether any layer (depth map or aggression bubbles) still wants frames.
     #[must_use]
     pub fn any_layer_enabled(&self) -> bool {
@@ -990,7 +996,10 @@ impl BookEngine {
         BookPublished {
             status: self.status.clone(),
             health: self.health(),
-            live_end_ms: if self.config.enabled {
+            // Gated on visibility, not on capture: the live tail and the strip
+            // are pixels, and a recorder nobody is watching must not pay for
+            // them.
+            live_end_ms: if self.config.depth_visible() {
                 self.history.latest_book_ms()
             } else {
                 None
@@ -1007,7 +1016,9 @@ impl BookEngine {
     /// at most [`LADDER_LEVELS_PER_SIDE`] levels per side are visited through
     /// `BTreeMap::range` — never a full book scan.
     fn ladder(&self) -> Option<Arc<BookLadder>> {
-        if !self.config.enabled || !self.history.book().is_initialized() {
+        // Visibility, not capture: with the map hidden nothing consumes the
+        // ladder, so the per-batch copy is pure waste.
+        if !self.config.depth_visible() || !self.history.book().is_initialized() {
             return None;
         }
         let book = self.history.book();
@@ -1453,6 +1464,64 @@ mod tests {
         // Disabling capture is a hard reset: the frame must vanish.
         engine.set_enabled(false, 12);
         assert!(engine.published().frame.is_none());
+    }
+
+    /// The user's complaint made executable: hiding the map is pixels only.
+    /// The recorder keeps filling history, the toggle punches no coverage gap,
+    /// and nothing is projected or published while nobody is watching.
+    #[test]
+    fn a_hidden_map_keeps_recording_and_costs_nothing_to_draw() {
+        let mut engine = BookEngine::new("BTCUSDT");
+        engine.set_enabled(true, 10);
+        engine.handle_depth_event(snapshot_event(10));
+        let bars = [bar(900, 1_100)];
+        engine.project(&request(&bars, (98.0, 102.0))).unwrap();
+        assert_eq!(engine.projection_builds, 1);
+
+        let hidden = HeatmapConfig {
+            show_depth: false,
+            ..engine.config.clone()
+        };
+        engine.apply_visual_config(hidden);
+        assert!(engine.enabled(), "the recorder keeps running");
+        assert!(!engine.depth_visible());
+        assert!(
+            !engine.any_layer_enabled(),
+            "the worker's projection gate is shut, so no frame is built"
+        );
+        let published = engine.published();
+        assert!(published.frame.is_none(), "nothing is left to draw");
+        assert!(published.ladder.is_none(), "no ladder is copied per batch");
+        assert!(published.live_end_ms.is_none());
+
+        // Depth keeps landing in history while the map is closed.
+        let updates_before = engine.depth_updates;
+        engine.handle_depth_event(DepthEvent::Update {
+            symbol: "BTCUSDT".to_owned(),
+            generation: 10,
+            event_time_ms: 1_050,
+            delta: BookDelta::new(11, 11, Vec::new(), Vec::new()),
+        });
+        assert_eq!(engine.depth_updates, updates_before + 1);
+        assert_eq!(
+            engine.projection_builds, 1,
+            "recording never triggers a build on its own"
+        );
+        assert_eq!(
+            engine.history.coverage_gaps().count(),
+            0,
+            "hiding the map punches no hole in the recording"
+        );
+
+        // Reopening repaints the past it kept recording.
+        let shown = HeatmapConfig {
+            show_depth: true,
+            ..engine.config.clone()
+        };
+        engine.apply_visual_config(shown);
+        let reopened = engine.project(&request(&bars, (98.0, 102.0))).unwrap();
+        assert!(!reopened.projection.cells.is_empty());
+        assert!(engine.published().ladder.is_some());
     }
 
     #[test]

--- a/crates/app/src/orderflow_render.rs
+++ b/crates/app/src/orderflow_render.rs
@@ -13,8 +13,8 @@ use rust_decimal::Decimal;
 use rust_decimal::prelude::ToPrimitive as _;
 
 use crate::orderflow::{
-    AggressionPrimitive, BubbleRenderMode, BubbleStyle, HeatmapConfig, HeatmapProjection,
-    HeatmapTheme, LiquidityEvidence,
+    AggressionPrimitive, BEFORE_CAPTURE, BubbleRenderMode, BubbleStyle, HeatmapConfig,
+    HeatmapProjection, HeatmapTheme, LiquidityEvidence,
 };
 use crate::viewport::Viewport;
 
@@ -131,7 +131,7 @@ impl OrderflowRenderStyle {
             theme: config.theme,
             bubbles: config.bubbles.clone(),
             show_legend: config.show_legend,
-            depth_layer: config.enabled,
+            depth_layer: config.depth_visible(),
             aggression_layer: config.show_aggressions,
             show_liquidity: config.show_liquidity,
             show_buy: config.show_buy_aggressions,
@@ -754,33 +754,39 @@ pub(crate) fn draw_heatmap_background(painter: &egui::Painter, context: &RenderC
         if !rect.is_positive() {
             continue;
         }
-        clip.rect_filled(rect, egui::Rounding::ZERO, palette.gap_fill);
-        draw_gap_hatch(&clip, rect, palette.gap_hatch);
-        draw_dashed_vertical(
-            &clip,
-            rect.left(),
-            rect,
-            4.0,
-            5.0,
-            palette.gap_boundary,
-            1.0,
-        );
-        draw_dashed_vertical(
-            &clip,
-            rect.right(),
-            rect,
-            4.0,
-            5.0,
-            palette.gap_boundary,
-            1.0,
-        );
+        let leading = gap.precedes_capture();
+        let marks = gap_marks(rect, context.layout.chart_rect, leading);
+        if marks.fill {
+            clip.rect_filled(rect, egui::Rounding::ZERO, palette.gap_fill);
+        }
+        for (draw, x) in [
+            (marks.left_boundary, rect.left()),
+            (marks.right_boundary, rect.right()),
+        ] {
+            if draw {
+                draw_dashed_vertical(&clip, x, rect, 4.0, 5.0, palette.gap_boundary, 1.0);
+            }
+        }
 
         if style.show_gap_labels && rect.width() >= 112.0 {
             let label = gap_label(&gap.reason);
+            // Centering the leading label would park text in the middle of an
+            // otherwise clean chart; it belongs to the divider, so it hugs it.
+            let (anchor, align) = if leading {
+                (
+                    rect.right_top() + egui::vec2(-GAP_LABEL_INSET_PX, 17.0),
+                    egui::Align2::RIGHT_TOP,
+                )
+            } else {
+                (
+                    rect.center_top() + egui::vec2(0.0, 17.0),
+                    egui::Align2::CENTER_TOP,
+                )
+            };
             draw_text_with_shadow(
                 &clip,
-                rect.center_top() + egui::vec2(0.0, 17.0),
-                egui::Align2::CENTER_TOP,
+                anchor,
+                align,
                 label,
                 egui::FontId::proportional(10.0),
                 palette.muted_text,
@@ -1432,7 +1438,6 @@ struct Palette {
     depth_only: egui::Color32,
     bubble_text: egui::Color32,
     gap_fill: egui::Color32,
-    gap_hatch: egui::Color32,
     gap_boundary: egui::Color32,
     muted_text: egui::Color32,
     legend_text: egui::Color32,
@@ -1449,8 +1454,7 @@ impl Palette {
                 consumption: egui::Color32::from_rgb(255, 246, 205),
                 depth_only: egui::Color32::from_rgb(184, 130, 240),
                 bubble_text: egui::Color32::WHITE,
-                gap_fill: egui::Color32::from_rgba_premultiplied(50, 58, 76, 48),
-                gap_hatch: egui::Color32::from_rgba_premultiplied(142, 151, 171, 30),
+                gap_fill: egui::Color32::from_rgba_premultiplied(21, 24, 32, 20),
                 gap_boundary: egui::Color32::from_rgba_premultiplied(157, 167, 188, 115),
                 muted_text: egui::Color32::from_rgb(186, 194, 209),
                 legend_text: egui::Color32::from_rgb(225, 230, 239),
@@ -1463,8 +1467,7 @@ impl Palette {
                 consumption: egui::Color32::WHITE,
                 depth_only: egui::Color32::from_rgb(225, 105, 255),
                 bubble_text: egui::Color32::WHITE,
-                gap_fill: egui::Color32::from_rgba_premultiplied(80, 80, 92, 64),
-                gap_hatch: egui::Color32::from_rgba_premultiplied(235, 235, 245, 42),
+                gap_fill: egui::Color32::from_rgba_premultiplied(35, 35, 40, 28),
                 gap_boundary: egui::Color32::from_rgb(218, 222, 235),
                 muted_text: egui::Color32::WHITE,
                 legend_text: egui::Color32::WHITE,
@@ -1477,8 +1480,7 @@ impl Palette {
                 consumption: egui::Color32::from_rgb(255, 238, 170),
                 depth_only: egui::Color32::from_rgb(220, 95, 205),
                 bubble_text: egui::Color32::WHITE,
-                gap_fill: egui::Color32::from_rgba_premultiplied(58, 60, 72, 52),
-                gap_hatch: egui::Color32::from_rgba_premultiplied(205, 205, 190, 34),
+                gap_fill: egui::Color32::from_rgba_premultiplied(25, 25, 30, 22),
                 gap_boundary: egui::Color32::from_rgb(176, 180, 190),
                 muted_text: egui::Color32::from_rgb(214, 215, 210),
                 legend_text: egui::Color32::from_rgb(232, 232, 226),
@@ -2000,6 +2002,49 @@ fn add_gradient_rect(
         .extend_from_slice(&[base, base + 1, base + 2, base, base + 2, base + 3]);
 }
 
+/// Pixel slack for deciding that a gap boundary coincides with the chart edge.
+/// Gap bounds arrive as normalized floats scaled into screen space, so an
+/// exact comparison would miss by a rounding bit and draw a stray frame line.
+const GAP_EDGE_EPSILON: f32 = 0.5;
+
+/// Gap between the leading span's label and the divider it annotates. Small
+/// enough that the text reads as belonging to the line rather than floating.
+const GAP_LABEL_INSET_PX: f32 = 6.0;
+
+/// Which marks one coverage gap gets.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct GapMarks {
+    fill: bool,
+    left_boundary: bool,
+    right_boundary: bool,
+}
+
+/// Decide how to mark a coverage gap.
+///
+/// The leading span — everything older than the first snapshot this session
+/// captured — routinely covers a third of the chart. Tinting it would bury the
+/// candles, bubbles and strip that are perfectly real there, so one boundary
+/// carries the whole message: where the book begins. Its left side is not a
+/// boundary at all, whether it lands on the viewport edge or on the oldest bar
+/// the chart holds — there is nothing on the far side of it to separate from.
+///
+/// An interior gap is different on both counts. It is narrow, so it keeps a
+/// faint fill (an untinted sliver reads as "no resting liquidity" rather than
+/// "no data"), and both its ends are real transitions. A boundary landing on
+/// the chart edge is still dropped: that marks the viewport, not a change in
+/// coverage, and drawing it would just frame the chart.
+fn gap_marks(rect: egui::Rect, chart_rect: egui::Rect, leading: bool) -> GapMarks {
+    let on_chart_edge = |x: f32| {
+        (x - chart_rect.left()).abs() < GAP_EDGE_EPSILON
+            || (x - chart_rect.right()).abs() < GAP_EDGE_EPSILON
+    };
+    GapMarks {
+        fill: !leading,
+        left_boundary: !leading && !on_chart_edge(rect.left()),
+        right_boundary: !on_chart_edge(rect.right()),
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn draw_dashed_vertical(
     painter: &egui::Painter,
@@ -2025,24 +2070,6 @@ fn draw_dashed_vertical(
     }
 }
 
-fn draw_gap_hatch(painter: &egui::Painter, rect: egui::Rect, color: egui::Color32) {
-    let mut x = rect.left() - rect.height();
-    while x < rect.right() {
-        let start_x = x.max(rect.left());
-        let start_y = rect.bottom() - (start_x - x);
-        let raw_end_x = x + rect.height();
-        let end_x = raw_end_x.min(rect.right());
-        let end_y = rect.top() + (raw_end_x - end_x);
-        if start_y >= rect.top() && end_y <= rect.bottom() {
-            painter.line_segment(
-                [egui::pos2(start_x, start_y), egui::pos2(end_x, end_y)],
-                egui::Stroke::new(0.55_f32, color),
-            );
-        }
-        x += 18.0;
-    }
-}
-
 fn draw_text_with_shadow(
     painter: &egui::Painter,
     anchor: egui::Pos2,
@@ -2063,7 +2090,7 @@ fn draw_text_with_shadow(
 
 fn gap_label(reason: &str) -> &'static str {
     match reason {
-        "book_unavailable_before_capture" => "L2 unavailable before capture",
+        BEFORE_CAPTURE => "L2 unavailable before capture",
         "capture_disabled" => "L2 capture disabled",
         "sequence_gap" => "L2 sequence gap · resynchronizing",
         _ => "L2 continuity unavailable",
@@ -2384,6 +2411,67 @@ mod tests {
             bubble_label(Decimal::ONE, 1, false, true),
             None,
             "one trade does not need a redundant count"
+        );
+    }
+
+    /// The stretch older than this session's capture used to be a hatched,
+    /// tinted block covering a third of the chart. It is now its boundary and
+    /// nothing else, so the candles and bubbles recorded there stay readable.
+    #[test]
+    fn the_pre_capture_span_is_marked_by_its_boundary_alone() {
+        let chart = egui::Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(400.0, 200.0));
+        let leading = egui::Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(120.0, 200.0));
+        assert_eq!(
+            gap_marks(leading, chart, true),
+            GapMarks {
+                fill: false,
+                left_boundary: false,
+                right_boundary: true,
+            }
+        );
+
+        // A chart the bars do not fill starts the span at the oldest bar
+        // instead of at the viewport edge. Still one line: there is nothing to
+        // the left of it to separate the span from.
+        let inset = egui::Rect::from_min_max(egui::pos2(60.0, 0.0), egui::pos2(120.0, 200.0));
+        assert_eq!(
+            gap_marks(inset, chart, true),
+            GapMarks {
+                fill: false,
+                left_boundary: false,
+                right_boundary: true,
+            }
+        );
+    }
+
+    /// An interior gap is a handful of pixels wide. Without a fill it would
+    /// read as an empty book rather than as missing data.
+    #[test]
+    fn an_interior_gap_keeps_its_fill_and_both_boundaries() {
+        let chart = egui::Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(400.0, 200.0));
+        let interior = egui::Rect::from_min_max(egui::pos2(180.0, 0.0), egui::pos2(186.0, 200.0));
+        assert_eq!(
+            gap_marks(interior, chart, false),
+            GapMarks {
+                fill: true,
+                left_boundary: true,
+                right_boundary: true,
+            }
+        );
+    }
+
+    /// Nothing captured at all: both bounds are the viewport, so no line is
+    /// drawn — framing the whole chart would say nothing the label does not.
+    #[test]
+    fn a_gap_spanning_the_whole_chart_draws_no_boundary() {
+        let chart = egui::Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(400.0, 200.0));
+        assert_eq!(
+            gap_marks(chart, chart, true),
+            GapMarks {
+                fill: false,
+                left_boundary: false,
+                right_boundary: false,
+            }
         );
     }
 

--- a/crates/app/src/orderflow_view.rs
+++ b/crates/app/src/orderflow_view.rs
@@ -142,10 +142,34 @@ impl OrderflowView {
         }
     }
 
-    /// Whether L2 depth capture is on. Says nothing about the bubble layer.
+    /// Whether L2 depth capture is recording. Says nothing about whether the
+    /// map is on screen — see [`depth_visible`](Self::depth_visible).
     #[must_use]
     pub fn enabled(&self) -> bool {
         self.config.enabled
+    }
+
+    /// Whether the depth map is drawn: recording *and* not hidden.
+    #[must_use]
+    pub fn depth_visible(&self) -> bool {
+        self.config.depth_visible()
+    }
+
+    /// Show or hide the depth map without touching L2 capture.
+    ///
+    /// No feed command is involved: the recorder keeps running, so turning the
+    /// map back on repaints the retained past instead of opening a gap in it.
+    pub fn set_depth_visible(&mut self, visible: bool) {
+        if self.config.show_depth == visible {
+            return;
+        }
+        let before = self.config.clone();
+        self.config.show_depth = visible;
+        if !visible {
+            // Drop the local frame immediately; the worker clears its own.
+            self.published.frame = None;
+        }
+        self.commit_config_changes(before);
     }
 
     /// Whether the aggression layer is on. Independent of the depth map: it
@@ -166,11 +190,11 @@ impl OrderflowView {
         self.commit_config_changes(before);
     }
 
-    /// Latest exchange timestamp for which live book state is known, while
-    /// capture is active. Drives how wide the forming bar's live tail grows.
+    /// Latest exchange timestamp for which live book state is known, while the
+    /// map is on screen. Drives how wide the forming bar's live tail grows.
     #[must_use]
     pub fn live_end_ms(&mut self) -> Option<i64> {
-        if !self.config.enabled {
+        if !self.config.depth_visible() {
             return None;
         }
         self.sync_published();
@@ -377,7 +401,9 @@ impl OrderflowView {
     }
 
     pub fn draw_status_badge(&self, painter: &egui::Painter, chart_rect: egui::Rect) {
-        if !self.config.enabled {
+        // Tied to the map, not to the recorder: a badge reporting on a book
+        // nobody asked to see is just chrome.
+        if !self.config.depth_visible() {
             return;
         }
         let text = self.published.status.label();
@@ -527,13 +553,16 @@ impl OrderflowView {
         self.published.health.clone()
     }
 
-    /// Whether capture is turned on but not yet (or no longer) delivering a
-    /// live book. What the app's loading overlay mirrors. Reads the frame's
-    /// mirror, refreshed by the panel/projection calls the frame already made;
-    /// which statuses count as a wait is [`CaptureStatus::is_syncing`]'s call.
+    /// Whether the map is open but not yet (or no longer) backed by a live
+    /// book. What the app's loading overlay mirrors. Reads the frame's mirror,
+    /// refreshed by the panel/projection calls the frame already made; which
+    /// statuses count as a wait is [`CaptureStatus::is_syncing`]'s call.
+    ///
+    /// Visibility-gated: the recorder synchronizing in the background is not
+    /// something to hold a loading overlay up for.
     #[must_use]
     pub fn is_syncing(&self) -> bool {
-        self.config.enabled && self.published.status.is_syncing()
+        self.config.depth_visible() && self.published.status.is_syncing()
     }
 
     pub fn reset_summary_counters(&mut self) {
@@ -1083,7 +1112,10 @@ impl OrderflowView {
                      depletion layers off, bubbles also lose their consumption marks",
                 );
                 ui.checkbox(&mut self.config.show_gaps, "L2 gap")
-                    .on_hover_text("hatching over intervals with no depth coverage");
+                    .on_hover_text(
+                        "dashed boundaries around intervals with no depth coverage; the stretch \
+                         older than this session's capture is marked by its boundary alone",
+                    );
 
                 ui.separator();
                 ui.strong("liquidity response");

--- a/crates/app/src/toolbar.rs
+++ b/crates/app/src/toolbar.rs
@@ -169,7 +169,7 @@ pub struct ToolbarModel<'a> {
     pub history_trades: usize,
     /// What the active source's backend can do.
     pub capabilities: FeedCapabilities,
-    /// Whether L2 capture is running.
+    /// Whether the L2 depth map is shown. Capture runs regardless.
     pub heatmap_on: bool,
     /// Whether the aggression layer is on.
     pub bubbles_on: bool,
@@ -186,7 +186,8 @@ pub struct ToolbarModel<'a> {
 pub enum ToolbarAction {
     /// Fetch and prepend one page of older trades.
     LoadOlder,
-    /// Start or stop L2 depth capture.
+    /// Show or hide the L2 depth map. Display-only: the recorder keeps
+    /// running, so reopening the map brings its history back whole.
     SetHeatmap(bool),
     /// Turn the aggression layer on or off.
     SetBubbles(bool),
@@ -423,7 +424,10 @@ fn draw_layers(ui: &mut egui::Ui, model: &ToolbarModel, actions: &mut Vec<Toolba
         .active(model.heatmap_on)
         .accent(theme::ACCENT)
         .enabled(model.capabilities.book_capture)
-        .hover_text("L2 heatmap: capture synchronized live depth — right-click for settings")
+        .hover_text(
+            "L2 heatmap: show the recorded depth map — recording never stops, so hiding it \
+             loses nothing. Right-click for settings",
+        )
         .disabled_explanation("order-book capture is not available for this source")
         .show(ui);
     if heatmap.clicked() {


### PR DESCRIPTION
## Summary

Two changes to the L2 depth layer, both from the same complaint: the map's toggle was doing a job it should not have, and the "no book here" region was shouting over data that is perfectly real.

**Recording and drawing are now separate concerns.** `HeatmapConfig` gains `show_depth` (display) beside `enabled` (the recorder), and the toolbar switch drives the first only. The recorder starts with any depth-capable feed through `ensure_book_capture` and stops only when the market changes — a feed/symbol switch, or a replay taking the chart over. Hiding the map therefore no longer punches a `capture_disabled` hole into the recorded book: reopen it and the whole retained window is there.

Hiding stays free. With the map closed `any_layer_enabled()` is false, so the worker builds no projection at all; the published ladder, the live tail, the status badge and the sync overlay all follow visibility rather than capture.

**The pre-capture span drops its fill and diagonal hatch** and is marked by a single dashed boundary where the book begins, with its label hugging that line. Interior gaps keep a faint fill between both boundaries — a few pixels of untinted chart would read as "no resting liquidity" rather than "no data". `draw_gap_hatch` and the `gap_hatch` palette entry are gone.

No linked issue: this came from a direct request in a `/goal` session, not from the board.

## Verification loop

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo build --workspace`
- [x] `cargo test --workspace` — 24 suites, 527 tests

## Notes for the reviewer

**Deliberate departure from "additive by default."** Capture now starts without being asked, which the repo rule says a new capability must not do. That is precisely the requested behaviour — a recorder that only runs while someone is watching is the bug being fixed. The map's own visibility default is unchanged (still hidden at startup), so no pixels move until the user asks. `QUANTICK_BOOK_AUTOSTART=1` now opens the map rather than starting capture; capture needs no flag.

**New cost, measured.** Live on BTCUSDT with the map hidden: `heatmap_projection_builds=0`, `heatmap_projection_ms=0.0`, frame CPU ~0.9 ms, versus 1.3–3.9 ms with the map open — so the drawing side really is free. What is new is the ingestion a hidden map now pays: ~10 depth updates/s and ~15 KB/s of history on BTCUSDT, on the book thread, bounded by the existing budget (`retention_ms` 30 min, `max_history_runs`, `max_history_bytes` 64 MiB). No new ceiling.

**Removed per-frame work.** `draw_gap_hatch` pushed one `line_segment` shape per 18 px of gap width every frame — roughly 60 shapes for a full-width leading span — plus a `rect_filled`. Both are gone for that span.

**Where to look hardest.** `gap_marks` in `orderflow_render.rs` is the whole visual decision as a pure function, with three tests. The case worth a second opinion is the leading span's left edge: when the bars do not fill the chart, that edge lands on the oldest bar rather than on the viewport edge, and it is deliberately *not* drawn — there is nothing on the far side of it to separate from. Caught by pixel-inspecting a live capture, not by a test I had written first.

**Test cover.** `hiding_the_heatmap_never_stops_the_recorder` (app) fails if the toggle goes back to driving capture; `a_hidden_map_keeps_recording_and_costs_nothing_to_draw` (engine) fails if the ladder, live tail or projection gate regress to capture-gating; `a_hidden_depth_map_projects_no_depth_primitives` (projection) fails if `depth_enabled` reverts to `config.enabled`; `a_source_without_depth_starts_no_recorder` guards a replay from spawning a recorder behind the chart. There is no painter harness in this file, so nothing asserts the hatch is *painted* nowhere — `GapMarks.fill == false` is the closest proxy the existing test style allows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CCkZphyrbJeaiWvTiP8CVu
