### PR TITLE
feat: add modular chart drawing tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2470,6 +2470,7 @@ dependencies = [
  "rfd",
  "rust_decimal",
  "serde",
+ "smallvec",
  "tokio",
  "toml 0.8.20",
  "tracing",

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -16,6 +16,7 @@ rust_decimal = "1"
 # dialog never blocks a frame.
 rfd = { version = "0.15", default-features = false, features = ["xdg-portal", "tokio"] }
 serde = { version = "1", features = ["derive"] }
+smallvec = "1"
 toml = "0.8"
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "net", "time", "process"] }
 tracing = "0.1"

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -58,6 +58,15 @@ const DRAWING_ANCHOR_RADIUS_PX: f32 = 12.0;
 const DRAWING_DRAG_THRESHOLD_PX: f32 = 4.0;
 /// Initial position of the selected-drawing inspector.
 const DRAWING_INSPECTOR_DEFAULT_POSITION: egui::Pos2 = egui::pos2(90.0, 120.0);
+/// Inspector width bounds (UX spec: resizable between 300 and 440 px).
+const INSPECTOR_MIN_WIDTH_PX: f32 = 300.0;
+/// See [`INSPECTOR_MIN_WIDTH_PX`].
+const INSPECTOR_MAX_WIDTH_PX: f32 = 440.0;
+/// Default inspector width for the shipped tools (the spec reserves 360 px
+/// for the Fib level editor).
+const INSPECTOR_DEFAULT_WIDTH_PX: f32 = 320.0;
+/// Gap kept between the inspector and the selected object's bounding box.
+const INSPECTOR_OBJECT_GAP_PX: f32 = 12.0;
 /// How long the delete toast keeps its Undo affordance on screen (UX spec).
 const TOAST_UNDO_MS: u64 = 8_000;
 /// Vertical clearance between the toast and the bottom chrome.
@@ -90,6 +99,29 @@ impl DrawingDrag {
 struct DrawingToast {
     message: &'static str,
     shown_at: Instant,
+}
+
+/// Which inspector tab is open. Tabs exist per capability: every tool gets
+/// Style and Coordinates; a tool with levels adds its own tab.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+enum InspectorTab {
+    #[default]
+    Style,
+    Coordinates,
+}
+
+/// What the inspector body asked for this frame. The caller owns every
+/// mutation, so the pinned panel and the floating window share one rule set.
+#[derive(Debug, Default, Clone, Copy)]
+struct InspectorActions {
+    toggle_hidden: bool,
+    toggle_lock: bool,
+    toggle_pin: bool,
+    delete: bool,
+    cancel_delete: bool,
+    force_delete: bool,
+    close: bool,
+    edited: bool,
 }
 
 /// Alpha of the last-price line: legible at a glance without competing with a
@@ -333,10 +365,26 @@ pub struct QuantickApp {
     drawing_drag: DrawingDrag,
     // Delete confirmation for a locked drawing, shown next to the trigger.
     drawing_delete_confirm: bool,
-    // Pre-edit copy of the selected drawing while an inspector style gesture
-    // (slider/color drag) is in flight; committed as one undo entry.
-    drawing_style_baseline: Option<(usize, drawings::Drawing)>,
+    // Pre-edit copy of the selected drawing while an inspector edit gesture
+    // (slider/color/coordinate drag) is in flight; committed as one undo
+    // entry once pointer and keyboard let go.
+    inspector_edit_baseline: Option<(usize, drawings::Drawing)>,
     drawing_toast: Option<DrawingToast>,
+    // Inspector chrome state: open tab, dock pin, whether the user moved the
+    // floating window this session (manual position wins over placement),
+    // and the selection the last placement was computed for.
+    inspector_tab: InspectorTab,
+    inspector_pinned: bool,
+    inspector_moved: bool,
+    inspector_last_selection: Option<usize>,
+    // The chart pane from the last frame (excludes axes and the live lane),
+    // for inspector placement and manager centring.
+    last_chart_area: Option<egui::Rect>,
+    drawing_manager_open: bool,
+    #[cfg(test)]
+    inspector_pin_rect: Option<egui::Rect>,
+    #[cfg(test)]
+    manager_action_rects: Vec<(usize, &'static str, egui::Rect)>,
 
     // Candle appearance + whether the style panel is open.
     style: ChartStyle,
@@ -436,8 +484,18 @@ impl QuantickApp {
             drawing_press_started_empty: false,
             drawing_drag: DrawingDrag::None,
             drawing_delete_confirm: false,
-            drawing_style_baseline: None,
+            inspector_edit_baseline: None,
             drawing_toast: None,
+            inspector_tab: InspectorTab::default(),
+            inspector_pinned: false,
+            inspector_moved: false,
+            inspector_last_selection: None,
+            last_chart_area: None,
+            drawing_manager_open: false,
+            #[cfg(test)]
+            inspector_pin_rect: None,
+            #[cfg(test)]
+            manager_action_rects: Vec::new(),
             style: ChartStyle::default(),
             show_style: false,
             style_revision: 0,
@@ -1087,7 +1145,8 @@ impl QuantickApp {
         self.drawing_press_started_empty = false;
         self.drawing_drag = DrawingDrag::None;
         self.drawing_delete_confirm = false;
-        self.drawing_style_baseline = None;
+        self.inspector_edit_baseline = None;
+        self.inspector_last_selection = None;
         // The cleared history cannot resurrect anything, so the toast's Undo
         // affordance would lie — drop it with the drawings.
         self.drawing_toast = None;
@@ -1474,6 +1533,9 @@ impl QuantickApp {
     /// that starts inside the tape moves nothing, and scrolling there zooms the
     /// tape's own window instead of the candles.
     fn handle_navigation(&mut self, ui: &egui::Ui, area: egui::Rect) {
+        // Remembered for inspector placement and manager centring: the pane
+        // where drawings live, already free of both axes and the live lane.
+        self.last_chart_area = Some(plot_split(area, self.live_strip_width()).chart);
         if self.handle_drawing_placement(ui, area) {
             return;
         }
@@ -1558,19 +1620,21 @@ impl QuantickApp {
                             point_index,
                         }
                     };
-                } else {
-                    let selected =
-                        self.drawing_at(position, areas.chart, history_right, total, &scale);
-                    self.drawings.select(selected);
-                    self.drawing_drag = match selected {
-                        Some(index) if self.drawings.items()[index].locked => DrawingDrag::Blocked,
-                        Some(_) => {
-                            self.drawings.begin_gesture();
-                            DrawingDrag::Translate
-                        }
-                        None => DrawingDrag::None,
+                } else if let Some(index) =
+                    self.drawing_at(position, areas.chart, history_right, total, &scale)
+                {
+                    self.drawings.select(Some(index));
+                    self.drawing_drag = if self.drawings.items()[index].locked {
+                        DrawingDrag::Blocked
+                    } else {
+                        self.drawings.begin_gesture();
+                        DrawingDrag::Translate
                     };
                 }
+                // A press that hits no geometry is not ours to interpret: it
+                // belongs to whatever egui routed it to (inspector, manager,
+                // chart pan). Deselection happens through the egui-routed
+                // click above, which already respects floating windows.
                 drawing_drag_started = self.drawing_drag.is_active();
             }
             if primary_down && !drawing_drag_started {
@@ -2525,9 +2589,9 @@ impl QuantickApp {
         }
     }
 
-    /// Commit a pending inspector style gesture as one undo entry.
-    fn commit_style_gesture(&mut self) {
-        if let Some((index, before)) = self.drawing_style_baseline.take() {
+    /// Commit a pending inspector edit gesture as one undo entry.
+    fn commit_inspector_gesture(&mut self) {
+        if let Some((index, before)) = self.inspector_edit_baseline.take() {
             self.drawings.record_edit_of(index, before);
         }
     }
@@ -2571,103 +2635,111 @@ impl QuantickApp {
         }
     }
 
-    /// The selected object's inspector mirrors the compact, contextual drawing
-    /// controls traders expect: styles are per object rather than global.
-    /// Non-modal by contract: it never captures the whole canvas and never
-    /// blocks moving the geometry underneath it.
-    fn draw_drawing_inspector(&mut self, ctx: &egui::Context, now: Instant) {
-        let Some(index) = self.drawings.selected() else {
-            self.drawing_delete_confirm = false;
-            self.commit_style_gesture();
-            return;
-        };
-        // A style gesture that outlived its object's selection commits now.
-        if self
-            .drawing_style_baseline
-            .as_ref()
-            .is_some_and(|(baseline_index, _)| *baseline_index != index)
-        {
-            self.commit_style_gesture();
-        }
-        let before = self.drawings.items()[index].clone();
-        let title = before.tool.settings_title();
-        let locked = before.locked;
-        let hidden = before.hidden;
+    /// Everything the inspector shows for the selected object, shared by the
+    /// floating window and the pinned dock panel. Sections are driven by the
+    /// tool's capabilities — an unsupported property is absent, not disabled.
+    fn drawing_inspector_body(&mut self, ui: &mut egui::Ui, index: usize) -> InspectorActions {
+        let mut actions = InspectorActions::default();
+        let drawing = &self.drawings.items()[index];
+        let tool = drawing.tool;
+        let locked = drawing.locked;
+        let hidden = drawing.hidden;
         let show_confirm = self.drawing_delete_confirm && locked;
-        let mut delete_requested = false;
-        let mut toggle_lock = false;
-        let mut toggle_hidden = false;
-        let mut cancel_delete = false;
-        let mut force_delete = false;
-        let mut style_changed = false;
-        let mut open = true;
-        let inspector_interactable = !self.drawing_drag.is_active();
-        egui::Window::new(title)
-            .id(egui::Id::new("drawing_inspector"))
-            .open(&mut open)
-            .default_pos(DRAWING_INSPECTOR_DEFAULT_POSITION)
-            .collapsible(false)
-            .movable(true)
-            .interactable(inspector_interactable)
-            .resizable(false)
-            .show(ctx, |ui| {
-                // Always-visible, textual object actions (UX spec: never
-                // glyph-only, never behind a scroll).
-                ui.horizontal(|ui| {
-                    let eye_label = if hidden {
-                        "Show drawing"
-                    } else {
-                        "Hide drawing"
-                    };
-                    if ui.button(eye_label).clicked() {
-                        toggle_hidden = true;
-                    }
-                    let lock_label = if locked {
-                        "Unlock drawing"
-                    } else {
-                        "Lock drawing"
-                    };
-                    if ui.button(lock_label).clicked() {
-                        toggle_lock = true;
-                    }
-                    if ui.button("Delete drawing").clicked() {
-                        delete_requested = true;
-                    }
-                });
-                if locked {
-                    ui.label("Locked - protected from accidental moves. Style stays editable.");
+
+        // Header: object identity plus the view controls.
+        ui.horizontal(|ui| {
+            ui.label(egui::RichText::new(tool.name()).strong());
+            ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                if ui.small_button("Close").clicked() {
+                    actions.close = true;
                 }
-                if hidden {
-                    ui.label("Hidden - Show drawing brings it back.");
+                let pin_label = if self.inspector_pinned {
+                    "Unpin"
+                } else {
+                    "Pin"
+                };
+                let pin = ui
+                    .small_button(pin_label)
+                    .on_hover_text("Dock the inspector at the side of the chart");
+                #[cfg(test)]
+                {
+                    self.inspector_pin_rect = Some(pin.rect);
                 }
-                if show_confirm {
-                    ui.separator();
-                    ui.label("Delete locked drawing?");
-                    ui.horizontal(|ui| {
-                        if ui.button("Cancel").clicked() {
-                            cancel_delete = true;
-                        }
-                        if ui.button("Delete anyway").clicked() {
-                            force_delete = true;
-                        }
-                    });
+                if pin.clicked() {
+                    actions.toggle_pin = true;
                 }
-                ui.separator();
-                if let Some(drawing) = self.drawings.selected_mut() {
-                    ui.label("Style");
-                    style_changed |= ui
-                        .color_edit_button_srgba(&mut drawing.style.color)
-                        .changed();
-                    style_changed |= ui
-                        .add(
-                            egui::Slider::new(
-                                &mut drawing.style.width_px,
-                                MIN_DRAWING_WIDTH_PX..=MAX_DRAWING_WIDTH_PX,
-                            )
-                            .text("line width (px)"),
+                let eye_label = if hidden { "Show" } else { "Hide" };
+                if ui.small_button(eye_label).clicked() {
+                    actions.toggle_hidden = true;
+                }
+            });
+        });
+
+        // The always-visible textual actions (UX spec: never glyph-only,
+        // never behind a scroll).
+        let intent = drawings::action_bar::draw(ui, locked);
+        actions.toggle_lock |= intent.toggle_lock;
+        actions.delete |= intent.delete;
+
+        if locked {
+            ui.label(
+                egui::RichText::new(
+                    "Locked - protected from accidental moves. Style stays editable.",
+                )
+                .small(),
+            );
+        }
+        if hidden {
+            ui.label(egui::RichText::new("Hidden - Show brings it back.").small());
+        }
+        if show_confirm {
+            ui.separator();
+            ui.label("Delete locked drawing?");
+            ui.horizontal(|ui| {
+                if ui.button("Cancel").clicked() {
+                    actions.cancel_delete = true;
+                }
+                if ui.button("Delete anyway").clicked() {
+                    actions.force_delete = true;
+                }
+            });
+        }
+        ui.separator();
+
+        ui.horizontal(|ui| {
+            ui.selectable_value(&mut self.inspector_tab, InspectorTab::Style, "Style");
+            ui.selectable_value(
+                &mut self.inspector_tab,
+                InspectorTab::Coordinates,
+                "Coordinates",
+            );
+        });
+        ui.separator();
+
+        let tab = self.inspector_tab;
+        let price_speed = self
+            .last_auto_range
+            .map_or(1.0, |(lo, hi)| ((hi - lo) / 200.0).abs().max(1e-9));
+        let Some(drawing) = self.drawings.selected_mut() else {
+            return actions;
+        };
+        match tab {
+            InspectorTab::Style => {
+                ui.label("Style");
+                actions.edited |= ui
+                    .color_edit_button_srgba(&mut drawing.style.color)
+                    .changed();
+                actions.edited |= ui
+                    .add(
+                        egui::Slider::new(
+                            &mut drawing.style.width_px,
+                            MIN_DRAWING_WIDTH_PX..=MAX_DRAWING_WIDTH_PX,
                         )
-                        .changed();
-                    style_changed |= ui
+                        .text("line width (px)"),
+                    )
+                    .changed();
+                if tool.supports_fill() {
+                    actions.edited |= ui
                         .add(
                             egui::Slider::new(
                                 &mut drawing.style.fill_alpha,
@@ -2677,32 +2749,77 @@ impl QuantickApp {
                         )
                         .changed();
                 }
-            });
-        // Coalesce the style gesture: capture the pre-edit object at the
-        // first change, commit one undo entry once pointer and keyboard let
-        // go. A whole slider drag lands as a single command.
-        if style_changed && self.drawing_style_baseline.is_none() {
-            self.drawing_style_baseline = Some((index, before));
+            }
+            InspectorTab::Coordinates => {
+                // Geometry through numbers: bar index and price per anchor,
+                // the same canonical coordinates drags write. Locked blocks
+                // geometry here exactly as it does on the canvas.
+                const ANCHOR_LABELS: [&str; 4] = ["A", "B", "C", "D"];
+                ui.add_enabled_ui(!locked, |ui| {
+                    for (point_index, point) in drawing.points.iter_mut().enumerate() {
+                        ui.horizontal(|ui| {
+                            ui.label(ANCHOR_LABELS.get(point_index).copied().unwrap_or("?"));
+                            actions.edited |= ui
+                                .add(
+                                    egui::DragValue::new(&mut point.bar)
+                                        .speed(0.25)
+                                        .prefix("bar "),
+                                )
+                                .changed();
+                            actions.edited |= ui
+                                .add(egui::DragValue::new(&mut point.price).speed(price_speed))
+                                .changed();
+                        });
+                    }
+                });
+                if locked {
+                    ui.label(
+                        egui::RichText::new("Unlock the drawing to edit its coordinates.").small(),
+                    );
+                }
+            }
+        }
+        actions
+    }
+
+    /// Apply what the inspector body asked for, with the shared undo
+    /// coalescing: the pre-edit object is captured at the first change and
+    /// committed once pointer and keyboard let go.
+    fn apply_inspector_actions(
+        &mut self,
+        ctx: &egui::Context,
+        actions: InspectorActions,
+        index: usize,
+        before: drawings::Drawing,
+        now: Instant,
+    ) {
+        if actions.edited && self.inspector_edit_baseline.is_none() {
+            self.inspector_edit_baseline = Some((index, before));
         }
         let gesture_settled = ctx.input(|input| !input.pointer.any_down())
             && ctx.memory(|memory| memory.focused().is_none());
         if gesture_settled {
-            self.commit_style_gesture();
+            self.commit_inspector_gesture();
         }
-        if toggle_hidden {
+        if actions.toggle_hidden {
+            let hidden = self.drawings.items()[index].hidden;
             self.drawings.set_selected_hidden(!hidden);
         }
-        if toggle_lock {
+        if actions.toggle_lock {
+            let locked = self.drawings.items()[index].locked;
             self.drawings.set_selected_locked(!locked);
             self.drawing_delete_confirm = false;
         }
-        if delete_requested {
+        if actions.toggle_pin {
+            self.inspector_pinned = !self.inspector_pinned;
+        }
+        if actions.delete {
             self.request_delete_selected(now);
         }
-        if cancel_delete {
+        if actions.cancel_delete {
             self.drawing_delete_confirm = false;
         }
-        if force_delete {
+        if actions.force_delete {
             self.drawing_delete_confirm = false;
             if self.drawings.delete_selected(true) == DeleteOutcome::Deleted {
                 self.drawing_toast = Some(DrawingToast {
@@ -2711,9 +2828,282 @@ impl QuantickApp {
                 });
             }
         }
-        if !open {
+        if actions.close {
             self.drawings.select(None);
             self.drawing_delete_confirm = false;
+        }
+    }
+
+    /// Where a freshly opened floating inspector should sit: 12 px right of
+    /// the object's bounding box, falling back to left, below and above, and
+    /// always clamped into the chart pane — which already excludes the price
+    /// and time axes, so the popup can never cover either or leave the view.
+    fn inspector_target_position(&self, ctx: &egui::Context, index: usize) -> Option<egui::Pos2> {
+        let chart = self.last_chart_area?;
+        let total = self.slots();
+        let (auto_lo, auto_hi) = self.last_auto_range?;
+        let (lo, hi) = self.price_view.resolve((auto_lo, auto_hi));
+        let scale = PriceScale::from_range(
+            lo,
+            hi,
+            self.last_chart_top,
+            self.last_chart_top + self.last_chart_height,
+        );
+        let history_right = self.last_lane_divider_x.unwrap_or(chart.right());
+        let drawing = self.drawings.items().get(index)?;
+        let points = self.projected_drawing_points(drawing, history_right, total, &scale);
+        let first = points.first()?;
+        let mut bbox = egui::Rect::from_min_max(*first, *first);
+        for point in &points {
+            bbox.extend_with(*point);
+        }
+        let bbox = bbox.expand(DRAWING_ANCHOR_RADIUS_PX);
+        let size = ctx
+            .memory(|memory| memory.area_rect(egui::Id::new("drawing_inspector")))
+            .map_or(egui::vec2(INSPECTOR_DEFAULT_WIDTH_PX, 280.0), |rect| {
+                rect.size()
+            });
+        let gap = INSPECTOR_OBJECT_GAP_PX;
+        let candidates = [
+            egui::pos2(bbox.right() + gap, bbox.top()),
+            egui::pos2(bbox.left() - gap - size.x, bbox.top()),
+            egui::pos2(bbox.left(), bbox.bottom() + gap),
+            egui::pos2(bbox.left(), bbox.top() - gap - size.y),
+        ];
+        let fits = |position: egui::Pos2| {
+            let rect = egui::Rect::from_min_size(position, size);
+            chart.contains_rect(rect) && !rect.intersects(bbox)
+        };
+        let chosen = candidates
+            .into_iter()
+            .find(|position| fits(*position))
+            .unwrap_or(candidates[0]);
+        let max_x = (chart.right() - size.x).max(chart.left());
+        let max_y = (chart.bottom() - size.y).max(chart.top());
+        Some(egui::pos2(
+            chosen.x.clamp(chart.left(), max_x),
+            chosen.y.clamp(chart.top(), max_y),
+        ))
+    }
+
+    /// Shared prologue of both inspector hosts. Returns the selection and its
+    /// pre-frame copy, or cleans up when nothing is selected.
+    fn inspector_selection(&mut self) -> Option<(usize, drawings::Drawing)> {
+        let Some(index) = self.drawings.selected() else {
+            self.drawing_delete_confirm = false;
+            self.commit_inspector_gesture();
+            self.inspector_last_selection = None;
+            return None;
+        };
+        // An edit gesture that outlived its object's selection commits now.
+        if self
+            .inspector_edit_baseline
+            .as_ref()
+            .is_some_and(|(baseline_index, _)| *baseline_index != index)
+        {
+            self.commit_inspector_gesture();
+        }
+        Some((index, self.drawings.items()[index].clone()))
+    }
+
+    /// The pinned inspector: a dock panel at the chart's side. Declared with
+    /// the chrome, before the central canvas, so the canvas pays its width.
+    fn draw_drawing_inspector_panel(&mut self, ctx: &egui::Context, now: Instant) {
+        if !self.inspector_pinned {
+            return;
+        }
+        let Some((index, before)) = self.inspector_selection() else {
+            return;
+        };
+        let mut actions = InspectorActions::default();
+        egui::SidePanel::right("drawing_inspector_panel")
+            .resizable(true)
+            .default_width(INSPECTOR_DEFAULT_WIDTH_PX)
+            .width_range(INSPECTOR_MIN_WIDTH_PX..=INSPECTOR_MAX_WIDTH_PX)
+            .show(ctx, |ui| {
+                egui::ScrollArea::vertical().show(ui, |ui| {
+                    actions = self.drawing_inspector_body(ui, index);
+                });
+            });
+        self.apply_inspector_actions(ctx, actions, index, before, now);
+    }
+
+    /// The selected object's floating inspector. Non-modal by contract: it
+    /// never captures the whole canvas and never blocks moving the geometry
+    /// underneath it. Opens beside the selection; once the user moves it, the
+    /// manual position wins for the rest of the session.
+    fn draw_drawing_inspector(&mut self, ctx: &egui::Context, now: Instant) {
+        if self.inspector_pinned {
+            // The pinned panel already drew (and cleaned up) this frame.
+            return;
+        }
+        let Some((index, before)) = self.inspector_selection() else {
+            return;
+        };
+        let selection_changed = self.inspector_last_selection != Some(index);
+        self.inspector_last_selection = Some(index);
+        let mut actions = InspectorActions::default();
+        let mut open = true;
+        let inspector_interactable = !self.drawing_drag.is_active();
+        let mut window = egui::Window::new(before.tool.settings_title())
+            .id(egui::Id::new("drawing_inspector"))
+            .open(&mut open)
+            .default_pos(DRAWING_INSPECTOR_DEFAULT_POSITION)
+            .default_width(INSPECTOR_DEFAULT_WIDTH_PX)
+            .min_width(INSPECTOR_MIN_WIDTH_PX)
+            .max_width(INSPECTOR_MAX_WIDTH_PX)
+            .collapsible(false)
+            .movable(true)
+            .interactable(inspector_interactable)
+            .resizable(true);
+        if selection_changed
+            && !self.inspector_moved
+            && let Some(position) = self.inspector_target_position(ctx, index)
+        {
+            window = window.current_pos(position);
+        }
+        let response = window.show(ctx, |ui| self.drawing_inspector_body(ui, index));
+        if let Some(response) = &response {
+            if response.response.dragged() {
+                self.inspector_moved = true;
+            }
+            if let Some(inner) = response.inner {
+                actions = inner;
+            }
+        }
+        if !open {
+            actions.close = true;
+        }
+        self.apply_inspector_actions(ctx, actions, index, before, now);
+    }
+
+    /// The object manager: a non-modal list of every drawing with the named
+    /// per-object actions. It sends the same store commands as the inspector
+    /// and the keyboard — nothing here re-implements lock or delete rules.
+    fn draw_drawing_manager(&mut self, ctx: &egui::Context, now: Instant) {
+        if !self.drawing_manager_open {
+            return;
+        }
+        #[cfg(test)]
+        self.manager_action_rects.clear();
+        let mut open = true;
+        let mut select_row: Option<usize> = None;
+        let mut eye_row: Option<usize> = None;
+        let mut lock_row: Option<usize> = None;
+        let mut front_row: Option<usize> = None;
+        let mut delete_row: Option<usize> = None;
+        let mut show_all = false;
+        let mut unlock_all = false;
+        egui::Window::new("Drawn objects")
+            .id(egui::Id::new("drawing_manager"))
+            .open(&mut open)
+            .default_pos(egui::pos2(70.0, 140.0))
+            .default_width(INSPECTOR_DEFAULT_WIDTH_PX)
+            .collapsible(false)
+            .resizable(false)
+            .show(ctx, |ui| {
+                let count = self.drawings.items().len();
+                if count == 0 {
+                    ui.label("No drawings yet.");
+                }
+                // Walked in reverse: the manager lists top-most first, the
+                // same order hit-testing resolves overlap.
+                for index in (0..count).rev() {
+                    let drawing = &self.drawings.items()[index];
+                    let selected = self.drawings.selected() == Some(index);
+                    let locked = drawing.locked;
+                    let hidden = drawing.hidden;
+                    let name = drawing.tool.name();
+                    ui.horizontal(|ui| {
+                        let mut label = egui::RichText::new(format!("{} {}", name, index + 1));
+                        if hidden {
+                            label = label.weak();
+                        }
+                        if ui.selectable_label(selected, label).clicked() {
+                            select_row = Some(index);
+                        }
+                        if locked {
+                            ui.label(egui::RichText::new("locked").small());
+                        }
+                        if hidden {
+                            ui.label(egui::RichText::new("hidden").small());
+                        }
+                        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                            let delete = ui.small_button("Delete");
+                            #[cfg(test)]
+                            self.manager_action_rects
+                                .push((index, "Delete", delete.rect));
+                            if delete.clicked() {
+                                delete_row = Some(index);
+                            }
+                            let front = ui.small_button("Front");
+                            #[cfg(test)]
+                            self.manager_action_rects.push((index, "Front", front.rect));
+                            if front.clicked() {
+                                front_row = Some(index);
+                            }
+                            let lock = ui.small_button(if locked { "Unlock" } else { "Lock" });
+                            #[cfg(test)]
+                            self.manager_action_rects.push((index, "Lock", lock.rect));
+                            if lock.clicked() {
+                                lock_row = Some(index);
+                            }
+                            let eye = ui.small_button(if hidden { "Show" } else { "Hide" });
+                            #[cfg(test)]
+                            self.manager_action_rects.push((index, "Eye", eye.rect));
+                            if eye.clicked() {
+                                eye_row = Some(index);
+                            }
+                        });
+                    });
+                }
+                ui.separator();
+                ui.horizontal(|ui| {
+                    if ui.button("Show all").clicked() {
+                        show_all = true;
+                    }
+                    if ui.button("Unlock all").clicked() {
+                        unlock_all = true;
+                    }
+                });
+            });
+        self.drawing_manager_open = open;
+        if let Some(index) = select_row {
+            self.drawings.select(Some(index));
+            // Centre the viewport on the object's bar span.
+            if let Some(chart) = self.last_chart_area {
+                let points = &self.drawings.items()[index].points;
+                if !points.is_empty() {
+                    let mid =
+                        points.iter().map(|point| point.bar).sum::<f32>() / points.len() as f32;
+                    self.viewport
+                        .center_on_bar(mid, chart.width(), self.slots());
+                }
+            }
+        }
+        if let Some(index) = eye_row {
+            let hidden = self.drawings.items()[index].hidden;
+            self.drawings.set_hidden_at(index, !hidden);
+        }
+        if let Some(index) = lock_row {
+            let locked = self.drawings.items()[index].locked;
+            self.drawings.set_locked_at(index, !locked);
+        }
+        if let Some(index) = front_row {
+            self.drawings.bring_to_front(index);
+        }
+        if let Some(index) = delete_row {
+            // The exact same command path as the inspector button and the
+            // keyboard: select, then request. Locked rows raise the same
+            // confirmation in the inspector.
+            self.drawings.select(Some(index));
+            self.request_delete_selected(now);
+        }
+        if show_all {
+            self.drawings.set_all_hidden(false);
+        }
+        if unlock_all {
+            self.drawings.set_all_locked(false);
         }
     }
 
@@ -2907,9 +3297,12 @@ impl QuantickApp {
         }
         {
             let Self {
-                toolrail, drawings, ..
+                toolrail,
+                drawings,
+                drawing_manager_open,
+                ..
             } = self;
-            toolrail.draw(ctx, drawings);
+            toolrail.draw(ctx, drawings, drawing_manager_open);
         }
         let dock_response = {
             let Self {
@@ -2934,6 +3327,9 @@ impl QuantickApp {
         if let Some(action) = dock_response.replay_action {
             self.apply_replay_action(action);
         }
+        // The pinned inspector is chrome: declared before the central canvas
+        // so the chart pays its width, exactly like the dock.
+        self.draw_drawing_inspector_panel(ctx, now);
         // Respawn the feed if the feed/symbol selection changed (resets the
         // chart), then apply any bar-type change (no-op if unchanged).
         self.maybe_switch_feed();
@@ -2961,6 +3357,7 @@ impl QuantickApp {
         // Floating drawing controls must be registered after the opaque
         // central canvas so they stay in front of the chart.
         self.draw_drawing_inspector(ctx, now);
+        self.draw_drawing_manager(ctx, now);
         self.draw_drawing_toast(ctx, now);
         if notice_action == notice_card::NoticeAction::Retry {
             self.restart_feed();
@@ -3716,30 +4113,216 @@ mod tests {
     }
 
     #[test]
-    fn an_open_inspector_never_blocks_moving_a_horizontal_line() {
+    fn inspector_never_blocks_drawing_drag() {
         let (mut app, _commands) = app_with_history(200);
         let ctx = egui::Context::default();
         run_frame(&mut app, &ctx);
         app.toolrail
             .arm(Tool::Drawing(drawing_tool("horizontal-line")));
-        let start = egui::pos2(300.0, 250.0);
-        click_chart(&mut app, &ctx, start);
+        let anchor = egui::pos2(300.0, 250.0);
+        click_chart(&mut app, &ctx, anchor);
+        run_frame(&mut app, &ctx);
 
+        // The horizontal stroke crosses the whole pane, so wherever placement
+        // put the window, some stroke pixel sits underneath it. Drag exactly
+        // that pixel: the gesture must stay with the drawing.
         let inspector = ctx
             .memory(|memory| memory.area_rect(egui::Id::new("drawing_inspector")))
             .expect("placing the selected line opens its inspector");
+        let line_y = anchor.y;
+        let start = egui::pos2(inspector.center().x, line_y);
         assert!(
             inspector.contains(start),
-            "the regression requires the floating inspector to cover the line handle"
+            "the regression requires the floating inspector to cover this stroke pixel"
         );
         let before = app.drawings.items()[0].points[0];
 
-        drag_chart(&mut app, &ctx, start, egui::pos2(300.0, 350.0));
+        drag_chart(&mut app, &ctx, start, egui::pos2(start.x, line_y + 100.0));
 
         assert_ne!(
             app.drawings.items()[0].points[0].price,
             before.price,
             "the open inspector must not trap the line underneath it"
+        );
+    }
+
+    #[test]
+    fn drawing_actions_visible_without_scroll_at_360px() {
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        run_frame(&mut app, &ctx);
+        app.toolrail
+            .arm(Tool::Drawing(drawing_tool("horizontal-line")));
+        click_chart(&mut app, &ctx, egui::pos2(700.0, 300.0));
+
+        let output = run_frame(&mut app, &ctx);
+        let inspector = ctx
+            .memory(|memory| memory.area_rect(egui::Id::new("drawing_inspector")))
+            .expect("the inspector is open");
+        assert!(
+            inspector.width() >= INSPECTOR_MIN_WIDTH_PX - 1.0,
+            "the inspector must respect its minimum width; got {}",
+            inspector.width()
+        );
+        let texts = painted_text(&output);
+        for label in ["Lock drawing", "Delete drawing"] {
+            assert!(
+                texts.iter().any(|text| text.contains(label)),
+                "the named action {label:?} must be visible without scrolling; painted: {texts:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn inspector_opens_beside_the_selection_inside_the_chart() {
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        run_frame(&mut app, &ctx);
+        arm_drawing_from_toolbox(&mut app, &ctx, "rectangle");
+        drag_chart(
+            &mut app,
+            &ctx,
+            egui::pos2(300.0, 300.0),
+            egui::pos2(400.0, 380.0),
+        );
+        run_frame(&mut app, &ctx);
+
+        let inspector = ctx
+            .memory(|memory| memory.area_rect(egui::Id::new("drawing_inspector")))
+            .expect("the inspector is open");
+        let chart = app.last_chart_area.expect("the chart pane was laid out");
+        let bbox = egui::Rect::from_min_max(egui::pos2(300.0, 300.0), egui::pos2(400.0, 380.0))
+            .expand(DRAWING_ANCHOR_RADIUS_PX);
+        assert!(
+            !inspector.intersects(bbox),
+            "the inspector must open beside the selection, not on top of it: {inspector:?} vs {bbox:?}"
+        );
+        assert!(
+            chart.contains_rect(inspector),
+            "the inspector must stay inside the chart pane (never over the axes): {inspector:?} vs {chart:?}"
+        );
+    }
+
+    #[test]
+    fn pinning_the_inspector_docks_it_and_frees_the_canvas() {
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        run_frame(&mut app, &ctx);
+        arm_drawing_from_toolbox(&mut app, &ctx, "rectangle");
+        drag_chart(
+            &mut app,
+            &ctx,
+            egui::pos2(300.0, 300.0),
+            egui::pos2(400.0, 380.0),
+        );
+        // Let the window settle its size and position before reading rects.
+        run_frame(&mut app, &ctx);
+        run_frame(&mut app, &ctx);
+        let chart_before = app.last_chart_area.expect("chart laid out");
+
+        let pin = app.inspector_pin_rect.expect("pin button rendered");
+        click_chart(&mut app, &ctx, pin.center());
+        assert!(app.inspector_pinned, "clicking Pin docks the inspector");
+        run_frame(&mut app, &ctx);
+        let chart_after = app.last_chart_area.expect("chart laid out");
+        assert!(
+            chart_after.width() < chart_before.width(),
+            "the docked inspector must be paid for by the canvas, not float over it"
+        );
+        let texts = painted_text(&run_frame(&mut app, &ctx));
+        assert!(
+            texts.iter().any(|text| text.contains("Delete drawing")),
+            "the docked panel still shows the named actions"
+        );
+    }
+
+    #[test]
+    fn button_manager_and_keyboard_send_the_same_delete_command() {
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        run_frame(&mut app, &ctx);
+        app.toolrail
+            .arm(Tool::Drawing(drawing_tool("horizontal-line")));
+        click_chart(&mut app, &ctx, egui::pos2(700.0, 300.0));
+        app.drawing_manager_open = true;
+        // Let the manager window settle its size before reading button rects.
+        run_frame(&mut app, &ctx);
+        run_frame(&mut app, &ctx);
+
+        let delete = app
+            .manager_action_rects
+            .iter()
+            .find(|(index, action, _)| *index == 0 && *action == "Delete")
+            .map(|(_, _, rect)| *rect)
+            .expect("the manager lists the drawing with a Delete action");
+        click_chart(&mut app, &ctx, delete.center());
+        assert!(
+            app.drawings.items().is_empty(),
+            "the manager's Delete lands the same command"
+        );
+        assert!(
+            app.drawing_toast.is_some(),
+            "the manager delete raises the same Undo toast as the keyboard"
+        );
+        run_frame_with_modifiers(
+            &mut app,
+            &ctx,
+            vec![key_press_with(egui::Key::Z, egui::Modifiers::COMMAND)],
+            egui::Modifiers::COMMAND,
+        );
+        assert_eq!(
+            app.drawings.items().len(),
+            1,
+            "one undo rewinds the manager delete, exactly like the keyboard one"
+        );
+    }
+
+    #[test]
+    fn the_object_manager_toggles_eye_lock_and_z_order_per_row() {
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        run_frame(&mut app, &ctx);
+        for price_y in [250.0, 350.0] {
+            app.toolrail
+                .arm(Tool::Drawing(drawing_tool("horizontal-line")));
+            click_chart(&mut app, &ctx, egui::pos2(700.0, price_y));
+        }
+        let objects = app
+            .toolrail
+            .objects_button_rect()
+            .expect("the toolbox shows the Objects entry");
+        click_chart(&mut app, &ctx, objects.center());
+        assert!(
+            app.drawing_manager_open,
+            "the Objects button opens the manager"
+        );
+        run_frame(&mut app, &ctx);
+
+        let rect_of = |app: &QuantickApp, index: usize, action: &str| {
+            app.manager_action_rects
+                .iter()
+                .find(|(row, name, _)| *row == index && *name == action)
+                .map(|(_, _, rect)| *rect)
+                .expect("manager action rendered")
+        };
+
+        let eye = rect_of(&app, 0, "Eye");
+        click_chart(&mut app, &ctx, eye.center());
+        assert!(app.drawings.items()[0].hidden, "the row's eye hides it");
+
+        run_frame(&mut app, &ctx);
+        let lock = rect_of(&app, 1, "Lock");
+        click_chart(&mut app, &ctx, lock.center());
+        assert!(app.drawings.items()[1].locked, "the row's lock locks it");
+
+        run_frame(&mut app, &ctx);
+        let front = rect_of(&app, 0, "Front");
+        let hidden_line_price = app.drawings.items()[0].points[0].price;
+        click_chart(&mut app, &ctx, front.center());
+        assert_eq!(
+            app.drawings.items()[1].points[0].price,
+            hidden_line_price,
+            "Front moves the object to the top of the z-order"
         );
     }
 

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -71,6 +71,8 @@ const INSPECTOR_LEVELS_WIDTH_PX: f32 = 360.0;
 const INSPECTOR_OBJECT_GAP_PX: f32 = 12.0;
 /// How long the delete toast keeps its Undo affordance on screen (UX spec).
 const TOAST_UNDO_MS: u64 = 8_000;
+/// Horizontal offset of a duplicated drawing, so the copy is visibly a copy.
+const DUPLICATE_OFFSET_BARS: f32 = 2.0;
 /// Vertical clearance between the toast and the bottom chrome.
 const TOAST_BOTTOM_MARGIN_PX: f32 = 44.0;
 
@@ -1455,7 +1457,11 @@ impl QuantickApp {
             payload
         });
         if completed {
-            self.toolrail.arm(Tool::Pointer);
+            // One-shot by default; the toolbox repeat pin keeps the tool
+            // armed for the next object.
+            if !self.toolrail.repeat() {
+                self.toolrail.arm(Tool::Pointer);
+            }
             self.drawing_hover = None;
         }
     }
@@ -1494,6 +1500,7 @@ impl QuantickApp {
                     payload: drawing.payload.as_ref(),
                     anchors: &drawing.points,
                     scale,
+                    style: drawing.style,
                     selected: self.drawings.selected() == Some(index),
                     halo: false,
                 };
@@ -1502,6 +1509,46 @@ impl QuantickApp {
                     .hit_test(chart_rect, &projected, pos, DRAWING_SELECT_RADIUS_PX, &ctxt)
                     .then_some(index)
             })
+    }
+
+    /// Alt+click: deterministic z-order cycling through every visible object
+    /// under the pointer. From the current selection, the next hit beneath
+    /// it wins; past the bottom it wraps back to the top.
+    fn drawing_below_selection(
+        &self,
+        pos: egui::Pos2,
+        chart_rect: egui::Rect,
+        history_right: f32,
+        total: usize,
+        scale: &PriceScale,
+    ) -> Option<usize> {
+        let hits: Vec<usize> = (0..self.drawings.items().len())
+            .rev()
+            .filter(|&index| self.drawings.is_visible(index))
+            .filter(|&index| {
+                let drawing = &self.drawings.items()[index];
+                let projected = self.projected_drawing_points(drawing, history_right, total, scale);
+                let ctxt = DrawContext {
+                    payload: drawing.payload.as_ref(),
+                    anchors: &drawing.points,
+                    scale,
+                    style: drawing.style,
+                    selected: self.drawings.selected() == Some(index),
+                    halo: false,
+                };
+                drawing
+                    .tool
+                    .hit_test(chart_rect, &projected, pos, DRAWING_SELECT_RADIUS_PX, &ctxt)
+            })
+            .collect();
+        match self
+            .drawings
+            .selected()
+            .and_then(|current| hits.iter().position(|&index| index == current))
+        {
+            Some(at) => Some(hits[(at + 1) % hits.len()]),
+            None => hits.first().copied(),
+        }
     }
 
     fn drawing_anchor_in(
@@ -1603,26 +1650,52 @@ impl QuantickApp {
             });
         let mut drawing_drag_consumes_gesture = false;
         if self.toolrail.tool() == Tool::Pointer {
+            // Hover feedback: a resize cursor over a selected anchor, a move
+            // cursor over any visible body, and not-allowed over locked
+            // geometry (visible objects in the viewport only — bounded work).
             if let Some(position) =
                 pointer_position.filter(|position| drawing_area.contains(*position))
                 && let Some(scale) = drawing_scale
-                && let Some(selected) = self.drawings.selected()
-                && self
-                    .drawing_anchor_in(selected, position, history_right, total, &scale)
-                    .is_some()
             {
-                ui.ctx()
-                    .set_cursor_icon(if self.drawings.items()[selected].locked {
-                        egui::CursorIcon::NotAllowed
-                    } else {
-                        egui::CursorIcon::ResizeNwSe
-                    });
+                if let Some(selected) = self.drawings.selected()
+                    && self
+                        .drawing_anchor_in(selected, position, history_right, total, &scale)
+                        .is_some()
+                {
+                    ui.ctx()
+                        .set_cursor_icon(if self.drawings.items()[selected].locked {
+                            egui::CursorIcon::NotAllowed
+                        } else {
+                            egui::CursorIcon::ResizeNwSe
+                        });
+                } else if let Some(hovered) =
+                    self.drawing_at(position, areas.chart, history_right, total, &scale)
+                {
+                    ui.ctx()
+                        .set_cursor_icon(if self.drawings.items()[hovered].locked {
+                            egui::CursorIcon::NotAllowed
+                        } else {
+                            egui::CursorIcon::Move
+                        });
+                }
             }
             if chart.clicked()
                 && let Some(position) = chart.interact_pointer_pos()
                 && let Some(scale) = drawing_scale
             {
-                let selected = self.drawing_at(position, areas.chart, history_right, total, &scale);
+                // Alt+click walks down the z-order through overlapping
+                // objects; a plain click selects the topmost hit.
+                let selected = if ui.input(|input| input.modifiers.alt) {
+                    self.drawing_below_selection(
+                        position,
+                        areas.chart,
+                        history_right,
+                        total,
+                        &scale,
+                    )
+                } else {
+                    self.drawing_at(position, areas.chart, history_right, total, &scale)
+                };
                 self.drawings.select(selected);
             }
             // Floating inspectors normally own pointer input over their whole
@@ -2258,6 +2331,7 @@ impl QuantickApp {
                 payload: drawing.payload.as_ref(),
                 anchors: &drawing.points,
                 scale,
+                style: drawing.style,
                 selected,
                 halo: false,
             };
@@ -2289,6 +2363,7 @@ impl QuantickApp {
                 payload: draft.payload.as_ref(),
                 anchors: &anchors,
                 scale,
+                style: draft.style,
                 selected: false,
                 halo: false,
             };
@@ -2614,26 +2689,98 @@ impl QuantickApp {
         if ctx.memory(|memory| memory.focused().is_some()) {
             return;
         }
-        let (delete, undo, redo) = ctx.input(|input| {
+        struct DrawingKeys {
+            escape: bool,
+            delete: bool,
+            backspace: bool,
+            undo: bool,
+            redo: bool,
+            lock: bool,
+            hide: bool,
+            duplicate: bool,
+            nudge_bars: f32,
+            nudge_px: f32,
+        }
+        let keys = ctx.input(|input| {
             let command = input.modifiers.command;
             let shift = input.modifiers.shift;
-            (
-                input.key_pressed(egui::Key::Delete) || input.key_pressed(egui::Key::Backspace),
-                command && !shift && input.key_pressed(egui::Key::Z),
-                (command && input.key_pressed(egui::Key::Y))
+            let alt = input.modifiers.alt;
+            // Shift turns a nudge into ten steps (UX spec).
+            let step = if shift { 10.0 } else { 1.0 };
+            let horizontal = f32::from(input.key_pressed(egui::Key::ArrowRight))
+                - f32::from(input.key_pressed(egui::Key::ArrowLeft));
+            let vertical = f32::from(input.key_pressed(egui::Key::ArrowUp))
+                - f32::from(input.key_pressed(egui::Key::ArrowDown));
+            DrawingKeys {
+                escape: input.key_pressed(egui::Key::Escape),
+                delete: input.key_pressed(egui::Key::Delete),
+                backspace: input.key_pressed(egui::Key::Backspace),
+                undo: command && !shift && input.key_pressed(egui::Key::Z),
+                redo: (command && input.key_pressed(egui::Key::Y))
                     || (command && shift && input.key_pressed(egui::Key::Z)),
-            )
+                lock: alt && input.key_pressed(egui::Key::L),
+                hide: alt && input.key_pressed(egui::Key::H),
+                duplicate: command && input.key_pressed(egui::Key::D),
+                nudge_bars: horizontal * step,
+                nudge_px: vertical * step,
+            }
         });
-        // While a draft is being placed the delete keys belong to the draft
-        // workflow, not to the previously selected object.
-        if delete && self.drawings.draft().is_none() {
+        // The escape stack: pending confirmation → draft → selection →
+        // Pointer, one layer per press.
+        if keys.escape {
+            if self.drawing_delete_confirm {
+                self.drawing_delete_confirm = false;
+            } else if self.drawings.draft().is_some() {
+                self.drawings.cancel_draft();
+                self.toolrail.arm(Tool::Pointer);
+            } else if self.drawings.selected().is_some() {
+                self.drawings.select(None);
+            } else {
+                self.toolrail.arm(Tool::Pointer);
+            }
+        }
+        if self.drawings.draft().is_some() {
+            // During placement the delete keys belong to the draft workflow:
+            // Backspace steps back one anchor.
+            if keys.backspace {
+                self.drawings.remove_last_draft_anchor();
+            }
+        } else if keys.delete || keys.backspace {
             self.request_delete_selected(now);
         }
-        if undo {
+        if keys.undo {
             self.drawings.undo();
         }
-        if redo {
+        if keys.redo {
             self.drawings.redo();
+        }
+        if keys.lock
+            && let Some(index) = self.drawings.selected()
+        {
+            let locked = self.drawings.items()[index].locked;
+            self.drawings.set_selected_locked(!locked);
+        }
+        if keys.hide
+            && let Some(index) = self.drawings.selected()
+        {
+            let hidden = self.drawings.items()[index].hidden;
+            self.drawings.set_selected_hidden(!hidden);
+        }
+        if keys.duplicate {
+            self.drawings.duplicate_selected(DUPLICATE_OFFSET_BARS);
+        }
+        if (keys.nudge_bars != 0.0 || keys.nudge_px != 0.0) && self.drawings.selected().is_some() {
+            // Arrows write the same honest chart coordinates a drag does:
+            // one bar per horizontal step, one pixel's worth of price per
+            // vertical step. Each press lands as one undo entry.
+            let price_per_px = self.last_auto_range.map_or(0.0, |auto| {
+                let (lo, hi) = self.price_view.resolve(auto);
+                (hi - lo) / f64::from(self.last_chart_height.max(1.0))
+            });
+            self.drawings.begin_gesture();
+            self.drawings
+                .translate_selected(keys.nudge_bars, f64::from(keys.nudge_px) * price_per_px);
+            self.drawings.commit_gesture();
         }
     }
 
@@ -4710,6 +4857,181 @@ mod tests {
             viewport_before,
             "over a hidden drawing the gesture belongs to the chart again"
         );
+    }
+
+    #[test]
+    fn escape_walks_confirm_draft_selection_then_pointer() {
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        run_frame(&mut app, &ctx);
+
+        // Draft first: Esc cancels it and returns to Pointer.
+        arm_drawing_from_toolbox(&mut app, &ctx, "rectangle");
+        click_chart(&mut app, &ctx, egui::pos2(700.0, 300.0));
+        assert_eq!(app.drawings.draft_len(), 1);
+        run_frame_with_events(&mut app, &ctx, vec![key_press(egui::Key::Escape)]);
+        assert!(app.drawings.draft().is_none(), "Esc cancels the draft");
+        assert_eq!(app.toolrail.tool(), Tool::Pointer);
+
+        // A locked selection with a pending confirmation: Esc peels one
+        // layer per press — confirm, then selection, then nothing new.
+        app.toolrail
+            .arm(Tool::Drawing(drawing_tool("horizontal-line")));
+        click_chart(&mut app, &ctx, egui::pos2(700.0, 300.0));
+        app.drawings.set_selected_locked(true);
+        run_frame_with_events(&mut app, &ctx, vec![key_press(egui::Key::Delete)]);
+        assert!(app.drawing_delete_confirm, "the confirmation is pending");
+
+        run_frame_with_events(&mut app, &ctx, vec![key_press(egui::Key::Escape)]);
+        assert!(!app.drawing_delete_confirm, "first Esc cancels the confirm");
+        assert!(app.drawings.selected().is_some(), "the selection survives");
+
+        run_frame_with_events(&mut app, &ctx, vec![key_press(egui::Key::Escape)]);
+        assert_eq!(app.drawings.selected(), None, "second Esc deselects");
+        assert_eq!(app.drawings.items().len(), 1, "nothing was deleted");
+    }
+
+    #[test]
+    fn backspace_steps_back_through_the_draft_anchors() {
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        run_frame(&mut app, &ctx);
+        arm_drawing_from_toolbox(&mut app, &ctx, "parallel-channel");
+        click_chart(&mut app, &ctx, egui::pos2(650.0, 280.0));
+        click_chart(&mut app, &ctx, egui::pos2(750.0, 300.0));
+        assert_eq!(app.drawings.draft_len(), 2);
+
+        run_frame_with_events(&mut app, &ctx, vec![key_press(egui::Key::Backspace)]);
+        assert_eq!(
+            app.drawings.draft_len(),
+            1,
+            "Backspace removes the last placed anchor"
+        );
+        assert!(
+            app.drawings.items().is_empty(),
+            "the draft workflow never deletes finished objects"
+        );
+    }
+
+    #[test]
+    fn alt_l_and_alt_h_protect_the_selection_from_the_keyboard() {
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        run_frame(&mut app, &ctx);
+        app.toolrail
+            .arm(Tool::Drawing(drawing_tool("horizontal-line")));
+        click_chart(&mut app, &ctx, egui::pos2(700.0, 300.0));
+
+        run_frame_with_modifiers(
+            &mut app,
+            &ctx,
+            vec![key_press_with(egui::Key::L, egui::Modifiers::ALT)],
+            egui::Modifiers::ALT,
+        );
+        assert!(app.drawings.items()[0].locked, "Alt+L locks the selection");
+
+        run_frame_with_modifiers(
+            &mut app,
+            &ctx,
+            vec![key_press_with(egui::Key::H, egui::Modifiers::ALT)],
+            egui::Modifiers::ALT,
+        );
+        assert!(app.drawings.items()[0].hidden, "Alt+H hides the selection");
+        assert_eq!(
+            app.toolrail.tool(),
+            Tool::Pointer,
+            "Alt+H must not arm the horizontal-line tool"
+        );
+    }
+
+    #[test]
+    fn ctrl_d_duplicates_the_selection_offset_and_selected() {
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        run_frame(&mut app, &ctx);
+        app.toolrail
+            .arm(Tool::Drawing(drawing_tool("horizontal-line")));
+        click_chart(&mut app, &ctx, egui::pos2(700.0, 300.0));
+        let original_bar = app.drawings.items()[0].points[0].bar;
+
+        run_frame_with_modifiers(
+            &mut app,
+            &ctx,
+            vec![key_press_with(egui::Key::D, egui::Modifiers::COMMAND)],
+            egui::Modifiers::COMMAND,
+        );
+        assert_eq!(app.drawings.items().len(), 2);
+        assert_eq!(app.drawings.selected(), Some(1));
+        assert_eq!(
+            app.drawings.items()[1].points[0].bar,
+            original_bar + DUPLICATE_OFFSET_BARS
+        );
+    }
+
+    #[test]
+    fn arrow_nudges_move_the_selection_and_shift_multiplies_by_ten() {
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        run_frame(&mut app, &ctx);
+        app.toolrail
+            .arm(Tool::Drawing(drawing_tool("horizontal-line")));
+        click_chart(&mut app, &ctx, egui::pos2(700.0, 300.0));
+        let start = app.drawings.items()[0].points[0];
+        let depth = app.drawings.undo_depth();
+
+        run_frame_with_events(&mut app, &ctx, vec![key_press(egui::Key::ArrowRight)]);
+        assert_eq!(
+            app.drawings.items()[0].points[0].bar,
+            start.bar + 1.0,
+            "one press is one bar"
+        );
+        assert_eq!(app.drawings.undo_depth(), depth + 1, "one press, one entry");
+
+        run_frame_with_modifiers(
+            &mut app,
+            &ctx,
+            vec![key_press_with(
+                egui::Key::ArrowRight,
+                egui::Modifiers::SHIFT,
+            )],
+            egui::Modifiers::SHIFT,
+        );
+        assert_eq!(
+            app.drawings.items()[0].points[0].bar,
+            start.bar + 11.0,
+            "Shift multiplies the nudge by ten"
+        );
+
+        run_frame_with_events(&mut app, &ctx, vec![key_press(egui::Key::ArrowUp)]);
+        assert!(
+            app.drawings.items()[0].points[0].price > start.price,
+            "ArrowUp raises the price"
+        );
+    }
+
+    #[test]
+    fn the_repeat_pin_keeps_the_drawing_tool_armed() {
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        run_frame(&mut app, &ctx);
+
+        // Default: one-shot back to Pointer.
+        app.toolrail
+            .arm(Tool::Drawing(drawing_tool("horizontal-line")));
+        click_chart(&mut app, &ctx, egui::pos2(650.0, 280.0));
+        assert_eq!(app.toolrail.tool(), Tool::Pointer);
+
+        // Pinned: the tool stays armed for the next object.
+        app.toolrail.set_repeat(true);
+        app.toolrail
+            .arm(Tool::Drawing(drawing_tool("horizontal-line")));
+        click_chart(&mut app, &ctx, egui::pos2(700.0, 320.0));
+        assert_eq!(
+            app.toolrail.tool().drawing_tool().map(|tool| tool.id()),
+            Some("horizontal-line"),
+            "the repeat pin keeps the tool armed"
+        );
+        assert_eq!(app.drawings.items().len(), 2);
     }
 
     #[test]

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -69,6 +69,15 @@ const INSPECTOR_DEFAULT_WIDTH_PX: f32 = 320.0;
 const INSPECTOR_LEVELS_WIDTH_PX: f32 = 360.0;
 /// Gap kept between the inspector and the selected object's bounding box.
 const INSPECTOR_OBJECT_GAP_PX: f32 = 12.0;
+/// Assumed inspector height for placement before its first frame reports one.
+const INSPECTOR_FALLBACK_HEIGHT_PX: f32 = 280.0;
+/// Dragging the price field across the whole visible range takes this many
+/// steps, whatever the symbol's price magnitude.
+const PRICE_DRAG_STEPS: f64 = 200.0;
+/// DragValue speed of bar-index coordinates, in bars per drag point.
+const BAR_DRAG_SPEED: f64 = 0.25;
+/// Where the object manager first opens: under the toolbox's home corner.
+const DRAWING_MANAGER_DEFAULT_POSITION: egui::Pos2 = egui::pos2(70.0, 140.0);
 /// How long the delete toast keeps its Undo affordance on screen (UX spec).
 const TOAST_UNDO_MS: u64 = 8_000;
 /// Horizontal offset of a duplicated drawing, so the copy is visibly a copy.
@@ -2933,9 +2942,9 @@ impl QuantickApp {
         ui.separator();
 
         let tab = self.inspector_tab;
-        let price_speed = self
-            .last_auto_range
-            .map_or(1.0, |(lo, hi)| ((hi - lo) / 200.0).abs().max(1e-9));
+        let price_speed = self.last_auto_range.map_or(1.0, |(lo, hi)| {
+            ((hi - lo) / PRICE_DRAG_STEPS).abs().max(1e-9)
+        });
         let Self {
             drawings,
             drawing_presets,
@@ -2986,7 +2995,7 @@ impl QuantickApp {
                             actions.edited |= ui
                                 .add(
                                     egui::DragValue::new(&mut point.bar)
-                                        .speed(0.25)
+                                        .speed(BAR_DRAG_SPEED)
                                         .prefix("bar "),
                                 )
                                 .changed();
@@ -3085,9 +3094,10 @@ impl QuantickApp {
         let bbox = bbox.expand(DRAWING_ANCHOR_RADIUS_PX);
         let size = ctx
             .memory(|memory| memory.area_rect(egui::Id::new("drawing_inspector")))
-            .map_or(egui::vec2(INSPECTOR_DEFAULT_WIDTH_PX, 280.0), |rect| {
-                rect.size()
-            });
+            .map_or(
+                egui::vec2(INSPECTOR_DEFAULT_WIDTH_PX, INSPECTOR_FALLBACK_HEIGHT_PX),
+                |rect| rect.size(),
+            );
         let gap = INSPECTOR_OBJECT_GAP_PX;
         let candidates = [
             egui::pos2(bbox.right() + gap, bbox.top()),
@@ -3228,7 +3238,7 @@ impl QuantickApp {
         egui::Window::new("Drawn objects")
             .id(egui::Id::new("drawing_manager"))
             .open(&mut open)
-            .default_pos(egui::pos2(70.0, 140.0))
+            .default_pos(DRAWING_MANAGER_DEFAULT_POSITION)
             .default_width(INSPECTOR_DEFAULT_WIDTH_PX)
             .collapsible(false)
             .resizable(false)

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -22,8 +22,8 @@ use crate::chart::{self, PriceScale};
 use crate::config::{AppConfig, FeedCapabilities};
 use crate::dock::{Dock, DockEnv, DockTab};
 use crate::drawings::{
-    self, ChartPoint, DeleteOutcome, Drawings, MAX_DRAWING_FILL_ALPHA, MAX_DRAWING_WIDTH_PX,
-    MIN_DRAWING_WIDTH_PX,
+    self, ChartPoint, DeleteOutcome, DrawContext, Drawings, MAX_DRAWING_FILL_ALPHA,
+    MAX_DRAWING_WIDTH_PX, MIN_DRAWING_WIDTH_PX, PresetHost,
 };
 use crate::feed::{self, FeedCommand, FeedEvent, FeedHandle, FeedNotice, ReplayLink};
 use crate::loading::{self, LoadingTask, LoadingTracker};
@@ -65,6 +65,8 @@ const INSPECTOR_MAX_WIDTH_PX: f32 = 440.0;
 /// Default inspector width for the shipped tools (the spec reserves 360 px
 /// for the Fib level editor).
 const INSPECTOR_DEFAULT_WIDTH_PX: f32 = 320.0;
+/// Default inspector width for tools that mount a level editor tab.
+const INSPECTOR_LEVELS_WIDTH_PX: f32 = 360.0;
 /// Gap kept between the inspector and the selected object's bounding box.
 const INSPECTOR_OBJECT_GAP_PX: f32 = 12.0;
 /// How long the delete toast keeps its Undo affordance on screen (UX spec).
@@ -102,11 +104,13 @@ struct DrawingToast {
 }
 
 /// Which inspector tab is open. Tabs exist per capability: every tool gets
-/// Style and Coordinates; a tool with levels adds its own tab.
+/// Style and Coordinates; a tool that brings its own tab (the Fib level
+/// editor) mounts it as Extra without the central code knowing its fields.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 enum InspectorTab {
     #[default]
     Style,
+    Extra,
     Coordinates,
 }
 
@@ -381,6 +385,9 @@ pub struct QuantickApp {
     // for inspector placement and manager centring.
     last_chart_area: Option<egui::Rect>,
     drawing_manager_open: bool,
+    // Custom drawing presets (named payload exports + default-for-new),
+    // persisted across restarts in a versioned file.
+    drawing_presets: drawings::presets::PresetStore,
     #[cfg(test)]
     inspector_pin_rect: Option<egui::Rect>,
     #[cfg(test)]
@@ -492,6 +499,9 @@ impl QuantickApp {
             inspector_last_selection: None,
             last_chart_area: None,
             drawing_manager_open: false,
+            drawing_presets: drawings::presets::PresetStore::load_from(
+                drawings::presets::PresetStore::default_path(),
+            ),
             #[cfg(test)]
             inspector_pin_rect: None,
             #[cfg(test)]
@@ -1432,7 +1442,19 @@ impl QuantickApp {
     }
 
     fn place_drawing_point(&mut self, tool: drawings::DrawingTool, point: ChartPoint) {
-        if self.drawings.place(tool, point) {
+        // A new object starts from the user's explicit default preset when
+        // one is set; existing objects are never touched by that choice.
+        let presets = &self.drawing_presets;
+        let completed = self.drawings.place_with(tool, point, |tool| {
+            let mut payload = tool.default_payload();
+            if let Some(name) = presets.default_preset(tool.id())
+                && let Some(value) = presets.load_custom_preset(tool.id(), &name)
+            {
+                payload.import_preset(&value);
+            }
+            payload
+        });
+        if completed {
             self.toolrail.arm(Tool::Pointer);
             self.drawing_hover = None;
         }
@@ -1468,9 +1490,16 @@ impl QuantickApp {
             .filter(|(index, _)| self.drawings.is_visible(*index))
             .find_map(|(index, drawing)| {
                 let projected = self.projected_drawing_points(drawing, history_right, total, scale);
+                let ctxt = DrawContext {
+                    payload: drawing.payload.as_ref(),
+                    anchors: &drawing.points,
+                    scale,
+                    selected: self.drawings.selected() == Some(index),
+                    halo: false,
+                };
                 drawing
                     .tool
-                    .hit_test(chart_rect, &projected, pos, DRAWING_SELECT_RADIUS_PX)
+                    .hit_test(chart_rect, &projected, pos, DRAWING_SELECT_RADIUS_PX, &ctxt)
                     .then_some(index)
             })
     }
@@ -2225,6 +2254,13 @@ impl QuantickApp {
             }
             let points = self.projected_drawing_points(drawing, history_right, total, scale);
             let selected = self.drawings.selected() == Some(index);
+            let ctxt = DrawContext {
+                payload: drawing.payload.as_ref(),
+                anchors: &drawing.points,
+                scale,
+                selected,
+                halo: false,
+            };
             // A locked object shows no resize handles: its geometry is not
             // editable, so the affordance would lie.
             drawing.tool.paint(
@@ -2232,21 +2268,33 @@ impl QuantickApp {
                 chart_rect,
                 drawing.style,
                 &points,
-                selected,
+                &ctxt,
                 selected && !drawing.locked,
             );
         }
 
         if let Some(draft) = self.drawings.draft() {
             let mut points = self.projected_drawing_points(draft, history_right, total, scale);
+            // The preview completes the geometry with the hovered anchor, in
+            // both screen and chart space, so payload-driven tools can show
+            // their real shape while placing.
+            let mut anchors: SmallVec<[ChartPoint; 4]> = SmallVec::from_slice(&draft.points);
             if points.len() < draft.tool.required_points()
                 && let Some(hover) = self.drawing_hover
             {
                 points.push(self.drawing_screen_point(hover, history_right, total, scale));
+                anchors.push(hover);
             }
+            let ctxt = DrawContext {
+                payload: draft.payload.as_ref(),
+                anchors: &anchors,
+                scale,
+                selected: false,
+                halo: false,
+            };
             draft
                 .tool
-                .paint(&clipped, chart_rect, draft.style, &points, false, false);
+                .paint(&clipped, chart_rect, draft.style, &points, &ctxt, false);
         }
     }
 
@@ -2706,8 +2754,17 @@ impl QuantickApp {
         }
         ui.separator();
 
+        if self.inspector_tab == InspectorTab::Extra && tool.extra_tab().is_none() {
+            // The previous selection had an extra tab; this tool brings none.
+            self.inspector_tab = InspectorTab::Style;
+        }
         ui.horizontal(|ui| {
             ui.selectable_value(&mut self.inspector_tab, InspectorTab::Style, "Style");
+            // A tool that brings its own tab (the Fib level editor) mounts it
+            // here by name; the central code never learns what is inside.
+            if let Some(extra) = tool.extra_tab() {
+                ui.selectable_value(&mut self.inspector_tab, InspectorTab::Extra, extra);
+            }
             ui.selectable_value(
                 &mut self.inspector_tab,
                 InspectorTab::Coordinates,
@@ -2720,10 +2777,18 @@ impl QuantickApp {
         let price_speed = self
             .last_auto_range
             .map_or(1.0, |(lo, hi)| ((hi - lo) / 200.0).abs().max(1e-9));
-        let Some(drawing) = self.drawings.selected_mut() else {
+        let Self {
+            drawings,
+            drawing_presets,
+            ..
+        } = self;
+        let Some(drawing) = drawings.selected_mut() else {
             return actions;
         };
         match tab {
+            InspectorTab::Extra => {
+                actions.edited |= tool.draw_extra_tab(ui, drawing, drawing_presets);
+            }
             InspectorTab::Style => {
                 ui.label("Style");
                 actions.edited |= ui
@@ -2945,11 +3010,17 @@ impl QuantickApp {
         let mut actions = InspectorActions::default();
         let mut open = true;
         let inspector_interactable = !self.drawing_drag.is_active();
+        // The level editor earns the wider default the spec reserves for it.
+        let default_width = if before.tool.extra_tab().is_some() {
+            INSPECTOR_LEVELS_WIDTH_PX
+        } else {
+            INSPECTOR_DEFAULT_WIDTH_PX
+        };
         let mut window = egui::Window::new(before.tool.settings_title())
             .id(egui::Id::new("drawing_inspector"))
             .open(&mut open)
             .default_pos(DRAWING_INSPECTOR_DEFAULT_POSITION)
-            .default_width(INSPECTOR_DEFAULT_WIDTH_PX)
+            .default_width(default_width)
             .min_width(INSPECTOR_MIN_WIDTH_PX)
             .max_width(INSPECTOR_MAX_WIDTH_PX)
             .collapsible(false)
@@ -4639,6 +4710,125 @@ mod tests {
             viewport_before,
             "over a hidden drawing the gesture belongs to the chart again"
         );
+    }
+
+    #[test]
+    fn the_fib_inspector_mounts_its_level_editor_tab() {
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        run_frame(&mut app, &ctx);
+        arm_drawing_from_toolbox(&mut app, &ctx, "fib-retracement");
+        drag_chart(
+            &mut app,
+            &ctx,
+            egui::pos2(600.0, 250.0),
+            egui::pos2(900.0, 400.0),
+        );
+        assert_eq!(app.drawings.items().len(), 1);
+
+        let texts = painted_text(&run_frame(&mut app, &ctx));
+        assert!(
+            texts.iter().any(|text| text.contains("Levels")),
+            "the tool-owned tab is offered by name; painted: {texts:?}"
+        );
+
+        app.inspector_tab = InspectorTab::Extra;
+        let texts = painted_text(&run_frame(&mut app, &ctx));
+        for label in ["Preset", "Standard", "band opacity", "log scale"] {
+            assert!(
+                texts.iter().any(|text| text.contains(label)),
+                "the level editor must show {label:?}; painted: {texts:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_placed_fib_paints_its_levels_and_labels() {
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        run_frame(&mut app, &ctx);
+        arm_drawing_from_toolbox(&mut app, &ctx, "fib-retracement");
+        drag_chart(
+            &mut app,
+            &ctx,
+            egui::pos2(600.0, 250.0),
+            egui::pos2(900.0, 400.0),
+        );
+
+        let texts = painted_text(&run_frame(&mut app, &ctx));
+        for label in ["61.8%", "38.2%", "50.0%"] {
+            assert!(
+                texts.iter().any(|text| text.contains(label)),
+                "the standard retracement labels paint on the chart; painted: {texts:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_default_preset_shapes_new_fibs_and_leaves_existing_ones_alone() {
+        use crate::drawings::DrawingPayload as _;
+        use crate::drawings::fib::FibPayload;
+
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        run_frame(&mut app, &ctx);
+
+        // First fib: the built-in standard start.
+        arm_drawing_from_toolbox(&mut app, &ctx, "fib-retracement");
+        drag_chart(
+            &mut app,
+            &ctx,
+            egui::pos2(600.0, 250.0),
+            egui::pos2(900.0, 400.0),
+        );
+        let standard_levels = app.drawings.items()[0]
+            .payload
+            .as_any()
+            .downcast_ref::<FibPayload>()
+            .expect("fib payload")
+            .levels
+            .len();
+        assert_eq!(standard_levels, 7);
+
+        // Save a compact custom preset and make it the default for new fibs.
+        let mut store = drawings::presets::PresetStore::load_from(std::env::temp_dir().join(
+            format!("quantick-default-preset-test-{}.toml", std::process::id()),
+        ));
+        let mut compact = FibPayload::new(drawings::fib::FibKind::Retracement);
+        compact.apply_preset(&drawings::fib::RETRACEMENT_PRESETS[1]);
+        let exported = compact.export_preset().expect("fib exports presets");
+        assert!(store.save_custom_preset("fib-retracement", "mine", exported, false));
+        store.set_default_preset("fib-retracement", Some("mine".into()));
+        let preset_path = store.path().to_path_buf();
+        app.drawing_presets = store;
+
+        // Second fib starts from the default preset...
+        arm_drawing_from_toolbox(&mut app, &ctx, "fib-retracement");
+        drag_chart(
+            &mut app,
+            &ctx,
+            egui::pos2(400.0, 250.0),
+            egui::pos2(550.0, 400.0),
+        );
+        let new_levels = app.drawings.items()[1]
+            .payload
+            .as_any()
+            .downcast_ref::<FibPayload>()
+            .expect("fib payload")
+            .levels
+            .len();
+        assert_eq!(new_levels, 5, "a new fib starts from the default preset");
+
+        // ...and the first one is untouched.
+        let old_levels = app.drawings.items()[0]
+            .payload
+            .as_any()
+            .downcast_ref::<FibPayload>()
+            .expect("fib payload")
+            .levels
+            .len();
+        assert_eq!(old_levels, 7, "the default never rewrites existing objects");
+        let _ = std::fs::remove_file(preset_path);
     }
 
     /// The whole point, on a real frame: after a spec change with the view

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -103,6 +103,10 @@ impl DrawingDrag {
 struct DrawingToast {
     message: &'static str,
     shown_at: Instant,
+    /// Whether the toast offers Undo. A delete does; the honest clear after
+    /// a bar rebuild does not — its history is gone with the drawings, and
+    /// a dead Undo button would lie.
+    offers_undo: bool,
 }
 
 /// Which inspector tab is open. Tabs exist per capability: every tool gets
@@ -1148,8 +1152,9 @@ impl QuantickApp {
 
     /// Bar-index anchors are meaningful only for the market/spec that created
     /// them. Clear them on a source or aggregation rebuild rather than
-    /// silently attaching a mark to different market data.
+    /// silently attaching a mark to different market data — and say so.
     fn reset_drawing_overlay(&mut self) {
+        let had_drawings = !self.drawings.items().is_empty();
         self.drawings.clear();
         self.toolrail.arm(Tool::Pointer);
         self.drawing_hover = None;
@@ -1159,9 +1164,14 @@ impl QuantickApp {
         self.drawing_delete_confirm = false;
         self.inspector_edit_baseline = None;
         self.inspector_last_selection = None;
-        // The cleared history cannot resurrect anything, so the toast's Undo
-        // affordance would lie — drop it with the drawings.
-        self.drawing_toast = None;
+        // The cleared history cannot resurrect anything, so this toast
+        // offers no Undo — a dead button would lie. But losing the marks is
+        // never silent.
+        self.drawing_toast = had_drawings.then(|| DrawingToast {
+            message: "Drawings cleared - the bars were rebuilt under them.",
+            shown_at: Instant::now(),
+            offers_undo: false,
+        });
     }
 
     /// Drain a bounded number of synchronized depth events. The separate
@@ -2676,6 +2686,7 @@ impl QuantickApp {
                 self.drawing_toast = Some(DrawingToast {
                     message: "Drawing deleted.",
                     shown_at: now,
+                    offers_undo: true,
                 });
             }
             DeleteOutcome::NeedsConfirmation => self.drawing_delete_confirm = true,
@@ -2802,6 +2813,7 @@ impl QuantickApp {
             return;
         }
         let message = toast.message;
+        let offers_undo = toast.offers_undo;
         let mut undo_clicked = false;
         egui::Area::new(egui::Id::new("drawing_toast"))
             .anchor(
@@ -2818,7 +2830,7 @@ impl QuantickApp {
                     .show(ui, |ui| {
                         ui.horizontal(|ui| {
                             ui.label(message);
-                            if ui.button("Undo").clicked() {
+                            if offers_undo && ui.button("Undo").clicked() {
                                 undo_clicked = true;
                             }
                         });
@@ -3037,6 +3049,7 @@ impl QuantickApp {
                 self.drawing_toast = Some(DrawingToast {
                     message: "Drawing deleted.",
                     shown_at: now,
+                    offers_undo: true,
                 });
             }
         }
@@ -4856,6 +4869,41 @@ mod tests {
             app.viewport.right_edge_bar(app.slots()),
             viewport_before,
             "over a hidden drawing the gesture belongs to the chart again"
+        );
+    }
+
+    #[test]
+    fn a_bar_rebuild_clears_drawings_with_an_explicit_notice_and_no_dead_undo() {
+        let (mut app, evt_tx, _cmd_rx, _book_tx) = test_app();
+        let ctx = egui::Context::default();
+        run_frame(&mut app, &ctx);
+        app.drawings.place(
+            drawing_tool("horizontal-line"),
+            ChartPoint {
+                bar: 1.0,
+                price: 100.0,
+            },
+        );
+
+        evt_tx.try_send(FeedEvent::Reset).unwrap();
+        app.drain_feed();
+        assert!(app.drawings.items().is_empty());
+        assert!(
+            app.drawing_toast.is_some(),
+            "the clear must raise the notice toast"
+        );
+
+        // A fresh egui Area sizes itself on its first frame; the text is
+        // on screen from the second one.
+        run_frame(&mut app, &ctx);
+        let texts = painted_text(&run_frame(&mut app, &ctx));
+        assert!(
+            texts.iter().any(|text| text.contains("Drawings cleared")),
+            "losing the marks is never silent; painted: {texts:?}"
+        );
+        assert!(
+            !texts.iter().any(|text| text == "Undo"),
+            "the clear toast must not offer an Undo it cannot honour"
         );
     }
 

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -22,7 +22,8 @@ use crate::chart::{self, PriceScale};
 use crate::config::{AppConfig, FeedCapabilities};
 use crate::dock::{Dock, DockEnv, DockTab};
 use crate::drawings::{
-    self, ChartPoint, Drawings, MAX_DRAWING_FILL_ALPHA, MAX_DRAWING_WIDTH_PX, MIN_DRAWING_WIDTH_PX,
+    self, ChartPoint, DeleteOutcome, Drawings, MAX_DRAWING_FILL_ALPHA, MAX_DRAWING_WIDTH_PX,
+    MIN_DRAWING_WIDTH_PX,
 };
 use crate::feed::{self, FeedCommand, FeedEvent, FeedHandle, FeedNotice, ReplayLink};
 use crate::loading::{self, LoadingTask, LoadingTracker};
@@ -57,6 +58,10 @@ const DRAWING_ANCHOR_RADIUS_PX: f32 = 12.0;
 const DRAWING_DRAG_THRESHOLD_PX: f32 = 4.0;
 /// Initial position of the selected-drawing inspector.
 const DRAWING_INSPECTOR_DEFAULT_POSITION: egui::Pos2 = egui::pos2(90.0, 120.0);
+/// How long the delete toast keeps its Undo affordance on screen (UX spec).
+const TOAST_UNDO_MS: u64 = 8_000;
+/// Vertical clearance between the toast and the bottom chrome.
+const TOAST_BOTTOM_MARGIN_PX: f32 = 44.0;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 enum DrawingDrag {
@@ -67,12 +72,24 @@ enum DrawingDrag {
         drawing_index: usize,
         point_index: usize,
     },
+    /// The press landed on a locked drawing: the gesture belongs to the
+    /// object (the chart must not pan) but the geometry stays put.
+    Blocked,
 }
 
 impl DrawingDrag {
     const fn is_active(self) -> bool {
         !matches!(self, Self::None)
     }
+}
+
+/// Transient confirmation of a destructive drawing command, with its escape
+/// hatch. Undo works from the button for [`TOAST_UNDO_MS`] and from Ctrl+Z
+/// for as long as the history holds.
+#[derive(Debug)]
+struct DrawingToast {
+    message: &'static str,
+    shown_at: Instant,
 }
 
 /// Alpha of the last-price line: legible at a glance without competing with a
@@ -314,6 +331,12 @@ pub struct QuantickApp {
     drawing_press_position: Option<egui::Pos2>,
     drawing_press_started_empty: bool,
     drawing_drag: DrawingDrag,
+    // Delete confirmation for a locked drawing, shown next to the trigger.
+    drawing_delete_confirm: bool,
+    // Pre-edit copy of the selected drawing while an inspector style gesture
+    // (slider/color drag) is in flight; committed as one undo entry.
+    drawing_style_baseline: Option<(usize, drawings::Drawing)>,
+    drawing_toast: Option<DrawingToast>,
 
     // Candle appearance + whether the style panel is open.
     style: ChartStyle,
@@ -412,6 +435,9 @@ impl QuantickApp {
             drawing_press_position: None,
             drawing_press_started_empty: false,
             drawing_drag: DrawingDrag::None,
+            drawing_delete_confirm: false,
+            drawing_style_baseline: None,
+            drawing_toast: None,
             style: ChartStyle::default(),
             show_style: false,
             style_revision: 0,
@@ -1060,6 +1086,11 @@ impl QuantickApp {
         self.drawing_press_position = None;
         self.drawing_press_started_empty = false;
         self.drawing_drag = DrawingDrag::None;
+        self.drawing_delete_confirm = false;
+        self.drawing_style_baseline = None;
+        // The cleared history cannot resurrect anything, so the toast's Undo
+        // affordance would lie — drop it with the drawings.
+        self.drawing_toast = None;
     }
 
     /// Drain a bounded number of synchronized depth events. The separate
@@ -1375,6 +1406,7 @@ impl QuantickApp {
             .iter()
             .enumerate()
             .rev()
+            .filter(|(index, _)| self.drawings.is_visible(*index))
             .find_map(|(index, drawing)| {
                 let projected = self.projected_drawing_points(drawing, history_right, total, scale);
                 drawing
@@ -1392,6 +1424,9 @@ impl QuantickApp {
         total: usize,
         scale: &PriceScale,
     ) -> Option<usize> {
+        if !self.drawings.is_visible(drawing_index) {
+            return None;
+        }
         let drawing = self.drawings.items().get(drawing_index)?;
         self.projected_drawing_points(drawing, history_right, total, scale)
             .iter()
@@ -1485,7 +1520,12 @@ impl QuantickApp {
                     .drawing_anchor_in(selected, position, history_right, total, &scale)
                     .is_some()
             {
-                ui.ctx().set_cursor_icon(egui::CursorIcon::ResizeNwSe);
+                ui.ctx()
+                    .set_cursor_icon(if self.drawings.items()[selected].locked {
+                        egui::CursorIcon::NotAllowed
+                    } else {
+                        egui::CursorIcon::ResizeNwSe
+                    });
             }
             if chart.clicked()
                 && let Some(position) = chart.interact_pointer_pos()
@@ -1509,18 +1549,26 @@ impl QuantickApp {
                     self.drawing_anchor_at(position, history_right, total, &scale)
                 {
                     self.drawings.select(Some(drawing_index));
-                    self.drawing_drag = DrawingDrag::Anchor {
-                        drawing_index,
-                        point_index,
+                    self.drawing_drag = if self.drawings.items()[drawing_index].locked {
+                        DrawingDrag::Blocked
+                    } else {
+                        self.drawings.begin_gesture();
+                        DrawingDrag::Anchor {
+                            drawing_index,
+                            point_index,
+                        }
                     };
                 } else {
                     let selected =
                         self.drawing_at(position, areas.chart, history_right, total, &scale);
                     self.drawings.select(selected);
-                    self.drawing_drag = if selected.is_some() {
-                        DrawingDrag::Translate
-                    } else {
-                        DrawingDrag::None
+                    self.drawing_drag = match selected {
+                        Some(index) if self.drawings.items()[index].locked => DrawingDrag::Blocked,
+                        Some(_) => {
+                            self.drawings.begin_gesture();
+                            DrawingDrag::Translate
+                        }
+                        None => DrawingDrag::None,
                     };
                 }
                 drawing_drag_started = self.drawing_drag.is_active();
@@ -1553,11 +1601,16 @@ impl QuantickApp {
                             self.drawings.translate_selected(delta_bar, delta_price);
                         }
                     }
+                    DrawingDrag::Blocked => {
+                        ui.ctx().set_cursor_icon(egui::CursorIcon::NotAllowed);
+                    }
                     DrawingDrag::None => {}
                 }
             }
             drawing_drag_consumes_gesture = self.drawing_drag.is_active();
             if primary_released {
+                // One gesture, one undo entry — recorded only if it moved.
+                self.drawings.commit_gesture();
                 self.drawing_drag = DrawingDrag::None;
             }
         } else {
@@ -2103,11 +2156,21 @@ impl QuantickApp {
     ) {
         let clipped = painter.with_clip_rect(chart_rect);
         for (index, drawing) in self.drawings.items().iter().enumerate() {
+            if !self.drawings.is_visible(index) {
+                continue;
+            }
             let points = self.projected_drawing_points(drawing, history_right, total, scale);
             let selected = self.drawings.selected() == Some(index);
-            drawing
-                .tool
-                .paint(&clipped, chart_rect, drawing.style, &points, selected);
+            // A locked object shows no resize handles: its geometry is not
+            // editable, so the affordance would lie.
+            drawing.tool.paint(
+                &clipped,
+                chart_rect,
+                drawing.style,
+                &points,
+                selected,
+                selected && !drawing.locked,
+            );
         }
 
         if let Some(draft) = self.drawings.draft() {
@@ -2119,7 +2182,7 @@ impl QuantickApp {
             }
             draft
                 .tool
-                .paint(&clipped, chart_rect, draft.style, &points, false);
+                .paint(&clipped, chart_rect, draft.style, &points, false, false);
         }
     }
 
@@ -2416,14 +2479,127 @@ impl QuantickApp {
             });
     }
 
-    /// The selected object's inspector mirrors the compact, contextual drawing
-    /// controls traders expect: styles are per object rather than global.
-    fn draw_drawing_inspector(&mut self, ctx: &egui::Context) {
-        let Some(index) = self.drawings.selected() else {
+    /// One delete command for every trigger (inspector button, keyboard,
+    /// manager). A locked object raises the confirmation next to the trigger
+    /// instead of deleting; a landed delete raises the Undo toast.
+    fn request_delete_selected(&mut self, now: Instant) {
+        match self.drawings.delete_selected(false) {
+            DeleteOutcome::Deleted => {
+                self.drawing_delete_confirm = false;
+                self.drawing_toast = Some(DrawingToast {
+                    message: "Drawing deleted.",
+                    shown_at: now,
+                });
+            }
+            DeleteOutcome::NeedsConfirmation => self.drawing_delete_confirm = true,
+            DeleteOutcome::NothingSelected => {}
+        }
+    }
+
+    /// Keyboard grammar for drawings. Any focused widget wins: while an input
+    /// owns the keyboard, chart shortcuts stay suspended.
+    fn handle_drawing_keys(&mut self, ctx: &egui::Context, now: Instant) {
+        if ctx.memory(|memory| memory.focused().is_some()) {
+            return;
+        }
+        let (delete, undo, redo) = ctx.input(|input| {
+            let command = input.modifiers.command;
+            let shift = input.modifiers.shift;
+            (
+                input.key_pressed(egui::Key::Delete) || input.key_pressed(egui::Key::Backspace),
+                command && !shift && input.key_pressed(egui::Key::Z),
+                (command && input.key_pressed(egui::Key::Y))
+                    || (command && shift && input.key_pressed(egui::Key::Z)),
+            )
+        });
+        // While a draft is being placed the delete keys belong to the draft
+        // workflow, not to the previously selected object.
+        if delete && self.drawings.draft().is_none() {
+            self.request_delete_selected(now);
+        }
+        if undo {
+            self.drawings.undo();
+        }
+        if redo {
+            self.drawings.redo();
+        }
+    }
+
+    /// Commit a pending inspector style gesture as one undo entry.
+    fn commit_style_gesture(&mut self) {
+        if let Some((index, before)) = self.drawing_style_baseline.take() {
+            self.drawings.record_edit_of(index, before);
+        }
+    }
+
+    /// The delete toast: visible for [`TOAST_UNDO_MS`], with an Undo button
+    /// driving the same history as Ctrl+Z.
+    fn draw_drawing_toast(&mut self, ctx: &egui::Context, now: Instant) {
+        let Some(toast) = &self.drawing_toast else {
             return;
         };
-        let title = self.drawings.items()[index].tool.settings_title();
-        let mut delete = false;
+        if now.saturating_duration_since(toast.shown_at) >= Duration::from_millis(TOAST_UNDO_MS) {
+            self.drawing_toast = None;
+            return;
+        }
+        let message = toast.message;
+        let mut undo_clicked = false;
+        egui::Area::new(egui::Id::new("drawing_toast"))
+            .anchor(
+                egui::Align2::CENTER_BOTTOM,
+                egui::vec2(0.0, -TOAST_BOTTOM_MARGIN_PX),
+            )
+            .order(egui::Order::Foreground)
+            .show(ctx, |ui| {
+                egui::Frame::none()
+                    .fill(theme::TAG_BG)
+                    .stroke(egui::Stroke::new(1.0_f32, theme::BORDER))
+                    .rounding(6.0_f32)
+                    .inner_margin(egui::Margin::symmetric(12.0, 8.0))
+                    .show(ui, |ui| {
+                        ui.horizontal(|ui| {
+                            ui.label(message);
+                            if ui.button("Undo").clicked() {
+                                undo_clicked = true;
+                            }
+                        });
+                    });
+            });
+        if undo_clicked {
+            self.drawings.undo();
+            self.drawing_toast = None;
+        }
+    }
+
+    /// The selected object's inspector mirrors the compact, contextual drawing
+    /// controls traders expect: styles are per object rather than global.
+    /// Non-modal by contract: it never captures the whole canvas and never
+    /// blocks moving the geometry underneath it.
+    fn draw_drawing_inspector(&mut self, ctx: &egui::Context, now: Instant) {
+        let Some(index) = self.drawings.selected() else {
+            self.drawing_delete_confirm = false;
+            self.commit_style_gesture();
+            return;
+        };
+        // A style gesture that outlived its object's selection commits now.
+        if self
+            .drawing_style_baseline
+            .as_ref()
+            .is_some_and(|(baseline_index, _)| *baseline_index != index)
+        {
+            self.commit_style_gesture();
+        }
+        let before = self.drawings.items()[index].clone();
+        let title = before.tool.settings_title();
+        let locked = before.locked;
+        let hidden = before.hidden;
+        let show_confirm = self.drawing_delete_confirm && locked;
+        let mut delete_requested = false;
+        let mut toggle_lock = false;
+        let mut toggle_hidden = false;
+        let mut cancel_delete = false;
+        let mut force_delete = false;
+        let mut style_changed = false;
         let mut open = true;
         let inspector_interactable = !self.drawing_drag.is_active();
         egui::Window::new(title)
@@ -2435,33 +2611,109 @@ impl QuantickApp {
             .interactable(inspector_interactable)
             .resizable(false)
             .show(ctx, |ui| {
+                // Always-visible, textual object actions (UX spec: never
+                // glyph-only, never behind a scroll).
+                ui.horizontal(|ui| {
+                    let eye_label = if hidden {
+                        "Show drawing"
+                    } else {
+                        "Hide drawing"
+                    };
+                    if ui.button(eye_label).clicked() {
+                        toggle_hidden = true;
+                    }
+                    let lock_label = if locked {
+                        "Unlock drawing"
+                    } else {
+                        "Lock drawing"
+                    };
+                    if ui.button(lock_label).clicked() {
+                        toggle_lock = true;
+                    }
+                    if ui.button("Delete drawing").clicked() {
+                        delete_requested = true;
+                    }
+                });
+                if locked {
+                    ui.label("Locked - protected from accidental moves. Style stays editable.");
+                }
+                if hidden {
+                    ui.label("Hidden - Show drawing brings it back.");
+                }
+                if show_confirm {
+                    ui.separator();
+                    ui.label("Delete locked drawing?");
+                    ui.horizontal(|ui| {
+                        if ui.button("Cancel").clicked() {
+                            cancel_delete = true;
+                        }
+                        if ui.button("Delete anyway").clicked() {
+                            force_delete = true;
+                        }
+                    });
+                }
+                ui.separator();
                 if let Some(drawing) = self.drawings.selected_mut() {
                     ui.label("Style");
-                    ui.color_edit_button_srgba(&mut drawing.style.color);
-                    ui.add(
-                        egui::Slider::new(
-                            &mut drawing.style.width_px,
-                            MIN_DRAWING_WIDTH_PX..=MAX_DRAWING_WIDTH_PX,
+                    style_changed |= ui
+                        .color_edit_button_srgba(&mut drawing.style.color)
+                        .changed();
+                    style_changed |= ui
+                        .add(
+                            egui::Slider::new(
+                                &mut drawing.style.width_px,
+                                MIN_DRAWING_WIDTH_PX..=MAX_DRAWING_WIDTH_PX,
+                            )
+                            .text("line width (px)"),
                         )
-                        .text("line width (px)"),
-                    );
-                    ui.add(
-                        egui::Slider::new(
-                            &mut drawing.style.fill_alpha,
-                            0..=MAX_DRAWING_FILL_ALPHA,
+                        .changed();
+                    style_changed |= ui
+                        .add(
+                            egui::Slider::new(
+                                &mut drawing.style.fill_alpha,
+                                0..=MAX_DRAWING_FILL_ALPHA,
+                            )
+                            .text("fill opacity"),
                         )
-                        .text("fill opacity"),
-                    );
-                    ui.separator();
-                    if ui.button("Delete drawing").clicked() {
-                        delete = true;
-                    }
+                        .changed();
                 }
             });
-        if delete {
-            self.drawings.delete_selected();
-        } else if !open {
+        // Coalesce the style gesture: capture the pre-edit object at the
+        // first change, commit one undo entry once pointer and keyboard let
+        // go. A whole slider drag lands as a single command.
+        if style_changed && self.drawing_style_baseline.is_none() {
+            self.drawing_style_baseline = Some((index, before));
+        }
+        let gesture_settled = ctx.input(|input| !input.pointer.any_down())
+            && ctx.memory(|memory| memory.focused().is_none());
+        if gesture_settled {
+            self.commit_style_gesture();
+        }
+        if toggle_hidden {
+            self.drawings.set_selected_hidden(!hidden);
+        }
+        if toggle_lock {
+            self.drawings.set_selected_locked(!locked);
+            self.drawing_delete_confirm = false;
+        }
+        if delete_requested {
+            self.request_delete_selected(now);
+        }
+        if cancel_delete {
+            self.drawing_delete_confirm = false;
+        }
+        if force_delete {
+            self.drawing_delete_confirm = false;
+            if self.drawings.delete_selected(true) == DeleteOutcome::Deleted {
+                self.drawing_toast = Some(DrawingToast {
+                    message: "Drawing deleted.",
+                    shown_at: now,
+                });
+            }
+        }
+        if !open {
             self.drawings.select(None);
+            self.drawing_delete_confirm = false;
         }
     }
 
@@ -2640,6 +2892,7 @@ impl QuantickApp {
         // Rail shortcuts first: Esc/1/2 must be read before any widget can
         // claim the keyboard this frame.
         self.toolrail.handle_keys(ctx);
+        self.handle_drawing_keys(ctx, now);
         // Chrome panels claim their zones outside-in (§5): menu and toolbar
         // on top, the status line at the very bottom with the replay
         // transport directly above it, then the corner toolbox and right dock.
@@ -2652,7 +2905,12 @@ impl QuantickApp {
         if let Some(action) = self.replay_view.draw(ctx, self.replay.as_ref()) {
             self.apply_replay_action(action);
         }
-        self.toolrail.draw(ctx);
+        {
+            let Self {
+                toolrail, drawings, ..
+            } = self;
+            toolrail.draw(ctx, drawings);
+        }
         let dock_response = {
             let Self {
                 dock,
@@ -2702,7 +2960,8 @@ impl QuantickApp {
             });
         // Floating drawing controls must be registered after the opaque
         // central canvas so they stay in front of the chart.
-        self.draw_drawing_inspector(ctx);
+        self.draw_drawing_inspector(ctx, now);
+        self.draw_drawing_toast(ctx, now);
         if notice_action == notice_card::NoticeAction::Retry {
             self.restart_feed();
         }
@@ -3258,12 +3517,22 @@ mod tests {
         ctx: &egui::Context,
         events: Vec<egui::Event>,
     ) -> egui::FullOutput {
+        run_frame_with_modifiers(app, ctx, events, egui::Modifiers::NONE)
+    }
+
+    fn run_frame_with_modifiers(
+        app: &mut QuantickApp,
+        ctx: &egui::Context,
+        events: Vec<egui::Event>,
+        modifiers: egui::Modifiers,
+    ) -> egui::FullOutput {
         let input = egui::RawInput {
             screen_rect: Some(egui::Rect::from_min_size(
                 egui::pos2(0.0, 0.0),
                 egui::vec2(1400.0, 900.0),
             )),
             events,
+            modifiers,
             ..Default::default()
         };
         ctx.run(input, |ctx| app.draw_frame(ctx, Instant::now()))
@@ -3545,6 +3814,247 @@ mod tests {
                 .iter()
                 .any(|text| text.contains("Rectangle settings")),
             "the non-modal settings window remains usable after resizing"
+        );
+    }
+
+    fn key_press(key: egui::Key) -> egui::Event {
+        key_press_with(key, egui::Modifiers::NONE)
+    }
+
+    fn key_press_with(key: egui::Key, modifiers: egui::Modifiers) -> egui::Event {
+        egui::Event::Key {
+            key,
+            physical_key: None,
+            pressed: true,
+            repeat: false,
+            modifiers,
+        }
+    }
+
+    /// Whether any painted line segment uses `color` — proof a stroke of that
+    /// colour reached the screen (or, negated, that a hidden object did not).
+    fn painted_line_with_color(output: &egui::FullOutput, color: egui::Color32) -> bool {
+        output.shapes.iter().any(|clipped| match &clipped.shape {
+            egui::Shape::LineSegment { stroke, .. } => {
+                stroke.color == egui::epaint::ColorMode::Solid(color)
+            }
+            _ => false,
+        })
+    }
+
+    #[test]
+    fn locked_drawing_rejects_geometry_and_keyboard_delete() {
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        run_frame(&mut app, &ctx);
+        app.toolrail
+            .arm(Tool::Drawing(drawing_tool("horizontal-line")));
+        click_chart(&mut app, &ctx, egui::pos2(700.0, 300.0));
+        app.drawings.set_selected_locked(true);
+
+        let before = app.drawings.items()[0].points[0];
+        let viewport_before = app.viewport.right_edge_bar(app.slots());
+        drag_chart(
+            &mut app,
+            &ctx,
+            egui::pos2(1_000.0, 300.0),
+            egui::pos2(1_040.0, 340.0),
+        );
+        assert_eq!(
+            app.drawings.items()[0].points[0],
+            before,
+            "locked geometry must not move"
+        );
+        assert_eq!(
+            app.viewport.right_edge_bar(app.slots()),
+            viewport_before,
+            "the blocked gesture still belongs to the drawing - the chart must not pan"
+        );
+
+        run_frame_with_events(&mut app, &ctx, vec![key_press(egui::Key::Delete)]);
+        assert_eq!(
+            app.drawings.items().len(),
+            1,
+            "keyboard delete must not remove a locked drawing"
+        );
+        let texts = painted_text(&run_frame(&mut app, &ctx));
+        assert!(
+            texts
+                .iter()
+                .any(|text| text.contains("Delete locked drawing?")),
+            "the same confirmation appears next to the trigger; painted: {texts:?}"
+        );
+    }
+
+    #[test]
+    fn one_drag_creates_one_undo_entry() {
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        run_frame(&mut app, &ctx);
+        app.toolrail
+            .arm(Tool::Drawing(drawing_tool("horizontal-line")));
+        click_chart(&mut app, &ctx, egui::pos2(700.0, 300.0));
+        assert_eq!(
+            app.drawings.undo_depth(),
+            1,
+            "creating the drawing is the first undo entry"
+        );
+
+        let before_drag = app.drawings.items()[0].points[0];
+        let start = egui::pos2(1_000.0, 300.0);
+        run_frame_with_events(
+            &mut app,
+            &ctx,
+            vec![
+                egui::Event::PointerMoved(start),
+                pointer_button(start, true),
+            ],
+        );
+        for step in [egui::pos2(1_010.0, 312.0), egui::pos2(1_025.0, 326.0)] {
+            run_frame_with_events(&mut app, &ctx, vec![egui::Event::PointerMoved(step)]);
+        }
+        let end = egui::pos2(1_040.0, 340.0);
+        run_frame_with_events(
+            &mut app,
+            &ctx,
+            vec![egui::Event::PointerMoved(end), pointer_button(end, false)],
+        );
+        assert_ne!(
+            app.drawings.items()[0].points[0],
+            before_drag,
+            "the drag really moved the line"
+        );
+
+        assert_eq!(
+            app.drawings.undo_depth(),
+            2,
+            "a multi-frame drag coalesces into exactly one undo entry"
+        );
+        assert!(app.drawings.undo(), "undo the drag");
+        assert_eq!(
+            app.drawings.items()[0].points[0],
+            before_drag,
+            "one undo rewinds the whole drag"
+        );
+        assert!(app.drawings.undo(), "undo the creation");
+        assert!(app.drawings.items().is_empty());
+    }
+
+    #[test]
+    fn delete_and_backspace_never_leak_out_of_focused_inputs() {
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        run_frame(&mut app, &ctx);
+        app.toolrail
+            .arm(Tool::Drawing(drawing_tool("horizontal-line")));
+        click_chart(&mut app, &ctx, egui::pos2(700.0, 300.0));
+        assert_eq!(app.drawings.items().len(), 1);
+
+        ctx.memory_mut(|memory| memory.request_focus(egui::Id::new("test-text-input")));
+        run_frame_with_events(
+            &mut app,
+            &ctx,
+            vec![
+                key_press(egui::Key::Delete),
+                key_press(egui::Key::Backspace),
+            ],
+        );
+        assert_eq!(
+            app.drawings.items().len(),
+            1,
+            "while an input owns the keyboard the delete keys stay in it"
+        );
+
+        run_frame_with_events(&mut app, &ctx, vec![key_press(egui::Key::Delete)]);
+        assert!(
+            app.drawings.items().is_empty(),
+            "with focus released the same key deletes the selection"
+        );
+    }
+
+    #[test]
+    fn keyboard_delete_offers_an_undo_toast_and_ctrl_z_restores() {
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        run_frame(&mut app, &ctx);
+        app.toolrail
+            .arm(Tool::Drawing(drawing_tool("horizontal-line")));
+        click_chart(&mut app, &ctx, egui::pos2(700.0, 300.0));
+
+        run_frame_with_events(&mut app, &ctx, vec![key_press(egui::Key::Delete)]);
+        assert!(app.drawings.items().is_empty());
+        let texts = painted_text(&run_frame(&mut app, &ctx));
+        for label in ["Drawing deleted.", "Undo"] {
+            assert!(
+                texts.iter().any(|text| text.contains(label)),
+                "the toast must offer {label:?}; painted: {texts:?}"
+            );
+        }
+
+        run_frame_with_modifiers(
+            &mut app,
+            &ctx,
+            vec![key_press_with(egui::Key::Z, egui::Modifiers::COMMAND)],
+            egui::Modifiers::COMMAND,
+        );
+        assert_eq!(
+            app.drawings.items().len(),
+            1,
+            "Ctrl+Z drives the same history as the toast's Undo"
+        );
+
+        run_frame_with_modifiers(
+            &mut app,
+            &ctx,
+            vec![key_press_with(egui::Key::Y, egui::Modifiers::COMMAND)],
+            egui::Modifiers::COMMAND,
+        );
+        assert!(
+            app.drawings.items().is_empty(),
+            "Ctrl+Y redoes the undone delete"
+        );
+    }
+
+    #[test]
+    fn hidden_drawing_neither_paints_nor_hit_tests() {
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        run_frame(&mut app, &ctx);
+        app.toolrail
+            .arm(Tool::Drawing(drawing_tool("horizontal-line")));
+        let stroke_position = egui::pos2(700.0, 300.0);
+        click_chart(&mut app, &ctx, stroke_position);
+        let marker = egui::Color32::from_rgb(1, 2, 3);
+        app.drawings
+            .selected_mut()
+            .expect("placement selects the line")
+            .style
+            .color = marker;
+        assert!(
+            painted_line_with_color(&run_frame(&mut app, &ctx), marker),
+            "the visible line paints its stroke"
+        );
+
+        app.drawings.set_selected_hidden(true);
+        assert!(
+            !painted_line_with_color(&run_frame(&mut app, &ctx), marker),
+            "a hidden drawing must not paint"
+        );
+
+        app.drawings.select(None);
+        click_chart(&mut app, &ctx, stroke_position);
+        assert_eq!(
+            app.drawings.selected(),
+            None,
+            "a hidden drawing must not hit-test"
+        );
+
+        let viewport_before = app.viewport.right_edge_bar(app.slots());
+        drag_chart(&mut app, &ctx, stroke_position, egui::pos2(640.0, 260.0));
+        assert_ne!(
+            app.viewport.right_edge_bar(app.slots()),
+            viewport_before,
+            "over a hidden drawing the gesture belongs to the chart again"
         );
     }
 

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -15,11 +15,15 @@ use rust_decimal::prelude::{FromPrimitive as _, ToPrimitive as _};
 use tokio::sync::{mpsc, watch};
 
 use quantick_feed_binance::depth::DepthEvent;
+use smallvec::SmallVec;
 
 use crate::candle_view::{draw_candle, draw_style_window};
 use crate::chart::{self, PriceScale};
 use crate::config::{AppConfig, FeedCapabilities};
 use crate::dock::{Dock, DockEnv, DockTab};
+use crate::drawings::{
+    self, ChartPoint, Drawings, MAX_DRAWING_FILL_ALPHA, MAX_DRAWING_WIDTH_PX, MIN_DRAWING_WIDTH_PX,
+};
 use crate::feed::{self, FeedCommand, FeedEvent, FeedHandle, FeedNotice, ReplayLink};
 use crate::loading::{self, LoadingTask, LoadingTracker};
 use crate::metrics::{self, FrameStats};
@@ -45,6 +49,31 @@ fn color32([r, g, b, a]: [u8; 4]) -> egui::Color32 {
 const AXIS_GUTTER: f32 = 64.0;
 /// Height of the bottom time-axis strip, in pixels (§5 zone 6).
 const TIME_STRIP: f32 = 24.0;
+/// Hit radius for selecting a drawing anchor, in logical pixels.
+const DRAWING_SELECT_RADIUS_PX: f32 = 10.0;
+/// Hit radius for a selected drawing's editable anchor.
+const DRAWING_ANCHOR_RADIUS_PX: f32 = 12.0;
+/// Minimum pointer travel that turns one press/release into drag placement.
+const DRAWING_DRAG_THRESHOLD_PX: f32 = 4.0;
+/// Initial position of the selected-drawing inspector.
+const DRAWING_INSPECTOR_DEFAULT_POSITION: egui::Pos2 = egui::pos2(90.0, 120.0);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+enum DrawingDrag {
+    #[default]
+    None,
+    Translate,
+    Anchor {
+        drawing_index: usize,
+        point_index: usize,
+    },
+}
+
+impl DrawingDrag {
+    const fn is_active(self) -> bool {
+        !matches!(self, Self::None)
+    }
+}
 
 /// Alpha of the last-price line: legible at a glance without competing with a
 /// candle or a bubble for attention.
@@ -231,10 +260,13 @@ pub struct QuantickApp {
     replay: Option<ReplayLink>,
     replay_view: ReplayView,
 
-    // The two chrome zones the design model reserves beside the chart: the
-    // tabbed right dock (settings) and the left tool rail (chart tools).
+    // External chart chrome: the tabbed right dock and the corner-docked
+    // drawing toolbox. Neither is painted over the chart canvas.
     dock: Dock,
     toolrail: ToolRail,
+    /// User drawings live entirely in the app overlay layer, never in market
+    /// state, so chart/backtest/bot determinism stays untouched.
+    drawings: Drawings,
 
     // How many older trades to pull per "load older" click, and how many
     // trades have been backfilled in total (for the readout).
@@ -273,8 +305,15 @@ pub struct QuantickApp {
     // in the input handler (which runs before the draw computes them).
     last_auto_range: Option<(f64, f64)>,
     last_chart_height: f32,
+    last_chart_top: f32,
     // Pointer position over the plot this frame, for the crosshair.
     hover_pos: Option<egui::Pos2>,
+    // Drawing placement/movement state. Anchors are chart coordinates; only
+    // the current hover and press position are transient pixels.
+    drawing_hover: Option<ChartPoint>,
+    drawing_press_position: Option<egui::Pos2>,
+    drawing_press_started_empty: bool,
+    drawing_drag: DrawingDrag,
 
     // Candle appearance + whether the style panel is open.
     style: ChartStyle,
@@ -349,6 +388,7 @@ impl QuantickApp {
             replay_view: ReplayView::new(),
             dock: Dock::new(),
             toolrail: ToolRail::new(),
+            drawings: Drawings::default(),
             config,
             feed_id,
             symbol,
@@ -366,7 +406,12 @@ impl QuantickApp {
             last_lane_divider_x: None,
             last_auto_range: None,
             last_chart_height: 1.0,
+            last_chart_top: 0.0,
             hover_pos: None,
+            drawing_hover: None,
+            drawing_press_position: None,
+            drawing_press_started_empty: false,
+            drawing_drag: DrawingDrag::None,
             style: ChartStyle::default(),
             show_style: false,
             style_revision: 0,
@@ -791,6 +836,7 @@ impl QuantickApp {
         self.price_view = PriceView::new();
         self.last_auto_range = None;
         self.hover_pos = None;
+        self.reset_drawing_overlay();
         self.history_trades = 0;
         // The old feed's unanswered loads died with its channel; the new feed
         // opens with exactly one backfill in flight.
@@ -838,6 +884,7 @@ impl QuantickApp {
                 // window past the end of the data, drawing nothing.
                 let anchor = self.right_edge_time();
                 self.state.set_spec(desired);
+                self.reset_drawing_overlay();
                 self.viewport.reanchor(
                     anchor.and_then(|ms| self.state.slot_at_time(ms)),
                     self.slots(),
@@ -947,6 +994,7 @@ impl QuantickApp {
                     self.history_trades += trades.len();
                     let added = self.state.prepend_history(&trades);
                     self.viewport.shift_right_edge(added);
+                    self.drawings.shift_bars(added);
                 }
                 Ok(FeedEvent::Live(trade)) => self.ingest_live_trade(&trade),
                 Ok(FeedEvent::LiveBatch(trades)) => {
@@ -991,6 +1039,7 @@ impl QuantickApp {
         self.price_view = PriceView::new();
         self.last_auto_range = None;
         self.hover_pos = None;
+        self.reset_drawing_overlay();
         self.history_trades = 0;
         self.latest_trade_ms = None;
         self.last_lane_divider_x = None;
@@ -999,6 +1048,18 @@ impl QuantickApp {
         // never be answered, so the count restarts rather than accumulates.
         self.loading.restart(LoadingTask::History);
         self.orderflow.reset_for_symbol(self.symbol.clone());
+    }
+
+    /// Bar-index anchors are meaningful only for the market/spec that created
+    /// them. Clear them on a source or aggregation rebuild rather than
+    /// silently attaching a mark to different market data.
+    fn reset_drawing_overlay(&mut self) {
+        self.drawings.clear();
+        self.toolrail.arm(Tool::Pointer);
+        self.drawing_hover = None;
+        self.drawing_press_position = None;
+        self.drawing_press_started_empty = false;
+        self.drawing_drag = DrawingDrag::None;
     }
 
     /// Drain a bounded number of synchronized depth events. The separate
@@ -1183,6 +1244,189 @@ impl QuantickApp {
         self.last_summary = now;
     }
 
+    /// Convert a chart pixel into an overlay anchor. The x coordinate is a
+    /// fractional bar slot, so drawings follow pan/zoom instead of being stuck
+    /// to one screen pixel.
+    fn drawing_point_at(
+        &self,
+        pos: egui::Pos2,
+        history_right: f32,
+        total: usize,
+    ) -> Option<ChartPoint> {
+        let (auto_lo, auto_hi) = self.last_auto_range?;
+        if total == 0 || self.last_chart_height <= 1.0 {
+            return None;
+        }
+        let (lo, hi) = self.price_view.resolve((auto_lo, auto_hi));
+        let scale = PriceScale::from_range(
+            lo,
+            hi,
+            self.last_chart_top,
+            self.last_chart_top + self.last_chart_height,
+        );
+        let bar = self.viewport.right_edge_bar(total) + 0.5
+            - (history_right - pos.x) / self.viewport.candle_width();
+        Some(ChartPoint {
+            bar,
+            price: scale.price_at(pos.y),
+        })
+    }
+
+    /// Placement consumes clicks while a drawing tool is armed, preventing a
+    /// mark from also panning the chart. A completed object returns to Pointer,
+    /// matching the one-shot TradingView interaction.
+    fn handle_drawing_placement(&mut self, ui: &egui::Ui, area: egui::Rect) -> bool {
+        let Some(tool) = self.toolrail.tool().drawing_tool() else {
+            self.drawings.cancel_draft();
+            self.drawing_hover = None;
+            self.drawing_press_position = None;
+            self.drawing_press_started_empty = false;
+            return false;
+        };
+        let areas = plot_split(area, self.live_strip_width());
+        let history_right = self.last_lane_divider_x.unwrap_or(areas.chart.right());
+        let history = egui::Rect::from_min_max(
+            areas.chart.min,
+            egui::pos2(history_right, areas.chart.bottom()),
+        );
+        let response = ui.interact(
+            history,
+            egui::Id::new("drawing_placement"),
+            egui::Sense::click_and_drag(),
+        );
+        self.hover_pos = response.hover_pos();
+        self.drawing_hover = response
+            .hover_pos()
+            .and_then(|position| self.drawing_point_at(position, history_right, self.slots()));
+        if response.hovered() || response.dragged() {
+            ui.ctx().set_cursor_icon(egui::CursorIcon::Crosshair);
+        }
+
+        let pressed_position = ui.input(|input| {
+            input
+                .pointer
+                .primary_pressed()
+                .then(|| input.pointer.interact_pos())
+                .flatten()
+        });
+        if let Some(position) = pressed_position.filter(|position| history.contains(*position))
+            && let Some(point) = self.drawing_point_at(position, history_right, self.slots())
+        {
+            self.drawing_press_started_empty = self.drawings.draft_len() == 0;
+            self.drawing_press_position = Some(position);
+            self.place_drawing_point(tool, point);
+        }
+
+        let released_position = ui.input(|input| {
+            input
+                .pointer
+                .primary_released()
+                .then(|| input.pointer.latest_pos())
+                .flatten()
+        });
+        if tool.required_points() > 1
+            && self.drawing_press_started_empty
+            && let Some(start) = self.drawing_press_position
+            && let Some(position) = released_position
+            && history.contains(position)
+            && start.distance(position) >= DRAWING_DRAG_THRESHOLD_PX
+            && let Some(point) = self.drawing_point_at(position, history_right, self.slots())
+        {
+            self.place_drawing_point(tool, point);
+        }
+        if released_position.is_some() {
+            self.drawing_press_position = None;
+            self.drawing_press_started_empty = false;
+        }
+        true
+    }
+
+    fn place_drawing_point(&mut self, tool: drawings::DrawingTool, point: ChartPoint) {
+        if self.drawings.place(tool, point) {
+            self.toolrail.arm(Tool::Pointer);
+            self.drawing_hover = None;
+        }
+    }
+
+    fn projected_drawing_points(
+        &self,
+        drawing: &drawings::Drawing,
+        history_right: f32,
+        total: usize,
+        scale: &PriceScale,
+    ) -> SmallVec<[egui::Pos2; 4]> {
+        drawing
+            .points
+            .iter()
+            .map(|point| self.drawing_screen_point(*point, history_right, total, scale))
+            .collect()
+    }
+
+    fn drawing_at(
+        &self,
+        pos: egui::Pos2,
+        chart_rect: egui::Rect,
+        history_right: f32,
+        total: usize,
+        scale: &PriceScale,
+    ) -> Option<usize> {
+        self.drawings
+            .items()
+            .iter()
+            .enumerate()
+            .rev()
+            .find_map(|(index, drawing)| {
+                let projected = self.projected_drawing_points(drawing, history_right, total, scale);
+                drawing
+                    .tool
+                    .hit_test(chart_rect, &projected, pos, DRAWING_SELECT_RADIUS_PX)
+                    .then_some(index)
+            })
+    }
+
+    fn drawing_anchor_in(
+        &self,
+        drawing_index: usize,
+        pos: egui::Pos2,
+        history_right: f32,
+        total: usize,
+        scale: &PriceScale,
+    ) -> Option<usize> {
+        let drawing = self.drawings.items().get(drawing_index)?;
+        self.projected_drawing_points(drawing, history_right, total, scale)
+            .iter()
+            .enumerate()
+            .map(|(point_index, point)| (point_index, point.distance_sq(pos)))
+            .filter(|(_, distance_sq)| {
+                *distance_sq <= DRAWING_ANCHOR_RADIUS_PX * DRAWING_ANCHOR_RADIUS_PX
+            })
+            .min_by(|left, right| left.1.total_cmp(&right.1))
+            .map(|(point_index, _)| point_index)
+    }
+
+    fn drawing_anchor_at(
+        &self,
+        pos: egui::Pos2,
+        history_right: f32,
+        total: usize,
+        scale: &PriceScale,
+    ) -> Option<(usize, usize)> {
+        let selected = self.drawings.selected();
+        if let Some(drawing_index) = selected
+            && let Some(point_index) =
+                self.drawing_anchor_in(drawing_index, pos, history_right, total, scale)
+        {
+            return Some((drawing_index, point_index));
+        }
+        (0..self.drawings.items().len())
+            .rev()
+            .filter(|drawing_index| Some(*drawing_index) != selected)
+            .find_map(|drawing_index| {
+                self.drawing_anchor_in(drawing_index, pos, history_right, total, scale)
+                    .map(|point_index| (drawing_index, point_index))
+            })
+    }
+
     /// Handle mouse navigation, TradingView-style:
     /// - drag the candles → pan time (x, moves the whole chart) and price (y);
     /// - scroll over them → zoom time;
@@ -1195,6 +1439,9 @@ impl QuantickApp {
     /// that starts inside the tape moves nothing, and scrolling there zooms the
     /// tape's own window instead of the candles.
     fn handle_navigation(&mut self, ui: &egui::Ui, area: egui::Rect) {
+        if self.handle_drawing_placement(ui, area) {
+            return;
+        }
         let areas = plot_split(area, self.live_strip_width());
         let auto = self.last_auto_range;
         let height = self.last_chart_height;
@@ -1209,12 +1456,119 @@ impl QuantickApp {
             egui::Sense::click_and_drag(),
         );
         self.hover_pos = chart.hover_pos();
+        let drawing_scale = auto.map(|(auto_lo, auto_hi)| {
+            let (lo, hi) = self.price_view.resolve((auto_lo, auto_hi));
+            PriceScale::from_range(lo, hi, areas.chart.top(), areas.chart.bottom())
+        });
+        let history_right = self.last_lane_divider_x.unwrap_or(areas.chart.right());
+        let drawing_area = egui::Rect::from_min_max(
+            areas.chart.min,
+            egui::pos2(history_right, areas.chart.bottom()),
+        );
+        let (primary_pressed, primary_down, primary_released, pointer_position, pointer_delta) = ui
+            .input(|input| {
+                (
+                    input.pointer.primary_pressed(),
+                    input.pointer.primary_down(),
+                    input.pointer.primary_released(),
+                    input.pointer.latest_pos(),
+                    input.pointer.delta(),
+                )
+            });
+        let mut drawing_drag_consumes_gesture = false;
+        if self.toolrail.tool() == Tool::Pointer {
+            if let Some(position) =
+                pointer_position.filter(|position| drawing_area.contains(*position))
+                && let Some(scale) = drawing_scale
+                && let Some(selected) = self.drawings.selected()
+                && self
+                    .drawing_anchor_in(selected, position, history_right, total, &scale)
+                    .is_some()
+            {
+                ui.ctx().set_cursor_icon(egui::CursorIcon::ResizeNwSe);
+            }
+            if chart.clicked()
+                && let Some(position) = chart.interact_pointer_pos()
+                && let Some(scale) = drawing_scale
+            {
+                let selected = self.drawing_at(position, areas.chart, history_right, total, &scale);
+                self.drawings.select(selected);
+            }
+            // Floating inspectors normally own pointer input over their whole
+            // rectangle. Read the raw press so an already-selected drawing
+            // remains draggable even when its stroke or handle is underneath
+            // that inspector. Only an actual drawing hit takes precedence;
+            // every other inspector click remains a style interaction.
+            let mut drawing_drag_started = false;
+            if primary_pressed
+                && let Some(position) =
+                    pointer_position.filter(|position| drawing_area.contains(*position))
+                && let Some(scale) = drawing_scale
+            {
+                if let Some((drawing_index, point_index)) =
+                    self.drawing_anchor_at(position, history_right, total, &scale)
+                {
+                    self.drawings.select(Some(drawing_index));
+                    self.drawing_drag = DrawingDrag::Anchor {
+                        drawing_index,
+                        point_index,
+                    };
+                } else {
+                    let selected =
+                        self.drawing_at(position, areas.chart, history_right, total, &scale);
+                    self.drawings.select(selected);
+                    self.drawing_drag = if selected.is_some() {
+                        DrawingDrag::Translate
+                    } else {
+                        DrawingDrag::None
+                    };
+                }
+                drawing_drag_started = self.drawing_drag.is_active();
+            }
+            if primary_down && !drawing_drag_started {
+                match self.drawing_drag {
+                    DrawingDrag::Anchor {
+                        drawing_index,
+                        point_index,
+                    } => {
+                        if let Some(position) = pointer_position {
+                            let position = egui::pos2(
+                                position.x.clamp(areas.chart.left(), history_right),
+                                position.y.clamp(areas.chart.top(), areas.chart.bottom()),
+                            );
+                            if let Some(point) =
+                                self.drawing_point_at(position, history_right, total)
+                            {
+                                self.drawings.move_anchor(drawing_index, point_index, point);
+                            }
+                            ui.ctx().set_cursor_icon(egui::CursorIcon::ResizeNwSe);
+                        }
+                    }
+                    DrawingDrag::Translate => {
+                        if let Some(scale) = drawing_scale {
+                            let (lo, hi) = scale.range();
+                            let delta_bar = pointer_delta.x / self.viewport.candle_width();
+                            let delta_price =
+                                -f64::from(pointer_delta.y / areas.chart.height()) * (hi - lo);
+                            self.drawings.translate_selected(delta_bar, delta_price);
+                        }
+                    }
+                    DrawingDrag::None => {}
+                }
+            }
+            drawing_drag_consumes_gesture = self.drawing_drag.is_active();
+            if primary_released {
+                self.drawing_drag = DrawingDrag::None;
+            }
+        } else {
+            self.drawing_drag = DrawingDrag::None;
+        }
         // Where the press landed, not where the pointer is now: a pan that
         // started on the candles keeps working when it crosses the divider.
         let dragging_candles = chart
             .interact_pointer_pos()
             .is_some_and(|press| !in_lane(press));
-        if total > 0 && chart.dragged() && dragging_candles {
+        if total > 0 && chart.dragged() && dragging_candles && !drawing_drag_consumes_gesture {
             let drag = chart.drag_delta();
             self.viewport.pan_pixels(drag.x, total);
             if let Some(auto) = auto
@@ -1513,6 +1867,10 @@ impl QuantickApp {
             );
         }
 
+        // Drawings sit above market layers and remain anchored to chart space,
+        // not the screen, while the viewport moves beneath them.
+        self.draw_drawings(painter, chart_rect, right, total, &scale);
+
         // Above the flow layers: everything else on the canvas is read against
         // it. Drawn on the unclipped painter so the chip reaches the gutter.
         if let Some(bar) = partial.or_else(|| closed.last()) {
@@ -1545,6 +1903,7 @@ impl QuantickApp {
         // runs before the draw and needs them for pixel↔price conversion.
         self.last_auto_range = Some(auto_range);
         self.last_chart_height = chart_rect.height();
+        self.last_chart_top = chart_rect.top();
     }
 
     /// Bottom time strip: a top border and a few `HH:MM:SS` labels for the
@@ -1716,6 +2075,52 @@ impl QuantickApp {
         );
         painter.rect_filled(bg, egui::Rounding::same(2.0), color);
         painter.galley(text_pos, galley, LAST_PRICE_CHIP_TEXT);
+    }
+
+    fn drawing_screen_point(
+        &self,
+        point: ChartPoint,
+        history_right: f32,
+        total: usize,
+        scale: &PriceScale,
+    ) -> egui::Pos2 {
+        egui::pos2(
+            self.viewport
+                .x_at_bar_position(point.bar, history_right, total),
+            scale.y(point.price),
+        )
+    }
+
+    /// Paint the completed drawing objects. This runs once per frame and is
+    /// O(number of drawings); it never touches the per-trade ingestion path.
+    fn draw_drawings(
+        &self,
+        painter: &egui::Painter,
+        chart_rect: egui::Rect,
+        history_right: f32,
+        total: usize,
+        scale: &PriceScale,
+    ) {
+        let clipped = painter.with_clip_rect(chart_rect);
+        for (index, drawing) in self.drawings.items().iter().enumerate() {
+            let points = self.projected_drawing_points(drawing, history_right, total, scale);
+            let selected = self.drawings.selected() == Some(index);
+            drawing
+                .tool
+                .paint(&clipped, chart_rect, drawing.style, &points, selected);
+        }
+
+        if let Some(draft) = self.drawings.draft() {
+            let mut points = self.projected_drawing_points(draft, history_right, total, scale);
+            if points.len() < draft.tool.required_points()
+                && let Some(hover) = self.drawing_hover
+            {
+                points.push(self.drawing_screen_point(hover, history_right, total, scale));
+            }
+            draft
+                .tool
+                .paint(&clipped, chart_rect, draft.style, &points, false);
+        }
     }
 
     /// Crosshair following the pointer, with the price shown on the axis.
@@ -1958,6 +2363,15 @@ impl QuantickApp {
                             self.dock.toggle_visible();
                             ui.close_menu();
                         }
+                        let toolbox_label = if self.toolrail.visible() {
+                            "Hide drawing toolbox"
+                        } else {
+                            "Show drawing toolbox"
+                        };
+                        if ui.button(toolbox_label).clicked() {
+                            self.toolrail.toggle_visible();
+                            ui.close_menu();
+                        }
                         for (tab, label) in [
                             (DockTab::L2, "L2 settings"),
                             (DockTab::Bubbles, "Bubble settings"),
@@ -2000,6 +2414,55 @@ impl QuantickApp {
                     });
                 });
             });
+    }
+
+    /// The selected object's inspector mirrors the compact, contextual drawing
+    /// controls traders expect: styles are per object rather than global.
+    fn draw_drawing_inspector(&mut self, ctx: &egui::Context) {
+        let Some(index) = self.drawings.selected() else {
+            return;
+        };
+        let title = self.drawings.items()[index].tool.settings_title();
+        let mut delete = false;
+        let mut open = true;
+        let inspector_interactable = !self.drawing_drag.is_active();
+        egui::Window::new(title)
+            .id(egui::Id::new("drawing_inspector"))
+            .open(&mut open)
+            .default_pos(DRAWING_INSPECTOR_DEFAULT_POSITION)
+            .collapsible(false)
+            .movable(true)
+            .interactable(inspector_interactable)
+            .resizable(false)
+            .show(ctx, |ui| {
+                if let Some(drawing) = self.drawings.selected_mut() {
+                    ui.label("Style");
+                    ui.color_edit_button_srgba(&mut drawing.style.color);
+                    ui.add(
+                        egui::Slider::new(
+                            &mut drawing.style.width_px,
+                            MIN_DRAWING_WIDTH_PX..=MAX_DRAWING_WIDTH_PX,
+                        )
+                        .text("line width (px)"),
+                    );
+                    ui.add(
+                        egui::Slider::new(
+                            &mut drawing.style.fill_alpha,
+                            0..=MAX_DRAWING_FILL_ALPHA,
+                        )
+                        .text("fill opacity"),
+                    );
+                    ui.separator();
+                    if ui.button("Delete drawing").clicked() {
+                        delete = true;
+                    }
+                }
+            });
+        if delete {
+            self.drawings.delete_selected();
+        } else if !open {
+            self.drawings.select(None);
+        }
     }
 
     /// Carry out what the replay interface asked for.
@@ -2179,8 +2642,8 @@ impl QuantickApp {
         self.toolrail.handle_keys(ctx);
         // Chrome panels claim their zones outside-in (§5): menu and toolbar
         // on top, the status line at the very bottom with the replay
-        // transport directly above it, then the tool rail and the dock on the
-        // sides. The chart keeps whatever remains.
+        // transport directly above it, then the corner toolbox and right dock.
+        // The chart keeps whatever remains.
         self.draw_menu_bar(ctx);
         self.draw_toolbar(ctx);
         let status = self.status_model();
@@ -2237,6 +2700,9 @@ impl QuantickApp {
                     notice_action = notice_card::draw(ui, area, &self.notice);
                 }
             });
+        // Floating drawing controls must be registered after the opaque
+        // central canvas so they stay in front of the chart.
+        self.draw_drawing_inspector(ctx);
         if notice_action == notice_card::NoticeAction::Retry {
             self.restart_feed();
         }
@@ -2580,16 +3046,34 @@ mod tests {
         app.request_older_history();
         app.request_older_history();
         assert_eq!(app.loading.count(LoadingTask::History), 3);
+        app.drawings.place(
+            drawing_tool("horizontal-line"),
+            ChartPoint {
+                bar: 1.0,
+                price: 100.0,
+            },
+        );
 
         evt_tx.try_send(FeedEvent::Reset).unwrap();
         app.drain_feed();
         assert_eq!(app.loading.count(LoadingTask::History), 1);
+        assert!(
+            app.drawings.items().is_empty(),
+            "bar-index drawings cannot survive a source reset honestly"
+        );
     }
 
     #[test]
     fn bar_spec_change_defers_one_frame_and_shows_the_rebuild() {
         let (mut app, _evt_tx, _cmd_rx, _book_tx) = test_app();
         app.tick_n = 100;
+        app.drawings.place(
+            drawing_tool("horizontal-line"),
+            ChartPoint {
+                bar: 1.0,
+                price: 100.0,
+            },
+        );
 
         app.apply_spec_change();
         assert!(app.loading.is_active(LoadingTask::BarRebuild));
@@ -2601,6 +3085,10 @@ mod tests {
 
         app.apply_spec_change();
         assert_eq!(app.state.spec(), &BarSpec::Tick(100));
+        assert!(
+            app.drawings.items().is_empty(),
+            "a new bar partition must not inherit old bar-index anchors"
+        );
         assert!(!app.loading.is_active(LoadingTask::BarRebuild));
     }
 
@@ -2762,14 +3250,302 @@ mod tests {
     }
 
     fn run_frame(app: &mut QuantickApp, ctx: &egui::Context) -> egui::FullOutput {
+        run_frame_with_events(app, ctx, Vec::new())
+    }
+
+    fn run_frame_with_events(
+        app: &mut QuantickApp,
+        ctx: &egui::Context,
+        events: Vec<egui::Event>,
+    ) -> egui::FullOutput {
         let input = egui::RawInput {
             screen_rect: Some(egui::Rect::from_min_size(
                 egui::pos2(0.0, 0.0),
                 egui::vec2(1400.0, 900.0),
             )),
+            events,
             ..Default::default()
         };
         ctx.run(input, |ctx| app.draw_frame(ctx, Instant::now()))
+    }
+
+    fn pointer_button(position: egui::Pos2, pressed: bool) -> egui::Event {
+        egui::Event::PointerButton {
+            pos: position,
+            button: egui::PointerButton::Primary,
+            pressed,
+            modifiers: egui::Modifiers::NONE,
+        }
+    }
+
+    fn click_chart(app: &mut QuantickApp, ctx: &egui::Context, position: egui::Pos2) {
+        run_frame_with_events(
+            app,
+            ctx,
+            vec![
+                egui::Event::PointerMoved(position),
+                pointer_button(position, true),
+            ],
+        );
+        run_frame_with_events(
+            app,
+            ctx,
+            vec![
+                egui::Event::PointerMoved(position),
+                pointer_button(position, false),
+            ],
+        );
+    }
+
+    fn drag_chart(app: &mut QuantickApp, ctx: &egui::Context, start: egui::Pos2, end: egui::Pos2) {
+        run_frame_with_events(
+            app,
+            ctx,
+            vec![
+                egui::Event::PointerMoved(start),
+                pointer_button(start, true),
+            ],
+        );
+        run_frame_with_events(app, ctx, vec![egui::Event::PointerMoved(end)]);
+        run_frame_with_events(
+            app,
+            ctx,
+            vec![egui::Event::PointerMoved(end), pointer_button(end, false)],
+        );
+    }
+
+    fn drawing_tool(id: &str) -> drawings::DrawingTool {
+        drawings::DRAWING_TOOLS
+            .into_iter()
+            .find(|tool| tool.id() == id)
+            .expect("drawing tool is registered")
+    }
+
+    fn arm_drawing_from_toolbox(
+        app: &mut QuantickApp,
+        ctx: &egui::Context,
+        id: &str,
+    ) -> drawings::DrawingTool {
+        let drawing = drawing_tool(id);
+        let tool = Tool::Drawing(drawing);
+        let button = app
+            .toolrail
+            .button_rect(tool)
+            .expect("drawing button was rendered");
+        click_chart(app, ctx, button.center());
+        assert_eq!(
+            app.toolrail.tool(),
+            tool,
+            "clicking {id} must arm that drawing tool"
+        );
+        drawing
+    }
+
+    /// Full UI interaction proof: every registered drawing is placed through
+    /// egui pointer events against the real chart frame. This catches the
+    /// original regression where multi-point tools silently ignored drags.
+    #[test]
+    fn every_toolbox_drawing_can_be_plotted_on_the_chart() {
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        run_frame(&mut app, &ctx);
+
+        arm_drawing_from_toolbox(&mut app, &ctx, "horizontal-line");
+        click_chart(&mut app, &ctx, egui::pos2(600.0, 250.0));
+
+        arm_drawing_from_toolbox(&mut app, &ctx, "rectangle");
+        drag_chart(
+            &mut app,
+            &ctx,
+            egui::pos2(620.0, 300.0),
+            egui::pos2(800.0, 450.0),
+        );
+
+        arm_drawing_from_toolbox(&mut app, &ctx, "parallel-channel");
+        drag_chart(
+            &mut app,
+            &ctx,
+            egui::pos2(650.0, 500.0),
+            egui::pos2(820.0, 350.0),
+        );
+        click_chart(&mut app, &ctx, egui::pos2(900.0, 280.0));
+
+        arm_drawing_from_toolbox(&mut app, &ctx, "fib-retracement");
+        drag_chart(
+            &mut app,
+            &ctx,
+            egui::pos2(700.0, 620.0),
+            egui::pos2(950.0, 300.0),
+        );
+
+        arm_drawing_from_toolbox(&mut app, &ctx, "fib-extension");
+        drag_chart(
+            &mut app,
+            &ctx,
+            egui::pos2(620.0, 650.0),
+            egui::pos2(820.0, 500.0),
+        );
+        click_chart(&mut app, &ctx, egui::pos2(1_000.0, 350.0));
+
+        let tools: Vec<_> = app
+            .drawings
+            .items()
+            .iter()
+            .map(|drawing| drawing.tool)
+            .collect();
+        assert_eq!(tools, drawings::DRAWING_TOOLS);
+        assert!(
+            app.drawings
+                .items()
+                .iter()
+                .all(|drawing| drawing.points.len() == drawing.tool.required_points())
+        );
+        assert_eq!(
+            app.toolrail.tool(),
+            Tool::Pointer,
+            "placing a complete drawing restores navigation"
+        );
+    }
+
+    #[test]
+    fn a_drawing_can_be_selected_from_its_stroke_and_moved_without_panning() {
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        run_frame(&mut app, &ctx);
+        app.toolrail
+            .arm(Tool::Drawing(drawing_tool("horizontal-line")));
+        click_chart(&mut app, &ctx, egui::pos2(700.0, 300.0));
+
+        let before = app.drawings.items()[0].points[0];
+        let viewport_before = app.viewport.right_edge_bar(app.slots());
+        drag_chart(
+            &mut app,
+            &ctx,
+            egui::pos2(1_000.0, 300.0),
+            egui::pos2(1_040.0, 340.0),
+        );
+        let after = app.drawings.items()[0].points[0];
+
+        assert!(
+            after.bar > before.bar,
+            "dragging right moves the anchor right"
+        );
+        assert!(
+            after.price < before.price,
+            "dragging down moves the anchor to a lower price"
+        );
+        assert_eq!(
+            app.viewport.right_edge_bar(app.slots()),
+            viewport_before,
+            "moving a drawing must not pan the market underneath it"
+        );
+        assert_eq!(
+            app.drawing_drag,
+            DrawingDrag::None,
+            "release ends the move gesture"
+        );
+    }
+
+    #[test]
+    fn an_open_inspector_never_blocks_moving_a_horizontal_line() {
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        run_frame(&mut app, &ctx);
+        app.toolrail
+            .arm(Tool::Drawing(drawing_tool("horizontal-line")));
+        let start = egui::pos2(300.0, 250.0);
+        click_chart(&mut app, &ctx, start);
+
+        let inspector = ctx
+            .memory(|memory| memory.area_rect(egui::Id::new("drawing_inspector")))
+            .expect("placing the selected line opens its inspector");
+        assert!(
+            inspector.contains(start),
+            "the regression requires the floating inspector to cover the line handle"
+        );
+        let before = app.drawings.items()[0].points[0];
+
+        drag_chart(&mut app, &ctx, start, egui::pos2(300.0, 350.0));
+
+        assert_ne!(
+            app.drawings.items()[0].points[0].price,
+            before.price,
+            "the open inspector must not trap the line underneath it"
+        );
+    }
+
+    #[test]
+    fn a_selected_drawing_exposes_its_edit_and_delete_controls() {
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        run_frame(&mut app, &ctx);
+        arm_drawing_from_toolbox(&mut app, &ctx, "rectangle");
+        drag_chart(
+            &mut app,
+            &ctx,
+            egui::pos2(620.0, 300.0),
+            egui::pos2(800.0, 450.0),
+        );
+        assert_eq!(app.drawings.items().len(), 1);
+        assert_eq!(app.drawings.selected(), Some(0));
+
+        let output = run_frame(&mut app, &ctx);
+        assert_eq!(app.drawings.selected(), Some(0));
+        let texts = painted_text(&output);
+        for label in [
+            "Rectangle settings",
+            "Style",
+            "line width (px)",
+            "fill opacity",
+            "Delete drawing",
+        ] {
+            assert!(
+                texts.iter().any(|text| text.contains(label)),
+                "selected drawing inspector omitted {label:?}; painted text: {texts:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn rectangle_anchor_resizes_while_the_settings_window_stays_non_modal() {
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        run_frame(&mut app, &ctx);
+        arm_drawing_from_toolbox(&mut app, &ctx, "rectangle");
+        let first_anchor = egui::pos2(620.0, 300.0);
+        let second_anchor = egui::pos2(800.0, 450.0);
+        drag_chart(&mut app, &ctx, first_anchor, second_anchor);
+        let before = app.drawings.items()[0].points.clone();
+        let viewport_before = app.viewport.right_edge_bar(app.slots());
+
+        let inspector = painted_text(&run_frame(&mut app, &ctx));
+        assert!(
+            inspector
+                .iter()
+                .any(|text| text.contains("Rectangle settings")),
+            "the settings window must be visible before the resize gesture"
+        );
+
+        drag_chart(&mut app, &ctx, first_anchor, egui::pos2(560.0, 240.0));
+        let after = &app.drawings.items()[0].points;
+
+        assert_ne!(after[0], before[0], "the dragged corner must move");
+        assert_eq!(
+            after[1], before[1],
+            "resizing one corner must leave the opposite corner fixed"
+        );
+        assert_eq!(
+            app.viewport.right_edge_bar(app.slots()),
+            viewport_before,
+            "resizing a drawing must not pan the chart"
+        );
+        assert_eq!(app.drawing_drag, DrawingDrag::None);
+        assert!(
+            painted_text(&run_frame(&mut app, &ctx))
+                .iter()
+                .any(|text| text.contains("Rectangle settings")),
+            "the non-modal settings window remains usable after resizing"
+        );
     }
 
     /// The whole point, on a real frame: after a spec change with the view

--- a/crates/app/src/drawings/action_bar.rs
+++ b/crates/app/src/drawings/action_bar.rs
@@ -1,0 +1,97 @@
+//! The reusable `DrawingActionBar`: the two always-visible, textual actions
+//! of a selected drawing — Lock/Unlock and Delete. Every host (inspector,
+//! object manager, future context menu) renders this bar and forwards its
+//! intents to the one store command for each action; none of them re-implement
+//! the lock/delete rules.
+
+use eframe::egui;
+
+/// What the user asked the action bar to do this frame. The caller owns the
+/// mutation (and its confirmation/undo flow); the bar only reports intent.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct ActionBarIntent {
+    pub toggle_lock: bool,
+    pub delete: bool,
+}
+
+/// Draw the two-column action bar. Labels are textual by contract — the
+/// destructive action is never a bare glyph — and the delete button carries
+/// its keyboard shortcut.
+pub fn draw(ui: &mut egui::Ui, locked: bool) -> ActionBarIntent {
+    let mut intent = ActionBarIntent::default();
+    let column_width = (ui.available_width() - ui.spacing().item_spacing.x) / 2.0;
+    let height = ui.spacing().interact_size.y;
+    ui.horizontal(|ui| {
+        let lock_label = if locked {
+            "Unlock drawing"
+        } else {
+            "Lock drawing"
+        };
+        if ui
+            .add_sized([column_width, height], egui::Button::new(lock_label))
+            .clicked()
+        {
+            intent.toggle_lock = true;
+        }
+        if ui
+            .add_sized(
+                [column_width, height],
+                egui::Button::new("Delete drawing").shortcut_text("Del"),
+            )
+            .clicked()
+        {
+            intent.delete = true;
+        }
+    });
+    intent
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn run_bar(locked: bool, events: Vec<egui::Event>) -> (ActionBarIntent, Vec<String>) {
+        let ctx = egui::Context::default();
+        let mut intent = ActionBarIntent::default();
+        let input = egui::RawInput {
+            screen_rect: Some(egui::Rect::from_min_size(
+                egui::Pos2::ZERO,
+                egui::vec2(360.0, 200.0),
+            )),
+            events,
+            ..Default::default()
+        };
+        let output = ctx.run(input, |ctx| {
+            egui::CentralPanel::default().show(ctx, |ui| {
+                intent = draw(ui, locked);
+            });
+        });
+        let texts = output
+            .shapes
+            .iter()
+            .filter_map(|clipped| match &clipped.shape {
+                egui::Shape::Text(text) => Some(text.galley.text().to_owned()),
+                _ => None,
+            })
+            .collect();
+        (intent, texts)
+    }
+
+    #[test]
+    fn the_bar_names_both_actions_and_the_delete_shortcut() {
+        let (_, texts) = run_bar(false, Vec::new());
+        for label in ["Lock drawing", "Delete drawing", "Del"] {
+            assert!(
+                texts.iter().any(|text| text.contains(label)),
+                "action bar must show {label:?}; painted: {texts:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_locked_object_offers_unlock_not_lock() {
+        let (_, texts) = run_bar(true, Vec::new());
+        assert!(texts.iter().any(|text| text.contains("Unlock drawing")));
+        assert!(!texts.iter().any(|text| *text == "Lock drawing"));
+    }
+}

--- a/crates/app/src/drawings/fib.rs
+++ b/crates/app/src/drawings/fib.rs
@@ -1,0 +1,1125 @@
+//! Fib is a level model, not seven fixed lines.
+//!
+//! Retracement and extension share this one module: the editable level list,
+//! the built-in presets, the linear and log formulas, band fills, label
+//! formatting (cached — labels are re-formatted only when an anchor price or
+//! the configuration changes, never per frame) and the level-editor tab both
+//! tools mount in the inspector. Only the geometry and the price formula
+//! differ between the two kinds.
+
+use std::any::Any;
+use std::cell::RefCell;
+
+use eframe::egui;
+use serde::{Deserialize, Serialize};
+
+use super::{
+    DrawContext, Drawing, DrawingPayload, DrawingStyle, FIB_LABEL_OFFSET_PX, FIB_LABEL_SIZE_PX,
+    PresetHost, distance_to_segment, drawing_stroke,
+};
+
+/// Ratios closer than this are the same level; a duplicate is rejected.
+pub const RATIO_DUPLICATE_TOLERANCE: f64 = 0.000_001;
+/// Longest accepted custom level label.
+pub const MAX_LEVEL_LABEL_LEN: usize = 40;
+/// Upper bound of the band-fill alpha (~60% opacity, the spec's slider cap).
+pub const MAX_BAND_ALPHA: u8 = 153;
+/// Default band-fill alpha (~9%, inside the spec's recommended 8-18%).
+pub const DEFAULT_BAND_ALPHA: u8 = 24;
+/// Dash geometry of the anchor guides shown while selected.
+const GUIDE_DASH_PX: f32 = 4.0;
+/// Version stamp of the exported preset format.
+const PRESET_FORMAT_VERSION: u32 = 1;
+
+/// Which price formula the object projects.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum FibKind {
+    /// Two anchors; levels give back part of the A→B move:
+    /// `P(r) = PA + (PB − PA)·r`.
+    Retracement,
+    /// Three anchors; the A→B impulse is projected from origin C:
+    /// `P(r) = PC + (PB − PA)·r`.
+    Extension,
+}
+
+impl FibKind {
+    #[must_use]
+    pub fn required_points(self) -> usize {
+        match self {
+            Self::Retracement => 2,
+            Self::Extension => 3,
+        }
+    }
+}
+
+/// How a level's text is composed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub enum LabelMode {
+    #[default]
+    PercentPrice,
+    RatioPrice,
+    PriceOnly,
+}
+
+impl LabelMode {
+    const ALL: [Self; 3] = [Self::PercentPrice, Self::RatioPrice, Self::PriceOnly];
+
+    #[must_use]
+    fn describe(self) -> &'static str {
+        match self {
+            Self::PercentPrice => "Percent + price",
+            Self::RatioPrice => "Ratio + price",
+            Self::PriceOnly => "Price only",
+        }
+    }
+}
+
+/// Where the labels sit relative to the level span.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub enum LabelPosition {
+    #[default]
+    RightOutside,
+    RightInside,
+    Left,
+}
+
+impl LabelPosition {
+    const ALL: [Self; 3] = [Self::RightOutside, Self::RightInside, Self::Left];
+
+    #[must_use]
+    fn describe(self) -> &'static str {
+        match self {
+            Self::RightOutside => "Right - outside",
+            Self::RightInside => "Right - inside",
+            Self::Left => "Left",
+        }
+    }
+}
+
+/// How far the level lines run horizontally.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub enum Extend {
+    #[default]
+    Anchors,
+    Right,
+    Both,
+}
+
+impl Extend {
+    const ALL: [Self; 3] = [Self::Anchors, Self::Right, Self::Both];
+
+    #[must_use]
+    fn describe(self) -> &'static str {
+        match self {
+            Self::Anchors => "Between anchors",
+            Self::Right => "To the right",
+            Self::Both => "Both sides",
+        }
+    }
+}
+
+/// One configurable level of a Fib object.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FibLevelSpec {
+    pub ratio: f64,
+    /// Custom text; empty means the automatic ratio label.
+    pub label: String,
+    pub visible: bool,
+    /// Per-level colour override; `None` inherits the object's colour.
+    pub color: Option<[u8; 3]>,
+    /// Fill from this level to the next visible one.
+    pub fill_to_next: bool,
+}
+
+impl FibLevelSpec {
+    #[must_use]
+    pub fn new(ratio: f64) -> Self {
+        Self {
+            ratio,
+            label: String::new(),
+            visible: true,
+            color: None,
+            fill_to_next: false,
+        }
+    }
+}
+
+/// A named built-in ratio set. Built-ins are read-only; custom presets go
+/// through the [`PresetHost`].
+pub struct FibPreset {
+    pub name: &'static str,
+    pub ratios: &'static [f64],
+}
+
+pub const RETRACEMENT_PRESETS: [FibPreset; 4] = [
+    FibPreset {
+        name: "Standard",
+        ratios: &[0.0, 0.236, 0.382, 0.5, 0.618, 0.786, 1.0],
+    },
+    FibPreset {
+        name: "Compact",
+        ratios: &[0.0, 0.382, 0.5, 0.618, 1.0],
+    },
+    FibPreset {
+        name: "Deep",
+        ratios: &[0.0, 0.236, 0.382, 0.5, 0.618, 0.705, 0.786, 0.886, 1.0],
+    },
+    FibPreset {
+        name: "Extended",
+        ratios: &[
+            -0.618, -0.272, 0.0, 0.236, 0.382, 0.5, 0.618, 0.786, 1.0, 1.272, 1.618,
+        ],
+    },
+];
+
+pub const EXTENSION_PRESETS: [FibPreset; 3] = [
+    FibPreset {
+        name: "Targets",
+        ratios: &[0.618, 1.0, 1.272, 1.618, 2.0, 2.618],
+    },
+    FibPreset {
+        name: "Conservative",
+        ratios: &[0.618, 1.0, 1.272, 1.618],
+    },
+    FibPreset {
+        name: "Expanded",
+        ratios: &[0.382, 0.618, 1.0, 1.272, 1.618, 2.0, 2.618, 4.236],
+    },
+];
+
+#[must_use]
+pub fn builtin_presets(kind: FibKind) -> &'static [FibPreset] {
+    match kind {
+        FibKind::Retracement => &RETRACEMENT_PRESETS,
+        FibKind::Extension => &EXTENSION_PRESETS,
+    }
+}
+
+/// Formatted level labels, rebuilt only when anchors or config change.
+#[derive(Debug, Clone, Default, PartialEq)]
+struct LabelCache {
+    key: (u64, u64, u64, u64),
+    labels: Vec<String>,
+}
+
+/// The tool-owned state of one Fib object.
+#[derive(Debug, Clone)]
+pub struct FibPayload {
+    pub kind: FibKind,
+    pub levels: Vec<FibLevelSpec>,
+    pub band_alpha: u8,
+    /// Explicit scale choice: log never follows the chart silently, and it
+    /// only ever computes over positive prices.
+    pub log_scale: bool,
+    pub label_mode: LabelMode,
+    pub label_position: LabelPosition,
+    pub extend: Extend,
+    /// Bumped by the editor so the label cache notices config edits.
+    revision: u64,
+    cache: RefCell<LabelCache>,
+}
+
+impl PartialEq for FibPayload {
+    fn eq(&self, other: &Self) -> bool {
+        // The cache and its revision are memoization, not state.
+        self.kind == other.kind
+            && self.levels == other.levels
+            && self.band_alpha == other.band_alpha
+            && self.log_scale == other.log_scale
+            && self.label_mode == other.label_mode
+            && self.label_position == other.label_position
+            && self.extend == other.extend
+    }
+}
+
+impl FibPayload {
+    #[must_use]
+    pub fn new(kind: FibKind) -> Self {
+        let standard = builtin_presets(kind)[0].ratios;
+        Self {
+            kind,
+            levels: standard
+                .iter()
+                .map(|&ratio| FibLevelSpec::new(ratio))
+                .collect(),
+            band_alpha: DEFAULT_BAND_ALPHA,
+            log_scale: false,
+            label_mode: LabelMode::default(),
+            label_position: LabelPosition::default(),
+            extend: Extend::default(),
+            revision: 0,
+            cache: RefCell::new(LabelCache::default()),
+        }
+    }
+
+    pub fn apply_preset(&mut self, preset: &FibPreset) {
+        self.levels = preset
+            .ratios
+            .iter()
+            .map(|&ratio| FibLevelSpec::new(ratio))
+            .collect();
+        self.touch();
+    }
+
+    fn touch(&mut self) {
+        self.revision = self.revision.wrapping_add(1);
+    }
+
+    /// Whether `ratio` would duplicate an existing level (other than `skip`).
+    #[must_use]
+    fn is_duplicate(&self, ratio: f64, skip: Option<usize>) -> bool {
+        self.levels.iter().enumerate().any(|(index, level)| {
+            Some(index) != skip && (level.ratio - ratio).abs() < RATIO_DUPLICATE_TOLERANCE
+        })
+    }
+
+    #[must_use]
+    fn visible_count(&self) -> usize {
+        self.levels.iter().filter(|level| level.visible).count()
+    }
+}
+
+/// The versioned on-disk shape of a saved preset. Coordinates, name, lock
+/// and visibility never travel with it.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+struct FibPresetData {
+    version: u32,
+    kind: FibKind,
+    levels: Vec<FibLevelSpec>,
+    band_alpha: u8,
+    label_mode: LabelMode,
+    label_position: LabelPosition,
+    extend: Extend,
+}
+
+impl DrawingPayload for FibPayload {
+    fn clone_box(&self) -> Box<dyn DrawingPayload> {
+        Box::new(self.clone())
+    }
+    fn eq_dyn(&self, other: &dyn DrawingPayload) -> bool {
+        other
+            .as_any()
+            .downcast_ref::<Self>()
+            .is_some_and(|other| self == other)
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+    fn export_preset(&self) -> Option<toml::Value> {
+        toml::Value::try_from(FibPresetData {
+            version: PRESET_FORMAT_VERSION,
+            kind: self.kind,
+            levels: self.levels.clone(),
+            band_alpha: self.band_alpha,
+            label_mode: self.label_mode,
+            label_position: self.label_position,
+            extend: self.extend,
+        })
+        .ok()
+    }
+    fn import_preset(&mut self, value: &toml::Value) -> bool {
+        let Ok(data) = value.clone().try_into::<FibPresetData>() else {
+            return false;
+        };
+        if data.version != PRESET_FORMAT_VERSION
+            || data.kind != self.kind
+            || data.levels.is_empty()
+            || !data.levels.iter().any(|level| level.visible)
+            || data.levels.iter().any(|level| !level.ratio.is_finite())
+        {
+            return false;
+        }
+        self.levels = data.levels;
+        self.band_alpha = data.band_alpha.min(MAX_BAND_ALPHA);
+        self.label_mode = data.label_mode;
+        self.label_position = data.label_position;
+        self.extend = data.extend;
+        self.touch();
+        true
+    }
+}
+
+/// Parse a level ratio the way a trader writes one: a bare number is always
+/// a ratio (`.618`, `0.618`, `-0.272`), percent needs the sign (`61.8%`),
+/// and the decimal comma is accepted alongside the dot.
+#[must_use]
+pub fn parse_ratio(input: &str) -> Option<f64> {
+    let trimmed = input.trim().replace(',', ".");
+    let (number, percent) = match trimmed.strip_suffix('%') {
+        Some(rest) => (rest.trim_end(), true),
+        None => (trimmed.as_str(), false),
+    };
+    let value: f64 = number.parse().ok()?;
+    if !value.is_finite() {
+        return None;
+    }
+    Some(if percent { value / 100.0 } else { value })
+}
+
+/// Whether the log formulas are computable over these anchor prices.
+#[must_use]
+pub fn log_scale_allowed(a: f64, b: f64, c: f64) -> bool {
+    a > 0.0 && b > 0.0 && c > 0.0
+}
+
+/// The price of one level. `c` is ignored by retracement; for extension it
+/// is the projection origin. Log demands positive prices — `None` otherwise.
+#[must_use]
+pub fn level_price(
+    kind: FibKind,
+    log_scale: bool,
+    a: f64,
+    b: f64,
+    c: f64,
+    ratio: f64,
+) -> Option<f64> {
+    if !log_scale {
+        return Some(match kind {
+            FibKind::Retracement => a + (b - a) * ratio,
+            FibKind::Extension => c + (b - a) * ratio,
+        });
+    }
+    if !log_scale_allowed(a, b, c) {
+        return None;
+    }
+    let log_move = (b / a).ln();
+    Some(match kind {
+        FibKind::Retracement => a * (log_move * ratio).exp(),
+        FibKind::Extension => c * (log_move * ratio).exp(),
+    })
+}
+
+fn format_price(price: f64) -> String {
+    if price.abs() < 1.0 {
+        format!("{price:.6}")
+    } else {
+        format!("{price:.2}")
+    }
+}
+
+fn format_label(mode: LabelMode, level: &FibLevelSpec, price: f64) -> String {
+    let ratio_part = if level.label.is_empty() {
+        match mode {
+            LabelMode::PercentPrice => format!("{:.1}%", level.ratio * 100.0),
+            LabelMode::RatioPrice => format!("{:.3}", level.ratio),
+            LabelMode::PriceOnly => String::new(),
+        }
+    } else {
+        level.label.clone()
+    };
+    if ratio_part.is_empty() {
+        format_price(price)
+    } else {
+        format!("{ratio_part} \u{00b7} {}", format_price(price))
+    }
+}
+
+fn level_color(level: &FibLevelSpec, style: DrawingStyle) -> egui::Color32 {
+    level
+        .color
+        .map_or(style.color, |[r, g, b]| egui::Color32::from_rgb(r, g, b))
+}
+
+/// The effective log flag: the explicit choice, honoured only while every
+/// anchor price is positive (never a silent approximation).
+fn effective_log(payload: &FibPayload, a: f64, b: f64, c: f64) -> bool {
+    payload.log_scale && log_scale_allowed(a, b, c)
+}
+
+struct Anchors {
+    a: f64,
+    b: f64,
+    c: f64,
+}
+
+fn anchor_prices(payload: &FibPayload, ctxt: &DrawContext<'_>) -> Option<Anchors> {
+    let required = payload.kind.required_points();
+    if ctxt.anchors.len() < required {
+        return None;
+    }
+    let a = ctxt.anchors[0].price;
+    let b = ctxt.anchors[1].price;
+    let c = if payload.kind == FibKind::Extension {
+        ctxt.anchors[2].price
+    } else {
+        b
+    };
+    Some(Anchors { a, b, c })
+}
+
+fn level_span(points: &[egui::Pos2], chart_rect: egui::Rect, extend: Extend) -> (f32, f32) {
+    let left = points
+        .iter()
+        .map(|point| point.x)
+        .fold(f32::INFINITY, f32::min);
+    let right = points
+        .iter()
+        .map(|point| point.x)
+        .fold(f32::NEG_INFINITY, f32::max);
+    match extend {
+        Extend::Anchors => (left, right),
+        Extend::Right => (left, chart_rect.right()),
+        Extend::Both => (chart_rect.left(), chart_rect.right()),
+    }
+}
+
+/// Paint one Fib object (both kinds). Levels are computed in price space and
+/// projected through the chart's scale, so linear and log both land exactly.
+pub(super) fn paint(
+    painter: &egui::Painter,
+    chart_rect: egui::Rect,
+    style: DrawingStyle,
+    points: &[egui::Pos2],
+    ctxt: &DrawContext<'_>,
+) {
+    let Some(payload) = ctxt.payload.as_any().downcast_ref::<FibPayload>() else {
+        return;
+    };
+    let stroke = drawing_stroke(style);
+    let Some(anchors) = anchor_prices(payload, ctxt) else {
+        // Draft preview: connect the anchors placed so far.
+        for pair in points.windows(2) {
+            painter.line_segment([pair[0], pair[1]], stroke);
+        }
+        return;
+    };
+    let Anchors { a, b, c } = anchors;
+    let log = effective_log(payload, a, b, c);
+    let (left, right) = level_span(points, chart_rect, payload.extend);
+
+    // Band fills first, under the level lines. Skipped on the halo pass.
+    if !ctxt.halo && payload.band_alpha > 0 {
+        let visible: Vec<(f32, egui::Color32)> = payload
+            .levels
+            .iter()
+            .filter(|level| level.visible)
+            .filter_map(|level| {
+                level_price(payload.kind, log, a, b, c, level.ratio)
+                    .map(|price| (ctxt.scale.y(price), level_color(level, style)))
+            })
+            .collect();
+        for (index, level) in payload
+            .levels
+            .iter()
+            .filter(|level| level.visible)
+            .enumerate()
+        {
+            if !level.fill_to_next || index + 1 >= visible.len() {
+                continue;
+            }
+            let (y, color) = visible[index];
+            let (next_y, _) = visible[index + 1];
+            let fill = egui::Color32::from_rgba_unmultiplied(
+                color.r(),
+                color.g(),
+                color.b(),
+                payload.band_alpha,
+            );
+            painter.rect_filled(
+                egui::Rect::from_min_max(
+                    egui::pos2(left, y.min(next_y)),
+                    egui::pos2(right, y.max(next_y)),
+                ),
+                egui::Rounding::ZERO,
+                fill,
+            );
+        }
+    }
+
+    // Level lines (and cached labels on the real pass).
+    let labels = (!ctxt.halo).then(|| labels_for(payload, a, b, c, log));
+    let mut label_index = 0usize;
+    for level in payload.levels.iter().filter(|level| level.visible) {
+        let Some(price) = level_price(payload.kind, log, a, b, c, level.ratio) else {
+            continue;
+        };
+        let y = ctxt.scale.y(price);
+        let line_stroke = if ctxt.halo {
+            stroke
+        } else {
+            egui::Stroke::new(style.width_px, level_color(level, style))
+        };
+        painter.line_segment([egui::pos2(left, y), egui::pos2(right, y)], line_stroke);
+        if let Some(labels) = &labels
+            && let Some(text) = labels.get(label_index)
+        {
+            let (anchor, x) = match payload.label_position {
+                LabelPosition::RightOutside => {
+                    (egui::Align2::LEFT_BOTTOM, right + FIB_LABEL_OFFSET_PX)
+                }
+                LabelPosition::RightInside => {
+                    (egui::Align2::RIGHT_BOTTOM, right - FIB_LABEL_OFFSET_PX)
+                }
+                LabelPosition::Left => (egui::Align2::LEFT_BOTTOM, left + FIB_LABEL_OFFSET_PX),
+            };
+            painter.text(
+                egui::pos2(x, y),
+                anchor,
+                text,
+                egui::FontId::monospace(FIB_LABEL_SIZE_PX),
+                level_color(level, style),
+            );
+        }
+        label_index += 1;
+    }
+
+    // Anchor guides while selected: dashed A-B (and B-C for extension).
+    if ctxt.selected && !ctxt.halo && points.len() >= 2 {
+        let guide = egui::Stroke::new(1.0_f32, style.color);
+        painter.add(egui::Shape::dashed_line(
+            &[points[0], points[1]],
+            guide,
+            GUIDE_DASH_PX,
+            GUIDE_DASH_PX,
+        ));
+        if payload.kind == FibKind::Extension && points.len() >= 3 {
+            painter.add(egui::Shape::dashed_line(
+                &[points[1], points[2]],
+                guide,
+                GUIDE_DASH_PX,
+                GUIDE_DASH_PX,
+            ));
+        }
+    }
+}
+
+/// Rebuild the label cache if anchors or config changed; return a clone of
+/// the cached strings (cheap: a handful of small strings, only while a Fib
+/// is actually painting labels).
+fn labels_for(payload: &FibPayload, a: f64, b: f64, c: f64, log: bool) -> Vec<String> {
+    let key = (
+        a.to_bits() ^ u64::from(log),
+        b.to_bits(),
+        c.to_bits(),
+        payload.revision,
+    );
+    let mut cache = payload.cache.borrow_mut();
+    if cache.key != key {
+        cache.key = key;
+        cache.labels = payload
+            .levels
+            .iter()
+            .filter(|level| level.visible)
+            .filter_map(|level| {
+                level_price(payload.kind, log, a, b, c, level.ratio)
+                    .map(|price| format_label(payload.label_mode, level, price))
+            })
+            .collect();
+    }
+    cache.labels.clone()
+}
+
+/// Hit-test one Fib object: any visible level line, or the anchor legs.
+pub(super) fn hit_test(
+    chart_rect: egui::Rect,
+    points: &[egui::Pos2],
+    position: egui::Pos2,
+    radius_px: f32,
+    ctxt: &DrawContext<'_>,
+) -> bool {
+    let Some(payload) = ctxt.payload.as_any().downcast_ref::<FibPayload>() else {
+        return false;
+    };
+    let Some(Anchors { a, b, c }) = anchor_prices(payload, ctxt) else {
+        return false;
+    };
+    if points.len() >= 2 && distance_to_segment(position, points[0], points[1]) <= radius_px {
+        return true;
+    }
+    if payload.kind == FibKind::Extension
+        && points.len() >= 3
+        && distance_to_segment(position, points[1], points[2]) <= radius_px
+    {
+        return true;
+    }
+    let log = effective_log(payload, a, b, c);
+    let (left, right) = level_span(points, chart_rect, payload.extend);
+    position.x >= left - radius_px
+        && position.x <= right + radius_px
+        && payload
+            .levels
+            .iter()
+            .filter(|level| level.visible)
+            .filter_map(|level| level_price(payload.kind, log, a, b, c, level.ratio))
+            .any(|price| (position.y - ctxt.scale.y(price)).abs() <= radius_px)
+}
+
+/// The Levels tab both Fib tools mount in the inspector. Returns whether the
+/// payload or the geometry changed (folded into the shared undo coalescing).
+pub(super) fn draw_levels_tab(
+    ui: &mut egui::Ui,
+    drawing: &mut Drawing,
+    host: &mut dyn PresetHost,
+) -> bool {
+    let tool_id = drawing.tool.id();
+    let anchor_prices: Vec<f64> = drawing.points.iter().map(|point| point.price).collect();
+    let Some(payload) = drawing.payload.as_any_mut().downcast_mut::<FibPayload>() else {
+        return false;
+    };
+    let mut edited = false;
+    let mut swap_anchors = false;
+
+    // Built-in presets: read-only ratio sets, applied as one edit.
+    ui.horizontal(|ui| {
+        ui.label("Preset");
+        for preset in builtin_presets(payload.kind) {
+            if ui.small_button(preset.name).clicked() {
+                payload.apply_preset(preset);
+                edited = true;
+            }
+        }
+    });
+
+    // Custom presets via the host: apply, save (with explicit overwrite),
+    // delete, and the explicit per-kind default for new objects.
+    let customs = host.custom_preset_names(tool_id);
+    ui.horizontal(|ui| {
+        let selected_id = ui.id().with("custom-preset");
+        let mut selected: String =
+            ui.data_mut(|data| data.get_temp(selected_id).unwrap_or_default());
+        egui::ComboBox::from_id_salt(selected_id)
+            .selected_text(if selected.is_empty() {
+                "Custom presets"
+            } else {
+                selected.as_str()
+            })
+            .show_ui(ui, |ui| {
+                for name in &customs {
+                    ui.selectable_value(&mut selected, name.clone(), name);
+                }
+            });
+        ui.data_mut(|data| data.insert_temp(selected_id, selected.clone()));
+        let has_selection = customs.contains(&selected);
+        if ui
+            .add_enabled(has_selection, egui::Button::new("Apply").small())
+            .clicked()
+            && let Some(value) = host.load_custom_preset(tool_id, &selected)
+            && payload.import_preset(&value)
+        {
+            edited = true;
+        }
+        if ui
+            .add_enabled(has_selection, egui::Button::new("Delete").small())
+            .clicked()
+        {
+            host.delete_custom_preset(tool_id, &selected);
+        }
+        if ui
+            .add_enabled(has_selection, egui::Button::new("Set as default").small())
+            .on_hover_text("New objects of this tool start from this preset")
+            .clicked()
+        {
+            host.set_default_preset(tool_id, Some(selected.clone()));
+        }
+    });
+    ui.horizontal(|ui| {
+        let name_id = ui.id().with("preset-name");
+        let mut name: String = ui.data_mut(|data| data.get_temp(name_id).unwrap_or_default());
+        ui.add(
+            egui::TextEdit::singleline(&mut name)
+                .hint_text("Preset name")
+                .desired_width(120.0),
+        );
+        let confirm_id = ui.id().with("preset-overwrite");
+        let pending: bool = ui.data_mut(|data| data.get_temp(confirm_id).unwrap_or(false));
+        let trimmed = name.trim();
+        let valid = !trimmed.is_empty() && trimmed.len() <= MAX_LEVEL_LABEL_LEN;
+        if pending {
+            ui.label("Overwrite?");
+            if ui.small_button("Yes").clicked() {
+                if let Some(value) = payload.export_preset() {
+                    host.save_custom_preset(tool_id, trimmed, value, true);
+                }
+                ui.data_mut(|data| data.insert_temp(confirm_id, false));
+            }
+            if ui.small_button("No").clicked() {
+                ui.data_mut(|data| data.insert_temp(confirm_id, false));
+            }
+        } else if ui
+            .add_enabled(valid, egui::Button::new("Save preset").small())
+            .clicked()
+            && let Some(value) = payload.export_preset()
+            && !host.save_custom_preset(tool_id, trimmed, value, false)
+        {
+            // The name exists: overwriting a custom needs explicit consent.
+            ui.data_mut(|data| data.insert_temp(confirm_id, true));
+        }
+        ui.data_mut(|data| data.insert_temp(name_id, name));
+        if host.default_preset(tool_id).is_some() && ui.small_button("Clear default").clicked() {
+            host.set_default_preset(tool_id, None);
+        }
+    });
+    ui.separator();
+
+    // The level list. Visible / ratio / label / colour / fill / delete.
+    let mut error: Option<&'static str> = None;
+    let mut remove: Option<usize> = None;
+    let single_level = payload.levels.len() == 1;
+    let single_visible = payload.visible_count() <= 1;
+    let mut ratio_edits: Vec<(usize, f64)> = Vec::new();
+    for (index, level) in payload.levels.iter_mut().enumerate() {
+        ui.horizontal(|ui| {
+            let mut visible = level.visible;
+            if ui
+                .checkbox(&mut visible, "")
+                .on_hover_text("Show this level")
+                .changed()
+            {
+                if !visible && single_visible && level.visible {
+                    error = Some("At least one level stays visible.");
+                } else {
+                    level.visible = visible;
+                    edited = true;
+                }
+            }
+            // Ratio as text: ".618", "0,618" and "61.8%" all parse.
+            let ratio_id = ui.id().with(("ratio", index));
+            let mut buffer: String = ui.data_mut(|data| {
+                data.get_temp(ratio_id)
+                    .unwrap_or_else(|| format!("{:.3}", level.ratio))
+            });
+            let response = ui.add(
+                egui::TextEdit::singleline(&mut buffer)
+                    .desired_width(56.0)
+                    .font(egui::TextStyle::Monospace),
+            );
+            if response.lost_focus() {
+                match parse_ratio(&buffer) {
+                    Some(ratio) if (ratio - level.ratio).abs() >= RATIO_DUPLICATE_TOLERANCE => {
+                        ratio_edits.push((index, ratio));
+                    }
+                    Some(_) => {}
+                    None => error = Some("Ratios read like 0.618 or 61.8%."),
+                }
+                buffer = format!("{:.3}", level.ratio);
+            }
+            ui.data_mut(|data| data.insert_temp(ratio_id, buffer));
+            // Custom label (empty = automatic).
+            let mut label = level.label.clone();
+            if ui
+                .add(
+                    egui::TextEdit::singleline(&mut label)
+                        .hint_text("auto")
+                        .desired_width(80.0),
+                )
+                .changed()
+            {
+                label.truncate(MAX_LEVEL_LABEL_LEN);
+                level.label = label;
+                edited = true;
+            }
+            // Colour override; the small x returns to the inherited colour.
+            let mut color = level.color.map_or(drawing_color_of(ui), |[r, g, b]| {
+                egui::Color32::from_rgb(r, g, b)
+            });
+            if ui.color_edit_button_srgba(&mut color).changed() {
+                level.color = Some([color.r(), color.g(), color.b()]);
+                edited = true;
+            }
+            if level.color.is_some()
+                && ui
+                    .small_button("x")
+                    .on_hover_text("Inherit colour")
+                    .clicked()
+            {
+                level.color = None;
+                edited = true;
+            }
+            let mut fill = level.fill_to_next;
+            if ui
+                .checkbox(&mut fill, "fill")
+                .on_hover_text("Fill to the next visible level")
+                .changed()
+            {
+                level.fill_to_next = fill;
+                edited = true;
+            }
+            if ui
+                .add_enabled(!single_level, egui::Button::new("\u{00d7}").small())
+                .on_hover_text("Delete this level")
+                .clicked()
+            {
+                remove = Some(index);
+            }
+        });
+    }
+    for (index, ratio) in ratio_edits {
+        if payload.is_duplicate(ratio, Some(index)) {
+            error = Some("That ratio already exists.");
+        } else {
+            payload.levels[index].ratio = ratio;
+            edited = true;
+        }
+    }
+    if let Some(index) = remove {
+        payload.levels.remove(index);
+        edited = true;
+    }
+    if let Some(message) = error {
+        ui.colored_label(crate::theme::WARN, message);
+    }
+    ui.horizontal(|ui| {
+        if ui.small_button("+ Add level").clicked() {
+            let mut candidate = 0.5;
+            while payload.is_duplicate(candidate, None) {
+                candidate += 0.1;
+            }
+            payload.levels.push(FibLevelSpec::new(candidate));
+            edited = true;
+        }
+        if ui.small_button("Sort").clicked() {
+            payload
+                .levels
+                .sort_by(|left, right| left.ratio.total_cmp(&right.ratio));
+            edited = true;
+        }
+        if ui.small_button("Restore").clicked() {
+            payload.apply_preset(&builtin_presets(payload.kind)[0]);
+            edited = true;
+        }
+    });
+    ui.separator();
+
+    // Bands, labels, extension and scale.
+    edited |= ui
+        .add(egui::Slider::new(&mut payload.band_alpha, 0..=MAX_BAND_ALPHA).text("band opacity"))
+        .changed();
+    ui.horizontal(|ui| {
+        egui::ComboBox::from_label("labels")
+            .selected_text(payload.label_mode.describe())
+            .show_ui(ui, |ui| {
+                for mode in LabelMode::ALL {
+                    edited |= ui
+                        .selectable_value(&mut payload.label_mode, mode, mode.describe())
+                        .changed();
+                }
+            });
+        egui::ComboBox::from_label("position")
+            .selected_text(payload.label_position.describe())
+            .show_ui(ui, |ui| {
+                for position in LabelPosition::ALL {
+                    edited |= ui
+                        .selectable_value(
+                            &mut payload.label_position,
+                            position,
+                            position.describe(),
+                        )
+                        .changed();
+                }
+            });
+    });
+    ui.horizontal(|ui| {
+        egui::ComboBox::from_label("extend")
+            .selected_text(payload.extend.describe())
+            .show_ui(ui, |ui| {
+                for extend in Extend::ALL {
+                    edited |= ui
+                        .selectable_value(&mut payload.extend, extend, extend.describe())
+                        .changed();
+                }
+            });
+        let log_allowed = anchor_prices.iter().all(|&price| price > 0.0);
+        let log = ui
+            .add_enabled(
+                log_allowed,
+                egui::Checkbox::new(&mut payload.log_scale, "log scale"),
+            )
+            .on_disabled_hover_text("Log needs every anchor price above zero.");
+        edited |= log.changed();
+        if ui
+            .small_button("Invert A \u{2194} B")
+            .on_hover_text("Swap the A and B anchors; C never moves")
+            .clicked()
+        {
+            swap_anchors = true;
+        }
+    });
+    if edited {
+        payload.touch();
+    }
+    if swap_anchors && drawing.points.len() >= 2 {
+        drawing.points.swap(0, 1);
+        edited = true;
+    }
+    edited
+}
+
+/// The colour the current drawing paints with, for the per-level colour
+/// button's initial value. Read from the style the caller stashed in the
+/// Ui's data (set by the tool impl before calling the editor).
+fn drawing_color_of(ui: &egui::Ui) -> egui::Color32 {
+    ui.data(|data| data.get_temp(egui::Id::new("fib-editor-drawing-color")))
+        .unwrap_or(super::DEFAULT_DRAWING_COLOR)
+}
+
+/// Stash the drawing colour for [`drawing_color_of`].
+pub(super) fn remember_drawing_color(ui: &egui::Ui, color: egui::Color32) {
+    ui.data_mut(|data| data.insert_temp(egui::Id::new("fib-editor-drawing-color"), color));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const EPS: f64 = 1e-9;
+
+    fn close(left: f64, right: f64) -> bool {
+        (left - right).abs() < EPS
+    }
+
+    #[test]
+    fn retracement_formula_is_exact_in_up_and_down_moves() {
+        // Down move: A above B (the prototype's 71,824.50 -> 69,111.50).
+        let (a, b) = (71_824.50, 69_111.50);
+        let golden = [
+            (0.0, 71_824.50),
+            (0.236, 71_184.232),
+            (0.382, 70_788.134),
+            (0.5, 70_468.0),
+            (0.618, 70_147.866),
+            (0.786, 69_692.082),
+            (1.0, 69_111.50),
+        ];
+        for (ratio, expected) in golden {
+            let price = level_price(FibKind::Retracement, false, a, b, b, ratio).unwrap();
+            assert!(
+                close(price, expected),
+                "ratio {ratio}: {price} vs {expected}"
+            );
+        }
+        // Up move mirrors exactly.
+        let price = level_price(FibKind::Retracement, false, 100.0, 200.0, 200.0, 0.618).unwrap();
+        assert!(close(price, 161.8));
+    }
+
+    #[test]
+    fn extension_projects_the_impulse_from_origin_c_and_reverse_keeps_c() {
+        let (a, b, c) = (100.0, 150.0, 120.0);
+        let price = level_price(FibKind::Extension, false, a, b, c, 1.618).unwrap();
+        assert!(close(price, 120.0 + 50.0 * 1.618));
+        // Reverse swaps A and B and never moves C.
+        let reversed = level_price(FibKind::Extension, false, b, a, c, 1.618).unwrap();
+        assert!(close(reversed, 120.0 - 50.0 * 1.618));
+    }
+
+    #[test]
+    fn log_formulas_compound_the_ratio_of_prices() {
+        // Retracement: P(r) = PA * (PB/PA)^r.
+        let price = level_price(FibKind::Retracement, true, 100.0, 400.0, 400.0, 0.5).unwrap();
+        assert!(close(price, 200.0), "half the log move of 100->400 is 200");
+        // Extension: P(r) = PC * (PB/PA)^r.
+        let projected = level_price(FibKind::Extension, true, 100.0, 400.0, 50.0, 0.5).unwrap();
+        assert!(close(projected, 100.0));
+        // Reverse swaps A/B: the ratio of prices inverts.
+        let reversed = level_price(FibKind::Retracement, true, 400.0, 100.0, 100.0, 0.5).unwrap();
+        assert!(close(reversed, 200.0));
+    }
+
+    #[test]
+    fn log_refuses_non_positive_prices_instead_of_guessing() {
+        assert!(level_price(FibKind::Retracement, true, 0.0, 10.0, 10.0, 0.5).is_none());
+        assert!(level_price(FibKind::Extension, true, 10.0, 20.0, -5.0, 0.5).is_none());
+        assert!(!log_scale_allowed(-1.0, 2.0, 3.0));
+        // Linear never needs the guard.
+        assert!(level_price(FibKind::Retracement, false, -10.0, 10.0, 10.0, 0.5).is_some());
+    }
+
+    #[test]
+    fn the_ratio_parser_reads_ratios_percents_and_decimal_commas() {
+        assert!(close(parse_ratio(".618").unwrap(), 0.618));
+        assert!(close(parse_ratio("0.618").unwrap(), 0.618));
+        assert!(close(parse_ratio("61.8%").unwrap(), 0.618));
+        assert!(close(parse_ratio("0,618").unwrap(), 0.618));
+        assert!(close(parse_ratio("61,8 %").unwrap(), 0.618));
+        assert!(close(parse_ratio("-0.272").unwrap(), -0.272));
+        assert!(close(parse_ratio("161.8%").unwrap(), 1.618));
+        assert!(parse_ratio("abc").is_none());
+        assert!(parse_ratio("").is_none());
+        assert!(parse_ratio("inf").is_none());
+    }
+
+    #[test]
+    fn presets_start_every_fib_and_round_trip_through_the_preset_format() {
+        let mut payload = FibPayload::new(FibKind::Retracement);
+        assert_eq!(payload.levels.len(), 7, "Standard retracement has 7 levels");
+        payload.levels[1].label = "golden".to_owned();
+        payload.levels[1].color = Some([255, 159, 67]);
+        payload.levels[1].fill_to_next = true;
+        payload.band_alpha = 40;
+        payload.label_mode = LabelMode::RatioPrice;
+        payload.extend = Extend::Right;
+
+        let exported = payload.export_preset().expect("fib exports its preset");
+        let mut restored = FibPayload::new(FibKind::Retracement);
+        assert!(restored.import_preset(&exported));
+        assert_eq!(restored, payload, "the preset format round-trips");
+
+        // A preset of the other kind is refused, not misapplied.
+        let mut extension = FibPayload::new(FibKind::Extension);
+        assert!(!extension.import_preset(&exported));
+    }
+
+    #[test]
+    fn imports_reject_broken_or_future_preset_files() {
+        let mut payload = FibPayload::new(FibKind::Retracement);
+        let mut exported = payload.export_preset().unwrap();
+        let table = exported.as_table_mut().unwrap();
+        table.insert("version".into(), toml::Value::Integer(99));
+        assert!(
+            !payload.import_preset(&exported),
+            "an unknown version must not half-apply"
+        );
+    }
+
+    #[test]
+    fn duplicate_ratios_within_tolerance_are_rejected() {
+        let payload = FibPayload::new(FibKind::Retracement);
+        assert!(payload.is_duplicate(0.618, None));
+        assert!(payload.is_duplicate(0.618 + RATIO_DUPLICATE_TOLERANCE / 2.0, None));
+        assert!(
+            !payload.is_duplicate(0.618, Some(4)),
+            "a level may keep its own ratio"
+        );
+        assert!(!payload.is_duplicate(0.9, None));
+    }
+
+    #[test]
+    fn labels_follow_the_mode_and_custom_text() {
+        let level = FibLevelSpec::new(0.618);
+        assert_eq!(
+            format_label(LabelMode::PercentPrice, &level, 70_147.866),
+            "61.8% \u{00b7} 70147.87"
+        );
+        assert_eq!(
+            format_label(LabelMode::RatioPrice, &level, 70_147.866),
+            "0.618 \u{00b7} 70147.87"
+        );
+        assert_eq!(
+            format_label(LabelMode::PriceOnly, &level, 70_147.866),
+            "70147.87"
+        );
+        let mut named = FibLevelSpec::new(0.618);
+        named.label = "golden".to_owned();
+        assert_eq!(
+            format_label(LabelMode::PercentPrice, &named, 1.0),
+            "golden \u{00b7} 1.00"
+        );
+    }
+
+    #[test]
+    fn the_label_cache_rebuilds_only_when_prices_or_config_change() {
+        let mut payload = FibPayload::new(FibKind::Retracement);
+        let first = labels_for(&payload, 200.0, 100.0, 100.0, false);
+        assert_eq!(first.len(), 7);
+        let again = labels_for(&payload, 200.0, 100.0, 100.0, false);
+        assert_eq!(first, again);
+        // A config edit bumps the revision and the labels follow.
+        payload.levels[0].label = "top".to_owned();
+        payload.touch();
+        let after = labels_for(&payload, 200.0, 100.0, 100.0, false);
+        assert!(after[0].starts_with("top"));
+    }
+}

--- a/crates/app/src/drawings/fib.rs
+++ b/crates/app/src/drawings/fib.rs
@@ -8,10 +8,11 @@
 //! differ between the two kinds.
 
 use std::any::Any;
-use std::cell::RefCell;
+use std::cell::{Ref, RefCell};
 
 use eframe::egui;
 use serde::{Deserialize, Serialize};
+use smallvec::SmallVec;
 
 use super::{
     DrawContext, Drawing, DrawingPayload, DrawingStyle, FIB_LABEL_OFFSET_PX, FIB_LABEL_SIZE_PX,
@@ -28,6 +29,10 @@ pub const MAX_BAND_ALPHA: u8 = 153;
 pub const DEFAULT_BAND_ALPHA: u8 = 24;
 /// Dash geometry of the anchor guides shown while selected.
 const GUIDE_DASH_PX: f32 = 4.0;
+/// Inline capacity of the per-frame level projection — one slot above the
+/// largest built-in preset (Extended, 11 levels), so no shipped preset ever
+/// touches the heap while painting.
+const PROJECTED_LEVELS_INLINE: usize = 12;
 /// Version stamp of the exported preset format.
 const PRESET_FORMAT_VERSION: u32 = 1;
 
@@ -203,7 +208,7 @@ struct LabelCache {
 }
 
 /// The tool-owned state of one Fib object.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct FibPayload {
     pub kind: FibKind,
     pub levels: Vec<FibLevelSpec>,
@@ -217,6 +222,25 @@ pub struct FibPayload {
     /// Bumped by the editor so the label cache notices config edits.
     revision: u64,
     cache: RefCell<LabelCache>,
+}
+
+impl Clone for FibPayload {
+    fn clone(&self) -> Self {
+        Self {
+            kind: self.kind,
+            levels: self.levels.clone(),
+            band_alpha: self.band_alpha,
+            log_scale: self.log_scale,
+            label_mode: self.label_mode,
+            label_position: self.label_position,
+            extend: self.extend,
+            revision: self.revision,
+            // The cache is memoization, not state: a clone (undo snapshot,
+            // inspector pre-edit copy) starts cold instead of copying
+            // formatted strings around.
+            cache: RefCell::new(LabelCache::default()),
+        }
+    }
 }
 
 impl PartialEq for FibPayload {
@@ -490,38 +514,42 @@ pub(super) fn paint(
     let log = effective_log(payload, a, b, c);
     let (left, right) = level_span(points, chart_rect, payload.extend);
 
+    // Project every visible level once — the bands, the lines and the label
+    // slots all read this one pass, so they can never drift apart.
+    struct ProjectedLevel<'a> {
+        level: &'a FibLevelSpec,
+        y: f32,
+        color: egui::Color32,
+    }
+    let projected: SmallVec<[ProjectedLevel<'_>; PROJECTED_LEVELS_INLINE]> = payload
+        .levels
+        .iter()
+        .filter(|level| level.visible)
+        .filter_map(|level| {
+            level_price(payload.kind, log, a, b, c, level.ratio).map(|price| ProjectedLevel {
+                level,
+                y: ctxt.scale.y(price),
+                color: level_color(level, style),
+            })
+        })
+        .collect();
+
     // Band fills first, under the level lines. Skipped on the halo pass.
     if !ctxt.halo && payload.band_alpha > 0 {
-        let visible: Vec<(f32, egui::Color32)> = payload
-            .levels
-            .iter()
-            .filter(|level| level.visible)
-            .filter_map(|level| {
-                level_price(payload.kind, log, a, b, c, level.ratio)
-                    .map(|price| (ctxt.scale.y(price), level_color(level, style)))
-            })
-            .collect();
-        for (index, level) in payload
-            .levels
-            .iter()
-            .filter(|level| level.visible)
-            .enumerate()
-        {
-            if !level.fill_to_next || index + 1 >= visible.len() {
+        for pair in projected.windows(2) {
+            if !pair[0].level.fill_to_next {
                 continue;
             }
-            let (y, color) = visible[index];
-            let (next_y, _) = visible[index + 1];
             let fill = egui::Color32::from_rgba_unmultiplied(
-                color.r(),
-                color.g(),
-                color.b(),
+                pair[0].color.r(),
+                pair[0].color.g(),
+                pair[0].color.b(),
                 payload.band_alpha,
             );
             painter.rect_filled(
                 egui::Rect::from_min_max(
-                    egui::pos2(left, y.min(next_y)),
-                    egui::pos2(right, y.max(next_y)),
+                    egui::pos2(left, pair[0].y.min(pair[1].y)),
+                    egui::pos2(right, pair[0].y.max(pair[1].y)),
                 ),
                 egui::Rounding::ZERO,
                 fill,
@@ -529,22 +557,21 @@ pub(super) fn paint(
         }
     }
 
-    // Level lines (and cached labels on the real pass).
+    // Level lines, with the cached labels on the real pass — the cache is
+    // borrowed, never copied, on the frame path.
     let labels = (!ctxt.halo).then(|| labels_for(payload, a, b, c, log));
-    let mut label_index = 0usize;
-    for level in payload.levels.iter().filter(|level| level.visible) {
-        let Some(price) = level_price(payload.kind, log, a, b, c, level.ratio) else {
-            continue;
-        };
-        let y = ctxt.scale.y(price);
+    for (index, level) in projected.iter().enumerate() {
         let line_stroke = if ctxt.halo {
             stroke
         } else {
-            egui::Stroke::new(style.width_px, level_color(level, style))
+            egui::Stroke::new(style.width_px, level.color)
         };
-        painter.line_segment([egui::pos2(left, y), egui::pos2(right, y)], line_stroke);
+        painter.line_segment(
+            [egui::pos2(left, level.y), egui::pos2(right, level.y)],
+            line_stroke,
+        );
         if let Some(labels) = &labels
-            && let Some(text) = labels.get(label_index)
+            && let Some(text) = labels.labels.get(index)
         {
             let (anchor, x) = match payload.label_position {
                 LabelPosition::RightOutside => {
@@ -556,14 +583,13 @@ pub(super) fn paint(
                 LabelPosition::Left => (egui::Align2::LEFT_BOTTOM, left + FIB_LABEL_OFFSET_PX),
             };
             painter.text(
-                egui::pos2(x, y),
+                egui::pos2(x, level.y),
                 anchor,
                 text,
                 egui::FontId::monospace(FIB_LABEL_SIZE_PX),
-                level_color(level, style),
+                level.color,
             );
         }
-        label_index += 1;
     }
 
     // Anchor guides while selected: dashed A-B (and B-C for extension).
@@ -586,30 +612,31 @@ pub(super) fn paint(
     }
 }
 
-/// Rebuild the label cache if anchors or config changed; return a clone of
-/// the cached strings (cheap: a handful of small strings, only while a Fib
-/// is actually painting labels).
-fn labels_for(payload: &FibPayload, a: f64, b: f64, c: f64, log: bool) -> Vec<String> {
+/// Rebuild the label cache if anchors or config changed, then hand out a
+/// borrow of it — the frame path never copies the formatted strings.
+fn labels_for(payload: &FibPayload, a: f64, b: f64, c: f64, log: bool) -> Ref<'_, LabelCache> {
     let key = (
         a.to_bits() ^ u64::from(log),
         b.to_bits(),
         c.to_bits(),
         payload.revision,
     );
-    let mut cache = payload.cache.borrow_mut();
-    if cache.key != key {
-        cache.key = key;
-        cache.labels = payload
-            .levels
-            .iter()
-            .filter(|level| level.visible)
-            .filter_map(|level| {
-                level_price(payload.kind, log, a, b, c, level.ratio)
-                    .map(|price| format_label(payload.label_mode, level, price))
-            })
-            .collect();
+    {
+        let mut cache = payload.cache.borrow_mut();
+        if cache.key != key {
+            cache.key = key;
+            cache.labels = payload
+                .levels
+                .iter()
+                .filter(|level| level.visible)
+                .filter_map(|level| {
+                    level_price(payload.kind, log, a, b, c, level.ratio)
+                        .map(|price| format_label(payload.label_mode, level, price))
+                })
+                .collect();
+        }
     }
-    cache.labels.clone()
+    payload.cache.borrow()
 }
 
 /// Hit-test one Fib object: any visible level line, or the anchor legs.
@@ -1112,14 +1139,18 @@ mod tests {
     #[test]
     fn the_label_cache_rebuilds_only_when_prices_or_config_change() {
         let mut payload = FibPayload::new(FibKind::Retracement);
-        let first = labels_for(&payload, 200.0, 100.0, 100.0, false);
+        let first = labels_for(&payload, 200.0, 100.0, 100.0, false)
+            .labels
+            .clone();
         assert_eq!(first.len(), 7);
-        let again = labels_for(&payload, 200.0, 100.0, 100.0, false);
+        let again = labels_for(&payload, 200.0, 100.0, 100.0, false)
+            .labels
+            .clone();
         assert_eq!(first, again);
         // A config edit bumps the revision and the labels follow.
         payload.levels[0].label = "top".to_owned();
         payload.touch();
         let after = labels_for(&payload, 200.0, 100.0, 100.0, false);
-        assert!(after[0].starts_with("top"));
+        assert!(after.labels[0].starts_with("top"));
     }
 }

--- a/crates/app/src/drawings/fib_extension.rs
+++ b/crates/app/src/drawings/fib_extension.rs
@@ -2,7 +2,7 @@ use eframe::egui;
 use egui_phosphor::regular as icons;
 
 use super::fib::{self, FibKind, FibPayload};
-use super::{DrawContext, Drawing, DrawingPayload, DrawingStyle, DrawingToolImpl, PresetHost};
+use super::{DrawContext, Drawing, DrawingPayload, DrawingStyle, DrawingToolImpl, ToolShortcut, PresetHost};
 
 pub(super) static TOOL: FibExtension = FibExtension;
 
@@ -22,10 +22,16 @@ impl DrawingToolImpl for FibExtension {
         icons::ROWS_PLUS_TOP
     }
     fn hover_text(&self) -> &'static str {
-        "Fib extension - set the first leg, then click the projection origin"
+        "Fib extension - set the first leg, then click the projection origin (Shift+F)"
     }
     fn required_points(&self) -> usize {
         FibKind::Extension.required_points()
+    }
+    fn shortcut(&self) -> Option<ToolShortcut> {
+        Some(ToolShortcut {
+            key: egui::Key::F,
+            shift: true,
+        })
     }
     fn default_payload(&self) -> Box<dyn DrawingPayload> {
         Box::new(FibPayload::new(FibKind::Extension))

--- a/crates/app/src/drawings/fib_extension.rs
+++ b/crates/app/src/drawings/fib_extension.rs
@@ -1,0 +1,84 @@
+use eframe::egui;
+use egui_phosphor::regular as icons;
+
+use super::{
+    DrawingStyle, DrawingToolImpl, FibGeometry, FibLevel, drawing_stroke, hit_fib_levels,
+    paint_fib_levels,
+};
+
+pub(super) static TOOL: FibExtension = FibExtension;
+const LEVELS: [FibLevel; 5] = [
+    FibLevel::new(0.0, "0.000"),
+    FibLevel::new(0.618, "0.618"),
+    FibLevel::new(1.0, "1.000"),
+    FibLevel::new(1.618, "1.618"),
+    FibLevel::new(2.618, "2.618"),
+];
+
+pub(super) struct FibExtension;
+
+impl DrawingToolImpl for FibExtension {
+    fn id(&self) -> &'static str {
+        "fib-extension"
+    }
+    fn settings_title(&self) -> &'static str {
+        "Fib extension settings"
+    }
+    fn icon(&self) -> &'static str {
+        icons::ROWS_PLUS_TOP
+    }
+    fn hover_text(&self) -> &'static str {
+        "Fib extension - set the first leg, then click the projection origin"
+    }
+    fn required_points(&self) -> usize {
+        3
+    }
+    fn paint(
+        &self,
+        painter: &egui::Painter,
+        _chart_rect: egui::Rect,
+        style: DrawingStyle,
+        points: &[egui::Pos2],
+        selected: bool,
+    ) {
+        if points.len() == 2 {
+            painter.line_segment([points[0], points[1]], drawing_stroke(style, selected));
+        } else if points.len() == 3 {
+            paint_fib_levels(
+                painter,
+                FibGeometry {
+                    left: points[0].x.min(points[1].x).min(points[2].x),
+                    right: points[0].x.max(points[1].x).max(points[2].x),
+                    first_y: points[0].y,
+                    second_y: points[1].y,
+                    origin_y: points[2].y,
+                },
+                &LEVELS,
+                drawing_stroke(style, selected),
+                style.color,
+            );
+        }
+    }
+    fn hit_test(
+        &self,
+        _chart_rect: egui::Rect,
+        points: &[egui::Pos2],
+        position: egui::Pos2,
+        radius_px: f32,
+    ) -> bool {
+        points.len() == 3
+            && hit_fib_levels(position, points, &LEVELS, points[2].y, radius_px)
+    }
+
+    #[cfg(test)]
+    fn test_geometry(&self) -> (Vec<egui::Pos2>, egui::Pos2) {
+        (
+            vec![
+                egui::pos2(100.0, 100.0),
+                egui::pos2(200.0, 200.0),
+                egui::pos2(250.0, 150.0),
+            ],
+            egui::pos2(175.0, 250.0),
+        )
+    }
+}

--- a/crates/app/src/drawings/fib_extension.rs
+++ b/crates/app/src/drawings/fib_extension.rs
@@ -39,10 +39,9 @@ impl DrawingToolImpl for FibExtension {
         _chart_rect: egui::Rect,
         style: DrawingStyle,
         points: &[egui::Pos2],
-        selected: bool,
     ) {
         if points.len() == 2 {
-            painter.line_segment([points[0], points[1]], drawing_stroke(style, selected));
+            painter.line_segment([points[0], points[1]], drawing_stroke(style));
         } else if points.len() == 3 {
             paint_fib_levels(
                 painter,
@@ -54,7 +53,7 @@ impl DrawingToolImpl for FibExtension {
                     origin_y: points[2].y,
                 },
                 &LEVELS,
-                drawing_stroke(style, selected),
+                drawing_stroke(style),
                 style.color,
             );
         }

--- a/crates/app/src/drawings/fib_extension.rs
+++ b/crates/app/src/drawings/fib_extension.rs
@@ -1,19 +1,10 @@
 use eframe::egui;
 use egui_phosphor::regular as icons;
 
-use super::{
-    DrawingStyle, DrawingToolImpl, FibGeometry, FibLevel, drawing_stroke, hit_fib_levels,
-    paint_fib_levels,
-};
+use super::fib::{self, FibKind, FibPayload};
+use super::{DrawContext, Drawing, DrawingPayload, DrawingStyle, DrawingToolImpl, PresetHost};
 
 pub(super) static TOOL: FibExtension = FibExtension;
-const LEVELS: [FibLevel; 5] = [
-    FibLevel::new(0.0, "0.000"),
-    FibLevel::new(0.618, "0.618"),
-    FibLevel::new(1.0, "1.000"),
-    FibLevel::new(1.618, "1.618"),
-    FibLevel::new(2.618, "2.618"),
-];
 
 pub(super) struct FibExtension;
 
@@ -34,42 +25,42 @@ impl DrawingToolImpl for FibExtension {
         "Fib extension - set the first leg, then click the projection origin"
     }
     fn required_points(&self) -> usize {
-        3
+        FibKind::Extension.required_points()
+    }
+    fn default_payload(&self) -> Box<dyn DrawingPayload> {
+        Box::new(FibPayload::new(FibKind::Extension))
+    }
+    fn extra_tab(&self) -> Option<&'static str> {
+        Some("Levels")
+    }
+    fn draw_extra_tab(
+        &self,
+        ui: &mut egui::Ui,
+        drawing: &mut Drawing,
+        host: &mut dyn PresetHost,
+    ) -> bool {
+        fib::remember_drawing_color(ui, drawing.style.color);
+        fib::draw_levels_tab(ui, drawing, host)
     }
     fn paint(
         &self,
         painter: &egui::Painter,
-        _chart_rect: egui::Rect,
+        chart_rect: egui::Rect,
         style: DrawingStyle,
         points: &[egui::Pos2],
+        ctxt: &DrawContext<'_>,
     ) {
-        if points.len() == 2 {
-            painter.line_segment([points[0], points[1]], drawing_stroke(style));
-        } else if points.len() == 3 {
-            paint_fib_levels(
-                painter,
-                FibGeometry {
-                    left: points[0].x.min(points[1].x).min(points[2].x),
-                    right: points[0].x.max(points[1].x).max(points[2].x),
-                    first_y: points[0].y,
-                    second_y: points[1].y,
-                    origin_y: points[2].y,
-                },
-                &LEVELS,
-                drawing_stroke(style),
-                style.color,
-            );
-        }
+        fib::paint(painter, chart_rect, style, points, ctxt);
     }
     fn hit_test(
         &self,
-        _chart_rect: egui::Rect,
+        chart_rect: egui::Rect,
         points: &[egui::Pos2],
         position: egui::Pos2,
         radius_px: f32,
+        ctxt: &DrawContext<'_>,
     ) -> bool {
-        points.len() == 3
-            && hit_fib_levels(position, points, &LEVELS, points[2].y, radius_px)
+        fib::hit_test(chart_rect, points, position, radius_px, ctxt)
     }
 
     #[cfg(test)]

--- a/crates/app/src/drawings/fib_extension.rs
+++ b/crates/app/src/drawings/fib_extension.rs
@@ -21,6 +21,9 @@ impl DrawingToolImpl for FibExtension {
     fn id(&self) -> &'static str {
         "fib-extension"
     }
+    fn name(&self) -> &'static str {
+        "Fib extension"
+    }
     fn settings_title(&self) -> &'static str {
         "Fib extension settings"
     }

--- a/crates/app/src/drawings/fib_retracement.rs
+++ b/crates/app/src/drawings/fib_retracement.rs
@@ -2,7 +2,7 @@ use eframe::egui;
 use egui_phosphor::regular as icons;
 
 use super::fib::{self, FibKind, FibPayload};
-use super::{DrawContext, Drawing, DrawingPayload, DrawingStyle, DrawingToolImpl, PresetHost};
+use super::{DrawContext, Drawing, DrawingPayload, DrawingStyle, DrawingToolImpl, ToolShortcut, PresetHost};
 
 pub(super) static TOOL: FibRetracement = FibRetracement;
 
@@ -22,10 +22,16 @@ impl DrawingToolImpl for FibRetracement {
         icons::ROWS
     }
     fn hover_text(&self) -> &'static str {
-        "Fib retracement - click two points or drag"
+        "Fib retracement - click two points or drag (F)"
     }
     fn required_points(&self) -> usize {
         FibKind::Retracement.required_points()
+    }
+    fn shortcut(&self) -> Option<ToolShortcut> {
+        Some(ToolShortcut {
+            key: egui::Key::F,
+            shift: false,
+        })
     }
     fn default_payload(&self) -> Box<dyn DrawingPayload> {
         Box::new(FibPayload::new(FibKind::Retracement))

--- a/crates/app/src/drawings/fib_retracement.rs
+++ b/crates/app/src/drawings/fib_retracement.rs
@@ -41,7 +41,6 @@ impl DrawingToolImpl for FibRetracement {
         _chart_rect: egui::Rect,
         style: DrawingStyle,
         points: &[egui::Pos2],
-        selected: bool,
     ) {
         if points.len() == 2 {
             paint_fib_levels(
@@ -54,7 +53,7 @@ impl DrawingToolImpl for FibRetracement {
                     origin_y: points[0].y,
                 },
                 &LEVELS,
-                drawing_stroke(style, selected),
+                drawing_stroke(style),
                 style.color,
             );
         }

--- a/crates/app/src/drawings/fib_retracement.rs
+++ b/crates/app/src/drawings/fib_retracement.rs
@@ -23,6 +23,9 @@ impl DrawingToolImpl for FibRetracement {
     fn id(&self) -> &'static str {
         "fib-retracement"
     }
+    fn name(&self) -> &'static str {
+        "Fib retracement"
+    }
     fn settings_title(&self) -> &'static str {
         "Fib retracement settings"
     }

--- a/crates/app/src/drawings/fib_retracement.rs
+++ b/crates/app/src/drawings/fib_retracement.rs
@@ -1,21 +1,10 @@
 use eframe::egui;
 use egui_phosphor::regular as icons;
 
-use super::{
-    DrawingStyle, DrawingToolImpl, FibGeometry, FibLevel, drawing_stroke, hit_fib_levels,
-    paint_fib_levels,
-};
+use super::fib::{self, FibKind, FibPayload};
+use super::{DrawContext, Drawing, DrawingPayload, DrawingStyle, DrawingToolImpl, PresetHost};
 
 pub(super) static TOOL: FibRetracement = FibRetracement;
-const LEVELS: [FibLevel; 7] = [
-    FibLevel::new(0.0, "0.000"),
-    FibLevel::new(0.236, "0.236"),
-    FibLevel::new(0.382, "0.382"),
-    FibLevel::new(0.5, "0.500"),
-    FibLevel::new(0.618, "0.618"),
-    FibLevel::new(0.786, "0.786"),
-    FibLevel::new(1.0, "1.000"),
-];
 
 pub(super) struct FibRetracement;
 
@@ -36,40 +25,42 @@ impl DrawingToolImpl for FibRetracement {
         "Fib retracement - click two points or drag"
     }
     fn required_points(&self) -> usize {
-        2
+        FibKind::Retracement.required_points()
+    }
+    fn default_payload(&self) -> Box<dyn DrawingPayload> {
+        Box::new(FibPayload::new(FibKind::Retracement))
+    }
+    fn extra_tab(&self) -> Option<&'static str> {
+        Some("Levels")
+    }
+    fn draw_extra_tab(
+        &self,
+        ui: &mut egui::Ui,
+        drawing: &mut Drawing,
+        host: &mut dyn PresetHost,
+    ) -> bool {
+        fib::remember_drawing_color(ui, drawing.style.color);
+        fib::draw_levels_tab(ui, drawing, host)
     }
     fn paint(
         &self,
         painter: &egui::Painter,
-        _chart_rect: egui::Rect,
+        chart_rect: egui::Rect,
         style: DrawingStyle,
         points: &[egui::Pos2],
+        ctxt: &DrawContext<'_>,
     ) {
-        if points.len() == 2 {
-            paint_fib_levels(
-                painter,
-                FibGeometry {
-                    left: points[0].x.min(points[1].x),
-                    right: points[0].x.max(points[1].x),
-                    first_y: points[0].y,
-                    second_y: points[1].y,
-                    origin_y: points[0].y,
-                },
-                &LEVELS,
-                drawing_stroke(style),
-                style.color,
-            );
-        }
+        fib::paint(painter, chart_rect, style, points, ctxt);
     }
     fn hit_test(
         &self,
-        _chart_rect: egui::Rect,
+        chart_rect: egui::Rect,
         points: &[egui::Pos2],
         position: egui::Pos2,
         radius_px: f32,
+        ctxt: &DrawContext<'_>,
     ) -> bool {
-        points.len() == 2
-            && hit_fib_levels(position, points, &LEVELS, points[0].y, radius_px)
+        fib::hit_test(chart_rect, points, position, radius_px, ctxt)
     }
 
     #[cfg(test)]

--- a/crates/app/src/drawings/fib_retracement.rs
+++ b/crates/app/src/drawings/fib_retracement.rs
@@ -1,0 +1,80 @@
+use eframe::egui;
+use egui_phosphor::regular as icons;
+
+use super::{
+    DrawingStyle, DrawingToolImpl, FibGeometry, FibLevel, drawing_stroke, hit_fib_levels,
+    paint_fib_levels,
+};
+
+pub(super) static TOOL: FibRetracement = FibRetracement;
+const LEVELS: [FibLevel; 7] = [
+    FibLevel::new(0.0, "0.000"),
+    FibLevel::new(0.236, "0.236"),
+    FibLevel::new(0.382, "0.382"),
+    FibLevel::new(0.5, "0.500"),
+    FibLevel::new(0.618, "0.618"),
+    FibLevel::new(0.786, "0.786"),
+    FibLevel::new(1.0, "1.000"),
+];
+
+pub(super) struct FibRetracement;
+
+impl DrawingToolImpl for FibRetracement {
+    fn id(&self) -> &'static str {
+        "fib-retracement"
+    }
+    fn settings_title(&self) -> &'static str {
+        "Fib retracement settings"
+    }
+    fn icon(&self) -> &'static str {
+        icons::ROWS
+    }
+    fn hover_text(&self) -> &'static str {
+        "Fib retracement - click two points or drag"
+    }
+    fn required_points(&self) -> usize {
+        2
+    }
+    fn paint(
+        &self,
+        painter: &egui::Painter,
+        _chart_rect: egui::Rect,
+        style: DrawingStyle,
+        points: &[egui::Pos2],
+        selected: bool,
+    ) {
+        if points.len() == 2 {
+            paint_fib_levels(
+                painter,
+                FibGeometry {
+                    left: points[0].x.min(points[1].x),
+                    right: points[0].x.max(points[1].x),
+                    first_y: points[0].y,
+                    second_y: points[1].y,
+                    origin_y: points[0].y,
+                },
+                &LEVELS,
+                drawing_stroke(style, selected),
+                style.color,
+            );
+        }
+    }
+    fn hit_test(
+        &self,
+        _chart_rect: egui::Rect,
+        points: &[egui::Pos2],
+        position: egui::Pos2,
+        radius_px: f32,
+    ) -> bool {
+        points.len() == 2
+            && hit_fib_levels(position, points, &LEVELS, points[0].y, radius_px)
+    }
+
+    #[cfg(test)]
+    fn test_geometry(&self) -> (Vec<egui::Pos2>, egui::Pos2) {
+        (
+            vec![egui::pos2(100.0, 100.0), egui::pos2(250.0, 200.0)],
+            egui::pos2(175.0, 150.0),
+        )
+    }
+}

--- a/crates/app/src/drawings/horizontal_line.rs
+++ b/crates/app/src/drawings/horizontal_line.rs
@@ -11,6 +11,9 @@ impl DrawingToolImpl for HorizontalLine {
     fn id(&self) -> &'static str {
         "horizontal-line"
     }
+    fn name(&self) -> &'static str {
+        "Horizontal line"
+    }
     fn settings_title(&self) -> &'static str {
         "Horizontal line settings"
     }

--- a/crates/app/src/drawings/horizontal_line.rs
+++ b/crates/app/src/drawings/horizontal_line.rs
@@ -1,7 +1,7 @@
 use eframe::egui;
 use egui_phosphor::regular as icons;
 
-use super::{DrawingStyle, DrawingToolImpl, drawing_stroke};
+use super::{DrawContext, DrawingStyle, DrawingToolImpl, drawing_stroke};
 
 pub(super) static TOOL: HorizontalLine = HorizontalLine;
 
@@ -32,6 +32,7 @@ impl DrawingToolImpl for HorizontalLine {
         chart_rect: egui::Rect,
         style: DrawingStyle,
         points: &[egui::Pos2],
+        _ctxt: &DrawContext<'_>,
     ) {
         if let Some(point) = points.first() {
             painter.line_segment(
@@ -49,6 +50,7 @@ impl DrawingToolImpl for HorizontalLine {
         points: &[egui::Pos2],
         position: egui::Pos2,
         radius_px: f32,
+        _ctxt: &DrawContext<'_>,
     ) -> bool {
         points.first().is_some_and(|point| {
             chart_rect.x_range().contains(position.x)

--- a/crates/app/src/drawings/horizontal_line.rs
+++ b/crates/app/src/drawings/horizontal_line.rs
@@ -1,7 +1,7 @@
 use eframe::egui;
 use egui_phosphor::regular as icons;
 
-use super::{DrawContext, DrawingStyle, DrawingToolImpl, drawing_stroke};
+use super::{DrawContext, DrawingStyle, DrawingToolImpl, ToolShortcut, drawing_stroke};
 
 pub(super) static TOOL: HorizontalLine = HorizontalLine;
 
@@ -21,10 +21,16 @@ impl DrawingToolImpl for HorizontalLine {
         icons::MINUS
     }
     fn hover_text(&self) -> &'static str {
-        "Horizontal line - click a price"
+        "Horizontal line - click a price (H)"
     }
     fn required_points(&self) -> usize {
         1
+    }
+    fn shortcut(&self) -> Option<ToolShortcut> {
+        Some(ToolShortcut {
+            key: egui::Key::H,
+            shift: false,
+        })
     }
     fn paint(
         &self,

--- a/crates/app/src/drawings/horizontal_line.rs
+++ b/crates/app/src/drawings/horizontal_line.rs
@@ -1,0 +1,61 @@
+use eframe::egui;
+use egui_phosphor::regular as icons;
+
+use super::{DrawingStyle, DrawingToolImpl, drawing_stroke};
+
+pub(super) static TOOL: HorizontalLine = HorizontalLine;
+
+pub(super) struct HorizontalLine;
+
+impl DrawingToolImpl for HorizontalLine {
+    fn id(&self) -> &'static str {
+        "horizontal-line"
+    }
+    fn settings_title(&self) -> &'static str {
+        "Horizontal line settings"
+    }
+    fn icon(&self) -> &'static str {
+        icons::MINUS
+    }
+    fn hover_text(&self) -> &'static str {
+        "Horizontal line - click a price"
+    }
+    fn required_points(&self) -> usize {
+        1
+    }
+    fn paint(
+        &self,
+        painter: &egui::Painter,
+        chart_rect: egui::Rect,
+        style: DrawingStyle,
+        points: &[egui::Pos2],
+        selected: bool,
+    ) {
+        if let Some(point) = points.first() {
+            painter.line_segment(
+                [
+                    egui::pos2(chart_rect.left(), point.y),
+                    egui::pos2(chart_rect.right(), point.y),
+                ],
+                drawing_stroke(style, selected),
+            );
+        }
+    }
+    fn hit_test(
+        &self,
+        chart_rect: egui::Rect,
+        points: &[egui::Pos2],
+        position: egui::Pos2,
+        radius_px: f32,
+    ) -> bool {
+        points.first().is_some_and(|point| {
+            chart_rect.x_range().contains(position.x)
+                && (position.y - point.y).abs() <= radius_px
+        })
+    }
+
+    #[cfg(test)]
+    fn test_geometry(&self) -> (Vec<egui::Pos2>, egui::Pos2) {
+        (vec![egui::pos2(100.0, 120.0)], egui::pos2(450.0, 123.0))
+    }
+}

--- a/crates/app/src/drawings/horizontal_line.rs
+++ b/crates/app/src/drawings/horizontal_line.rs
@@ -29,7 +29,6 @@ impl DrawingToolImpl for HorizontalLine {
         chart_rect: egui::Rect,
         style: DrawingStyle,
         points: &[egui::Pos2],
-        selected: bool,
     ) {
         if let Some(point) = points.first() {
             painter.line_segment(
@@ -37,7 +36,7 @@ impl DrawingToolImpl for HorizontalLine {
                     egui::pos2(chart_rect.left(), point.y),
                     egui::pos2(chart_rect.right(), point.y),
                 ],
-                drawing_stroke(style, selected),
+                drawing_stroke(style),
             );
         }
     }

--- a/crates/app/src/drawings/mod.rs
+++ b/crates/app/src/drawings/mod.rs
@@ -10,14 +10,27 @@ use std::fmt;
 
 use eframe::egui;
 
+use crate::theme;
+
 pub const DEFAULT_DRAWING_COLOR: egui::Color32 = egui::Color32::from_rgb(138, 180, 248);
 pub const DEFAULT_DRAWING_WIDTH_PX: f32 = 1.5;
 pub const DEFAULT_DRAWING_FILL_ALPHA: u8 = 24;
 pub const MIN_DRAWING_WIDTH_PX: f32 = 0.5;
 pub const MAX_DRAWING_WIDTH_PX: f32 = 6.0;
 pub const MAX_DRAWING_FILL_ALPHA: u8 = 160;
+/// Undo history depth. One entry per committed command (a whole drag or
+/// slider gesture is one command), so this bounds memory without cutting a
+/// working session short.
+const UNDO_HISTORY_LIMIT: usize = 64;
 const SELECTED_ANCHOR_RADIUS_PX: f32 = 4.0;
 const SELECTED_ANCHOR_FILL: egui::Color32 = egui::Color32::WHITE;
+const SELECTED_ANCHOR_RING_WIDTH_PX: f32 = 1.5;
+/// Selection never repaints the object white: it keeps the configured colour
+/// and paints this soft halo underneath instead, plus white anchor handles.
+/// Premultiplied ~16% white, matching the UX spec's `.halo` treatment.
+const SELECTION_HALO_COLOR: egui::Color32 = egui::Color32::from_rgba_premultiplied(40, 40, 40, 40);
+/// How much wider than the object's own stroke the halo pass paints.
+const SELECTION_HALO_EXTRA_WIDTH_PX: f32 = 3.5;
 pub(super) const FIB_LABEL_OFFSET_PX: f32 = 3.0;
 pub(super) const FIB_LABEL_SIZE_PX: f32 = 10.0;
 
@@ -41,7 +54,9 @@ impl FibLevel {
     }
 }
 
-/// The implementation port every drawing plugs into.
+/// The implementation port every drawing plugs into. Selection visuals (halo
+/// and anchor handles) are common chrome painted by the wrapper, so a tool
+/// only ever paints its own geometry in the style it is given.
 trait DrawingToolImpl: Sync {
     fn id(&self) -> &'static str;
     fn settings_title(&self) -> &'static str;
@@ -54,7 +69,6 @@ trait DrawingToolImpl: Sync {
         chart_rect: egui::Rect,
         style: DrawingStyle,
         points: &[egui::Pos2],
-        selected: bool,
     );
     fn hit_test(
         &self,
@@ -97,6 +111,9 @@ impl DrawingTool {
         self.0.required_points()
     }
 
+    /// Paint the object. Selection adds a halo *under* the geometry and, when
+    /// `show_handles` (not locked), white anchor handles on top — the object's
+    /// configured colour keeps carrying meaning either way.
     pub fn paint(
         self,
         painter: &egui::Painter,
@@ -104,13 +121,22 @@ impl DrawingTool {
         style: DrawingStyle,
         points: &[egui::Pos2],
         selected: bool,
+        show_handles: bool,
     ) {
-        self.0.paint(painter, chart_rect, style, points, selected);
         if selected {
-            let stroke = drawing_stroke(style, true);
+            let halo = DrawingStyle {
+                color: SELECTION_HALO_COLOR,
+                width_px: style.width_px + SELECTION_HALO_EXTRA_WIDTH_PX,
+                fill_alpha: 0,
+            };
+            self.0.paint(painter, chart_rect, halo, points);
+        }
+        self.0.paint(painter, chart_rect, style, points);
+        if selected && show_handles {
+            let ring = egui::Stroke::new(SELECTED_ANCHOR_RING_WIDTH_PX, theme::ACCENT);
             for point in points {
                 painter.circle_filled(*point, SELECTED_ANCHOR_RADIUS_PX, SELECTED_ANCHOR_FILL);
-                painter.circle_stroke(*point, SELECTED_ANCHOR_RADIUS_PX, stroke);
+                painter.circle_stroke(*point, SELECTED_ANCHOR_RADIUS_PX, ring);
             }
         }
     }
@@ -198,6 +224,28 @@ pub struct Drawing {
     pub tool: DrawingTool,
     pub points: Vec<ChartPoint>,
     pub style: DrawingStyle,
+    /// A locked drawing keeps rejecting geometry edits and unforced deletes;
+    /// its style stays editable.
+    pub locked: bool,
+    /// A hidden drawing neither paints nor hit-tests, and stays recoverable.
+    pub hidden: bool,
+}
+
+/// What a delete request did. Locked objects demand an explicit `force`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeleteOutcome {
+    Deleted,
+    NeedsConfirmation,
+    NothingSelected,
+}
+
+/// One undo step: the whole collection plus the global-hide layer. Selection,
+/// viewport and inspector state deliberately stay out, so undo never yanks
+/// the camera or the UI around.
+#[derive(Debug, Clone, PartialEq)]
+struct UndoEntry {
+    items: Vec<Drawing>,
+    all_hidden: bool,
 }
 
 #[derive(Debug, Default)]
@@ -205,6 +253,14 @@ pub struct Drawings {
     items: Vec<Drawing>,
     draft: Option<Drawing>,
     selected: Option<usize>,
+    /// Global hide layer. Independent from each drawing's own eye, so
+    /// "show all" restores exactly the per-object visibility it found.
+    all_hidden: bool,
+    undo: Vec<UndoEntry>,
+    redo: Vec<UndoEntry>,
+    /// Snapshot taken when a pointer gesture starts; committed (as one undo
+    /// entry) on release, so a whole drag coalesces into one command.
+    gesture_baseline: Option<UndoEntry>,
 }
 
 impl Drawings {
@@ -237,21 +293,112 @@ impl Drawings {
         self.draft.as_ref().map_or(0, |draft| draft.points.len())
     }
 
-    /// Add a placement anchor. `true` means the object became complete.
+    #[must_use]
+    pub fn all_hidden(&self) -> bool {
+        self.all_hidden
+    }
+
+    /// Whether the object at `index` paints and hit-tests this frame.
+    #[must_use]
+    pub fn is_visible(&self, index: usize) -> bool {
+        !self.all_hidden && self.items.get(index).is_some_and(|item| !item.hidden)
+    }
+
+    fn snapshot(&self) -> UndoEntry {
+        UndoEntry {
+            items: self.items.clone(),
+            all_hidden: self.all_hidden,
+        }
+    }
+
+    /// Push `before` as one undo step if the store actually changed since.
+    fn record(&mut self, before: UndoEntry) {
+        if before == self.snapshot() {
+            return;
+        }
+        self.undo.push(before);
+        if self.undo.len() > UNDO_HISTORY_LIMIT {
+            self.undo.remove(0);
+        }
+        self.redo.clear();
+    }
+
+    /// Start coalescing: the next [`Self::commit_gesture`] records everything
+    /// mutated in between as a single undo entry. Idempotent within a gesture.
+    pub fn begin_gesture(&mut self) {
+        if self.gesture_baseline.is_none() {
+            self.gesture_baseline = Some(self.snapshot());
+        }
+    }
+
+    /// End coalescing. A gesture that changed nothing records nothing.
+    pub fn commit_gesture(&mut self) {
+        if let Some(baseline) = self.gesture_baseline.take() {
+            self.record(baseline);
+        }
+    }
+
+    /// Record an already-applied edit to one object, given its pre-edit
+    /// state. Used by the inspector to coalesce slider/color gestures.
+    pub fn record_edit_of(&mut self, index: usize, before_drawing: Drawing) {
+        let mut before = self.snapshot();
+        let Some(slot) = before.items.get_mut(index) else {
+            return;
+        };
+        *slot = before_drawing;
+        self.record(before);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn undo_depth(&self) -> usize {
+        self.undo.len()
+    }
+
+    fn restore(&mut self, entry: UndoEntry) {
+        self.items = entry.items;
+        self.all_hidden = entry.all_hidden;
+        self.draft = None;
+        self.selected = self.selected.filter(|&index| index < self.items.len());
+    }
+
+    pub fn undo(&mut self) -> bool {
+        let Some(entry) = self.undo.pop() else {
+            return false;
+        };
+        self.redo.push(self.snapshot());
+        self.restore(entry);
+        true
+    }
+
+    pub fn redo(&mut self) -> bool {
+        let Some(entry) = self.redo.pop() else {
+            return false;
+        };
+        self.undo.push(self.snapshot());
+        self.restore(entry);
+        true
+    }
+
+    /// Add a placement anchor. `true` means the object became complete;
+    /// completing an object records one undo entry for the whole creation.
     pub fn place(&mut self, tool: DrawingTool, point: ChartPoint) -> bool {
         if self.draft.as_ref().is_none_or(|draft| draft.tool != tool) {
             self.draft = Some(Drawing {
                 tool,
                 points: Vec::with_capacity(tool.required_points()),
                 style: DrawingStyle::default(),
+                locked: false,
+                hidden: false,
             });
         }
         let draft = self.draft.as_mut().expect("draft was installed above");
         draft.points.push(point);
         if draft.points.len() == tool.required_points() {
+            let before = self.snapshot();
             self.items
                 .push(self.draft.take().expect("draft has points"));
             self.selected = Some(self.items.len() - 1);
+            self.record(before);
             true
         } else {
             false
@@ -262,55 +409,128 @@ impl Drawings {
         self.draft = None;
     }
 
+    /// Honest reset: the anchors cannot survive a source or bar-spec change,
+    /// and neither can a history that would resurrect them onto different
+    /// market data.
     pub fn clear(&mut self) {
         self.items.clear();
         self.draft = None;
         self.selected = None;
+        self.all_hidden = false;
+        self.undo.clear();
+        self.redo.clear();
+        self.gesture_baseline = None;
     }
 
     pub fn shift_bars(&mut self, added: usize) {
         let delta = added as f32;
-        for drawing in &mut self.items {
-            for point in &mut drawing.points {
-                point.bar += delta;
+        let shift = |items: &mut Vec<Drawing>| {
+            for drawing in items {
+                for point in &mut drawing.points {
+                    point.bar += delta;
+                }
             }
-        }
+        };
+        shift(&mut self.items);
         if let Some(draft) = &mut self.draft {
             for point in &mut draft.points {
                 point.bar += delta;
             }
         }
-    }
-
-    pub fn delete_selected(&mut self) {
-        if let Some(index) = self.selected.take()
-            && index < self.items.len()
-        {
-            self.items.remove(index);
+        // History snapshots hold the same bar-index coordinates, so a prepend
+        // shifts them too — undoing later must not re-anchor objects to bars
+        // that moved underneath them.
+        for entry in self.undo.iter_mut().chain(self.redo.iter_mut()) {
+            shift(&mut entry.items);
+        }
+        if let Some(baseline) = &mut self.gesture_baseline {
+            shift(&mut baseline.items);
         }
     }
 
+    /// One delete command for every trigger (button, manager, keyboard).
+    /// A locked object is never deleted without `force`.
+    pub fn delete_selected(&mut self, force: bool) -> DeleteOutcome {
+        let Some(index) = self.selected.filter(|&index| index < self.items.len()) else {
+            return DeleteOutcome::NothingSelected;
+        };
+        if self.items[index].locked && !force {
+            return DeleteOutcome::NeedsConfirmation;
+        }
+        let before = self.snapshot();
+        self.items.remove(index);
+        self.selected = None;
+        self.record(before);
+        DeleteOutcome::Deleted
+    }
+
+    pub fn set_selected_locked(&mut self, locked: bool) {
+        let before = self.snapshot();
+        if let Some(drawing) = self.selected_mut() {
+            drawing.locked = locked;
+            self.record(before);
+        }
+    }
+
+    pub fn set_selected_hidden(&mut self, hidden: bool) {
+        let before = self.snapshot();
+        if let Some(drawing) = self.selected_mut() {
+            drawing.hidden = hidden;
+            self.record(before);
+        }
+    }
+
+    pub fn set_all_hidden(&mut self, hidden: bool) {
+        let before = self.snapshot();
+        self.all_hidden = hidden;
+        self.record(before);
+    }
+
+    /// Whether every drawing is individually locked (used by the toolbox's
+    /// lock-all toggle). An empty collection is not "all locked".
+    #[must_use]
+    pub fn all_locked(&self) -> bool {
+        !self.items.is_empty() && self.items.iter().all(|item| item.locked)
+    }
+
+    /// Reversible bulk protection: locks (or unlocks) every drawing as one
+    /// undo entry. Never deletes anything.
+    pub fn set_all_locked(&mut self, locked: bool) {
+        let before = self.snapshot();
+        for item in &mut self.items {
+            item.locked = locked;
+        }
+        self.record(before);
+    }
+
+    /// Rigid translation of the selected object. Locked geometry stays put.
     pub fn translate_selected(&mut self, delta_bar: f32, delta_price: f64) {
         let Some(drawing) = self.selected_mut() else {
             return;
         };
+        if drawing.locked {
+            return;
+        }
         for point in &mut drawing.points {
             point.bar += delta_bar;
             point.price += delta_price;
         }
     }
 
+    /// Move one anchor of one object. Locked geometry stays put.
     pub fn move_anchor(
         &mut self,
         drawing_index: usize,
         point_index: usize,
         point: ChartPoint,
     ) -> bool {
-        let Some(anchor) = self
-            .items
-            .get_mut(drawing_index)
-            .and_then(|drawing| drawing.points.get_mut(point_index))
-        else {
+        let Some(drawing) = self.items.get_mut(drawing_index) else {
+            return false;
+        };
+        if drawing.locked {
+            return false;
+        }
+        let Some(anchor) = drawing.points.get_mut(point_index) else {
             return false;
         };
         *anchor = point;
@@ -318,15 +538,8 @@ impl Drawings {
     }
 }
 
-pub(super) fn drawing_stroke(style: DrawingStyle, selected: bool) -> egui::Stroke {
-    egui::Stroke::new(
-        style.width_px,
-        if selected {
-            egui::Color32::WHITE
-        } else {
-            style.color
-        },
-    )
+pub(super) fn drawing_stroke(style: DrawingStyle) -> egui::Stroke {
+    egui::Stroke::new(style.width_px, style.color)
 }
 
 pub(super) fn drawing_fill(style: DrawingStyle) -> egui::Color32 {
@@ -526,10 +739,274 @@ mod tests {
         ));
         assert_eq!(drawings.selected(), Some(0));
 
-        drawings.delete_selected();
+        assert_eq!(drawings.delete_selected(false), DeleteOutcome::Deleted);
 
         assert!(drawings.items().is_empty());
         assert_eq!(drawings.selected(), None);
+    }
+
+    #[test]
+    fn a_locked_drawing_ignores_geometry_edits_until_unlocked() {
+        let mut drawings = Drawings::default();
+        drawings.place(
+            tool("horizontal-line"),
+            ChartPoint {
+                bar: 2.0,
+                price: 100.0,
+            },
+        );
+        drawings.set_selected_locked(true);
+
+        drawings.translate_selected(3.0, 5.0);
+        assert!(!drawings.move_anchor(
+            0,
+            0,
+            ChartPoint {
+                bar: 9.0,
+                price: 50.0,
+            }
+        ));
+        assert_eq!(
+            drawings.items()[0].points[0],
+            ChartPoint {
+                bar: 2.0,
+                price: 100.0,
+            },
+            "locked geometry must not move"
+        );
+
+        drawings.set_selected_locked(false);
+        drawings.translate_selected(3.0, 5.0);
+        assert_eq!(
+            drawings.items()[0].points[0],
+            ChartPoint {
+                bar: 5.0,
+                price: 105.0,
+            }
+        );
+    }
+
+    #[test]
+    fn deleting_a_locked_drawing_requires_explicit_force() {
+        let mut drawings = Drawings::default();
+        drawings.place(
+            tool("horizontal-line"),
+            ChartPoint {
+                bar: 1.0,
+                price: 100.0,
+            },
+        );
+        drawings.set_selected_locked(true);
+
+        assert_eq!(
+            drawings.delete_selected(false),
+            DeleteOutcome::NeedsConfirmation
+        );
+        assert_eq!(drawings.items().len(), 1, "unforced delete must not land");
+
+        assert_eq!(drawings.delete_selected(true), DeleteOutcome::Deleted);
+        assert!(drawings.items().is_empty());
+
+        assert!(drawings.undo(), "a forced delete is still undoable");
+        assert_eq!(drawings.items().len(), 1);
+        assert!(drawings.items()[0].locked, "undo restores the lock too");
+    }
+
+    #[test]
+    fn creating_dragging_and_deleting_are_one_undo_entry_each() {
+        let mut drawings = Drawings::default();
+        let rectangle = tool("rectangle");
+        // Creation: two anchors, one entry.
+        drawings.place(
+            rectangle,
+            ChartPoint {
+                bar: 1.0,
+                price: 100.0,
+            },
+        );
+        drawings.place(
+            rectangle,
+            ChartPoint {
+                bar: 3.0,
+                price: 110.0,
+            },
+        );
+        assert_eq!(drawings.undo_depth(), 1);
+
+        // One drag over many frames: one entry.
+        drawings.begin_gesture();
+        for _ in 0..5 {
+            drawings.translate_selected(0.5, 1.0);
+        }
+        drawings.commit_gesture();
+        assert_eq!(drawings.undo_depth(), 2);
+
+        // A gesture that changes nothing records nothing.
+        drawings.begin_gesture();
+        drawings.commit_gesture();
+        assert_eq!(drawings.undo_depth(), 2);
+
+        drawings.delete_selected(false);
+        assert_eq!(drawings.undo_depth(), 3);
+
+        assert!(drawings.undo(), "undo the delete");
+        assert_eq!(drawings.items().len(), 1);
+        assert!(drawings.undo(), "undo the drag");
+        assert_eq!(
+            drawings.items()[0].points[0],
+            ChartPoint {
+                bar: 1.0,
+                price: 100.0,
+            }
+        );
+        assert!(drawings.undo(), "undo the creation");
+        assert!(drawings.items().is_empty());
+        assert!(!drawings.undo(), "history is exhausted");
+    }
+
+    #[test]
+    fn redo_replays_an_undone_edit_until_a_new_command_clears_it() {
+        let mut drawings = Drawings::default();
+        drawings.place(
+            tool("horizontal-line"),
+            ChartPoint {
+                bar: 1.0,
+                price: 100.0,
+            },
+        );
+        drawings.undo();
+        assert!(drawings.items().is_empty());
+        assert!(drawings.redo());
+        assert_eq!(drawings.items().len(), 1);
+
+        drawings.undo();
+        drawings.place(
+            tool("horizontal-line"),
+            ChartPoint {
+                bar: 4.0,
+                price: 90.0,
+            },
+        );
+        assert!(!drawings.redo(), "a new command clears the redo stack");
+    }
+
+    #[test]
+    fn hide_all_is_a_layer_over_each_drawings_own_eye() {
+        let mut drawings = Drawings::default();
+        for price in [100.0, 105.0] {
+            drawings.place(tool("horizontal-line"), ChartPoint { bar: 1.0, price });
+        }
+        drawings.select(Some(0));
+        drawings.set_selected_hidden(true);
+        assert!(!drawings.is_visible(0));
+        assert!(drawings.is_visible(1));
+
+        drawings.set_all_hidden(true);
+        assert!(!drawings.is_visible(0));
+        assert!(!drawings.is_visible(1));
+
+        drawings.set_all_hidden(false);
+        assert!(
+            !drawings.is_visible(0),
+            "show-all must preserve the individual eye"
+        );
+        assert!(drawings.is_visible(1));
+
+        drawings.select(Some(0));
+        drawings.set_selected_hidden(false);
+        assert!(drawings.is_visible(0));
+    }
+
+    #[test]
+    fn lock_all_is_one_reversible_undo_entry_and_never_deletes() {
+        let mut drawings = Drawings::default();
+        for price in [100.0, 105.0] {
+            drawings.place(tool("horizontal-line"), ChartPoint { bar: 1.0, price });
+        }
+        let depth_before = drawings.undo_depth();
+
+        drawings.set_all_locked(true);
+        assert!(drawings.all_locked());
+        assert_eq!(drawings.items().len(), 2);
+        assert_eq!(drawings.undo_depth(), depth_before + 1);
+
+        assert!(drawings.undo());
+        assert!(!drawings.all_locked(), "undo releases the bulk lock");
+        assert_eq!(drawings.items().len(), 2);
+    }
+
+    #[test]
+    fn undo_snapshots_shift_with_prepended_history() {
+        let mut drawings = Drawings::default();
+        drawings.place(
+            tool("horizontal-line"),
+            ChartPoint {
+                bar: 2.0,
+                price: 100.0,
+            },
+        );
+        drawings.begin_gesture();
+        drawings.translate_selected(1.0, 0.0);
+        drawings.commit_gesture();
+
+        drawings.shift_bars(3);
+        assert_eq!(drawings.items()[0].points[0].bar, 6.0);
+
+        drawings.undo();
+        assert_eq!(
+            drawings.items()[0].points[0].bar,
+            5.0,
+            "the undone position must sit on the shifted bars, not the stale ones"
+        );
+    }
+
+    #[test]
+    fn selection_preserves_the_drawing_color_and_adds_white_handles() {
+        let chart = egui::Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(500.0, 300.0));
+        let color = egui::Color32::from_rgb(0xFF, 0x9F, 0x43);
+        let style = DrawingStyle {
+            color,
+            ..DrawingStyle::default()
+        };
+        let line = tool("horizontal-line");
+        let ctx = egui::Context::default();
+        let input = egui::RawInput {
+            screen_rect: Some(chart),
+            ..Default::default()
+        };
+        let output = ctx.run(input, |ctx| {
+            let painter = ctx.layer_painter(egui::LayerId::new(
+                egui::Order::Foreground,
+                egui::Id::new("selection-test"),
+            ));
+            line.paint(
+                &painter,
+                chart,
+                style,
+                &[egui::pos2(100.0, 120.0)],
+                true,
+                true,
+            );
+        });
+
+        let mut kept_color = false;
+        let mut white_handle = false;
+        for clipped in &output.shapes {
+            match &clipped.shape {
+                egui::Shape::LineSegment { stroke, .. } => {
+                    kept_color |= stroke.color == egui::epaint::ColorMode::Solid(color);
+                }
+                egui::Shape::Circle(circle) => {
+                    white_handle |= circle.fill == SELECTED_ANCHOR_FILL;
+                }
+                _ => {}
+            }
+        }
+        assert!(
+            kept_color,
+            "selection must keep painting the configured colour"
+        );
+        assert!(white_handle, "selection must add white anchor handles");
     }
 
     #[test]
@@ -608,7 +1085,14 @@ mod tests {
                     egui::Order::Foreground,
                     egui::Id::new(drawing_tool.id()),
                 ));
-                drawing_tool.paint(&painter, chart, DrawingStyle::default(), &points, false);
+                drawing_tool.paint(
+                    &painter,
+                    chart,
+                    DrawingStyle::default(),
+                    &points,
+                    false,
+                    false,
+                );
             });
             assert!(
                 !output.shapes.is_empty(),

--- a/crates/app/src/drawings/mod.rs
+++ b/crates/app/src/drawings/mod.rs
@@ -142,10 +142,21 @@ pub struct DrawContext<'a> {
     pub payload: &'a dyn DrawingPayload,
     pub anchors: &'a [ChartPoint],
     pub scale: &'a PriceScale,
+    /// The object's own style — hit-testing reads it too (an invisible fill
+    /// takes no part in the interior hit-test).
+    pub style: DrawingStyle,
     pub selected: bool,
     /// True while the wrapper paints the selection halo pass: tools draw
     /// only their stroke geometry then — no fills, no labels.
     pub halo: bool,
+}
+
+/// A tool's arming shortcut, declared by the tool itself so the keyboard
+/// map never becomes a central match.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ToolShortcut {
+    pub key: egui::Key,
+    pub shift: bool,
 }
 
 /// The implementation port every drawing plugs into. Selection visuals (halo
@@ -161,6 +172,10 @@ trait DrawingToolImpl: Sync {
     fn icon(&self) -> &'static str;
     fn hover_text(&self) -> &'static str;
     fn required_points(&self) -> usize;
+    /// The key that arms this tool from the chart, if it has one.
+    fn shortcut(&self) -> Option<ToolShortcut> {
+        None
+    }
     /// Whether the tool paints an interior that the fill controls affect.
     fn supports_fill(&self) -> bool {
         false
@@ -231,6 +246,11 @@ impl DrawingTool {
     #[must_use]
     pub fn default_payload(self) -> Box<dyn DrawingPayload> {
         self.0.default_payload()
+    }
+
+    #[must_use]
+    pub fn shortcut(self) -> Option<ToolShortcut> {
+        self.0.shortcut()
     }
 
     #[must_use]
@@ -595,6 +615,34 @@ impl Drawings {
 
     pub fn cancel_draft(&mut self) {
         self.draft = None;
+    }
+
+    /// Backspace during placement: drop the last placed anchor; dropping the
+    /// only one cancels the draft.
+    pub fn remove_last_draft_anchor(&mut self) {
+        if let Some(draft) = &mut self.draft {
+            draft.points.pop();
+            if draft.points.is_empty() {
+                self.draft = None;
+            }
+        }
+    }
+
+    /// Duplicate the selected object as one undo entry: the copy lands
+    /// `offset_bars` to the right, unlocked, and becomes the selection.
+    pub fn duplicate_selected(&mut self, offset_bars: f32) {
+        let Some(index) = self.selected.filter(|&index| index < self.items.len()) else {
+            return;
+        };
+        let before = self.snapshot();
+        let mut copy = self.items[index].clone();
+        for point in &mut copy.points {
+            point.bar += offset_bars;
+        }
+        copy.locked = false;
+        self.items.push(copy);
+        self.selected = Some(self.items.len() - 1);
+        self.record(before);
     }
 
     /// Honest reset: the anchors cannot survive a source or bar-spec change,
@@ -1094,6 +1142,89 @@ mod tests {
     }
 
     #[test]
+    fn duplicate_lands_offset_unlocked_and_selected_as_one_entry() {
+        let mut drawings = Drawings::default();
+        drawings.place(
+            tool("horizontal-line"),
+            ChartPoint {
+                bar: 4.0,
+                price: 100.0,
+            },
+        );
+        drawings.set_selected_locked(true);
+        let depth = drawings.undo_depth();
+
+        drawings.duplicate_selected(2.0);
+
+        assert_eq!(drawings.items().len(), 2);
+        assert_eq!(drawings.selected(), Some(1), "the copy becomes selected");
+        assert_eq!(drawings.items()[1].points[0].bar, 6.0, "the copy is offset");
+        assert!(
+            !drawings.items()[1].locked,
+            "a copy starts unlocked even when the source was locked"
+        );
+        assert_eq!(drawings.undo_depth(), depth + 1);
+        drawings.undo();
+        assert_eq!(drawings.items().len(), 1);
+    }
+
+    #[test]
+    fn backspace_steps_back_one_draft_anchor_at_a_time() {
+        let mut drawings = Drawings::default();
+        let channel = tool("parallel-channel");
+        for bar in [1.0, 2.0] {
+            drawings.place(channel, ChartPoint { bar, price: 1.0 });
+        }
+        assert_eq!(drawings.draft_len(), 2);
+
+        drawings.remove_last_draft_anchor();
+        assert_eq!(drawings.draft_len(), 1);
+        drawings.remove_last_draft_anchor();
+        assert!(
+            drawings.draft().is_none(),
+            "dropping the only anchor cancels the draft"
+        );
+    }
+
+    #[test]
+    fn rectangle_interior_hit_tests_only_while_the_fill_is_visible() {
+        let chart = egui::Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(500.0, 300.0));
+        let rectangle = tool("rectangle");
+        let scale = PriceScale::from_range(0.0, 300.0, 0.0, 300.0);
+        let payload = rectangle.default_payload();
+        let points = [egui::pos2(100.0, 100.0), egui::pos2(200.0, 200.0)];
+        let anchors = anchors_for(&points, &scale);
+        let center = egui::pos2(150.0, 150.0);
+        let border = egui::pos2(100.0, 150.0);
+
+        let filled = DrawContext {
+            payload: payload.as_ref(),
+            anchors: &anchors,
+            scale: &scale,
+            style: DrawingStyle::default(),
+            selected: false,
+            halo: false,
+        };
+        assert!(rectangle.hit_test(chart, &points, center, 5.0, &filled));
+
+        let outline_only = DrawContext {
+            style: DrawingStyle {
+                fill_alpha: 0,
+                ..DrawingStyle::default()
+            },
+            ..filled
+        };
+        assert!(
+            !rectangle.hit_test(chart, &points, center, 5.0, &outline_only),
+            "with no visible fill the interior belongs to the chart"
+        );
+        assert!(
+            rectangle.hit_test(chart, &points, border, 5.0, &outline_only),
+            "the border stays selectable without a fill"
+        );
+    }
+
+    #[test]
     fn lock_all_is_one_reversible_undo_entry_and_never_deletes() {
         let mut drawings = Drawings::default();
         for price in [100.0, 105.0] {
@@ -1165,6 +1296,7 @@ mod tests {
                 payload: payload.as_ref(),
                 anchors: &anchors,
                 scale: &scale,
+                style,
                 selected: true,
                 halo: false,
             };
@@ -1266,6 +1398,7 @@ mod tests {
             payload: payload.as_ref(),
             anchors: &anchors,
             scale: &scale,
+            style: DrawingStyle::default(),
             selected: false,
             halo: false,
         };
@@ -1285,6 +1418,7 @@ mod tests {
                 payload: payload.as_ref(),
                 anchors: &anchors,
                 scale: &scale,
+                style: DrawingStyle::default(),
                 selected: false,
                 halo: false,
             };

--- a/crates/app/src/drawings/mod.rs
+++ b/crates/app/src/drawings/mod.rs
@@ -1,0 +1,620 @@
+//! Modular user-authored chart drawings.
+//!
+//! Each drawing tool implements [`DrawingToolImpl`] in its own file. The
+//! registry macro is the only docking point: add a module name there and the
+//! toolbox, placement state, renderer and hit-testing all see the new tool.
+//! Market data remains immutable and the deterministic engine never learns
+//! about UI marks.
+
+use std::fmt;
+
+use eframe::egui;
+
+pub const DEFAULT_DRAWING_COLOR: egui::Color32 = egui::Color32::from_rgb(138, 180, 248);
+pub const DEFAULT_DRAWING_WIDTH_PX: f32 = 1.5;
+pub const DEFAULT_DRAWING_FILL_ALPHA: u8 = 24;
+pub const MIN_DRAWING_WIDTH_PX: f32 = 0.5;
+pub const MAX_DRAWING_WIDTH_PX: f32 = 6.0;
+pub const MAX_DRAWING_FILL_ALPHA: u8 = 160;
+const SELECTED_ANCHOR_RADIUS_PX: f32 = 4.0;
+const SELECTED_ANCHOR_FILL: egui::Color32 = egui::Color32::WHITE;
+pub(super) const FIB_LABEL_OFFSET_PX: f32 = 3.0;
+pub(super) const FIB_LABEL_SIZE_PX: f32 = 10.0;
+
+pub(super) struct FibGeometry {
+    pub left: f32,
+    pub right: f32,
+    pub first_y: f32,
+    pub second_y: f32,
+    pub origin_y: f32,
+}
+
+#[derive(Clone, Copy)]
+pub(super) struct FibLevel {
+    ratio: f64,
+    label: &'static str,
+}
+
+impl FibLevel {
+    pub(super) const fn new(ratio: f64, label: &'static str) -> Self {
+        Self { ratio, label }
+    }
+}
+
+/// The implementation port every drawing plugs into.
+trait DrawingToolImpl: Sync {
+    fn id(&self) -> &'static str;
+    fn settings_title(&self) -> &'static str;
+    fn icon(&self) -> &'static str;
+    fn hover_text(&self) -> &'static str;
+    fn required_points(&self) -> usize;
+    fn paint(
+        &self,
+        painter: &egui::Painter,
+        chart_rect: egui::Rect,
+        style: DrawingStyle,
+        points: &[egui::Pos2],
+        selected: bool,
+    );
+    fn hit_test(
+        &self,
+        chart_rect: egui::Rect,
+        points: &[egui::Pos2],
+        position: egui::Pos2,
+        radius_px: f32,
+    ) -> bool;
+    #[cfg(test)]
+    fn test_geometry(&self) -> (Vec<egui::Pos2>, egui::Pos2);
+}
+
+/// A cheap, copyable reference to one registered implementation.
+#[derive(Clone, Copy)]
+pub struct DrawingTool(&'static dyn DrawingToolImpl);
+
+impl DrawingTool {
+    #[must_use]
+    pub fn id(self) -> &'static str {
+        self.0.id()
+    }
+
+    #[must_use]
+    pub fn settings_title(self) -> &'static str {
+        self.0.settings_title()
+    }
+
+    #[must_use]
+    pub fn icon(self) -> &'static str {
+        self.0.icon()
+    }
+
+    #[must_use]
+    pub fn hover_text(self) -> &'static str {
+        self.0.hover_text()
+    }
+
+    #[must_use]
+    pub fn required_points(self) -> usize {
+        self.0.required_points()
+    }
+
+    pub fn paint(
+        self,
+        painter: &egui::Painter,
+        chart_rect: egui::Rect,
+        style: DrawingStyle,
+        points: &[egui::Pos2],
+        selected: bool,
+    ) {
+        self.0.paint(painter, chart_rect, style, points, selected);
+        if selected {
+            let stroke = drawing_stroke(style, true);
+            for point in points {
+                painter.circle_filled(*point, SELECTED_ANCHOR_RADIUS_PX, SELECTED_ANCHOR_FILL);
+                painter.circle_stroke(*point, SELECTED_ANCHOR_RADIUS_PX, stroke);
+            }
+        }
+    }
+
+    #[must_use]
+    pub fn hit_test(
+        self,
+        chart_rect: egui::Rect,
+        points: &[egui::Pos2],
+        position: egui::Pos2,
+        radius_px: f32,
+    ) -> bool {
+        points
+            .iter()
+            .any(|point| point.distance_sq(position) <= radius_px * radius_px)
+            || self.0.hit_test(chart_rect, points, position, radius_px)
+    }
+
+    #[cfg(test)]
+    fn test_geometry(self) -> (Vec<egui::Pos2>, egui::Pos2) {
+        self.0.test_geometry()
+    }
+}
+
+impl PartialEq for DrawingTool {
+    fn eq(&self, other: &Self) -> bool {
+        self.id() == other.id()
+    }
+}
+
+impl Eq for DrawingTool {}
+
+impl fmt::Debug for DrawingTool {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_tuple("DrawingTool")
+            .field(&self.id())
+            .finish()
+    }
+}
+
+macro_rules! register_drawing_tools {
+    ($($module:ident),+ $(,)?) => {
+        $(mod $module;)+
+        pub const DRAWING_TOOLS: [DrawingTool; [$(stringify!($module)),+].len()] = [
+            $(DrawingTool(&$module::TOOL)),+
+        ];
+    };
+}
+
+// The extension port: a new tool is one implementation file plus one name here.
+register_drawing_tools!(
+    horizontal_line,
+    rectangle,
+    parallel_channel,
+    fib_retracement,
+    fib_extension,
+);
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ChartPoint {
+    pub bar: f32,
+    pub price: f64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct DrawingStyle {
+    pub color: egui::Color32,
+    pub width_px: f32,
+    pub fill_alpha: u8,
+}
+
+impl Default for DrawingStyle {
+    fn default() -> Self {
+        Self {
+            color: DEFAULT_DRAWING_COLOR,
+            width_px: DEFAULT_DRAWING_WIDTH_PX,
+            fill_alpha: DEFAULT_DRAWING_FILL_ALPHA,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Drawing {
+    pub tool: DrawingTool,
+    pub points: Vec<ChartPoint>,
+    pub style: DrawingStyle,
+}
+
+#[derive(Debug, Default)]
+pub struct Drawings {
+    items: Vec<Drawing>,
+    draft: Option<Drawing>,
+    selected: Option<usize>,
+}
+
+impl Drawings {
+    #[must_use]
+    pub fn items(&self) -> &[Drawing] {
+        &self.items
+    }
+
+    #[must_use]
+    pub fn selected(&self) -> Option<usize> {
+        self.selected
+    }
+
+    pub fn select(&mut self, selected: Option<usize>) {
+        self.selected = selected.filter(|&index| index < self.items.len());
+    }
+
+    #[must_use]
+    pub fn selected_mut(&mut self) -> Option<&mut Drawing> {
+        self.selected.and_then(|index| self.items.get_mut(index))
+    }
+
+    #[must_use]
+    pub fn draft(&self) -> Option<&Drawing> {
+        self.draft.as_ref()
+    }
+
+    #[must_use]
+    pub fn draft_len(&self) -> usize {
+        self.draft.as_ref().map_or(0, |draft| draft.points.len())
+    }
+
+    /// Add a placement anchor. `true` means the object became complete.
+    pub fn place(&mut self, tool: DrawingTool, point: ChartPoint) -> bool {
+        if self.draft.as_ref().is_none_or(|draft| draft.tool != tool) {
+            self.draft = Some(Drawing {
+                tool,
+                points: Vec::with_capacity(tool.required_points()),
+                style: DrawingStyle::default(),
+            });
+        }
+        let draft = self.draft.as_mut().expect("draft was installed above");
+        draft.points.push(point);
+        if draft.points.len() == tool.required_points() {
+            self.items
+                .push(self.draft.take().expect("draft has points"));
+            self.selected = Some(self.items.len() - 1);
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn cancel_draft(&mut self) {
+        self.draft = None;
+    }
+
+    pub fn clear(&mut self) {
+        self.items.clear();
+        self.draft = None;
+        self.selected = None;
+    }
+
+    pub fn shift_bars(&mut self, added: usize) {
+        let delta = added as f32;
+        for drawing in &mut self.items {
+            for point in &mut drawing.points {
+                point.bar += delta;
+            }
+        }
+        if let Some(draft) = &mut self.draft {
+            for point in &mut draft.points {
+                point.bar += delta;
+            }
+        }
+    }
+
+    pub fn delete_selected(&mut self) {
+        if let Some(index) = self.selected.take()
+            && index < self.items.len()
+        {
+            self.items.remove(index);
+        }
+    }
+
+    pub fn translate_selected(&mut self, delta_bar: f32, delta_price: f64) {
+        let Some(drawing) = self.selected_mut() else {
+            return;
+        };
+        for point in &mut drawing.points {
+            point.bar += delta_bar;
+            point.price += delta_price;
+        }
+    }
+
+    pub fn move_anchor(
+        &mut self,
+        drawing_index: usize,
+        point_index: usize,
+        point: ChartPoint,
+    ) -> bool {
+        let Some(anchor) = self
+            .items
+            .get_mut(drawing_index)
+            .and_then(|drawing| drawing.points.get_mut(point_index))
+        else {
+            return false;
+        };
+        *anchor = point;
+        true
+    }
+}
+
+pub(super) fn drawing_stroke(style: DrawingStyle, selected: bool) -> egui::Stroke {
+    egui::Stroke::new(
+        style.width_px,
+        if selected {
+            egui::Color32::WHITE
+        } else {
+            style.color
+        },
+    )
+}
+
+pub(super) fn drawing_fill(style: DrawingStyle) -> egui::Color32 {
+    egui::Color32::from_rgba_unmultiplied(
+        style.color.r(),
+        style.color.g(),
+        style.color.b(),
+        style.fill_alpha,
+    )
+}
+
+pub(super) fn distance_to_segment(position: egui::Pos2, start: egui::Pos2, end: egui::Pos2) -> f32 {
+    let segment = end - start;
+    let length_sq = segment.length_sq();
+    if length_sq <= f32::EPSILON {
+        return position.distance(start);
+    }
+    let projection = ((position - start).dot(segment) / length_sq).clamp(0.0, 1.0);
+    position.distance(start + segment * projection)
+}
+
+pub(super) fn paint_fib_levels(
+    painter: &egui::Painter,
+    geometry: FibGeometry,
+    levels: &[FibLevel],
+    stroke: egui::Stroke,
+    color: egui::Color32,
+) {
+    for level in levels {
+        let y = geometry.origin_y + (geometry.second_y - geometry.first_y) * level.ratio as f32;
+        painter.line_segment(
+            [egui::pos2(geometry.left, y), egui::pos2(geometry.right, y)],
+            stroke,
+        );
+        painter.text(
+            egui::pos2(geometry.left + FIB_LABEL_OFFSET_PX, y),
+            egui::Align2::LEFT_BOTTOM,
+            level.label,
+            egui::FontId::monospace(FIB_LABEL_SIZE_PX),
+            color,
+        );
+    }
+}
+
+pub(super) fn hit_fib_levels(
+    position: egui::Pos2,
+    points: &[egui::Pos2],
+    levels: &[FibLevel],
+    origin_y: f32,
+    radius_px: f32,
+) -> bool {
+    let left = points
+        .iter()
+        .map(|point| point.x)
+        .fold(f32::INFINITY, f32::min);
+    let right = points
+        .iter()
+        .map(|point| point.x)
+        .fold(f32::NEG_INFINITY, f32::max);
+    position.x >= left - radius_px
+        && position.x <= right + radius_px
+        && levels.iter().any(|level| {
+            let y = origin_y + (points[1].y - points[0].y) * level.ratio as f32;
+            (position.y - y).abs() <= radius_px
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tool(id: &str) -> DrawingTool {
+        DRAWING_TOOLS
+            .into_iter()
+            .find(|tool| tool.id() == id)
+            .expect("registered test tool")
+    }
+
+    #[test]
+    fn every_registered_tool_has_metadata_and_a_valid_point_count() {
+        let mut ids = Vec::with_capacity(DRAWING_TOOLS.len());
+        for tool in DRAWING_TOOLS {
+            assert!(!tool.id().is_empty());
+            assert!(!ids.contains(&tool.id()), "duplicate tool id {}", tool.id());
+            ids.push(tool.id());
+            assert!(!tool.icon().is_empty());
+            assert!(!tool.settings_title().is_empty());
+            assert!(!tool.hover_text().is_empty());
+            assert!(tool.required_points() > 0);
+        }
+    }
+
+    #[test]
+    fn horizontal_line_completes_with_one_point() {
+        let mut drawings = Drawings::default();
+        assert!(drawings.place(
+            tool("horizontal-line"),
+            ChartPoint {
+                bar: 3.0,
+                price: 100.0
+            }
+        ));
+    }
+
+    #[test]
+    fn channel_needs_three_points() {
+        let mut drawings = Drawings::default();
+        let channel = tool("parallel-channel");
+        for bar in [1.0, 2.0] {
+            assert!(!drawings.place(channel, ChartPoint { bar, price: 1.0 }));
+        }
+        assert!(drawings.place(
+            channel,
+            ChartPoint {
+                bar: 3.0,
+                price: 1.0
+            }
+        ));
+    }
+
+    #[test]
+    fn moving_a_selected_drawing_preserves_its_shape() {
+        let mut drawings = Drawings::default();
+        let rectangle = tool("rectangle");
+        drawings.place(
+            rectangle,
+            ChartPoint {
+                bar: 1.0,
+                price: 100.0,
+            },
+        );
+        drawings.place(
+            rectangle,
+            ChartPoint {
+                bar: 3.0,
+                price: 110.0,
+            },
+        );
+        drawings.translate_selected(2.0, -5.0);
+        assert_eq!(
+            drawings.items()[0].points,
+            [
+                ChartPoint {
+                    bar: 3.0,
+                    price: 95.0
+                },
+                ChartPoint {
+                    bar: 5.0,
+                    price: 105.0
+                }
+            ]
+        );
+    }
+
+    #[test]
+    fn moving_one_anchor_does_not_move_the_other_points() {
+        let mut drawings = Drawings::default();
+        let rectangle = tool("rectangle");
+        drawings.place(
+            rectangle,
+            ChartPoint {
+                bar: 1.0,
+                price: 100.0,
+            },
+        );
+        drawings.place(
+            rectangle,
+            ChartPoint {
+                bar: 3.0,
+                price: 110.0,
+            },
+        );
+        let opposite = drawings.items()[0].points[1];
+        let replacement = ChartPoint {
+            bar: 0.5,
+            price: 95.0,
+        };
+
+        assert!(drawings.move_anchor(0, 0, replacement));
+
+        assert_eq!(drawings.items()[0].points[0], replacement);
+        assert_eq!(drawings.items()[0].points[1], opposite);
+        assert!(!drawings.move_anchor(5, 0, replacement));
+        assert!(!drawings.move_anchor(0, 5, replacement));
+    }
+
+    #[test]
+    fn deleting_the_selected_drawing_clears_both_object_and_selection() {
+        let mut drawings = Drawings::default();
+        let line = tool("horizontal-line");
+        assert!(drawings.place(
+            line,
+            ChartPoint {
+                bar: 1.0,
+                price: 100.0,
+            }
+        ));
+        assert_eq!(drawings.selected(), Some(0));
+
+        drawings.delete_selected();
+
+        assert!(drawings.items().is_empty());
+        assert_eq!(drawings.selected(), None);
+    }
+
+    #[test]
+    fn clearing_drawings_also_discards_an_unfinished_draft() {
+        let mut drawings = Drawings::default();
+        assert!(!drawings.place(
+            tool("rectangle"),
+            ChartPoint {
+                bar: 1.0,
+                price: 100.0,
+            }
+        ));
+        drawings.clear();
+        assert!(drawings.items().is_empty());
+        assert!(drawings.draft().is_none());
+        assert_eq!(drawings.selected(), None);
+    }
+
+    #[test]
+    fn prepending_history_shifts_completed_and_draft_bar_anchors() {
+        let mut drawings = Drawings::default();
+        drawings.place(
+            tool("horizontal-line"),
+            ChartPoint {
+                bar: 2.5,
+                price: 100.0,
+            },
+        );
+        drawings.place(
+            tool("rectangle"),
+            ChartPoint {
+                bar: 4.0,
+                price: 101.0,
+            },
+        );
+
+        drawings.shift_bars(3);
+
+        assert_eq!(drawings.items()[0].points[0].bar, 5.5);
+        assert_eq!(
+            drawings.draft().expect("rectangle draft").points[0].bar,
+            7.0
+        );
+    }
+
+    #[test]
+    fn horizontal_line_is_selectable_from_anywhere_on_its_stroke() {
+        let chart = egui::Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(500.0, 300.0));
+        assert!(tool("horizontal-line").hit_test(
+            chart,
+            &[egui::pos2(100.0, 120.0)],
+            egui::pos2(450.0, 123.0),
+            5.0
+        ));
+    }
+
+    #[test]
+    fn every_registered_tool_paints_and_hits_its_finished_geometry() {
+        let chart = egui::Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(500.0, 300.0));
+        for drawing_tool in DRAWING_TOOLS {
+            let (points, hit) = drawing_tool.test_geometry();
+            assert_eq!(points.len(), drawing_tool.required_points());
+            assert!(
+                drawing_tool.hit_test(chart, &points, hit, 5.0),
+                "{} cannot be selected from its visible geometry",
+                drawing_tool.id()
+            );
+
+            let ctx = egui::Context::default();
+            let input = egui::RawInput {
+                screen_rect: Some(chart),
+                ..Default::default()
+            };
+            let output = ctx.run(input, |ctx| {
+                let painter = ctx.layer_painter(egui::LayerId::new(
+                    egui::Order::Foreground,
+                    egui::Id::new(drawing_tool.id()),
+                ));
+                drawing_tool.paint(&painter, chart, DrawingStyle::default(), &points, false);
+            });
+            assert!(
+                !output.shapes.is_empty(),
+                "{} rendered no geometry",
+                drawing_tool.id()
+            );
+        }
+    }
+}

--- a/crates/app/src/drawings/mod.rs
+++ b/crates/app/src/drawings/mod.rs
@@ -7,11 +7,15 @@
 //! about UI marks.
 
 pub mod action_bar;
+pub mod fib;
+pub mod presets;
 
+use std::any::Any;
 use std::fmt;
 
 use eframe::egui;
 
+use crate::chart::PriceScale;
 use crate::theme;
 
 pub const DEFAULT_DRAWING_COLOR: egui::Color32 = egui::Color32::from_rgb(138, 180, 248);
@@ -36,24 +40,112 @@ const SELECTION_HALO_EXTRA_WIDTH_PX: f32 = 3.5;
 pub(super) const FIB_LABEL_OFFSET_PX: f32 = 3.0;
 pub(super) const FIB_LABEL_SIZE_PX: f32 = 10.0;
 
-pub(super) struct FibGeometry {
-    pub left: f32,
-    pub right: f32,
-    pub first_y: f32,
-    pub second_y: f32,
-    pub origin_y: f32,
-}
-
-#[derive(Clone, Copy)]
-pub(super) struct FibLevel {
-    ratio: f64,
-    label: &'static str,
-}
-
-impl FibLevel {
-    pub(super) const fn new(ratio: f64, label: &'static str) -> Self {
-        Self { ratio, label }
+/// Tool-owned state beyond anchors and common style. A property unique to
+/// one tool lives in that tool's payload, never in the shared envelope, so
+/// the next tool cannot force the model or the central inspector open.
+pub trait DrawingPayload: fmt::Debug {
+    fn clone_box(&self) -> Box<dyn DrawingPayload>;
+    fn eq_dyn(&self, other: &dyn DrawingPayload) -> bool;
+    fn as_any(&self) -> &dyn Any;
+    fn as_any_mut(&mut self) -> &mut dyn Any;
+    /// Serialize the payload for a named preset. Coordinates, lock and
+    /// visibility never travel with a preset, only the tool-owned config.
+    fn export_preset(&self) -> Option<toml::Value> {
+        None
     }
+    /// Apply a previously exported preset. `false` leaves the payload alone.
+    fn import_preset(&mut self, _value: &toml::Value) -> bool {
+        false
+    }
+}
+
+impl Clone for Box<dyn DrawingPayload> {
+    fn clone(&self) -> Self {
+        self.clone_box()
+    }
+}
+
+/// Payload of tools whose whole state is anchors + common style.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct NoPayload;
+
+impl DrawingPayload for NoPayload {
+    fn clone_box(&self) -> Box<dyn DrawingPayload> {
+        Box::new(Self)
+    }
+    fn eq_dyn(&self, other: &dyn DrawingPayload) -> bool {
+        other.as_any().downcast_ref::<Self>().is_some()
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+/// Named-preset storage a tool's inspector tab can talk to without knowing
+/// where presets live. Presets carry an opaque payload export; the host
+/// stores them per tool id, versioned, surviving restarts.
+pub trait PresetHost {
+    fn custom_preset_names(&self, tool_id: &str) -> Vec<String>;
+    fn load_custom_preset(&self, tool_id: &str, name: &str) -> Option<toml::Value>;
+    /// `false` means the name exists and `overwrite` was not set — the
+    /// caller asks the user before trying again.
+    fn save_custom_preset(
+        &mut self,
+        tool_id: &str,
+        name: &str,
+        value: toml::Value,
+        overwrite: bool,
+    ) -> bool;
+    fn delete_custom_preset(&mut self, tool_id: &str, name: &str);
+    fn default_preset(&self, tool_id: &str) -> Option<String>;
+    fn set_default_preset(&mut self, tool_id: &str, name: Option<String>);
+}
+
+/// A host with no storage: custom presets are absent, saving reports success
+/// and drops the value. For contexts without a store (tests, previews).
+#[cfg(test)]
+#[derive(Debug, Default)]
+pub struct NullPresetHost;
+
+#[cfg(test)]
+impl PresetHost for NullPresetHost {
+    fn custom_preset_names(&self, _tool_id: &str) -> Vec<String> {
+        Vec::new()
+    }
+    fn load_custom_preset(&self, _tool_id: &str, _name: &str) -> Option<toml::Value> {
+        None
+    }
+    fn save_custom_preset(
+        &mut self,
+        _tool_id: &str,
+        _name: &str,
+        _value: toml::Value,
+        _overwrite: bool,
+    ) -> bool {
+        true
+    }
+    fn delete_custom_preset(&mut self, _tool_id: &str, _name: &str) {}
+    fn default_preset(&self, _tool_id: &str) -> Option<String> {
+        None
+    }
+    fn set_default_preset(&mut self, _tool_id: &str, _name: Option<String>) {}
+}
+
+/// Everything a tool may need beyond raw screen anchors when painting or
+/// hit-testing: its own payload, the chart-space anchors and the price scale
+/// that projected them (log-scaled tools compute prices, then project).
+#[derive(Clone, Copy)]
+pub struct DrawContext<'a> {
+    pub payload: &'a dyn DrawingPayload,
+    pub anchors: &'a [ChartPoint],
+    pub scale: &'a PriceScale,
+    pub selected: bool,
+    /// True while the wrapper paints the selection halo pass: tools draw
+    /// only their stroke geometry then — no fills, no labels.
+    pub halo: bool,
 }
 
 /// The implementation port every drawing plugs into. Selection visuals (halo
@@ -73,12 +165,31 @@ trait DrawingToolImpl: Sync {
     fn supports_fill(&self) -> bool {
         false
     }
+    /// Fresh tool-owned state for a newly placed object.
+    fn default_payload(&self) -> Box<dyn DrawingPayload> {
+        Box::new(NoPayload)
+    }
+    /// Title of the tool-owned inspector tab, if the tool brings one.
+    fn extra_tab(&self) -> Option<&'static str> {
+        None
+    }
+    /// Draw the tool-owned inspector tab. Returns whether anything was
+    /// edited (the caller folds it into the shared undo coalescing).
+    fn draw_extra_tab(
+        &self,
+        _ui: &mut egui::Ui,
+        _drawing: &mut Drawing,
+        _host: &mut dyn PresetHost,
+    ) -> bool {
+        false
+    }
     fn paint(
         &self,
         painter: &egui::Painter,
         chart_rect: egui::Rect,
         style: DrawingStyle,
         points: &[egui::Pos2],
+        ctxt: &DrawContext<'_>,
     );
     fn hit_test(
         &self,
@@ -86,6 +197,7 @@ trait DrawingToolImpl: Sync {
         points: &[egui::Pos2],
         position: egui::Pos2,
         radius_px: f32,
+        ctxt: &DrawContext<'_>,
     ) -> bool;
     #[cfg(test)]
     fn test_geometry(&self) -> (Vec<egui::Pos2>, egui::Pos2);
@@ -117,6 +229,26 @@ impl DrawingTool {
     }
 
     #[must_use]
+    pub fn default_payload(self) -> Box<dyn DrawingPayload> {
+        self.0.default_payload()
+    }
+
+    #[must_use]
+    pub fn extra_tab(self) -> Option<&'static str> {
+        self.0.extra_tab()
+    }
+
+    /// Draw the tool-owned inspector tab; returns whether anything changed.
+    pub fn draw_extra_tab(
+        self,
+        ui: &mut egui::Ui,
+        drawing: &mut Drawing,
+        host: &mut dyn PresetHost,
+    ) -> bool {
+        self.0.draw_extra_tab(ui, drawing, host)
+    }
+
+    #[must_use]
     pub fn icon(self) -> &'static str {
         self.0.icon()
     }
@@ -140,19 +272,24 @@ impl DrawingTool {
         chart_rect: egui::Rect,
         style: DrawingStyle,
         points: &[egui::Pos2],
-        selected: bool,
+        ctxt: &DrawContext<'_>,
         show_handles: bool,
     ) {
-        if selected {
-            let halo = DrawingStyle {
+        if ctxt.selected {
+            let halo_style = DrawingStyle {
                 color: SELECTION_HALO_COLOR,
                 width_px: style.width_px + SELECTION_HALO_EXTRA_WIDTH_PX,
                 fill_alpha: 0,
             };
-            self.0.paint(painter, chart_rect, halo, points);
+            let halo_ctxt = DrawContext {
+                halo: true,
+                ..*ctxt
+            };
+            self.0
+                .paint(painter, chart_rect, halo_style, points, &halo_ctxt);
         }
-        self.0.paint(painter, chart_rect, style, points);
-        if selected && show_handles {
+        self.0.paint(painter, chart_rect, style, points, ctxt);
+        if ctxt.selected && show_handles {
             let ring = egui::Stroke::new(SELECTED_ANCHOR_RING_WIDTH_PX, theme::ACCENT);
             for point in points {
                 painter.circle_filled(*point, SELECTED_ANCHOR_RADIUS_PX, SELECTED_ANCHOR_FILL);
@@ -168,11 +305,14 @@ impl DrawingTool {
         points: &[egui::Pos2],
         position: egui::Pos2,
         radius_px: f32,
+        ctxt: &DrawContext<'_>,
     ) -> bool {
         points
             .iter()
             .any(|point| point.distance_sq(position) <= radius_px * radius_px)
-            || self.0.hit_test(chart_rect, points, position, radius_px)
+            || self
+                .0
+                .hit_test(chart_rect, points, position, radius_px, ctxt)
     }
 
     #[cfg(test)]
@@ -239,7 +379,7 @@ impl Default for DrawingStyle {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct Drawing {
     pub tool: DrawingTool,
     pub points: Vec<ChartPoint>,
@@ -249,6 +389,20 @@ pub struct Drawing {
     pub locked: bool,
     /// A hidden drawing neither paints nor hit-tests, and stays recoverable.
     pub hidden: bool,
+    /// Tool-owned state (Fib levels, a future tool's own properties). The
+    /// registry creates it; the shared envelope never learns its fields.
+    pub payload: Box<dyn DrawingPayload>,
+}
+
+impl PartialEq for Drawing {
+    fn eq(&self, other: &Self) -> bool {
+        self.tool == other.tool
+            && self.points == other.points
+            && self.style == other.style
+            && self.locked == other.locked
+            && self.hidden == other.hidden
+            && self.payload.eq_dyn(other.payload.as_ref())
+    }
 }
 
 /// What a delete request did. Locked objects demand an explicit `force`.
@@ -399,9 +553,22 @@ impl Drawings {
         true
     }
 
-    /// Add a placement anchor. `true` means the object became complete;
-    /// completing an object records one undo entry for the whole creation.
+    /// [`Self::place_with`] with the tool's stock payload — the test-side
+    /// shorthand; the app always goes through `place_with` to honour the
+    /// user's default preset.
+    #[cfg(test)]
     pub fn place(&mut self, tool: DrawingTool, point: ChartPoint) -> bool {
+        self.place_with(tool, point, DrawingTool::default_payload)
+    }
+
+    /// [`Self::place`] with a caller-chosen payload for a new draft — how the
+    /// app applies the user's default preset to newly created objects only.
+    pub fn place_with(
+        &mut self,
+        tool: DrawingTool,
+        point: ChartPoint,
+        new_payload: impl FnOnce(DrawingTool) -> Box<dyn DrawingPayload>,
+    ) -> bool {
         if self.draft.as_ref().is_none_or(|draft| draft.tool != tool) {
             self.draft = Some(Drawing {
                 tool,
@@ -409,6 +576,7 @@ impl Drawings {
                 style: DrawingStyle::default(),
                 locked: false,
                 hidden: false,
+                payload: new_payload(tool),
             });
         }
         let draft = self.draft.as_mut().expect("draft was installed above");
@@ -613,52 +781,6 @@ pub(super) fn distance_to_segment(position: egui::Pos2, start: egui::Pos2, end: 
     }
     let projection = ((position - start).dot(segment) / length_sq).clamp(0.0, 1.0);
     position.distance(start + segment * projection)
-}
-
-pub(super) fn paint_fib_levels(
-    painter: &egui::Painter,
-    geometry: FibGeometry,
-    levels: &[FibLevel],
-    stroke: egui::Stroke,
-    color: egui::Color32,
-) {
-    for level in levels {
-        let y = geometry.origin_y + (geometry.second_y - geometry.first_y) * level.ratio as f32;
-        painter.line_segment(
-            [egui::pos2(geometry.left, y), egui::pos2(geometry.right, y)],
-            stroke,
-        );
-        painter.text(
-            egui::pos2(geometry.left + FIB_LABEL_OFFSET_PX, y),
-            egui::Align2::LEFT_BOTTOM,
-            level.label,
-            egui::FontId::monospace(FIB_LABEL_SIZE_PX),
-            color,
-        );
-    }
-}
-
-pub(super) fn hit_fib_levels(
-    position: egui::Pos2,
-    points: &[egui::Pos2],
-    levels: &[FibLevel],
-    origin_y: f32,
-    radius_px: f32,
-) -> bool {
-    let left = points
-        .iter()
-        .map(|point| point.x)
-        .fold(f32::INFINITY, f32::min);
-    let right = points
-        .iter()
-        .map(|point| point.x)
-        .fold(f32::NEG_INFINITY, f32::max);
-    position.x >= left - radius_px
-        && position.x <= right + radius_px
-        && levels.iter().any(|level| {
-            let y = origin_y + (points[1].y - points[0].y) * level.ratio as f32;
-            (position.y - y).abs() <= radius_px
-        })
 }
 
 #[cfg(test)]
@@ -1028,17 +1150,30 @@ mod tests {
             screen_rect: Some(chart),
             ..Default::default()
         };
+        let scale = PriceScale::from_range(0.0, 300.0, 0.0, 300.0);
+        let payload = line.default_payload();
+        let anchors = [ChartPoint {
+            bar: 0.0,
+            price: scale.price_at(120.0),
+        }];
         let output = ctx.run(input, |ctx| {
             let painter = ctx.layer_painter(egui::LayerId::new(
                 egui::Order::Foreground,
                 egui::Id::new("selection-test"),
             ));
+            let ctxt = DrawContext {
+                payload: payload.as_ref(),
+                anchors: &anchors,
+                scale: &scale,
+                selected: true,
+                halo: false,
+            };
             line.paint(
                 &painter,
                 chart,
                 style,
                 &[egui::pos2(100.0, 120.0)],
-                true,
+                &ctxt,
                 true,
             );
         });
@@ -1106,25 +1241,55 @@ mod tests {
         );
     }
 
+    /// Chart anchors consistent with `points` under `scale` — the identity
+    /// projection the tool tests run with.
+    fn anchors_for(points: &[egui::Pos2], scale: &PriceScale) -> Vec<ChartPoint> {
+        points
+            .iter()
+            .enumerate()
+            .map(|(index, point)| ChartPoint {
+                bar: index as f32,
+                price: scale.price_at(point.y),
+            })
+            .collect()
+    }
+
     #[test]
     fn horizontal_line_is_selectable_from_anywhere_on_its_stroke() {
         let chart = egui::Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(500.0, 300.0));
-        assert!(tool("horizontal-line").hit_test(
-            chart,
-            &[egui::pos2(100.0, 120.0)],
-            egui::pos2(450.0, 123.0),
-            5.0
-        ));
+        let line = tool("horizontal-line");
+        let scale = PriceScale::from_range(0.0, 300.0, 0.0, 300.0);
+        let payload = line.default_payload();
+        let points = [egui::pos2(100.0, 120.0)];
+        let anchors = anchors_for(&points, &scale);
+        let ctxt = DrawContext {
+            payload: payload.as_ref(),
+            anchors: &anchors,
+            scale: &scale,
+            selected: false,
+            halo: false,
+        };
+        assert!(line.hit_test(chart, &points, egui::pos2(450.0, 123.0), 5.0, &ctxt));
     }
 
     #[test]
     fn every_registered_tool_paints_and_hits_its_finished_geometry() {
         let chart = egui::Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(500.0, 300.0));
+        let scale = PriceScale::from_range(0.0, 300.0, 0.0, 300.0);
         for drawing_tool in DRAWING_TOOLS {
             let (points, hit) = drawing_tool.test_geometry();
             assert_eq!(points.len(), drawing_tool.required_points());
+            let payload = drawing_tool.default_payload();
+            let anchors = anchors_for(&points, &scale);
+            let ctxt = DrawContext {
+                payload: payload.as_ref(),
+                anchors: &anchors,
+                scale: &scale,
+                selected: false,
+                halo: false,
+            };
             assert!(
-                drawing_tool.hit_test(chart, &points, hit, 5.0),
+                drawing_tool.hit_test(chart, &points, hit, 5.0, &ctxt),
                 "{} cannot be selected from its visible geometry",
                 drawing_tool.id()
             );
@@ -1144,7 +1309,7 @@ mod tests {
                     chart,
                     DrawingStyle::default(),
                     &points,
-                    false,
+                    &ctxt,
                     false,
                 );
             });
@@ -1154,5 +1319,166 @@ mod tests {
                 drawing_tool.id()
             );
         }
+    }
+
+    /// The extension port, proven end to end: a fake tool with a property no
+    /// other tool has (`ray_count`) docks through the registry surface alone.
+    /// Its payload rides the envelope, survives undo snapshots and renders
+    /// its own inspector tab — with zero edits to the shared model or the
+    /// central inspector code.
+    #[test]
+    fn a_fake_tool_with_its_own_payload_docks_without_touching_the_model() {
+        #[derive(Debug, Clone, PartialEq)]
+        struct RayPayload {
+            ray_count: u32,
+        }
+        impl DrawingPayload for RayPayload {
+            fn clone_box(&self) -> Box<dyn DrawingPayload> {
+                Box::new(self.clone())
+            }
+            fn eq_dyn(&self, other: &dyn DrawingPayload) -> bool {
+                other
+                    .as_any()
+                    .downcast_ref::<Self>()
+                    .is_some_and(|other| self == other)
+            }
+            fn as_any(&self) -> &dyn std::any::Any {
+                self
+            }
+            fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+                self
+            }
+        }
+        struct RayTool;
+        impl DrawingToolImpl for RayTool {
+            fn id(&self) -> &'static str {
+                "test-ray"
+            }
+            fn name(&self) -> &'static str {
+                "Ray fan"
+            }
+            fn settings_title(&self) -> &'static str {
+                "Ray fan settings"
+            }
+            fn icon(&self) -> &'static str {
+                "R"
+            }
+            fn hover_text(&self) -> &'static str {
+                "Ray fan - test tool"
+            }
+            fn required_points(&self) -> usize {
+                1
+            }
+            fn default_payload(&self) -> Box<dyn DrawingPayload> {
+                Box::new(RayPayload { ray_count: 2 })
+            }
+            fn extra_tab(&self) -> Option<&'static str> {
+                Some("Rays")
+            }
+            fn draw_extra_tab(
+                &self,
+                ui: &mut egui::Ui,
+                drawing: &mut Drawing,
+                _host: &mut dyn PresetHost,
+            ) -> bool {
+                let payload = drawing
+                    .payload
+                    .as_any_mut()
+                    .downcast_mut::<RayPayload>()
+                    .expect("a ray tool always carries a ray payload");
+                ui.add(egui::Slider::new(&mut payload.ray_count, 1..=8).text("rays"))
+                    .changed()
+            }
+            fn paint(
+                &self,
+                painter: &egui::Painter,
+                _chart_rect: egui::Rect,
+                style: DrawingStyle,
+                points: &[egui::Pos2],
+                ctxt: &DrawContext<'_>,
+            ) {
+                let payload = ctxt
+                    .payload
+                    .as_any()
+                    .downcast_ref::<RayPayload>()
+                    .expect("ray payload");
+                if let Some(origin) = points.first() {
+                    for ray in 0..payload.ray_count {
+                        let target = *origin + egui::vec2(40.0, 10.0 * (ray as f32 + 1.0));
+                        painter.line_segment([*origin, target], drawing_stroke(style));
+                    }
+                }
+            }
+            fn hit_test(
+                &self,
+                _chart_rect: egui::Rect,
+                points: &[egui::Pos2],
+                position: egui::Pos2,
+                radius_px: f32,
+                _ctxt: &DrawContext<'_>,
+            ) -> bool {
+                points
+                    .first()
+                    .is_some_and(|point| point.distance(position) <= radius_px * 10.0)
+            }
+            #[cfg(test)]
+            fn test_geometry(&self) -> (Vec<egui::Pos2>, egui::Pos2) {
+                (vec![egui::pos2(50.0, 50.0)], egui::pos2(60.0, 60.0))
+            }
+        }
+        static RAY: RayTool = RayTool;
+        let ray_tool = DrawingTool(&RAY);
+
+        let mut drawings = Drawings::default();
+        assert!(drawings.place(
+            ray_tool,
+            ChartPoint {
+                bar: 1.0,
+                price: 100.0,
+            }
+        ));
+        // The unique property lives in the payload and rides the undo
+        // history exactly like the shared fields do.
+        drawings.begin_gesture();
+        drawings
+            .selected_mut()
+            .expect("placement selects")
+            .payload
+            .as_any_mut()
+            .downcast_mut::<RayPayload>()
+            .expect("ray payload")
+            .ray_count = 5;
+        drawings.commit_gesture();
+        assert!(drawings.undo(), "the payload edit is one undo entry");
+        let restored = drawings.items()[0]
+            .payload
+            .as_any()
+            .downcast_ref::<RayPayload>()
+            .expect("ray payload")
+            .ray_count;
+        assert_eq!(restored, 2, "undo restores the tool-owned property");
+
+        // The tool-owned inspector tab renders through the same port every
+        // tool uses — no central match, no central form edit.
+        assert_eq!(ray_tool.extra_tab(), Some("Rays"));
+        let ctx = egui::Context::default();
+        let mut host = NullPresetHost;
+        let mut painted = Vec::new();
+        let input = egui::RawInput::default();
+        let output = ctx.run(input, |ctx| {
+            egui::CentralPanel::default().show(ctx, |ui| {
+                let drawing = drawings.selected_mut().expect("still selected");
+                ray_tool.draw_extra_tab(ui, drawing, &mut host);
+            });
+        });
+        for clipped in &output.shapes {
+            if let egui::Shape::Text(text) = &clipped.shape {
+                painted.push(text.galley.text().to_owned());
+            }
+        }
+        assert!(
+            painted.iter().any(|text| text.contains("rays")),
+            "the fake tool's own section rendered: {painted:?}"
+        );
     }
 }

--- a/crates/app/src/drawings/mod.rs
+++ b/crates/app/src/drawings/mod.rs
@@ -6,6 +6,8 @@
 //! Market data remains immutable and the deterministic engine never learns
 //! about UI marks.
 
+pub mod action_bar;
+
 use std::fmt;
 
 use eframe::egui;
@@ -56,13 +58,21 @@ impl FibLevel {
 
 /// The implementation port every drawing plugs into. Selection visuals (halo
 /// and anchor handles) are common chrome painted by the wrapper, so a tool
-/// only ever paints its own geometry in the style it is given.
+/// only ever paints its own geometry in the style it is given. Capability
+/// methods drive which inspector sections exist for the tool — an
+/// unsupported property is absent, never disabled.
 trait DrawingToolImpl: Sync {
     fn id(&self) -> &'static str;
+    /// Human name shown in the inspector header and the object manager.
+    fn name(&self) -> &'static str;
     fn settings_title(&self) -> &'static str;
     fn icon(&self) -> &'static str;
     fn hover_text(&self) -> &'static str;
     fn required_points(&self) -> usize;
+    /// Whether the tool paints an interior that the fill controls affect.
+    fn supports_fill(&self) -> bool {
+        false
+    }
     fn paint(
         &self,
         painter: &egui::Painter,
@@ -92,8 +102,18 @@ impl DrawingTool {
     }
 
     #[must_use]
+    pub fn name(self) -> &'static str {
+        self.0.name()
+    }
+
+    #[must_use]
     pub fn settings_title(self) -> &'static str {
         self.0.settings_title()
+    }
+
+    #[must_use]
+    pub fn supports_fill(self) -> bool {
+        self.0.supports_fill()
     }
 
     #[must_use]
@@ -465,19 +485,53 @@ impl Drawings {
     }
 
     pub fn set_selected_locked(&mut self, locked: bool) {
+        if let Some(index) = self.selected {
+            self.set_locked_at(index, locked);
+        }
+    }
+
+    pub fn set_selected_hidden(&mut self, hidden: bool) {
+        if let Some(index) = self.selected {
+            self.set_hidden_at(index, hidden);
+        }
+    }
+
+    pub fn set_locked_at(&mut self, index: usize, locked: bool) {
         let before = self.snapshot();
-        if let Some(drawing) = self.selected_mut() {
+        if let Some(drawing) = self.items.get_mut(index) {
             drawing.locked = locked;
             self.record(before);
         }
     }
 
-    pub fn set_selected_hidden(&mut self, hidden: bool) {
+    pub fn set_hidden_at(&mut self, index: usize, hidden: bool) {
         let before = self.snapshot();
-        if let Some(drawing) = self.selected_mut() {
+        if let Some(drawing) = self.items.get_mut(index) {
             drawing.hidden = hidden;
             self.record(before);
         }
+    }
+
+    /// Z-order: painting walks the list front-to-back, hit-testing walks it
+    /// back-to-front, so the last item is the topmost object.
+    pub fn bring_to_front(&mut self, index: usize) {
+        if index >= self.items.len() || index + 1 == self.items.len() {
+            return;
+        }
+        let before = self.snapshot();
+        let drawing = self.items.remove(index);
+        self.items.push(drawing);
+        // Selection follows the object, not the slot it used to occupy.
+        self.selected = self.selected.map(|selected| {
+            if selected == index {
+                self.items.len() - 1
+            } else if selected > index {
+                selected - 1
+            } else {
+                selected
+            }
+        });
+        self.record(before);
     }
 
     pub fn set_all_hidden(&mut self, hidden: bool) {

--- a/crates/app/src/drawings/parallel_channel.rs
+++ b/crates/app/src/drawings/parallel_channel.rs
@@ -39,9 +39,8 @@ impl DrawingToolImpl for ParallelChannel {
         _chart_rect: egui::Rect,
         style: DrawingStyle,
         points: &[egui::Pos2],
-        selected: bool,
     ) {
-        let stroke = drawing_stroke(style, selected);
+        let stroke = drawing_stroke(style);
         if points.len() >= 2 {
             painter.line_segment([points[0], points[1]], stroke);
         }

--- a/crates/app/src/drawings/parallel_channel.rs
+++ b/crates/app/src/drawings/parallel_channel.rs
@@ -1,7 +1,7 @@
 use eframe::egui;
 use egui_phosphor::regular as icons;
 
-use super::{DrawContext, DrawingStyle, DrawingToolImpl, distance_to_segment, drawing_fill, drawing_stroke};
+use super::{DrawContext, DrawingStyle, DrawingToolImpl, ToolShortcut, distance_to_segment, drawing_fill, drawing_stroke};
 
 pub(super) static TOOL: ParallelChannel = ParallelChannel;
 
@@ -31,10 +31,16 @@ impl DrawingToolImpl for ParallelChannel {
         icons::PARALLELOGRAM
     }
     fn hover_text(&self) -> &'static str {
-        "Parallel channel - set the baseline, then click the channel width"
+        "Parallel channel - set the baseline, then click the channel width (C)"
     }
     fn required_points(&self) -> usize {
         3
+    }
+    fn shortcut(&self) -> Option<ToolShortcut> {
+        Some(ToolShortcut {
+            key: egui::Key::C,
+            shift: false,
+        })
     }
     fn supports_fill(&self) -> bool {
         true

--- a/crates/app/src/drawings/parallel_channel.rs
+++ b/crates/app/src/drawings/parallel_channel.rs
@@ -1,7 +1,7 @@
 use eframe::egui;
 use egui_phosphor::regular as icons;
 
-use super::{DrawingStyle, DrawingToolImpl, distance_to_segment, drawing_stroke};
+use super::{DrawingStyle, DrawingToolImpl, distance_to_segment, drawing_fill, drawing_stroke};
 
 pub(super) static TOOL: ParallelChannel = ParallelChannel;
 
@@ -21,6 +21,9 @@ impl DrawingToolImpl for ParallelChannel {
     fn id(&self) -> &'static str {
         "parallel-channel"
     }
+    fn name(&self) -> &'static str {
+        "Parallel channel"
+    }
     fn settings_title(&self) -> &'static str {
         "Parallel channel settings"
     }
@@ -32,6 +35,9 @@ impl DrawingToolImpl for ParallelChannel {
     }
     fn required_points(&self) -> usize {
         3
+    }
+    fn supports_fill(&self) -> bool {
+        true
     }
     fn paint(
         &self,
@@ -46,6 +52,13 @@ impl DrawingToolImpl for ParallelChannel {
         }
         if points.len() == 3 {
             let offset = channel_offset(points);
+            if style.fill_alpha > 0 {
+                painter.add(egui::Shape::convex_polygon(
+                    vec![points[0], points[1], points[1] + offset, points[0] + offset],
+                    drawing_fill(style),
+                    egui::Stroke::NONE,
+                ));
+            }
             painter.line_segment([points[0] + offset, points[1] + offset], stroke);
             painter.line_segment([points[0], points[0] + offset], stroke);
             painter.line_segment([points[1], points[1] + offset], stroke);

--- a/crates/app/src/drawings/parallel_channel.rs
+++ b/crates/app/src/drawings/parallel_channel.rs
@@ -1,0 +1,87 @@
+use eframe::egui;
+use egui_phosphor::regular as icons;
+
+use super::{DrawingStyle, DrawingToolImpl, distance_to_segment, drawing_stroke};
+
+pub(super) static TOOL: ParallelChannel = ParallelChannel;
+
+pub(super) struct ParallelChannel;
+
+fn channel_offset(points: &[egui::Pos2]) -> egui::Vec2 {
+    let baseline = points[1] - points[0];
+    let to_width_anchor = points[2] - points[0];
+    let baseline_length_sq = baseline.length_sq();
+    if baseline_length_sq <= f32::EPSILON {
+        return to_width_anchor;
+    }
+    to_width_anchor - baseline * (to_width_anchor.dot(baseline) / baseline_length_sq)
+}
+
+impl DrawingToolImpl for ParallelChannel {
+    fn id(&self) -> &'static str {
+        "parallel-channel"
+    }
+    fn settings_title(&self) -> &'static str {
+        "Parallel channel settings"
+    }
+    fn icon(&self) -> &'static str {
+        icons::PARALLELOGRAM
+    }
+    fn hover_text(&self) -> &'static str {
+        "Parallel channel - set the baseline, then click the channel width"
+    }
+    fn required_points(&self) -> usize {
+        3
+    }
+    fn paint(
+        &self,
+        painter: &egui::Painter,
+        _chart_rect: egui::Rect,
+        style: DrawingStyle,
+        points: &[egui::Pos2],
+        selected: bool,
+    ) {
+        let stroke = drawing_stroke(style, selected);
+        if points.len() >= 2 {
+            painter.line_segment([points[0], points[1]], stroke);
+        }
+        if points.len() == 3 {
+            let offset = channel_offset(points);
+            painter.line_segment([points[0] + offset, points[1] + offset], stroke);
+            painter.line_segment([points[0], points[0] + offset], stroke);
+            painter.line_segment([points[1], points[1] + offset], stroke);
+        }
+    }
+    fn hit_test(
+        &self,
+        _chart_rect: egui::Rect,
+        points: &[egui::Pos2],
+        position: egui::Pos2,
+        radius_px: f32,
+    ) -> bool {
+        if points.len() != 3 {
+            return false;
+        }
+        let offset = channel_offset(points);
+        [
+            (points[0], points[1]),
+            (points[0] + offset, points[1] + offset),
+            (points[0], points[0] + offset),
+            (points[1], points[1] + offset),
+        ]
+        .into_iter()
+        .any(|(start, end)| distance_to_segment(position, start, end) <= radius_px)
+    }
+
+    #[cfg(test)]
+    fn test_geometry(&self) -> (Vec<egui::Pos2>, egui::Pos2) {
+        (
+            vec![
+                egui::pos2(100.0, 100.0),
+                egui::pos2(200.0, 120.0),
+                egui::pos2(100.0, 160.0),
+            ],
+            egui::pos2(150.0, 170.0),
+        )
+    }
+}

--- a/crates/app/src/drawings/parallel_channel.rs
+++ b/crates/app/src/drawings/parallel_channel.rs
@@ -1,7 +1,7 @@
 use eframe::egui;
 use egui_phosphor::regular as icons;
 
-use super::{DrawingStyle, DrawingToolImpl, distance_to_segment, drawing_fill, drawing_stroke};
+use super::{DrawContext, DrawingStyle, DrawingToolImpl, distance_to_segment, drawing_fill, drawing_stroke};
 
 pub(super) static TOOL: ParallelChannel = ParallelChannel;
 
@@ -45,6 +45,7 @@ impl DrawingToolImpl for ParallelChannel {
         _chart_rect: egui::Rect,
         style: DrawingStyle,
         points: &[egui::Pos2],
+        _ctxt: &DrawContext<'_>,
     ) {
         let stroke = drawing_stroke(style);
         if points.len() >= 2 {
@@ -70,6 +71,7 @@ impl DrawingToolImpl for ParallelChannel {
         points: &[egui::Pos2],
         position: egui::Pos2,
         radius_px: f32,
+        _ctxt: &DrawContext<'_>,
     ) -> bool {
         if points.len() != 3 {
             return false;

--- a/crates/app/src/drawings/presets.rs
+++ b/crates/app/src/drawings/presets.rs
@@ -1,0 +1,254 @@
+//! Persistent storage of custom drawing presets.
+//!
+//! One versioned TOML file holds, per tool id, the named payload exports and
+//! the explicit "default for new objects" choice. Reading a file from a
+//! future version leaves the store empty rather than guessing — the file on
+//! disk is never rewritten until the user saves something again.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use super::PresetHost;
+
+/// Environment override for the preset file location.
+pub const PRESETS_ENV: &str = "QUANTICK_DRAWING_PRESETS";
+/// Default preset file, next to the working directory's quantick.toml.
+pub const PRESETS_FILE: &str = "quantick-drawing-presets.toml";
+/// Version this build writes and the only one it reads.
+const STORE_FORMAT_VERSION: u32 = 1;
+
+/// Per-tool slot: named presets plus the optional default-for-new choice.
+/// `BTreeMap` keeps the file diff-stable across saves.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+struct ToolPresets {
+    #[serde(default)]
+    presets: BTreeMap<String, toml::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    default: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+struct StoreFile {
+    version: u32,
+    #[serde(default)]
+    tools: BTreeMap<String, ToolPresets>,
+}
+
+/// The app-side [`PresetHost`]: an in-memory copy of the preset file that
+/// writes itself back after every mutation (preset edits are rare,
+/// event-driven work — never on the frame path).
+#[derive(Debug)]
+pub struct PresetStore {
+    path: PathBuf,
+    tools: BTreeMap<String, ToolPresets>,
+}
+
+impl PresetStore {
+    /// Resolve the preset file the same way the app config resolves:
+    /// the env override first, then the working directory.
+    #[must_use]
+    pub fn default_path() -> PathBuf {
+        std::env::var_os(PRESETS_ENV).map_or_else(|| PathBuf::from(PRESETS_FILE), PathBuf::from)
+    }
+
+    /// Load the store, empty when the file is missing, unreadable or from an
+    /// unknown version (reported, never silently half-read).
+    #[must_use]
+    pub fn load_from(path: impl Into<PathBuf>) -> Self {
+        let path = path.into();
+        let tools = match std::fs::read_to_string(&path) {
+            Ok(text) => match toml::from_str::<StoreFile>(&text) {
+                Ok(file) if file.version == STORE_FORMAT_VERSION => file.tools,
+                Ok(file) => {
+                    tracing::warn!(
+                        path = %path.display(),
+                        version = file.version,
+                        "drawing preset file is from an unknown version; starting empty"
+                    );
+                    BTreeMap::new()
+                }
+                Err(error) => {
+                    tracing::warn!(
+                        path = %path.display(),
+                        %error,
+                        "drawing preset file is unreadable; starting empty"
+                    );
+                    BTreeMap::new()
+                }
+            },
+            Err(_) => BTreeMap::new(),
+        };
+        Self { path, tools }
+    }
+
+    #[cfg(test)]
+    #[must_use]
+    pub fn path(&self) -> &std::path::Path {
+        &self.path
+    }
+
+    fn persist(&self) {
+        let file = StoreFile {
+            version: STORE_FORMAT_VERSION,
+            tools: self.tools.clone(),
+        };
+        match toml::to_string_pretty(&file) {
+            Ok(text) => {
+                if let Err(error) = std::fs::write(&self.path, text) {
+                    tracing::warn!(
+                        path = %self.path.display(),
+                        %error,
+                        "could not save drawing presets"
+                    );
+                }
+            }
+            Err(error) => {
+                tracing::warn!(%error, "could not serialize drawing presets");
+            }
+        }
+    }
+}
+
+impl PresetHost for PresetStore {
+    fn custom_preset_names(&self, tool_id: &str) -> Vec<String> {
+        self.tools
+            .get(tool_id)
+            .map(|slot| slot.presets.keys().cloned().collect())
+            .unwrap_or_default()
+    }
+
+    fn load_custom_preset(&self, tool_id: &str, name: &str) -> Option<toml::Value> {
+        self.tools.get(tool_id)?.presets.get(name).cloned()
+    }
+
+    fn save_custom_preset(
+        &mut self,
+        tool_id: &str,
+        name: &str,
+        value: toml::Value,
+        overwrite: bool,
+    ) -> bool {
+        let slot = self.tools.entry(tool_id.to_owned()).or_default();
+        if slot.presets.contains_key(name) && !overwrite {
+            return false;
+        }
+        slot.presets.insert(name.to_owned(), value);
+        self.persist();
+        true
+    }
+
+    fn delete_custom_preset(&mut self, tool_id: &str, name: &str) {
+        if let Some(slot) = self.tools.get_mut(tool_id) {
+            slot.presets.remove(name);
+            // Deleting the default preset falls back to the built-in start;
+            // objects that already copied its values keep them.
+            if slot.default.as_deref() == Some(name) {
+                slot.default = None;
+            }
+            self.persist();
+        }
+    }
+
+    fn default_preset(&self, tool_id: &str) -> Option<String> {
+        let slot = self.tools.get(tool_id)?;
+        let name = slot.default.clone()?;
+        // A dangling default (preset deleted by hand in the file) is no
+        // default at all.
+        slot.presets.contains_key(&name).then_some(name)
+    }
+
+    fn set_default_preset(&mut self, tool_id: &str, name: Option<String>) {
+        let slot = self.tools.entry(tool_id.to_owned()).or_default();
+        slot.default = name;
+        self.persist();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scratch_path(name: &str) -> PathBuf {
+        let mut path = std::env::temp_dir();
+        path.push(format!(
+            "quantick-preset-test-{name}-{}.toml",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&path);
+        path
+    }
+
+    fn sample_value(marker: &str) -> toml::Value {
+        toml::Value::Table(
+            [(String::from("marker"), toml::Value::String(marker.into()))]
+                .into_iter()
+                .collect(),
+        )
+    }
+
+    #[test]
+    fn custom_presets_survive_a_restart_via_the_versioned_file() {
+        let path = scratch_path("roundtrip");
+        {
+            let mut store = PresetStore::load_from(&path);
+            assert!(store.save_custom_preset("fib-retracement", "mine", sample_value("a"), false));
+            store.set_default_preset("fib-retracement", Some("mine".into()));
+        }
+        // A fresh load — the "restart".
+        let store = PresetStore::load_from(&path);
+        assert_eq!(store.custom_preset_names("fib-retracement"), ["mine"]);
+        assert_eq!(
+            store.load_custom_preset("fib-retracement", "mine"),
+            Some(sample_value("a"))
+        );
+        assert_eq!(
+            store.default_preset("fib-retracement"),
+            Some("mine".to_owned())
+        );
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn overwriting_needs_explicit_consent() {
+        let path = scratch_path("overwrite");
+        let mut store = PresetStore::load_from(&path);
+        assert!(store.save_custom_preset("fib-retracement", "mine", sample_value("a"), false));
+        assert!(
+            !store.save_custom_preset("fib-retracement", "mine", sample_value("b"), false),
+            "an existing name is not silently replaced"
+        );
+        assert_eq!(
+            store.load_custom_preset("fib-retracement", "mine"),
+            Some(sample_value("a"))
+        );
+        assert!(store.save_custom_preset("fib-retracement", "mine", sample_value("b"), true));
+        assert_eq!(
+            store.load_custom_preset("fib-retracement", "mine"),
+            Some(sample_value("b"))
+        );
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn deleting_the_default_preset_returns_to_the_builtin_start() {
+        let path = scratch_path("delete-default");
+        let mut store = PresetStore::load_from(&path);
+        store.save_custom_preset("fib-extension", "targets+", sample_value("x"), false);
+        store.set_default_preset("fib-extension", Some("targets+".into()));
+        store.delete_custom_preset("fib-extension", "targets+");
+        assert_eq!(store.default_preset("fib-extension"), None);
+        assert!(store.custom_preset_names("fib-extension").is_empty());
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn an_unknown_file_version_starts_empty_instead_of_guessing() {
+        let path = scratch_path("future-version");
+        std::fs::write(&path, "version = 99\n[tools]\n").unwrap();
+        let store = PresetStore::load_from(&path);
+        assert!(store.custom_preset_names("fib-retracement").is_empty());
+        let _ = std::fs::remove_file(&path);
+    }
+}

--- a/crates/app/src/drawings/rectangle.rs
+++ b/crates/app/src/drawings/rectangle.rs
@@ -1,7 +1,7 @@
 use eframe::egui;
 use egui_phosphor::regular as icons;
 
-use super::{DrawingStyle, DrawingToolImpl, drawing_fill, drawing_stroke};
+use super::{DrawContext, DrawingStyle, DrawingToolImpl, drawing_fill, drawing_stroke};
 
 pub(super) static TOOL: Rectangle = Rectangle;
 
@@ -35,6 +35,7 @@ impl DrawingToolImpl for Rectangle {
         _chart_rect: egui::Rect,
         style: DrawingStyle,
         points: &[egui::Pos2],
+        _ctxt: &DrawContext<'_>,
     ) {
         if points.len() == 2 {
             let rect = egui::Rect::from_two_pos(points[0], points[1]);
@@ -52,6 +53,7 @@ impl DrawingToolImpl for Rectangle {
         points: &[egui::Pos2],
         position: egui::Pos2,
         radius_px: f32,
+        _ctxt: &DrawContext<'_>,
     ) -> bool {
         points.len() == 2
             && egui::Rect::from_two_pos(points[0], points[1])

--- a/crates/app/src/drawings/rectangle.rs
+++ b/crates/app/src/drawings/rectangle.rs
@@ -1,7 +1,7 @@
 use eframe::egui;
 use egui_phosphor::regular as icons;
 
-use super::{DrawContext, DrawingStyle, DrawingToolImpl, drawing_fill, drawing_stroke};
+use super::{DrawContext, DrawingStyle, DrawingToolImpl, ToolShortcut, drawing_fill, drawing_stroke};
 
 pub(super) static TOOL: Rectangle = Rectangle;
 
@@ -21,10 +21,16 @@ impl DrawingToolImpl for Rectangle {
         icons::RECTANGLE
     }
     fn hover_text(&self) -> &'static str {
-        "Rectangle - click two corners or drag"
+        "Rectangle - click two corners or drag (R)"
     }
     fn required_points(&self) -> usize {
         2
+    }
+    fn shortcut(&self) -> Option<ToolShortcut> {
+        Some(ToolShortcut {
+            key: egui::Key::R,
+            shift: false,
+        })
     }
     fn supports_fill(&self) -> bool {
         true
@@ -53,12 +59,19 @@ impl DrawingToolImpl for Rectangle {
         points: &[egui::Pos2],
         position: egui::Pos2,
         radius_px: f32,
-        _ctxt: &DrawContext<'_>,
+        ctxt: &DrawContext<'_>,
     ) -> bool {
-        points.len() == 2
-            && egui::Rect::from_two_pos(points[0], points[1])
-                .expand(radius_px)
-                .contains(position)
+        if points.len() != 2 {
+            return false;
+        }
+        let rect = egui::Rect::from_two_pos(points[0], points[1]);
+        if !rect.expand(radius_px).contains(position) {
+            return false;
+        }
+        // The interior only takes part in the hit-test while the fill is
+        // visible; an outline-only rectangle is selectable by its border,
+        // and clicks through its middle keep belonging to the chart.
+        ctxt.style.fill_alpha > 0 || !rect.shrink(radius_px).contains(position)
     }
 
     #[cfg(test)]

--- a/crates/app/src/drawings/rectangle.rs
+++ b/crates/app/src/drawings/rectangle.rs
@@ -11,6 +11,9 @@ impl DrawingToolImpl for Rectangle {
     fn id(&self) -> &'static str {
         "rectangle"
     }
+    fn name(&self) -> &'static str {
+        "Rectangle"
+    }
     fn settings_title(&self) -> &'static str {
         "Rectangle settings"
     }
@@ -22,6 +25,9 @@ impl DrawingToolImpl for Rectangle {
     }
     fn required_points(&self) -> usize {
         2
+    }
+    fn supports_fill(&self) -> bool {
+        true
     }
     fn paint(
         &self,

--- a/crates/app/src/drawings/rectangle.rs
+++ b/crates/app/src/drawings/rectangle.rs
@@ -1,0 +1,64 @@
+use eframe::egui;
+use egui_phosphor::regular as icons;
+
+use super::{DrawingStyle, DrawingToolImpl, drawing_fill, drawing_stroke};
+
+pub(super) static TOOL: Rectangle = Rectangle;
+
+pub(super) struct Rectangle;
+
+impl DrawingToolImpl for Rectangle {
+    fn id(&self) -> &'static str {
+        "rectangle"
+    }
+    fn settings_title(&self) -> &'static str {
+        "Rectangle settings"
+    }
+    fn icon(&self) -> &'static str {
+        icons::RECTANGLE
+    }
+    fn hover_text(&self) -> &'static str {
+        "Rectangle - click two corners or drag"
+    }
+    fn required_points(&self) -> usize {
+        2
+    }
+    fn paint(
+        &self,
+        painter: &egui::Painter,
+        _chart_rect: egui::Rect,
+        style: DrawingStyle,
+        points: &[egui::Pos2],
+        selected: bool,
+    ) {
+        if points.len() == 2 {
+            let rect = egui::Rect::from_two_pos(points[0], points[1]);
+            painter.rect_filled(rect, egui::Rounding::ZERO, drawing_fill(style));
+            painter.rect_stroke(
+                rect,
+                egui::Rounding::ZERO,
+                drawing_stroke(style, selected),
+            );
+        }
+    }
+    fn hit_test(
+        &self,
+        _chart_rect: egui::Rect,
+        points: &[egui::Pos2],
+        position: egui::Pos2,
+        radius_px: f32,
+    ) -> bool {
+        points.len() == 2
+            && egui::Rect::from_two_pos(points[0], points[1])
+                .expand(radius_px)
+                .contains(position)
+    }
+
+    #[cfg(test)]
+    fn test_geometry(&self) -> (Vec<egui::Pos2>, egui::Pos2) {
+        (
+            vec![egui::pos2(100.0, 100.0), egui::pos2(200.0, 200.0)],
+            egui::pos2(150.0, 150.0),
+        )
+    }
+}

--- a/crates/app/src/drawings/rectangle.rs
+++ b/crates/app/src/drawings/rectangle.rs
@@ -29,7 +29,6 @@ impl DrawingToolImpl for Rectangle {
         _chart_rect: egui::Rect,
         style: DrawingStyle,
         points: &[egui::Pos2],
-        selected: bool,
     ) {
         if points.len() == 2 {
             let rect = egui::Rect::from_two_pos(points[0], points[1]);
@@ -37,7 +36,7 @@ impl DrawingToolImpl for Rectangle {
             painter.rect_stroke(
                 rect,
                 egui::Rounding::ZERO,
-                drawing_stroke(style, selected),
+                drawing_stroke(style),
             );
         }
     }

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -17,6 +17,7 @@ mod candle_view;
 mod chart;
 mod config;
 mod dock;
+mod drawings;
 mod feed;
 mod live_strip;
 mod loading;

--- a/crates/app/src/toolrail.rs
+++ b/crates/app/src/toolrail.rs
@@ -104,6 +104,8 @@ pub struct ToolRail {
     hide_all_rect: Option<egui::Rect>,
     #[cfg(test)]
     lock_all_rect: Option<egui::Rect>,
+    #[cfg(test)]
+    objects_rect: Option<egui::Rect>,
 }
 
 impl Default for ToolRail {
@@ -120,6 +122,8 @@ impl Default for ToolRail {
             hide_all_rect: None,
             #[cfg(test)]
             lock_all_rect: None,
+            #[cfg(test)]
+            objects_rect: None,
         }
     }
 }
@@ -159,6 +163,11 @@ impl ToolRail {
             .find_map(|(candidate, rect)| (*candidate == tool).then_some(*rect))
     }
 
+    #[cfg(test)]
+    pub(crate) fn objects_button_rect(&self) -> Option<egui::Rect> {
+        self.objects_rect
+    }
+
     pub fn handle_keys(&mut self, ctx: &egui::Context) {
         if ctx.memory(|memory| memory.focused().is_some()) {
             return;
@@ -175,9 +184,9 @@ impl ToolRail {
 
     /// Draw the toolbox in an external top/bottom strip. Drag the grip and
     /// release anywhere: the closest of the four screen corners becomes its
-    /// new dock. The rail also hosts the global protection toggles
-    /// (hide-all / lock-all), which act on the drawings store.
-    pub fn draw(&mut self, ctx: &egui::Context, drawings: &mut Drawings) {
+    /// new dock. The rail also hosts the object-manager entry and the global
+    /// protection toggles (hide-all / lock-all), which act on the store.
+    pub fn draw(&mut self, ctx: &egui::Context, drawings: &mut Drawings, manager_open: &mut bool) {
         if !self.visible {
             return;
         }
@@ -199,7 +208,23 @@ impl ToolRail {
                         TOOLBOX_ITEM_GAP_PX,
                     )),
             )
-            .show(ctx, |ui| self.draw_contents(ui, drawings));
+            .show(ctx, |ui| self.draw_contents(ui, drawings, manager_open));
+    }
+
+    /// The entry to the drawn-objects manager. A toggle, not a tool: it never
+    /// changes which tool is armed.
+    fn draw_objects_button(&mut self, ui: &mut egui::Ui, manager_open: &mut bool) {
+        let response = IconButton::new(icons::LIST, RAIL_ICON)
+            .active(*manager_open)
+            .hover_text("Drawn objects")
+            .show(ui);
+        #[cfg(test)]
+        {
+            self.objects_rect = Some(response.rect);
+        }
+        if response.clicked() {
+            *manager_open = !*manager_open;
+        }
     }
 
     /// The reversible global protections. Hide-all is a view layer over each
@@ -253,13 +278,19 @@ impl ToolRail {
         }
     }
 
-    fn draw_contents(&mut self, ui: &mut egui::Ui, drawings: &mut Drawings) {
+    fn draw_contents(
+        &mut self,
+        ui: &mut egui::Ui,
+        drawings: &mut Drawings,
+        manager_open: &mut bool,
+    ) {
         #[cfg(test)]
         {
             self.button_rects.fill(None);
             self.grip_rect = None;
             self.hide_all_rect = None;
             self.lock_all_rect = None;
+            self.objects_rect = None;
         }
         let left = self.dock.is_left();
         let layout = if left {
@@ -294,9 +325,11 @@ impl ToolRail {
                     self.draw_button(ui, Tool::Drawing(tool));
                 }
                 ui.separator();
+                self.draw_objects_button(ui, manager_open);
                 self.draw_global_buttons(ui, drawings);
             } else {
                 self.draw_global_buttons(ui, drawings);
+                self.draw_objects_button(ui, manager_open);
                 ui.separator();
                 for tool in DRAWING_TOOLS.into_iter().rev() {
                     self.draw_button(ui, Tool::Drawing(tool));
@@ -377,7 +410,10 @@ mod tests {
             ..Default::default()
         };
         let mut drawings = Drawings::default();
-        let _ = ctx.run(input, |ctx| rail.draw(ctx, &mut drawings));
+        let mut manager_open = false;
+        let _ = ctx.run(input, |ctx| {
+            rail.draw(ctx, &mut drawings, &mut manager_open)
+        });
     }
 
     fn primary_button(position: egui::Pos2, pressed: bool) -> egui::Event {
@@ -451,7 +487,8 @@ mod tests {
             events,
             ..Default::default()
         };
-        let _ = ctx.run(input, |ctx| rail.draw(ctx, drawings));
+        let mut manager_open = false;
+        let _ = ctx.run(input, |ctx| rail.draw(ctx, drawings, &mut manager_open));
     }
 
     fn click_at(
@@ -540,8 +577,9 @@ mod tests {
                 ..Default::default()
             };
             let mut drawings = Drawings::default();
+            let mut manager_open = false;
             let _ = ctx.run(input, |ctx| {
-                rail.draw(ctx, &mut drawings);
+                rail.draw(ctx, &mut drawings, &mut manager_open);
                 egui::CentralPanel::default().show(ctx, |ui| {
                     central = ui.max_rect();
                 });

--- a/crates/app/src/toolrail.rs
+++ b/crates/app/src/toolrail.rs
@@ -1,84 +1,156 @@
-//! The tool rail: chart-acting tools on the left edge
-//! (`docs/ux/ui-design-model.md` §7).
+//! Drawing-tool selection and the four-corner toolbox dock.
 //!
-//! Exclusive selection — exactly one tool is armed, `Esc` always returns to
-//! Pointer. It ships with Pointer and Crosshair and reserves the geometry the
-//! drawing tools will fill; the selection state machine lives here, pure and
-//! tested, while the chart reads [`ToolRail::tool`] to decide what the pointer
-//! does.
+//! The dock owns only chrome state. Drawing definitions and metadata live in
+//! [`crate::drawings`], so registering a new drawing does not require another
+//! matching list in this module.
 
 use eframe::egui;
 use egui_phosphor::regular as icons;
 
+use crate::drawings::{DRAWING_TOOLS, DrawingTool};
 use crate::theme;
 use crate::widgets::{IconButton, RAIL_ICON};
 
-/// Width of the rail, in pixels (§5 zone 3).
-pub const RAIL_WIDTH: f32 = 44.0;
+const TOOLBOX_HEIGHT_PX: f32 = 44.0;
+const TOOLBOX_HORIZONTAL_MARGIN_PX: f32 = 8.0;
+const TOOLBOX_ITEM_GAP_PX: f32 = 6.0;
+#[cfg(test)]
+const TOOLBOX_BUTTON_COUNT: usize = DRAWING_TOOLS.len() + 2;
 
-/// A chart-acting tool. Body slots are exclusive; footer modifiers (magnet,
-/// lock) arrive with the drawing tools.
+/// A chart-acting tool. Only one is armed at a time.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum Tool {
-    /// Pan, zoom and select — the default interaction.
     #[default]
     Pointer,
-    /// The hover crosshair, as an armed mode instead of an always-on layer.
     Crosshair,
+    Drawing(DrawingTool),
 }
 
 impl Tool {
-    /// Every tool, in rail order.
-    pub const ALL: [Self; 2] = [Self::Pointer, Self::Crosshair];
-
-    /// The Phosphor glyph on the rail slot.
     #[must_use]
-    pub fn icon(self) -> &'static str {
+    pub fn drawing_tool(self) -> Option<DrawingTool> {
+        match self {
+            Self::Drawing(tool) => Some(tool),
+            Self::Pointer | Self::Crosshair => None,
+        }
+    }
+
+    #[must_use]
+    fn icon(self) -> &'static str {
         match self {
             Self::Pointer => icons::CURSOR,
             Self::Crosshair => icons::CROSSHAIR,
+            Self::Drawing(tool) => tool.icon(),
         }
     }
 
-    /// Tooltip, shortcut included.
     #[must_use]
-    pub fn hover_text(self) -> &'static str {
+    fn hover_text(self) -> &'static str {
         match self {
-            Self::Pointer => "Pointer — pan, zoom, select (1, Esc)",
+            Self::Pointer => "Pointer - pan, zoom, select and move (1, Esc)",
             Self::Crosshair => "Crosshair (2)",
+            Self::Drawing(tool) => tool.hover_text(),
         }
     }
 }
 
-/// The rail's state: which tool is armed.
-#[derive(Debug, Default)]
+/// One of the four external chart corners where the toolbox can dock.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ToolboxDock {
+    #[default]
+    TopLeft,
+    TopRight,
+    BottomLeft,
+    BottomRight,
+}
+
+impl ToolboxDock {
+    #[must_use]
+    const fn is_top(self) -> bool {
+        matches!(self, Self::TopLeft | Self::TopRight)
+    }
+
+    #[must_use]
+    const fn is_left(self) -> bool {
+        matches!(self, Self::TopLeft | Self::BottomLeft)
+    }
+
+    #[must_use]
+    fn nearest(pointer: egui::Pos2, screen: egui::Rect) -> Self {
+        match (
+            pointer.y <= screen.center().y,
+            pointer.x <= screen.center().x,
+        ) {
+            (true, true) => Self::TopLeft,
+            (true, false) => Self::TopRight,
+            (false, true) => Self::BottomLeft,
+            (false, false) => Self::BottomRight,
+        }
+    }
+}
+
+/// Toolbox chrome state. The panel is always outside `CentralPanel`, so the
+/// chart never renders behind it.
+#[derive(Debug)]
 pub struct ToolRail {
     tool: Tool,
+    visible: bool,
+    dock: ToolboxDock,
+    #[cfg(test)]
+    button_rects: [Option<(Tool, egui::Rect)>; TOOLBOX_BUTTON_COUNT],
+    #[cfg(test)]
+    grip_rect: Option<egui::Rect>,
+}
+
+impl Default for ToolRail {
+    fn default() -> Self {
+        Self {
+            tool: Tool::Pointer,
+            visible: true,
+            dock: ToolboxDock::TopLeft,
+            #[cfg(test)]
+            button_rects: [None; TOOLBOX_BUTTON_COUNT],
+            #[cfg(test)]
+            grip_rect: None,
+        }
+    }
 }
 
 impl ToolRail {
-    /// A rail with the Pointer armed.
     #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
 
-    /// The armed tool.
     #[must_use]
     pub fn tool(&self) -> Tool {
         self.tool
     }
 
-    /// Arm `tool`, replacing whatever was armed — the exclusive-selection
-    /// rule.
+    #[must_use]
+    pub fn visible(&self) -> bool {
+        self.visible
+    }
+
+    pub fn toggle_visible(&mut self) {
+        self.visible = !self.visible;
+        if !self.visible {
+            self.tool = Tool::Pointer;
+        }
+    }
+
     pub fn arm(&mut self, tool: Tool) {
         self.tool = tool;
     }
 
-    /// Apply the rail shortcuts: `Esc`/`1` arm the Pointer, `2` the
-    /// Crosshair. Single letters stay modifier-free, so they are ignored
-    /// whenever a widget owns the keyboard (typing in a field must not switch
-    /// tools).
+    #[cfg(test)]
+    pub(crate) fn button_rect(&self, tool: Tool) -> Option<egui::Rect> {
+        self.button_rects
+            .iter()
+            .flatten()
+            .find_map(|(candidate, rect)| (*candidate == tool).then_some(*rect))
+    }
+
     pub fn handle_keys(&mut self, ctx: &egui::Context) {
         if ctx.memory(|memory| memory.focused().is_some()) {
             return;
@@ -93,28 +165,95 @@ impl ToolRail {
         });
     }
 
-    /// Draw the rail as the left 44 px panel.
+    /// Draw the toolbox in an external top/bottom strip. Drag the grip and
+    /// release anywhere: the closest of the four screen corners becomes its
+    /// new dock.
     pub fn draw(&mut self, ctx: &egui::Context) {
-        egui::SidePanel::left("tool_rail")
-            .exact_width(RAIL_WIDTH)
+        if !self.visible {
+            return;
+        }
+
+        let panel = if self.dock.is_top() {
+            egui::TopBottomPanel::top("drawing_toolbox_top")
+        } else {
+            egui::TopBottomPanel::bottom("drawing_toolbox_bottom")
+        };
+        panel
+            .exact_height(TOOLBOX_HEIGHT_PX)
             .resizable(false)
             .frame(
                 egui::Frame::none()
                     .fill(theme::CHROME)
-                    .inner_margin(egui::Margin::symmetric(7.0, 8.0)),
+                    .stroke(egui::Stroke::new(1.0_f32, theme::BORDER))
+                    .inner_margin(egui::Margin::symmetric(
+                        TOOLBOX_HORIZONTAL_MARGIN_PX,
+                        TOOLBOX_ITEM_GAP_PX,
+                    )),
             )
-            .show(ctx, |ui| {
-                ui.spacing_mut().item_spacing.y = 6.0;
-                for tool in Tool::ALL {
-                    let response = IconButton::new(tool.icon(), RAIL_ICON)
-                        .active(self.tool == tool)
-                        .hover_text(tool.hover_text())
-                        .show(ui);
-                    if response.clicked() {
-                        self.arm(tool);
-                    }
+            .show(ctx, |ui| self.draw_contents(ui));
+    }
+
+    fn draw_contents(&mut self, ui: &mut egui::Ui) {
+        #[cfg(test)]
+        {
+            self.button_rects.fill(None);
+            self.grip_rect = None;
+        }
+        let left = self.dock.is_left();
+        let layout = if left {
+            egui::Layout::left_to_right(egui::Align::Center)
+        } else {
+            egui::Layout::right_to_left(egui::Align::Center)
+        };
+
+        ui.with_layout(layout, |ui| {
+            ui.spacing_mut().item_spacing.x = TOOLBOX_ITEM_GAP_PX;
+            let grip = ui
+                .add(egui::Label::new(icons::DOTS_SIX_VERTICAL).sense(egui::Sense::drag()))
+                .on_hover_text("Drag to dock the toolbox in another corner");
+            #[cfg(test)]
+            {
+                self.grip_rect = Some(grip.rect);
+            }
+            if grip.dragged() {
+                ui.ctx().set_cursor_icon(egui::CursorIcon::Grabbing);
+            }
+            if grip.drag_stopped()
+                && let Some(pointer) = ui.ctx().input(|input| input.pointer.interact_pos())
+            {
+                self.dock = ToolboxDock::nearest(pointer, ui.ctx().screen_rect());
+            }
+
+            if left {
+                for tool in [Tool::Pointer, Tool::Crosshair] {
+                    self.draw_button(ui, tool);
                 }
-            });
+                for tool in DRAWING_TOOLS {
+                    self.draw_button(ui, Tool::Drawing(tool));
+                }
+            } else {
+                for tool in DRAWING_TOOLS.into_iter().rev() {
+                    self.draw_button(ui, Tool::Drawing(tool));
+                }
+                for tool in [Tool::Crosshair, Tool::Pointer] {
+                    self.draw_button(ui, tool);
+                }
+            }
+        });
+    }
+
+    fn draw_button(&mut self, ui: &mut egui::Ui, tool: Tool) {
+        let response = IconButton::new(tool.icon(), RAIL_ICON)
+            .active(self.tool == tool)
+            .hover_text(tool.hover_text())
+            .show(ui);
+        #[cfg(test)]
+        if let Some(slot) = self.button_rects.iter_mut().find(|slot| slot.is_none()) {
+            *slot = Some((tool, response.rect));
+        }
+        if response.clicked() {
+            self.arm(tool);
+        }
     }
 }
 
@@ -123,36 +262,148 @@ mod tests {
     use super::*;
 
     #[test]
-    fn the_rail_opens_on_the_pointer() {
-        assert_eq!(ToolRail::new().tool(), Tool::Pointer);
+    fn toolbox_opens_outside_the_chart_at_top_left() {
+        let rail = ToolRail::new();
+        assert!(rail.visible());
+        assert_eq!(rail.tool(), Tool::Pointer);
+        assert_eq!(rail.dock, ToolboxDock::TopLeft);
     }
 
     #[test]
-    fn arming_is_exclusive() {
+    fn hiding_the_toolbox_cannot_leave_an_invisible_drawing_tool_armed() {
         let mut rail = ToolRail::new();
-        rail.arm(Tool::Crosshair);
-        assert_eq!(rail.tool(), Tool::Crosshair);
-        rail.arm(Tool::Pointer);
+        rail.arm(Tool::Drawing(DRAWING_TOOLS[0]));
+        rail.toggle_visible();
+        assert!(!rail.visible());
         assert_eq!(rail.tool(), Tool::Pointer);
     }
 
     #[test]
-    fn every_tool_has_a_glyph_and_a_tooltip() {
-        for tool in Tool::ALL {
-            assert!(!tool.icon().is_empty());
-            assert!(!tool.hover_text().is_empty());
+    fn every_quadrant_maps_to_its_nearest_corner() {
+        let screen = egui::Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(100.0, 100.0));
+        assert_eq!(
+            ToolboxDock::nearest(egui::pos2(10.0, 10.0), screen),
+            ToolboxDock::TopLeft
+        );
+        assert_eq!(
+            ToolboxDock::nearest(egui::pos2(90.0, 10.0), screen),
+            ToolboxDock::TopRight
+        );
+        assert_eq!(
+            ToolboxDock::nearest(egui::pos2(10.0, 90.0), screen),
+            ToolboxDock::BottomLeft
+        );
+        assert_eq!(
+            ToolboxDock::nearest(egui::pos2(90.0, 90.0), screen),
+            ToolboxDock::BottomRight
+        );
+    }
+
+    fn draw_rail_frame(
+        rail: &mut ToolRail,
+        ctx: &egui::Context,
+        screen: egui::Rect,
+        events: Vec<egui::Event>,
+    ) {
+        let input = egui::RawInput {
+            screen_rect: Some(screen),
+            events,
+            ..Default::default()
+        };
+        let _ = ctx.run(input, |ctx| rail.draw(ctx));
+    }
+
+    fn primary_button(position: egui::Pos2, pressed: bool) -> egui::Event {
+        egui::Event::PointerButton {
+            pos: position,
+            button: egui::PointerButton::Primary,
+            pressed,
+            modifiers: egui::Modifiers::NONE,
         }
     }
 
-    /// Lay the rail out for real, off-screen: an un-clicked frame must leave
-    /// the armed tool alone.
     #[test]
-    fn the_rail_lays_out_against_a_real_context() {
+    fn dragging_the_real_grip_docks_at_each_screen_corner() {
+        let screen = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(800.0, 600.0));
         let ctx = egui::Context::default();
         let mut rail = ToolRail::new();
-        for _ in 0..2 {
-            let _ = ctx.run(egui::RawInput::default(), |ctx| rail.draw(ctx));
+        draw_rail_frame(&mut rail, &ctx, screen, Vec::new());
+
+        for (target, expected) in [
+            (egui::pos2(790.0, 10.0), ToolboxDock::TopRight),
+            (egui::pos2(10.0, 590.0), ToolboxDock::BottomLeft),
+            (egui::pos2(790.0, 590.0), ToolboxDock::BottomRight),
+            (egui::pos2(10.0, 10.0), ToolboxDock::TopLeft),
+        ] {
+            let start = rail.grip_rect.expect("grip was rendered").center();
+            draw_rail_frame(
+                &mut rail,
+                &ctx,
+                screen,
+                vec![
+                    egui::Event::PointerMoved(start),
+                    primary_button(start, true),
+                ],
+            );
+            draw_rail_frame(
+                &mut rail,
+                &ctx,
+                screen,
+                vec![egui::Event::PointerMoved(target)],
+            );
+            draw_rail_frame(
+                &mut rail,
+                &ctx,
+                screen,
+                vec![
+                    egui::Event::PointerMoved(target),
+                    primary_button(target, false),
+                ],
+            );
+            assert_eq!(rail.dock, expected);
+            draw_rail_frame(&mut rail, &ctx, screen, Vec::new());
         }
-        assert_eq!(rail.tool(), Tool::Pointer);
+    }
+
+    #[test]
+    fn drawing_tool_carries_the_registered_implementation_without_an_adapter_match() {
+        for tool in DRAWING_TOOLS {
+            assert_eq!(Tool::Drawing(tool).drawing_tool(), Some(tool));
+        }
+    }
+
+    #[test]
+    fn every_dock_position_reserves_space_outside_the_central_chart() {
+        let screen = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(800.0, 600.0));
+        for dock in [
+            ToolboxDock::TopLeft,
+            ToolboxDock::TopRight,
+            ToolboxDock::BottomLeft,
+            ToolboxDock::BottomRight,
+        ] {
+            let ctx = egui::Context::default();
+            let mut rail = ToolRail {
+                tool: Tool::Pointer,
+                visible: true,
+                dock,
+                ..ToolRail::default()
+            };
+            let mut central = egui::Rect::NOTHING;
+            let input = egui::RawInput {
+                screen_rect: Some(screen),
+                ..Default::default()
+            };
+            let _ = ctx.run(input, |ctx| {
+                rail.draw(ctx);
+                egui::CentralPanel::default().show(ctx, |ui| {
+                    central = ui.max_rect();
+                });
+            });
+            if dock.is_top() {
+                assert!(central.top() >= TOOLBOX_HEIGHT_PX);
+            } else {
+                assert!(central.bottom() <= screen.bottom() - TOOLBOX_HEIGHT_PX);
+            }
+        }
     }
 }

--- a/crates/app/src/toolrail.rs
+++ b/crates/app/src/toolrail.rs
@@ -7,7 +7,7 @@
 use eframe::egui;
 use egui_phosphor::regular as icons;
 
-use crate::drawings::{DRAWING_TOOLS, DrawingTool};
+use crate::drawings::{DRAWING_TOOLS, DrawingTool, Drawings};
 use crate::theme;
 use crate::widgets::{IconButton, RAIL_ICON};
 
@@ -100,6 +100,10 @@ pub struct ToolRail {
     button_rects: [Option<(Tool, egui::Rect)>; TOOLBOX_BUTTON_COUNT],
     #[cfg(test)]
     grip_rect: Option<egui::Rect>,
+    #[cfg(test)]
+    hide_all_rect: Option<egui::Rect>,
+    #[cfg(test)]
+    lock_all_rect: Option<egui::Rect>,
 }
 
 impl Default for ToolRail {
@@ -112,6 +116,10 @@ impl Default for ToolRail {
             button_rects: [None; TOOLBOX_BUTTON_COUNT],
             #[cfg(test)]
             grip_rect: None,
+            #[cfg(test)]
+            hide_all_rect: None,
+            #[cfg(test)]
+            lock_all_rect: None,
         }
     }
 }
@@ -167,8 +175,9 @@ impl ToolRail {
 
     /// Draw the toolbox in an external top/bottom strip. Drag the grip and
     /// release anywhere: the closest of the four screen corners becomes its
-    /// new dock.
-    pub fn draw(&mut self, ctx: &egui::Context) {
+    /// new dock. The rail also hosts the global protection toggles
+    /// (hide-all / lock-all), which act on the drawings store.
+    pub fn draw(&mut self, ctx: &egui::Context, drawings: &mut Drawings) {
         if !self.visible {
             return;
         }
@@ -190,14 +199,67 @@ impl ToolRail {
                         TOOLBOX_ITEM_GAP_PX,
                     )),
             )
-            .show(ctx, |ui| self.draw_contents(ui));
+            .show(ctx, |ui| self.draw_contents(ui, drawings));
     }
 
-    fn draw_contents(&mut self, ui: &mut egui::Ui) {
+    /// The reversible global protections. Hide-all is a view layer over each
+    /// drawing's own eye; lock-all mutates every lock at once. Neither is a
+    /// delete, and both are one undo entry.
+    fn draw_global_buttons(&mut self, ui: &mut egui::Ui, drawings: &mut Drawings) {
+        let all_hidden = drawings.all_hidden();
+        let eye_icon = if all_hidden {
+            icons::EYE_SLASH
+        } else {
+            icons::EYE
+        };
+        let eye_hover = if all_hidden {
+            "Show all drawings"
+        } else {
+            "Hide all drawings"
+        };
+        let eye = IconButton::new(eye_icon, RAIL_ICON)
+            .active(all_hidden)
+            .hover_text(eye_hover)
+            .show(ui);
+        #[cfg(test)]
+        {
+            self.hide_all_rect = Some(eye.rect);
+        }
+        if eye.clicked() {
+            drawings.set_all_hidden(!all_hidden);
+        }
+
+        let all_locked = drawings.all_locked();
+        let lock_icon = if all_locked {
+            icons::LOCK_SIMPLE
+        } else {
+            icons::LOCK_SIMPLE_OPEN
+        };
+        let lock_hover = if all_locked {
+            "Unlock all drawings"
+        } else {
+            "Lock all drawings"
+        };
+        let lock = IconButton::new(lock_icon, RAIL_ICON)
+            .active(all_locked)
+            .hover_text(lock_hover)
+            .show(ui);
+        #[cfg(test)]
+        {
+            self.lock_all_rect = Some(lock.rect);
+        }
+        if lock.clicked() {
+            drawings.set_all_locked(!all_locked);
+        }
+    }
+
+    fn draw_contents(&mut self, ui: &mut egui::Ui, drawings: &mut Drawings) {
         #[cfg(test)]
         {
             self.button_rects.fill(None);
             self.grip_rect = None;
+            self.hide_all_rect = None;
+            self.lock_all_rect = None;
         }
         let left = self.dock.is_left();
         let layout = if left {
@@ -231,7 +293,11 @@ impl ToolRail {
                 for tool in DRAWING_TOOLS {
                     self.draw_button(ui, Tool::Drawing(tool));
                 }
+                ui.separator();
+                self.draw_global_buttons(ui, drawings);
             } else {
+                self.draw_global_buttons(ui, drawings);
+                ui.separator();
                 for tool in DRAWING_TOOLS.into_iter().rev() {
                     self.draw_button(ui, Tool::Drawing(tool));
                 }
@@ -310,7 +376,8 @@ mod tests {
             events,
             ..Default::default()
         };
-        let _ = ctx.run(input, |ctx| rail.draw(ctx));
+        let mut drawings = Drawings::default();
+        let _ = ctx.run(input, |ctx| rail.draw(ctx, &mut drawings));
     }
 
     fn primary_button(position: egui::Pos2, pressed: bool) -> egui::Event {
@@ -372,6 +439,85 @@ mod tests {
         }
     }
 
+    fn rail_frame_with(
+        rail: &mut ToolRail,
+        drawings: &mut Drawings,
+        ctx: &egui::Context,
+        screen: egui::Rect,
+        events: Vec<egui::Event>,
+    ) {
+        let input = egui::RawInput {
+            screen_rect: Some(screen),
+            events,
+            ..Default::default()
+        };
+        let _ = ctx.run(input, |ctx| rail.draw(ctx, drawings));
+    }
+
+    fn click_at(
+        rail: &mut ToolRail,
+        drawings: &mut Drawings,
+        ctx: &egui::Context,
+        screen: egui::Rect,
+        position: egui::Pos2,
+    ) {
+        rail_frame_with(
+            rail,
+            drawings,
+            ctx,
+            screen,
+            vec![
+                egui::Event::PointerMoved(position),
+                primary_button(position, true),
+            ],
+        );
+        rail_frame_with(
+            rail,
+            drawings,
+            ctx,
+            screen,
+            vec![
+                egui::Event::PointerMoved(position),
+                primary_button(position, false),
+            ],
+        );
+    }
+
+    #[test]
+    fn global_eye_and_lock_buttons_protect_every_drawing_without_deleting() {
+        use crate::drawings::ChartPoint;
+
+        let screen = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(800.0, 600.0));
+        let ctx = egui::Context::default();
+        let mut rail = ToolRail::new();
+        let mut drawings = Drawings::default();
+        drawings.place(
+            DRAWING_TOOLS[0],
+            ChartPoint {
+                bar: 1.0,
+                price: 100.0,
+            },
+        );
+        rail_frame_with(&mut rail, &mut drawings, &ctx, screen, Vec::new());
+
+        let eye = rail.hide_all_rect.expect("hide-all rendered").center();
+        click_at(&mut rail, &mut drawings, &ctx, screen, eye);
+        assert!(drawings.all_hidden(), "hide-all engages the global layer");
+        click_at(&mut rail, &mut drawings, &ctx, screen, eye);
+        assert!(!drawings.all_hidden(), "hide-all toggles back off");
+
+        let lock = rail.lock_all_rect.expect("lock-all rendered").center();
+        click_at(&mut rail, &mut drawings, &ctx, screen, lock);
+        assert!(drawings.all_locked(), "lock-all locks every drawing");
+        click_at(&mut rail, &mut drawings, &ctx, screen, lock);
+        assert!(!drawings.all_locked(), "lock-all toggles back to unlocked");
+        assert_eq!(
+            drawings.items().len(),
+            1,
+            "global protections must never delete"
+        );
+    }
+
     #[test]
     fn every_dock_position_reserves_space_outside_the_central_chart() {
         let screen = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(800.0, 600.0));
@@ -393,8 +539,9 @@ mod tests {
                 screen_rect: Some(screen),
                 ..Default::default()
             };
+            let mut drawings = Drawings::default();
             let _ = ctx.run(input, |ctx| {
-                rail.draw(ctx);
+                rail.draw(ctx, &mut drawings);
                 egui::CentralPanel::default().show(ctx, |ui| {
                     central = ui.max_rect();
                 });

--- a/crates/app/src/toolrail.rs
+++ b/crates/app/src/toolrail.rs
@@ -14,8 +14,23 @@ use crate::widgets::{IconButton, RAIL_ICON};
 const TOOLBOX_HEIGHT_PX: f32 = 44.0;
 const TOOLBOX_HORIZONTAL_MARGIN_PX: f32 = 8.0;
 const TOOLBOX_ITEM_GAP_PX: f32 = 6.0;
+/// One 32 px rail button plus its gap — the slot the width budget counts.
+const TOOLBOX_BUTTON_SLOT_PX: f32 = 32.0 + TOOLBOX_ITEM_GAP_PX;
+/// Room the grip and the two separators take beyond the button slots.
+const TOOLBOX_CHROME_ALLOWANCE_PX: f32 = 60.0;
 #[cfg(test)]
 const TOOLBOX_BUTTON_COUNT: usize = DRAWING_TOOLS.len() + 2;
+
+/// The width the full strip needs. Below this the drawing tools collapse
+/// into the More-tools flyout; Pointer, the active tool and Objects always
+/// survive, and the strip never wraps into a second row.
+fn full_toolbox_width() -> f32 {
+    // Pointer + Crosshair + every tool + repeat + objects + two globals.
+    let buttons = (2 + DRAWING_TOOLS.len() + 4) as f32;
+    2.0 * TOOLBOX_HORIZONTAL_MARGIN_PX
+        + buttons * TOOLBOX_BUTTON_SLOT_PX
+        + TOOLBOX_CHROME_ALLOWANCE_PX
+}
 
 /// A chart-acting tool. Only one is armed at a time.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -96,6 +111,9 @@ pub struct ToolRail {
     tool: Tool,
     visible: bool,
     dock: ToolboxDock,
+    /// The repeat pin: `true` keeps a drawing tool armed after it completes
+    /// an object; the default is one-shot back to Pointer.
+    repeat: bool,
     #[cfg(test)]
     button_rects: [Option<(Tool, egui::Rect)>; TOOLBOX_BUTTON_COUNT],
     #[cfg(test)]
@@ -114,6 +132,7 @@ impl Default for ToolRail {
             tool: Tool::Pointer,
             visible: true,
             dock: ToolboxDock::TopLeft,
+            repeat: false,
             #[cfg(test)]
             button_rects: [None; TOOLBOX_BUTTON_COUNT],
             #[cfg(test)]
@@ -155,6 +174,17 @@ impl ToolRail {
         self.tool = tool;
     }
 
+    /// Whether the repeat pin keeps the tool armed after an object completes.
+    #[must_use]
+    pub fn repeat(&self) -> bool {
+        self.repeat
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_repeat(&mut self, repeat: bool) {
+        self.repeat = repeat;
+    }
+
     #[cfg(test)]
     pub(crate) fn button_rect(&self, tool: Tool) -> Option<egui::Rect> {
         self.button_rects
@@ -168,18 +198,34 @@ impl ToolRail {
         self.objects_rect
     }
 
+    /// Tool-arming keys. Escape lives in the app's escape stack (input →
+    /// draft → selection → Pointer), not here. Each drawing tool declares
+    /// its own shortcut through the registry.
     pub fn handle_keys(&mut self, ctx: &egui::Context) {
         if ctx.memory(|memory| memory.focused().is_some()) {
             return;
         }
-        ctx.input(|input| {
-            if input.key_pressed(egui::Key::Escape) || input.key_pressed(egui::Key::Num1) {
-                self.arm(Tool::Pointer);
+        let armed = ctx.input(|input| {
+            if input.modifiers.command || input.modifiers.alt {
+                return None;
+            }
+            if input.key_pressed(egui::Key::Num1) {
+                return Some(Tool::Pointer);
             }
             if input.key_pressed(egui::Key::Num2) {
-                self.arm(Tool::Crosshair);
+                return Some(Tool::Crosshair);
             }
+            DRAWING_TOOLS.into_iter().find_map(|tool| {
+                tool.shortcut()
+                    .filter(|shortcut| {
+                        input.key_pressed(shortcut.key) && input.modifiers.shift == shortcut.shift
+                    })
+                    .map(|_| Tool::Drawing(tool))
+            })
         });
+        if let Some(tool) = armed {
+            self.arm(tool);
+        }
     }
 
     /// Draw the toolbox in an external top/bottom strip. Drag the grip and
@@ -209,6 +255,58 @@ impl ToolRail {
                     )),
             )
             .show(ctx, |ui| self.draw_contents(ui, drawings, manager_open));
+    }
+
+    /// The repeat pin: keep the armed drawing tool active after it completes
+    /// an object, instead of the one-shot return to Pointer.
+    fn draw_repeat_button(&mut self, ui: &mut egui::Ui) {
+        let response = IconButton::new(icons::ARROW_CLOCKWISE, RAIL_ICON)
+            .active(self.repeat)
+            .hover_text("Keep the drawing tool active after drawing")
+            .show(ui);
+        if response.clicked() {
+            self.repeat = !self.repeat;
+        }
+    }
+
+    /// The More-tools flyout of the collapsed strip: everything that lost
+    /// its slot stays reachable by name, plus the global protections.
+    fn draw_more_tools_menu(&mut self, ui: &mut egui::Ui, drawings: &mut Drawings) {
+        ui.menu_button(icons::PLUS, |ui| {
+            for tool in [Tool::Crosshair]
+                .into_iter()
+                .chain(DRAWING_TOOLS.into_iter().map(Tool::Drawing))
+            {
+                let name = match tool {
+                    Tool::Crosshair => "Crosshair",
+                    Tool::Drawing(tool) => tool.name(),
+                    Tool::Pointer => unreachable!("pointer keeps its own slot"),
+                };
+                if ui.button(name).clicked() {
+                    self.arm(tool);
+                    ui.close_menu();
+                }
+            }
+            ui.separator();
+            let all_hidden = drawings.all_hidden();
+            if ui
+                .button(if all_hidden { "Show all" } else { "Hide all" })
+                .clicked()
+            {
+                drawings.set_all_hidden(!all_hidden);
+                ui.close_menu();
+            }
+            let all_locked = drawings.all_locked();
+            if ui
+                .button(if all_locked { "Unlock all" } else { "Lock all" })
+                .clicked()
+            {
+                drawings.set_all_locked(!all_locked);
+                ui.close_menu();
+            }
+        })
+        .response
+        .on_hover_text("More tools");
     }
 
     /// The entry to the drawn-objects manager. A toggle, not a tool: it never
@@ -317,13 +415,26 @@ impl ToolRail {
                 self.dock = ToolboxDock::nearest(pointer, ui.ctx().screen_rect());
             }
 
-            if left {
+            // Below the full-strip budget the tools collapse into the
+            // More-tools flyout: Pointer, the active tool and Objects keep
+            // their slots, and the strip never wraps into a second row.
+            let overflow = ui.available_width() < full_toolbox_width();
+            if overflow {
+                self.draw_button(ui, Tool::Pointer);
+                if let Some(active) = self.tool.drawing_tool() {
+                    self.draw_button(ui, Tool::Drawing(active));
+                }
+                self.draw_more_tools_menu(ui, drawings);
+                ui.separator();
+                self.draw_objects_button(ui, manager_open);
+            } else if left {
                 for tool in [Tool::Pointer, Tool::Crosshair] {
                     self.draw_button(ui, tool);
                 }
                 for tool in DRAWING_TOOLS {
                     self.draw_button(ui, Tool::Drawing(tool));
                 }
+                self.draw_repeat_button(ui);
                 ui.separator();
                 self.draw_objects_button(ui, manager_open);
                 self.draw_global_buttons(ui, drawings);
@@ -331,6 +442,7 @@ impl ToolRail {
                 self.draw_global_buttons(ui, drawings);
                 self.draw_objects_button(ui, manager_open);
                 ui.separator();
+                self.draw_repeat_button(ui);
                 for tool in DRAWING_TOOLS.into_iter().rev() {
                     self.draw_button(ui, Tool::Drawing(tool));
                 }
@@ -518,6 +630,88 @@ mod tests {
                 primary_button(position, false),
             ],
         );
+    }
+
+    #[test]
+    fn tool_shortcuts_arm_their_declared_tools() {
+        let ctx = egui::Context::default();
+        let mut rail = ToolRail::new();
+        let send = |rail: &mut ToolRail, key: egui::Key, modifiers: egui::Modifiers| {
+            let input = egui::RawInput {
+                events: vec![egui::Event::Key {
+                    key,
+                    physical_key: None,
+                    pressed: true,
+                    repeat: false,
+                    modifiers,
+                }],
+                modifiers,
+                ..Default::default()
+            };
+            let _ = ctx.run(input, |ctx| rail.handle_keys(ctx));
+        };
+
+        send(&mut rail, egui::Key::H, egui::Modifiers::NONE);
+        assert_eq!(
+            rail.tool().drawing_tool().map(DrawingTool::id),
+            Some("horizontal-line")
+        );
+        send(&mut rail, egui::Key::R, egui::Modifiers::NONE);
+        assert_eq!(
+            rail.tool().drawing_tool().map(DrawingTool::id),
+            Some("rectangle")
+        );
+        send(&mut rail, egui::Key::C, egui::Modifiers::NONE);
+        assert_eq!(
+            rail.tool().drawing_tool().map(DrawingTool::id),
+            Some("parallel-channel")
+        );
+        send(&mut rail, egui::Key::F, egui::Modifiers::NONE);
+        assert_eq!(
+            rail.tool().drawing_tool().map(DrawingTool::id),
+            Some("fib-retracement")
+        );
+        send(&mut rail, egui::Key::F, egui::Modifiers::SHIFT);
+        assert_eq!(
+            rail.tool().drawing_tool().map(DrawingTool::id),
+            Some("fib-extension")
+        );
+        send(&mut rail, egui::Key::Num1, egui::Modifiers::NONE);
+        assert_eq!(rail.tool(), Tool::Pointer);
+        // A held command modifier keeps the letters out of the tool map.
+        send(&mut rail, egui::Key::R, egui::Modifiers::COMMAND);
+        assert_eq!(rail.tool(), Tool::Pointer);
+    }
+
+    #[test]
+    fn the_narrow_strip_keeps_pointer_active_tool_and_objects() {
+        let ctx = egui::Context::default();
+        let mut rail = ToolRail::new();
+        rail.arm(Tool::Drawing(DRAWING_TOOLS[1]));
+        let mut drawings = Drawings::default();
+
+        // Narrow: the strip collapses; Pointer, the active tool and the
+        // Objects entry survive, the rest folds into the More flyout.
+        let narrow = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(400.0, 600.0));
+        rail_frame_with(&mut rail, &mut drawings, &ctx, narrow, Vec::new());
+        assert!(rail.button_rect(Tool::Pointer).is_some());
+        assert!(rail.button_rect(Tool::Drawing(DRAWING_TOOLS[1])).is_some());
+        assert!(
+            rail.button_rect(Tool::Drawing(DRAWING_TOOLS[0])).is_none(),
+            "inactive tools give up their slots in the narrow strip"
+        );
+        assert!(rail.objects_button_rect().is_some());
+
+        // Wide: every tool has its slot back.
+        let wide = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(900.0, 600.0));
+        rail_frame_with(&mut rail, &mut drawings, &ctx, wide, Vec::new());
+        for tool in DRAWING_TOOLS {
+            assert!(
+                rail.button_rect(Tool::Drawing(tool)).is_some(),
+                "{} lost its slot on a wide strip",
+                tool.id()
+            );
+        }
     }
 
     #[test]

--- a/crates/app/src/viewport.rs
+++ b/crates/app/src/viewport.rs
@@ -101,6 +101,20 @@ impl Viewport {
         self.follow = true;
     }
 
+    /// Bring `bar` to the middle of a window `width_px` wide — the object
+    /// manager's "select and centre". Clamped to the newest bar (no future
+    /// margin: nothing to centre on out there), so centring an object near
+    /// the live edge lands on it and resumes following.
+    pub fn center_on_bar(&mut self, bar: f32, width_px: f32, total: usize) {
+        if total == 0 || self.candle_width <= 0.0 {
+            return;
+        }
+        let newest = (total - 1) as f32;
+        let half_window = 0.5 * width_px / self.candle_width;
+        self.right_bar = (bar + half_window).clamp(0.0, newest);
+        self.follow = (self.right_bar - newest).abs() <= 0.5;
+    }
+
     /// Account for `added` bars newly prepended at the front of the series: shift
     /// the right-edge bar index by the same amount so the visible window keeps
     /// showing the same bars instead of jumping. A no-op while following live —
@@ -187,6 +201,19 @@ mod tests {
         let v = Viewport::new();
         assert!(v.follows_live());
         assert_eq!(v.right_edge_bar(500), 499.0);
+    }
+
+    #[test]
+    fn center_on_bar_puts_the_target_mid_window() {
+        let mut v = Viewport::new();
+        // 100 bars visible in an 800 px window at 8 px per candle.
+        v.center_on_bar(200.0, 800.0, 500);
+        assert!(!v.follows_live());
+        assert_eq!(v.right_edge_bar(500), 250.0);
+
+        // Centring near the newest bar lands on the live edge and follows.
+        v.center_on_bar(499.0, 800.0, 500);
+        assert!(v.follows_live());
     }
 
     #[test]

--- a/docs/ux/drawing-tools-ux-spec.html
+++ b/docs/ux/drawing-tools-ux-spec.html
@@ -1,0 +1,1402 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="dark">
+  <title>Quantick · UX das ferramentas de desenho</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --canvas:#131722; --chrome:#171b26; --inset:#10141d; --control:#232936;
+      --border:#2e3648; --soft:#252c3b; --text:#d2dae2; --muted:#96a0af;
+      --faint:#8692a4; --faint-token:#6e7887; --buy:#26a69a; --sell:#ef5350; --accent:#8ab4f8;
+      --amber:#f0b90b; --warn:#ff6347; --tag:#373f50; --yellow:#ffd166;
+      --purple:#b39ddb; --cyan:#4dd0e1; --orange:#ff9f43;
+      --mono:"Cascadia Code","JetBrains Mono",Consolas,monospace;
+      --sans:Inter,ui-sans-serif,system-ui,-apple-system,"Segoe UI",sans-serif;
+    }
+    * { box-sizing:border-box }
+    html { scroll-behavior:smooth; background:#0c0f16 }
+    body {
+      margin:0; color:var(--text); font:15px/1.58 var(--sans);
+      background:
+        radial-gradient(900px 500px at 78% -10%,rgb(138 180 248/.09),transparent 62%),
+        radial-gradient(700px 400px at 8% 2%,rgb(38 166 154/.05),transparent 58%),#0c0f16;
+      -webkit-font-smoothing:antialiased;
+    }
+    button,input,select { font:inherit }
+    button { color:inherit }
+    a { color:var(--accent) }
+    code,kbd,.mono { font-family:var(--mono) }
+    code { padding:2px 5px; color:#cfe1ff; background:rgb(138 180 248/.09); border-radius:4px; font-size:.9em }
+    kbd {
+      display:inline-flex; min-width:24px; min-height:22px; padding:1px 6px;
+      align-items:center; justify-content:center; color:var(--text); background:var(--control);
+      border:1px solid var(--border); border-bottom-color:#4a556c; border-radius:5px;
+      box-shadow:0 1px 0 rgb(255 255 255/.04); font:11px/1 var(--mono);
+    }
+    .page { width:min(1220px,calc(100% - 36px)); margin:auto; padding:38px 0 84px }
+    .hero {
+      display:grid; grid-template-columns:minmax(0,1fr) 300px; gap:40px; align-items:end;
+      padding:24px 0 30px; border-bottom:1px solid var(--soft);
+    }
+    .eyebrow,.index,.micro {
+      font:11px var(--mono); letter-spacing:.13em; text-transform:uppercase;
+    }
+    .eyebrow { margin:0 0 13px; color:var(--accent) }
+    h1 { max-width:840px; margin:0; font-size:clamp(32px,5vw,54px); line-height:1.04; letter-spacing:-.035em; font-weight:650 }
+    h1 span { color:var(--muted); font-weight:420 }
+    .lede { max-width:780px; margin:19px 0 0; color:var(--muted); font-size:17px }
+    .meta { display:grid; gap:7px }
+    .meta div { display:flex; justify-content:space-between; gap:14px; padding:9px 0; border-bottom:1px solid var(--soft); font:11px var(--mono) }
+    .meta span:first-child { color:var(--faint) }
+    .meta span:last-child { text-align:right }
+    nav {
+      position:sticky; z-index:50; top:0; display:flex; gap:4px; margin:0 -8px; padding:9px 8px;
+      overflow:auto; background:rgb(12 15 22/.92); border-bottom:1px solid var(--soft);
+      backdrop-filter:blur(14px);
+    }
+    nav a { flex:none; padding:7px 9px; color:var(--muted); border-radius:6px; text-decoration:none; font:10px var(--mono) }
+    nav a:hover,nav a:focus-visible { color:var(--text); background:var(--control) }
+    section { scroll-margin-top:62px; padding-top:58px }
+    .head { display:grid; grid-template-columns:145px minmax(0,1fr); gap:24px; margin-bottom:23px }
+    .index { padding-top:8px; color:var(--faint) }
+    h2 { margin:0; font-size:clamp(25px,3vw,34px); line-height:1.16; letter-spacing:-.02em; font-weight:620 }
+    h3 { margin:0 0 8px; font-size:18px; line-height:1.3; font-weight:620 }
+    h4 { margin:0 0 5px; font-size:14px }
+    p { margin:0 0 12px }
+    .sub { max-width:800px; margin:10px 0 0; color:var(--muted) }
+    .grid2,.grid3,.grid4 { display:grid; gap:14px }
+    .grid2 { grid-template-columns:repeat(2,minmax(0,1fr)) }
+    .grid3 { grid-template-columns:repeat(3,minmax(0,1fr)) }
+    .grid4 { grid-template-columns:repeat(4,minmax(0,1fr)) }
+    .card {
+      padding:18px; background:linear-gradient(180deg,rgb(23 27 38/.98),rgb(16 20 29/.98));
+      border:1px solid var(--soft); border-radius:10px;
+    }
+    .card p,.card li { color:var(--muted) }
+    .card strong { color:var(--text) }
+    .top-accent { border-top:2px solid var(--accent) }
+    .top-buy { border-top:2px solid var(--buy) }
+    .top-yellow { border-top:2px solid var(--yellow) }
+    .micro { display:block; margin-bottom:8px; color:var(--faint) }
+    .rule {
+      display:grid; grid-template-columns:40px minmax(0,1fr); gap:13px; align-items:start;
+      margin-top:17px; padding:15px 17px; color:var(--muted); background:rgb(138 180 248/.065);
+      border:1px solid rgb(138 180 248/.25); border-radius:10px;
+    }
+    .rule strong { color:var(--text) }
+    .rule i {
+      display:grid; width:36px; height:36px; place-items:center; color:var(--accent);
+      background:rgb(138 180 248/.12); border-radius:9px; font-style:normal; font-size:18px;
+    }
+    ul.clean,ol.clean { margin:0; padding-left:20px }
+    ul.clean li,ol.clean li { margin:7px 0 }
+    .table { overflow:auto; border-top:1px solid var(--border); border-bottom:1px solid var(--border) }
+    table { width:100%; border-collapse:collapse; font-size:13px }
+    th,td { padding:11px 12px; border-bottom:1px solid var(--soft); text-align:left; vertical-align:top }
+    tr:last-child td { border-bottom:0 }
+    th { color:var(--faint); white-space:nowrap; font:10px var(--mono); letter-spacing:.06em; text-transform:uppercase }
+    td { color:var(--muted) }
+    td:first-child,td strong { color:var(--text) }
+
+    /* Protótipo */
+    .prototype { overflow:hidden; background:#0c1018; border:1px solid var(--border); border-radius:14px; box-shadow:0 22px 58px rgb(0 0 0/.38) }
+    .proto-top {
+      display:flex; min-height:42px; align-items:center; gap:14px; padding:0 14px;
+      background:var(--chrome); border-bottom:1px solid var(--border); font:11px var(--mono);
+    }
+    .spacer { flex:1 }
+    .live { display:flex; align-items:center; gap:6px; color:var(--buy) }
+    .live::before { content:""; width:6px; height:6px; background:currentColor; border-radius:50%; box-shadow:0 0 8px currentColor }
+    .stage { position:relative; min-height:620px; overflow:hidden; outline:none; background:var(--canvas) }
+    .stage:focus-visible { outline:2px solid var(--accent); outline-offset:-3px }
+    .stage.drawing-hover { cursor:move }
+    .stage.anchor-hover { cursor:nwse-resize }
+    .stage.locked.drawing-hover,.stage.locked.anchor-hover { cursor:not-allowed }
+    .chart { position:absolute; inset:0; width:100%; height:100%; transition:width .12s }
+    .gridline { stroke:var(--control); stroke-width:1; opacity:.7 }
+    .up { stroke:var(--buy); fill:rgb(38 166 154/.23) }
+    .down { stroke:var(--sell); fill:rgb(239 83 80/.2) }
+    .wick-up { stroke:var(--buy) }.wick-down { stroke:var(--sell) }
+    .fib { cursor:move; transition:opacity .12s }
+    .fib.hidden { opacity:0; pointer-events:none }
+    .fib.unselected .halo,.fib.unselected .handle,.fib.unselected .guide,.fib.unselected .anchorlabel,.fib.unselected #direction-label { opacity:0 }
+    .fib.hovered.unselected .halo { opacity:.14 }
+    .band { fill:rgb(138 180 248/.04) }
+    .level { stroke:var(--draw-color,var(--accent)); stroke-width:var(--draw-width,1.5); vector-effect:non-scaling-stroke }
+    .fib text { fill:var(--draw-color,var(--accent)); font:10px var(--mono) }
+    .guide { stroke:var(--draw-color,var(--accent)); stroke-width:1; stroke-dasharray:4 4; opacity:.55; vector-effect:non-scaling-stroke }
+    .anchorlabel { font-weight:700!important }
+    .halo { stroke:#f3f6fb; stroke-width:5; opacity:.16; vector-effect:non-scaling-stroke }
+    .handle { fill:#f3f6fb; stroke:var(--accent); stroke-width:2; cursor:nwse-resize; vector-effect:non-scaling-stroke }
+    .stage.locked .fib,.stage.locked .handle { cursor:not-allowed }
+    .stage.locked .handle { opacity:0 }
+    .stage.locked .halo { stroke-dasharray:5 4; opacity:.28 }
+    .toolbox {
+      position:absolute; z-index:8; top:14px; left:14px; display:flex; flex-direction:column;
+      gap:3px; width:44px; padding:5px; background:rgb(23 27 38/.98); border:1px solid var(--border);
+      border-radius:10px; box-shadow:0 12px 28px rgb(0 0 0/.3);
+    }
+    .toolbox.dock-right { right:14px; left:auto }
+    .stage.docked.inspector-open .toolbox.dock-right { right:374px }
+    .toolbox.dock-top,.toolbox.dock-bottom { flex-direction:row; width:auto; height:44px }
+    .toolbox.dock-top { top:14px; bottom:auto; left:14px; right:auto }
+    .toolbox.dock-bottom { top:auto; bottom:14px; left:14px; right:auto }
+    .grip { width:32px; height:15px; padding:0; color:var(--faint); text-align:center; background:none; border:0; cursor:grab; line-height:11px }
+    .toolbox.dock-top .grip,.toolbox.dock-bottom .grip { width:15px; height:32px }
+    .toolbox.dock-top .divider,.toolbox.dock-bottom .divider { width:1px; height:24px; margin:4px 3px }
+    .divider { height:1px; margin:3px 2px; background:var(--soft) }
+    .ib {
+      display:grid; width:32px; height:32px; padding:0; place-items:center; color:var(--muted);
+      background:transparent; border:0; border-radius:6px; cursor:pointer; line-height:1;
+    }
+    .ib:hover { color:var(--text); background:var(--border) }
+    .ib:focus-visible,.small:focus-visible,.tab:focus-visible { outline:2px solid var(--accent); outline-offset:1px }
+    .ib[aria-pressed=true],.ib.active { color:var(--accent); background:rgb(138 180 248/.18) }
+    .toolstate {
+      position:absolute; z-index:5; left:70px; bottom:13px; display:flex; gap:8px; padding:7px 10px;
+      color:var(--muted); background:rgb(16 20 29/.92); border:1px solid var(--soft);
+      border-radius:7px; font:11px var(--mono); cursor:default;
+    }
+    .toolstate:focus-visible { outline:2px solid var(--accent); outline-offset:2px }
+    .toolstate b { color:var(--text); font-weight:500 }
+    .lockbadge {
+      position:absolute; z-index:7; left:42%; top:43%; display:none; padding:4px 7px; transform:translate(-50%,-100%);
+      background:var(--tag); border:1px solid var(--border); border-radius:999px; font:10px var(--mono);
+    }
+    .stage.locked.drawing-visible .lockbadge { display:block }
+    .inspector {
+      position:absolute; z-index:12; top:14px; right:14px; width:360px; min-width:300px; max-width:440px;
+      max-height:calc(100% - 28px); overflow:auto; resize:both; background:rgb(23 27 38/.99);
+      border:1px solid var(--border); border-radius:12px; box-shadow:0 12px 32px rgb(0 0 0/.4);
+      transition:opacity .12s,transform .12s; scrollbar-color:var(--border) transparent;
+    }
+    .stage.docked.inspector-open .chart { width:calc(100% - 360px) }
+    .stage.docked .inspector { top:0!important; right:0!important; bottom:0; left:auto!important; width:360px; max-width:440px; max-height:none; border-radius:0; resize:horizontal }
+    .inspector.closed { opacity:0; pointer-events:none; transform:translateX(10px) }
+    .inspector-sticky { position:sticky; z-index:3; top:0; background:rgb(23 27 38/.99) }
+    .ins-head {
+      position:relative; display:grid; grid-template-columns:minmax(0,1fr) auto;
+      gap:7px; align-items:center; min-height:48px; padding:7px 8px 7px 12px;
+      background:rgb(23 27 38/.99); border-bottom:1px solid var(--soft); cursor:grab;
+    }
+    .obj { display:flex; min-width:0; gap:8px; align-items:center }
+    .obj strong,.obj small { display:block }
+    .obj strong { overflow:hidden; font-size:13px; text-overflow:ellipsis; white-space:nowrap }
+    .obj small { color:var(--faint); font:9px var(--mono) }
+    .actions { display:flex; gap:1px }.actions .ib { width:28px; height:28px }
+    .state-chip { display:none!important; width:max-content; margin-top:3px; padding:2px 6px; color:var(--yellow); background:rgb(255 209 102/.1); border:1px solid rgb(255 209 102/.28); border-radius:999px; font:9px var(--mono) }
+    .inspector.is-locked .state-chip { display:inline-flex!important }
+    .drawing-actions {
+      display:grid; grid-template-columns:1fr 1fr; gap:6px;
+      padding:7px 10px; background:rgb(23 27 38/.99); border-bottom:1px solid var(--soft);
+    }
+    .drawing-action {
+      display:flex; min-height:38px; min-width:0; align-items:center; justify-content:center; gap:7px; padding:6px 8px;
+      color:var(--text); background:var(--control); border:1px solid var(--border); border-radius:7px; cursor:pointer; font-size:11px;
+    }
+    .drawing-action:hover { background:var(--border) }
+    .drawing-action:focus-visible { outline:2px solid var(--accent); outline-offset:2px }
+    .drawing-action[aria-pressed=true] { color:var(--yellow); background:rgb(255 209 102/.1); border-color:rgb(255 209 102/.34) }
+    .drawing-action.danger { color:#ffab9c; border-color:rgb(255 99 71/.28) }
+    .drawing-action kbd { margin-left:auto; color:var(--faint) }
+    .tabs {
+      position:relative; display:grid; grid-template-columns:repeat(3,1fr);
+      padding:0 10px; background:rgb(23 27 38/.99); border-bottom:1px solid var(--soft);
+    }
+    .tab { padding:10px 4px 8px; color:var(--faint); background:none; border:0; border-bottom:2px solid transparent; cursor:pointer; font-size:11px }
+    .tab[aria-selected=true] { color:var(--accent); border-bottom-color:var(--accent) }
+    .panel { display:none; padding:13px }.panel.active { display:block }
+    .group { padding:12px 0; border-bottom:1px solid var(--soft) }.group:first-child { padding-top:0 }.group:last-child { border:0 }
+    .fieldtitle { display:flex; justify-content:space-between; gap:10px; margin-bottom:8px; color:var(--muted); font-size:11px; font-weight:600 }
+    .fieldtitle output { color:var(--text); font:11px var(--mono) }
+    .row { display:flex; gap:8px; align-items:center; margin-top:8px }.row:first-child { margin-top:0 }.wrap { flex-wrap:wrap }.between { justify-content:space-between }
+    .swatch { width:24px; height:24px; padding:0; background:var(--c); border:2px solid transparent; border-radius:50%; cursor:pointer; box-shadow:inset 0 0 0 1px rgb(255 255 255/.17) }
+    .swatch[aria-pressed=true] { border-color:#fff; box-shadow:0 0 0 2px rgb(138 180 248/.34) }
+    .input,.select {
+      min-width:0; height:31px; color:var(--text); background:var(--inset);
+      border:1px solid var(--border); border-radius:6px; outline:none; font-size:11px;
+    }
+    .input:focus-visible,.select:focus-visible,input[type=color]:focus-visible,input[type=range]:focus-visible { border-color:var(--accent); outline:2px solid var(--accent); outline-offset:2px }
+    .input { width:100%; padding:0 8px }.number { font-family:var(--mono) }.select { flex:1; padding:0 8px }
+    input[type=range] { width:100%; accent-color:var(--accent) }
+    .check { display:flex; gap:6px; align-items:center; color:var(--muted); font-size:11px }.check input { accent-color:var(--accent) }
+    .small {
+      display:inline-flex; min-height:30px; align-items:center; justify-content:center; padding:5px 9px;
+      color:var(--muted); background:var(--control); border:1px solid var(--border); border-radius:6px;
+      cursor:pointer; font-size:11px;
+    }
+    .small:hover { color:var(--text); background:var(--border) }.small.primary { color:var(--accent) }.small.danger { color:#ff9a86 }
+    .small:disabled { opacity:.4; cursor:not-allowed }
+    .levels { display:grid; gap:4px }
+    .levelrow {
+      display:grid; grid-template-columns:24px 18px 58px minmax(0,1fr) 20px 26px; gap:5px; align-items:center;
+      min-height:31px; padding:3px; border-radius:6px;
+    }
+    .levelrow:hover { background:var(--control) }.dots { color:var(--faint); cursor:grab }
+    .levelrow .input { height:26px; padding:0 5px }.levelrow .ib { width:24px; height:24px }.levelcolor { width:20px; height:20px; padding:0; background:none; border:0; border-radius:4px; cursor:pointer }
+    .banner { display:none; margin-bottom:10px; padding:8px 9px; color:var(--yellow); background:rgb(255 209 102/.08); border:1px solid rgb(255 209 102/.25); border-radius:7px; font-size:11px }
+    .inspector.is-hidden .banner { display:block }
+    .lock-notice { display:none; gap:6px; align-items:flex-start; padding:8px 11px; color:var(--yellow); background:rgb(255 209 102/.07); border-bottom:1px solid rgb(255 209 102/.2); font-size:11px }
+    .inspector.is-locked .lock-notice { display:flex }
+    .lock-notice strong { color:#ffe19a; white-space:nowrap }
+    .footer { display:flex; justify-content:space-between; gap:8px; padding:10px 13px 12px; border-top:1px solid var(--soft) }
+    .confirm { display:none; margin:0 13px 11px; padding:9px; background:rgb(255 99 71/.08); border:1px solid rgb(255 99 71/.3); border-radius:7px; color:#ffab9c; font-size:11px }
+    .confirm.visible { display:block }
+    .manager-pop {
+      position:absolute; z-index:18; top:14px; left:64px; width:min(310px,calc(100% - 16px)); overflow:hidden;
+      background:rgb(23 27 38/.99); border:1px solid var(--border); border-radius:10px;
+      box-shadow:0 16px 36px rgb(0 0 0/.38);
+    }
+    .manager-pop[hidden] { display:none }
+    .tool-pop { position:absolute; z-index:19; display:none; gap:4px; padding:6px; background:rgb(23 27 38/.99); border:1px solid var(--border); border-radius:9px; box-shadow:0 12px 28px rgb(0 0 0/.35) }
+    .tool-pop[hidden] { display:none }
+    .more-tools { display:none }
+    .manager-pop header { display:flex; justify-content:space-between; align-items:center; padding:10px 11px; border-bottom:1px solid var(--soft); font-size:12px }
+    .manager-live-row { display:grid; grid-template-columns:minmax(0,1fr); gap:4px; align-items:center; padding:7px 8px 4px }
+    .manager-live-row .small { min-width:0; padding:4px }
+    .manager-select { justify-content:flex-start; text-align:left }
+    .manager-actions { display:grid; grid-template-columns:1fr 1fr; gap:5px; padding:0 8px 8px }
+    .manager-actions .small { min-width:0; justify-content:flex-start }
+    .toast {
+      position:absolute; z-index:30; left:50%; bottom:14px; display:flex; min-width:290px; max-width:calc(100% - 30px);
+      justify-content:space-between; align-items:center; gap:16px; padding:9px 10px 9px 13px;
+      background:var(--tag); border:1px solid #4a556c; border-radius:8px; box-shadow:0 12px 28px rgb(0 0 0/.34);
+      opacity:0; pointer-events:none; transform:translate(-50%,10px); transition:.16s; font-size:12px;
+    }
+    .toast.show { opacity:1; pointer-events:auto; transform:translate(-50%,0) }.toast button { color:var(--accent); background:none; border:0; cursor:pointer; font-weight:600 }
+    .proto-note { display:flex; flex-wrap:wrap; gap:8px 18px; padding:12px 14px; color:var(--faint); background:var(--inset); border-top:1px solid var(--border); font:10px var(--mono) }
+    .proto-note span::before { content:"•"; margin-right:6px; color:var(--accent) }
+
+    .flow { display:grid; grid-template-columns:repeat(5,1fr); gap:24px }
+    .step { position:relative; padding:14px; background:var(--chrome); border:1px solid var(--soft); border-radius:9px }
+    .step:not(:last-child)::after { content:"→"; position:absolute; top:50%; right:-18px; color:var(--faint); transform:translateY(-50%) }
+    .step b { display:block; margin-bottom:4px; font-size:12px }.step span { color:var(--muted); font-size:11px }
+    .chip { display:inline-flex; align-items:center; gap:6px; padding:3px 7px; background:var(--control); border-radius:999px; white-space:nowrap; font:10px var(--mono) }
+    .chip::before { content:""; width:6px; height:6px; background:var(--s,var(--faint)); border-radius:50% }
+    .formula { padding:13px 15px; color:#cfe1ff; background:var(--inset); border-left:3px solid var(--accent); border-radius:0 8px 8px 0; font:12px/1.7 var(--mono) }
+    .palette { display:grid; grid-template-columns:repeat(8,1fr); gap:8px }
+    .colorcard { padding:9px 5px; text-align:center; background:var(--chrome); border:1px solid var(--soft); border-radius:8px }
+    .colorcard i { display:block; width:22px; height:22px; margin:0 auto 6px; background:var(--c); border:1px solid rgb(255 255 255/.16); border-radius:50% }
+    .colorcard b { display:block; color:var(--muted); font:9px var(--mono) }
+    .manager { display:grid; grid-template-columns:330px minmax(0,1fr); gap:22px; align-items:start }
+    .managerbox { overflow:hidden; background:var(--chrome); border:1px solid var(--border); border-radius:10px; box-shadow:0 18px 40px rgb(0 0 0/.3) }
+    .managerhead { display:flex; justify-content:space-between; padding:11px 12px; border-bottom:1px solid var(--soft); font-size:12px; font-weight:620 }
+    .objectrow { display:grid; width:100%; grid-template-columns:24px minmax(0,1fr) 26px 26px; gap:6px; align-items:center; padding:8px 10px; color:var(--text); background:none; border:0; border-bottom:1px solid var(--soft); text-align:left; cursor:pointer; font-size:11px }
+    .objectrow:last-child { border:0 }.objectrow.selected { background:rgb(138 180 248/.1) }.objectrow small { display:block; color:var(--faint); font:9px var(--mono) }
+    .architecture { display:grid; grid-template-columns:repeat(5,1fr); gap:12px }
+    .node { position:relative; padding:14px 10px; text-align:center; background:var(--chrome); border:1px solid var(--border); border-radius:8px }
+    .node:not(:last-child)::after { content:"→"; position:absolute; z-index:2; top:50%; right:-10px; color:var(--accent); transform:translate(50%,-50%) }
+    .node b { display:block; font:11px var(--mono) }.node span { display:block; margin-top:5px; color:var(--faint); font-size:10px }
+    .accept { display:grid; grid-template-columns:repeat(2,1fr); gap:8px 18px; margin:0; padding:0; list-style:none; counter-reset:ac }
+    .accept li { position:relative; min-height:50px; padding:10px 11px 10px 48px; color:var(--muted); background:var(--chrome); border:1px solid var(--soft); border-radius:8px; counter-increment:ac }
+    .accept li::before { content:"AC-" counter(ac,decimal-leading-zero); position:absolute; top:13px; left:10px; color:var(--accent); font:9px var(--mono) }
+    .accept strong { color:var(--text) }
+    .phase { border-top:2px solid var(--pc,var(--accent)) }
+    footer { margin-top:64px; padding-top:21px; color:var(--faint); border-top:1px solid var(--soft); font-size:12px }
+    footer strong { color:var(--muted) }
+    @media(min-width:800px) and (max-width:1179px){
+      .stage.inspector-open .chart { width:calc(100% - 330px) }
+      .stage .inspector { top:0!important; right:0!important; bottom:0; left:auto!important; width:330px; max-height:none; border-radius:0; resize:horizontal }
+      .stage.inspector-open .toolbox.dock-right { right:344px }
+    }
+    @media(max-width:1020px){
+      .hero { grid-template-columns:1fr }.meta { grid-template-columns:repeat(3,1fr) }.meta div { display:grid }
+      .flow { grid-template-columns:repeat(3,1fr) }.step:nth-child(3)::after { display:none }
+      .architecture { grid-template-columns:repeat(3,1fr) }.node:nth-child(3)::after { display:none }
+      .stage { min-height:680px }.inspector { width:330px }
+    }
+    @media(max-width:799px){
+      .page { width:calc(100% - 24px); padding-top:18px }.head { grid-template-columns:1fr; gap:4px }.index { padding:0 }
+      section { padding-top:45px }.grid2,.grid3,.grid4,.accept { grid-template-columns:1fr }
+      .stage { min-height:880px }.stage .chart,.stage.docked.inspector-open .chart { width:100% }.stage .chart { height:100% }.stage.inspector-open .chart { height:44% }.inspector,.stage.docked .inspector { top:auto!important; right:8px!important; bottom:8px; left:58px!important; width:auto; height:calc(56% - 16px); max-width:none; max-height:none; border-radius:12px; resize:none }
+      .toolbox .tool:not(.active):not([data-tool="Pointer"]),.toolbox #all-lock,.toolbox #all-eye { display:none }
+      .toolbox .more-tools { display:grid }
+      .tool-pop { display:grid }
+      .toolstate { left:58px; right:8px; bottom:8px; width:max-content; max-width:calc(100% - 74px); overflow:hidden; white-space:nowrap }
+      .stage.inspector-open .toolstate { bottom:calc(56% + 2px) }
+      .drawing-action { min-height:44px }
+      .flow,.architecture { grid-template-columns:1fr; gap:9px }.step::after,.node::after { display:none!important }
+      .manager { grid-template-columns:1fr }.palette { grid-template-columns:repeat(4,1fr) }
+    }
+    @media(max-width:470px){
+      .meta { grid-template-columns:1fr }.proto-top .market { display:none }.stage { min-height:920px }
+      .stage .inspector,.stage.docked .inspector { left:8px!important; max-height:63% }.grid4 { grid-template-columns:1fr }.footer { flex-wrap:wrap }
+    }
+    @media(prefers-reduced-motion:reduce){ html{scroll-behavior:auto} *,*::before,*::after{transition:none!important} }
+  </style>
+</head>
+<body>
+<main class="page">
+  <header class="hero">
+    <div>
+      <p class="eyebrow">quantick · product/ux specification</p>
+      <h1>Ferramentas de desenho <span>rápidas no gráfico, profundas só quando necessário.</span></h1>
+      <p class="lede">Especificação visual e comportamental da barra, seleção, bloqueio, visibilidade, exclusão, propriedades e configuração completa de Fibonacci. O alvo é um sistema bonito, previsível e modular, no qual novas ferramentas entram sem redesenhar toda a interface.</p>
+    </div>
+    <aside class="meta" aria-label="Metadados">
+      <div><span>Status</span><span>direção recomendada</span></div>
+      <div><span>Base auditada</span><span>drawing tools / PR 94</span></div>
+      <div><span>Atualizado</span><span>31 jul 2026</span></div>
+    </aside>
+  </header>
+
+  <nav aria-label="Índice">
+    <a href="#decision">Decisão</a><a href="#prototype">Protótipo</a><a href="#bar">Barra</a>
+    <a href="#interaction">Interação</a><a href="#inspector-spec">Inspetor</a><a href="#fib">Fibonacci</a>
+    <a href="#tools">Ferramentas</a><a href="#keys">Atalhos</a><a href="#color">Cores</a>
+    <a href="#objects">Objetos</a><a href="#a11y">A11y</a><a href="#architecture">Arquitetura</a><a href="#acceptance">Aceite</a>
+  </nav>
+
+  <section id="decision">
+    <div class="head"><div class="index">01 · decisão</div><div>
+      <h2>Escolher, desenhar, ajustar e proteger — sem prender o gráfico.</h2>
+      <p class="sub">A barra é compacta e acoplável. O inspetor aparece por contexto, mas não é modal. Bloqueio protege a geometria; visibilidade apenas esconde. Delete é rápido, seguro e reversível.</p>
+    </div></div>
+    <div class="grid3">
+      <article class="card top-accent"><span class="micro">Direção 01</span><h3>Barra de 44 px</h3><p>Cápsula vertical por padrão, com botões 32 × 32. Pode acoplar nas laterais; no topo/rodapé gira para horizontal. Nunca ocupa uma faixa vazia da largura inteira.</p></article>
+      <article class="card top-buy"><span class="micro">Direção 02</span><h3>Inspetor não modal</h3><p>Abre ao selecionar, evita alças, continua durante drag e pode ser movido, redimensionado ou fixado no dock. O canvas segue ativo fora da caixa.</p></article>
+      <article class="card top-yellow"><span class="micro">Direção 03</span><h3>Excluir + Undo</h3><p>O botão textual <strong>Excluir desenho</strong> e <kbd>Delete</kbd>/<kbd>Backspace</kbd> usam o mesmo comando. Toast oferece Desfazer por 8 s. Um desenho travado exige confirmação explícita.</p></article>
+    </div>
+    <div class="rule"><i>↔</i><div><strong>Regra crítica:</strong> abrir propriedades nunca muda a ferramenta, nunca captura o canvas inteiro e nunca impede mover/redimensionar. Se a caixa cobrir um traço ou alça, um gesto iniciado exatamente nessa geometria continua pertencendo ao desenho; os demais cliques continuam pertencendo ao inspetor.</div></div>
+    <h3 style="margin-top:26px">Auditoria do protótipo atual</h3>
+    <div class="table"><table><thead><tr><th>Área</th><th>Existe hoje</th><th>Lacuna que esta especificação resolve</th></tr></thead><tbody>
+      <tr><td>Arquitetura</td><td>um módulo por ferramenta e um registry único</td><td>levar a mesma modularidade para propriedades via capabilities, sem form central</td></tr>
+      <tr><td>Toolbox</td><td>44 px, ferramenta exclusiva e dock nos quatro cantos</td><td>evitar a faixa vazia, criar favoritos/flyouts, pin e gerenciador</td></tr>
+      <tr><td>Seleção</td><td>hit-test, movimento do corpo e resize por âncoras</td><td>hover, cursor de movimento, z-order, cor preservada e lock/visibility</td></tr>
+      <tr><td>Inspetor</td><td>móvel e não modal; cor, width, fill e botão delete</td><td>posição inteligente, resize/dock, propriedades específicas e undo</td></tr>
+      <tr><td>Delete</td><td>somente botão no popup</td><td>Delete/Backspace, foco seguro, proteção locked e toast Undo</td></tr>
+      <tr><td>Fib</td><td>níveis fixos, uma cor e rótulo decimal</td><td>editor de níveis, preços/%, presets, bands, rays, direção e escala</td></tr>
+      <tr><td>Rectangle</td><td>interior participa do hit-test mesmo sem fill</td><td>interior só selecionável quando o preenchimento está visível</td></tr>
+    </tbody></table></div>
+  </section>
+
+  <section id="prototype">
+    <div class="head"><div class="index">02 · protótipo</div><div>
+      <h2>Experimente os estados que hoje causam atrito.</h2>
+      <p class="sub">Troque ferramenta, cor e espessura; trave, esconda ou exclua o Fib. As ações essenciais permanecem nomeadas e visíveis sem rolar. A simulação define o comportamento esperado, não afirma que tudo já está implementado.</p>
+    </div></div>
+    <div class="prototype" id="demo">
+      <div class="proto-top"><strong>QUANTICK</strong><span class="market">BTCUSDT · Tick 100</span><span class="live">LIVE</span><span class="spacer"></span><span id="drawing-count" style="color:var(--faint)">1 desenho</span></div>
+      <div class="stage" id="stage" aria-label="Gráfico interativo com Fibonacci selecionado">
+        <svg class="chart" viewBox="0 0 1160 620" preserveAspectRatio="none" role="img" aria-label="Candles com Fibonacci retracement selecionado">
+          <g id="viewport-layer">
+          <g id="market-layer">
+            <path class="gridline" d="M0 80H1160M0 160H1160M0 240H1160M0 320H1160M0 400H1160M0 480H1160M100 0V620M220 0V620M340 0V620M460 0V620M580 0V620M700 0V620M820 0V620M940 0V620"></path>
+            <g class="up"><path class="wick-up" d="M110 420V492M190 382V452M270 352V430M350 310V380M430 286V360M510 244V320M590 210V290M670 178V260M750 146V232"></path><rect x="100" y="440" width="20" height="32"></rect><rect x="180" y="400" width="20" height="35"></rect><rect x="260" y="370" width="20" height="38"></rect><rect x="340" y="328" width="20" height="35"></rect><rect x="420" y="306" width="20" height="34"></rect><rect x="500" y="262" width="20" height="39"></rect><rect x="580" y="229" width="20" height="38"></rect><rect x="660" y="198" width="20" height="37"></rect><rect x="740" y="167" width="20" height="38"></rect></g>
+            <g class="down"><path class="wick-down" d="M150 403V468M230 392V458M310 326V402M390 306V378M470 268V342M550 230V314M630 192V275M710 158V244M790 134V218"></path><rect x="140" y="419" width="20" height="32"></rect><rect x="220" y="409" width="20" height="34"></rect><rect x="300" y="347" width="20" height="35"></rect><rect x="380" y="324" width="20" height="33"></rect><rect x="460" y="286" width="20" height="38"></rect><rect x="540" y="250" width="20" height="39"></rect><rect x="620" y="211" width="20" height="38"></rect><rect x="700" y="179" width="20" height="39"></rect><rect x="780" y="151" width="20" height="37"></rect></g>
+          </g>
+          <g class="fib" id="fib-object">
+            <rect class="band" data-from="0.236" data-to="0.382"></rect>
+            <rect class="band" data-from="0.500" data-to="0.618"></rect>
+            <line class="guide" id="fib-guide"></line>
+            <line class="halo" data-ratio="0"></line><line class="halo" data-ratio="1"></line>
+            <line class="level" data-ratio="0"></line><line class="level" data-ratio="0.236"></line>
+            <line class="level" data-ratio="0.382"></line><line class="level" data-ratio="0.5"></line>
+            <line class="level" data-ratio="0.618"></line><line class="level" data-ratio="0.786"></line>
+            <line class="level" data-ratio="1"></line>
+            <text data-ratio="0">0% · 71.824,50</text><text data-ratio="0.236">23,6% · 71.184,32</text>
+            <text data-ratio="0.382">38,2% · 70.788,14</text><text data-ratio="0.5">50% · 70.468,00</text>
+            <text data-ratio="0.618">61,8% · 70.147,86</text><text data-ratio="0.786">78,6% · 69.692,20</text>
+            <text data-ratio="1">100% · 69.111,50</text>
+            <circle class="handle" data-anchor="a" r="5"></circle><circle class="handle" data-anchor="b" r="5"></circle>
+            <text class="anchorlabel" id="label-a">A</text><text class="anchorlabel" id="label-b">B</text>
+            <text id="direction-label">Baixa · A → B</text>
+          </g>
+          </g>
+        </svg>
+
+        <div class="toolbox" id="toolbox" aria-label="Barra de desenho">
+          <button class="grip" id="tool-grip" aria-label="Arrastar ou pressionar Enter para mudar o acoplamento">⠿</button>
+          <button class="ib tool active" data-tool="Pointer" aria-label="Pointer — 1 ou Esc" aria-pressed="true">➤</button>
+          <button class="ib tool" data-tool="Crosshair" aria-label="Crosshair — 2" aria-pressed="false">⌖</button>
+          <div class="divider"></div>
+          <button class="ib tool" data-tool="Horizontal line" aria-label="Horizontal line — H" aria-pressed="false">―</button>
+          <button class="ib tool" data-tool="Rectangle" aria-label="Rectangle — R" aria-pressed="false">□</button>
+          <button class="ib tool" data-tool="Parallel channel" aria-label="Parallel channel — C" aria-pressed="false">▱</button>
+          <button class="ib tool" data-tool="Fib retracement" aria-label="Fib retracement — F" aria-pressed="false">☷</button>
+          <button class="ib tool" data-tool="Fib extension" aria-label="Fib extension — Shift F" aria-pressed="false">≢</button>
+          <div class="divider"></div>
+          <button class="ib" id="repeat-tool" aria-label="Manter ferramenta ativa após desenhar" aria-pressed="false">↻</button>
+          <button class="ib more-tools" id="more-tools" aria-label="Mais ferramentas" aria-expanded="false">＋</button>
+          <button class="ib" id="objects-button" aria-label="Abrir objetos desenhados — 1 objeto" aria-expanded="false">☰</button>
+          <button class="ib" id="all-lock" aria-label="Travar todos" aria-pressed="false">🔓</button>
+          <button class="ib" id="all-eye" aria-label="Ocultar todos" aria-pressed="false">◉</button>
+        </div>
+        <div class="tool-pop" id="tool-popover" role="menu" aria-label="Mais ferramentas" hidden>
+          <button class="small" role="menuitem" data-tool-target="Crosshair">⌖ Crosshair</button>
+          <button class="small" role="menuitem" data-tool-target="Horizontal line">― Horizontal</button>
+          <button class="small" role="menuitem" data-tool-target="Rectangle">□ Retângulo</button>
+          <button class="small" role="menuitem" data-tool-target="Parallel channel">▱ Canal</button>
+          <button class="small" role="menuitem" data-tool-target="Fib retracement">☷ Fib retracement</button>
+          <button class="small" role="menuitem" data-tool-target="Fib extension">≢ Fib extension</button>
+        </div>
+        <div class="manager-pop" id="object-popover" role="dialog" aria-label="Gerenciador de objetos desenhados" hidden>
+          <header><strong>Objetos desenhados</strong><button class="ib" id="manager-close" aria-label="Fechar gerenciador">×</button></header>
+          <div class="manager-live-row">
+            <button class="small manager-select" id="manager-select"><span>☷ Fib retracement 1<br><small style="color:var(--faint)">BTCUSDT · Tick 100</small></span></button>
+          </div>
+          <div class="manager-actions" aria-label="Ações do Fib retracement">
+            <button class="small" id="manager-eye" aria-label="Ocultar Fib retracement"><span aria-hidden="true">◉</span> <span id="manager-eye-label">Ocultar</span></button>
+            <button class="small" id="manager-lock" aria-label="Travar Fib retracement" aria-pressed="false"><span id="manager-lock-icon" aria-hidden="true">🔓</span> <span id="manager-lock-label">Travar</span></button>
+            <button class="small" id="manager-up" aria-label="Trazer Fib retracement para frente">↑ Trazer à frente</button>
+            <button class="small danger" id="manager-delete" aria-label="Excluir desenho Fib retracement">⌫ Excluir desenho</button>
+          </div>
+          <div class="row" style="padding:0 8px 8px">
+            <button class="small" id="manager-show-all">Mostrar todos</button>
+            <button class="small" id="manager-unlock-all">Destravar todos</button>
+          </div>
+        </div>
+        <div class="toolstate" id="canvas-focus" tabindex="0" role="application" aria-label="Canvas do gráfico. Delete exclui o desenho selecionado; setas movem; Escape remove a seleção."><b id="active-tool">Pointer</b><span>drag no corpo move · alças redimensionam</span></div>
+        <div class="lockbadge">🔒 Travado</div>
+
+        <aside class="inspector" id="inspector" aria-label="Propriedades do Fib retracement">
+          <div class="inspector-sticky">
+          <header class="ins-head">
+            <div class="obj"><span style="color:var(--accent)">☷</span><span><strong>Fib retracement</strong><small>BTCUSDT · Tick 100</small><span class="state-chip" id="lock-chip">🔒 Travado</span></span></div>
+            <div class="actions">
+              <button class="ib" id="eye" aria-label="Ocultar desenho" aria-pressed="false">◉</button>
+              <button class="ib" id="pin" aria-label="Fixar na lateral" aria-pressed="false">⌖</button>
+              <button class="ib" id="close" aria-label="Fechar propriedades">×</button>
+            </div>
+          </header>
+          <div class="drawing-actions" role="toolbar" aria-label="Ações do desenho selecionado">
+            <button class="drawing-action" id="lock" aria-label="Travar desenho" aria-pressed="false"><span id="lock-icon" aria-hidden="true">🔓</span><span id="lock-label">Travar desenho</span></button>
+            <button class="drawing-action danger" id="delete" aria-label="Excluir desenho selecionado — tecla Delete"><span aria-hidden="true">⌫</span><span>Excluir desenho</span><kbd>Del</kbd></button>
+          </div>
+          <div class="confirm" id="confirm" role="alertdialog" aria-modal="false" aria-labelledby="confirm-title" tabindex="-1"><strong id="confirm-title">Excluir desenho travado?</strong><div class="row"><button class="small" id="cancel-delete">Cancelar</button><button class="small danger" id="force-delete">Excluir mesmo assim</button></div></div>
+          <div class="tabs" role="tablist" aria-label="Propriedades">
+            <button class="tab" id="tab-style" role="tab" data-panel="style-panel" aria-controls="style-panel" aria-selected="true" tabindex="0">Estilo</button>
+            <button class="tab" id="tab-levels" role="tab" data-panel="levels-panel" aria-controls="levels-panel" aria-selected="false" tabindex="-1">Níveis</button>
+            <button class="tab" id="tab-coords" role="tab" data-panel="coords-panel" aria-controls="coords-panel" aria-selected="false" tabindex="-1">Coordenadas</button>
+          </div>
+          </div>
+          <div class="lock-notice" role="status"><strong>🔒 Desenho travado</strong><span>Protegido contra movimentos acidentais. Cores e estilo continuam editáveis.</span></div>
+          <div class="panel active" id="style-panel" role="tabpanel" aria-labelledby="tab-style">
+            <div class="banner">Objeto oculto · use o olho para mostrar novamente.</div>
+            <div class="group"><div class="fieldtitle"><span>Cor principal</span><output id="color-value">#8AB4F8</output></div>
+              <div class="row wrap" id="swatches">
+                <button class="swatch" style="--c:#8ab4f8" data-color="#8ab4f8" aria-label="Azul accent" aria-pressed="true"></button>
+                <button class="swatch" style="--c:#4dd0e1" data-color="#4dd0e1" aria-label="Ciano" aria-pressed="false"></button>
+                <button class="swatch" style="--c:#26a69a" data-color="#26a69a" aria-label="Verde teal" aria-pressed="false"></button>
+                <button class="swatch" style="--c:#b39ddb" data-color="#b39ddb" aria-label="Roxo" aria-pressed="false"></button>
+                <button class="swatch" style="--c:#ffd166" data-color="#ffd166" aria-label="Amarelo" aria-pressed="false"></button>
+                <button class="swatch" style="--c:#ff9f43" data-color="#ff9f43" aria-label="Laranja" aria-pressed="false"></button>
+                <button class="swatch" style="--c:#ef5350" data-color="#ef5350" aria-label="Vermelho" aria-pressed="false"></button>
+                <button class="swatch" style="--c:#d2dae2" data-color="#d2dae2" aria-label="Branco neutro" aria-pressed="false"></button>
+              </div>
+              <div class="row between"><label class="check" for="custom-color">Cor personalizada</label><input id="custom-color" type="color" value="#8ab4f8" aria-label="Escolher cor personalizada"></div>
+              <p id="contrast-note" role="status" style="margin:7px 0 0;color:var(--faint);font-size:11px">Contraste adequado no canvas padrão.</p>
+            </div>
+            <div class="group"><div class="fieldtitle"><span>Espessura</span><output id="width-value">1.5 px</output></div>
+              <input id="width" type="range" min=".5" max="6" step=".5" value="1.5" aria-label="Espessura">
+              <div class="row"><select class="select" aria-label="Estilo da linha"><option>Contínua</option><option>Tracejada</option><option>Pontilhada</option></select><select class="select" aria-label="Extensão"><option>Entre âncoras</option><option>À direita</option><option>Ambos os lados</option></select></div>
+            </div>
+            <div class="group"><div class="fieldtitle"><span>Bandas</span><output>8%</output></div>
+              <input type="range" min="0" max="60" value="8" aria-label="Opacidade das bandas">
+              <div class="row between"><label class="check"><input type="checkbox" checked> Alternar fill</label><label class="check"><input type="checkbox"> Sempre mostrar guia</label></div>
+            </div>
+            <div class="group"><div class="fieldtitle"><span>Rótulos</span></div>
+              <div class="row"><select class="select" aria-label="Conteúdo dos rótulos"><option>Percentual + preço</option><option>Razão + preço</option><option>Só preço</option></select><select class="select" aria-label="Posição dos rótulos"><option>Direita · fora</option><option>Direita · dentro</option><option>Esquerda</option></select></div>
+            </div>
+          </div>
+
+          <div class="panel" id="levels-panel" role="tabpanel" aria-labelledby="tab-levels">
+            <div class="group"><div class="row"><select class="select" aria-label="Preset"><option>Standard retracement</option><option>Compact</option><option>Deep</option><option>Extended</option><option>Custom…</option></select><button class="small">Salvar</button></div></div>
+            <div class="group"><div class="fieldtitle"><span>Visível · razão · rótulo</span><output id="level-count">7 níveis</output></div>
+              <div class="levels" id="level-list"></div>
+              <div class="row"><button class="small primary" id="add-level">＋ Adicionar</button><button class="small" id="sort-levels">Ordenar</button><button class="small" id="restore-levels">Restaurar</button></div>
+            </div>
+            <div class="group"><div class="row between"><label class="check"><input type="checkbox" id="log-scale"> Escala log explícita</label><button class="small" id="invert-anchors">Inverter A ↔ B</button></div></div>
+          </div>
+
+          <div class="panel" id="coords-panel" role="tabpanel" aria-labelledby="tab-coords">
+            <div class="group"><div class="fieldtitle"><span>Âncora A</span><output>topo</output></div><div class="row"><input class="input number" id="anchor-a-time" value="2026-07-31 10:42:18" aria-label="Data e hora da âncora A"><input class="input number" id="anchor-a-price" value="71.824,50" aria-label="Preço da âncora A"></div></div>
+            <div class="group"><div class="fieldtitle"><span>Âncora B</span><output>fundo</output></div><div class="row"><input class="input number" id="anchor-b-time" value="2026-07-31 11:07:03" aria-label="Data e hora da âncora B"><input class="input number" id="anchor-b-price" value="69.111,50" aria-label="Preço da âncora B"></div></div>
+            <div class="group"><div class="fieldtitle"><span>Snapping</span></div><select class="select" style="width:100%" aria-label="Modo de snapping"><option>OHLC mais próximo</option><option>High / Low</option><option>Close</option><option>Desligado</option></select><p style="margin-top:8px;color:var(--faint);font-size:11px">O preço salvo é sempre exibido; nada é corrigido silenciosamente.</p></div>
+          </div>
+
+          <div class="footer"><div class="row" style="margin:0"><button class="small">Duplicar</button><button class="small">Redefinir estilo</button></div></div>
+        </aside>
+        <div class="toast" id="toast" role="status" aria-live="polite" aria-hidden="true" inert><span id="toast-text">Desenho excluído.</span><button id="undo">Desfazer</button></div>
+      </div>
+      <div class="proto-note"><span>use “Travar desenho” e tente arrastar</span><span>“Excluir desenho” e Delete usam a mesma regra</span><span>inputs protegem Backspace/Delete</span><span>adicione um nível</span></div>
+    </div>
+  </section>
+
+  <section id="bar">
+    <div class="head"><div class="index">03 · barra</div><div><h2>Pequena no uso diário, expansível para dezenas de ferramentas.</h2><p class="sub">A barra nunca quebra linha nem cresce sem limite. Um registro fornece ícone, atalho, instrução, quantidade de pontos e capacidades; favoritos e flyouts cuidam da escala.</p></div></div>
+    <div class="grid2">
+      <article class="card"><h3>Anatomia e ordem</h3><ol class="clean">
+        <li><strong>Grip:</strong> arrasta e persiste dock/orientação.</li><li><strong>Pointer e Crosshair:</strong> modos de canvas separados.</li>
+        <li><strong>Favoritos:</strong> Horizontal, Rectangle, Channel e dois Fibs.</li><li><strong>Pin:</strong> “manter ferramenta ativa”; padrão one-shot.</li>
+        <li><strong>Objetos:</strong> contador + gerenciador.</li><li><strong>Proteções globais:</strong> lock-all/hide-all em menu ou rodapé.</li>
+      </ol></article>
+      <article class="card"><h3>Geometria e estados</h3><div class="table"><table><tbody>
+        <tr><td>Barra</td><td>44 px; botões 32 × 32; ícones 18–20 px; gap 3 px</td></tr>
+        <tr><td>Idle</td><td>glyph muted, fundo transparente</td></tr><tr><td>Hover</td><td>texto primário sobre border; tooltip após 350 ms</td></tr>
+        <tr><td>Active</td><td>accent sobre tint 22%; draft recebe badge 1/2 ou 2/3</td></tr><tr><td>Focus</td><td>outline 2 px separado de hover/active</td></tr>
+        <tr><td>Disabled</td><td>40% e tooltip explicando o motivo</td></tr>
+      </tbody></table></div></article>
+    </div>
+    <div class="rule"><i>∞</i><div><strong>Adaptação:</strong> abaixo de 960 px os Fibs viram split-button; abaixo de 800 px ficam Pointer, ferramenta ativa e Objetos, com as demais em “Mais ferramentas”. A barra nunca cria outra faixa de chrome.</div></div>
+  </section>
+
+  <section id="interaction">
+    <div class="head"><div class="index">04 · interação</div><div><h2>O objeto responde antes da janela.</h2><p class="sub">Selecionar preserva a cor escolhida e adiciona halo accent. O topo do z-order vence sobreposição; <kbd>Alt</kbd>+click percorre objetos sobrepostos.</p></div></div>
+    <div class="flow">
+      <div class="step"><b>1 · Armar</b><span>ícone active e instrução do ponto A</span></div><div class="step"><b>2 · Preview</b><span>70% opacity; labels A/B/C</span></div>
+      <div class="step"><b>3 · Selecionar</b><span>halo, alças e inspetor</span></div><div class="step"><b>4 · Ajustar</b><span>corpo move; alça edita um ponto</span></div>
+      <div class="step"><b>5 · Proteger</b><span>lock impede geometria e teclado delete</span></div>
+    </div>
+    <div class="table" style="margin-top:22px"><table><thead><tr><th>Estado</th><th>Objeto</th><th>Canvas / cursor</th><th>Inspetor</th></tr></thead><tbody>
+      <tr><td><span class="chip" style="--s:var(--faint)">Idle</span></td><td>cor configurada, sem halo</td><td>pan/zoom normal</td><td>fechado</td></tr>
+      <tr><td><span class="chip" style="--s:var(--accent)">Hover</span></td><td>halo fino; fill só conta quando visível</td><td>move/resize conforme hit</td><td>não muda</td></tr>
+      <tr><td><span class="chip" style="--s:var(--accent)">Selected</span></td><td>cor real + halo + alças brancas</td><td>gesto do objeto vence pan</td><td>abre sem modal</td></tr>
+      <tr><td><span class="chip" style="--s:var(--yellow)">Locked</span></td><td>badge, halo tracejado, sem handles</td><td>drag consumido + cursor proibido</td><td>style editável; delete confirma</td></tr>
+      <tr><td><span class="chip" style="--s:var(--faint)">Hidden</span></td><td>não pinta nem recebe hit-test</td><td>interação passa ao chart</td><td>banner com Mostrar</td></tr>
+      <tr><td><span class="chip" style="--s:var(--buy)">Dragging</span></td><td>preview ao vivo</td><td>um gesto = um comando de undo</td><td>aberto e visualmente normal</td></tr>
+    </tbody></table></div>
+    <div class="grid2" style="margin-top:16px">
+      <article class="card"><h3>Modificadores</h3><ul class="clean"><li><kbd>Shift</kbd> restringe horizontal/vertical, quadrado ou ângulo conforme a ferramenta.</li><li><kbd>Alt</kbd> durante drag desativa snap temporariamente.</li><li><kbd>Backspace</kbd> durante draft remove a última âncora.</li><li><kbd>Esc</kbd> cancela draft e retorna ao Pointer.</li></ul></article>
+      <article class="card"><h3>Undo/redo</h3><p>Criar, mover, resize, style, preset, lock, hide, z-order e delete usam um histórico. Drags, sliders e color picker são coalescidos do pointer-down ao release: uma ação, um undo. <code>ViewportState</code> e <code>UiState</code> ficam fora dos snapshots; cada comando captura apenas o drawing e qualquer estado global que ele próprio altera.</p></article>
+    </div>
+  </section>
+
+  <section id="inspector-spec">
+    <div class="head"><div class="index">05 · inspetor</div><div><h2>Controles comuns estáveis; complexidade somente onde faz sentido.</h2><p class="sub">320 px nas ferramentas simples e 360 px no Fib, redimensionável entre 300–440 px. Conteúdo rola em janela baixa. Fecha = deseleciona; nunca exclui.</p></div></div>
+    <div class="grid2">
+      <article class="card"><h3>Posicionamento</h3><ol class="clean"><li>Tenta 12 px à direita da bounding box + handles.</li><li>Se não couber: esquerda, abaixo e acima.</li><li>Nunca cobre price/time axis nem sai da viewport.</li><li>Sem espaço: acopla ao dock e o canvas encolhe.</li><li>Depois de movido manualmente, mantém a posição na sessão.</li></ol></article>
+      <article class="card"><h3>Cabeçalho e ações</h3><div class="table"><table><tbody>
+        <tr><td>Grip + nome</td><td>tipo, nome customizável e chip textual <code>🔒 Travado</code></td></tr><tr><td>Eye</td><td>hide/show individual; banner quando oculto</td></tr>
+        <tr><td><code>DrawingActionBar</code></td><td>sticky, duas colunas: <strong>Travar/Destravar desenho</strong> e <strong>Excluir desenho · Del</strong>; nunca depende só de glyph</td></tr><tr><td>Pin</td><td>fixa no dock lateral</td></tr><tr><td>Close</td><td>deseleciona, sem mutar o objeto</td></tr>
+      </tbody></table></div></article>
+    </div>
+    <div class="table" style="margin-top:18px"><table><thead><tr><th>Seção</th><th>Campos</th><th>Capacidade</th><th>Regra</th></tr></thead><tbody>
+      <tr><td>Style</td><td>preset, cor/alpha, 0.5–6 px, solid/dashed/dotted</td><td>todas</td><td>preview ao vivo; default opcional para novos</td></tr>
+      <tr><td>Fill</td><td>cor e 0–60%</td><td>rectangle/channel/bandas</td><td>ausente em horizontal line, não disabled</td></tr>
+      <tr><td>Labels</td><td>texto, preço, ratio/%, posição, fundo</td><td>linha/channel/Fib</td><td>decimais Auto seguem o símbolo</td></tr>
+      <tr><td>Geometry</td><td>rays, middle line, direction, snap</td><td>tool-driven</td><td>opções impossíveis não aparecem</td></tr>
+      <tr><td>Levels</td><td>preset + lista editável</td><td>Fib</td><td>linha por nível; validação inline</td></tr>
+      <tr><td>Coordinates</td><td>bar/tempo e preço por A/B/C</td><td>todas</td><td>Enter confirma; Esc reverte o campo</td></tr>
+      <tr><td>Actions</td><td>sticky lock/unlock + delete; duplicate, z-order e reset no rodapé/menu</td><td>todas</td><td>delete travado requer confirmação explícita junto ao gatilho</td></tr>
+    </tbody></table></div>
+    <div class="rule"><i>✦</i><div><strong>Sem Apply:</strong> valores válidos entram ao vivo e podem ser desfeitos. Enquanto um input tem foco, atalhos do chart ficam suspensos. O inspetor nunca fica cinza/desabilitado durante drag.</div></div>
+  </section>
+
+  <section id="fib">
+    <div class="head"><div class="index">06 · fibonacci</div><div><h2>Fib é um modelo de níveis, não sete linhas fixas.</h2><p class="sub">Retracement e Extension compartilham editor, presets, labels e estilos. Mudam somente a geometria e a fórmula. Alças A, B e C são rotuladas na construção e seleção.</p></div></div>
+    <div class="grid2">
+      <article class="card"><span class="micro">Retracement · A/B</span><h3>Devolução do movimento</h3><div class="formula">Preço(r) = PreçoA + (PreçoB − PreçoA) × r<br>Standard: 0 · .236 · .382 · .5 · .618 · .786 · 1</div><p style="margin-top:12px">Direção deriva dos preços. “Inverter” troca A/B em uma ação de undo.</p></article>
+      <article class="card"><span class="micro">Extension · A/B/C</span><h3>Projeção a partir de C</h3><div class="formula">Preço(r) = PreçoC + (PreçoB − PreçoA) × r<br>Standard: 0 · .618 · 1 · 1.272 · 1.618 · 2 · 2.618</div><p style="margin-top:12px">A→B define direção; C é origem. Inverter troca A/B e nunca move C.</p></article>
+    </div>
+    <h3 style="margin-top:26px">Editor de níveis — contrato</h3>
+    <div class="table"><table><thead><tr><th>Campo</th><th>Comportamento</th><th>Validação</th></tr></thead><tbody>
+      <tr><td>Eye</td><td>oculta sem remover a configuração</td><td>ao menos um nível visível</td></tr>
+      <tr><td>Ratio</td><td>número sem símbolo é sempre razão (<code>.618</code> ou <code>0.618</code>); percentual exige <code>61.8%</code>. Separador decimal local também é aceito</td><td>finito; negativos e >100% permitidos; duplicata com tolerância 0.000001 é rejeitada</td></tr>
+      <tr><td>Texto</td><td>Auto ou custom até 40 caracteres</td><td>preço calculado é somente leitura</td></tr>
+      <tr><td>Cor/style</td><td>herdar principal ou override por nível</td><td>override marcado; “aplicar a todos” disponível</td></tr>
+      <tr><td>Fill</td><td>preenche até o próximo nível</td><td>desligado por padrão; recomendação 8–18%</td></tr>
+      <tr><td>Ordem</td><td>drag pelo grip ou ordenar numericamente</td><td>ordenar não inverte a geometria</td></tr>
+      <tr><td>Add/delete</td><td>insere abaixo do foco; remove por menu/lixeira</td><td>undo disponível</td></tr>
+    </tbody></table></div>
+    <div class="grid3" style="margin-top:18px">
+      <article class="card"><h3>Retracement presets</h3><ul class="clean"><li>Standard: 0, .236, .382, .5, .618, .786, 1</li><li>Compact: 0, .382, .5, .618, 1</li><li>Deep: 0, .236, .382, .5, .618, .705, .786, .886, 1</li><li>Extended: −.618, −.272, 0 … 1.272, 1.618</li></ul></article>
+      <article class="card"><h3>Extension presets</h3><ul class="clean"><li>Targets: .618, 1, 1.272, 1.618, 2, 2.618</li><li>Conservative: .618, 1, 1.272, 1.618</li><li>Expanded: .382, .618, 1, 1.272, 1.618, 2, 2.618, 4.236</li></ul></article>
+      <article class="card"><h3>Ciclo dos presets</h3><ul class="clean"><li>Built-ins são somente leitura; custom aceita criar, renomear e excluir.</li><li>Nome é aparado, tem 1–40 caracteres e precisa ser único sem diferenciar maiúsculas/minúsculas.</li><li>Salvar copia levels, styles, fills, labels, rays e guides; nunca coordinates, nome, lock ou visibility.</li><li>Sobrescrever um custom exige confirmação; aplicar ou excluir um custom é uma única ação de undo.</li><li>“Definir como padrão” é explícito, separado por tipo e só afeta novos Fibs.</li><li>Excluir custom não altera objetos que já copiaram seus valores; se era default, volta ao built-in Standard.</li><li>Formato versionado sobrevive ao restart e faz round-trip.</li></ul></article>
+    </div>
+    <div class="grid2" style="margin-top:14px">
+      <article class="card"><h3>Linhas e guias</h3><ul class="clean"><li>segment, ray left/right ou ambos</li><li>Extension começa em C e projeta à direita por padrão</li><li>guias A–B e B–C tracejadas quando selected</li><li>connector sempre visível opcional</li></ul></article>
+      <article class="card"><h3>Labels e escala</h3><ul class="clean"><li>ratio, percentual, preço e custom independentes</li><li>o protótipo usa pt-BR: <code>61,8% · 101.234,50</code>; armazenamento continua decimal canônico</li><li>posição esquerda/centro/direita; acima/abaixo, com deslocamento por prioridade e leader tick quando colidir</li><li>se não houver espaço, oculta primeiro o label menos prioritário e nunca sobrepõe silenciosamente</li><li>precisão Auto ou 0–8; Linear/Log é explícito e nunca segue o chart silenciosamente</li></ul></article>
+    </div>
+    <div class="rule"><i>ƒ</i><div><strong>Fórmula log, somente para preços positivos:</strong> Retracement usa <code>P(r) = PA × (PB / PA)^r</code>; Extension usa <code>P(r) = PC × (PB / PA)^r</code>. Reverse troca A/B, mantém C e inverte a razão de preços. Preço zero/negativo desabilita Log com explicação. Goldens cobrem alta, baixa, reverse e inputs inválidos.</div></div>
+  </section>
+
+  <section id="tools">
+    <div class="head"><div class="index">07 · ferramentas</div><div><h2>Cada peça encaixa controles próprios no mesmo inspetor.</h2><p class="sub">Comuns nunca são duplicados. Cada módulo declara capabilities e defaults; controles irrelevantes ficam ausentes.</p></div></div>
+    <div class="table"><table><thead><tr><th>Ferramenta</th><th>Colocação</th><th>Propriedades específicas</th><th>Alças/modificadores</th></tr></thead><tbody>
+      <tr><td>Horizontal line</td><td>um click</td><td>preço, label, axis tag, full/segment</td><td>uma alça; Shift mantém tick snap</td></tr>
+      <tr><td>Rectangle</td><td>click-click ou drag</td><td>outline, fill, radius, label, 2 coordinates</td><td>8 alças; Shift quadrado; Alt pelo centro; interior só recebe hit se fill visível</td></tr>
+      <tr><td>Parallel channel</td><td>A–B base, C largura</td><td>bordas, meio, divisões, fill, rays</td><td>A/B inclinação; C largura; Shift restringe ângulo</td></tr>
+      <tr><td>Fib retracement</td><td>A–B</td><td>levels, presets, bands, labels, direction, scale</td><td>A/B, reverse, snap individual</td></tr>
+      <tr><td>Fib extension</td><td>A–B, depois C</td><td>mesmo editor + connectors/projection origin</td><td>A/B impulso; C origem; badge 1/3, 2/3</td></tr>
+    </tbody></table></div>
+  </section>
+
+  <section id="keys">
+    <div class="head"><div class="index">08 · atalhos</div><div><h2>Rápidos no canvas, inofensivos dentro de inputs.</h2><p class="sub">Tooltips mostram nome + tecla + instrução. Todos os atalhos ficam suspensos quando um campo aceita texto.</p></div></div>
+    <div class="table"><table><thead><tr><th>Ação</th><th>Atalho</th><th>Regra</th></tr></thead><tbody>
+      <tr><td>Pointer / cancelar</td><td><kbd>Esc</kbd>, <kbd>1</kbd></td><td>Esc reverte campo/menu antes de draft/seleção/tool</td></tr>
+      <tr><td>Crosshair</td><td><kbd>2</kbd></td><td>modo exclusivo</td></tr>
+      <tr><td>Horizontal / Rectangle / Channel</td><td><kbd>H</kbd> · <kbd>R</kbd> · <kbd>C</kbd></td><td>one-shot salvo pin</td></tr>
+      <tr><td>Fib Retracement / Extension</td><td><kbd>F</kbd> · <kbd>Shift</kbd>+<kbd>F</kbd></td><td>2 ou 3 anchors</td></tr>
+      <tr><td>Excluir desenho</td><td><kbd>Delete</kbd>, <kbd>Backspace</kbd></td><td>travado abre a mesma confirmação do botão; input sempre vence</td></tr>
+      <tr><td>Undo / redo</td><td><kbd>Ctrl</kbd>+<kbd>Z</kbd> · <kbd>Ctrl</kbd>+<kbd>Y</kbd> · <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Z</kbd></td><td>todas as mutações</td></tr>
+      <tr><td>Lock / hide</td><td><kbd>Alt</kbd>+<kbd>L</kbd> · <kbd>Alt</kbd>+<kbd>H</kbd></td><td>seleção individual</td></tr>
+      <tr><td>Duplicar</td><td><kbd>Ctrl</kbd>+<kbd>D</kbd></td><td>cópia deslocada e selecionada</td></tr>
+      <tr><td>Nudge</td><td>setas; <kbd>Shift</kbd> = 10 passos</td><td>converte para coordinates honestas</td></tr>
+    </tbody></table></div>
+  </section>
+
+  <section id="color">
+    <div class="head"><div class="index">09 · cores</div><div><h2>Cor do desenho é conteúdo; accent é estado.</h2><p class="sub">Seleção nunca pinta tudo de branco. Buy/sell continuam semânticos. O âmbar <code>#F0B90B</code> permanece reservado a replay, backfill e proveniência — não entra na paleta decorativa.</p></div></div>
+    <div class="palette" aria-label="Paleta rápida">
+      <div class="colorcard"><i style="--c:#8ab4f8"></i><b>Blue</b></div><div class="colorcard"><i style="--c:#4dd0e1"></i><b>Cyan</b></div>
+      <div class="colorcard"><i style="--c:#26a69a"></i><b>Green</b></div><div class="colorcard"><i style="--c:#b39ddb"></i><b>Purple</b></div>
+      <div class="colorcard"><i style="--c:#ffd166"></i><b>Yellow</b></div><div class="colorcard"><i style="--c:#ff9f43"></i><b>Orange</b></div>
+      <div class="colorcard"><i style="--c:#ef5350"></i><b>Red</b></div><div class="colorcard"><i style="--c:#d2dae2"></i><b>Neutral</b></div>
+    </div>
+    <div class="grid2" style="margin-top:14px">
+      <article class="card"><h3>Fazer</h3><ul class="clean"><li>oito rápidas + custom + recentes</li><li>default por ferramenta, sem alterar existentes</li><li>warning de baixo contraste contra o canvas</li><li>halo/forma/texto além de cor para estados</li></ul></article>
+      <article class="card"><h3>Evitar</h3><ul class="clean"><li>branco substituindo a cor na seleção</li><li>âmbar como decoração</li><li>vermelho como selection ou azul como error</li><li>fill opaco escondendo candles/order flow</li></ul></article>
+    </div>
+  </section>
+
+  <section id="objects">
+    <div class="head"><div class="index">10 · objetos</div><div><h2>Ocultar exige um caminho óbvio para mostrar novamente.</h2><p class="sub">O botão Objetos abre lista não modal. Resolve hidden, overlap, z-order, lock-all e delete-all sem painel permanente.</p></div></div>
+    <div class="manager">
+      <div class="managerbox" aria-label="Gerenciador de objetos">
+        <div class="managerhead"><span>Desenhos · BTCUSDT</span><span style="color:var(--faint)">5</span></div>
+        <button class="objectrow selected" aria-label="Selecionar Fib retracement 1, visível e travado"><span style="color:var(--accent)">☷</span><span>Fib retracement 1<small>Tick 100 · visível · 🔒 Travado</small></span><span>◉</span><span>🔒</span></button>
+        <button class="objectrow" aria-label="Selecionar Resistência 72k"><span style="color:var(--yellow)">―</span><span>Resistência 72k<small>Linha horizontal</small></span><span>◉</span><span>□</span></button>
+        <button class="objectrow" aria-label="Selecionar Canal de rompimento"><span style="color:var(--buy)">▱</span><span>Canal de rompimento<small>Canal paralelo</small></span><span>◉</span><span>□</span></button>
+        <button class="objectrow" style="opacity:.58" aria-label="Selecionar Faixa anterior, oculto e travado"><span>□</span><span>Faixa anterior<small>Retângulo · oculto · 🔒 Travado</small></span><span>○</span><span>🔒</span></button>
+        <button class="objectrow" aria-label="Selecionar Projeção de alvo"><span style="color:var(--purple)">≢</span><span>Projeção de alvo<small>Fib extension</small></span><span>◉</span><span>□</span></button>
+      </div>
+      <article class="card"><h3>Regras</h3><ul class="clean">
+        <li>Clique na linha seleciona e centraliza, sem alterar visibilidade ou trava.</li><li>Ações nomeadas por objeto: Mostrar/Ocultar, Travar/Destravar, z-order e Excluir desenho.</li>
+        <li>Inspetor, manager e menu de contexto enviam os mesmos commands; nenhum replica a regra de lock/delete.</li>
+        <li>Ordem vertical é z-order; drag reordena com undo.</li><li>Hide-all é camada global e preserva eyes individuais.</li>
+        <li>Delete-all sempre confirma, contando visíveis, ocultos e travados.</li><li>Hidden não pinta/hit-test; inspetor mostra banner até fechar.</li>
+      </ul></article>
+    </div>
+  </section>
+
+  <section id="a11y">
+    <div class="head"><div class="index">11 · layout &amp; a11y</div><div><h2>Desktop primeiro, resiliente quando os painéis apertam o canvas.</h2><p class="sub">A adaptação usa o espaço real do chart, não a resolução do monitor.</p></div></div>
+    <div class="grid3">
+      <article class="card"><span class="micro">≥ 1180 px</span><h3>Flutuante</h3><p>Inspetor evita a seleção; barra vertical. Melhor área útil.</p></article>
+      <article class="card"><span class="micro">800–1179 px</span><h3>Dock automático</h3><p>Sem quadrante livre, fixa à direita e recalcula o canvas.</p></article>
+      <article class="card"><span class="micro">&lt; 800 px</span><h3>Drawer inferior</h3><p>Até 56% da altura; favoritos agrupam no overflow.</p></article>
+    </div>
+    <div class="table" style="margin-top:18px"><table><thead><tr><th>Critério</th><th>Contrato</th></tr></thead><tbody>
+      <tr><td>Focus</td><td>ordem barra → canvas → inspector; outline 2 px; close devolve foco ao canvas</td></tr>
+      <tr><td>Teclado</td><td>header, tabs, levels e ações operáveis; Enter confirma input; Esc reverte antes do chart</td></tr>
+      <tr><td>Nomes</td><td>botões anunciam ação, tool, atalho e estado; swatch anuncia nome, hex e alpha</td></tr>
+      <tr><td>Targets</td><td>botões 32 px; anchor visual 7 px e hit area invisível 14–16 px</td></tr>
+      <tr><td>Contraste</td><td>texto 4.5:1; controls/ícones 3:1; supporting text usa <code>#8692A4</code>. O token atual TEXT_FAINT <code>#6E7887</code> fica restrito a decoração/disabled, nunca informação essencial</td></tr>
+      <tr><td>Escala</td><td>DPI e texto a 200%; sem clipping; inspector scrollável</td></tr>
+      <tr><td>Motion</td><td>80–120 ms; sem loop; respeita reduced motion</td></tr>
+      <tr><td>Toast</td><td>live region; Undo por 8 s e também via Ctrl+Z</td></tr>
+    </tbody></table></div>
+  </section>
+
+  <section id="architecture">
+    <div class="head"><div class="index">12 · arquitetura</div><div><h2>O UX vira capabilities e comandos, não condicionais espalhadas.</h2><p class="sub">Tudo continua na crate app. Engine, feeds e domínio não conhecem drawings. O registry modular atual é preservado e o inspetor passa a ser schema-driven.</p></div></div>
+    <div class="architecture" aria-label="Arquitetura modular">
+      <div class="node"><b>Registry</b><span>id, icon, key, points</span></div><div class="node"><b>Section ports</b><span>common + tool-owned sections</span></div>
+      <div class="node"><b>Inspector</b><span>composição, sem match central</span></div><div class="node"><b>Commands</b><span>undo/redo + coalesce</span></div><div class="node"><b>Store</b><span>envelope + payload versionado</span></div>
+    </div>
+    <div class="table" style="margin-top:18px"><table><thead><tr><th>Módulo</th><th>Responsabilidade</th><th>Não faz</th></tr></thead><tbody>
+      <tr><td><code>drawings/registry.rs</code></td><td>metadata/factory/capabilities estáticos</td><td>UI ou mutações</td></tr>
+      <tr><td><code>drawings/model.rs</code></td><td>envelope comum: id, anchors, common style, lock, visibility e z-order</td><td>campos de Fib, rede, clock ou engine</td></tr>
+      <tr><td><code>drawings/tools/*.rs</code></td><td>geometry, paint, hit-test, payload versionado e seções específicas</td><td>editar o form central ou recriar widgets common</td></tr>
+      <tr><td><code>drawings/inspector/*.rs</code></td><td>portas para common sections e composição de seções fornecidas pela tool</td><td>enum/lista fechada de capabilities ou match por tool id</td></tr>
+      <tr><td><code>drawings/action_bar.rs</code></td><td><code>DrawingActionBar</code> reutilizável: lock state + intents de Travar/Destravar e Excluir</td><td>duplicar regras de mutação, confirmação ou Undo</td></tr>
+      <tr><td><code>drawings/commands.rs</code></td><td>mutações reversíveis/coalescing</td><td>render/projection</td></tr>
+      <tr><td><code>drawings/store.rs</code></td><td>collection, selection, z-order, scope, persistence</td><td>depender de feed específico</td></tr>
+      <tr><td><code>toolrail.rs</code></td><td>dock, favorites, active tool, manager entry</td><td>conhecer fields do Fib</td></tr>
+    </tbody></table></div>
+    <p style="margin-top:12px;color:var(--muted)">O envelope guarda um <code>Box&lt;dyn DrawingPayload&gt;</code> (clone/serialize/version/section providers) criado pelo registry. Propriedade inédita pertence ao payload e à seção da própria ferramenta; portanto a próxima tool não reabre <code>model.rs</code> nem o inspetor central. Capabilities comuns são conveniências reutilizáveis, não uma lista fechada.</p>
+    <h3 style="margin-top:24px">Taxa de execução e constantes</h3>
+    <div class="table"><table><thead><tr><th>Caminho</th><th>Taxa</th><th>Contrato</th></tr></thead><tbody>
+      <tr><td>Paint/projection</td><td>por frame, alvo ~60 Hz</td><td>sem alocar metadata/labels estáveis; buffers pequenos reutilizados</td></tr>
+      <tr><td>Hover/hit-test</td><td>por movimento do ponteiro</td><td>somente visíveis no viewport, ordem reversa de z-order, trabalho limitado</td></tr>
+      <tr><td>Drag/slider</td><td>por frame durante o gesto</td><td>preview incremental; um command alocado/gravado no release</td></tr>
+      <tr><td>Editar preset/config</td><td>raro, orientado a evento</td><td>clareza e validação vencem micro-otimização</td></tr>
+      <tr><td>Persistência</td><td>startup/save</td><td>formato versionado, round-trip e nenhum impacto no render loop</td></tr>
+    </tbody></table></div>
+    <p style="margin-top:12px;color:var(--muted)">Geometria de UI não vira literal espalhado: implementação deve nomear <code>TOOLBOX_WIDTH_PX</code>, <code>TOOL_BUTTON_SIZE_PX</code>, <code>INSPECTOR_MIN_WIDTH_PX</code>, <code>INSPECTOR_MAX_WIDTH_PX</code>, <code>ANCHOR_HIT_RADIUS_PX</code>, <code>INSPECTOR_OBJECT_GAP_PX</code>, <code>TOAST_UNDO_MS</code> e <code>INTERACTION_MOTION_MS</code>. Presets e cores rápidas ficam em dados estáticos registráveis.</p>
+    <div class="grid2" style="margin-top:16px">
+      <article class="card"><h3>Contrato de performance</h3><ul class="clean"><li>metadata, tooltips e níveis built-in estáticos</li><li>labels formatados só quando preço/config muda</li><li>buffers pequenos/reutilizados para projection</li><li>hit-test somente visíveis, viewport e z-order</li><li>drag pinta por frame, grava command no release</li></ul></article>
+      <article class="card"><h3>Persistência honesta</h3><ul class="clean"><li>scope: símbolo + feed + bar spec/layout</li><li>lock, visibility, z-order, styles e presets versionados</li><li>rebuild incompatível nunca reaproveita índice silenciosamente</li><li>enquanto for bar-index + price, limpa com aviso explícito</li><li>migração time + price exige round-trip tests</li></ul></article>
+    </div>
+  </section>
+
+  <section id="acceptance">
+    <div class="head"><div class="index">13 · aceite</div><div><h2>Evidências observáveis de que a experiência está pronta.</h2><p class="sub">Cada item deve virar teste unitário/input egui ou roteiro visual manual.</p></div></div>
+    <ol class="accept">
+      <li><strong>Não modal:</strong> inspector aberto não impede pan, zoom, move ou resize fora da caixa.</li>
+      <li><strong>Prioridade:</strong> gesto iniciado no stroke/handle mantém pointer capture mesmo quando o ponteiro cruza sob o inspector.</li>
+      <li><strong>Placement:</strong> popup não sai da tela nem cobre permanentemente handles/eixos.</li>
+      <li><strong>Move/resize:</strong> corpo translada rigidamente até a borda; alça muda só seu ponto; chart não paneia.</li>
+      <li><strong>Ações visíveis:</strong> Travar/Destravar e Excluir desenho aparecem sem scroll em 360 px, com texto e target mínimo de 44 px no mobile.</li>
+      <li><strong>Delete:</strong> botão, manager, menu contextual e teclado enviam o mesmo command; inputs vencem e toast oferece Undo por 8 s.</li>
+      <li><strong>Locked:</strong> chip no header + badge no desenho + estado no manager; sem move/resize, style editável e delete confirma.</li>
+      <li><strong>Hidden:</strong> sem paint/hit-test e sempre recuperável no manager.</li>
+      <li><strong>Seleção:</strong> preserva cor real e adiciona halo/handles.</li>
+      <li><strong>Tool-driven:</strong> somente propriedades suportadas aparecem.</li>
+      <li><strong>Fib:</strong> add/edit/hide/delete/reorder/style por nível atualiza ao vivo.</li>
+      <li><strong>Fórmulas:</strong> Retracement/Extension exatos em alta e baixa; reverse preserva C.</li>
+      <li><strong>Presets:</strong> custom sobrevive restart e default só afeta novos Fibs.</li>
+      <li><strong>Undo:</strong> drag/slider/preset inteiro = uma entrada; pan/zoom e estado do inspetor não voltam junto.</li>
+      <li><strong>Coordenadas:</strong> drag/nudge e edição textual mantêm tempo/bar-index e preço na mesma fonte canônica.</li>
+      <li><strong>Toolbar:</strong> não quebra linha; Pointer/tool active/manager sobrevivem a pouca largura.</li>
+      <li><strong>Esc:</strong> input/menu → draft → selection → Pointer, nessa ordem.</li>
+      <li><strong>A11y:</strong> ações essenciais por teclado, nomes completos e foco visível.</li>
+      <li><strong>Modularidade:</strong> tool fake entra via registry/capabilities sem alterar form central.</li>
+      <li><strong>Performance:</strong> metadata/labels estáveis não alocam por frame.</li>
+      <li><strong>Data honesty:</strong> rebuild incompatível avisa e nunca liga desenho à barra errada.</li>
+      <li><strong>Rectangle:</strong> interior só entra no hit-test quando o fill está visível.</li>
+    </ol>
+    <h3 style="margin-top:28px">Mapa mínimo de testes</h3>
+    <div class="table"><table><thead><tr><th>Camada</th><th>Provas obrigatórias</th></tr></thead><tbody>
+      <tr><td>Modelo/commands</td><td><code>locked_drawing_rejects_geometry_and_keyboard_delete</code>; <code>one_drag_creates_one_undo_entry</code>; undo não restaura viewport/UI; hide/global-hide preservam estados individuais</td></tr>
+      <tr><td>Input egui</td><td><code>inspector_never_blocks_drawing_drag</code>; <code>drawing_actions_visible_without_scroll_at_360px</code>; botão/manager/teclado produzem o mesmo delete command; Delete/Backspace não vazam de inputs; Esc respeita a pilha; locked drag não paneia</td></tr>
+      <tr><td>Fib puro</td><td>goldens das duas fórmulas em alta/baixa; reverse mantém C; parser normaliza decimal/%; presets e levels fazem round-trip</td></tr>
+      <tr><td>Extension port</td><td>uma ferramenta fake traz uma propriedade inédita (<code>ray_count</code>) no próprio payload/section e recebe toolbar, placement, inspector e persistence sem editar modelo ou formulário central</td></tr>
+      <tr><td>Render/hit-test</td><td>selection preserva cor; hidden sai do paint/hit; body move rigidamente nas bordas; cursor segue hit-slop; rectangle sem fill só acerta borda; z-order e Alt+click são determinísticos</td></tr>
+      <tr><td>Persistência</td><td>versão antiga migra; custom presets sobrevivem restart; identity incompatível nunca reaproveita bar-index</td></tr>
+      <tr><td>Layout/a11y</td><td>snapshots em 1280/960/720 px e 200% de texto; foco, nomes e estados no accessibility tree</td></tr>
+    </tbody></table></div>
+    <h3 style="margin-top:28px">Fases recomendadas</h3>
+    <div class="grid4">
+      <article class="card phase" style="--pc:var(--accent)"><h4>1 · Fundamentos</h4><p>Delete, lock/visibility model, undo/redo, selection halo e collision-aware inspector.</p></article>
+      <article class="card phase" style="--pc:var(--buy)"><h4>2 · Inspetor</h4><p>Capabilities, tabs, styles, labels, coords, resize/pin e object manager.</p></article>
+      <article class="card phase" style="--pc:var(--yellow)"><h4>3 · Fib completo</h4><p>Level model, presets, formulas, bands, per-level styles e persistence.</p></article>
+      <article class="card phase" style="--pc:var(--purple)"><h4>4 · Polimento</h4><p>Favorites, repeat, snap, context menu, responsive/a11y e visual QA.</p></article>
+    </div>
+  </section>
+
+  <footer>
+    <p><strong>Decisão de produto:</strong> drawings são overlay da aplicação e permanecem fora do engine determinístico. Esta é a direção UX; implementação deve preservar dependências unidirecionais, dados honestos e o orçamento de frame.</p>
+    <p><code>docs/ux/drawing-tools-ux-spec.html</code> · pt-BR · tokens visuais reais do Quantick · sem dependências externas.</p>
+  </footer>
+</main>
+<script>
+(function(){
+  var root=document.getElementById("demo");
+  var stage=document.getElementById("stage");
+  var chart=root.querySelector(".chart");
+  var fib=document.getElementById("fib-object");
+  var viewport=document.getElementById("viewport-layer");
+  var inspector=document.getElementById("inspector");
+  var toolbox=document.getElementById("toolbox");
+  var popover=document.getElementById("object-popover");
+  var toolPopover=document.getElementById("tool-popover");
+  var canvasFocus=document.getElementById("canvas-focus");
+  var lockBadge=root.querySelector(".lockbadge");
+  var toast=document.getElementById("toast");
+  var toastText=document.getElementById("toast-text");
+  var confirmBox=document.getElementById("confirm");
+  var undoButton=document.getElementById("undo");
+  var VIEW_WIDTH=1160,VIEW_HEIGHT=620,PRICE_ORIGIN=72800,PRICE_PER_Y=10;
+  var TIME_PER_X_MS=1485000/340,TIME_AT_X_ZERO_MS=Date.UTC(2026,6,31,10,42,18)-220*TIME_PER_X_MS;
+  var HISTORY_LIMIT=24,TOAST_DURATION_MS=8000,HANDLE_HIT_RADIUS_PX=16,LEVEL_HIT_RADIUS_PX=6,CLICK_SLOP_PX=4;
+  var MIN_DRAWING_X=40,MAX_DRAWING_X=920,MIN_DRAWING_Y=55,MAX_DRAWING_Y=560;
+  var MIN_ZOOM=.82,MAX_ZOOM=1.28,ZOOM_IN_FACTOR=1.06,ZOOM_OUT_FACTOR=.94;
+  var defaultLevels=[
+    {ratio:0,label:"0 · Topo",visible:true,color:null},{ratio:.236,label:"23,6%",visible:true,color:null},
+    {ratio:.382,label:"38,2%",visible:true,color:null},{ratio:.5,label:"50%",visible:true,color:null},
+    {ratio:.618,label:"61,8%",visible:true,color:null},{ratio:.786,label:"78,6%",visible:true,color:null},
+    {ratio:1,label:"1 · Fundo",visible:true,color:null}
+  ];
+  var model={
+    a:{x:220,y:97.55},b:{x:560,y:368.85},locked:false,hidden:false,deleted:false,
+    color:"#8ab4f8",width:1.5,logScale:false,levels:JSON.parse(JSON.stringify(defaultLevels))
+  };
+  var viewportState={panX:0,zoom:1};
+  var uiState={globalHidden:false,selected:true,closed:false,pinned:false,repeat:false};
+  var history=[];
+  var redoHistory=[];
+  var gesture=null;
+  var inspectorGesture=null;
+  var toolboxGesture=null;
+  var inspectorWasMoved=false;
+  var toastTimer=null;
+  var widthBefore=null;
+  var deleteOrigin=null;
+  var dockCycle=["dock-left","dock-top","dock-right","dock-bottom"];
+  var dockIndex=0;
+  var suppressGripClick=false;
+
+  function cloneDrawing(){return JSON.parse(JSON.stringify(model))}
+  function captureUndoState(){return{drawing:cloneDrawing(),globalHidden:uiState.globalHidden}}
+  function say(text,undo){
+    clearTimeout(toastTimer);
+    toastText.textContent=text;
+    undoButton.hidden=!undo;
+    toast.inert=false;
+    toast.setAttribute("aria-hidden","false");
+    toast.classList.add("show");
+    toastTimer=setTimeout(hideToast,TOAST_DURATION_MS);
+  }
+  function hideToast(){
+    var returnFocus=toast.contains(document.activeElement);
+    toast.classList.remove("show");if(returnFocus)canvasFocus.focus({preventScroll:true});toast.inert=true;toast.setAttribute("aria-hidden","true");
+  }
+  function record(before,message){
+    history.push(before);
+    if(history.length>HISTORY_LIMIT)history.shift();
+    redoHistory=[];
+    say(message,true);
+  }
+  function undoAction(){
+    var before=history.pop();if(!before)return;
+    redoHistory.push(captureUndoState());restore(before);
+  }
+  function redoAction(){
+    var after=redoHistory.pop();if(!after)return;
+    history.push(captureUndoState());restore(after);
+  }
+  function restore(snapshot){
+    var wasDeleted=model.deleted;
+    Object.keys(model).forEach(function(key){delete model[key]});
+    Object.assign(model,JSON.parse(JSON.stringify(snapshot.drawing)));
+    uiState.globalHidden=snapshot.globalHidden;
+    if(model.deleted){uiState.selected=false;uiState.closed=true}
+    else if(wasDeleted){uiState.selected=true;uiState.closed=false}
+    renderAll();
+  }
+  function formatPercent(ratio){
+    return new Intl.NumberFormat("pt-BR",{maximumFractionDigits:1}).format(ratio*100)+"%";
+  }
+  function formatPrice(y){
+    var price=PRICE_ORIGIN-y*PRICE_PER_Y;
+    return new Intl.NumberFormat("pt-BR",{minimumFractionDigits:2,maximumFractionDigits:2}).format(price);
+  }
+  function parsePtBrNumber(value){
+    var normalized=String(value).trim().replace(/\s/g,"").replace(/\./g,"").replace(",",".");
+    var number=Number(normalized);
+    return Number.isFinite(number)?number:null;
+  }
+  function formatChartTime(x){
+    var date=new Date(TIME_AT_X_ZERO_MS+x*TIME_PER_X_MS),pad=function(value){return String(value).padStart(2,"0")};
+    return date.getUTCFullYear()+"-"+pad(date.getUTCMonth()+1)+"-"+pad(date.getUTCDate())+" "+pad(date.getUTCHours())+":"+pad(date.getUTCMinutes())+":"+pad(date.getUTCSeconds());
+  }
+  function parseChartTime(value){
+    var match=String(value).trim().match(/^(\d{4})-(\d{2})-(\d{2})[ T](\d{2}):(\d{2}):(\d{2})$/);if(!match)return null;
+    var timestamp=Date.UTC(Number(match[1]),Number(match[2])-1,Number(match[3]),Number(match[4]),Number(match[5]),Number(match[6]));
+    return Number.isFinite(timestamp)?(timestamp-TIME_AT_X_ZERO_MS)/TIME_PER_X_MS:null;
+  }
+  function levelY(ratio){
+    if(!model.logScale)return model.a.y+(model.b.y-model.a.y)*ratio;
+    var priceA=PRICE_ORIGIN-model.a.y*PRICE_PER_Y,priceB=PRICE_ORIGIN-model.b.y*PRICE_PER_Y;
+    var price=Math.exp(Math.log(priceA)+(Math.log(priceB)-Math.log(priceA))*ratio);
+    return(PRICE_ORIGIN-price)/PRICE_PER_Y;
+  }
+  function setLine(line,x1,y1,x2,y2){
+    line.setAttribute("x1",x1);line.setAttribute("y1",y1);
+    line.setAttribute("x2",x2);line.setAttribute("y2",y2);
+  }
+  function renderFib(){
+    var left=Math.min(model.a.x,model.b.x),right=Math.max(model.a.x,model.b.x);
+    fib.querySelectorAll(".level,text[data-ratio]").forEach(function(node){node.remove()});
+    var insertionPoint=fib.querySelector('[data-anchor="a"]');
+    model.levels.filter(function(level){return level.visible}).forEach(function(level){
+      var line=document.createElementNS("http://www.w3.org/2000/svg","line");
+      line.setAttribute("class","level");line.dataset.ratio=String(level.ratio);
+      var y=levelY(level.ratio);setLine(line,left,y,right,y);
+      if(level.color)line.style.stroke=level.color;
+      fib.insertBefore(line,insertionPoint);
+      var label=document.createElementNS("http://www.w3.org/2000/svg","text");
+      label.dataset.ratio=String(level.ratio);label.setAttribute("x",right+10);label.setAttribute("y",y+4);
+      label.textContent=(level.label.trim()||formatPercent(level.ratio))+" · "+formatPrice(y);
+      if(level.color)label.style.fill=level.color;
+      fib.insertBefore(label,insertionPoint);
+    });
+    fib.querySelectorAll("line[data-ratio]").forEach(function(line){
+      var y=levelY(Number(line.dataset.ratio));
+      setLine(line,left,y,right,y);
+    });
+    fib.querySelectorAll(".band").forEach(function(band){
+      var first=levelY(Number(band.dataset.from)),second=levelY(Number(band.dataset.to));
+      band.setAttribute("x",left);band.setAttribute("y",Math.min(first,second));
+      band.setAttribute("width",Math.max(1,right-left));band.setAttribute("height",Math.abs(second-first));
+    });
+    setLine(document.getElementById("fib-guide"),model.a.x,model.a.y,model.b.x,model.b.y);
+    var handleA=fib.querySelector('[data-anchor="a"]'),handleB=fib.querySelector('[data-anchor="b"]');
+    handleA.setAttribute("cx",model.a.x);handleA.setAttribute("cy",model.a.y);
+    handleB.setAttribute("cx",model.b.x);handleB.setAttribute("cy",model.b.y);
+    var labelA=document.getElementById("label-a"),labelB=document.getElementById("label-b");
+    labelA.setAttribute("x",model.a.x+8);labelA.setAttribute("y",model.a.y-8);
+    labelB.setAttribute("x",model.b.x+8);labelB.setAttribute("y",model.b.y-8);
+    var direction=document.getElementById("direction-label");
+    direction.setAttribute("x",left);direction.setAttribute("y",Math.min(model.a.y,model.b.y)-18);
+    direction.textContent=(model.b.y<model.a.y?"Alta":"Baixa")+" · A → B";
+    document.getElementById("anchor-a-time").value=formatChartTime(model.a.x);
+    document.getElementById("anchor-b-time").value=formatChartTime(model.b.x);
+    document.getElementById("anchor-a-price").value=formatPrice(model.a.y);
+    document.getElementById("anchor-b-price").value=formatPrice(model.b.y);
+  }
+  function renderLevelEditor(){
+    var list=document.getElementById("level-list");
+    list.replaceChildren();
+    model.levels.forEach(function(level,index){
+      var row=document.createElement("div");row.className="levelrow";
+      var move=document.createElement("button");move.className="ib dots";move.type="button";move.textContent="⠿";move.disabled=index===0;move.setAttribute("aria-label","Mover nível "+(level.label||formatPercent(level.ratio))+" para cima");
+      var visible=document.createElement("input");visible.type="checkbox";visible.checked=level.visible;visible.setAttribute("aria-label","Mostrar nível "+level.ratio);
+      var ratio=document.createElement("input");ratio.className="input number";ratio.value=Number(level.ratio).toFixed(3);ratio.setAttribute("aria-label","Razão do nível "+level.ratio);
+      var label=document.createElement("input");label.className="input";label.value=level.label;label.setAttribute("aria-label","Rótulo do nível "+level.ratio);
+      var color=document.createElement("input");color.type="color";color.className="levelcolor";color.value=level.color||model.color;color.setAttribute("aria-label","Cor do nível "+level.ratio);
+      var remove=document.createElement("button");remove.className="ib";remove.type="button";remove.textContent="×";remove.disabled=model.levels.length===1;remove.setAttribute("aria-label","Excluir nível "+level.ratio);
+      move.onclick=function(){var before=captureUndoState();model.levels.splice(index-1,0,model.levels.splice(index,1)[0]);renderAll();record(before,"Nível reordenado.")};
+      visible.onchange=function(){var before=captureUndoState();model.levels[index].visible=visible.checked;renderFib();record(before,visible.checked?"Nível exibido.":"Nível ocultado.")};
+      ratio.onchange=function(){
+        var raw=ratio.value.trim(),percent=raw.endsWith("%"),next=Number(raw.replace("%","").replace(",","."));if(percent)next/=100;
+        if(!Number.isFinite(next)||model.levels.some(function(item,i){return i!==index&&Math.abs(item.ratio-next)<.000001})){renderLevelEditor();say("Use uma razão numérica única, como 0,618 ou 61,8%.",false);return}
+        var before=captureUndoState();model.levels[index].ratio=next;renderAll();record(before,"Razão do nível alterada.");
+      };
+      label.onchange=function(){var before=captureUndoState();model.levels[index].label=label.value.trim();renderFib();record(before,"Rótulo do nível alterado.")};
+      color.onchange=function(){var before=captureUndoState();model.levels[index].color=color.value;renderFib();record(before,"Cor do nível alterada.")};
+      remove.onclick=function(){var before=captureUndoState();model.levels.splice(index,1);renderAll();record(before,"Nível excluído.")};
+      row.append(move,visible,ratio,label,color,remove);list.appendChild(row);
+    });
+    document.getElementById("level-count").textContent=model.levels.length+" "+(model.levels.length===1?"nível":"níveis");
+  }
+  function renderState(){
+    var inspectorOpen=!(model.deleted||uiState.closed||!uiState.selected);
+    var drawingVisible=!(model.hidden||uiState.globalHidden||model.deleted);
+    stage.classList.toggle("locked",model.locked);
+    stage.classList.toggle("drawing-visible",drawingVisible);
+    stage.classList.toggle("docked",uiState.pinned);
+    stage.classList.toggle("inspector-open",inspectorOpen);
+    fib.classList.toggle("hidden",model.hidden||uiState.globalHidden||model.deleted);
+    fib.classList.toggle("unselected",!uiState.selected);
+    inspector.classList.toggle("is-hidden",model.hidden);
+    inspector.classList.toggle("is-locked",model.locked);
+    inspector.classList.toggle("closed",!inspectorOpen);
+    inspector.inert=!inspectorOpen;
+    inspector.setAttribute("aria-hidden",String(!inspectorOpen));
+    root.style.setProperty("--draw-color",model.color);
+    root.style.setProperty("--draw-width",model.width);
+    viewport.setAttribute("transform","translate("+viewportState.panX+" 310) scale("+viewportState.zoom+" 1) translate(0 -310)");
+    var badgePoint=svgToClient({x:(model.a.x+model.b.x)/2,y:Math.min(model.a.y,model.b.y)}),stageRect=stage.getBoundingClientRect();
+    lockBadge.style.left=Math.max(54,Math.min(stageRect.width-54,badgePoint.x-stageRect.left))+"px";
+    lockBadge.style.top=Math.max(34,badgePoint.y-stageRect.top-8)+"px";
+    document.getElementById("color-value").textContent=model.color.toUpperCase();
+    document.getElementById("custom-color").value=model.color;
+    root.querySelectorAll(".swatch").forEach(function(item){item.setAttribute("aria-pressed",String(item.dataset.color===model.color))});
+    document.getElementById("width-value").textContent=Number(model.width).toFixed(1)+" px";
+    document.getElementById("width").value=model.width;
+    ["lock","all-lock","manager-lock"].forEach(function(id){document.getElementById(id).setAttribute("aria-pressed",String(model.locked))});
+    document.getElementById("all-lock").setAttribute("aria-label",model.locked?"Destravar todos":"Travar todos");
+    document.getElementById("all-lock").textContent=model.locked?"🔒":"🔓";
+    document.getElementById("eye").setAttribute("aria-pressed",String(model.hidden));
+    document.getElementById("eye").textContent=model.hidden?"○":"◉";
+    document.getElementById("eye").setAttribute("aria-label",model.hidden?"Mostrar desenho":"Ocultar desenho");
+    document.querySelector("#manager-eye [aria-hidden]").textContent=model.hidden?"○":"◉";
+    document.getElementById("manager-eye-label").textContent=model.hidden?"Mostrar":"Ocultar";
+    document.getElementById("manager-eye").setAttribute("aria-label",model.hidden?"Mostrar Fib retracement":"Ocultar Fib retracement");
+    document.getElementById("lock").setAttribute("aria-label",model.locked?"Destravar desenho":"Travar desenho");
+    document.getElementById("lock-icon").textContent=model.locked?"🔒":"🔓";
+    document.getElementById("lock-label").textContent=model.locked?"Destravar desenho":"Travar desenho";
+    document.getElementById("manager-lock").setAttribute("aria-label",model.locked?"Destravar Fib retracement":"Travar Fib retracement");
+    document.getElementById("manager-lock-icon").textContent=model.locked?"🔒":"🔓";
+    document.getElementById("manager-lock-label").textContent=model.locked?"Destravar":"Travar";
+    document.getElementById("all-eye").setAttribute("aria-pressed",String(uiState.globalHidden));
+    document.getElementById("all-eye").setAttribute("aria-label",uiState.globalHidden?"Mostrar todos":"Ocultar todos");
+    document.getElementById("pin").setAttribute("aria-pressed",String(uiState.pinned));
+    document.getElementById("repeat-tool").setAttribute("aria-pressed",String(uiState.repeat));
+    document.getElementById("drawing-count").textContent=model.deleted?"0 desenhos":"1 desenho";
+    document.getElementById("objects-button").setAttribute("aria-label","Abrir objetos desenhados — "+(model.deleted?"0 objetos":"1 objeto"));
+    ["manager-select","manager-eye","manager-lock","manager-up","manager-delete"].forEach(function(id){document.getElementById(id).disabled=model.deleted});
+    document.getElementById("manager-unlock-all").disabled=model.deleted||!model.locked;
+    document.getElementById("log-scale").checked=model.logScale;
+    if(!popover.hidden)requestAnimationFrame(function(){positionPopover(popover,document.getElementById("objects-button"))});
+  }
+  function renderAll(){renderFib();renderLevelEditor();renderState()}
+  function svgToClient(point){
+    var rect=chart.getBoundingClientRect();
+    var projectedX=viewportState.panX+viewportState.zoom*point.x;
+    return{x:rect.left+projectedX/VIEW_WIDTH*rect.width,y:rect.top+point.y/VIEW_HEIGHT*rect.height};
+  }
+  function clientToSvg(x,y){
+    var rect=chart.getBoundingClientRect();
+    var projectedX=(x-rect.left)/rect.width*VIEW_WIDTH;
+    return{x:(projectedX-viewportState.panX)/viewportState.zoom,y:(y-rect.top)/rect.height*VIEW_HEIGHT};
+  }
+  function hitDrawing(clientX,clientY){
+    if(model.deleted||model.hidden||uiState.globalHidden)return null;
+    var a=svgToClient(model.a),b=svgToClient(model.b);
+    function distance(p){return Math.hypot(clientX-p.x,clientY-p.y)}
+    if(uiState.selected&&distance(a)<=HANDLE_HIT_RADIUS_PX)return{kind:"anchor",anchor:"a"};
+    if(uiState.selected&&distance(b)<=HANDLE_HIT_RADIUS_PX)return{kind:"anchor",anchor:"b"};
+    var left=Math.min(a.x,b.x),right=Math.max(a.x,b.x);
+    var ratios=model.levels.filter(function(level){return level.visible}).map(function(level){return level.ratio});
+    var hitLevel=ratios.some(function(ratio){
+      var point=svgToClient({x:model.a.x,y:levelY(ratio)});
+      return clientX>=left-LEVEL_HIT_RADIUS_PX&&clientX<=right+LEVEL_HIT_RADIUS_PX&&Math.abs(clientY-point.y)<=LEVEL_HIT_RADIUS_PX;
+    });
+    return hitLevel?{kind:"body"}:null;
+  }
+  function boundedTranslation(a,b,dx,dy){
+    var boundedDx=Math.max(MIN_DRAWING_X-Math.min(a.x,b.x),Math.min(MAX_DRAWING_X-Math.max(a.x,b.x),dx));
+    var boundedDy=Math.max(MIN_DRAWING_Y-Math.min(a.y,b.y),Math.min(MAX_DRAWING_Y-Math.max(a.y,b.y),dy));
+    return{a:{x:a.x+boundedDx,y:a.y+boundedDy},b:{x:b.x+boundedDx,y:b.y+boundedDy}};
+  }
+  function selectDrawing(){
+    if(model.deleted||model.hidden||uiState.globalHidden)return;
+    uiState.selected=true;uiState.closed=false;renderState();
+  }
+  function deselectDrawing(){
+    uiState.selected=false;uiState.closed=true;renderState();
+  }
+  function placeInspector(){
+    if(uiState.pinned||inspectorWasMoved||window.matchMedia("(max-width:1179px)").matches)return;
+    var stageRect=stage.getBoundingClientRect();
+    var a=svgToClient(model.a),b=svgToClient(model.b);
+    var left=Math.min(a.x,b.x)-stageRect.left-16;
+    var right=Math.max(a.x,b.x)-stageRect.left+165;
+    var top=Math.min(a.y,b.y)-stageRect.top-32;
+    var bottom=Math.max(a.y,b.y)-stageRect.top+20;
+    var width=inspector.offsetWidth||360,height=Math.min(inspector.offsetHeight||500,stageRect.height-28);
+    var candidates=[
+      {x:right+12,y:Math.max(14,top)},
+      {x:left-width-12,y:Math.max(14,top)},
+      {x:Math.max(14,left),y:bottom+12},
+      {x:Math.max(14,left),y:top-height-12}
+    ];
+    var chosen=candidates.find(function(p){return p.x>=14&&p.y>=14&&p.x+width<=stageRect.width-14&&p.y+height<=stageRect.height-14});
+    if(!chosen){uiState.pinned=true;renderState();return}
+    inspector.style.right="auto";inspector.style.left=chosen.x+"px";inspector.style.top=chosen.y+"px";
+  }
+  function toggleDrawingLock(){
+    var before=captureUndoState();model.locked=!model.locked;
+    if(!model.locked&&confirmBox.classList.contains("visible"))cancelDeleteConfirmation();
+    renderState();record(before,model.locked?"Desenho travado contra movimentos acidentais.":"Desenho destravado.");
+  }
+  function toggleDrawingVisibility(){
+    var before=captureUndoState();model.hidden=!model.hidden;renderState();record(before,model.hidden?"Desenho oculto; restaure pelo olho ou gerenciador.":"Desenho visível.");
+  }
+  function cancelDeleteConfirmation(){
+    confirmBox.classList.remove("visible");
+    var origin=deleteOrigin;deleteOrigin=null;
+    if(origin&&origin.isConnected&&!origin.closest("[inert]")&&!origin.closest("[hidden]"))origin.focus({preventScroll:true});
+    else canvasFocus.focus({preventScroll:true});
+  }
+  function removeDrawing(force){
+    if(!uiState.selected){say("Selecione um desenho antes de excluir.",false);return}
+    if(model.locked&&!force){
+      if(!deleteOrigin)deleteOrigin=document.activeElement;
+      confirmBox.classList.add("visible");
+      say("O desenho está travado. Confirme a exclusão no inspetor.",false);
+      setTimeout(function(){confirmBox.scrollIntoView({block:"nearest"});document.getElementById("cancel-delete").focus()},0);
+      return;
+    }
+    var before=captureUndoState();
+    confirmBox.classList.remove("visible");
+    deleteOrigin=null;
+    model.deleted=true;uiState.selected=false;uiState.closed=true;
+    renderState();record(before,"Desenho excluído.");undoButton.focus({preventScroll:true});
+  }
+  function beginDrawingGesture(event,hit){
+    selectDrawing();
+    canvasFocus.focus({preventScroll:true});
+    if(model.locked){
+      event.preventDefault();event.stopPropagation();
+      say("Desenho travado — use “Destravar desenho” para mover ou redimensionar.",false);
+      return;
+    }
+    event.preventDefault();event.stopPropagation();
+    gesture={kind:hit.kind,anchor:hit.anchor,startClient:{x:event.clientX,y:event.clientY},before:captureUndoState()};
+    stage.setPointerCapture(event.pointerId);
+  }
+  function beginPan(event){
+    canvasFocus.focus({preventScroll:true});
+    gesture={kind:"pan",startClient:{x:event.clientX,y:event.clientY},startPan:viewportState.panX,moved:false};
+    stage.setPointerCapture(event.pointerId);
+  }
+  stage.addEventListener("pointerdown",function(event){
+    if(event.button!==0)return;
+    if(event.target.closest(".toolbox,.manager-pop,.tool-pop,.inspector,.toast"))return;
+    var hit=hitDrawing(event.clientX,event.clientY);
+    if(hit){beginDrawingGesture(event,hit);return}
+    beginPan(event);
+  },true);
+  stage.addEventListener("pointermove",function(event){
+    if(!gesture){
+      var overControl=event.target.closest(".toolbox,.manager-pop,.tool-pop,.inspector,.toast");
+      var hoverHit=overControl?null:hitDrawing(event.clientX,event.clientY);
+      fib.classList.toggle("hovered",Boolean(hoverHit));
+      stage.classList.toggle("drawing-hover",Boolean(hoverHit));
+      stage.classList.toggle("anchor-hover",Boolean(hoverHit&&hoverHit.kind==="anchor"));
+      return;
+    }
+    if(gesture.kind==="pan"){
+      gesture.moved=gesture.moved||Math.hypot(event.clientX-gesture.startClient.x,event.clientY-gesture.startClient.y)>CLICK_SLOP_PX;
+      viewportState.panX=gesture.startPan+(event.clientX-gesture.startClient.x)/chart.getBoundingClientRect().width*VIEW_WIDTH;
+      renderState();return;
+    }
+    var current=clientToSvg(event.clientX,event.clientY);
+    var start=clientToSvg(gesture.startClient.x,gesture.startClient.y);
+    var dx=current.x-start.x,dy=current.y-start.y;
+    if(gesture.kind==="anchor"){
+      var point=gesture.before.drawing[gesture.anchor];
+      model[gesture.anchor]={x:Math.max(MIN_DRAWING_X,Math.min(MAX_DRAWING_X,point.x+dx)),y:Math.max(MIN_DRAWING_Y,Math.min(MAX_DRAWING_Y,point.y+dy))};
+    }else{
+      var translated=boundedTranslation(gesture.before.drawing.a,gesture.before.drawing.b,dx,dy);
+      model.a=translated.a;model.b=translated.b;
+    }
+    renderFib();
+  });
+  function finishGesture(event){
+    if(!gesture)return;
+    if(gesture.kind==="pan"&&!gesture.moved)deselectDrawing();
+    if(gesture.kind==="body"||gesture.kind==="anchor"){
+      var changed=gesture.before.drawing.a.x!==model.a.x||gesture.before.drawing.a.y!==model.a.y||gesture.before.drawing.b.x!==model.b.x||gesture.before.drawing.b.y!==model.b.y;
+      if(changed)record(gesture.before,gesture.kind==="body"?"Fib movido.":"Âncora redimensionada.");
+      placeInspector();
+    }
+    if(stage.hasPointerCapture(event.pointerId))stage.releasePointerCapture(event.pointerId);
+    gesture=null;
+  }
+  stage.addEventListener("pointerup",finishGesture);
+  stage.addEventListener("pointercancel",finishGesture);
+  stage.addEventListener("pointerleave",function(){if(!gesture){fib.classList.remove("hovered");stage.classList.remove("drawing-hover","anchor-hover")}});
+  stage.addEventListener("wheel",function(event){
+    if(event.target.closest(".inspector,.toolbox,.manager-pop,.tool-pop,.toast"))return;
+    event.preventDefault();
+    viewportState.zoom=Math.max(MIN_ZOOM,Math.min(MAX_ZOOM,viewportState.zoom*(event.deltaY<0?ZOOM_IN_FACTOR:ZOOM_OUT_FACTOR)));
+    renderState();say("Zoom do canvas: "+Math.round(viewportState.zoom*100)+"%.",false);
+  },{passive:false});
+
+  document.querySelector(".ins-head").addEventListener("pointerdown",function(event){
+    if(event.button!==0||event.target.closest("button")||uiState.pinned||window.matchMedia("(max-width:1179px)").matches)return;
+    var rect=inspector.getBoundingClientRect(),stageRect=stage.getBoundingClientRect();
+    inspectorGesture={startX:event.clientX,startY:event.clientY,left:rect.left-stageRect.left,top:rect.top-stageRect.top,pointerId:event.pointerId};
+    event.currentTarget.setPointerCapture(event.pointerId);
+  });
+  window.addEventListener("pointermove",function(event){
+    if(inspectorGesture){
+      var stageRect=stage.getBoundingClientRect();
+      var left=Math.max(0,Math.min(stageRect.width-inspector.offsetWidth,inspectorGesture.left+event.clientX-inspectorGesture.startX));
+      var top=Math.max(0,Math.min(stageRect.height-80,inspectorGesture.top+event.clientY-inspectorGesture.startY));
+      inspector.style.right="auto";inspector.style.left=left+"px";inspector.style.top=top+"px";
+      inspectorWasMoved=true;
+    }
+    if(toolboxGesture){
+      toolboxGesture.moved=toolboxGesture.moved||Math.hypot(event.clientX-toolboxGesture.startX,event.clientY-toolboxGesture.startY)>CLICK_SLOP_PX;
+      var stageRect2=stage.getBoundingClientRect();
+      toolbox.className="toolbox";
+      toolbox.style.left=Math.max(0,Math.min(stageRect2.width-toolbox.offsetWidth,event.clientX-stageRect2.left-toolboxGesture.offsetX))+"px";
+      toolbox.style.top=Math.max(0,Math.min(stageRect2.height-toolbox.offsetHeight,event.clientY-stageRect2.top-toolboxGesture.offsetY))+"px";
+    }
+  });
+  window.addEventListener("pointerup",function(event){
+    if(inspectorGesture&&event.pointerId===inspectorGesture.pointerId)inspectorGesture=null;
+    if(toolboxGesture&&event.pointerId===toolboxGesture.pointerId){
+      if(toolboxGesture.moved){
+        var rect=stage.getBoundingClientRect();
+        var distances=[
+          {name:"dock-left",value:event.clientX-rect.left},
+          {name:"dock-top",value:event.clientY-rect.top},
+          {name:"dock-right",value:rect.right-event.clientX},
+          {name:"dock-bottom",value:rect.bottom-event.clientY}
+        ].sort(function(a,b){return a.value-b.value});
+        applyToolboxDock(distances[0].name);
+        suppressGripClick=true;
+      }
+      toolboxGesture=null;
+    }
+  });
+  function applyToolboxDock(name){
+    toolbox.className="toolbox "+name;
+    toolbox.style.left="";toolbox.style.right="";toolbox.style.top="";toolbox.style.bottom="";
+    dockIndex=Math.max(0,dockCycle.indexOf(name));
+    if(!popover.hidden)positionPopover(popover,document.getElementById("objects-button"));
+    if(!toolPopover.hidden)positionPopover(toolPopover,document.getElementById("more-tools"));
+    say("Barra acoplada: "+name.replace("dock-","")+".",false);
+  }
+  document.getElementById("tool-grip").addEventListener("pointerdown",function(event){
+    var rect=toolbox.getBoundingClientRect();
+    toolboxGesture={startX:event.clientX,startY:event.clientY,offsetX:event.clientX-rect.left,offsetY:event.clientY-rect.top,pointerId:event.pointerId,moved:false};
+  });
+  document.getElementById("tool-grip").addEventListener("click",function(){
+    if(suppressGripClick){suppressGripClick=false;return}
+    dockIndex=(dockIndex+1)%dockCycle.length;applyToolboxDock(dockCycle[dockIndex]);
+  });
+
+  document.getElementById("lock").onclick=toggleDrawingLock;
+  document.getElementById("all-lock").onclick=toggleDrawingLock;
+  document.getElementById("eye").onclick=toggleDrawingVisibility;
+  document.getElementById("all-eye").onclick=function(){var before=captureUndoState();uiState.globalHidden=!uiState.globalHidden;renderState();record(before,uiState.globalHidden?"Todos ocultos; estados individuais preservados.":"Visibilidade global restaurada.")};
+  document.getElementById("delete").onclick=function(){removeDrawing(false)};
+  document.getElementById("force-delete").onclick=function(){removeDrawing(true)};
+  document.getElementById("cancel-delete").onclick=cancelDeleteConfirmation;
+  undoButton.onclick=function(){undoAction();hideToast();canvasFocus.focus({preventScroll:true})};
+  document.getElementById("close").onclick=function(){deselectDrawing();canvasFocus.focus({preventScroll:true});say("Propriedades fechadas; desenho preservado.",false)};
+  document.getElementById("pin").onclick=function(){uiState.pinned=!uiState.pinned;inspectorWasMoved=false;inspector.style.left="";inspector.style.top="";inspector.style.right="";renderState();if(!uiState.pinned)placeInspector();say(uiState.pinned?"Inspetor fixado; canvas recalculado.":"Inspetor flutuante.",false)};
+  document.getElementById("repeat-tool").onclick=function(){uiState.repeat=!uiState.repeat;renderState();say(uiState.repeat?"Manter ferramenta ativa: ligado.":"Modo one-shot: ligado.",false)};
+
+  function positionPopover(panel,anchor){
+    var stageRect=stage.getBoundingClientRect(),anchorRect=anchor.getBoundingClientRect();
+    var width=panel.offsetWidth||310,height=panel.offsetHeight||160;
+    var left=anchorRect.right-stageRect.left+8,top=anchorRect.top-stageRect.top;
+    if(left+width>stageRect.width-8)left=anchorRect.left-stageRect.left-width-8;
+    if(top+height>stageRect.height-8)top=anchorRect.bottom-stageRect.top-height;
+    left=Math.max(8,Math.min(stageRect.width-width-8,left));
+    top=Math.max(8,Math.min(stageRect.height-height-8,top));
+    panel.style.left=left+"px";panel.style.top=top+"px";
+  }
+  function closeObjectPopover(returnFocus){
+    popover.hidden=true;document.getElementById("objects-button").setAttribute("aria-expanded","false");
+    if(returnFocus)document.getElementById("objects-button").focus();
+  }
+  document.getElementById("objects-button").onclick=function(){
+    var open=popover.hidden;popover.hidden=!open;
+    this.setAttribute("aria-expanded",String(open));
+    toolPopover.hidden=true;document.getElementById("more-tools").setAttribute("aria-expanded","false");
+    if(open){positionPopover(popover,this);document.getElementById("manager-select").focus()}
+  };
+  document.getElementById("manager-close").onclick=function(){closeObjectPopover(true)};
+  popover.addEventListener("keydown",function(event){if(event.key==="Escape"){event.preventDefault();closeObjectPopover(true)}});
+  document.getElementById("manager-select").onclick=function(){selectDrawing();placeInspector();say("Fib selecionado pelo gerenciador.",false)};
+  document.getElementById("manager-eye").onclick=toggleDrawingVisibility;
+  document.getElementById("manager-lock").onclick=toggleDrawingLock;
+  document.getElementById("manager-up").onclick=function(){var before=captureUndoState();model.zOrder=(model.zOrder||1)+1;record(before,"Fib trazido para frente; z-order atualizado.")};
+  document.getElementById("manager-delete").onclick=function(){var origin=document.getElementById("objects-button");closeObjectPopover(false);uiState.selected=true;uiState.closed=false;renderState();placeInspector();deleteOrigin=origin;removeDrawing(false)};
+  document.getElementById("manager-show-all").onclick=function(){var before=captureUndoState();uiState.globalHidden=false;model.hidden=false;renderState();record(before,"Todos os desenhos visíveis.")};
+  document.getElementById("manager-unlock-all").onclick=function(){if(model.locked)toggleDrawingLock()};
+  document.querySelectorAll(".objectrow").forEach(function(row){
+    row.onclick=function(){
+      document.querySelectorAll(".objectrow").forEach(function(item){item.classList.remove("selected")});
+      row.classList.add("selected");
+      say(row.textContent.trim()+" selecionado no exemplo.",false);
+    };
+  });
+
+  function activateTool(name){
+    var button=Array.from(root.querySelectorAll(".tool")).find(function(item){return item.dataset.tool===name});
+    if(!button)return;
+    root.querySelectorAll(".tool").forEach(function(item){item.classList.remove("active");item.setAttribute("aria-pressed","false")});
+    button.classList.add("active");button.setAttribute("aria-pressed","true");
+    document.getElementById("active-tool").textContent=name;say(name+" ativado.",false);
+  }
+  root.querySelectorAll(".tool").forEach(function(button){button.onclick=function(){activateTool(button.dataset.tool)}});
+  document.getElementById("more-tools").onclick=function(){
+    var open=toolPopover.hidden;toolPopover.hidden=!open;this.setAttribute("aria-expanded",String(open));
+    closeObjectPopover(false);
+    if(open){positionPopover(toolPopover,this);toolPopover.querySelector("button").focus()}
+  };
+  toolPopover.querySelectorAll("[data-tool-target]").forEach(function(button){button.onclick=function(){activateTool(button.dataset.toolTarget);toolPopover.hidden=true;document.getElementById("more-tools").setAttribute("aria-expanded","false");canvasFocus.focus({preventScroll:true})}});
+  toolPopover.addEventListener("keydown",function(event){if(event.key==="Escape"){event.preventDefault();toolPopover.hidden=true;document.getElementById("more-tools").setAttribute("aria-expanded","false");document.getElementById("more-tools").focus()}});
+  window.addEventListener("resize",function(){
+    if(window.matchMedia("(min-width:800px)").matches&&!toolPopover.hidden){toolPopover.hidden=true;document.getElementById("more-tools").setAttribute("aria-expanded","false")}
+    if(!popover.hidden)positionPopover(popover,document.getElementById("objects-button"));if(!toolPopover.hidden)positionPopover(toolPopover,document.getElementById("more-tools"));
+  });
+  root.addEventListener("focusin",function(event){
+    if(event.target.matches("input,select,textarea")){event.target.dataset.escapeValue=event.target.value;event.target.dataset.escapeChecked=String(event.target.checked);event.target.escapeState=captureUndoState();event.target.escapeHistoryLength=history.length}
+  });
+  root.addEventListener("keydown",function(event){
+    if(event.key!=="Escape"||event.target===canvasFocus)return;
+    var target=event.target;
+    function consume(){event.preventDefault();event.stopPropagation()}
+    if(confirmBox.classList.contains("visible")){consume();cancelDeleteConfirmation();return}
+    if(!toolPopover.hidden){consume();toolPopover.hidden=true;document.getElementById("more-tools").setAttribute("aria-expanded","false");document.getElementById("more-tools").focus();return}
+    if(!popover.hidden){consume();closeObjectPopover(true);return}
+    if(toast.contains(target)){consume();hideToast();canvasFocus.focus({preventScroll:true});return}
+    if(target.matches("input,select,textarea")){
+      consume();
+      history.length=Math.min(history.length,target.escapeHistoryLength===undefined?history.length:target.escapeHistoryLength);redoHistory=[];
+      if(target.id==="width"&&widthBefore){restore(widthBefore);widthBefore=null}
+      else{if(target.dataset.escapeValue!==undefined)target.value=target.dataset.escapeValue;if(target.dataset.escapeChecked!==undefined)target.checked=target.dataset.escapeChecked==="true";restore(target.escapeState||captureUndoState())}
+      inspector.querySelector('.tab[aria-selected="true"]').focus();return;
+    }
+    if(inspector.contains(target)){consume();deselectDrawing();canvasFocus.focus({preventScroll:true});say("Propriedades fechadas; desenho preservado.",false);return}
+    if(toolbox.contains(target)){consume();activateTool("Pointer");deselectDrawing();canvasFocus.focus({preventScroll:true});say("Seleção removida; Pointer ativo.",false)}
+  },true);
+  function activateTab(button){
+    root.querySelectorAll(".tab").forEach(function(item){item.setAttribute("aria-selected","false");item.tabIndex=-1});
+    root.querySelectorAll(".panel").forEach(function(panel){panel.classList.remove("active")});
+    button.setAttribute("aria-selected","true");button.tabIndex=0;
+    document.getElementById(button.dataset.panel).classList.add("active");
+  }
+  root.querySelectorAll(".tab").forEach(function(button){
+    button.onclick=function(){activateTab(button)};
+    button.onkeydown=function(event){
+      var tabs=Array.from(root.querySelectorAll(".tab")),index=tabs.indexOf(button),next=null;
+      if(event.key==="ArrowRight")next=tabs[(index+1)%tabs.length];
+      if(event.key==="ArrowLeft")next=tabs[(index-1+tabs.length)%tabs.length];
+      if(event.key==="Home")next=tabs[0];
+      if(event.key==="End")next=tabs[tabs.length-1];
+      if(next){event.preventDefault();activateTab(next);next.focus()}
+    };
+  });
+  function relativeLuminance(hex){
+    var channels=[1,3,5].map(function(index){var value=parseInt(hex.slice(index,index+2),16)/255;return value<=.03928?value/12.92:Math.pow((value+.055)/1.055,2.4)});
+    return .2126*channels[0]+.7152*channels[1]+.0722*channels[2];
+  }
+  function applyColor(color,before){
+    model.color=color;
+    document.getElementById("custom-color").value=color;
+    var light=relativeLuminance(color),dark=relativeLuminance("#131722");
+    var contrast=(Math.max(light,dark)+.05)/(Math.min(light,dark)+.05);
+    var note=document.getElementById("contrast-note");
+    note.textContent=contrast<3?"Contraste baixo no canvas padrão — escolha uma cor mais clara.":"Contraste adequado no canvas padrão.";
+    note.style.color=contrast<3?"var(--warn)":"var(--faint)";
+    renderAll();record(before,"Cor aplicada.");
+  }
+  document.getElementById("swatches").onclick=function(event){
+    var button=event.target.closest(".swatch");if(!button)return;
+    var before=captureUndoState();
+    root.querySelectorAll(".swatch").forEach(function(item){item.setAttribute("aria-pressed",String(item===button))});
+    applyColor(button.dataset.color,before);
+  };
+  document.getElementById("custom-color").onchange=function(event){
+    var before=captureUndoState();
+    root.querySelectorAll(".swatch").forEach(function(item){item.setAttribute("aria-pressed","false")});
+    applyColor(event.target.value,before);
+  };
+  document.getElementById("width").onpointerdown=function(){widthBefore=captureUndoState()};
+  document.getElementById("width").onfocus=function(){if(!widthBefore)widthBefore=captureUndoState()};
+  document.getElementById("width").oninput=function(event){model.width=Number(event.target.value);renderState()};
+  document.getElementById("width").onchange=function(){if(widthBefore){record(widthBefore,"Espessura alterada.");widthBefore=null}};
+  document.getElementById("add-level").onclick=function(){
+    var before=captureUndoState(),candidate=1.272;
+    while(model.levels.some(function(level){return Math.abs(level.ratio-candidate)<.000001}))candidate+=.1;
+    model.levels.push({ratio:candidate,label:formatPercent(candidate),visible:true,color:null});
+    renderAll();record(before,"Nível "+candidate.toFixed(3)+" adicionado.");
+    document.querySelector("#level-list .levelrow:last-child .number").focus();
+  };
+  document.getElementById("sort-levels").onclick=function(){var before=captureUndoState();model.levels.sort(function(a,b){return a.ratio-b.ratio});renderAll();record(before,"Níveis ordenados por razão.")};
+  document.getElementById("restore-levels").onclick=function(){var before=captureUndoState();model.levels=JSON.parse(JSON.stringify(defaultLevels));renderAll();record(before,"Níveis padrão restaurados.")};
+  document.getElementById("invert-anchors").onclick=function(){var before=captureUndoState(),a=model.a;model.a=model.b;model.b=a;renderFib();record(before,"Âncoras A e B invertidas.")};
+  document.getElementById("log-scale").onchange=function(event){var before=captureUndoState();model.logScale=event.target.checked;renderFib();record(before,model.logScale?"Escala logarítmica aplicada.":"Escala linear aplicada.")};
+  ["a","b"].forEach(function(anchor){
+    document.getElementById("anchor-"+anchor+"-time").onchange=function(event){
+      var x=parseChartTime(event.target.value);
+      if(x===null||x<MIN_DRAWING_X||x>MAX_DRAWING_X){renderFib();say("Use AAAA-MM-DD HH:mm:ss dentro da janela demonstrada.",false);return}
+      var before=captureUndoState();model[anchor].x=x;renderFib();record(before,"Data/hora da âncora "+anchor.toUpperCase()+" alterada.");
+    };
+    document.getElementById("anchor-"+anchor+"-price").onchange=function(event){
+      var price=parsePtBrNumber(event.target.value);
+      if(price===null||price<=0){renderFib();say("Informe um preço positivo no formato 71.824,50.",false);return}
+      var before=captureUndoState();model[anchor].y=(PRICE_ORIGIN-price)/PRICE_PER_Y;renderFib();record(before,"Preço da âncora "+anchor.toUpperCase()+" alterado.");
+    };
+  });
+  canvasFocus.onkeydown=function(event){
+    if(event.target!==canvasFocus)return;
+    var key=event.key.toLowerCase();
+    if(event.ctrlKey&&key==="z"){event.preventDefault();if(event.shiftKey)redoAction();else undoAction();return}
+    if(event.ctrlKey&&key==="y"){event.preventDefault();redoAction();return}
+    if(event.altKey&&key==="l"){event.preventDefault();document.getElementById("lock").click();return}
+    if(event.altKey&&key==="h"){event.preventDefault();document.getElementById("eye").click();return}
+    var toolName={"1":"Pointer","2":"Crosshair","h":"Horizontal line","r":"Rectangle","c":"Parallel channel","f":event.shiftKey?"Fib extension":"Fib retracement"}[key];
+    if(toolName){event.preventDefault();activateTool(toolName);return}
+    if(event.key==="Delete"||event.key==="Backspace"){event.preventDefault();removeDrawing(false)}
+    if(event.key==="Escape"){activateTool("Pointer");deselectDrawing();say("Seleção removida; Pointer ativo.",false);return}
+    if(uiState.selected&&!model.locked&&["ArrowLeft","ArrowRight","ArrowUp","ArrowDown"].includes(event.key)){
+      event.preventDefault();
+      var before=captureUndoState(),step=event.shiftKey?12:2,dx=event.key==="ArrowLeft"?-step:event.key==="ArrowRight"?step:0,dy=event.key==="ArrowUp"?-step:event.key==="ArrowDown"?step:0;
+      var translated=boundedTranslation(model.a,model.b,dx,dy);model.a=translated.a;model.b=translated.b;renderFib();record(before,"Desenho deslocado pelo teclado.");
+    }
+  };
+  renderAll();
+  placeInspector();
+})();
+</script>
+</body>
+</html>

--- a/docs/ux/ui-design-model.md
+++ b/docs/ux/ui-design-model.md
@@ -8,6 +8,11 @@ live today, and where they will live as the app grows into indicators, drawing
 tools and beyond. This document is the reference for every future UI change:
 a new feature first finds its home here, then gets built.
 
+The detailed interaction target for user-authored chart objects lives in
+[Drawing tools UX specification](drawing-tools-ux-spec.html). It covers the
+toolbox, non-modal inspector, selection, lock/visibility/delete semantics,
+keyboard grammar, object management and the complete Fibonacci level editor.
+
 The companion images in [`img/`](img/) are part of the spec, not decoration.
 Everything in `CLAUDE.md` applies unchanged; this model adds UI placement rules
 on top of it.
@@ -197,7 +202,11 @@ bar §8) and both panel-opening buttons (the dock's tab strip replaces them).
 ![Tool rail and dock](img/04-tool-rail-dock.svg)
 
 > The diagram records the original vertical-rail skeleton. The corner-docked
-> external toolbox described below supersedes that rail geometry.
+> external toolbox described below supersedes that rail geometry, and the
+> detailed [Drawing tools UX specification](drawing-tools-ux-spec.html) is
+> authoritative for drawing interactions beyond it: favourites/flyouts, the
+> repeat pin, the Objects manager, lock/visibility/delete semantics, the
+> keyboard grammar and the complete Fibonacci level editor.
 
 **Drawing toolbox (external, 44 px).** Exclusive selection; exactly one tool
 is armed and `Esc` always returns to Pointer. Its grip docks the controls at
@@ -228,6 +237,10 @@ When the floating inspector overlaps selected geometry, that stroke or anchor
 keeps pointer priority during its drag; all other clicks still edit the
 inspector normally.
 Closing the inspector deselects the object.
+
+The target keeps destructive bulk actions inside the Objects manager. Lock-all
+and hide-all are reversible protection/view actions; neither shares the
+selected object's delete control.
 
 **Dock (right, 280–360 px).** One tabbed panel replaces today's stack of
 left `SidePanel`s: tabs **L2**, **Bubbles**, **Indicators**, **Session**.

--- a/docs/ux/ui-design-model.md
+++ b/docs/ux/ui-design-model.md
@@ -46,6 +46,8 @@ Inventory, from code:
 | Candle style editor | floating window | `candle_view.rs::draw_style_window` |
 | Market Replay browser | floating window (Ctrl+R) | `replay_view.rs::draw_browser` |
 | Replay transport | bottom panel (while replaying) | `replay_view.rs::draw_transport` |
+| Drawing toolbox | external 44 px top/bottom panel, corner-docked | `toolrail.rs` |
+| Selected-drawing inspector | floating window | `app.rs::draw_drawing_inspector` |
 | Timezone picker | floating area, pinned bottom-right | `app.rs::draw_timezone_selector` |
 | Header line (symbol · spec · bar counts · mode) | text painted on chart | `app.rs::draw_header` |
 | Perf overlay (fps, frame ms, lag, trades) | box painted on chart | `app.rs::draw_overlay` |
@@ -143,7 +145,7 @@ Icons (§6–§7 use them):
 |---|---|---|---|
 | 1 | Menu bar | 28 px | rare actions, discoverability, shortcuts (§10) |
 | 2 | Context toolbar | 44 px | source · bars · history · layers · look · panels (§6) |
-| 3 | Tool rail | 44 px | chart-acting tools: cursor, crosshair, drawings (§7) |
+| 3 | Drawing toolbox | 44 px top/bottom, left/right aligned | cursor, crosshair, drawings (§7) |
 | 4 | Chart canvas | elastic | candles, flow layers, overlay legends, drawings |
 | 5 | Sub-panes | ≤ 40% of 4, max 3 | pane indicators: CVD, delta… (§9) |
 | 6 | Time axis | 24 px | time labels, x-zoom drag |
@@ -151,10 +153,12 @@ Icons (§6–§7 use them):
 | 8 | Dock | 280–360 px, collapsible to 36 | tabbed settings panels (§7) |
 | 9 | Price axis | 64 px | price labels, y-zoom drag |
 
-Vertical chrome while live: 28+44+24+28 = **124 px** — 4 px more than today's
-120 px (menu 26 + controls 36 + time 22 + header/overlays ≈ 36 painted over
-candles). In exchange, nothing is painted over the candles anymore except the
-legend and honest markers.
+Vertical chrome while live with the drawing toolbox visible:
+28+44+44+24+28 = **168 px**. The toolbox can be hidden from **View**, or
+docked above the status area instead of below the context toolbar. In
+exchange, persistent chrome never covers the candles; only contextual floating
+windows such as the selected-drawing inspector may overlap them. Canvas layers
+remain limited to the legend and honest market markers.
 
 **The rule that keeps this stable:** a new feature must claim a slot inside
 zones 1–9. If it genuinely cannot, the shell — not the feature — is what gets
@@ -192,31 +196,38 @@ bar §8) and both panel-opening buttons (the dock's tab strip replaces them).
 
 ![Tool rail and dock](img/04-tool-rail-dock.svg)
 
-**Tool rail (left, 44 px).** Exclusive selection; exactly one tool armed;
-`Esc` always returns to Pointer. Ships now with Pointer and Crosshair —
-2 slots that already earn their place — and gives drawing tools their
-permanent home the day they land:
+> The diagram records the original vertical-rail skeleton. The corner-docked
+> external toolbox described below supersedes that rail geometry.
+
+**Drawing toolbox (external, 44 px).** Exclusive selection; exactly one tool
+is armed and `Esc` always returns to Pointer. Its grip docks the controls at
+the nearest of the four chart-shell corners: top-left, top-right, bottom-left
+or bottom-right. The top/bottom panel reserves layout space, so the toolbox
+never floats over market data.
 
 | Tool | Key | Notes |
 |---|---|---|
-| Pointer | `Esc`/`1` | pan/zoom/select — today's default interaction |
-| Crosshair | `2` | today's hover crosshair becomes a mode |
-| Trend line | `T` | two anchors, **bar-index coordinates** (Pine-compatible) |
-| Horizontal level | `H` | one price, extends both ways |
-| Zone (rectangle) | `R` | supply/demand boxes |
-| Measure | `M` | Δprice, Δbars — and Δdelta: an order-flow-native measure |
-| Note | `N` | text pinned to bar + price |
-| *(footer)* Magnet | | snap anchors to nearest bar OHLC |
-| *(footer)* Lock | | drawings ignore edits until unlocked |
+| Pointer | `Esc`/`1` | pan, zoom, select and move |
+| Crosshair | `2` | hover crosshair as an armed mode |
+| Horizontal line | — | one price anchor, extends across the chart |
+| Rectangle | — | two corners; click-click or drag |
+| Parallel channel | — | baseline plus a perpendicular width anchor |
+| Fib retracement | — | two anchors and standard retracement levels |
+| Fib extension | — | first leg plus projection origin |
 
-Footer slots are toggling *modifiers*, body slots are exclusive *tools*.
-Object deletion happens on the selected object (`Del` / context row) — no
-global "clear all" icon within reach of a slip.
+Every drawing implementation owns its metadata, renderer and hit-test in one
+module and is exposed through one static registry. Coordinates are
+bar-index + price. A history prepend shifts every stored bar index by the same
+net bar count as the viewport. A source or bar-spec rebuild clears the active
+set rather than silently attaching anchors to different market data.
 
-User drawings persist per symbol; coordinates are bar-index + price, the same
-x-model the indicator plan locks for scripts, so replay seeks and history
-prepends shift them correctly (`viewport.shift_right_edge` already models
-this).
+Selecting visible geometry opens per-object color, line-width, fill-opacity
+and delete controls. The inspector is non-modal: dragging the visible body
+moves the whole object, while dragging a white anchor edits only that point.
+When the floating inspector overlaps selected geometry, that stroke or anchor
+keeps pointer priority during its drag; all other clicks still edit the
+inspector normally.
+Closing the inspector deselects the object.
 
 **Dock (right, 280–360 px).** One tabbed panel replaces today's stack of
 left `SidePanel`s: tabs **L2**, **Bubbles**, **Indicators**, **Session**.
@@ -303,9 +314,8 @@ the only path:
 - **Help** — replay file format…, future: Pine dialect reference,
   shortcut list.
 
-Shortcut map (reserved now so nothing collides later):
-`Esc/1` pointer · `2` crosshair · `T/H/R/M/N` drawing tools · `Del` delete
-selected drawing · `Ctrl+R` replay browser · `Ctrl+B` dock · `Space`
+Shortcut map currently implemented:
+`Esc/1` pointer · `2` crosshair · `Ctrl+R` replay browser · `Ctrl+B` dock · `Space`
 play/pause while replaying · `+`/`−` replay speed. Single letters stay free
 of modifiers (no text inputs live on the chart).
 
@@ -316,7 +326,7 @@ Where future features land — decided now, so they never claim new chrome:
 | Future feature | Toggle/entry | Settings | Canvas presence | Status |
 |---|---|---|---|---|
 | Indicators (M1–M5) | LAYERS icon + Insert menu | dock tab Indicators | legend rows, overlays, sub-panes | recompute progress |
-| Drawing tools | tool rail + Insert menu | selected-object popover | drawings layer | object count (View) |
+| Drawing tools | corner-docked toolbox | selected-object inspector | drawings layer | — |
 | Alerts | on indicator/level context | dock tab Alerts | triggered marker on bar | armed count + last fired |
 | Bot / strategy monitor | LAYERS icon | dock tab | order/position markers | connection + P&L cell |
 | Second chart / layouts | File → Layout | — | split canvas (zones 4–6 duplicate per chart; zones 1–3, 7–9 stay singular) | per-chart provenance |


### PR DESCRIPTION
## What changed

Implements the full drawing-tools UX specification (`docs/ux/drawing-tools-ux-spec.html`, committed here), on top of the original modular tool registry. Delivered in four phases matching the spec's own plan:

1. **Foundations** — lock/visibility/delete semantics, undo/redo with gesture coalescing, an 8 s Undo toast, selection that keeps the object's colour (halo + white handles instead of repainting the stroke white), global hide-all/lock-all protections on the toolbox, and history snapshots that shift with prepended bars.
2. **Inspector** — one body shared by a floating window (resizable 300–440 px, smart placement beside the selection, clamped inside the chart pane, manual moves win for the session) and a pinned dock panel the canvas pays for; capability-driven Style/Levels/Coordinates tabs; the reusable `DrawingActionBar`; the Objects manager (per-row show/hide, lock, bring-to-front, delete via the shared command, show-all/unlock-all, select-and-centre).
3. **Full Fib** — a payload port on the envelope (`Box<dyn DrawingPayload>`), the shared level model (editable ratios/labels/colours/fills, ≥1 visible, 1e-6 duplicate tolerance, `.618`/`61.8%`/decimal-comma parser), built-in + custom presets persisted in a versioned `quantick-drawing-presets.toml` (explicit overwrite; per-kind default shapes new objects only), linear and log formulas computed in price space with golden tests, band fills, label modes/positions with a rebuild-only-on-change cache, extension origin C, invert A↔B.
4. **Polish** — repeat pin (one-shot by default), registry-declared tool shortcuts (H/R/C/F/Shift+F), the escape stack (confirm → draft → selection → Pointer), Backspace stepping back draft anchors, Alt+L/Alt+H, Ctrl+D duplicate, arrow nudges (Shift = ×10) as one undo entry each, the narrow toolbox collapsing into a More-tools flyout without wrapping, hover cursors (move / not-allowed), Alt+click cycling overlap, the fill-aware rectangle interior hit-test, and an explicit no-Undo notice when a rebuild clears the drawings.

## Architecture

Each tool lives in its own module behind one registry; capabilities (fill, extra tab, shortcut) are declared by the tool, so the toolbox, inspector and keyboard map never grow a central match. Tool-unique state lives in the tool's payload and rides the envelope's clone/equality (undo) and the inspector's Extra tab — a fake test tool proves a new property (`ray_count`) docks with zero edits to the shared model or central form. Drawings remain an app-only overlay: no reverse workspace dependency, and the deterministic engine, replay and feed crates are untouched.

Frame-path contracts: metadata and built-in presets are static; Fib labels are cached and re-formatted only when an anchor price or the config changes; hit-testing walks visible objects in reverse z-order; a drag paints per frame and records one undo command on release. Geometry and timing constants are named (`INSPECTOR_MIN/MAX_WIDTH_PX`, `INSPECTOR_OBJECT_GAP_PX`, `TOAST_UNDO_MS`, `UNDO_HISTORY_LIMIT`, …).

## Spec acceptance criteria (AC-01…AC-22)

| AC | Status | Evidence |
|---|---|---|
| 01 non-modal inspector | ✅ | `inspector_never_blocks_drawing_drag`, `rectangle_anchor_resizes_while_the_settings_window_stays_non_modal` |
| 02 gesture priority under the window | ✅ | `inspector_never_blocks_drawing_drag` (drags a stroke pixel underneath the inspector) |
| 03 placement inside the view, off the axes | ✅ | `inspector_opens_beside_the_selection_inside_the_chart` |
| 04 rigid move / single-anchor resize, no pan | ✅ | `a_drawing_can_be_selected_from_its_stroke_and_moved_without_panning`, `moving_one_anchor_does_not_move_the_other_points` |
| 05 named actions visible without scroll | ✅ | `drawing_actions_visible_without_scroll_at_360px` (44 px mobile targets deferred — desktop app) |
| 06 one delete command everywhere + Undo toast | ✅ | `button_manager_and_keyboard_send_the_same_delete_command`, `delete_and_backspace_never_leak_out_of_focused_inputs`, `keyboard_delete_offers_an_undo_toast_and_ctrl_z_restores` |
| 07 locked semantics | ✅ | `locked_drawing_rejects_geometry_and_keyboard_delete`, `deleting_a_locked_drawing_requires_explicit_force` (state shown in inspector chip text + manager row; on-canvas badge deferred) |
| 08 hidden: no paint/hit, recoverable | ✅ | `hidden_drawing_neither_paints_nor_hit_tests`, `hide_all_is_a_layer_over_each_drawings_own_eye`, manager row test |
| 09 selection keeps the colour | ✅ | `selection_preserves_the_drawing_color_and_adds_white_handles` |
| 10 tool-driven properties only | ✅ | fill slider only for `supports_fill` tools; Levels tab only on Fib (`the_fib_inspector_mounts_its_level_editor_tab`) |
| 11 live per-level editing | ✅ | level editor (`draw_levels_tab`) + `the_label_cache_rebuilds_only_when_prices_or_config_change` |
| 12 exact formulas, reverse keeps C | ✅ | golden tests in `fib.rs` (`retracement_formula_is_exact…`, `extension_projects_the_impulse_from_origin_c_and_reverse_keeps_c`, log variants) |
| 13 presets survive restart, default only for new | ✅ | `custom_presets_survive_a_restart_via_the_versioned_file`, `a_default_preset_shapes_new_fibs_and_leaves_existing_ones_alone` |
| 14 one gesture = one undo entry, no viewport/UI | ✅ | `one_drag_creates_one_undo_entry`, `creating_dragging_and_deleting_are_one_undo_entry_each`; snapshots hold drawings only by construction |
| 15 one canonical coordinate source | ✅ | Coordinates tab edits the same `ChartPoint`s drags write; `arrow_nudges_move_the_selection_and_shift_multiplies_by_ten` |
| 16 toolbar never wraps, essentials survive | ✅ | `the_narrow_strip_keeps_pointer_active_tool_and_objects` |
| 17 escape stack | ✅ | `escape_walks_confirm_draft_selection_then_pointer` |
| 18 a11y | ⚠️ partial | full keyboard grammar + textual actions + hover names; accessibility-tree audit and 200% text snapshots deferred |
| 19 modular extension port | ✅ | `a_fake_tool_with_its_own_payload_docks_without_touching_the_model` |
| 20 no per-frame metadata/label allocs | ✅ | static metadata; label cache test; SmallVec projection buffers |
| 21 honest rebuild | ✅ | `a_source_reset_restarts_the_history_wait` (clears), `undo_snapshots_shift_with_prepended_history`, `a_bar_rebuild_clears_drawings_with_an_explicit_notice_and_no_dead_undo` |
| 22 rectangle interior only with fill | ✅ | `rectangle_interior_hit_tests_only_while_the_fill_is_visible` |

## Deliberate deferrals (noted per CLAUDE.md)

- Anchor snapping modes (OHLC magnet) and the Shift/Alt geometric constraints during placement.
- Context menu; drag-reorder of z-order in the manager (Bring-to-front button ships instead).
- Label collision handling (priority hiding, leader ticks) and the on-canvas "locked" badge.
- The <800 px drawer layout, 200% text / DPI snapshot suite, accessibility-tree audit.
- Undo of preset-store mutations (saving/deleting a *custom preset file entry*); applying a preset to an object is undoable.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo build --workspace`
- `cargo test --workspace` (445 app tests; 2 live Binance tests remain intentionally ignored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016PsYf3dQGziobJwfngM1Sv
