### PR TITLE
feat: TradingView-style drawing toolbar rail and inspector UX

### DIFF
--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -555,6 +555,10 @@ pub struct QuantickApp {
     // Whether the user ever toggled the pin — the auto-pin width rule stops
     // firing once they have expressed a preference.
     inspector_pin_touched: bool,
+    // Set on the unpin frame: the side panel still occupies that frame's
+    // layout, so the floating host waits one frame and places against the
+    // settled chart instead of the pinned-era geometry.
+    inspector_settle_frame: bool,
     // The chart pane from the last frame (excludes axes and the live lane),
     // for inspector placement and manager centring.
     last_chart_area: Option<egui::Rect>,
@@ -694,6 +698,7 @@ impl QuantickApp {
             inspector_last_selection: None,
             inspector_pos: None,
             inspector_pin_touched: false,
+            inspector_settle_frame: false,
             last_chart_area: None,
             drawing_manager_open: false,
             drawing_manager_was_open: false,
@@ -4012,6 +4017,14 @@ impl QuantickApp {
             // The user has expressed a preference: the auto-pin width rule
             // stops firing for the rest of the session.
             self.inspector_pin_touched = true;
+            if !self.inspector_pinned {
+                // Unpinning re-opens the floating window. The pinned host
+                // has been claiming the selection each frame, so treat it
+                // as fresh again — otherwise automatic placement never runs
+                // and the window falls back to the fixed default corner.
+                self.inspector_last_selection = None;
+                self.inspector_settle_frame = true;
+            }
         }
         if actions.delete {
             self.request_delete_selected(now);
@@ -4137,6 +4150,13 @@ impl QuantickApp {
         let Some((index, before)) = self.inspector_selection() else {
             return;
         };
+        if std::mem::take(&mut self.inspector_settle_frame) {
+            // The unpin happened this frame: the side panel still occupies
+            // this frame's layout and the drawing projects against the
+            // pinned-era chart. Wait one frame and place against the
+            // settled geometry.
+            return;
+        }
         let selection_changed = self.inspector_last_selection != Some(index);
         // The auto-pin (§4.2): a fresh selection on a chart too narrow for a
         // floating window opens pinned instead — decided here because this
@@ -6118,6 +6138,25 @@ plot(close)
         click_sized(&mut app, &ctx, narrow, pin.center());
         assert!(!app.inspector_pinned, "the pin toggles the panel off");
         assert!(app.inspector_pin_touched, "the preference is recorded");
+
+        // Unpinning with the same selection must recompute placement — not
+        // fall back to the fixed default corner (the pinned host claimed the
+        // selection each frame, so the floating host has to re-place it).
+        run_sized_frame(&mut app, &ctx, narrow, Vec::new());
+        run_sized_frame(&mut app, &ctx, narrow, Vec::new());
+        let floating = ctx
+            .memory(|memory| memory.area_rect(egui::Id::new("drawing_inspector")))
+            .expect("unpinning reopens the floating inspector");
+        assert_ne!(
+            floating.min, DRAWING_INSPECTOR_DEFAULT_POSITION,
+            "the reopened window must be placed, not parked at the default"
+        );
+        // The selected line's anchor bbox (anchor ± select radius).
+        let bbox = egui::Rect::from_center_size(egui::pos2(600.0, 300.0), egui::vec2(24.0, 24.0));
+        assert!(
+            !floating.intersects(bbox),
+            "the reopened window sits beside the selected object: {floating:?}"
+        );
 
         // Deselect, reselect: same width, but the touched pin wins now.
         run_sized_frame(

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -96,6 +96,12 @@ const INSPECTOR_FALLBACK_HEIGHT_PX: f32 = 280.0;
 const INSPECTOR_AUTO_PIN_CHART_WIDTH_PX: f32 = 1180.0;
 /// Height of the floating inspector's custom title bar.
 const INSPECTOR_TITLE_HEIGHT_PX: f32 = 28.0;
+/// Title-bar paint metrics: leading padding, the title column when the grip
+/// glyph precedes it, and the two font sizes.
+const INSPECTOR_TITLE_PAD_X_PX: f32 = 2.0;
+const INSPECTOR_TITLE_TEXT_X_PX: f32 = 18.0;
+const INSPECTOR_TITLE_GRIP_GLYPH_PX: f32 = 14.0;
+const INSPECTOR_TITLE_TEXT_PX: f32 = 13.0;
 /// Gap between the object manager and the rail edge it opens beside.
 const DRAWING_MANAGER_GAP_PX: f32 = 12.0;
 /// Dragging the price field across the whole visible range takes this many
@@ -3747,19 +3753,26 @@ impl QuantickApp {
             let painter = ui.painter();
             if floating {
                 painter.text(
-                    egui::pos2(bar_rect.left() + 2.0, bar_rect.center().y),
+                    egui::pos2(
+                        bar_rect.left() + INSPECTOR_TITLE_PAD_X_PX,
+                        bar_rect.center().y,
+                    ),
                     egui::Align2::LEFT_CENTER,
                     icons::DOTS_SIX_VERTICAL,
-                    egui::FontId::proportional(14.0),
+                    egui::FontId::proportional(INSPECTOR_TITLE_GRIP_GLYPH_PX),
                     theme::TEXT_FAINT,
                 );
             }
-            let title_x = if floating { 18.0 } else { 2.0 };
+            let title_x = if floating {
+                INSPECTOR_TITLE_TEXT_X_PX
+            } else {
+                INSPECTOR_TITLE_PAD_X_PX
+            };
             painter.text(
                 egui::pos2(bar_rect.left() + title_x, bar_rect.center().y),
                 egui::Align2::LEFT_CENTER,
                 title,
-                egui::FontId::proportional(13.0),
+                egui::FontId::proportional(INSPECTOR_TITLE_TEXT_PX),
                 theme::TEXT_PRIMARY,
             );
         }
@@ -6154,6 +6167,39 @@ plot(close)
             ),
             "the chart must not read a hover through the inspector; got {:?}",
             output.platform_output.cursor_icon
+        );
+    }
+
+    #[test]
+    fn the_object_manager_opens_beside_the_rail() {
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        run_frame(&mut app, &ctx);
+        let objects = app
+            .toolrail
+            .objects_button_rect()
+            .expect("the rail shows the Objects entry");
+        click_chart(&mut app, &ctx, objects.center());
+        assert!(app.drawing_manager_open);
+        run_frame(&mut app, &ctx);
+
+        let manager = ctx
+            .memory(|memory| memory.area_rect(egui::Id::new("drawing_manager")))
+            .expect("the manager is open");
+        let chart = app.last_chart_area.expect("chart laid out");
+        // Default dock is Left: the manager opens one gap inboard of the
+        // rail's inner edge, aligned with its leading (top) end.
+        assert!(
+            (manager.left() - (chart.left() + DRAWING_MANAGER_GAP_PX)).abs() < 1.0,
+            "manager left edge: {} vs chart {}",
+            manager.left(),
+            chart.left()
+        );
+        assert!(
+            (manager.top() - (chart.top() + DRAWING_MANAGER_GAP_PX)).abs() < 1.0,
+            "manager top edge: {} vs chart {}",
+            manager.top(),
+            chart.top()
         );
     }
 

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -10,6 +10,7 @@
 use std::time::{Duration, Instant};
 
 use eframe::egui;
+use egui_phosphor::regular as icons;
 use rust_decimal::Decimal;
 use rust_decimal::prelude::{FromPrimitive as _, ToPrimitive as _};
 use tokio::sync::{mpsc, watch};
@@ -48,8 +49,9 @@ use crate::style::{CandlePreset, ChartStyle};
 use crate::theme;
 use crate::timezone::TzOffset;
 use crate::toolbar::{self, ToolbarAction};
-use crate::toolrail::{Tool, ToolRail};
+use crate::toolrail::{Tool, ToolRail, ToolboxDock};
 use crate::viewport::Viewport;
+use crate::widgets::{IconButton, TOOLBAR_ICON};
 
 /// Convert an explicit unmultiplied RGBA style colour to egui.
 fn color32([r, g, b, a]: [u8; 4]) -> egui::Color32 {
@@ -88,6 +90,14 @@ const INSPECTOR_LEVELS_WIDTH_PX: f32 = 360.0;
 const INSPECTOR_OBJECT_GAP_PX: f32 = 12.0;
 /// Assumed inspector height for placement before its first frame reports one.
 const INSPECTOR_FALLBACK_HEIGHT_PX: f32 = 280.0;
+/// Below this chart width a fresh selection opens the inspector pinned —
+/// there is no floating position that would not crowd the geometry. Stops
+/// applying once the user touches the pin either way.
+const INSPECTOR_AUTO_PIN_CHART_WIDTH_PX: f32 = 1180.0;
+/// Height of the floating inspector's custom title bar.
+const INSPECTOR_TITLE_HEIGHT_PX: f32 = 28.0;
+/// Gap between the object manager and the rail edge it opens beside.
+const DRAWING_MANAGER_GAP_PX: f32 = 12.0;
 /// Dragging the price field across the whole visible range takes this many
 /// steps, whatever the symbol's price magnitude.
 const PRICE_DRAG_STEPS: f64 = 200.0;
@@ -158,6 +168,21 @@ struct InspectorActions {
     force_delete: bool,
     close: bool,
     edited: bool,
+}
+
+impl InspectorActions {
+    /// Fold another frame section's requests into this one — the title bar
+    /// and the body each report intent, the host applies the union.
+    fn merge(&mut self, other: Self) {
+        self.toggle_hidden |= other.toggle_hidden;
+        self.toggle_lock |= other.toggle_lock;
+        self.toggle_pin |= other.toggle_pin;
+        self.delete |= other.delete;
+        self.cancel_delete |= other.cancel_delete;
+        self.force_delete |= other.force_delete;
+        self.close |= other.close;
+        self.edited |= other.edited;
+    }
 }
 
 /// Alpha of the last-price line: legible at a glance without competing with a
@@ -249,6 +274,65 @@ fn plot_split(area: egui::Rect, live_strip_width: f32, pane_count: usize) -> Plo
 /// Without a lane every pixel belongs to the candles, exactly as before.
 fn gesture_hits_lane(divider_x: Option<f32>, x: f32) -> bool {
     divider_x.is_some_and(|divider| x >= divider)
+}
+
+/// Clamp a window of `size` at `position` into `chart`, top-left biased when
+/// the window is larger than the pane.
+fn clamp_into_chart(position: egui::Pos2, size: egui::Vec2, chart: egui::Rect) -> egui::Pos2 {
+    let max_x = (chart.right() - size.x).max(chart.left());
+    let max_y = (chart.bottom() - size.y).max(chart.top());
+    egui::pos2(
+        position.x.clamp(chart.left(), max_x),
+        position.y.clamp(chart.top(), max_y),
+    )
+}
+
+/// The inspector placement rule (`docs/drawing-toolbar-ux.md` §4.2): eight
+/// candidates — beside the object, then the chart corners — each clamped
+/// into the chart *before* scoring, then least `bbox` overlap wins. Ties
+/// break toward the greater centre distance, then candidate order, so the
+/// result is deterministic and, at zero overlap, keeps the classic
+/// right / left / below / above preference.
+fn inspector_placement(chart: egui::Rect, bbox: egui::Rect, size: egui::Vec2) -> egui::Pos2 {
+    let gap = INSPECTOR_OBJECT_GAP_PX;
+    let candidates = [
+        egui::pos2(bbox.right() + gap, bbox.top()),
+        egui::pos2(bbox.left() - gap - size.x, bbox.top()),
+        egui::pos2(bbox.left(), bbox.bottom() + gap),
+        egui::pos2(bbox.left(), bbox.top() - gap - size.y),
+        egui::pos2(chart.left() + gap, chart.top() + gap),
+        egui::pos2(chart.right() - gap - size.x, chart.top() + gap),
+        egui::pos2(chart.left() + gap, chart.bottom() - gap - size.y),
+        egui::pos2(chart.right() - gap - size.x, chart.bottom() - gap - size.y),
+    ];
+    let mut best: Option<(egui::Pos2, f32, f32)> = None;
+    for candidate in candidates {
+        let position = clamp_into_chart(candidate, size, chart);
+        let rect = egui::Rect::from_min_size(position, size);
+        let overlap = rect.intersect(bbox);
+        let overlap_area = if overlap.is_positive() {
+            overlap.area()
+        } else {
+            0.0
+        };
+        let distance = rect.center().distance(bbox.center());
+        // A clear (zero-overlap) candidate wins on order alone, keeping the
+        // beside-the-object preference over the corners; among genuinely
+        // overlapping candidates the farther-away one crowds least.
+        let wins = match &best {
+            None => true,
+            Some((_, best_area, best_distance)) => {
+                overlap_area < *best_area
+                    || (overlap_area == *best_area
+                        && overlap_area > 0.0
+                        && distance > *best_distance)
+            }
+        };
+        if wins {
+            best = Some((position, overlap_area, distance));
+        }
+    }
+    best.map_or_else(|| chart.left_top(), |(position, _, _)| position)
 }
 
 /// Split the bottom time strip at the lane's divider: the candles' own time
@@ -459,10 +543,19 @@ pub struct QuantickApp {
     inspector_pinned: bool,
     inspector_moved: bool,
     inspector_last_selection: Option<usize>,
+    // The floating inspector's position: automatic placement until the user
+    // drags the title bar, manual from then on (only ever re-clamped).
+    inspector_pos: Option<egui::Pos2>,
+    // Whether the user ever toggled the pin — the auto-pin width rule stops
+    // firing once they have expressed a preference.
+    inspector_pin_touched: bool,
     // The chart pane from the last frame (excludes axes and the live lane),
     // for inspector placement and manager centring.
     last_chart_area: Option<egui::Rect>,
     drawing_manager_open: bool,
+    // Last frame's open state: the manager places itself beside the rail on
+    // the frame it opens, and only then.
+    drawing_manager_was_open: bool,
     // Custom drawing presets (named payload exports + default-for-new),
     // persisted across restarts in a versioned file.
     drawing_presets: drawings::presets::PresetStore,
@@ -593,8 +686,11 @@ impl QuantickApp {
             inspector_pinned: false,
             inspector_moved: false,
             inspector_last_selection: None,
+            inspector_pos: None,
+            inspector_pin_touched: false,
             last_chart_area: None,
             drawing_manager_open: false,
+            drawing_manager_was_open: false,
             drawing_presets: drawings::presets::PresetStore::load_from(
                 drawings::presets::PresetStore::default_path(),
             ),
@@ -2338,13 +2434,22 @@ impl QuantickApp {
                     input.pointer.delta(),
                 )
             });
+        // Floating chrome (inspector, manager, toast, flyouts) is opaque to
+        // the pointer: while it sits under the cursor the chart neither sets
+        // a cursor nor selects nor starts a drag. The gate applies at press
+        // time only — a drag that started on the canvas keeps running while
+        // the pointer travels across a panel (continuity, not priority).
+        let over_chrome = pointer_position
+            .and_then(|position| ui.ctx().layer_id_at(position))
+            .is_some_and(|layer| layer != ui.layer_id());
         let mut drawing_drag_consumes_gesture = false;
         if self.toolrail.tool() == Tool::Pointer {
             // Hover feedback: a resize cursor over a selected anchor, a move
             // cursor over any visible body, and not-allowed over locked
             // geometry (visible objects in the viewport only — bounded work).
-            if let Some(position) =
-                pointer_position.filter(|position| drawing_area.contains(*position))
+            if !over_chrome
+                && let Some(position) =
+                    pointer_position.filter(|position| drawing_area.contains(*position))
                 && let Some(scale) = drawing_scale
             {
                 if let Some(selected) = self.drawings.selected()
@@ -2388,13 +2493,13 @@ impl QuantickApp {
                 };
                 self.drawings.select(selected);
             }
-            // Floating inspectors normally own pointer input over their whole
-            // rectangle. Read the raw press so an already-selected drawing
-            // remains draggable even when its stroke or handle is underneath
-            // that inspector. Only an actual drawing hit takes precedence;
-            // every other inspector click remains a style interaction.
+            // Drag initiation reads the raw press (an `interact` per object
+            // would be unbounded work), so it must honour the chrome gate
+            // itself: a press on the inspector never grabs the stroke or the
+            // handle underneath — the panel is opaque by contract.
             let mut drawing_drag_started = false;
             if primary_pressed
+                && !over_chrome
                 && let Some(position) =
                     pointer_position.filter(|position| drawing_area.contains(*position))
                 && let Some(scale) = drawing_scale
@@ -3377,10 +3482,26 @@ impl QuantickApp {
                             self.dock.toggle_visible();
                             ui.close_menu();
                         }
+                        ui.menu_button("Drawing toolbar", |ui| {
+                            for (dock, label) in [
+                                (ToolboxDock::Left, "Left"),
+                                (ToolboxDock::Right, "Right"),
+                                (ToolboxDock::Top, "Top"),
+                                (ToolboxDock::Bottom, "Bottom"),
+                            ] {
+                                if ui
+                                    .selectable_label(self.toolrail.dock() == dock, label)
+                                    .clicked()
+                                {
+                                    self.toolrail.set_dock(dock);
+                                    ui.close_menu();
+                                }
+                            }
+                        });
                         let toolbox_label = if self.toolrail.visible() {
-                            "Hide drawing toolbox"
+                            "Hide drawing toolbar"
                         } else {
-                            "Show drawing toolbox"
+                            "Show drawing toolbar"
                         };
                         if ui.button(toolbox_label).clicked() {
                             self.toolrail.toggle_visible();
@@ -3490,10 +3611,12 @@ impl QuantickApp {
                 nudge_px: vertical * step,
             }
         });
-        // The escape stack: pending confirmation → draft → selection →
-        // Pointer, one layer per press.
+        // The escape stack: rail drag → pending confirmation → draft →
+        // selection → Pointer, one layer per press.
         if keys.escape {
-            if self.drawing_delete_confirm {
+            if self.toolrail.drag_active() {
+                // The rail consumes this Esc to abort its dock drag.
+            } else if self.drawing_delete_confirm {
                 self.drawing_delete_confirm = false;
             } else if self.drawings.draft().is_some() {
                 self.drawings.cancel_draft();
@@ -3596,6 +3719,112 @@ impl QuantickApp {
         }
     }
 
+    /// The inspector's title bar, shared by both hosts: grip + title, then
+    /// the view controls (hide, pin, close) as icon buttons. In the floating
+    /// host the whole bar is the drag surface — the body never is, so a
+    /// slider drag can never move the window; double-click re-runs the
+    /// automatic placement.
+    fn draw_inspector_title_bar(
+        &mut self,
+        ui: &mut egui::Ui,
+        index: usize,
+        floating: bool,
+    ) -> InspectorActions {
+        let mut actions = InspectorActions::default();
+        let drawing = &self.drawings.items()[index];
+        let hidden = drawing.hidden;
+        let title = drawing.tool.settings_title();
+        let sense = if floating {
+            egui::Sense::click_and_drag()
+        } else {
+            egui::Sense::hover()
+        };
+        let (bar_rect, bar) = ui.allocate_exact_size(
+            egui::vec2(ui.available_width(), INSPECTOR_TITLE_HEIGHT_PX),
+            sense,
+        );
+        if ui.is_rect_visible(bar_rect) {
+            let painter = ui.painter();
+            if floating {
+                painter.text(
+                    egui::pos2(bar_rect.left() + 2.0, bar_rect.center().y),
+                    egui::Align2::LEFT_CENTER,
+                    icons::DOTS_SIX_VERTICAL,
+                    egui::FontId::proportional(14.0),
+                    theme::TEXT_FAINT,
+                );
+            }
+            let title_x = if floating { 18.0 } else { 2.0 };
+            painter.text(
+                egui::pos2(bar_rect.left() + title_x, bar_rect.center().y),
+                egui::Align2::LEFT_CENTER,
+                title,
+                egui::FontId::proportional(13.0),
+                theme::TEXT_PRIMARY,
+            );
+        }
+        // The controls are registered after the bar, so they win its pointer.
+        ui.allocate_new_ui(egui::UiBuilder::new().max_rect(bar_rect), |ui| {
+            ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                let close = IconButton::new(icons::X, TOOLBAR_ICON)
+                    .hover_text("Close - keeps the drawing, clears the selection")
+                    .show(ui);
+                if close.clicked() {
+                    actions.close = true;
+                }
+                let pin_hover = if self.inspector_pinned {
+                    "Unpin - float the inspector over the chart"
+                } else {
+                    "Pin - dock the inspector at the side of the chart"
+                };
+                let pin = IconButton::new(icons::PUSH_PIN, TOOLBAR_ICON)
+                    .active(self.inspector_pinned)
+                    .hover_text(pin_hover)
+                    .show(ui);
+                #[cfg(test)]
+                {
+                    self.inspector_pin_rect = Some(pin.rect);
+                }
+                if pin.clicked() {
+                    actions.toggle_pin = true;
+                }
+                let eye_icon = if hidden { icons::EYE_SLASH } else { icons::EYE };
+                let eye_hover = if hidden {
+                    "Show this drawing again"
+                } else {
+                    "Hide this drawing - the inspector keeps the way back"
+                };
+                let eye = IconButton::new(eye_icon, TOOLBAR_ICON)
+                    .active(hidden)
+                    .hover_text(eye_hover)
+                    .show(ui);
+                if eye.clicked() {
+                    actions.toggle_hidden = true;
+                }
+            });
+        });
+        if floating {
+            let bar = bar.on_hover_text("Drag to move · double-click to reposition automatically");
+            if bar.double_clicked() {
+                // The reset path: back to automatic placement.
+                self.inspector_moved = false;
+                self.inspector_pos = self.inspector_target_position(ui.ctx(), index);
+            } else if bar.dragged() {
+                self.inspector_moved = true;
+                let position = self.inspector_pos.or_else(|| {
+                    ui.ctx()
+                        .memory(|memory| memory.area_rect(egui::Id::new("drawing_inspector")))
+                        .map(|rect| rect.min)
+                });
+                if let Some(position) = position {
+                    self.inspector_pos = Some(position + bar.drag_delta());
+                }
+            }
+        }
+        ui.separator();
+        actions
+    }
+
     /// Everything the inspector shows for the selected object, shared by the
     /// floating window and the pinned dock panel. Sections are driven by the
     /// tool's capabilities — an unsupported property is absent, not disabled.
@@ -3607,37 +3836,9 @@ impl QuantickApp {
         let hidden = drawing.hidden;
         let show_confirm = self.drawing_delete_confirm && locked;
 
-        // Header: object identity plus the view controls.
-        ui.horizontal(|ui| {
-            ui.label(egui::RichText::new(tool.name()).strong());
-            ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                if ui.small_button("Close").clicked() {
-                    actions.close = true;
-                }
-                let pin_label = if self.inspector_pinned {
-                    "Unpin"
-                } else {
-                    "Pin"
-                };
-                let pin = ui
-                    .small_button(pin_label)
-                    .on_hover_text("Dock the inspector at the side of the chart");
-                #[cfg(test)]
-                {
-                    self.inspector_pin_rect = Some(pin.rect);
-                }
-                if pin.clicked() {
-                    actions.toggle_pin = true;
-                }
-                let eye_label = if hidden { "Show" } else { "Hide" };
-                if ui.small_button(eye_label).clicked() {
-                    actions.toggle_hidden = true;
-                }
-            });
-        });
-
         // The always-visible textual actions (UX spec: never glyph-only,
-        // never behind a scroll).
+        // never behind a scroll). Identity and the view controls live in the
+        // host's title bar, not here.
         let intent = drawings::action_bar::draw(ui, locked);
         actions.toggle_lock |= intent.toggle_lock;
         actions.delete |= intent.delete;
@@ -3647,11 +3848,16 @@ impl QuantickApp {
                 egui::RichText::new(
                     "Locked - protected from accidental moves. Style stays editable.",
                 )
-                .small(),
+                .small()
+                .color(theme::TEXT_SUPPORT),
             );
         }
         if hidden {
-            ui.label(egui::RichText::new("Hidden - Show brings it back.").small());
+            ui.label(
+                egui::RichText::new("Hidden - Show brings it back.")
+                    .small()
+                    .color(theme::TEXT_SUPPORT),
+            );
         }
         if show_confirm {
             ui.separator();
@@ -3790,6 +3996,9 @@ impl QuantickApp {
         }
         if actions.toggle_pin {
             self.inspector_pinned = !self.inspector_pinned;
+            // The user has expressed a preference: the auto-pin width rule
+            // stops firing for the rest of the session.
+            self.inspector_pin_touched = true;
         }
         if actions.delete {
             self.request_delete_selected(now);
@@ -3813,12 +4022,29 @@ impl QuantickApp {
         }
     }
 
-    /// Where a freshly opened floating inspector should sit: 12 px right of
-    /// the object's bounding box, falling back to left, below and above, and
-    /// always clamped into the chart pane — which already excludes the price
-    /// and time axes, so the popup can never cover either or leave the view.
+    /// Where a freshly opened floating inspector should sit. Eight
+    /// candidates — four beside the object's bounding box, four in the
+    /// chart's corners — every one clamped into the chart pane *before*
+    /// scoring, then the least bbox overlap wins (ties: farther from the
+    /// object's centre, then candidate order). At zero overlap the order
+    /// tie-break keeps the right / left / below / above preference. The
+    /// chart pane already excludes both axes and the live lane, so the
+    /// popup can never cover them or leave the view.
     fn inspector_target_position(&self, ctx: &egui::Context, index: usize) -> Option<egui::Pos2> {
         let chart = self.last_chart_area?;
+        let bbox = self.drawing_bbox_on_screen(chart, index)?;
+        let size = ctx
+            .memory(|memory| memory.area_rect(egui::Id::new("drawing_inspector")))
+            .map_or(
+                egui::vec2(INSPECTOR_DEFAULT_WIDTH_PX, INSPECTOR_FALLBACK_HEIGHT_PX),
+                |rect| rect.size(),
+            );
+        Some(inspector_placement(chart, bbox, size))
+    }
+
+    /// The selected object's screen bounding box, expanded by the anchor
+    /// radius — the rectangle the inspector must not cover.
+    fn drawing_bbox_on_screen(&self, chart: egui::Rect, index: usize) -> Option<egui::Rect> {
         let total = self.slots();
         let (auto_lo, auto_hi) = self.last_auto_range?;
         let (lo, hi) = self.price_view.resolve((auto_lo, auto_hi));
@@ -3836,34 +4062,7 @@ impl QuantickApp {
         for point in &points {
             bbox.extend_with(*point);
         }
-        let bbox = bbox.expand(DRAWING_ANCHOR_RADIUS_PX);
-        let size = ctx
-            .memory(|memory| memory.area_rect(egui::Id::new("drawing_inspector")))
-            .map_or(
-                egui::vec2(INSPECTOR_DEFAULT_WIDTH_PX, INSPECTOR_FALLBACK_HEIGHT_PX),
-                |rect| rect.size(),
-            );
-        let gap = INSPECTOR_OBJECT_GAP_PX;
-        let candidates = [
-            egui::pos2(bbox.right() + gap, bbox.top()),
-            egui::pos2(bbox.left() - gap - size.x, bbox.top()),
-            egui::pos2(bbox.left(), bbox.bottom() + gap),
-            egui::pos2(bbox.left(), bbox.top() - gap - size.y),
-        ];
-        let fits = |position: egui::Pos2| {
-            let rect = egui::Rect::from_min_size(position, size);
-            chart.contains_rect(rect) && !rect.intersects(bbox)
-        };
-        let chosen = candidates
-            .into_iter()
-            .find(|position| fits(*position))
-            .unwrap_or(candidates[0]);
-        let max_x = (chart.right() - size.x).max(chart.left());
-        let max_y = (chart.bottom() - size.y).max(chart.top());
-        Some(egui::pos2(
-            chosen.x.clamp(chart.left(), max_x),
-            chosen.y.clamp(chart.top(), max_y),
-        ))
+        Some(bbox.expand(DRAWING_ANCHOR_RADIUS_PX))
     }
 
     /// Shared prologue of both inspector hosts. Returns the selection and its
@@ -3895,23 +4094,28 @@ impl QuantickApp {
         let Some((index, before)) = self.inspector_selection() else {
             return;
         };
+        self.inspector_last_selection = Some(index);
         let mut actions = InspectorActions::default();
         egui::SidePanel::right("drawing_inspector_panel")
             .resizable(true)
             .default_width(INSPECTOR_DEFAULT_WIDTH_PX)
             .width_range(INSPECTOR_MIN_WIDTH_PX..=INSPECTOR_MAX_WIDTH_PX)
             .show(ctx, |ui| {
+                actions = self.draw_inspector_title_bar(ui, index, false);
                 egui::ScrollArea::vertical().show(ui, |ui| {
-                    actions = self.drawing_inspector_body(ui, index);
+                    let body = self.drawing_inspector_body(ui, index);
+                    actions.merge(body);
                 });
             });
         self.apply_inspector_actions(ctx, actions, index, before, now);
     }
 
     /// The selected object's floating inspector. Non-modal by contract: it
-    /// never captures the whole canvas and never blocks moving the geometry
-    /// underneath it. Opens beside the selection; once the user moves it, the
-    /// manual position wins for the rest of the session.
+    /// never captures the whole canvas — but it is opaque to the pointer, so
+    /// a press on it never falls through to the chart. Opens beside the
+    /// selection; once the user drags the title bar, the manual position
+    /// wins for the rest of the session (selection changes never snap it
+    /// back; the only automatic move is the re-clamp when the pane shrinks).
     fn draw_drawing_inspector(&mut self, ctx: &egui::Context, now: Instant) {
         if self.inspector_pinned {
             // The pinned panel already drew (and cleaned up) this frame.
@@ -3921,10 +4125,42 @@ impl QuantickApp {
             return;
         };
         let selection_changed = self.inspector_last_selection != Some(index);
+        // The auto-pin (§4.2): a fresh selection on a chart too narrow for a
+        // floating window opens pinned instead — decided here because this
+        // host is the one that would otherwise claim the selection. Stops
+        // firing once the user touches the pin.
+        if selection_changed
+            && !self.inspector_pin_touched
+            && self
+                .last_chart_area
+                .is_some_and(|chart| chart.width() < INSPECTOR_AUTO_PIN_CHART_WIDTH_PX)
+        {
+            self.inspector_pinned = true;
+            // The pinned panel draws from the next frame on.
+            return;
+        }
         self.inspector_last_selection = Some(index);
-        let mut actions = InspectorActions::default();
-        let mut open = true;
-        let inspector_interactable = !self.drawing_drag.is_active();
+        // Automatic placement only while the window is untouched.
+        if selection_changed
+            && !self.inspector_moved
+            && let Some(position) = self.inspector_target_position(ctx, index)
+        {
+            self.inspector_pos = Some(position);
+        }
+        // Repair, never override: a position that no longer fits the chart
+        // pane is clamped back in, and `inspector_moved` survives.
+        if let (Some(position), Some(chart)) = (self.inspector_pos, self.last_chart_area) {
+            let size = ctx
+                .memory(|memory| memory.area_rect(egui::Id::new("drawing_inspector")))
+                .map_or(
+                    egui::vec2(INSPECTOR_DEFAULT_WIDTH_PX, INSPECTOR_FALLBACK_HEIGHT_PX),
+                    |rect| rect.size(),
+                );
+            let clamped = clamp_into_chart(position, size, chart);
+            if clamped != position {
+                self.inspector_pos = Some(clamped);
+            }
+        }
         // The level editor earns the wider default the spec reserves for it.
         let default_width = if before.tool.extra_tab().is_some() {
             INSPECTOR_LEVELS_WIDTH_PX
@@ -3933,34 +4169,48 @@ impl QuantickApp {
         };
         let mut window = egui::Window::new(before.tool.settings_title())
             .id(egui::Id::new("drawing_inspector"))
-            .open(&mut open)
+            .title_bar(false)
             .default_pos(DRAWING_INSPECTOR_DEFAULT_POSITION)
             .default_width(default_width)
             .min_width(INSPECTOR_MIN_WIDTH_PX)
             .max_width(INSPECTOR_MAX_WIDTH_PX)
-            .collapsible(false)
-            .movable(true)
-            .interactable(inspector_interactable)
+            .movable(false)
+            .interactable(true)
             .resizable(true);
-        if selection_changed
-            && !self.inspector_moved
-            && let Some(position) = self.inspector_target_position(ctx, index)
-        {
+        if let Some(position) = self.inspector_pos {
             window = window.current_pos(position);
         }
-        let response = window.show(ctx, |ui| self.drawing_inspector_body(ui, index));
-        if let Some(response) = &response {
-            if response.response.dragged() {
-                self.inspector_moved = true;
-            }
-            if let Some(inner) = response.inner {
-                actions = inner;
-            }
-        }
-        if !open {
-            actions.close = true;
-        }
+        let response = window.show(ctx, |ui| {
+            let mut actions = self.draw_inspector_title_bar(ui, index, true);
+            actions.merge(self.drawing_inspector_body(ui, index));
+            actions
+        });
+        let actions = response
+            .and_then(|response| response.inner)
+            .unwrap_or_default();
         self.apply_inspector_actions(ctx, actions, index, before, now);
+    }
+
+    /// Where the object manager opens: one gap inboard of the rail's inner
+    /// edge, aligned with the rail's leading end, clamped into the chart —
+    /// beside the button that opened it in all four docks.
+    fn manager_target_position(&self, ctx: &egui::Context) -> Option<egui::Pos2> {
+        let chart = self.last_chart_area?;
+        let size = ctx
+            .memory(|memory| memory.area_rect(egui::Id::new("drawing_manager")))
+            .map_or(
+                egui::vec2(INSPECTOR_DEFAULT_WIDTH_PX, INSPECTOR_FALLBACK_HEIGHT_PX),
+                |rect| rect.size(),
+            );
+        let gap = DRAWING_MANAGER_GAP_PX;
+        let position = match self.toolrail.dock() {
+            ToolboxDock::Left | ToolboxDock::Top => {
+                egui::pos2(chart.left() + gap, chart.top() + gap)
+            }
+            ToolboxDock::Right => egui::pos2(chart.right() - gap - size.x, chart.top() + gap),
+            ToolboxDock::Bottom => egui::pos2(chart.left() + gap, chart.bottom() - gap - size.y),
+        };
+        Some(clamp_into_chart(position, size, chart))
     }
 
     /// The object manager: a non-modal list of every drawing with the named
@@ -3968,8 +4218,11 @@ impl QuantickApp {
     /// and the keyboard — nothing here re-implements lock or delete rules.
     fn draw_drawing_manager(&mut self, ctx: &egui::Context, now: Instant) {
         if !self.drawing_manager_open {
+            self.drawing_manager_was_open = false;
             return;
         }
+        let just_opened = !self.drawing_manager_was_open;
+        self.drawing_manager_was_open = true;
         #[cfg(test)]
         self.manager_action_rects.clear();
         let mut open = true;
@@ -3980,79 +4233,82 @@ impl QuantickApp {
         let mut delete_row: Option<usize> = None;
         let mut show_all = false;
         let mut unlock_all = false;
-        egui::Window::new("Drawn objects")
+        let mut window = egui::Window::new("Drawn objects")
             .id(egui::Id::new("drawing_manager"))
             .open(&mut open)
             .default_pos(DRAWING_MANAGER_DEFAULT_POSITION)
             .default_width(INSPECTOR_DEFAULT_WIDTH_PX)
             .collapsible(false)
-            .resizable(false)
-            .show(ctx, |ui| {
-                let count = self.drawings.items().len();
-                if count == 0 {
-                    ui.label("No drawings yet.");
-                }
-                // Walked in reverse: the manager lists top-most first, the
-                // same order hit-testing resolves overlap.
-                for index in (0..count).rev() {
-                    let drawing = &self.drawings.items()[index];
-                    let selected = self.drawings.selected() == Some(index);
-                    let locked = drawing.locked;
-                    let hidden = drawing.hidden;
-                    let name = drawing.tool.name();
-                    ui.horizontal(|ui| {
-                        let mut label = egui::RichText::new(format!("{} {}", name, index + 1));
-                        if hidden {
-                            label = label.weak();
-                        }
-                        if ui.selectable_label(selected, label).clicked() {
-                            select_row = Some(index);
-                        }
-                        if locked {
-                            ui.label(egui::RichText::new("locked").small());
-                        }
-                        if hidden {
-                            ui.label(egui::RichText::new("hidden").small());
-                        }
-                        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                            let delete = ui.small_button("Delete");
-                            #[cfg(test)]
-                            self.manager_action_rects
-                                .push((index, "Delete", delete.rect));
-                            if delete.clicked() {
-                                delete_row = Some(index);
-                            }
-                            let front = ui.small_button("Front");
-                            #[cfg(test)]
-                            self.manager_action_rects.push((index, "Front", front.rect));
-                            if front.clicked() {
-                                front_row = Some(index);
-                            }
-                            let lock = ui.small_button(if locked { "Unlock" } else { "Lock" });
-                            #[cfg(test)]
-                            self.manager_action_rects.push((index, "Lock", lock.rect));
-                            if lock.clicked() {
-                                lock_row = Some(index);
-                            }
-                            let eye = ui.small_button(if hidden { "Show" } else { "Hide" });
-                            #[cfg(test)]
-                            self.manager_action_rects.push((index, "Eye", eye.rect));
-                            if eye.clicked() {
-                                eye_row = Some(index);
-                            }
-                        });
-                    });
-                }
-                ui.separator();
+            .resizable(false);
+        if just_opened && let Some(position) = self.manager_target_position(ctx) {
+            window = window.current_pos(position);
+        }
+        window.show(ctx, |ui| {
+            let count = self.drawings.items().len();
+            if count == 0 {
+                ui.label("No drawings yet.");
+            }
+            // Walked in reverse: the manager lists top-most first, the
+            // same order hit-testing resolves overlap.
+            for index in (0..count).rev() {
+                let drawing = &self.drawings.items()[index];
+                let selected = self.drawings.selected() == Some(index);
+                let locked = drawing.locked;
+                let hidden = drawing.hidden;
+                let name = drawing.tool.name();
                 ui.horizontal(|ui| {
-                    if ui.button("Show all").clicked() {
-                        show_all = true;
+                    let mut label = egui::RichText::new(format!("{} {}", name, index + 1));
+                    if hidden {
+                        label = label.weak();
                     }
-                    if ui.button("Unlock all").clicked() {
-                        unlock_all = true;
+                    if ui.selectable_label(selected, label).clicked() {
+                        select_row = Some(index);
                     }
+                    if locked {
+                        ui.label(egui::RichText::new("locked").small());
+                    }
+                    if hidden {
+                        ui.label(egui::RichText::new("hidden").small());
+                    }
+                    ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                        let delete = ui.small_button("Delete");
+                        #[cfg(test)]
+                        self.manager_action_rects
+                            .push((index, "Delete", delete.rect));
+                        if delete.clicked() {
+                            delete_row = Some(index);
+                        }
+                        let front = ui.small_button("Front");
+                        #[cfg(test)]
+                        self.manager_action_rects.push((index, "Front", front.rect));
+                        if front.clicked() {
+                            front_row = Some(index);
+                        }
+                        let lock = ui.small_button(if locked { "Unlock" } else { "Lock" });
+                        #[cfg(test)]
+                        self.manager_action_rects.push((index, "Lock", lock.rect));
+                        if lock.clicked() {
+                            lock_row = Some(index);
+                        }
+                        let eye = ui.small_button(if hidden { "Show" } else { "Hide" });
+                        #[cfg(test)]
+                        self.manager_action_rects.push((index, "Eye", eye.rect));
+                        if eye.clicked() {
+                            eye_row = Some(index);
+                        }
+                    });
                 });
+            }
+            ui.separator();
+            ui.horizontal(|ui| {
+                if ui.button("Show all").clicked() {
+                    show_all = true;
+                }
+                if ui.button("Unlock all").clicked() {
+                    unlock_all = true;
+                }
             });
+        });
         self.drawing_manager_open = open;
         if let Some(index) = select_row {
             self.drawings.select(Some(index));
@@ -5327,15 +5583,36 @@ plot(close)
     ) -> drawings::DrawingTool {
         let drawing = drawing_tool(id);
         let tool = Tool::Drawing(drawing);
-        let button = app
-            .toolrail
-            .button_rect(tool)
-            .expect("drawing button was rendered");
-        click_chart(app, ctx, button.center());
+        if let Some(button) = app.toolrail.button_rect(tool) {
+            click_chart(app, ctx, button.center());
+        } else {
+            // A folded family member has no direct slot: open the family
+            // flyout through the slot's caret zone and arm it by its row —
+            // the same pointer path a user takes.
+            let family = drawing
+                .family()
+                .expect("only family members lack a direct slot");
+            let slot = drawings::DRAWING_TOOLS
+                .into_iter()
+                .filter(|candidate| {
+                    candidate
+                        .family()
+                        .is_some_and(|candidate_family| candidate_family.id == family.id)
+                })
+                .find_map(|candidate| app.toolrail.button_rect(Tool::Drawing(candidate)))
+                .expect("the family slot was rendered");
+            click_chart(app, ctx, slot.max - egui::vec2(4.0, 4.0));
+            run_frame(app, ctx);
+            let row = app
+                .toolrail
+                .flyout_row_rect(drawing)
+                .expect("the flyout lists the folded member");
+            click_chart(app, ctx, row.center());
+        }
         assert_eq!(
             app.toolrail.tool(),
             tool,
-            "clicking {id} must arm that drawing tool"
+            "arming {id} through the rail must land"
         );
         drawing
     }
@@ -5417,11 +5694,13 @@ plot(close)
 
         let before = app.drawings.items()[0].points[0];
         let viewport_before = app.viewport.right_edge_bar(app.slots());
+        // Left of the anchor: clear of the inspector, which opens to its
+        // right — the panel is opaque to presses by contract.
         drag_chart(
             &mut app,
             &ctx,
-            egui::pos2(1_000.0, 300.0),
-            egui::pos2(1_040.0, 340.0),
+            egui::pos2(400.0, 300.0),
+            egui::pos2(440.0, 340.0),
         );
         let after = app.drawings.items()[0].points[0];
 
@@ -5446,19 +5725,19 @@ plot(close)
     }
 
     #[test]
-    fn inspector_never_blocks_drawing_drag() {
+    fn a_press_on_the_inspector_never_grabs_the_stroke_beneath_it() {
         let (mut app, _commands) = app_with_history(200);
         let ctx = egui::Context::default();
         run_frame(&mut app, &ctx);
         app.toolrail
             .arm(Tool::Drawing(drawing_tool("horizontal-line")));
-        let anchor = egui::pos2(300.0, 250.0);
+        let anchor = egui::pos2(700.0, 300.0);
         click_chart(&mut app, &ctx, anchor);
         run_frame(&mut app, &ctx);
 
-        // The horizontal stroke crosses the whole pane, so wherever placement
-        // put the window, some stroke pixel sits underneath it. Drag exactly
-        // that pixel: the gesture must stay with the drawing.
+        // The horizontal stroke crosses the whole pane, so a stroke pixel
+        // sits under the inspector. Press exactly there: the panel is opaque
+        // — the press is a style interaction, never a drawing drag.
         let inspector = ctx
             .memory(|memory| memory.area_rect(egui::Id::new("drawing_inspector")))
             .expect("placing the selected line opens its inspector");
@@ -5466,16 +5745,52 @@ plot(close)
         let start = egui::pos2(inspector.center().x, line_y);
         assert!(
             inspector.contains(start),
-            "the regression requires the floating inspector to cover this stroke pixel"
+            "this proof needs the inspector to cover a stroke pixel"
         );
         let before = app.drawings.items()[0].points[0];
 
         drag_chart(&mut app, &ctx, start, egui::pos2(start.x, line_y + 100.0));
 
+        assert_eq!(
+            app.drawings.items()[0].points[0],
+            before,
+            "a press on the inspector must never fall through to the chart"
+        );
+        assert_eq!(
+            app.drawing_drag,
+            DrawingDrag::None,
+            "no drawing drag may start from a press on the inspector"
+        );
+    }
+
+    #[test]
+    fn a_canvas_drag_keeps_running_while_crossing_the_inspector() {
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        run_frame(&mut app, &ctx);
+        app.toolrail
+            .arm(Tool::Drawing(drawing_tool("horizontal-line")));
+        click_chart(&mut app, &ctx, egui::pos2(700.0, 300.0));
+        run_frame(&mut app, &ctx);
+
+        let inspector = ctx
+            .memory(|memory| memory.area_rect(egui::Id::new("drawing_inspector")))
+            .expect("the inspector is open");
+        let start = egui::pos2(400.0, 300.0);
+        assert!(
+            !inspector.contains(start),
+            "the gesture must begin on the open canvas"
+        );
+        let before = app.drawings.items()[0].points[0];
+
+        // The gate applies at press time only: a drag that began on the
+        // canvas keeps moving the object while the pointer crosses the panel.
+        drag_chart(&mut app, &ctx, start, inspector.center());
+
         assert_ne!(
             app.drawings.items()[0].points[0].price,
             before.price,
-            "the open inspector must not trap the line underneath it"
+            "continuity: the drag survives crossing the inspector"
         );
     }
 
@@ -5566,6 +5881,279 @@ plot(close)
         assert!(
             texts.iter().any(|text| text.contains("Delete drawing")),
             "the docked panel still shows the named actions"
+        );
+    }
+
+    /// The eight §4.2 candidates, clamped — restated here so a drifted
+    /// implementation cannot silently shrink its own search space.
+    fn placement_candidates(
+        chart: egui::Rect,
+        bbox: egui::Rect,
+        size: egui::Vec2,
+    ) -> [egui::Pos2; 8] {
+        let gap = INSPECTOR_OBJECT_GAP_PX;
+        [
+            egui::pos2(bbox.right() + gap, bbox.top()),
+            egui::pos2(bbox.left() - gap - size.x, bbox.top()),
+            egui::pos2(bbox.left(), bbox.bottom() + gap),
+            egui::pos2(bbox.left(), bbox.top() - gap - size.y),
+            egui::pos2(chart.left() + gap, chart.top() + gap),
+            egui::pos2(chart.right() - gap - size.x, chart.top() + gap),
+            egui::pos2(chart.left() + gap, chart.bottom() - gap - size.y),
+            egui::pos2(chart.right() - gap - size.x, chart.bottom() - gap - size.y),
+        ]
+        .map(|candidate| clamp_into_chart(candidate, size, chart))
+    }
+
+    #[test]
+    fn placement_beside_a_centered_object_clears_it_and_prefers_the_right() {
+        let chart = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(1_400.0, 800.0));
+        let bbox = egui::Rect::from_center_size(chart.center(), egui::vec2(40.0, 40.0));
+        let size = egui::vec2(320.0, 280.0);
+        let position = inspector_placement(chart, bbox, size);
+        let rect = egui::Rect::from_min_size(position, size);
+        assert!(!rect.intersects(bbox), "a clear candidate exists and wins");
+        assert!(chart.contains_rect(rect));
+        assert_eq!(
+            position,
+            egui::pos2(bbox.right() + INSPECTOR_OBJECT_GAP_PX, bbox.top()),
+            "at zero overlap the order tie-break keeps the right-of-object preference"
+        );
+        assert_eq!(
+            position,
+            inspector_placement(chart, bbox, size),
+            "identical inputs give identical placements"
+        );
+    }
+
+    #[test]
+    fn placement_picks_the_least_overlap_when_nothing_clears() {
+        let chart = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(1_000.0, 600.0));
+        // The object spans ~90% of the pane: every candidate overlaps.
+        let bbox = chart.shrink2(egui::vec2(50.0, 30.0));
+        let size = egui::vec2(320.0, 280.0);
+        let position = inspector_placement(chart, bbox, size);
+        let chosen = egui::Rect::from_min_size(position, size)
+            .intersect(bbox)
+            .area();
+        for candidate in placement_candidates(chart, bbox, size) {
+            let overlap = egui::Rect::from_min_size(candidate, size)
+                .intersect(bbox)
+                .area();
+            assert!(
+                chosen <= overlap + 0.01,
+                "the chosen spot must cover the object least: {chosen} vs {overlap}"
+            );
+        }
+        assert!(chart.contains_rect(egui::Rect::from_min_size(position, size)));
+    }
+
+    #[test]
+    fn placement_never_returns_the_blind_first_candidate_at_the_right_edge() {
+        let chart = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(1_000.0, 600.0));
+        let bbox = egui::Rect::from_min_max(egui::pos2(900.0, 200.0), egui::pos2(1_000.0, 300.0));
+        let size = egui::vec2(320.0, 280.0);
+        let position = inspector_placement(chart, bbox, size);
+        let rect = egui::Rect::from_min_size(position, size);
+        assert!(
+            !rect.intersects(bbox),
+            "left of the object clears; the old code clamped right-of back onto it"
+        );
+        assert!(
+            position.x < bbox.left(),
+            "the panel must sit clear on the left, not clamp over the object"
+        );
+    }
+
+    #[test]
+    fn a_moved_inspector_keeps_its_position_across_selection_changes() {
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        run_frame(&mut app, &ctx);
+        for price_y in [250.0, 400.0] {
+            app.toolrail
+                .arm(Tool::Drawing(drawing_tool("horizontal-line")));
+            click_chart(&mut app, &ctx, egui::pos2(700.0, price_y));
+        }
+        click_chart(&mut app, &ctx, egui::pos2(400.0, 250.0));
+        run_frame(&mut app, &ctx);
+
+        let inspector = ctx
+            .memory(|memory| memory.area_rect(egui::Id::new("drawing_inspector")))
+            .expect("the inspector is open");
+        // Drag by the title bar (left of the trailing icons).
+        let bar = egui::pos2(inspector.left() + 60.0, inspector.top() + 14.0);
+        drag_chart(&mut app, &ctx, bar, bar + egui::vec2(150.0, 120.0));
+        assert!(
+            app.inspector_moved,
+            "a title-bar drag records the manual move"
+        );
+        let held = app.inspector_pos.expect("the manual position is recorded");
+
+        // Selecting the other line must not snap the window back.
+        click_chart(&mut app, &ctx, egui::pos2(400.0, 400.0));
+        run_frame(&mut app, &ctx);
+        assert_eq!(
+            app.inspector_pos,
+            Some(held),
+            "the manual position survives a selection change"
+        );
+        assert!(app.inspector_moved, "the manual flag is never auto-cleared");
+    }
+
+    #[test]
+    fn double_clicking_the_title_bar_returns_to_automatic_placement() {
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        run_frame(&mut app, &ctx);
+        app.toolrail
+            .arm(Tool::Drawing(drawing_tool("horizontal-line")));
+        click_chart(&mut app, &ctx, egui::pos2(700.0, 300.0));
+        run_frame(&mut app, &ctx);
+
+        let inspector = ctx
+            .memory(|memory| memory.area_rect(egui::Id::new("drawing_inspector")))
+            .expect("the inspector is open");
+        let bar = egui::pos2(inspector.left() + 60.0, inspector.top() + 14.0);
+        drag_chart(&mut app, &ctx, bar, bar + egui::vec2(120.0, 90.0));
+        assert!(app.inspector_moved);
+
+        let inspector = ctx
+            .memory(|memory| memory.area_rect(egui::Id::new("drawing_inspector")))
+            .expect("still open");
+        let bar = egui::pos2(inspector.left() + 60.0, inspector.top() + 14.0);
+        run_frame_with_events(
+            &mut app,
+            &ctx,
+            vec![
+                egui::Event::PointerMoved(bar),
+                pointer_button(bar, true),
+                pointer_button(bar, false),
+                pointer_button(bar, true),
+                pointer_button(bar, false),
+            ],
+        );
+        assert!(
+            !app.inspector_moved,
+            "double-click on the title bar re-arms automatic placement"
+        );
+    }
+
+    fn run_sized_frame(
+        app: &mut QuantickApp,
+        ctx: &egui::Context,
+        size: egui::Vec2,
+        events: Vec<egui::Event>,
+    ) -> egui::FullOutput {
+        let input = egui::RawInput {
+            screen_rect: Some(egui::Rect::from_min_size(egui::Pos2::ZERO, size)),
+            events,
+            ..Default::default()
+        };
+        ctx.run(input, |ctx| app.draw_frame(ctx, Instant::now()))
+    }
+
+    fn click_sized(
+        app: &mut QuantickApp,
+        ctx: &egui::Context,
+        size: egui::Vec2,
+        position: egui::Pos2,
+    ) {
+        run_sized_frame(
+            app,
+            ctx,
+            size,
+            vec![
+                egui::Event::PointerMoved(position),
+                pointer_button(position, true),
+            ],
+        );
+        run_sized_frame(
+            app,
+            ctx,
+            size,
+            vec![
+                egui::Event::PointerMoved(position),
+                pointer_button(position, false),
+            ],
+        );
+    }
+
+    #[test]
+    fn a_narrow_chart_opens_the_inspector_pinned_until_the_pin_is_touched() {
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        let narrow = egui::vec2(1_150.0, 900.0);
+        run_sized_frame(&mut app, &ctx, narrow, Vec::new());
+        assert!(
+            app.last_chart_area
+                .is_some_and(|chart| chart.width() < INSPECTOR_AUTO_PIN_CHART_WIDTH_PX),
+            "this proof needs a chart narrower than the auto-pin threshold"
+        );
+        app.toolrail
+            .arm(Tool::Drawing(drawing_tool("horizontal-line")));
+        click_sized(&mut app, &ctx, narrow, egui::pos2(600.0, 300.0));
+        run_sized_frame(&mut app, &ctx, narrow, Vec::new());
+        assert!(
+            app.inspector_pinned,
+            "a fresh selection on a narrow chart opens pinned"
+        );
+
+        // The user unpins: their preference holds from here on.
+        run_sized_frame(&mut app, &ctx, narrow, Vec::new());
+        let pin = app.inspector_pin_rect.expect("the panel renders its pin");
+        click_sized(&mut app, &ctx, narrow, pin.center());
+        assert!(!app.inspector_pinned, "the pin toggles the panel off");
+        assert!(app.inspector_pin_touched, "the preference is recorded");
+
+        // Deselect, reselect: same width, but the touched pin wins now.
+        run_sized_frame(
+            &mut app,
+            &ctx,
+            narrow,
+            vec![egui::Event::Key {
+                key: egui::Key::Escape,
+                physical_key: None,
+                pressed: true,
+                repeat: false,
+                modifiers: egui::Modifiers::NONE,
+            }],
+        );
+        click_sized(&mut app, &ctx, narrow, egui::pos2(500.0, 300.0));
+        run_sized_frame(&mut app, &ctx, narrow, Vec::new());
+        assert!(
+            !app.inspector_pinned,
+            "once touched, the auto-pin width rule stops firing"
+        );
+    }
+
+    #[test]
+    fn hovering_the_inspector_sets_no_chart_cursor() {
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        run_frame(&mut app, &ctx);
+        app.toolrail
+            .arm(Tool::Drawing(drawing_tool("horizontal-line")));
+        click_chart(&mut app, &ctx, egui::pos2(700.0, 300.0));
+        run_frame(&mut app, &ctx);
+
+        let inspector = ctx
+            .memory(|memory| memory.area_rect(egui::Id::new("drawing_inspector")))
+            .expect("the inspector is open");
+        // Over the inspector AND over the selected line's stroke: without
+        // the chrome gate this hover would show a Move cursor.
+        let hover = egui::pos2(inspector.center().x, 300.0);
+        assert!(inspector.contains(hover));
+        let output = run_frame_with_events(&mut app, &ctx, vec![egui::Event::PointerMoved(hover)]);
+        assert!(
+            !matches!(
+                output.platform_output.cursor_icon,
+                egui::CursorIcon::Move
+                    | egui::CursorIcon::ResizeNwSe
+                    | egui::CursorIcon::NotAllowed
+            ),
+            "the chart must not read a hover through the inspector; got {:?}",
+            output.platform_output.cursor_icon
         );
     }
 
@@ -5817,7 +6405,8 @@ plot(close)
         );
 
         let before_drag = app.drawings.items()[0].points[0];
-        let start = egui::pos2(1_000.0, 300.0);
+        // Left of the anchor, clear of the inspector that opened beside it.
+        let start = egui::pos2(400.0, 300.0);
         run_frame_with_events(
             &mut app,
             &ctx,
@@ -5826,10 +6415,10 @@ plot(close)
                 pointer_button(start, true),
             ],
         );
-        for step in [egui::pos2(1_010.0, 312.0), egui::pos2(1_025.0, 326.0)] {
+        for step in [egui::pos2(410.0, 312.0), egui::pos2(425.0, 326.0)] {
             run_frame_with_events(&mut app, &ctx, vec![egui::Event::PointerMoved(step)]);
         }
-        let end = egui::pos2(1_040.0, 340.0);
+        let end = egui::pos2(440.0, 340.0);
         run_frame_with_events(
             &mut app,
             &ctx,

--- a/crates/app/src/drawings/fib.rs
+++ b/crates/app/src/drawings/fib.rs
@@ -16,7 +16,15 @@ use smallvec::SmallVec;
 
 use super::{
     DrawContext, Drawing, DrawingPayload, DrawingStyle, FIB_LABEL_OFFSET_PX, FIB_LABEL_SIZE_PX,
-    PresetHost, distance_to_segment, drawing_stroke,
+    PresetHost, ToolFamily, distance_to_segment, drawing_stroke,
+};
+
+/// The one rail family both Fib tools declare, shared here so the two
+/// members can never drift onto different family ids.
+pub(super) const FIB_FAMILY: ToolFamily = ToolFamily {
+    id: "fib",
+    title: "Fibonacci",
+    icon: egui_phosphor::regular::ROWS,
 };
 
 /// Ratios closer than this are the same level; a duplicate is rejected.

--- a/crates/app/src/drawings/fib_extension.rs
+++ b/crates/app/src/drawings/fib_extension.rs
@@ -33,6 +33,9 @@ impl DrawingToolImpl for FibExtension {
             shift: true,
         })
     }
+    fn family(&self) -> Option<super::ToolFamily> {
+        Some(fib::FIB_FAMILY)
+    }
     fn default_payload(&self) -> Box<dyn DrawingPayload> {
         Box::new(FibPayload::new(FibKind::Extension))
     }

--- a/crates/app/src/drawings/fib_retracement.rs
+++ b/crates/app/src/drawings/fib_retracement.rs
@@ -33,6 +33,9 @@ impl DrawingToolImpl for FibRetracement {
             shift: false,
         })
     }
+    fn family(&self) -> Option<super::ToolFamily> {
+        Some(fib::FIB_FAMILY)
+    }
     fn default_payload(&self) -> Box<dyn DrawingPayload> {
         Box::new(FibPayload::new(FibKind::Retracement))
     }

--- a/crates/app/src/drawings/mod.rs
+++ b/crates/app/src/drawings/mod.rs
@@ -159,6 +159,18 @@ pub struct ToolShortcut {
     pub shift: bool,
 }
 
+/// A family of related tools sharing one rail slot. Declared by each member,
+/// never listed centrally — the rail folds consecutive registry entries with
+/// equal `id` into a single split button.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ToolFamily {
+    pub id: &'static str,
+    /// Header of the family flyout.
+    pub title: &'static str,
+    /// Slot icon before any member has been armed.
+    pub icon: &'static str,
+}
+
 /// The implementation port every drawing plugs into. Selection visuals (halo
 /// and anchor handles) are common chrome painted by the wrapper, so a tool
 /// only ever paints its own geometry in the style it is given. Capability
@@ -174,6 +186,11 @@ trait DrawingToolImpl: Sync {
     fn required_points(&self) -> usize;
     /// The key that arms this tool from the chart, if it has one.
     fn shortcut(&self) -> Option<ToolShortcut> {
+        None
+    }
+    /// The rail family this tool belongs to, if any. Consecutive registry
+    /// entries with the same family id share one rail slot.
+    fn family(&self) -> Option<ToolFamily> {
         None
     }
     /// Whether the tool paints an interior that the fill controls affect.
@@ -251,6 +268,11 @@ impl DrawingTool {
     #[must_use]
     pub fn shortcut(self) -> Option<ToolShortcut> {
         self.0.shortcut()
+    }
+
+    #[must_use]
+    pub fn family(self) -> Option<ToolFamily> {
+        self.0.family()
     }
 
     #[must_use]

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -132,6 +132,10 @@ fn main() -> eframe::Result {
     let options = eframe::NativeOptions {
         viewport: egui::ViewportBuilder::default()
             .with_inner_size([1100.0, 650.0])
+            // Below this the drawing rail would fall past its Minimal stage
+            // (191 px of long axis, docs/drawing-toolbar-ux.md §2.8) and
+            // clip chrome instead of collapsing it.
+            .with_min_inner_size([900.0, 560.0])
             .with_title("quantick")
             .with_icon(icon),
         ..Default::default()

--- a/crates/app/src/theme.rs
+++ b/crates/app/src/theme.rs
@@ -47,9 +47,17 @@ pub const AMBER: Color32 = Color32::from_rgb(0xF0, 0xB9, 0x0B);
 pub const WARN: Color32 = Color32::from_rgb(0xFF, 0x63, 0x47);
 /// `tag/bg` — tooltips and the axis price tag.
 pub const TAG_BG: Color32 = Color32::from_rgb(0x37, 0x3F, 0x50);
+/// `text/support` — small explanatory lines that carry real information
+/// (the inspector's locked/hidden notes). [`TEXT_FAINT`] stays reserved for
+/// decoration and disabled states, where 4.5:1 contrast is not required.
+pub const TEXT_SUPPORT: Color32 = Color32::from_rgb(0x86, 0x92, 0xA4);
 
 /// Alpha of an "active" tint: a layer accent at 22% over the chrome.
 const ACTIVE_TINT_ALPHA: u8 = 56; // ≈ 22% of 255
+/// Alpha of a "pressed" tint: a layer accent at 33% over the chrome. One
+/// step deeper than [`ACTIVE_TINT_ALPHA`], so a press on an already-active
+/// button is still visible.
+const PRESS_TINT_ALPHA: u8 = 84;
 
 /// `accent` reduced to the 22% tint used behind an active icon.
 #[must_use]
@@ -57,10 +65,19 @@ pub fn active_tint(accent: Color32) -> Color32 {
     Color32::from_rgba_unmultiplied(accent.r(), accent.g(), accent.b(), ACTIVE_TINT_ALPHA)
 }
 
+/// `accent` at the 33% tint painted while an icon button is held down.
+#[must_use]
+pub fn press_tint(accent: Color32) -> Color32 {
+    Color32::from_rgba_unmultiplied(accent.r(), accent.g(), accent.b(), PRESS_TINT_ALPHA)
+}
+
 /// Point egui's own widgets at the tokens, so combos, sliders and windows
 /// drawn anywhere in the app match the chrome without per-call overrides.
 pub fn apply(ctx: &egui::Context) {
     let mut style = (*ctx.style()).clone();
+    // Tooltips wait a beat (350 ms) so a sweep across the tool rail does not
+    // flash a trail of labels.
+    style.interaction.tooltip_delay = 0.35;
     let visuals = &mut style.visuals;
     *visuals = egui::Visuals::dark();
     visuals.panel_fill = CHROME;
@@ -142,5 +159,20 @@ mod tests {
         let tint = active_tint(ACCENT);
         assert_eq!(tint, Color32::from_rgba_unmultiplied(0x8A, 0xB4, 0xF8, 56));
         assert_eq!(tint.a(), 56);
+    }
+
+    #[test]
+    fn press_tint_is_one_step_deeper_than_active() {
+        let tint = press_tint(ACCENT);
+        assert_eq!(tint, Color32::from_rgba_unmultiplied(0x8A, 0xB4, 0xF8, 84));
+        assert!(
+            tint.a() > active_tint(ACCENT).a(),
+            "a press on an armed button must be distinguishable"
+        );
+    }
+
+    #[test]
+    fn support_text_matches_the_redesign_spec() {
+        assert_eq!(TEXT_SUPPORT, Color32::from_rgb(0x86, 0x92, 0xA4));
     }
 }

--- a/crates/app/src/toolrail.rs
+++ b/crates/app/src/toolrail.rs
@@ -36,6 +36,17 @@ const TOOLBOX_FLYOUT_WIDTH_PX: f32 = 208.0;
 const TOOLBOX_FLYOUT_ROW_HEIGHT_PX: f32 = 26.0;
 /// Chart-facing accent line of the drop preview band.
 const TOOLBOX_DROP_BAND_EDGE_PX: f32 = 3.0;
+/// Flyout paint metrics: popup corner radius, row backdrop radius, the
+/// glyph centre / name / shortcut columns and their font sizes.
+const FLYOUT_CORNER_RADIUS_PX: f32 = 6.0;
+const FLYOUT_ROW_RADIUS_PX: f32 = 4.0;
+const FLYOUT_GLYPH_CENTER_X_PX: f32 = 12.0;
+const FLYOUT_NAME_X_PX: f32 = 26.0;
+const FLYOUT_SHORTCUT_INSET_PX: f32 = 6.0;
+const FLYOUT_GLYPH_PX: f32 = 18.0;
+const FLYOUT_NAME_TEXT_PX: f32 = 12.0;
+const FLYOUT_SHORTCUT_TEXT_PX: f32 = 11.0;
+const FLYOUT_HEADER_TEXT_PX: f32 = 11.0;
 /// Side of the caret triangle on a family slot.
 const CARET_SIDE_PX: f32 = 5.0;
 /// Inset of the caret from the button's trailing-bottom corner.
@@ -194,29 +205,34 @@ enum RailSlot {
 /// Fold the registry into rail slots. Consecutive entries with the same
 /// family id share one slot — consecutive, not sorted, so rail order stays
 /// registry order and adding a tool cannot silently reorder the rail.
-fn tool_slots() -> Vec<RailSlot> {
-    let mut slots: Vec<RailSlot> = Vec::new();
-    for tool in DRAWING_TOOLS {
-        match tool.family() {
-            Some(family) => {
-                if let Some(RailSlot::Family {
-                    family: previous,
-                    members,
-                }) = slots.last_mut()
-                    && previous.id == family.id
-                {
-                    members.push(tool);
-                } else {
-                    slots.push(RailSlot::Family {
-                        family,
-                        members: vec![tool],
-                    });
+/// Folded once per process: the registry is `const`, so rebuilding this
+/// every frame would be per-frame allocation of stable data.
+fn tool_slots() -> &'static [RailSlot] {
+    static SLOTS: std::sync::OnceLock<Vec<RailSlot>> = std::sync::OnceLock::new();
+    SLOTS.get_or_init(|| {
+        let mut slots: Vec<RailSlot> = Vec::new();
+        for tool in DRAWING_TOOLS {
+            match tool.family() {
+                Some(family) => {
+                    if let Some(RailSlot::Family {
+                        family: previous,
+                        members,
+                    }) = slots.last_mut()
+                        && previous.id == family.id
+                    {
+                        members.push(tool);
+                    } else {
+                        slots.push(RailSlot::Family {
+                            family,
+                            members: vec![tool],
+                        });
+                    }
                 }
+                None => slots.push(RailSlot::Single(tool)),
             }
-            None => slots.push(RailSlot::Single(tool)),
         }
-    }
-    slots
+        slots
+    })
 }
 
 /// Long-axis length of the full rail (§2.8 of the spec).
@@ -552,7 +568,7 @@ impl ToolRail {
             }
             match stage {
                 RailStage::Full => {
-                    for slot in &slots {
+                    for slot in slots {
                         match slot {
                             RailSlot::Single(tool) => {
                                 self.draw_button(ui, Tool::Drawing(*tool), drawings);
@@ -968,9 +984,9 @@ impl ToolRail {
         let Some((family_id, anchor)) = self.flyout else {
             return;
         };
-        let Some((family, members)) = tool_slots().into_iter().find_map(|slot| match slot {
+        let Some((family, members)) = tool_slots().iter().find_map(|slot| match slot {
             RailSlot::Family { family, members } if family.id == family_id => {
-                Some((family, members))
+                Some((*family, members.as_slice()))
             }
             _ => None,
         }) else {
@@ -1010,15 +1026,15 @@ impl ToolRail {
                 egui::Frame::popup(ui.style())
                     .fill(theme::CONTROL)
                     .stroke(egui::Stroke::new(1.0_f32, theme::BORDER))
-                    .rounding(egui::Rounding::same(6.0))
+                    .rounding(egui::Rounding::same(FLYOUT_CORNER_RADIUS_PX))
                     .show(ui, |ui| {
                         ui.set_width(TOOLBOX_FLYOUT_WIDTH_PX - 2.0 * TOOLBOX_ITEM_GAP_PX);
                         ui.label(
                             egui::RichText::new(family.title)
                                 .color(theme::TEXT_MUTED)
-                                .size(11.0),
+                                .size(FLYOUT_HEADER_TEXT_PX),
                         );
-                        for member in &members {
+                        for member in members {
                             if self.draw_flyout_row(ui, *member) {
                                 self.arm(Tool::Drawing(*member));
                                 self.flyout = None;
@@ -1056,12 +1072,15 @@ impl ToolRail {
             if armed {
                 ui.painter().rect_filled(
                     rect,
-                    egui::Rounding::same(4.0),
+                    egui::Rounding::same(FLYOUT_ROW_RADIUS_PX),
                     theme::active_tint(theme::ACCENT),
                 );
             } else if response.hovered() {
-                ui.painter()
-                    .rect_filled(rect, egui::Rounding::same(4.0), theme::BORDER);
+                ui.painter().rect_filled(
+                    rect,
+                    egui::Rounding::same(FLYOUT_ROW_RADIUS_PX),
+                    theme::BORDER,
+                );
             }
             let glyph_color = if armed {
                 theme::ACCENT
@@ -1069,25 +1088,25 @@ impl ToolRail {
                 theme::TEXT_MUTED
             };
             ui.painter().text(
-                egui::pos2(rect.left() + 12.0, rect.center().y),
+                egui::pos2(rect.left() + FLYOUT_GLYPH_CENTER_X_PX, rect.center().y),
                 egui::Align2::CENTER_CENTER,
                 member.icon(),
-                egui::FontId::proportional(18.0),
+                egui::FontId::proportional(FLYOUT_GLYPH_PX),
                 glyph_color,
             );
             ui.painter().text(
-                egui::pos2(rect.left() + 26.0, rect.center().y),
+                egui::pos2(rect.left() + FLYOUT_NAME_X_PX, rect.center().y),
                 egui::Align2::LEFT_CENTER,
                 member.name(),
-                egui::FontId::proportional(12.0),
+                egui::FontId::proportional(FLYOUT_NAME_TEXT_PX),
                 theme::TEXT_PRIMARY,
             );
             if let Some(shortcut) = Tool::Drawing(member).shortcut_label() {
                 ui.painter().text(
-                    egui::pos2(rect.right() - 6.0, rect.center().y),
+                    egui::pos2(rect.right() - FLYOUT_SHORTCUT_INSET_PX, rect.center().y),
                     egui::Align2::RIGHT_CENTER,
                     shortcut,
-                    egui::FontId::proportional(11.0),
+                    egui::FontId::proportional(FLYOUT_SHORTCUT_TEXT_PX),
                     theme::TEXT_FAINT,
                 );
             }
@@ -1569,9 +1588,9 @@ mod tests {
         rail_frame_with(&mut rail, &mut drawings, &ctx, wide, Vec::new());
         for slot in tool_slots() {
             let shown = match slot {
-                RailSlot::Single(tool) => tool,
+                RailSlot::Single(tool) => *tool,
                 RailSlot::Family { family, members } => {
-                    rail.family_member(family, &members).unwrap_or(members[0])
+                    rail.family_member(*family, members).unwrap_or(members[0])
                 }
             };
             assert!(

--- a/crates/app/src/toolrail.rs
+++ b/crates/app/src/toolrail.rs
@@ -1,36 +1,58 @@
-//! Drawing-tool selection and the four-corner toolbox dock.
+//! Drawing-tool selection and the four-edge toolbar rail.
 //!
-//! The dock owns only chrome state. Drawing definitions and metadata live in
+//! The rail owns only chrome state. Drawing definitions and metadata live in
 //! [`crate::drawings`], so registering a new drawing does not require another
-//! matching list in this module.
+//! matching list in this module. Geometry, states and docking behaviour
+//! follow `docs/drawing-toolbar-ux.md`.
+
+use std::collections::BTreeMap;
 
 use eframe::egui;
 use egui_phosphor::regular as icons;
 
-use crate::drawings::{DRAWING_TOOLS, DrawingTool, Drawings};
+use crate::drawings::{DRAWING_TOOLS, DrawingTool, Drawings, ToolFamily};
 use crate::theme;
-use crate::widgets::{IconButton, RAIL_ICON};
+use crate::widgets::{IconButton, MarkerEdge, TOOLRAIL_ICON};
 
-const TOOLBOX_HEIGHT_PX: f32 = 44.0;
-const TOOLBOX_HORIZONTAL_MARGIN_PX: f32 = 8.0;
-const TOOLBOX_ITEM_GAP_PX: f32 = 6.0;
-/// One 32 px rail button plus its gap — the slot the width budget counts.
-const TOOLBOX_BUTTON_SLOT_PX: f32 = 32.0 + TOOLBOX_ITEM_GAP_PX;
-/// Room the grip and the two separators take beyond the button slots.
-const TOOLBOX_CHROME_ALLOWANCE_PX: f32 = 60.0;
+/// Rail cross axis, all four docks: `44 = 6 + 32 + 6`.
+const TOOLBOX_THICKNESS_PX: f32 = 44.0;
+/// Outer margin, both axes.
+const TOOLBOX_MARGIN_PX: f32 = 6.0;
+/// Gap between buttons inside a cluster.
+const TOOLBOX_ITEM_GAP_PX: f32 = 4.0;
+/// Inset of a separator hairline from each rail edge, so the rule floats.
+const TOOLBOX_SEPARATOR_INSET_PX: f32 = 8.0;
+/// Grip extent along the rail.
+const TOOLBOX_GRIP_LENGTH_PX: f32 = 18.0;
+/// Grip glyph font size.
+const TOOLBOX_GRIP_GLYPH_PX: f32 = 14.0;
+/// Smallest allowed gap between the leading and trailing clusters.
+const TOOLBOX_MIN_CLUSTER_GAP_PX: f32 = 12.0;
+/// Square corner zone of a family button that opens its flyout.
+const TOOLBOX_CARET_ZONE_PX: f32 = 10.0;
+/// Family flyout popup width.
+const TOOLBOX_FLYOUT_WIDTH_PX: f32 = 208.0;
+/// One family flyout row.
+const TOOLBOX_FLYOUT_ROW_HEIGHT_PX: f32 = 26.0;
+/// Chart-facing accent line of the drop preview band.
+const TOOLBOX_DROP_BAND_EDGE_PX: f32 = 3.0;
+/// Side of the caret triangle on a family slot.
+const CARET_SIDE_PX: f32 = 5.0;
+/// Inset of the caret from the button's trailing-bottom corner.
+const CARET_INSET_PX: f32 = 3.0;
+/// Badge pill geometry (§2.5 of the spec).
+const BADGE_HEIGHT_PX: f32 = 12.0;
+const BADGE_RADIUS_PX: f32 = 3.0;
+const BADGE_TEXT_PX: f32 = 9.0;
+const BADGE_PAD_X_PX: f32 = 3.0;
+const BADGE_CORNER_INSET_PX: f32 = 2.0;
+/// A separator block along the long axis: the hairline; its 4 px clear space
+/// each side comes from the cluster's item spacing.
+const SEPARATOR_BLOCK_PX: f32 = 2.0 * TOOLBOX_ITEM_GAP_PX + 1.0;
+/// The grip block: its extent plus the item gap that follows.
+const GRIP_BLOCK_PX: f32 = TOOLBOX_GRIP_LENGTH_PX + TOOLBOX_ITEM_GAP_PX;
 #[cfg(test)]
-const TOOLBOX_BUTTON_COUNT: usize = DRAWING_TOOLS.len() + 2;
-
-/// The width the full strip needs. Below this the drawing tools collapse
-/// into the More-tools flyout; Pointer, the active tool and Objects always
-/// survive, and the strip never wraps into a second row.
-fn full_toolbox_width() -> f32 {
-    // Pointer + Crosshair + every tool + repeat + objects + two globals.
-    let buttons = (2 + DRAWING_TOOLS.len() + 4) as f32;
-    2.0 * TOOLBOX_HORIZONTAL_MARGIN_PX
-        + buttons * TOOLBOX_BUTTON_SLOT_PX
-        + TOOLBOX_CHROME_ALLOWANCE_PX
-}
+const TOOLBOX_BUTTON_COUNT: usize = DRAWING_TOOLS.len() + 4;
 
 /// A chart-acting tool. Only one is armed at a time.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -60,6 +82,15 @@ impl Tool {
     }
 
     #[must_use]
+    fn name(self) -> &'static str {
+        match self {
+            Self::Pointer => "Pointer",
+            Self::Crosshair => "Crosshair",
+            Self::Drawing(tool) => tool.name(),
+        }
+    }
+
+    #[must_use]
     fn hover_text(self) -> &'static str {
         match self {
             Self::Pointer => "Pointer - pan, zoom, select and move (1, Esc)",
@@ -67,44 +98,185 @@ impl Tool {
             Self::Drawing(tool) => tool.hover_text(),
         }
     }
-}
 
-/// One of the four external chart corners where the toolbox can dock.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum ToolboxDock {
-    #[default]
-    TopLeft,
-    TopRight,
-    BottomLeft,
-    BottomRight,
-}
-
-impl ToolboxDock {
+    /// The shortcut label shown in menus, `None` when the tool has no key.
     #[must_use]
-    const fn is_top(self) -> bool {
-        matches!(self, Self::TopLeft | Self::TopRight)
-    }
-
-    #[must_use]
-    const fn is_left(self) -> bool {
-        matches!(self, Self::TopLeft | Self::BottomLeft)
-    }
-
-    #[must_use]
-    fn nearest(pointer: egui::Pos2, screen: egui::Rect) -> Self {
-        match (
-            pointer.y <= screen.center().y,
-            pointer.x <= screen.center().x,
-        ) {
-            (true, true) => Self::TopLeft,
-            (true, false) => Self::TopRight,
-            (false, true) => Self::BottomLeft,
-            (false, false) => Self::BottomRight,
+    fn shortcut_label(self) -> Option<String> {
+        match self {
+            Self::Pointer => Some("1".to_owned()),
+            Self::Crosshair => Some("2".to_owned()),
+            Self::Drawing(tool) => tool.shortcut().map(|shortcut| {
+                let key = shortcut.key.name();
+                if shortcut.shift {
+                    format!("Shift+{key}")
+                } else {
+                    key.to_owned()
+                }
+            }),
         }
     }
 }
 
-/// Toolbox chrome state. The panel is always outside `CentralPanel`, so the
+/// One of the four window edges the toolbar can dock against.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ToolboxDock {
+    #[default]
+    Left,
+    Right,
+    Top,
+    Bottom,
+}
+
+impl ToolboxDock {
+    #[must_use]
+    pub const fn is_vertical(self) -> bool {
+        matches!(self, Self::Left | Self::Right)
+    }
+
+    /// The nearest edge by *normalised* distance — raw pixels would bias
+    /// every drop toward top/bottom on a wide window. Ties resolve
+    /// Left > Right > Top > Bottom, so the result is deterministic.
+    #[must_use]
+    fn nearest(pointer: egui::Pos2, screen: egui::Rect) -> Self {
+        let pointer = pointer.clamp(screen.min, screen.max);
+        let width = screen.width().max(f32::EPSILON);
+        let height = screen.height().max(f32::EPSILON);
+        let candidates = [
+            (Self::Left, (pointer.x - screen.left()) / width),
+            (Self::Right, (screen.right() - pointer.x) / width),
+            (Self::Top, (pointer.y - screen.top()) / height),
+            (Self::Bottom, (screen.bottom() - pointer.y) / height),
+        ];
+        let mut best = candidates[0];
+        for candidate in &candidates[1..] {
+            if candidate.1 < best.1 {
+                best = *candidate;
+            }
+        }
+        best.0
+    }
+
+    /// The button edge the active marker hugs: the one facing the window
+    /// border this dock sits against.
+    #[must_use]
+    const fn marker_edge(self) -> MarkerEdge {
+        match self {
+            Self::Left => MarkerEdge::Left,
+            Self::Right => MarkerEdge::Right,
+            Self::Top => MarkerEdge::Top,
+            Self::Bottom => MarkerEdge::Bottom,
+        }
+    }
+}
+
+/// How much of the rail fits along its long axis. Stages are pure functions
+/// of the available extent, so a resize is hysteresis-free.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RailStage {
+    /// Every tool slot visible.
+    Full,
+    /// Pointer, Crosshair, the armed tool and More; full trailing cluster.
+    Compact,
+    /// Pointer, the armed tool, More and Objects.
+    Minimal,
+}
+
+/// One leading-cluster slot after family folding: a lone tool, or a family
+/// of consecutive registry entries sharing the slot.
+enum RailSlot {
+    Single(DrawingTool),
+    Family {
+        family: ToolFamily,
+        members: Vec<DrawingTool>,
+    },
+}
+
+/// Fold the registry into rail slots. Consecutive entries with the same
+/// family id share one slot — consecutive, not sorted, so rail order stays
+/// registry order and adding a tool cannot silently reorder the rail.
+fn tool_slots() -> Vec<RailSlot> {
+    let mut slots: Vec<RailSlot> = Vec::new();
+    for tool in DRAWING_TOOLS {
+        match tool.family() {
+            Some(family) => {
+                if let Some(RailSlot::Family {
+                    family: previous,
+                    members,
+                }) = slots.last_mut()
+                    && previous.id == family.id
+                {
+                    members.push(tool);
+                } else {
+                    slots.push(RailSlot::Family {
+                        family,
+                        members: vec![tool],
+                    });
+                }
+            }
+            None => slots.push(RailSlot::Single(tool)),
+        }
+    }
+    slots
+}
+
+/// Long-axis length of the full rail (§2.8 of the spec).
+fn full_length(tool_slot_count: usize) -> f32 {
+    let n = tool_slot_count as f32;
+    2.0 * TOOLBOX_MARGIN_PX
+        + GRIP_BLOCK_PX
+        + (2.0 * TOOLRAIL_ICON.hit + TOOLBOX_ITEM_GAP_PX)
+        + SEPARATOR_BLOCK_PX
+        + (n * TOOLRAIL_ICON.hit + (n - 1.0) * TOOLBOX_ITEM_GAP_PX)
+        + TOOLBOX_MIN_CLUSTER_GAP_PX
+        + trailing_length()
+}
+
+/// Long-axis length at the Compact stage: the tool run gives way to the
+/// armed slot plus More.
+fn compact_length() -> f32 {
+    2.0 * TOOLBOX_MARGIN_PX
+        + GRIP_BLOCK_PX
+        + (2.0 * TOOLRAIL_ICON.hit + TOOLBOX_ITEM_GAP_PX)
+        + SEPARATOR_BLOCK_PX
+        + (2.0 * TOOLRAIL_ICON.hit + TOOLBOX_ITEM_GAP_PX)
+        + TOOLBOX_MIN_CLUSTER_GAP_PX
+        + trailing_length()
+}
+
+/// Long-axis length at the Minimal stage: grip, Pointer, the armed tool,
+/// More, the cluster gap, one separator and Objects. The spec's 191 px
+/// floor — `main.rs` sets a minimum window size that keeps it unreachable.
+#[cfg(test)]
+fn minimal_length() -> f32 {
+    2.0 * TOOLBOX_MARGIN_PX
+        + GRIP_BLOCK_PX
+        + (3.0 * TOOLRAIL_ICON.hit + 2.0 * TOOLBOX_ITEM_GAP_PX)
+        + TOOLBOX_MIN_CLUSTER_GAP_PX
+        + SEPARATOR_BLOCK_PX
+        + TOOLRAIL_ICON.hit
+}
+
+/// The full trailing cluster: separator, repeat, hide-all, lock-all,
+/// separator, Objects.
+fn trailing_length() -> f32 {
+    SEPARATOR_BLOCK_PX
+        + (3.0 * TOOLRAIL_ICON.hit + 2.0 * TOOLBOX_ITEM_GAP_PX)
+        + SEPARATOR_BLOCK_PX
+        + TOOLRAIL_ICON.hit
+}
+
+/// Resolve the stage for an available long-axis extent (margins included).
+fn stage_for(available: f32, tool_slot_count: usize) -> RailStage {
+    if available >= full_length(tool_slot_count) {
+        RailStage::Full
+    } else if available >= compact_length() {
+        RailStage::Compact
+    } else {
+        RailStage::Minimal
+    }
+}
+
+/// Toolbar chrome state. The panel is always outside `CentralPanel`, so the
 /// chart never renders behind it.
 #[derive(Debug)]
 pub struct ToolRail {
@@ -114,16 +286,30 @@ pub struct ToolRail {
     /// The repeat pin: `true` keeps a drawing tool armed after it completes
     /// an object; the default is one-shot back to Pointer.
     repeat: bool,
+    /// Last-armed member of each tool family, keyed by family id.
+    last_family_member: BTreeMap<&'static str, DrawingTool>,
+    /// Currently-nearest drop edge while a grip drag is live.
+    drag_preview: Option<ToolboxDock>,
+    dragging: bool,
+    drag_cancelled: bool,
+    /// Open family flyout: the family id and the slot rect it anchors to.
+    flyout: Option<(&'static str, egui::Rect)>,
     #[cfg(test)]
     button_rects: [Option<(Tool, egui::Rect)>; TOOLBOX_BUTTON_COUNT],
     #[cfg(test)]
     grip_rect: Option<egui::Rect>,
+    #[cfg(test)]
+    more_rect: Option<egui::Rect>,
     #[cfg(test)]
     hide_all_rect: Option<egui::Rect>,
     #[cfg(test)]
     lock_all_rect: Option<egui::Rect>,
     #[cfg(test)]
     objects_rect: Option<egui::Rect>,
+    #[cfg(test)]
+    rail_rect: Option<egui::Rect>,
+    #[cfg(test)]
+    flyout_rects: Vec<(DrawingTool, egui::Rect)>,
 }
 
 impl Default for ToolRail {
@@ -131,18 +317,29 @@ impl Default for ToolRail {
         Self {
             tool: Tool::Pointer,
             visible: true,
-            dock: ToolboxDock::TopLeft,
+            dock: ToolboxDock::Left,
             repeat: false,
+            last_family_member: BTreeMap::new(),
+            drag_preview: None,
+            dragging: false,
+            drag_cancelled: false,
+            flyout: None,
             #[cfg(test)]
             button_rects: [None; TOOLBOX_BUTTON_COUNT],
             #[cfg(test)]
             grip_rect: None,
+            #[cfg(test)]
+            more_rect: None,
             #[cfg(test)]
             hide_all_rect: None,
             #[cfg(test)]
             lock_all_rect: None,
             #[cfg(test)]
             objects_rect: None,
+            #[cfg(test)]
+            rail_rect: None,
+            #[cfg(test)]
+            flyout_rects: Vec::new(),
         }
     }
 }
@@ -163,6 +360,23 @@ impl ToolRail {
         self.visible
     }
 
+    #[must_use]
+    pub fn dock(&self) -> ToolboxDock {
+        self.dock
+    }
+
+    /// Dock the rail against `dock` — the menu path beside dragging.
+    pub fn set_dock(&mut self, dock: ToolboxDock) {
+        self.dock = dock;
+    }
+
+    /// Whether a grip drag is live this frame — the app's escape stack must
+    /// yield Esc to the drag while it is.
+    #[must_use]
+    pub fn drag_active(&self) -> bool {
+        self.dragging
+    }
+
     pub fn toggle_visible(&mut self) {
         self.visible = !self.visible;
         if !self.visible {
@@ -171,6 +385,11 @@ impl ToolRail {
     }
 
     pub fn arm(&mut self, tool: Tool) {
+        if let Tool::Drawing(drawing_tool) = tool
+            && let Some(family) = drawing_tool.family()
+        {
+            self.last_family_member.insert(family.id, drawing_tool);
+        }
         self.tool = tool;
     }
 
@@ -198,9 +417,16 @@ impl ToolRail {
         self.objects_rect
     }
 
-    /// Tool-arming keys. Escape lives in the app's escape stack (input →
-    /// draft → selection → Pointer), not here. Each drawing tool declares
-    /// its own shortcut through the registry.
+    #[cfg(test)]
+    pub(crate) fn flyout_row_rect(&self, tool: DrawingTool) -> Option<egui::Rect> {
+        self.flyout_rects
+            .iter()
+            .find_map(|(candidate, rect)| (*candidate == tool).then_some(*rect))
+    }
+
+    /// Tool-arming keys. Escape lives in the app's escape stack (rail drag →
+    /// input → draft → selection → Pointer), not here. Each drawing tool
+    /// declares its own shortcut through the registry.
     pub fn handle_keys(&mut self, ctx: &egui::Context) {
         if ctx.memory(|memory| memory.focused().is_some()) {
             return;
@@ -228,151 +454,40 @@ impl ToolRail {
         }
     }
 
-    /// Draw the toolbox in an external top/bottom strip. Drag the grip and
-    /// release anywhere: the closest of the four screen corners becomes its
-    /// new dock. The rail also hosts the object-manager entry and the global
-    /// protection toggles (hide-all / lock-all), which act on the store.
+    /// Draw the rail docked against its edge. Drag the grip and release: the
+    /// nearest window edge becomes the new dock, previewed live by a band.
+    /// The rail also hosts the object-manager entry and the global protection
+    /// toggles (hide-all / lock-all), which act on the store.
     pub fn draw(&mut self, ctx: &egui::Context, drawings: &mut Drawings, manager_open: &mut bool) {
         if !self.visible {
             return;
         }
 
-        let panel = if self.dock.is_top() {
-            egui::TopBottomPanel::top("drawing_toolbox_top")
-        } else {
-            egui::TopBottomPanel::bottom("drawing_toolbox_bottom")
+        match self.dock {
+            ToolboxDock::Left => egui::SidePanel::left("drawing_toolbox_left")
+                .exact_width(TOOLBOX_THICKNESS_PX)
+                .resizable(false)
+                .frame(rail_frame())
+                .show(ctx, |ui| self.draw_contents(ui, drawings, manager_open)),
+            ToolboxDock::Right => egui::SidePanel::right("drawing_toolbox_right")
+                .exact_width(TOOLBOX_THICKNESS_PX)
+                .resizable(false)
+                .frame(rail_frame())
+                .show(ctx, |ui| self.draw_contents(ui, drawings, manager_open)),
+            ToolboxDock::Top => egui::TopBottomPanel::top("drawing_toolbox_top")
+                .exact_height(TOOLBOX_THICKNESS_PX)
+                .resizable(false)
+                .frame(rail_frame())
+                .show(ctx, |ui| self.draw_contents(ui, drawings, manager_open)),
+            ToolboxDock::Bottom => egui::TopBottomPanel::bottom("drawing_toolbox_bottom")
+                .exact_height(TOOLBOX_THICKNESS_PX)
+                .resizable(false)
+                .frame(rail_frame())
+                .show(ctx, |ui| self.draw_contents(ui, drawings, manager_open)),
         };
-        panel
-            .exact_height(TOOLBOX_HEIGHT_PX)
-            .resizable(false)
-            .frame(
-                egui::Frame::none()
-                    .fill(theme::CHROME)
-                    .stroke(egui::Stroke::new(1.0_f32, theme::BORDER))
-                    .inner_margin(egui::Margin::symmetric(
-                        TOOLBOX_HORIZONTAL_MARGIN_PX,
-                        TOOLBOX_ITEM_GAP_PX,
-                    )),
-            )
-            .show(ctx, |ui| self.draw_contents(ui, drawings, manager_open));
-    }
 
-    /// The repeat pin: keep the armed drawing tool active after it completes
-    /// an object, instead of the one-shot return to Pointer.
-    fn draw_repeat_button(&mut self, ui: &mut egui::Ui) {
-        let response = IconButton::new(icons::ARROW_CLOCKWISE, RAIL_ICON)
-            .active(self.repeat)
-            .hover_text("Keep the drawing tool active after drawing")
-            .show(ui);
-        if response.clicked() {
-            self.repeat = !self.repeat;
-        }
-    }
-
-    /// The More-tools flyout of the collapsed strip: everything that lost
-    /// its slot stays reachable by name, plus the global protections.
-    fn draw_more_tools_menu(&mut self, ui: &mut egui::Ui, drawings: &mut Drawings) {
-        ui.menu_button(icons::PLUS, |ui| {
-            for tool in [Tool::Crosshair]
-                .into_iter()
-                .chain(DRAWING_TOOLS.into_iter().map(Tool::Drawing))
-            {
-                let name = match tool {
-                    Tool::Crosshair => "Crosshair",
-                    Tool::Drawing(tool) => tool.name(),
-                    Tool::Pointer => unreachable!("pointer keeps its own slot"),
-                };
-                if ui.button(name).clicked() {
-                    self.arm(tool);
-                    ui.close_menu();
-                }
-            }
-            ui.separator();
-            let all_hidden = drawings.all_hidden();
-            if ui
-                .button(if all_hidden { "Show all" } else { "Hide all" })
-                .clicked()
-            {
-                drawings.set_all_hidden(!all_hidden);
-                ui.close_menu();
-            }
-            let all_locked = drawings.all_locked();
-            if ui
-                .button(if all_locked { "Unlock all" } else { "Lock all" })
-                .clicked()
-            {
-                drawings.set_all_locked(!all_locked);
-                ui.close_menu();
-            }
-        })
-        .response
-        .on_hover_text("More tools");
-    }
-
-    /// The entry to the drawn-objects manager. A toggle, not a tool: it never
-    /// changes which tool is armed.
-    fn draw_objects_button(&mut self, ui: &mut egui::Ui, manager_open: &mut bool) {
-        let response = IconButton::new(icons::LIST, RAIL_ICON)
-            .active(*manager_open)
-            .hover_text("Drawn objects")
-            .show(ui);
-        #[cfg(test)]
-        {
-            self.objects_rect = Some(response.rect);
-        }
-        if response.clicked() {
-            *manager_open = !*manager_open;
-        }
-    }
-
-    /// The reversible global protections. Hide-all is a view layer over each
-    /// drawing's own eye; lock-all mutates every lock at once. Neither is a
-    /// delete, and both are one undo entry.
-    fn draw_global_buttons(&mut self, ui: &mut egui::Ui, drawings: &mut Drawings) {
-        let all_hidden = drawings.all_hidden();
-        let eye_icon = if all_hidden {
-            icons::EYE_SLASH
-        } else {
-            icons::EYE
-        };
-        let eye_hover = if all_hidden {
-            "Show all drawings"
-        } else {
-            "Hide all drawings"
-        };
-        let eye = IconButton::new(eye_icon, RAIL_ICON)
-            .active(all_hidden)
-            .hover_text(eye_hover)
-            .show(ui);
-        #[cfg(test)]
-        {
-            self.hide_all_rect = Some(eye.rect);
-        }
-        if eye.clicked() {
-            drawings.set_all_hidden(!all_hidden);
-        }
-
-        let all_locked = drawings.all_locked();
-        let lock_icon = if all_locked {
-            icons::LOCK_SIMPLE
-        } else {
-            icons::LOCK_SIMPLE_OPEN
-        };
-        let lock_hover = if all_locked {
-            "Unlock all drawings"
-        } else {
-            "Lock all drawings"
-        };
-        let lock = IconButton::new(lock_icon, RAIL_ICON)
-            .active(all_locked)
-            .hover_text(lock_hover)
-            .show(ui);
-        #[cfg(test)]
-        {
-            self.lock_all_rect = Some(lock.rect);
-        }
-        if lock.clicked() {
-            drawings.set_all_locked(!all_locked);
+        if let Some(target) = self.drag_preview.take() {
+            paint_drop_preview(ctx, target);
         }
     }
 
@@ -386,78 +501,350 @@ impl ToolRail {
         {
             self.button_rects.fill(None);
             self.grip_rect = None;
+            self.more_rect = None;
             self.hide_all_rect = None;
             self.lock_all_rect = None;
             self.objects_rect = None;
+            self.rail_rect = Some(ui.max_rect().expand(TOOLBOX_MARGIN_PX));
+            self.flyout_rects.clear();
         }
-        let left = self.dock.is_left();
-        let layout = if left {
+
+        let vertical = self.dock.is_vertical();
+        let available = if vertical {
+            ui.available_height()
+        } else {
+            ui.available_width()
+        } + 2.0 * TOOLBOX_MARGIN_PX;
+        let slots = tool_slots();
+        let stage = stage_for(available, slots.len());
+
+        // Chart-facing hairline: the only stroke the rail paints — a
+        // four-sided stroke would draw a seam against the window edge.
+        let rail_rect = ui.max_rect().expand(TOOLBOX_MARGIN_PX);
+        let edge = match self.dock {
+            ToolboxDock::Left => [rail_rect.right_top(), rail_rect.right_bottom()],
+            ToolboxDock::Right => [rail_rect.left_top(), rail_rect.left_bottom()],
+            ToolboxDock::Top => [rail_rect.left_bottom(), rail_rect.right_bottom()],
+            ToolboxDock::Bottom => [rail_rect.left_top(), rail_rect.right_top()],
+        };
+        ui.painter()
+            .line_segment(edge, egui::Stroke::new(1.0_f32, theme::BORDER));
+
+        let leading = if vertical {
+            egui::Layout::top_down(egui::Align::Center)
+        } else {
             egui::Layout::left_to_right(egui::Align::Center)
+        };
+        let trailing = if vertical {
+            egui::Layout::bottom_up(egui::Align::Center)
         } else {
             egui::Layout::right_to_left(egui::Align::Center)
         };
 
-        ui.with_layout(layout, |ui| {
-            ui.spacing_mut().item_spacing.x = TOOLBOX_ITEM_GAP_PX;
-            let grip = ui
-                .add(egui::Label::new(icons::DOTS_SIX_VERTICAL).sense(egui::Sense::drag()))
-                .on_hover_text("Drag to dock the toolbox in another corner");
-            #[cfg(test)]
-            {
-                self.grip_rect = Some(grip.rect);
+        ui.with_layout(leading, |ui| {
+            ui.spacing_mut().item_spacing = egui::vec2(TOOLBOX_ITEM_GAP_PX, TOOLBOX_ITEM_GAP_PX);
+            ui.set_min_size(egui::Vec2::ZERO);
+            self.draw_grip(ui, vertical);
+            self.draw_button(ui, Tool::Pointer, drawings);
+            if stage != RailStage::Minimal {
+                self.draw_button(ui, Tool::Crosshair, drawings);
+                self.draw_separator(ui, vertical);
             }
-            if grip.dragged() {
-                ui.ctx().set_cursor_icon(egui::CursorIcon::Grabbing);
+            match stage {
+                RailStage::Full => {
+                    for slot in &slots {
+                        match slot {
+                            RailSlot::Single(tool) => {
+                                self.draw_button(ui, Tool::Drawing(*tool), drawings);
+                            }
+                            RailSlot::Family { family, members } => {
+                                self.draw_family_slot(ui, *family, members, drawings);
+                            }
+                        }
+                    }
+                }
+                RailStage::Compact | RailStage::Minimal => {
+                    if let Some(armed) = self.tool.drawing_tool() {
+                        self.draw_button(ui, Tool::Drawing(armed), drawings);
+                    }
+                    self.draw_more_menu(ui, drawings, stage);
+                }
             }
-            if grip.drag_stopped()
+        });
+
+        // The trailing cluster is pinned to the rail's far end — laid from
+        // that end backwards, so the flexible gap sits between the clusters.
+        ui.with_layout(trailing, |ui| {
+            ui.spacing_mut().item_spacing = egui::vec2(TOOLBOX_ITEM_GAP_PX, TOOLBOX_ITEM_GAP_PX);
+            self.draw_objects_button(ui, drawings, manager_open);
+            self.draw_separator(ui, vertical);
+            if stage != RailStage::Minimal {
+                self.draw_global_buttons(ui, drawings);
+                self.draw_repeat_button(ui);
+                self.draw_separator(ui, vertical);
+            }
+        });
+
+        self.draw_family_flyout(ui.ctx());
+    }
+
+    /// The grip: hold and drag to dock the rail against another window edge.
+    fn draw_grip(&mut self, ui: &mut egui::Ui, vertical: bool) {
+        let size = if vertical {
+            egui::vec2(TOOLRAIL_ICON.hit, TOOLBOX_GRIP_LENGTH_PX)
+        } else {
+            egui::vec2(TOOLBOX_GRIP_LENGTH_PX, TOOLRAIL_ICON.hit)
+        };
+        let (rect, grip) = ui.allocate_exact_size(size, egui::Sense::drag());
+        #[cfg(test)]
+        {
+            self.grip_rect = Some(rect);
+        }
+        if ui.is_rect_visible(rect) {
+            // The dots always run across the rail, reading as a handle.
+            let glyph = if vertical {
+                icons::DOTS_SIX
+            } else {
+                icons::DOTS_SIX_VERTICAL
+            };
+            let color = if grip.hovered() || self.dragging {
+                theme::TEXT_MUTED
+            } else {
+                theme::TEXT_FAINT
+            };
+            ui.painter().text(
+                rect.center(),
+                egui::Align2::CENTER_CENTER,
+                glyph,
+                egui::FontId::proportional(TOOLBOX_GRIP_GLYPH_PX),
+                color,
+            );
+        }
+        let grip = grip.on_hover_text("Drag to dock the toolbar on another edge");
+        if grip.hovered() && !self.dragging {
+            ui.ctx().set_cursor_icon(egui::CursorIcon::Grab);
+        }
+        if grip.drag_started() {
+            self.dragging = true;
+            self.drag_cancelled = false;
+        }
+        if self.dragging && ui.ctx().input(|input| input.key_pressed(egui::Key::Escape)) {
+            // Esc aborts the drag and keeps the current dock — the topmost
+            // level of the app's escape stack.
+            self.dragging = false;
+            self.drag_cancelled = true;
+        }
+        if self.dragging {
+            ui.ctx().set_cursor_icon(egui::CursorIcon::Grabbing);
+            if let Some(pointer) = ui.ctx().input(|input| input.pointer.interact_pos()) {
+                self.drag_preview = Some(ToolboxDock::nearest(pointer, ui.ctx().screen_rect()));
+            }
+        }
+        if grip.drag_stopped() {
+            if self.dragging
+                && !self.drag_cancelled
                 && let Some(pointer) = ui.ctx().input(|input| input.pointer.interact_pos())
             {
                 self.dock = ToolboxDock::nearest(pointer, ui.ctx().screen_rect());
             }
+            self.dragging = false;
+            self.drag_cancelled = false;
+            self.drag_preview = None;
+        }
+    }
 
-            // Below the full-strip budget the tools collapse into the
-            // More-tools flyout: Pointer, the active tool and Objects keep
-            // their slots, and the strip never wraps into a second row.
-            let overflow = ui.available_width() < full_toolbox_width();
-            if overflow {
-                self.draw_button(ui, Tool::Pointer);
-                if let Some(active) = self.tool.drawing_tool() {
-                    self.draw_button(ui, Tool::Drawing(active));
+    /// A separator: a 1 px hairline across the rail, floated off both edges.
+    /// The 4 px clear space each side comes from the cluster's item spacing.
+    fn draw_separator(&self, ui: &mut egui::Ui, vertical: bool) {
+        let size = if vertical {
+            egui::vec2(ui.available_width(), 1.0)
+        } else {
+            egui::vec2(1.0, ui.available_height())
+        };
+        let (rect, _) = ui.allocate_exact_size(size, egui::Sense::hover());
+        // The rail edge sits one margin outside the content rect; the spec
+        // insets the hairline from the rail edge itself.
+        let inset = TOOLBOX_SEPARATOR_INSET_PX - TOOLBOX_MARGIN_PX;
+        let (from, to) = if vertical {
+            (
+                egui::pos2(rect.left() + inset, rect.center().y),
+                egui::pos2(rect.right() - inset, rect.center().y),
+            )
+        } else {
+            (
+                egui::pos2(rect.center().x, rect.top() + inset),
+                egui::pos2(rect.center().x, rect.bottom() - inset),
+            )
+        };
+        ui.painter()
+            .line_segment([from, to], egui::Stroke::new(1.0_f32, theme::BORDER));
+    }
+
+    /// The repeat pin: keep the armed drawing tool active after it completes
+    /// an object, instead of the one-shot return to Pointer.
+    fn draw_repeat_button(&mut self, ui: &mut egui::Ui) {
+        let response = IconButton::new(icons::ARROW_CLOCKWISE, TOOLRAIL_ICON)
+            .active(self.repeat)
+            .active_marker(self.dock.marker_edge())
+            .hover_text("Keep the drawing tool active after drawing")
+            .show(ui);
+        if response.clicked() {
+            self.repeat = !self.repeat;
+        }
+    }
+
+    /// The More flyout of a collapsed rail: everything that lost its slot
+    /// stays reachable by name with its shortcut, in registry order.
+    fn draw_more_menu(&mut self, ui: &mut egui::Ui, drawings: &mut Drawings, stage: RailStage) {
+        let response = ui.menu_button(icons::DOTS_THREE, |ui| {
+            for tool in self.swallowed_tools(stage) {
+                let mut button = egui::Button::new(tool.name());
+                if let Some(shortcut) = tool.shortcut_label() {
+                    button = button.shortcut_text(shortcut);
                 }
-                self.draw_more_tools_menu(ui, drawings);
+                if ui.add(button).clicked() {
+                    self.arm(tool);
+                    ui.close_menu();
+                }
+            }
+            if stage == RailStage::Minimal {
                 ui.separator();
-                self.draw_objects_button(ui, manager_open);
-            } else if left {
-                for tool in [Tool::Pointer, Tool::Crosshair] {
-                    self.draw_button(ui, tool);
+                if ui
+                    .add(egui::Button::new("Keep tool active after drawing").selected(self.repeat))
+                    .clicked()
+                {
+                    self.repeat = !self.repeat;
+                    ui.close_menu();
                 }
-                for tool in DRAWING_TOOLS {
-                    self.draw_button(ui, Tool::Drawing(tool));
+                let all_hidden = drawings.all_hidden();
+                if ui
+                    .button(if all_hidden { "Show all" } else { "Hide all" })
+                    .clicked()
+                {
+                    drawings.set_all_hidden(!all_hidden);
+                    ui.close_menu();
                 }
-                self.draw_repeat_button(ui);
-                ui.separator();
-                self.draw_objects_button(ui, manager_open);
-                self.draw_global_buttons(ui, drawings);
-            } else {
-                self.draw_global_buttons(ui, drawings);
-                self.draw_objects_button(ui, manager_open);
-                ui.separator();
-                self.draw_repeat_button(ui);
-                for tool in DRAWING_TOOLS.into_iter().rev() {
-                    self.draw_button(ui, Tool::Drawing(tool));
-                }
-                for tool in [Tool::Crosshair, Tool::Pointer] {
-                    self.draw_button(ui, tool);
+                let all_locked = drawings.all_locked();
+                if ui
+                    .button(if all_locked { "Unlock all" } else { "Lock all" })
+                    .clicked()
+                {
+                    drawings.set_all_locked(!all_locked);
+                    ui.close_menu();
                 }
             }
         });
+        #[cfg(test)]
+        {
+            self.more_rect = Some(response.response.rect);
+        }
+        response.response.on_hover_text("More tools");
     }
 
-    fn draw_button(&mut self, ui: &mut egui::Ui, tool: Tool) {
-        let response = IconButton::new(tool.icon(), RAIL_ICON)
+    /// The tools the given stage swallowed into the More flyout — exactly
+    /// the ones without a rail slot, in registry order.
+    fn swallowed_tools(&self, stage: RailStage) -> Vec<Tool> {
+        let armed = self.tool.drawing_tool();
+        let mut swallowed = Vec::new();
+        if stage == RailStage::Minimal {
+            swallowed.push(Tool::Crosshair);
+        }
+        swallowed.extend(
+            DRAWING_TOOLS
+                .into_iter()
+                .filter(|tool| Some(*tool) != armed)
+                .map(Tool::Drawing),
+        );
+        swallowed
+    }
+
+    /// The entry to the drawn-objects manager. A toggle, not a tool: it never
+    /// changes which tool is armed. Carries the object count as a badge.
+    fn draw_objects_button(
+        &mut self,
+        ui: &mut egui::Ui,
+        drawings: &Drawings,
+        manager_open: &mut bool,
+    ) {
+        let response = IconButton::new(icons::LIST, TOOLRAIL_ICON)
+            .active(*manager_open)
+            .active_marker(self.dock.marker_edge())
+            .hover_text("Drawn objects")
+            .show(ui);
+        let count = drawings.items().len();
+        if count > 0 {
+            paint_badge(ui, response.rect, &count.to_string(), theme::TEXT_MUTED);
+        }
+        #[cfg(test)]
+        {
+            self.objects_rect = Some(response.rect);
+        }
+        if response.clicked() {
+            *manager_open = !*manager_open;
+        }
+    }
+
+    /// The reversible global protections. Hide-all is a view layer over each
+    /// drawing's own eye; lock-all mutates every lock at once. Neither is a
+    /// delete, and both are one undo entry. Drawn lock-first because the
+    /// trailing layout lays from the rail's far end backwards.
+    fn draw_global_buttons(&mut self, ui: &mut egui::Ui, drawings: &mut Drawings) {
+        let all_locked = drawings.all_locked();
+        let lock_icon = if all_locked {
+            icons::LOCK_SIMPLE
+        } else {
+            icons::LOCK_SIMPLE_OPEN
+        };
+        let lock_hover = if all_locked {
+            "Unlock all drawings"
+        } else {
+            "Lock all drawings"
+        };
+        let lock = IconButton::new(lock_icon, TOOLRAIL_ICON)
+            .active(all_locked)
+            .active_marker(self.dock.marker_edge())
+            .hover_text(lock_hover)
+            .show(ui);
+        #[cfg(test)]
+        {
+            self.lock_all_rect = Some(lock.rect);
+        }
+        if lock.clicked() {
+            drawings.set_all_locked(!all_locked);
+        }
+
+        let all_hidden = drawings.all_hidden();
+        let eye_icon = if all_hidden {
+            icons::EYE_SLASH
+        } else {
+            icons::EYE
+        };
+        let eye_hover = if all_hidden {
+            "Show all drawings"
+        } else {
+            "Hide all drawings"
+        };
+        let eye = IconButton::new(eye_icon, TOOLRAIL_ICON)
+            .active(all_hidden)
+            .active_marker(self.dock.marker_edge())
+            .hover_text(eye_hover)
+            .show(ui);
+        #[cfg(test)]
+        {
+            self.hide_all_rect = Some(eye.rect);
+        }
+        if eye.clicked() {
+            drawings.set_all_hidden(!all_hidden);
+        }
+    }
+
+    fn draw_button(&mut self, ui: &mut egui::Ui, tool: Tool, drawings: &Drawings) {
+        let response = IconButton::new(tool.icon(), TOOLRAIL_ICON)
             .active(self.tool == tool)
+            .active_marker(self.dock.marker_edge())
             .hover_text(tool.hover_text())
             .show(ui);
+        self.paint_draft_badge(ui, &response, tool, drawings);
         #[cfg(test)]
         if let Some(slot) = self.button_rects.iter_mut().find(|slot| slot.is_none()) {
             *slot = Some((tool, response.rect));
@@ -466,6 +853,331 @@ impl ToolRail {
             self.arm(tool);
         }
     }
+
+    /// Draft progress on the armed tool while a multi-point object is being
+    /// placed — answers "how many more clicks?" in place. Returns whether a
+    /// badge occupies the button's corner this frame.
+    fn paint_draft_badge(
+        &self,
+        ui: &egui::Ui,
+        response: &egui::Response,
+        tool: Tool,
+        drawings: &Drawings,
+    ) -> bool {
+        let Some(drawing_tool) = tool.drawing_tool() else {
+            return false;
+        };
+        if self.tool != tool || drawings.draft().is_none() || drawing_tool.required_points() < 2 {
+            return false;
+        }
+        let text = format!(
+            "{}/{}",
+            drawings.draft_len(),
+            drawing_tool.required_points()
+        );
+        paint_badge(ui, response.rect, &text, theme::ACCENT);
+        true
+    }
+
+    /// A family's shown member: the last-armed one, or `None` before any
+    /// member has been used.
+    fn family_member(&self, family: ToolFamily, members: &[DrawingTool]) -> Option<DrawingTool> {
+        self.last_family_member
+            .get(family.id)
+            .copied()
+            .filter(|member| members.contains(member))
+    }
+
+    /// The family split button: left-click arms the shown member; the caret
+    /// zone or a right-click opens the member flyout.
+    fn draw_family_slot(
+        &mut self,
+        ui: &mut egui::Ui,
+        family: ToolFamily,
+        members: &[DrawingTool],
+        drawings: &Drawings,
+    ) {
+        let shown = self.family_member(family, members);
+        let armed = self
+            .tool
+            .drawing_tool()
+            .is_some_and(|tool| members.contains(&tool));
+        let icon = shown.map_or(family.icon, DrawingTool::icon);
+        let hover = shown.map_or(family.title, DrawingTool::hover_text);
+        let response = IconButton::new(icon, TOOLRAIL_ICON)
+            .active(armed)
+            .active_marker(self.dock.marker_edge())
+            .hover_text(hover)
+            .show(ui);
+        let badge_shown = shown
+            .map(Tool::Drawing)
+            .is_some_and(|tool| self.paint_draft_badge(ui, &response, tool, drawings));
+
+        // The caret marks the flyout; it yields the corner to a draft badge,
+        // because a tool mid-draft is unambiguously armed already.
+        let caret_zone = egui::Rect::from_min_max(
+            egui::pos2(
+                response.rect.right() - TOOLBOX_CARET_ZONE_PX,
+                response.rect.bottom() - TOOLBOX_CARET_ZONE_PX,
+            ),
+            response.rect.max,
+        );
+        if !badge_shown && ui.is_rect_visible(response.rect) {
+            let caret_color = if armed {
+                theme::ACCENT
+            } else if response.hovered() {
+                theme::TEXT_PRIMARY
+            } else {
+                theme::TEXT_FAINT
+            };
+            let corner = egui::pos2(
+                response.rect.right() - CARET_INSET_PX,
+                response.rect.bottom() - CARET_INSET_PX,
+            );
+            ui.painter().add(egui::Shape::convex_polygon(
+                vec![
+                    egui::pos2(corner.x - CARET_SIDE_PX, corner.y),
+                    corner,
+                    egui::pos2(corner.x, corner.y - CARET_SIDE_PX),
+                ],
+                caret_color,
+                egui::Stroke::NONE,
+            ));
+        }
+
+        #[cfg(test)]
+        if let Some(slot) = self.button_rects.iter_mut().find(|slot| slot.is_none()) {
+            let recorded = shown.unwrap_or(members[0]);
+            *slot = Some((Tool::Drawing(recorded), response.rect));
+        }
+
+        let caret_clicked = response.clicked()
+            && response
+                .interact_pointer_pos()
+                .is_some_and(|position| caret_zone.contains(position));
+        if response.secondary_clicked() || caret_clicked {
+            self.flyout = Some((family.id, response.rect));
+        } else if response.clicked() {
+            self.arm(Tool::Drawing(shown.unwrap_or(members[0])));
+        }
+    }
+
+    /// The open family flyout, on the rail's chart-facing side, first row
+    /// aligned with the slot's leading edge.
+    fn draw_family_flyout(&mut self, ctx: &egui::Context) {
+        let Some((family_id, anchor)) = self.flyout else {
+            return;
+        };
+        let Some((family, members)) = tool_slots().into_iter().find_map(|slot| match slot {
+            RailSlot::Family { family, members } if family.id == family_id => {
+                Some((family, members))
+            }
+            _ => None,
+        }) else {
+            self.flyout = None;
+            return;
+        };
+
+        if ctx.input(|input| input.key_pressed(egui::Key::Escape)) {
+            self.flyout = None;
+            return;
+        }
+
+        let screen = ctx.screen_rect();
+        let height =
+            TOOLBOX_FLYOUT_ROW_HEIGHT_PX * (members.len() + 1) as f32 + 2.0 * TOOLBOX_ITEM_GAP_PX;
+        let position = match self.dock {
+            ToolboxDock::Left => egui::pos2(anchor.right() + TOOLBOX_MARGIN_PX, anchor.top()),
+            ToolboxDock::Right => egui::pos2(
+                anchor.left() - TOOLBOX_MARGIN_PX - TOOLBOX_FLYOUT_WIDTH_PX,
+                anchor.top(),
+            ),
+            ToolboxDock::Top => egui::pos2(anchor.left(), anchor.bottom() + TOOLBOX_MARGIN_PX),
+            ToolboxDock::Bottom => {
+                egui::pos2(anchor.left(), anchor.top() - TOOLBOX_MARGIN_PX - height)
+            }
+        };
+        let max_position = egui::pos2(
+            (screen.right() - TOOLBOX_FLYOUT_WIDTH_PX).max(screen.left()),
+            (screen.bottom() - height).max(screen.top()),
+        );
+        let position = position.clamp(screen.min, max_position);
+
+        let area = egui::Area::new(egui::Id::new("toolbox_family_flyout"))
+            .order(egui::Order::Foreground)
+            .fixed_pos(position)
+            .show(ctx, |ui| {
+                egui::Frame::popup(ui.style())
+                    .fill(theme::CONTROL)
+                    .stroke(egui::Stroke::new(1.0_f32, theme::BORDER))
+                    .rounding(egui::Rounding::same(6.0))
+                    .show(ui, |ui| {
+                        ui.set_width(TOOLBOX_FLYOUT_WIDTH_PX - 2.0 * TOOLBOX_ITEM_GAP_PX);
+                        ui.label(
+                            egui::RichText::new(family.title)
+                                .color(theme::TEXT_MUTED)
+                                .size(11.0),
+                        );
+                        for member in &members {
+                            if self.draw_flyout_row(ui, *member) {
+                                self.arm(Tool::Drawing(*member));
+                                self.flyout = None;
+                            }
+                        }
+                    });
+            });
+
+        // A press anywhere outside closes the flyout without arming.
+        if self.flyout.is_some() {
+            let pressed_outside = ctx.input(|input| {
+                input.pointer.any_pressed()
+                    && input.pointer.interact_pos().is_some_and(|position| {
+                        !area.response.rect.contains(position) && !anchor.contains(position)
+                    })
+            });
+            if pressed_outside {
+                self.flyout = None;
+            }
+        }
+    }
+
+    /// One flyout row: glyph, name, right-aligned shortcut. Returns whether
+    /// the row was clicked.
+    fn draw_flyout_row(&mut self, ui: &mut egui::Ui, member: DrawingTool) -> bool {
+        let width = ui.available_width();
+        let (rect, response) = ui.allocate_exact_size(
+            egui::vec2(width, TOOLBOX_FLYOUT_ROW_HEIGHT_PX),
+            egui::Sense::click(),
+        );
+        #[cfg(test)]
+        self.flyout_rects.push((member, rect));
+        if ui.is_rect_visible(rect) {
+            let armed = self.tool == Tool::Drawing(member);
+            if armed {
+                ui.painter().rect_filled(
+                    rect,
+                    egui::Rounding::same(4.0),
+                    theme::active_tint(theme::ACCENT),
+                );
+            } else if response.hovered() {
+                ui.painter()
+                    .rect_filled(rect, egui::Rounding::same(4.0), theme::BORDER);
+            }
+            let glyph_color = if armed {
+                theme::ACCENT
+            } else {
+                theme::TEXT_MUTED
+            };
+            ui.painter().text(
+                egui::pos2(rect.left() + 12.0, rect.center().y),
+                egui::Align2::CENTER_CENTER,
+                member.icon(),
+                egui::FontId::proportional(18.0),
+                glyph_color,
+            );
+            ui.painter().text(
+                egui::pos2(rect.left() + 26.0, rect.center().y),
+                egui::Align2::LEFT_CENTER,
+                member.name(),
+                egui::FontId::proportional(12.0),
+                theme::TEXT_PRIMARY,
+            );
+            if let Some(shortcut) = Tool::Drawing(member).shortcut_label() {
+                ui.painter().text(
+                    egui::pos2(rect.right() - 6.0, rect.center().y),
+                    egui::Align2::RIGHT_CENTER,
+                    shortcut,
+                    egui::FontId::proportional(11.0),
+                    theme::TEXT_FAINT,
+                );
+            }
+        }
+        response.clicked()
+    }
+}
+
+/// The rail's frame: chrome fill, margins, and no stroke — the chart-facing
+/// hairline is painted by the rail itself.
+fn rail_frame() -> egui::Frame {
+    egui::Frame::none()
+        .fill(theme::CHROME)
+        .inner_margin(egui::Margin::same(TOOLBOX_MARGIN_PX))
+}
+
+/// The drop preview: the band the rail will occupy on the candidate edge,
+/// with an accent line on its chart-facing side.
+fn paint_drop_preview(ctx: &egui::Context, target: ToolboxDock) {
+    let screen = ctx.screen_rect();
+    let thickness = TOOLBOX_THICKNESS_PX;
+    let band = match target {
+        ToolboxDock::Left => egui::Rect::from_min_max(
+            screen.min,
+            egui::pos2(screen.left() + thickness, screen.bottom()),
+        ),
+        ToolboxDock::Right => egui::Rect::from_min_max(
+            egui::pos2(screen.right() - thickness, screen.top()),
+            screen.max,
+        ),
+        ToolboxDock::Top => egui::Rect::from_min_max(
+            screen.min,
+            egui::pos2(screen.right(), screen.top() + thickness),
+        ),
+        ToolboxDock::Bottom => egui::Rect::from_min_max(
+            egui::pos2(screen.left(), screen.bottom() - thickness),
+            screen.max,
+        ),
+    };
+    let edge = TOOLBOX_DROP_BAND_EDGE_PX;
+    let line = match target {
+        ToolboxDock::Left => egui::Rect::from_min_max(
+            egui::pos2(band.right() - edge, band.top()),
+            band.right_bottom(),
+        ),
+        ToolboxDock::Right => egui::Rect::from_min_max(
+            band.left_top(),
+            egui::pos2(band.left() + edge, band.bottom()),
+        ),
+        ToolboxDock::Top => egui::Rect::from_min_max(
+            egui::pos2(band.left(), band.bottom() - edge),
+            band.right_bottom(),
+        ),
+        ToolboxDock::Bottom => {
+            egui::Rect::from_min_max(band.left_top(), egui::pos2(band.right(), band.top() + edge))
+        }
+    };
+    let painter = ctx.layer_painter(egui::LayerId::new(
+        egui::Order::Foreground,
+        egui::Id::new("toolbox_drop_preview"),
+    ));
+    painter.rect_filled(band, 0.0, theme::active_tint(theme::ACCENT));
+    painter.rect_filled(line, 0.0, theme::ACCENT);
+}
+
+/// A pill badge in a button's trailing-bottom corner (§2.5).
+fn paint_badge(ui: &egui::Ui, button: egui::Rect, text: &str, color: egui::Color32) {
+    let painter = ui.painter();
+    let font = egui::FontId::monospace(BADGE_TEXT_PX);
+    let galley = painter.layout_no_wrap(text.to_owned(), font, color);
+    let size = egui::vec2(galley.size().x + 2.0 * BADGE_PAD_X_PX, BADGE_HEIGHT_PX);
+    let rect = egui::Rect::from_min_max(
+        egui::pos2(
+            button.right() - BADGE_CORNER_INSET_PX - size.x,
+            button.bottom() - BADGE_CORNER_INSET_PX - size.y,
+        ),
+        egui::pos2(
+            button.right() - BADGE_CORNER_INSET_PX,
+            button.bottom() - BADGE_CORNER_INSET_PX,
+        ),
+    );
+    painter.rect_filled(rect, egui::Rounding::same(BADGE_RADIUS_PX), theme::INSET);
+    painter.galley(
+        egui::pos2(
+            rect.left() + BADGE_PAD_X_PX,
+            rect.center().y - galley.size().y / 2.0,
+        ),
+        galley,
+        color,
+    );
 }
 
 #[cfg(test)]
@@ -473,11 +1185,40 @@ mod tests {
     use super::*;
 
     #[test]
-    fn toolbox_opens_outside_the_chart_at_top_left() {
+    fn toolbox_opens_outside_the_chart_docked_left() {
         let rail = ToolRail::new();
         assert!(rail.visible());
         assert_eq!(rail.tool(), Tool::Pointer);
-        assert_eq!(rail.dock, ToolboxDock::TopLeft);
+        assert_eq!(rail.dock, ToolboxDock::Left);
+    }
+
+    #[test]
+    fn the_rail_never_borrows_the_provenance_amber() {
+        // Amber is reserved for data honesty (replay, backfill, inferred
+        // data) and is never rail decoration — grep-guarded like the
+        // indicators crate's libm rule.
+        let source = include_str!("toolrail.rs");
+        assert!(
+            !source.contains(concat!("theme::", "AM", "BER")),
+            "the rail's only accent is ACCENT"
+        );
+    }
+
+    #[test]
+    fn rail_thickness_is_margin_button_margin() {
+        assert_eq!(
+            TOOLBOX_THICKNESS_PX,
+            2.0 * TOOLBOX_MARGIN_PX + TOOLRAIL_ICON.hit
+        );
+    }
+
+    #[test]
+    fn stage_lengths_match_the_spec_for_the_shipped_registry() {
+        let slots = tool_slots().len();
+        assert_eq!(slots, 4, "fib family folds two registry entries into one");
+        assert_eq!(full_length(slots), 417.0);
+        assert_eq!(compact_length(), 345.0);
+        assert_eq!(minimal_length(), 191.0);
     }
 
     #[test]
@@ -490,23 +1231,33 @@ mod tests {
     }
 
     #[test]
-    fn every_quadrant_maps_to_its_nearest_corner() {
-        let screen = egui::Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(100.0, 100.0));
+    fn nearest_picks_each_edge_from_its_midpoint() {
+        let screen = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(800.0, 600.0));
         assert_eq!(
-            ToolboxDock::nearest(egui::pos2(10.0, 10.0), screen),
-            ToolboxDock::TopLeft
+            ToolboxDock::nearest(egui::pos2(10.0, 300.0), screen),
+            ToolboxDock::Left
         );
         assert_eq!(
-            ToolboxDock::nearest(egui::pos2(90.0, 10.0), screen),
-            ToolboxDock::TopRight
+            ToolboxDock::nearest(egui::pos2(790.0, 300.0), screen),
+            ToolboxDock::Right
         );
         assert_eq!(
-            ToolboxDock::nearest(egui::pos2(10.0, 90.0), screen),
-            ToolboxDock::BottomLeft
+            ToolboxDock::nearest(egui::pos2(400.0, 10.0), screen),
+            ToolboxDock::Top
         );
         assert_eq!(
-            ToolboxDock::nearest(egui::pos2(90.0, 90.0), screen),
-            ToolboxDock::BottomRight
+            ToolboxDock::nearest(egui::pos2(400.0, 590.0), screen),
+            ToolboxDock::Bottom
+        );
+    }
+
+    #[test]
+    fn nearest_normalises_so_a_wide_screen_does_not_bias_top_bottom() {
+        let screen = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(1920.0, 600.0));
+        // Raw pixel distances tie at 300 vs 300; normalised 0.156 vs 0.5.
+        assert_eq!(
+            ToolboxDock::nearest(egui::pos2(300.0, 300.0), screen),
+            ToolboxDock::Left
         );
     }
 
@@ -516,16 +1267,8 @@ mod tests {
         screen: egui::Rect,
         events: Vec<egui::Event>,
     ) {
-        let input = egui::RawInput {
-            screen_rect: Some(screen),
-            events,
-            ..Default::default()
-        };
         let mut drawings = Drawings::default();
-        let mut manager_open = false;
-        let _ = ctx.run(input, |ctx| {
-            rail.draw(ctx, &mut drawings, &mut manager_open)
-        });
+        rail_frame_with(rail, &mut drawings, ctx, screen, events);
     }
 
     fn primary_button(position: egui::Pos2, pressed: bool) -> egui::Event {
@@ -538,17 +1281,17 @@ mod tests {
     }
 
     #[test]
-    fn dragging_the_real_grip_docks_at_each_screen_corner() {
+    fn dragging_the_real_grip_docks_at_each_screen_edge() {
         let screen = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(800.0, 600.0));
         let ctx = egui::Context::default();
         let mut rail = ToolRail::new();
         draw_rail_frame(&mut rail, &ctx, screen, Vec::new());
 
         for (target, expected) in [
-            (egui::pos2(790.0, 10.0), ToolboxDock::TopRight),
-            (egui::pos2(10.0, 590.0), ToolboxDock::BottomLeft),
-            (egui::pos2(790.0, 590.0), ToolboxDock::BottomRight),
-            (egui::pos2(10.0, 10.0), ToolboxDock::TopLeft),
+            (egui::pos2(790.0, 300.0), ToolboxDock::Right),
+            (egui::pos2(400.0, 10.0), ToolboxDock::Top),
+            (egui::pos2(400.0, 590.0), ToolboxDock::Bottom),
+            (egui::pos2(10.0, 300.0), ToolboxDock::Left),
         ] {
             let start = rail.grip_rect.expect("grip was rendered").center();
             draw_rail_frame(
@@ -578,6 +1321,56 @@ mod tests {
             assert_eq!(rail.dock, expected);
             draw_rail_frame(&mut rail, &ctx, screen, Vec::new());
         }
+    }
+
+    #[test]
+    fn escape_during_a_grip_drag_keeps_the_current_dock() {
+        let screen = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(800.0, 600.0));
+        let ctx = egui::Context::default();
+        let mut rail = ToolRail::new();
+        draw_rail_frame(&mut rail, &ctx, screen, Vec::new());
+
+        let start = rail.grip_rect.expect("grip was rendered").center();
+        draw_rail_frame(
+            &mut rail,
+            &ctx,
+            screen,
+            vec![
+                egui::Event::PointerMoved(start),
+                primary_button(start, true),
+            ],
+        );
+        let target = egui::pos2(400.0, 590.0);
+        draw_rail_frame(
+            &mut rail,
+            &ctx,
+            screen,
+            vec![egui::Event::PointerMoved(target)],
+        );
+        assert!(rail.drag_active());
+        draw_rail_frame(
+            &mut rail,
+            &ctx,
+            screen,
+            vec![egui::Event::Key {
+                key: egui::Key::Escape,
+                physical_key: None,
+                pressed: true,
+                repeat: false,
+                modifiers: egui::Modifiers::NONE,
+            }],
+        );
+        assert!(!rail.drag_active());
+        draw_rail_frame(
+            &mut rail,
+            &ctx,
+            screen,
+            vec![
+                egui::Event::PointerMoved(target),
+                primary_button(target, false),
+            ],
+        );
+        assert_eq!(rail.dock, ToolboxDock::Left, "Esc aborted the drag");
     }
 
     #[test]
@@ -684,33 +1477,244 @@ mod tests {
     }
 
     #[test]
-    fn the_narrow_strip_keeps_pointer_active_tool_and_objects() {
+    fn arming_a_family_member_becomes_the_slot_memory() {
+        let mut rail = ToolRail::new();
+        let extension = DRAWING_TOOLS
+            .into_iter()
+            .find(|tool| tool.id() == "fib-extension")
+            .expect("registered");
+        rail.arm(Tool::Drawing(extension));
+        let family = extension.family().expect("fib family");
+        assert_eq!(
+            rail.family_member(family, &[extension]),
+            Some(extension),
+            "the slot remembers the last-armed member"
+        );
+    }
+
+    #[test]
+    fn the_full_vertical_rail_folds_the_fib_family_into_one_slot() {
         let ctx = egui::Context::default();
         let mut rail = ToolRail::new();
+        let mut drawings = Drawings::default();
+        let screen = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(900.0, 600.0));
+        rail_frame_with(&mut rail, &mut drawings, &ctx, screen, Vec::new());
+
+        let retracement = DRAWING_TOOLS
+            .into_iter()
+            .find(|tool| tool.id() == "fib-retracement")
+            .expect("registered");
+        let extension = DRAWING_TOOLS
+            .into_iter()
+            .find(|tool| tool.id() == "fib-extension")
+            .expect("registered");
+        assert!(
+            rail.button_rect(Tool::Drawing(retracement)).is_some(),
+            "the family slot records its shown member"
+        );
+        assert!(
+            rail.button_rect(Tool::Drawing(extension)).is_none(),
+            "the second fib entry must not hold its own slot"
+        );
+    }
+
+    #[test]
+    fn stages_are_pure_functions_of_extent() {
+        let slots = tool_slots().len();
+        for extent in [100.0_f32, 200.0, 344.9, 345.0, 416.9, 417.0, 1000.0] {
+            let first = stage_for(extent, slots);
+            let second = stage_for(extent, slots);
+            assert_eq!(first, second);
+        }
+        assert_eq!(stage_for(417.0, slots), RailStage::Full);
+        assert_eq!(stage_for(416.9, slots), RailStage::Compact);
+        assert_eq!(stage_for(345.0, slots), RailStage::Compact);
+        assert_eq!(stage_for(344.9, slots), RailStage::Minimal);
+    }
+
+    #[test]
+    fn the_compact_rail_keeps_pointer_crosshair_armed_tool_and_objects() {
+        let ctx = egui::Context::default();
+        let mut rail = ToolRail::new();
+        rail.set_dock(ToolboxDock::Top);
         rail.arm(Tool::Drawing(DRAWING_TOOLS[1]));
         let mut drawings = Drawings::default();
 
-        // Narrow: the strip collapses; Pointer, the active tool and the
-        // Objects entry survive, the rest folds into the More flyout.
-        let narrow = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(400.0, 600.0));
-        rail_frame_with(&mut rail, &mut drawings, &ctx, narrow, Vec::new());
+        // 400 px wide: Compact for a horizontal rail.
+        let compact = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(400.0, 600.0));
+        rail_frame_with(&mut rail, &mut drawings, &ctx, compact, Vec::new());
         assert!(rail.button_rect(Tool::Pointer).is_some());
+        assert!(rail.button_rect(Tool::Crosshair).is_some());
         assert!(rail.button_rect(Tool::Drawing(DRAWING_TOOLS[1])).is_some());
         assert!(
             rail.button_rect(Tool::Drawing(DRAWING_TOOLS[0])).is_none(),
-            "inactive tools give up their slots in the narrow strip"
+            "unarmed tools give up their slots at Compact"
         );
-        assert!(rail.objects_button_rect().is_some());
+        assert!(rail.more_rect.is_some());
+        assert!(rail.objects_rect.is_some());
+        assert!(rail.hide_all_rect.is_some(), "trailing cluster survives");
 
-        // Wide: every tool has its slot back.
+        // 250 px: Minimal — Crosshair and the globals fold into More.
+        let minimal = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(250.0, 600.0));
+        rail_frame_with(&mut rail, &mut drawings, &ctx, minimal, Vec::new());
+        assert!(rail.button_rect(Tool::Pointer).is_some());
+        assert!(rail.button_rect(Tool::Crosshair).is_none());
+        assert!(rail.button_rect(Tool::Drawing(DRAWING_TOOLS[1])).is_some());
+        assert!(rail.hide_all_rect.is_none());
+        assert!(rail.lock_all_rect.is_none());
+        assert!(rail.objects_rect.is_some());
+
+        // Wide again: every slot returns.
         let wide = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(900.0, 600.0));
         rail_frame_with(&mut rail, &mut drawings, &ctx, wide, Vec::new());
-        for tool in DRAWING_TOOLS {
+        for slot in tool_slots() {
+            let shown = match slot {
+                RailSlot::Single(tool) => tool,
+                RailSlot::Family { family, members } => {
+                    rail.family_member(family, &members).unwrap_or(members[0])
+                }
+            };
             assert!(
-                rail.button_rect(Tool::Drawing(tool)).is_some(),
-                "{} lost its slot on a wide strip",
-                tool.id()
+                rail.button_rect(Tool::Drawing(shown)).is_some(),
+                "{} lost its slot on a wide rail",
+                shown.id()
             );
+        }
+    }
+
+    #[test]
+    fn the_more_flyout_lists_exactly_what_each_stage_swallowed() {
+        let mut rail = ToolRail::new();
+        rail.arm(Tool::Drawing(DRAWING_TOOLS[1]));
+
+        let compact = rail.swallowed_tools(RailStage::Compact);
+        assert!(!compact.contains(&Tool::Crosshair));
+        assert!(!compact.contains(&Tool::Drawing(DRAWING_TOOLS[1])));
+        for tool in DRAWING_TOOLS {
+            if tool != DRAWING_TOOLS[1] {
+                assert!(compact.contains(&Tool::Drawing(tool)));
+            }
+        }
+
+        let minimal = rail.swallowed_tools(RailStage::Minimal);
+        assert!(minimal.contains(&Tool::Crosshair));
+        assert!(!minimal.contains(&Tool::Drawing(DRAWING_TOOLS[1])));
+    }
+
+    #[test]
+    fn orientation_changes_positions_never_inventory() {
+        let screen = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(900.0, 900.0));
+        let mut inventories: Vec<Vec<&'static str>> = Vec::new();
+        for dock in [
+            ToolboxDock::Left,
+            ToolboxDock::Right,
+            ToolboxDock::Top,
+            ToolboxDock::Bottom,
+        ] {
+            let ctx = egui::Context::default();
+            let mut rail = ToolRail::new();
+            rail.set_dock(dock);
+            let mut drawings = Drawings::default();
+            rail_frame_with(&mut rail, &mut drawings, &ctx, screen, Vec::new());
+            let mut tools: Vec<&'static str> = rail
+                .button_rects
+                .iter()
+                .flatten()
+                .map(|(tool, _)| tool.name())
+                .collect();
+            tools.sort_unstable();
+            inventories.push(tools);
+        }
+        assert!(
+            inventories.windows(2).all(|pair| pair[0] == pair[1]),
+            "every dock shows the same buttons at the same extent: {inventories:?}"
+        );
+    }
+
+    #[test]
+    fn the_grip_leads_and_objects_trails_in_every_dock() {
+        let screen = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(900.0, 900.0));
+        for dock in [
+            ToolboxDock::Left,
+            ToolboxDock::Right,
+            ToolboxDock::Top,
+            ToolboxDock::Bottom,
+        ] {
+            let ctx = egui::Context::default();
+            let mut rail = ToolRail::new();
+            rail.set_dock(dock);
+            let mut drawings = Drawings::default();
+            rail_frame_with(&mut rail, &mut drawings, &ctx, screen, Vec::new());
+
+            let grip = rail.grip_rect.expect("grip rendered");
+            let objects = rail.objects_rect.expect("objects rendered");
+            let rail_rect = rail.rail_rect.expect("rail rect recorded");
+            let along = |rect: egui::Rect| {
+                if dock.is_vertical() {
+                    rect.top()
+                } else {
+                    rect.left()
+                }
+            };
+            for (_, rect) in rail.button_rects.iter().flatten() {
+                assert!(
+                    along(grip) <= along(*rect),
+                    "the grip precedes every button in {dock:?}"
+                );
+            }
+            // The trailing cluster is pinned: Objects sits one margin off
+            // the rail's far end.
+            let far_gap = if dock.is_vertical() {
+                rail_rect.bottom() - objects.bottom()
+            } else {
+                rail_rect.right() - objects.right()
+            };
+            assert!(
+                (far_gap - TOOLBOX_MARGIN_PX).abs() < 0.6,
+                "objects must trail one margin off the rail end in {dock:?}, gap {far_gap}"
+            );
+        }
+    }
+
+    #[test]
+    fn every_dock_position_reserves_space_outside_the_central_chart() {
+        let screen = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(800.0, 600.0));
+        for dock in [
+            ToolboxDock::Left,
+            ToolboxDock::Right,
+            ToolboxDock::Top,
+            ToolboxDock::Bottom,
+        ] {
+            let ctx = egui::Context::default();
+            let mut rail = ToolRail {
+                tool: Tool::Pointer,
+                visible: true,
+                dock,
+                ..ToolRail::default()
+            };
+            let mut central = egui::Rect::NOTHING;
+            let input = egui::RawInput {
+                screen_rect: Some(screen),
+                ..Default::default()
+            };
+            let mut drawings = Drawings::default();
+            let mut manager_open = false;
+            let _ = ctx.run(input, |ctx| {
+                rail.draw(ctx, &mut drawings, &mut manager_open);
+                egui::CentralPanel::default().show(ctx, |ui| {
+                    central = ui.max_rect();
+                });
+            });
+            match dock {
+                ToolboxDock::Left => assert!(central.left() >= TOOLBOX_THICKNESS_PX),
+                ToolboxDock::Right => {
+                    assert!(central.right() <= screen.right() - TOOLBOX_THICKNESS_PX);
+                }
+                ToolboxDock::Top => assert!(central.top() >= TOOLBOX_THICKNESS_PX),
+                ToolboxDock::Bottom => {
+                    assert!(central.bottom() <= screen.bottom() - TOOLBOX_THICKNESS_PX);
+                }
+            }
         }
     }
 
@@ -747,42 +1751,5 @@ mod tests {
             1,
             "global protections must never delete"
         );
-    }
-
-    #[test]
-    fn every_dock_position_reserves_space_outside_the_central_chart() {
-        let screen = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(800.0, 600.0));
-        for dock in [
-            ToolboxDock::TopLeft,
-            ToolboxDock::TopRight,
-            ToolboxDock::BottomLeft,
-            ToolboxDock::BottomRight,
-        ] {
-            let ctx = egui::Context::default();
-            let mut rail = ToolRail {
-                tool: Tool::Pointer,
-                visible: true,
-                dock,
-                ..ToolRail::default()
-            };
-            let mut central = egui::Rect::NOTHING;
-            let input = egui::RawInput {
-                screen_rect: Some(screen),
-                ..Default::default()
-            };
-            let mut drawings = Drawings::default();
-            let mut manager_open = false;
-            let _ = ctx.run(input, |ctx| {
-                rail.draw(ctx, &mut drawings, &mut manager_open);
-                egui::CentralPanel::default().show(ctx, |ui| {
-                    central = ui.max_rect();
-                });
-            });
-            if dock.is_top() {
-                assert!(central.top() >= TOOLBOX_HEIGHT_PX);
-            } else {
-                assert!(central.bottom() <= screen.bottom() - TOOLBOX_HEIGHT_PX);
-            }
-        }
     }
 }

--- a/crates/app/src/widgets.rs
+++ b/crates/app/src/widgets.rs
@@ -23,10 +23,62 @@ pub const RAIL_ICON: IconSize = IconSize {
     hit: 30.0,
 };
 
+/// Drawing-rail geometry: an 18 px glyph on a 32 px hit target — the 32 px
+/// touch target the accessibility contract requires, with enough padding
+/// around the glyph that a 44 px rail does not read as cramped.
+pub const TOOLRAIL_ICON: IconSize = IconSize {
+    glyph: 18.0,
+    hit: 32.0,
+};
+
 /// Opacity of a disabled glyph.
 const DISABLED_OPACITY: f32 = 0.4;
 /// Corner radius of the hover/active backdrop.
 const CORNER_RADIUS: f32 = 4.0;
+/// Thickness of the accent bar hugging an armed button's outer edge.
+pub const ACTIVE_MARKER_WIDTH_PX: f32 = 2.0;
+/// Inset of the accent bar from both ends of the button edge it hugs.
+pub const ACTIVE_MARKER_INSET_PX: f32 = 6.0;
+/// Stroke width of the keyboard-focus ring.
+pub const FOCUS_RING_WIDTH_PX: f32 = 1.5;
+
+/// Which outer edge of the button the active marker hugs — the edge facing
+/// the window border the owning rail is docked against.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MarkerEdge {
+    Left,
+    Right,
+    Top,
+    Bottom,
+}
+
+impl MarkerEdge {
+    /// The marker bar for a button `rect`, inset from both ends so the bar
+    /// floats rather than touching the corners.
+    #[must_use]
+    fn bar(self, rect: egui::Rect) -> egui::Rect {
+        let inset = ACTIVE_MARKER_INSET_PX;
+        let width = ACTIVE_MARKER_WIDTH_PX;
+        match self {
+            Self::Left => egui::Rect::from_min_max(
+                egui::pos2(rect.left(), rect.top() + inset),
+                egui::pos2(rect.left() + width, rect.bottom() - inset),
+            ),
+            Self::Right => egui::Rect::from_min_max(
+                egui::pos2(rect.right() - width, rect.top() + inset),
+                egui::pos2(rect.right(), rect.bottom() - inset),
+            ),
+            Self::Top => egui::Rect::from_min_max(
+                egui::pos2(rect.left() + inset, rect.top()),
+                egui::pos2(rect.right() - inset, rect.top() + width),
+            ),
+            Self::Bottom => egui::Rect::from_min_max(
+                egui::pos2(rect.left() + inset, rect.bottom() - width),
+                egui::pos2(rect.right() - inset, rect.bottom()),
+            ),
+        }
+    }
+}
 
 /// Glyph and hit-target sizes for one icon-button family.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -47,14 +99,27 @@ pub struct IconPaint {
     pub glyph: egui::Color32,
 }
 
-/// Resolve the §4 state table: disabled beats everything, active tints in the
-/// layer accent, hover lifts an idle glyph, idle stays muted.
+/// Resolve the §4 state table, in precedence order: disabled beats pressed
+/// beats active beats hover beats idle. The focus ring is painted on top of
+/// whichever state won — a keyboard affordance, not a state of its own.
 #[must_use]
-pub fn icon_paint(enabled: bool, active: bool, hovered: bool, accent: egui::Color32) -> IconPaint {
+pub fn icon_paint(
+    enabled: bool,
+    pressed: bool,
+    active: bool,
+    hovered: bool,
+    accent: egui::Color32,
+) -> IconPaint {
     if !enabled {
         return IconPaint {
             fill: None,
             glyph: theme::TEXT_MUTED.gamma_multiply(DISABLED_OPACITY),
+        };
+    }
+    if pressed {
+        return IconPaint {
+            fill: Some(theme::press_tint(accent)),
+            glyph: accent,
         };
     }
     if active {
@@ -84,6 +149,7 @@ pub struct IconButton<'a> {
     accent: egui::Color32,
     hover_text: &'a str,
     disabled_text: &'a str,
+    marker_edge: Option<MarkerEdge>,
 }
 
 impl<'a> IconButton<'a> {
@@ -98,7 +164,16 @@ impl<'a> IconButton<'a> {
             accent: theme::ACCENT,
             hover_text: "",
             disabled_text: "",
+            marker_edge: None,
         }
+    }
+
+    /// Paint a 2 px accent bar on this outer edge while the button is active
+    /// — the marker that keeps the armed tool findable in peripheral vision.
+    #[must_use]
+    pub fn active_marker(mut self, edge: MarkerEdge) -> Self {
+        self.marker_edge = Some(edge);
+        self
     }
 
     /// Whether the button renders in its active (tinted) state.
@@ -148,7 +223,13 @@ impl<'a> IconButton<'a> {
         let (rect, response) =
             ui.allocate_exact_size(egui::vec2(self.size.hit, self.size.hit), sense);
         if ui.is_rect_visible(rect) {
-            let paint = icon_paint(self.enabled, self.active, response.hovered(), self.accent);
+            let paint = icon_paint(
+                self.enabled,
+                response.is_pointer_button_down_on(),
+                self.active,
+                response.hovered(),
+                self.accent,
+            );
             let painter = ui.painter();
             if let Some(fill) = paint.fill {
                 painter.rect_filled(rect, egui::Rounding::same(CORNER_RADIUS), fill);
@@ -160,6 +241,18 @@ impl<'a> IconButton<'a> {
                 egui::FontId::proportional(self.size.glyph),
                 paint.glyph,
             );
+            if self.active
+                && let Some(edge) = self.marker_edge
+            {
+                painter.rect_filled(edge.bar(rect), egui::Rounding::same(1.0), self.accent);
+            }
+            if response.has_focus() {
+                painter.rect_stroke(
+                    rect.shrink(1.0),
+                    egui::Rounding::same(CORNER_RADIUS),
+                    egui::Stroke::new(FOCUS_RING_WIDTH_PX, self.accent),
+                );
+            }
         }
         let hover = if self.enabled {
             self.hover_text
@@ -180,14 +273,14 @@ mod tests {
 
     #[test]
     fn idle_is_muted_on_bare_chrome() {
-        let paint = icon_paint(true, false, false, theme::ACCENT);
+        let paint = icon_paint(true, false, false, false, theme::ACCENT);
         assert_eq!(paint.fill, None);
         assert_eq!(paint.glyph, theme::TEXT_MUTED);
     }
 
     #[test]
     fn hover_lifts_the_glyph_on_a_border_fill() {
-        let paint = icon_paint(true, false, true, theme::ACCENT);
+        let paint = icon_paint(true, false, false, true, theme::ACCENT);
         assert_eq!(paint.fill, Some(theme::BORDER));
         assert_eq!(paint.glyph, theme::TEXT_PRIMARY);
     }
@@ -195,21 +288,38 @@ mod tests {
     #[test]
     fn active_tints_in_the_layer_accent_even_under_hover() {
         for hovered in [false, true] {
-            let paint = icon_paint(true, true, hovered, theme::BUY);
+            let paint = icon_paint(true, false, true, hovered, theme::BUY);
             assert_eq!(paint.fill, Some(theme::active_tint(theme::BUY)));
             assert_eq!(paint.glyph, theme::BUY);
         }
     }
 
     #[test]
-    fn disabled_beats_every_other_state_and_dims_the_glyph() {
-        for (active, hovered) in [(false, false), (true, false), (false, true), (true, true)] {
-            let paint = icon_paint(false, active, hovered, theme::ACCENT);
-            assert_eq!(paint.fill, None);
-            assert!(
-                paint.glyph.a() < theme::TEXT_MUTED.a(),
-                "disabled glyph must be dimmer than idle"
-            );
+    fn precedence_is_disabled_pressed_active_hover_idle() {
+        // The full boolean cross-product, so no state combination can drift.
+        for pressed in [false, true] {
+            for active in [false, true] {
+                for hovered in [false, true] {
+                    let disabled = icon_paint(false, pressed, active, hovered, theme::ACCENT);
+                    assert_eq!(disabled.fill, None, "disabled beats everything");
+                    assert!(
+                        disabled.glyph.a() < theme::TEXT_MUTED.a(),
+                        "disabled glyph must be dimmer than idle"
+                    );
+
+                    let paint = icon_paint(true, pressed, active, hovered, theme::ACCENT);
+                    let expected_fill = if pressed {
+                        Some(theme::press_tint(theme::ACCENT))
+                    } else if active {
+                        Some(theme::active_tint(theme::ACCENT))
+                    } else if hovered {
+                        Some(theme::BORDER)
+                    } else {
+                        None
+                    };
+                    assert_eq!(paint.fill, expected_fill);
+                }
+            }
         }
     }
 
@@ -219,5 +329,24 @@ mod tests {
         assert_eq!(TOOLBAR_ICON.hit, 28.0);
         assert_eq!(RAIL_ICON.glyph, 20.0);
         assert_eq!(RAIL_ICON.hit, 30.0);
+        assert_eq!(TOOLRAIL_ICON.glyph, 18.0);
+        assert_eq!(TOOLRAIL_ICON.hit, 32.0);
+    }
+
+    #[test]
+    fn marker_bars_hug_their_edge_inset_from_both_ends() {
+        let rect = egui::Rect::from_min_size(egui::pos2(100.0, 200.0), egui::vec2(32.0, 32.0));
+        let left = MarkerEdge::Left.bar(rect);
+        assert_eq!(left.left(), rect.left());
+        assert_eq!(left.width(), ACTIVE_MARKER_WIDTH_PX);
+        assert_eq!(left.top(), rect.top() + ACTIVE_MARKER_INSET_PX);
+        assert_eq!(left.bottom(), rect.bottom() - ACTIVE_MARKER_INSET_PX);
+        let top = MarkerEdge::Top.bar(rect);
+        assert_eq!(top.top(), rect.top());
+        assert_eq!(top.height(), ACTIVE_MARKER_WIDTH_PX);
+        let right = MarkerEdge::Right.bar(rect);
+        assert_eq!(right.right(), rect.right());
+        let bottom = MarkerEdge::Bottom.bar(rect);
+        assert_eq!(bottom.bottom(), rect.bottom());
     }
 }

--- a/docs/drawing-toolbar-ux.md
+++ b/docs/drawing-toolbar-ux.md
@@ -1,0 +1,679 @@
+# Drawing toolbar & inspector — UX redesign
+
+Status: **specification, not yet implemented.** Supersedes the corner-docked
+toolbox geometry described in [`ux/ui-design-model.md`](ux/ui-design-model.md)
+§7 and the placement bullets in
+[`ux/drawing-tools-ux-spec.html`](ux/drawing-tools-ux-spec.html) §05. Everything
+else in both documents survives unchanged and stays authoritative — the
+registry contract, the level editor, the escape stack, the textual action bar,
+lock/hide/delete semantics, the undo coalescing and the colour rules.
+
+Three user complaints drive this redesign:
+
+1. the toolbar reads as a placeholder rather than a tool;
+2. the properties popup opens on top of the drawing it describes and eats
+   clicks meant for the chart;
+3. the toolbar cannot be docked on a lateral edge — the four "corners" only
+   flip the reading direction of the same top/bottom strip.
+
+---
+
+## 1. Design direction
+
+**What "TradingView quality" means here, concretely.** Not more chrome — more
+*resolution* in the chrome that already exists. TradingView's left rail is
+persuasive for four reasons, and all four are cheap in egui: it is **vertical
+and lateral**, so it never eats the chart's vertical budget where price lives;
+it is **grouped**, with hairline rules separating cursors from drawing tools
+from global protections, so the eye lands on a cluster rather than scanning a
+run of glyphs; it **scales through families**, where a whole class of tools
+occupies one slot that remembers which member you last used and opens the rest
+on a caret; and its **states are legible from the corner of your eye** — the
+armed tool carries a tinted backdrop *and* an accent edge marker, so you never
+have to look directly at the rail to know what a click will do. The current
+strip has none of these: it is a flat, evenly spaced run of eleven buttons in a
+44 px band across the top of the window, which reads as unfinished because it
+*is* undifferentiated.
+
+**What stays quantick.** We are not cloning the rail. Three things stay ours.
+First, the size discipline: `CLAUDE.md` says this is not a trading platform,
+and §5 of the design model says the chart buys every pixel. TradingView's rail
+is 52 px wide and hosts thirty tools behind eight family flyouts; ours is
+**44 px in its cross axis in every orientation** — the same 44 the design
+model already budgets for the top/bottom strip, so the shell's pixel accounting
+survives docking verbatim — and ships exactly one family flyout, because
+exactly one family (Fibonacci) currently has two members. The flyout mechanism
+exists so the tenth tool costs zero new chrome, not so we can look busy on day
+one. Second, the amber thread: `#F0B90B` is reserved for provenance honesty and
+does not appear anywhere in this document. The rail's only colour is
+`accent/overlay` `#8AB4F8`, and it means exactly one thing — *this control is
+armed*. Third, the honesty rule applied to chrome: a control that cannot act
+is dimmed and explains itself on hover, never hidden, and the overflow flyout
+lists what it swallowed **by name with its shortcut**, so a collapsed rail is
+still a readable inventory rather than a mystery button.
+
+**The one deliberate risk.** The trailing cluster (repeat pin, hide-all,
+lock-all, Objects) is **pinned to the far end of the rail**, not packed behind
+the tools. That leaves a variable empty gap in the middle of the rail, which
+looks wrong in a mockup and right in use: the two clusters answer different
+questions (*what am I about to draw?* vs *what have I already drawn?*), and
+separating them by whitespace rather than by another hairline means the hand
+learns two destinations instead of one list. It also gives the overflow
+staging a place to absorb pressure without ever reflowing the top of the rail —
+the tools stay exactly where they were on the last window size.
+
+---
+
+## 2. Tool rail
+
+### 2.1 Geometry
+
+One thickness for every orientation. `TOOLBOX_HEIGHT_PX` is renamed
+`TOOLBOX_THICKNESS_PX` because it is now a width half the time.
+
+| Constant | Value | Meaning |
+|---|---|---|
+| `TOOLBOX_THICKNESS_PX` | `44.0` | rail cross axis, all four docks |
+| `TOOLBOX_MARGIN_PX` | `6.0` | outer margin, both axes |
+| `TOOLBOX_ITEM_GAP_PX` | `4.0` | gap between buttons inside a cluster (was 6.0) |
+| `TOOLBOX_GROUP_GAP_PX` | `4.0` | clear space each side of a separator |
+| `TOOLBOX_SEPARATOR_THICKNESS_PX` | `1.0` | the hairline itself |
+| `TOOLBOX_SEPARATOR_INSET_PX` | `8.0` | inset from each rail edge, so the rule floats |
+| `TOOLBOX_GRIP_LENGTH_PX` | `18.0` | grip extent along the rail |
+| `TOOLBOX_GRIP_GLYPH_PX` | `14.0` | grip glyph font size |
+| `TOOLBOX_MIN_CLUSTER_GAP_PX` | `12.0` | smallest allowed gap between leading and trailing clusters |
+| `TOOLBOX_CARET_ZONE_PX` | `10.0` | square corner zone of a family button that opens its flyout |
+| `TOOLBOX_FLYOUT_WIDTH_PX` | `208.0` | flyout popup width |
+| `TOOLBOX_FLYOUT_ROW_HEIGHT_PX` | `26.0` | one flyout row |
+| `TOOLBOX_TOOLTIP_DELAY_MS` | `350` | hover delay before a tooltip appears |
+
+Buttons get their own icon geometry rather than borrowing `RAIL_ICON` (which
+the dock tab strip also uses and which must not move). In `widgets.rs`:
+
+```rust
+/// Drawing-rail geometry: an 18 px glyph on a 32 px hit target — the 32 px
+/// touch target the accessibility contract requires, with enough padding
+/// around the glyph that a 44 px rail does not read as cramped.
+pub const TOOLRAIL_ICON: IconSize = IconSize { glyph: 18.0, hit: 32.0 };
+```
+
+A 32 px button centred in a 44 px rail leaves 6 px each side — exactly
+`TOOLBOX_MARGIN_PX`, so the rail is one arithmetic identity:
+`44 = 6 + 32 + 6`.
+
+### 2.2 Cluster order
+
+Reading order in every dock: **leading → trailing**. Top-to-bottom in a
+vertical rail, left-to-right in a horizontal one. The old `is_left()` layout
+reversal disappears with the corners — a top rail and a bottom rail now lay
+out identically, and so do a left rail and a right rail.
+
+```
+LEADING (packed at the rail's start)          TRAILING (pinned at the rail's end)
+┌────────┐                                    ┌────────┐
+│  grip  │  DOTS_SIX_VERTICAL / DOTS_SIX      │  ───   │  separator
+├────────┤                                    │ repeat │  REPEAT
+│pointer │  CURSOR            (1, Esc)        │hide-all│  EYE / EYE_SLASH
+│crossh. │  CROSSHAIR         (2)             │lock-all│  LOCK_SIMPLE(_OPEN)
+│  ───   │  separator                         │  ───   │  separator
+│  horz  │  MINUS             (H)             │objects │  LIST + count badge
+│  rect  │  RECTANGLE         (R)             └────────┘
+│channel │  PARALLELOGRAM     (C)
+│  fib ⌄ │  family slot       (F / Shift+F)
+└────────┘
+         ⋮  flexible gap, ≥ TOOLBOX_MIN_CLUSTER_GAP_PX
+```
+
+Nothing is lost relative to today's rail. Pointer, Crosshair, the five
+registry tools, the repeat pin, the Objects toggle, hide-all, lock-all and the
+overflow flyout all survive; the repeat pin moves from "after the tools" into
+the trailing cluster, next to the other two things that modify *how drawing
+behaves* rather than *what gets drawn*, and the two Fibonacci tools share one
+slot.
+
+### 2.3 Tool families
+
+Two Fib entries side by side in a five-tool rail is the shape of a rail that
+does not scale. A family is declared by the tool, in the registry, so the rail
+never grows a central match and no dependency reverses:
+
+```rust
+/// A family of related tools sharing one rail slot. Declared by each member,
+/// never listed centrally — the rail folds consecutive registry entries with
+/// equal `id` into a single split button.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ToolFamily {
+    pub id: &'static str,
+    pub title: &'static str,
+    pub icon: &'static str,
+}
+
+// on DrawingToolImpl, defaulted so existing tools need no edit:
+fn family(&self) -> Option<ToolFamily> { None }
+```
+
+`fib_retracement.rs` and `fib_extension.rs` both return
+`ToolFamily { id: "fib", title: "Fibonacci", icon: icons::ROWS }`. Rules:
+
+- The rail folds a **consecutive run** of registry entries with equal
+  `family.id` into one slot. Consecutive, not sorted — rail order stays
+  registry order, so the layout is deterministic and adding a tool cannot
+  silently reorder the rail.
+- The slot paints the **last-armed member's** own icon, not the family icon.
+  The family icon is the fallback before any member has been used, and the
+  title labels the flyout header.
+- Last-armed memory is a `BTreeMap<&'static str, DrawingTool>` on `ToolRail`
+  (`BTreeMap` over `HashMap` per the project's ordering rule, even though this
+  one is chrome).
+- **Left-click** arms the shown member. **Right-click anywhere on the button**,
+  or a left-click inside the trailing-corner `TOOLBOX_CARET_ZONE_PX` square,
+  opens the flyout.
+- The caret is a 5 px filled triangle in the button's trailing-bottom corner,
+  inset 3 px: `TEXT_FAINT` idle, `TEXT_PRIMARY` on hover, `ACCENT` when the
+  family is armed. It is hidden while a draft badge occupies that corner
+  (§2.5) — a tool mid-draft is unambiguously armed, so the caret has nothing
+  to add.
+- The flyout is an `egui::Area` at `Order::Foreground`, opening on the rail's
+  **chart-facing side**, its first row aligned with the button's leading edge,
+  clamped into the screen rect. `CONTROL` `#232936` fill, 1 px `BORDER`
+  stroke, 6 px corner radius, `POPOVER_SHADOW` (offset `[0, 4]`, blur `12.0`,
+  spread `0.0`, colour `#000000` at alpha `96`).
+- Each row is `TOOLBOX_FLYOUT_ROW_HEIGHT_PX` tall: 18 px glyph, name in
+  `TEXT_PRIMARY`, shortcut right-aligned in `TEXT_FAINT`. The armed member's
+  row carries the active fill.
+- Escape, a click outside, or arming a member closes the flyout. A closed
+  flyout returns focus to the rail button.
+
+### 2.4 Button states
+
+Keep `widgets::icon_paint` and its four resolved states — the function is
+already unit-tested and the state table it encodes is the design model's. Two
+additions:
+
+| State | Backdrop | Glyph | Extra |
+|---|---|---|---|
+| Idle | none | `TEXT_MUTED` `#96A0AF` | — |
+| Hover | `BORDER` `#2E3648` | `TEXT_PRIMARY` `#D2DAE2` | tooltip after 350 ms |
+| **Pressed** (new) | `press_tint(ACCENT)` = `#8AB4F8` @ alpha `84` | `ACCENT` `#8AB4F8` | — |
+| Active | `active_tint(ACCENT)` = `#8AB4F8` @ alpha `56` | `ACCENT` `#8AB4F8` | accent edge marker |
+| **Focused** (new) | as its other state | as its other state | 1.5 px `ACCENT` ring, inset 1 px, radius 4 |
+| Disabled | none | `TEXT_MUTED` @ 40 % | tooltip explains why |
+
+Precedence, resolved before any egui call so it stays testable:
+`disabled > pressed > active > hover > idle`. The focus ring composes on top
+of whichever of those won — it is a keyboard affordance, not a state.
+
+Two new tokens in `theme.rs`, no parallel palette:
+
+```rust
+/// Alpha of a "pressed" tint: a layer accent at 33% over the chrome. One
+/// step deeper than ACTIVE_TINT_ALPHA, so a press on an already-active
+/// button is still visible.
+const PRESS_TINT_ALPHA: u8 = 84;
+
+#[must_use]
+pub fn press_tint(accent: Color32) -> Color32 {
+    Color32::from_rgba_unmultiplied(accent.r(), accent.g(), accent.b(), PRESS_TINT_ALPHA)
+}
+
+/// `text/support` — small explanatory lines that carry real information
+/// (the inspector's locked/hidden notes). TEXT_FAINT stays reserved for
+/// decoration and disabled states, where 4.5:1 is not required.
+pub const TEXT_SUPPORT: Color32 = Color32::from_rgb(0x86, 0x92, 0xA4);
+```
+
+**Active edge marker.** A 2 px `ACCENT` bar hugging the button's **outer**
+edge — the one facing the window edge the rail is docked against — inset
+`ACTIVE_MARKER_INSET_PX` from both ends, radius 1 px. In a left rail it is a
+2×20 px vertical bar at the button's left; in a top rail a 20×2 px horizontal
+bar at the button's top. It rotates with the dock and is the single detail
+that makes the armed tool findable in peripheral vision.
+
+```rust
+// widgets.rs
+pub const ACTIVE_MARKER_WIDTH_PX: f32 = 2.0;
+pub const ACTIVE_MARKER_INSET_PX: f32 = 6.0;
+pub const FOCUS_RING_WIDTH_PX: f32 = 1.5;
+```
+
+Corner radius stays `CORNER_RADIUS = 4.0`.
+
+### 2.5 Badges
+
+A badge is a pill in the button's trailing-bottom corner, inset 2 px:
+`BADGE_HEIGHT_PX = 12.0`, `BADGE_RADIUS_PX = 3.0`, `BADGE_TEXT_PX = 9.0`
+monospace, horizontal padding 3 px, `INSET` `#10141D` fill.
+
+- **Draft progress** on the armed tool while a multi-point object is being
+  placed: `1/3`, text in `ACCENT`. Answers "how many more clicks?" without a
+  status-bar trip. Absent for one-point tools.
+- **Object count** on the Objects button when the store is non-empty: the
+  item count, text in `TEXT_MUTED` — it is a reading, not a state. Counts
+  from ten upward render as-is; the badge grows, the button does not.
+
+### 2.6 Rail chrome
+
+Fill `CHROME` `#171B26`. **No four-sided stroke** — instead a single 1 px
+`BORDER` `#2E3648` line along the rail's chart-facing edge. The current
+`Frame::stroke` paints a hairline against the window edge too, which reads as
+a seam that is not there.
+
+Separators are 1 px `BORDER` lines spanning the rail's cross axis inset
+`TOOLBOX_SEPARATOR_INSET_PX` from both edges (so 28 px of line in a 44 px
+rail), with `TOOLBOX_GROUP_GAP_PX` of clear space on each side.
+
+Grip: `DOTS_SIX_VERTICAL` in a vertical rail, `DOTS_SIX` in a horizontal one —
+the dots always run across the rail, reading as something to take hold of.
+`TOOLBOX_GRIP_GLYPH_PX` = 14, `TEXT_FAINT` idle, `TEXT_MUTED` on hover, hit
+area `32 × TOOLBOX_GRIP_LENGTH_PX` (rotated for horizontal docks).
+
+### 2.7 Panel construction and declaration order
+
+```rust
+match dock {
+    Left   => SidePanel::left("drawing_toolbox_left"),
+    Right  => SidePanel::right("drawing_toolbox_right"),
+    Top    => TopBottomPanel::top("drawing_toolbox_top"),
+    Bottom => TopBottomPanel::bottom("drawing_toolbox_bottom"),
+}
+.exact_width(TOOLBOX_THICKNESS_PX)   // exact_height for the top/bottom pair
+.resizable(false)
+```
+
+Keep the current declaration order in `App::update`: menu → toolbar → status
+bar → **rail** → dock → pinned inspector → `CentralPanel`. Two consequences
+worth stating, because they are both correct and both free:
+
+- A vertical rail automatically spans only the space between the toolbar and
+  the status bar, because those panels are declared first.
+- When the rail and the dock are both on the right, the rail sits **outermost**
+  (against the window edge) and the dock sits inboard of it, matching
+  TradingView and keeping the rail's distance from the window edge constant
+  across docks.
+
+The rail remains outside `CentralPanel`, so the chart never renders behind it —
+the existing test `every_dock_position_reserves_space_outside_the_central_chart`
+extends to the two new docks unchanged in spirit.
+
+### 2.8 Length budget and overflow
+
+The rail never wraps and never scrolls. It has three stages, chosen from the
+available **long-axis** extent — the same rule in both orientations, so one
+function serves all four docks.
+
+Slot arithmetic: one button slot is `32 + 4 = 36` px; a separator block is
+`4 + 1 + 4 = 9` px; the grip block is `18 + 4 = 22` px.
+
+```
+full_length(n_tool_slots) =
+      MARGIN(6) + grip(22)
+    + modes(32 + 4 + 32 = 68) + sep(9)
+    + tools(n*32 + (n-1)*4)
+    + MIN_CLUSTER_GAP(12)
+    + sep(9) + globals(32 + 4 + 32 + 4 + 32 = 104) + sep(9) + objects(32)
+    + MARGIN(6)
+```
+
+For today's registry (`n = 4`: horizontal, rectangle, channel, fib family):
+
+| Stage | Trigger | Rail shows | Length |
+|---|---|---|---|
+| **Full** | available ≥ `417` | everything above | 417 px |
+| **Compact** | `345` ≤ available < `417` | Pointer, Crosshair, armed tool, More; full trailing cluster | 345 px |
+| **Minimal** | available < `345` | Pointer, armed tool, More, Objects | 191 px |
+
+- The armed tool always keeps a real slot; it is never buried in the flyout.
+- The More flyout (`DOTS_THREE`, replacing today's misleading `PLUS`) lists
+  everything the stage swallowed, by name and shortcut, in registry order:
+  Crosshair and the unarmed tools at Compact, plus repeat / hide-all /
+  lock-all at Minimal. The existing narrow-strip rule — *Pointer, the armed
+  tool and Objects always survive* — is preserved exactly; this spec only adds
+  the intermediate stage and makes the budget axis-aware.
+- Stage changes are hysteresis-free: pure functions of available extent, so a
+  window resize gives the same rail whichever direction it was dragged from.
+- **Minimum:** 191 px. The app opens at `1100 × 650` and sets no minimum
+  window size; add `with_min_inner_size([900.0, 560.0])` in `main.rs` so a
+  horizontal rail (191 px of a 900 px window) and a vertical rail (191 px of
+  560 px minus the 100 px of menu + toolbar + status bar = 460 px) are both
+  unreachable failure modes rather than clipped chrome.
+
+---
+
+## 3. Docking & drag
+
+### 3.1 From corners to edges
+
+`ToolboxDock` becomes four **edges**, not four corners:
+
+```rust
+pub enum ToolboxDock { #[default] Left, Right, Top, Bottom }
+```
+
+This is the behavioural change the third complaint asks for. `TopLeft`,
+`TopRight`, `BottomLeft` and `BottomRight` are gone; the layout-direction flip
+they controlled disappears with them (§2.2).
+
+**Default dock: `Left`.** TradingView-style, and the right choice here for a
+reason beyond familiarity — the right edge is already claimed by the price
+axis, the dock and the pinned inspector, while the left edge is empty in every
+shipped configuration.
+
+### 3.2 Drop rule — nearest edge, normalised
+
+Pixel distance would bias every drop toward the top or bottom, because the
+window is wider than it is tall. Normalise first, which partitions the screen
+into four triangles meeting at the centre:
+
+```rust
+fn nearest(pointer: Pos2, screen: Rect) -> ToolboxDock {
+    let left   = (pointer.x - screen.left())   / screen.width();
+    let right  = (screen.right() - pointer.x)  / screen.width();
+    let top    = (pointer.y - screen.top())    / screen.height();
+    let bottom = (screen.bottom() - pointer.y) / screen.height();
+    // ties resolve Left > Right > Top > Bottom, so the result is deterministic
+}
+```
+
+A release outside the screen rect clamps into it first; there is no "cancel by
+dropping outside".
+
+### 3.3 Grip and drag feedback
+
+- **Affordance.** The grip (§2.6) sets `CursorIcon::Grab` on hover and
+  `CursorIcon::Grabbing` while dragging. Hover text:
+  `"Drag to dock the toolbar on another edge"`.
+- **Feedback: an edge preview band, and nothing else.** While the drag is
+  live, an `egui::Area` at `Order::Foreground` covering the screen rect paints,
+  along the currently-nearest edge, a `TOOLBOX_THICKNESS_PX`-wide band filled
+  with `active_tint(ACCENT)` (`#8AB4F8` at alpha 56) and edged on its
+  chart-facing side with a `TOOLBOX_DROP_BAND_EDGE_PX = 3.0` line in solid
+  `ACCENT`. The band is the exact rectangle the rail will occupy, so the
+  preview is the answer, not an approximation of it.
+- **No cursor ghost.** A translucent copy of the rail trailing the pointer was
+  considered and cut: it duplicates information the band already carries, and
+  in a 44 px rail it is mostly empty space chasing the mouse. One accessory
+  removed.
+- The rail itself keeps painting in place during the drag — it does not go
+  translucent and does not vanish. Nothing moves until release.
+- The band updates every frame as the nearest edge changes, so crossing a
+  diagonal snaps the preview from one edge to the next; that snap *is* the
+  feedback that the partition exists.
+- **Escape cancels.** While a rail drag is live, `Esc` aborts it and keeps the
+  current dock. This becomes the topmost level of the app's existing escape
+  stack (rail drag → text input → draft → selection → Pointer); every level
+  below it is untouched.
+
+### 3.4 Keyboard and menu path
+
+Dragging is not the only path. The **View** menu's existing drawing-toolbox
+entry gains a sibling submenu:
+
+```
+View → Drawing toolbar → Left · Right · Top · Bottom     (radio, current checked)
+       Hide drawing toolbar                              (existing entry, renamed)
+```
+
+"Toolbox" becomes "toolbar" in user-facing strings throughout — it is a
+toolbar, and the code already calls the module `toolrail`.
+
+### 3.5 Persistence
+
+The dock is a `dock: ToolboxDock` field on `ToolRail`, session state today.
+It persists through the UI-state file named as the open question in
+`ux/ui-design-model.md` §13 — a `ui-state.toml` sibling of
+`indicators-state.toml` — alongside dock width, active dock tab and rail
+visibility, whenever that file lands. Until then a restart returns to `Left`.
+No new persistence mechanism is invented for this feature alone.
+
+---
+
+## 4. Properties inspector
+
+### 4.1 The two failures
+
+The popup lands on the drawing because `inspector_target_position` tries four
+candidates, and when none fits it falls back to `candidates[0]` — *right of the
+bounding box* — and then clamps that into the chart. On a wide object, or near
+the right edge, the clamp walks the panel straight back over the geometry. A
+blind first candidate is the worst possible fallback: it is the one position we
+already know does not fit.
+
+The popup eats clicks because `handle_navigation` reads the raw
+`primary_pressed` and hit-tests drawings **regardless of what the pointer is
+over**, deliberately, "so an already-selected drawing remains draggable even
+when its stroke or handle is underneath that inspector". With a horizontal line
+— whose stroke spans the whole chart width — that exception fires for a press
+anywhere on the inspector at that price row, and the press lands twice: once on
+the slider, once as the start of a drag.
+
+### 4.2 Placement algorithm
+
+Inputs: `bbox` (projected anchors expanded by `DRAWING_ANCHOR_RADIUS_PX` =
+12 px), `size` (the measured area rect, else `320 × 280`, or `360 × 280` for a
+tool with an extra tab), `chart` (`last_chart_area`, already excluding both
+axes and the live lane), `gap` = `INSPECTOR_OBJECT_GAP_PX` = 12 px.
+
+**Candidates, in preference order** — four beside the object, four in the
+chart's corners:
+
+| # | Position |
+|---|---|
+| C1 | `(bbox.right + gap, bbox.top)` — right of the object |
+| C2 | `(bbox.left - gap - w, bbox.top)` — left of it |
+| C3 | `(bbox.left, bbox.bottom + gap)` — below it |
+| C4 | `(bbox.left, bbox.top - gap - h)` — above it |
+| C5 | `(chart.left + gap, chart.top + gap)` — chart top-left |
+| C6 | `(chart.right - gap - w, chart.top + gap)` — chart top-right |
+| C7 | `(chart.left + gap, chart.bottom - gap - h)` — chart bottom-left |
+| C8 | `(chart.right - gap - w, chart.bottom - gap - h)` — chart bottom-right |
+
+**Selection:**
+
+1. Clamp **every** candidate into `chart` first, so the score is computed on
+   the rectangle that will actually be used — not on one that the clamp is
+   about to move.
+2. Score each clamped candidate by `intersect(rect, bbox).area()`, `0.0` when
+   disjoint.
+3. Pick the minimum. Break ties by the **greater** distance between
+   `rect.center()` and `bbox.center()`; break remaining ties by candidate
+   index. Deterministic, and at zero overlap the index tie-break reproduces
+   today's C1 → C2 → C3 → C4 preference exactly.
+
+The four corner candidates are what make "least overlap" meaningful: an object
+in the middle of the chart always has a clear corner unless the inspector is
+larger than a chart quadrant, and when it *is* larger, the corner that clips
+the object least wins instead of the corner the loop happened to reach first.
+
+**When even the best candidate is bad.** Rather than an overlap ratio
+threshold, reuse the trigger the previous spec already chose: if
+`chart.width() < INSPECTOR_AUTO_PIN_CHART_WIDTH_PX` (`1180.0`), the inspector
+**opens pinned** to the side panel, where it cannot overlap anything at all and
+the canvas pays for it honestly. Auto-pin applies only until the user expresses
+a preference: once the pin button is toggled in either direction, that choice
+holds for the session and the width rule stops firing.
+
+### 4.3 Manual position always wins
+
+- `inspector_moved` is set the first time the user drags the window and is
+  **never cleared automatically**. Selection changes, tool changes, new objects
+  and closing/reopening the inspector all leave the manual position alone.
+- One exception, and it is a repair rather than an override: if the stored
+  rectangle no longer fits inside `chart` (the window shrank, the dock opened,
+  a sub-pane appeared), clamp it back inside using the same clamp as §4.2 and
+  **keep** `inspector_moved` set. The user's intent survives; the off-screen
+  panel does not.
+- **Reset path:** double-clicking the title bar clears `inspector_moved` and
+  re-runs the placement algorithm on the current selection. The title bar's
+  hover text states this: `"Drag to move · double-click to reposition
+  automatically"`.
+
+### 4.4 Title bar
+
+A 28 px title bar (`INSPECTOR_TITLE_HEIGHT_PX`), leading to trailing:
+
+| Element | Icon | Behaviour |
+|---|---|---|
+| Grip + title | `DOTS_SIX_VERTICAL` 14 px `TEXT_FAINT`, then `tool.settings_title()` in `TEXT_PRIMARY` | the **whole title bar** is the drag area; the body never is, so a slider drag can never move the window |
+| Hide / Show | `EYE` / `EYE_SLASH` | per-object visibility; when hidden, the body's banner keeps the way back |
+| Pin | `PUSH_PIN` | active-tinted while pinned; docks to the side panel |
+| Close | `X` | deselects, mutates nothing |
+
+All three use `TOOLBAR_ICON` (16 px glyph / 28 px hit) so the bar stays 28 px,
+and all three carry tooltips naming the action and its resulting state. This
+replaces today's `small_button("Close")` / `("Pin")` / `("Hide")` text row.
+
+The **`DrawingActionBar` stays exactly as it is**: two full-width textual
+buttons, "Lock drawing" / "Unlock drawing" and "Delete drawing · Del", always
+visible, never behind a scroll, never glyph-only. The rule that destructive
+and protective actions are named in words applies to the body, not to standard
+window chrome. Likewise keep the locked/hidden explanatory lines, the inline
+delete confirmation for locked objects, the tab strip, and the Undo toast —
+all of it already matches the previous spec. The explanatory lines move from
+default text to the new `TEXT_SUPPORT` `#8692A4` token, which clears 4.5:1 on
+`CHROME` where `TEXT_FAINT` does not.
+
+### 4.5 Pointer routing
+
+**The inspector is opaque to the pointer.** No chart interaction reads a press
+that lands on it.
+
+Concretely, in `handle_navigation`, the entire drawing-interaction block —
+hover cursors, the selection click, and drag *initiation* — is gated on the
+pointer not being over a floating surface:
+
+```
+let over_chrome = ctx.is_pointer_over_area();   // any Area/Window/Panel above the canvas
+```
+
+When `over_chrome` is true, the chart does not hit-test drawings, does not set
+a cursor, does not select and does not start a drag. This covers the inspector,
+the object manager, the toast, the rail flyouts and every future popup with one
+rule instead of a list.
+
+**The current exception is removed.** Deciding the case the brief asks about —
+*a click on a drawing that lies under the inspector's edge* — the drawing does
+**not** receive it; the inspector does. The exception bought one rare
+convenience (dragging geometry hidden beneath the panel) at the cost of a
+common bug (every press near a horizontal line firing twice), and §4.2 removes
+most of its reason to exist: the inspector no longer sits on the selected
+object. The escape hatches are all cheap and discoverable — move the inspector
+by its title bar, pin it to the side, close it with `Esc`, or grab the object
+anywhere else along its geometry.
+
+**One carve-out, and it is about continuity, not priority:** the gate applies
+at *press* time only. A drag that started on the canvas keeps running while the
+pointer travels across the inspector, so moving an object under the panel never
+breaks mid-gesture. `drawing_drag.is_active()` already distinguishes these two
+moments.
+
+The inspector also stops going non-interactive during a drag: today it is
+built with `.interactable(!self.drawing_drag.is_active())`, which the previous
+spec explicitly forbids ("o inspetor nunca fica cinza/desabilitado durante
+drag"). With the press gate above, that workaround is no longer load-bearing
+and should go.
+
+### 4.6 Object manager placement
+
+The manager's fixed `(70, 140)` opening position assumed a top-left toolbox.
+It now opens `DRAWING_MANAGER_GAP_PX = 12.0` inboard of the rail's inner edge,
+aligned with the rail's leading end, clamped into `chart` — so it appears next
+to the button that opened it in all four docks.
+
+---
+
+## 5. Acceptance details
+
+Measurable checks an engineer can turn into unit tests. Each is a pure
+function of state that egui can drive headlessly, in the style of the existing
+`toolrail.rs` and `app.rs` test modules.
+
+**Rail geometry and layout**
+
+1. `TOOLBOX_THICKNESS_PX == 44.0`, and for each of the four docks the
+   `CentralPanel` rect is inset by exactly 44 px on that edge and by 0 px on
+   the other three (extends the existing
+   `every_dock_position_reserves_space_outside_the_central_chart`).
+2. `44.0 == 2.0 * TOOLBOX_MARGIN_PX + TOOLRAIL_ICON.hit`.
+3. In every dock, the Objects button's rect is the last one along the rail's
+   long axis, and its distance to the rail's trailing inner edge equals
+   `TOOLBOX_MARGIN_PX` — the trailing cluster is pinned, not packed.
+4. In every dock, the grip's rect precedes every button along the long axis.
+5. Rendering left, right, top and bottom at the same available extent yields
+   the same set of visible buttons — orientation changes positions, never
+   inventory.
+
+**Overflow staging**
+
+6. At Full extent (≥ 417 px for the shipped registry) every registry tool has
+   a rect except the folded family members, and the fib family occupies
+   exactly one.
+7. At Compact extent (345–416 px) the armed tool and Pointer and Crosshair and
+   Objects all have rects; an unarmed non-family tool has none.
+8. At Minimal extent (< 345 px) Pointer, the armed tool, More and Objects have
+   rects; Crosshair, hide-all and lock-all have none.
+9. Rendering at extent *E* after shrinking from a larger extent produces the
+   same stage as rendering at *E* after growing from a smaller one.
+10. The More flyout at each stage lists exactly the controls that lost their
+    slot — no duplicates, no omissions — comparing against `DRAWING_TOOLS`.
+
+**Docking**
+
+11. `ToolboxDock::nearest` on an 800 × 600 screen returns `Left` for
+    `(10, 300)`, `Right` for `(790, 300)`, `Top` for `(400, 10)` and `Bottom`
+    for `(400, 590)`.
+12. Normalisation holds on a wide screen: on 1920 × 600, `(300, 300)` returns
+    `Left`, not `Top` — the raw pixel distances are 300 vs 300, the normalised
+    ones 0.156 vs 0.5.
+13. Dragging the real grip and releasing at each of the four edge midpoints
+    docks there, driven through `egui::Context::run` exactly like today's
+    `dragging_the_real_grip_docks_at_each_screen_corner`.
+14. `Esc` during a live grip drag leaves `dock` unchanged.
+15. Default `ToolRail::new().dock == ToolboxDock::Left`.
+
+**Inspector placement**
+
+16. With a 40 × 40 bbox at the chart's centre and a 1400 × 800 chart, the
+    chosen rect does not intersect the bbox.
+17. With a bbox spanning 90 % of the chart, the chosen rect's overlap with the
+    bbox is less than or equal to that of all seven other clamped candidates.
+18. For every candidate the algorithm can return, `chart.contains_rect(rect)`
+    holds — the inspector never leaves the chart pane, so it can never cover
+    the price axis, the time axis or the live lane.
+19. With a bbox hugging the chart's right edge, the result is not C1 — the
+    old blind fallback is gone.
+20. Two calls with identical inputs return identical positions.
+
+**Inspector behaviour**
+
+21. After `inspector_moved` is set, changing the selection to a different
+    object leaves the window position unchanged.
+22. Shrinking the chart so the manual position falls outside it moves the
+    window back inside and leaves `inspector_moved` set.
+23. Double-clicking the title bar clears `inspector_moved`, and the next frame
+    places the window at `inspector_target_position`.
+24. With `chart.width() < 1180.0` and no user pin preference recorded, the
+    inspector opens pinned; after the user toggles the pin, a further
+    selection at the same width respects the user's choice.
+
+**Pointer routing**
+
+25. A press inside the inspector's rect that also lies on a selected
+    horizontal line's stroke leaves `drawing_drag == DrawingDrag::None` and
+    does not change the selection.
+26. A press on the chart that starts a drag, followed by pointer motion across
+    the inspector's rect, keeps the drag active and keeps moving the object.
+27. Hovering the inspector sets no chart cursor icon (no `Move`, no
+    `ResizeNwSe`, no `NotAllowed`).
+28. The inspector's `Window` is built with `interactable(true)` on every frame,
+    including frames where `drawing_drag.is_active()`.
+
+**Tokens**
+
+29. `press_tint(ACCENT) == Color32::from_rgba_unmultiplied(0x8A, 0xB4, 0xF8, 84)`
+    and its alpha exceeds `active_tint`'s, so a press on an armed button is
+    distinguishable.
+30. `icon_paint` precedence: disabled beats pressed beats active beats hover
+    beats idle, checked across the full boolean cross-product.
+31. `TEXT_SUPPORT == Color32::from_rgb(0x86, 0x92, 0xA4)`, and no rail or
+    inspector surface uses `AMBER` — grep-guarded the way the `libm` rule is
+    in the indicators crate.

--- a/docs/ux/ui-design-model.md
+++ b/docs/ux/ui-design-model.md
@@ -51,7 +51,7 @@ Inventory, from code:
 | Candle style editor | floating window | `candle_view.rs::draw_style_window` |
 | Market Replay browser | floating window (Ctrl+R) | `replay_view.rs::draw_browser` |
 | Replay transport | bottom panel (while replaying) | `replay_view.rs::draw_transport` |
-| Drawing toolbox | external 44 px top/bottom panel, corner-docked | `toolrail.rs` |
+| Drawing toolbar | external 44 px rail, edge-docked | `toolrail.rs` |
 | Selected-drawing inspector | floating window | `app.rs::draw_drawing_inspector` |
 | Timezone picker | floating area, pinned bottom-right | `app.rs::draw_timezone_selector` |
 | Header line (symbol · spec · bar counts · mode) | text painted on chart | `app.rs::draw_header` |
@@ -150,7 +150,7 @@ Icons (§6–§7 use them):
 |---|---|---|---|
 | 1 | Menu bar | 28 px | rare actions, discoverability, shortcuts (§10) |
 | 2 | Context toolbar | 44 px | source · bars · history · layers · look · panels (§6) |
-| 3 | Drawing toolbox | 44 px top/bottom, left/right aligned | cursor, crosshair, drawings (§7) |
+| 3 | Drawing toolbar | 44 px rail, edge-docked (default left) | cursor, crosshair, drawings (§7) |
 | 4 | Chart canvas | elastic | candles, flow layers, overlay legends, drawings |
 | 5 | Sub-panes | ≤ 40% of 4, max 3 | pane indicators: CVD, delta… (§9) |
 | 6 | Time axis | 24 px | time labels, x-zoom drag |
@@ -158,12 +158,14 @@ Icons (§6–§7 use them):
 | 8 | Dock | 280–360 px, collapsible to 36 | tabbed settings panels (§7) |
 | 9 | Price axis | 64 px | price labels, y-zoom drag |
 
-Vertical chrome while live with the drawing toolbox visible:
-28+44+44+24+28 = **168 px**. The toolbox can be hidden from **View**, or
-docked above the status area instead of below the context toolbar. In
-exchange, persistent chrome never covers the candles; only contextual floating
-windows such as the selected-drawing inspector may overlap them. Canvas layers
-remain limited to the legend and honest market markers.
+Vertical chrome while live with the drawing toolbar on its default left
+edge: 28+44+24+28 = **124 px** — a lateral rail spends horizontal budget,
+not the vertical budget where price lives. Docked top or bottom it costs the
+familiar 168 px, and it can be hidden from **View** or re-docked on any of
+the four edges. In exchange, persistent chrome never covers the candles;
+only contextual floating windows such as the selected-drawing inspector may
+overlap them. Canvas layers remain limited to the legend and honest market
+markers.
 
 **The rule that keeps this stable:** a new feature must claim a slot inside
 zones 1–9. If it genuinely cannot, the shell — not the feature — is what gets
@@ -201,18 +203,21 @@ bar §8) and both panel-opening buttons (the dock's tab strip replaces them).
 
 ![Tool rail and dock](img/04-tool-rail-dock.svg)
 
-> The diagram records the original vertical-rail skeleton. The corner-docked
-> external toolbox described below supersedes that rail geometry, and the
-> detailed [Drawing tools UX specification](drawing-tools-ux-spec.html) is
-> authoritative for drawing interactions beyond it: favourites/flyouts, the
-> repeat pin, the Objects manager, lock/visibility/delete semantics, the
-> keyboard grammar and the complete Fibonacci level editor.
+> The rail geometry, docking, button states and inspector placement are now
+> specified in [drawing-toolbar-ux.md](../drawing-toolbar-ux.md), which
+> supersedes the corner-docked toolbox this section used to describe. The
+> detailed [Drawing tools UX specification](drawing-tools-ux-spec.html)
+> stays authoritative for drawing interactions beyond the chrome:
+> favourites/flyouts, the repeat pin, the Objects manager,
+> lock/visibility/delete semantics, the keyboard grammar and the complete
+> Fibonacci level editor.
 
-**Drawing toolbox (external, 44 px).** Exclusive selection; exactly one tool
-is armed and `Esc` always returns to Pointer. Its grip docks the controls at
-the nearest of the four chart-shell corners: top-left, top-right, bottom-left
-or bottom-right. The top/bottom panel reserves layout space, so the toolbox
-never floats over market data.
+**Drawing toolbar (external, 44 px rail).** Exclusive selection; exactly one
+tool is armed and `Esc` always returns to Pointer. Its grip docks the rail
+against the nearest of the four window edges — left (the default), right,
+top or bottom — vertical on the lateral edges, horizontal on the others.
+The panel reserves layout space, so the toolbar never floats over market
+data.
 
 | Tool | Key | Notes |
 |---|---|---|
@@ -339,7 +344,7 @@ Where future features land — decided now, so they never claim new chrome:
 | Future feature | Toggle/entry | Settings | Canvas presence | Status |
 |---|---|---|---|---|
 | Indicators (M1–M5) | LAYERS icon + Insert menu | dock tab Indicators | legend rows, overlays, sub-panes | recompute progress |
-| Drawing tools | corner-docked toolbox | selected-object inspector | drawings layer | — |
+| Drawing tools | edge-docked toolbar | selected-object inspector | drawings layer | — |
 | Alerts | on indicator/level context | dock tab Alerts | triggered marker on bar | armed count + last fired |
 | Bot / strategy monitor | LAYERS icon | dock tab | order/position markers | connection + P&L cell |
 | Second chart / layouts | File → Layout | — | split canvas (zones 4–6 duplicate per chart; zones 1–3, 7–9 stay singular) | per-chart provenance |


### PR DESCRIPTION
## What

Redesigns the drawing-tools chrome to TradingView quality, driven by three complaints: the toolbar read as a placeholder, the properties popup opened on top of the drawing and ate clicks, and the toolbar could not dock on a lateral edge.

Design spec: `docs/drawing-toolbar-ux.md` (written by a dedicated UX pass; supersedes the corner-docked geometry in `ui-design-model.md` §7).

### Toolbar (`toolrail.rs`, rewritten)
- Four **edge** docks replace the four corners: a vertical 44 px rail on Left (new default) / Right, horizontal on Top / Bottom. Grip drag shows a drop-preview band on the candidate edge (normalised nearest-edge rule, so a wide window doesn't bias top/bottom); **Esc cancels** the drag; `View → Drawing toolbar` is the keyboard path.
- Leading / trailing clusters with the trailing cluster (repeat, hide-all, lock-all, Objects) **pinned to the rail's far end**; hairline separators; accent **edge marker** on the armed tool; new pressed state and focus ring; draft-progress and object-count badges.
- The two Fib tools fold into one **family slot** (declared per tool in the registry — no central match): left-click arms the last-used member, right-click or the caret corner opens a flyout listing members with shortcuts.
- Overflow has three axis-aware stages (Full 417 px / Compact 345 px / Minimal 191 px for the shipped registry); `main.rs` gains `with_min_inner_size` so the floor is unreachable.

### Inspector (`app.rs`)
- Placement scores **eight clamped candidates** (four beside the object, four chart corners) by least overlap — the blind `candidates[0]` fallback that parked the panel on top of the drawing is gone.
- A chart narrower than 1180 px opens the inspector **pinned**, until the user touches the pin (their preference then holds).
- Custom 28 px title bar: the whole bar drags (the body never does), icons for hide / pin / close; **manual position sticks for the session** — selection changes never snap it back, the only automatic move is a re-clamp when the pane shrinks; double-click the bar to re-arm auto placement.
- **The inspector is opaque to the pointer**: the raw-press exception that let a press land twice (once on the panel, once as a drawing drag — every press near a horizontal line hit it) is removed. The gate applies at press time only, so a drag that started on the canvas keeps running across the panel; the `interactable(!drag)` workaround is gone.
- The object manager opens beside the rail's inner edge in all four docks.

### Tokens (`theme.rs` / `widgets.rs`)
`press_tint()` (accent @ 33%), `TEXT_SUPPORT` for explanatory lines (4.5:1 on chrome), `TOOLRAIL_ICON` 18/32, active-marker + focus-ring constants, 350 ms tooltip delay. Amber stays provenance-only (grep-guarded test).

## Verification

- `cargo fmt --all -- --check` ✓ · `cargo clippy --workspace --all-targets -- -D warnings` ✓ · `cargo build --workspace` ✓ · `cargo test --workspace` ✓ (527 app tests; 43 new/updated across rail geometry, docking drag, overflow stages, family folding, placement, manual-position stickiness, auto-pin, pointer routing, tokens)
- arch-review run over the diff: 4 findings (per-frame registry refold, magic paint numbers ×2, missing manager-placement test) **fixed in `9af8ab3`**.

## Deferred (from arch-review)

- The tool-family port is exercised by a single real family (Fibonacci). A fake second family can't be registered from `toolrail` tests because `DrawingTool` wraps a private static trait object; when a second family lands, add a registry-level folding test for two adjacent distinct families.

## Behavioural changes to note

- Toolbar default moves from a top strip to a **left vertical rail**.
- `inspector_never_blocks_drawing_drag` encoded the old click-through exception and was replaced by two tests of the new contract (opaque press + drag continuity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016rZDvD7peQrgE5e9UvbTVG