### PR TITLE
feat(app): let a feed declare the bubble preset it opens with

### DIFF
--- a/config/bubbles.toml
+++ b/config/bubbles.toml
@@ -149,6 +149,7 @@ label_min_radius = 16.0
 [[presets]]
 name = "dense tape btc"
 cluster_ms = 500
+candle_summary = true
 
 [presets.bubbles]
 min_radius = 2.2

--- a/crates/app/config/bubbles.toml
+++ b/crates/app/config/bubbles.toml
@@ -168,6 +168,7 @@ label_min_radius = 16.0
 [[presets]]
 name = "dense tape btc"
 cluster_ms = 500
+candle_summary = true
 
 [presets.bubbles]
 min_radius = 2.2

--- a/crates/app/config/feeds.toml
+++ b/crates/app/config/feeds.toml
@@ -14,11 +14,15 @@ default_feed = "binance"
 default_symbol = "BTCUSDT"
 
 # Each [[feeds]] entry is one selectable feed.
-#   id       — stable identifier, referenced by `default_feed` (unique).
-#   name     — label shown in the feed selector.
-#   provider — which backend streams it; maps to a code path.
-#              Supported today: "binance", "metatrader".
-#   symbols  — the assets offered for this feed (first is its fallback).
+#   id            — stable identifier, referenced by `default_feed` (unique).
+#   name          — label shown in the feed selector.
+#   provider      — which backend streams it; maps to a code path.
+#                   Supported today: "binance", "metatrader".
+#   symbols       — the assets offered for this feed (first is its fallback).
+#   bubble_preset — optional: a bubble preset (by name, from bubbles.toml)
+#                   applied whenever this feed is selected. Leave it out and
+#                   the panel keeps whatever preset is active. An unknown name
+#                   is reported and ignored.
 [[feeds]]
 id = "binance"
 name = "Binance"
@@ -42,6 +46,10 @@ id = "metatrader"
 name = "MetaTrader 5"
 provider = "metatrader"
 symbols = ["WIN$N", "WDO$N", "US500"]
+# The B3 mini index reads best as per-bar pie summaries: bars close in seconds
+# and the candle summary keeps the last bars carrying marks instead of leaving
+# the lane window bare.
+bubble_preset = "live lane pie"
 
 # MetaTrader bridge settings (defaults shown; the section is optional).
 #   listen_addr — where quantick listens; the EA dials this address.

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -385,6 +385,8 @@ impl QuantickApp {
         // Recording is not a display choice: it starts with the feed, so
         // hiding the map later never leaves a hole in what was captured.
         app.ensure_book_capture();
+        // A feed that declares its own look opens wearing it.
+        app.apply_feed_bubble_preset();
         // The map itself stays hidden until asked for — a layer nobody
         // requested must cost no projection. Dev/ops can open it without a
         // click; capture is already running either way.
@@ -742,6 +744,7 @@ impl QuantickApp {
         if self.active == (self.feed_id.clone(), self.symbol.clone()) {
             return;
         }
+        let previous_feed = self.active.0.clone();
         let Some(provider) = self.config.provider_of(&self.feed_id) else {
             tracing::warn!(
                 target: "quantick::app",
@@ -800,6 +803,55 @@ impl QuantickApp {
 
         self.active = (self.feed_id.clone(), self.symbol.clone());
         self.ensure_book_capture();
+        self.apply_feed_bubble_preset_after_switch(&previous_feed);
+    }
+
+    /// Apply the arrived-at feed's declared preset — only when the switch
+    /// actually crossed feeds. A symbol hop inside one feed keeps the user's
+    /// panel tweaks: the declared look belongs to the feed, not the symbol.
+    fn apply_feed_bubble_preset_after_switch(&mut self, previous_feed: &str) {
+        if previous_feed == self.feed_id {
+            return;
+        }
+        self.apply_feed_bubble_preset();
+    }
+
+    /// Apply the bubble preset the current feed declares, if it declares one.
+    ///
+    /// A feed with no `bubble_preset` changes nothing: the panel keeps the look
+    /// the user last chose. An unknown name is reported and ignored — the
+    /// presets file is user-edited, and a typo there must not silently restyle
+    /// the chart.
+    fn apply_feed_bubble_preset(&mut self) {
+        let Some(name) = self
+            .config
+            .feed(&self.feed_id)
+            .and_then(|feed| feed.bubble_preset.clone())
+        else {
+            return;
+        };
+        let applied = self.orderflow.apply_preset(&name);
+        if applied {
+            tracing::info!(
+                target: "quantick::app",
+                schema_version = 1_u8,
+                event_code = "FEED_BUBBLE_PRESET",
+                feed = %self.feed_id,
+                preset = name.as_str(),
+                action = "apply_preset",
+                "feed declares a bubble preset; applied"
+            );
+        } else {
+            tracing::warn!(
+                target: "quantick::app",
+                schema_version = 1_u8,
+                event_code = "FEED_BUBBLE_PRESET_UNKNOWN",
+                feed = %self.feed_id,
+                preset = name.as_str(),
+                action = "keep_current_look",
+                "feed declares a bubble preset that is not in the presets file; ignoring"
+            );
+        }
     }
 
     /// Apply a bar-type/parameter change one frame after the selectors settle.
@@ -2323,6 +2375,7 @@ mod tests {
                 name: "Binance".to_string(),
                 provider: ProviderKind::Binance,
                 symbols: vec!["TESTUSDT".to_string(), "ETHUSDT".to_string()],
+                bubble_preset: None,
             }],
             metatrader: Default::default(),
         }
@@ -2837,12 +2890,14 @@ mod tests {
                     name: "A".to_string(),
                     provider: ProviderKind::Binance,
                     symbols: vec!["AAA".to_string()],
+                    bubble_preset: None,
                 },
                 FeedConfig {
                     id: "b".to_string(),
                     name: "B".to_string(),
                     provider: ProviderKind::Binance,
                     symbols: vec!["BBB".to_string()],
+                    bubble_preset: None,
                 },
             ],
             metatrader: Default::default(),
@@ -2870,6 +2925,103 @@ mod tests {
         app.symbol = "BBB".to_string();
         app.ensure_symbol_valid();
         assert_eq!(app.symbol, "BBB");
+    }
+
+    /// One app on `config`, opened on `feed_id`/symbol — the smallest harness
+    /// that exercises the constructor path (where a feed's declared bubble
+    /// preset is applied).
+    fn app_on(config: AppConfig, feed_id: &str, symbol: &str) -> QuantickApp {
+        let (_evt_tx, evt_rx) = mpsc::channel(8);
+        let (_book_tx, book_rx) = mpsc::channel(8);
+        let (cmd_tx, _cmd_rx) = mpsc::channel(8);
+        QuantickApp::new(
+            config,
+            feed_id,
+            symbol,
+            BarSpec::Tick(50),
+            FeedHandle {
+                events: evt_rx,
+                book_events: book_rx,
+                notices: feed::silent_notices(),
+                capabilities: feed::fixed_capabilities(ProviderKind::Binance.capabilities()),
+                commands: cmd_tx,
+                replay: None,
+            },
+        )
+    }
+
+    #[test]
+    fn a_feed_declaring_a_bubble_preset_opens_wearing_it() {
+        let mut config = test_config();
+        config.feeds[0].bubble_preset = Some("live lane pie".to_string());
+        let app = app_on(config, "binance", "TESTUSDT");
+        assert_eq!(app.orderflow.active_preset_for_test(), "live lane pie");
+        assert!(
+            app.orderflow.config_for_test().bubble_candle_summary,
+            "the pie preset folds closed bars into per-price summaries"
+        );
+    }
+
+    #[test]
+    fn a_feed_declaring_an_unknown_bubble_preset_changes_nothing() {
+        let mut config = test_config();
+        config.feeds[0].bubble_preset = Some("no such preset".to_string());
+        let with_unknown = app_on(config, "binance", "TESTUSDT");
+        let untouched = app_on(test_config(), "binance", "TESTUSDT");
+        assert_eq!(
+            with_unknown.orderflow.active_preset_for_test(),
+            untouched.orderflow.active_preset_for_test(),
+            "a typo in the config must not restyle the chart"
+        );
+        assert_eq!(
+            with_unknown.orderflow.config_for_test(),
+            untouched.orderflow.config_for_test()
+        );
+    }
+
+    #[test]
+    fn switching_to_a_feed_with_a_declared_preset_applies_it_then() {
+        // Feed "binance" declares nothing; a second feed declares the pie
+        // look. Opening on the first must not apply it — moving to the
+        // second must.
+        let mut config = test_config();
+        config.feeds.push(FeedConfig {
+            id: "mt".to_string(),
+            name: "MetaTrader 5".to_string(),
+            provider: ProviderKind::MetaTrader,
+            symbols: vec!["WINQ26".to_string()],
+            bubble_preset: Some("live lane pie".to_string()),
+        });
+        let mut app = app_on(config, "binance", "TESTUSDT");
+        let opened_with = app.orderflow.active_preset_for_test().to_string();
+        assert_ne!(
+            opened_with, "live lane pie",
+            "nothing declared, nothing applied"
+        );
+
+        // The switch path runs this after installing the new feed handle.
+        app.feed_id = "mt".to_string();
+        app.apply_feed_bubble_preset_after_switch("binance");
+        assert_eq!(app.orderflow.active_preset_for_test(), "live lane pie");
+    }
+
+    #[test]
+    fn a_symbol_hop_inside_one_feed_keeps_the_panel_look() {
+        let mut config = test_config();
+        config.feeds[0].bubble_preset = Some("live lane pie".to_string());
+        let mut app = app_on(config, "binance", "TESTUSDT");
+        assert_eq!(app.orderflow.active_preset_for_test(), "live lane pie");
+
+        // The user picks a different look by hand mid-session...
+        assert!(app.orderflow.apply_preset("dense tape"));
+        // ...then hops symbols inside the same feed: the hand-picked look
+        // survives — the declared preset belongs to the feed, not the symbol.
+        app.apply_feed_bubble_preset_after_switch("binance");
+        assert_eq!(app.orderflow.active_preset_for_test(), "dense tape");
+
+        // Arriving from another feed is what re-applies the declared look.
+        app.apply_feed_bubble_preset_after_switch("other-feed");
+        assert_eq!(app.orderflow.active_preset_for_test(), "live lane pie");
     }
 
     #[test]

--- a/crates/app/src/config.rs
+++ b/crates/app/src/config.rs
@@ -192,6 +192,16 @@ pub struct FeedConfig {
     /// Assets offered for this feed; the first is used as a fallback when the
     /// current symbol is not valid for a newly selected feed.
     pub symbols: Vec<String>,
+    /// Bubble preset applied when this feed is selected, by name.
+    ///
+    /// A market dictates how its tape reads — the B3 mini index wants the
+    /// candle summary that a dense BTC tape does not — so a feed may declare
+    /// the look it opens with. Absent, nothing changes: the panel keeps
+    /// whatever preset is active, exactly as before the field existed. The
+    /// name must exist in the bubble presets file; an unknown name is reported
+    /// and ignored rather than silently altering the panel.
+    #[serde(default)]
+    pub bubble_preset: Option<String>,
 }
 
 /// The whole feed/asset configuration.
@@ -255,6 +265,15 @@ impl AppConfig {
             }
             if self.feeds.iter().filter(|f| f.id == feed.id).count() > 1 {
                 return Err(format!("duplicate feed id '{}'", feed.id));
+            }
+            // Whether the name resolves is the presets file's business (checked
+            // when the preset is applied); an empty name is a config typo.
+            if feed
+                .bubble_preset
+                .as_ref()
+                .is_some_and(|name| name.trim().is_empty())
+            {
+                return Err(format!("feed '{}' names an empty bubble_preset", feed.id));
             }
         }
         let Some(default) = self.feed(&self.default_feed) else {
@@ -396,6 +415,30 @@ mod tests {
         assert!(mt5.symbols.contains(&"WIN$N".to_string()));
         assert_eq!(config.metatrader.side_source, Mt5SideSource::TickRule);
         assert!(!config.metatrader.listen_addr.is_empty());
+
+        // The mini index opens on the pie summary; Binance declares nothing
+        // and keeps whatever the presets file says.
+        assert_eq!(mt5.bubble_preset.as_deref(), Some("live lane pie"));
+        assert_eq!(binance.bubble_preset, None);
+    }
+
+    #[test]
+    fn an_empty_bubble_preset_is_a_config_error() {
+        let text = r#"
+            default_feed = "b"
+            default_symbol = "AAA"
+            [[feeds]]
+            id = "b"
+            name = "B"
+            provider = "binance"
+            symbols = ["AAA"]
+            bubble_preset = "  "
+        "#;
+        let err = parse(text, ConfigSource::Embedded).expect_err("blank name");
+        assert!(
+            err.to_string().contains("bubble_preset"),
+            "the message names the field: {err}"
+        );
     }
 
     #[test]

--- a/crates/app/src/orderflow_view.rs
+++ b/crates/app/src/orderflow_view.rs
@@ -249,6 +249,18 @@ impl OrderflowView {
         self.config.live_lane.window_ms(reserved_span_ms(closed))
     }
 
+    /// Name of the preset the panel currently wears.
+    #[cfg(test)]
+    pub(crate) fn active_preset_for_test(&self) -> &str {
+        &self.presets.active
+    }
+
+    /// Read-only view of the heatmap config, for app-level assertions.
+    #[cfg(test)]
+    pub(crate) fn config_for_test(&self) -> &HeatmapConfig {
+        &self.config
+    }
+
     #[cfg(test)]
     pub(crate) fn stage_capture_grouping_for_test(&mut self, grouping: Decimal) -> bool {
         let before = self.config.clone();
@@ -697,14 +709,20 @@ impl OrderflowView {
         }
     }
 
-    fn apply_preset(&mut self, name: &str) {
+    /// Apply the stored preset called `name`, reporting whether it exists.
+    ///
+    /// The panel's picker and a feed's declared preset both land here, so a
+    /// preset applies identically no matter who asked. An unknown name changes
+    /// nothing and returns `false`; the caller decides how loudly to say so.
+    pub(crate) fn apply_preset(&mut self, name: &str) -> bool {
         let Some(preset) = self.presets.get(name).cloned() else {
-            return;
+            return false;
         };
         preset.apply_to(&mut self.config);
         self.presets.active = preset.name.clone();
         self.preset_name_draft = preset.name.clone();
         self.preset_status = Some(format!("'{}' applied", preset.name));
+        true
     }
 
     fn save_preset(&mut self) {
@@ -1690,7 +1708,7 @@ mod tests {
                 show_marks: true,
             },
         });
-        view.apply_preset("wide");
+        assert!(view.apply_preset("wide"), "a stored name applies");
         assert_eq!(view.config.bubbles.max_radius, 42.0);
         assert_eq!(view.config.bubble_cluster_ms, 100);
         assert_eq!(view.config.bubble_dust_merge_ms, 3_000);
@@ -1707,9 +1725,9 @@ mod tests {
         assert_eq!(view.config.gamma, before.gamma);
         assert_eq!(view.config.price_grouping, before.price_grouping);
 
-        // An unknown name changes nothing at all.
+        // An unknown name changes nothing at all, and says so.
         let after = view.config.clone();
-        view.apply_preset("nope");
+        assert!(!view.apply_preset("nope"));
         assert_eq!(view.config, after);
         assert_eq!(view.presets.active, "wide");
     }


### PR DESCRIPTION
## Why

On MetaTrader the last candles before the live lane divider rendered no
aggression marks at all (user-reported with an annotated screenshot). Root
cause: with `candle_summary` off, a raw print is drawn exactly once — on the
tape — so every bar still inside the lane window shows nothing on the chart.
The pie-summary rendering that fixes this shipped with #89 but only behind the
`"live lane pie"` preset, which nothing selected by default.

## What

- **`FeedConfig.bubble_preset`** (optional): a feed may declare the bubble
  preset it opens with, applied at startup and when a switch arrives at that
  feed. Absent → nothing changes. Unknown name → reported
  (`FEED_BUBBLE_PRESET_UNKNOWN`) and ignored. A symbol hop inside one feed
  keeps the user's hand-picked panel look.
- The built-in `metatrader` feed declares `"live lane pie"` — B3 mini-index
  bars close in seconds, so the candle summary is what keeps recent bars
  carrying marks.
- **`dense tape btc` now sets `candle_summary = true`** in both preset files
  (tracked + embedded mirror), per the user's decision: closed bars fold into
  one two-sided pie per price level, the forming bar's pies grow with each
  order.

## Proof

- `a_feed_declaring_a_bubble_preset_opens_wearing_it`,
  `a_feed_declaring_an_unknown_bubble_preset_changes_nothing`,
  `switching_to_a_feed_with_a_declared_preset_applies_it_then`,
  `a_symbol_hop_inside_one_feed_keeps_the_panel_look`,
  `an_empty_bubble_preset_is_a_config_error` — all fail without the change.
- Full loop green locally: fmt, clippy `-D warnings`, build, test (workspace).
- Live validation on MT5 WINQ26 (private port, own bridge): the app opened
  straight into the pie look with zero clicks (`FEED_BUBBLE_PRESET` logged),
  no mark-less span before the lane divider, and a 1.2 s capture burst shows
  the forming candle's column accumulating marks while no historical mark
  moves.

## Arch review

Ran per repo workflow; one Should-fix found and fixed in-branch (symbol hop
inside one feed re-applied the declared preset, clobbering manual panel
tweaks — now gated on actually crossing feeds, with a regression test).

Known follow-up (out of scope, will file separately): the aggression
primitive cap (700) truncates by quantity when exceeded, which can hide small
recent marks on long retention windows; observed live before this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0199NtGb9AusnjcronpxCU1y
