### PR TITLE
docs: name the backtest runner as the next roadmap step

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,7 @@ The project is a Cargo workspace of small, one-way-dependent crates (`app` → `
 - **Market replay** — ✅ recorded sessions played back through the live feed channel, at 1×–50× (`crates/replay`)
 - **Desktop app** — ✅ native chart (egui) showing bars form in real time, with a Bookmap-inspired L2 liquidity heatmap (`crates/app`)
 - **Indicators & scripting** — ✅ an indicator runtime with incremental `ta.*` kernels, and "Quantick Pine", a Pine v5 subset compiled and run in-process, plotted on the chart and readable headlessly by a backtest or bot (`crates/indicators`, `crates/pine`)
+- **Backtest runner** — ⏳ next up: a headless strategy runner over recorded sessions, consuming the exact engine and indicator path the chart draws
 - **Bindings** — ⏳ Python bindings and a C API are planned, so the engine plugs into existing backtest stacks and bots in any language
 
 ## Design principles
@@ -341,10 +342,12 @@ The project is a Cargo workspace of small, one-way-dependent crates (`app` → `
 - [x] Imbalance bars (López de Prado information-driven sampling)
 - [x] MetaTrader 5 feed
 - [x] Bookmap-inspired L2 liquidity heatmap (egui/glow; wgpu migration still open)
-- [x] Market replay of recorded sessions (trades; depth replay still open)
+- [x] Market replay of recorded sessions (trades only; depth is the open item below)
 - [x] CVD & delta visuals (native EMA/CVD indicators, delta histograms, order-flow series in scripts)
 - [x] Scriptable indicators — "Quantick Pine", a Pine v5 subset with order-flow builtins (`delta`, `cvd`, `buy_volume`, …), drawing objects, hot reload and a persisted indicator set; see [docs/pine-dialect.md](docs/pine-dialect.md)
-- [ ] Python bindings
+- [ ] **Next up: backtest runner** — a headless crate + CLI that replays a recorded session through the exact bar/indicator path the chart uses and executes a strategy's orders against the tape, with a disclosed, conservative fill model; strategies read indicator plot columns, and the order/fill/position core is designed to be shared with a future paper-trading simulator
+- [ ] Depth replay — record L2 depth alongside a session's trades, so the liquidity heatmap works in market replay and the book pipeline gets deterministic fixtures
+- [ ] Python bindings, once the backtest runner has exercised the engine API from outside the chart
 - [ ] C API, so bots in C++ (or any language) can consume the engine
 
 ## Contributing


### PR DESCRIPTION
## What

Docs-only. The README roadmap now names the **backtest runner** as the next step, adds **depth replay** as an explicit open item, and sequences Python bindings / C API after them. The architecture status list gains the matching ⏳ line.

## Why — decided by a three-lens agent panel

Three independent agents ranked six candidates (Python bindings, C API, wgpu migration, depth replay, issue #68 analytics, native backtest runner):

- **User/adoption value (quant lens)** — picked depth replay first: the heatmap is the signature feature and it disables itself in replay today. Ranked the backtest runner 4th on sequencing concerns (see below, both were refuted on the facts).
- **Architectural leverage (tech-lead lens)** — picked the backtest runner first: it creates the *second real consumer* of the engine. "One engine, three consumers" is currently proven only on the read side (`crates/indicators/tests/bot_readiness.rs`); the write side (order, fill, position, P&L) exists nowhere. Exposing FFI before a second in-repo consumer risks freezing the wrong API — how `rust_decimal::Decimal` crosses the boundary is still an open question.
- **Cost/risk against the real code** — picked the backtest runner first: the headless chain already exists and passes CI today (session → bars → `IndicatorHost` → plot columns → a strategy loop, all in `bot_readiness.rs`); the engine API is effectively frozen (6 commits to `crates/engine/src` in the repo's entire history); the only genuinely new piece is the execution core, whose conservative tape-based fill semantics are already specified.

**Decision: backtest runner next**, with `strategy.*` explicitly deferred — the Pine dialect already rejects it by design (`PINE_NO_STRATEGY`: "backtesting consumes their plots through the host instead"), so v1 strategies read indicator plot columns. The order/fill/position core is designed as a shared crate the future paper-trading simulator also consumes — built once, no forked execution logic.

Why the runners-up wait:

- **Depth replay** — next in line, kept as an explicit roadmap item: it un-breaks the heatmap in replay, gives the book pipeline deterministic fixtures, and is a stated validation prerequisite of issue #68.
- **Python bindings** — cheaper and safer once the runner has exercised the engine API from outside the chart; the Decimal-across-FFI representation gets decided by real usage instead of speculation.
- **C API** — a permanent ABI with no proven demand yet; stays last.
- **Issue #68 analytics** — an epic, not a next step: it needs depth replay for validation, and `crates/app` is binary-only, so "chart and bot read the same series" first requires extracting `orderflow/` into a crate.
- **wgpu migration** — the mechanical backend swap is ~one line and buys nothing (the documented hot cost is CPU tessellation, identical on both backends); the expensive custom-pipeline version has no measurement justifying it.

## Verification

- `cargo fmt --all -- --check` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo build --workspace` ✅
- `cargo test --workspace` ✅
- `arch-review` over the diff: two minor standardisation/readability findings, both fixed in this diff; no Blockers, no Should-fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)