### PR TITLE
fix(app): the live region follows the tape, not just the book

### DIFF
--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -1186,7 +1186,8 @@ impl QuantickApp {
             return;
         }
 
-        // Live region: while following a live book, the forming bar grows to
+        // Live region: while following the live edge — the newest timestamp any
+        // recorded stream has reached, book or trades — the forming bar grows to
         // the right on a FIXED time-per-slot scale (the previous bar's
         // duration spread over the full width). Linear growth means an event
         // keeps its exact screen position while the region widens — bubbles
@@ -1200,7 +1201,7 @@ impl QuantickApp {
                 .last()
                 .map(|b| (b.close_time - b.open_time).max(1))
                 .unwrap_or(1_000);
-            // Up to ~55% of the chart for the live book.
+            // Up to ~55% of the chart for the live region.
             let max_span =
                 (chart_rect.width() / self.viewport.candle_width() * 0.55).clamp(8.0, 18.0);
             crate::orderflow_render::live_span_for(elapsed, ref_dur, max_span)

--- a/crates/app/src/orderflow/history.rs
+++ b/crates/app/src/orderflow/history.rs
@@ -236,6 +236,7 @@ pub struct LiquidityHistory {
     generation: Option<u64>,
     last_generation: Option<u64>,
     latest_book_ms: Option<i64>,
+    latest_aggression_ms: Option<i64>,
     archived: VecDeque<LiquidityRun>,
     active: BTreeMap<LevelKey, LiquidityRun>,
     aggressions: VecDeque<Aggression>,
@@ -255,6 +256,7 @@ impl LiquidityHistory {
             generation: None,
             last_generation: None,
             latest_book_ms: None,
+            latest_aggression_ms: None,
             archived: VecDeque::new(),
             active: BTreeMap::new(),
             aggressions: VecDeque::new(),
@@ -331,6 +333,24 @@ impl LiquidityHistory {
     #[must_use]
     pub fn latest_book_ms(&self) -> Option<i64> {
         self.latest_book_ms
+    }
+
+    /// Latest exchange timestamp observed on *any* retained stream.
+    ///
+    /// The live edge of the chart: how far market time has advanced according
+    /// to the data actually being recorded. Depth and trades are two windows
+    /// onto the same clock, and a venue that streams only one of them still has
+    /// a present — asking the book alone froze the forming bar's tail on every
+    /// feed without a Depth of Market.
+    ///
+    /// The trade side is monotonic on purpose: a late-delivered print must not
+    /// pull the live edge backwards and shrink the tail for a frame.
+    #[must_use]
+    pub fn latest_flow_ms(&self) -> Option<i64> {
+        match (self.latest_book_ms, self.latest_aggression_ms) {
+            (Some(book_ms), Some(trade_ms)) => Some(book_ms.max(trade_ms)),
+            (book_ms, trade_ms) => book_ms.or(trade_ms),
+        }
     }
 
     /// Oldest timestamp still renderable under the configured retention
@@ -526,6 +546,10 @@ impl LiquidityHistory {
             generation: self.generation,
         });
         self.counters.aggressions_recorded += 1;
+        self.latest_aggression_ms = Some(
+            self.latest_aggression_ms
+                .map_or(trade.timestamp_ms, |latest| latest.max(trade.timestamp_ms)),
+        );
         let prune_at = self.latest_book_ms.map_or(trade.timestamp_ms, |book_ms| {
             book_ms.max(trade.timestamp_ms)
         });
@@ -553,6 +577,7 @@ impl LiquidityHistory {
         self.book = OrderBook::new();
         self.generation = None;
         self.latest_book_ms = None;
+        self.latest_aggression_ms = None;
         self.archived.clear();
         self.active.clear();
         self.aggressions.clear();
@@ -841,6 +866,36 @@ mod tests {
             quantity: dec("2"),
             side,
         }
+    }
+
+    /// A venue with no Depth of Market still has a present. The live edge is
+    /// whatever the recorded streams have seen, so a trade-only feed advances
+    /// it exactly like a book-only one.
+    #[test]
+    fn the_live_edge_follows_trades_when_no_book_is_streaming() {
+        let mut history = LiquidityHistory::new(enabled_config());
+        assert_eq!(history.latest_flow_ms(), None);
+
+        history.record_aggression(&trade(1, 1_000, Side::Buy));
+        assert_eq!(history.latest_aggression_ms, Some(1_000));
+        assert_eq!(history.latest_book_ms(), None);
+        assert_eq!(history.latest_flow_ms(), Some(1_000));
+
+        history.record_aggression(&trade(2, 1_400, Side::Sell));
+        assert_eq!(history.latest_flow_ms(), Some(1_400));
+
+        // A late delivery must not pull the edge back and shrink the tail.
+        history.record_aggression(&trade(3, 1_200, Side::Buy));
+        assert_eq!(history.latest_flow_ms(), Some(1_400));
+
+        // With both streams the edge is the furthest one, whichever it is.
+        history
+            .install_snapshot(2_000, 9, snapshot(1))
+            .expect("snapshot installs");
+        assert_eq!(history.latest_book_ms(), Some(2_000));
+        assert_eq!(history.latest_flow_ms(), Some(2_000));
+        history.record_aggression(&trade(4, 2_500, Side::Sell));
+        assert_eq!(history.latest_flow_ms(), Some(2_500));
     }
 
     #[test]

--- a/crates/app/src/orderflow_engine.rs
+++ b/crates/app/src/orderflow_engine.rs
@@ -866,7 +866,9 @@ impl BookEngine {
             &request.closed,
             request.partial.as_ref(),
             if request.extend_live_end {
-                self.history.latest_book_ms()
+                // The same live edge the chart widens the forming slot with, so
+                // a bubble lands on the x the tail reserved for it.
+                self.history.latest_flow_ms()
             } else {
                 None
             },
@@ -998,9 +1000,11 @@ impl BookEngine {
             health: self.health(),
             // Gated on visibility, not on capture: the live tail and the strip
             // are pixels, and a recorder nobody is watching must not pay for
-            // them.
-            live_end_ms: if self.config.depth_visible() {
-                self.history.latest_book_ms()
+            // them. Which layer is visible does not narrow the clock, though:
+            // market time comes from every stream being recorded, so a venue
+            // that publishes no Depth of Market still has a present.
+            live_end_ms: if self.config.any_layer_enabled() {
+                self.history.latest_flow_ms()
             } else {
                 None
             },
@@ -1361,6 +1365,72 @@ mod tests {
         assert!(
             engine.published().ladder.is_none(),
             "capture off publishes no ladder"
+        );
+    }
+
+    /// The MetaTrader complaint made executable: a feed streaming trades and
+    /// no Depth of Market must still open the forming bar's live region.
+    ///
+    /// Before this, the live edge was the book's clock alone, so a venue with
+    /// no DOM (and a chart with the map hidden) reported no present at all: the
+    /// tail never grew and every print of the forming bar piled up inside the
+    /// single candle slot, exactly where the tape stopped reading as a tape.
+    #[test]
+    fn trades_alone_advance_the_live_edge_and_spread_the_forming_bar() {
+        let mut engine = BookEngine::new("BTCUSDT");
+        let bubbles_only = HeatmapConfig {
+            show_aggressions: true,
+            bubble_cluster_ms: 0,
+            bubble_dust_merge_ms: 0,
+            ..engine.config.clone()
+        };
+        engine.apply_visual_config(bubbles_only);
+        assert!(!engine.depth_visible(), "no book is streaming here");
+
+        let forming = bar(1_000, 1_000);
+        for (agg_id, timestamp_ms) in [(1_u64, 1_000_i64), (2, 3_000), (3, 5_000)] {
+            engine.record_trade(&Trade {
+                agg_id,
+                timestamp_ms,
+                price: Decimal::from(100),
+                quantity: Decimal::ONE,
+                side: Side::Buy,
+            });
+        }
+        assert_eq!(engine.history.latest_book_ms(), None);
+        assert_eq!(engine.published().live_end_ms, Some(5_000));
+
+        let frame = engine
+            .project(&ProjectionRequest {
+                first_bar_index: 0,
+                closed: Vec::new(),
+                partial: Some(forming),
+                extend_live_end: true,
+                price_range: (98.0, 102.0),
+            })
+            .expect("bubbles project without a book");
+
+        let mut positions: Vec<f64> = frame
+            .projection
+            .aggressions
+            .iter()
+            .map(|bubble| bubble.x)
+            .collect();
+        positions.sort_by(f64::total_cmp);
+        assert_eq!(positions.len(), 3);
+        // The forming slot now spans 1 000 → 5 000 ms, so the three prints land
+        // at the start, the middle and the live edge instead of on one x.
+        assert!(
+            (positions[0] - 0.0).abs() < 1e-9,
+            "first print opens the bar"
+        );
+        assert!(
+            (positions[1] - 0.5).abs() < 1e-9,
+            "the middle print is mid-slot"
+        );
+        assert!(
+            (positions[2] - 1.0).abs() < 1e-9,
+            "the newest print is the live edge"
         );
     }
 

--- a/crates/app/src/orderflow_render.rs
+++ b/crates/app/src/orderflow_render.rs
@@ -581,7 +581,7 @@ pub(crate) struct ProjectedLayout<'a> {
     /// Visual width, in candle-widths, of the last slot (the forming bar). `1.0`
     /// keeps equal-width slots; `> 1.0` expands the forming bar's live tail to
     /// the right so its order flow rolls on a real-time scale instead of
-    /// recompressing every depth update.
+    /// recompressing every time the live edge advances.
     pub(crate) live_span: f32,
 }
 

--- a/crates/app/src/orderflow_view.rs
+++ b/crates/app/src/orderflow_view.rs
@@ -190,11 +190,16 @@ impl OrderflowView {
         self.commit_config_changes(before);
     }
 
-    /// Latest exchange timestamp for which live book state is known, while the
-    /// map is on screen. Drives how wide the forming bar's live tail grows.
+    /// Latest exchange timestamp any visible layer has data for. Drives how
+    /// wide the forming bar's live tail grows.
+    ///
+    /// Deliberately not the book's clock alone: the bubbles are built from the
+    /// trade stream, so tying the tail to Depth of Market froze the live region
+    /// on every feed that has none — the flow kept arriving and kept being
+    /// drawn inside the forming candle's single slot.
     #[must_use]
     pub fn live_end_ms(&mut self) -> Option<i64> {
-        if !self.config.depth_visible() {
+        if !self.config.any_layer_enabled() {
             return None;
         }
         self.sync_published();


### PR DESCRIPTION
## The bug

The forming bar's live region — the space to the right of the newest candle where real-time flow rolls — never opened on MetaTrader. Every print of the forming bar piled up inside the candle's single slot, which is exactly where a tape stops reading as a tape.

The cause is the clock behind it. `live_end_ms` was `latest_book_ms` gated on `depth_visible()`: a timestamp only a *depth* event advances, published only while the heatmap is on screen. A MetaTrader session may publish no Depth of Market at all, and the map is often hidden precisely so the bubbles can be read — either one alone left the chart reporting no present. Binance hid the flaw because its book never stops ticking.

## The fix

`LiquidityHistory::latest_flow_ms()` — the furthest of the book's clock and the trade stream's — and the tail gates on `any_layer_enabled()` rather than on the depth map specifically. Depth and trades are two windows onto the same clock; a venue that streams only one of them still has a present. The same edge feeds the projection's timeline, so a bubble lands on the x the tail reserved for it.

The trade side is monotonic on purpose: a late-delivered print must not pull the edge backwards and shrink the tail for a frame.

What deliberately did not change:

- With no layer visible the clock is still withheld — a recorder nobody watches pays for no pixels.
- Coverage gaps are still marked at the last timestamp the **book** was observed. Using the trade clock there would claim book knowledge nobody has.
- Capture, retention and the book's own state machine are untouched.

## Proof

Two tests, both verified to fail without the change:

- `orderflow::history::tests::the_live_edge_follows_trades_when_no_book_is_streaming` — the edge advances on trades alone, takes the furthest of the two streams when both run, and never regresses on a late print.
- `orderflow_engine::tests::trades_alone_advance_the_live_edge_and_spread_the_forming_bar` — the user's report made executable. Three prints at 1 000 / 3 000 / 5 000 ms in a forming bar with no book land at x = 0.0 / 0.5 / 1.0. Reverting the published clock drops `live_end_ms` to `None`; reverting the timeline clock alone leaves **1 of 3** bubbles on screen — the pile-up, measured.

`a_hidden_map_keeps_recording_and_costs_nothing_to_draw` still passes: hiding every layer still publishes no clock.

## Verification

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo build --workspace`
- [x] `cargo test --workspace`
- [x] `arch-review` — no Blocker, no Should-fix. Performance: one `max` and one `Option<i64>` write per trade on the ingest path (no allocation); the live region now projects on feeds that lacked it, bounded as before by `max_aggression_primitives`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V9Ao2QbeY3gcYPy7iqszv7
