### PR TITLE
feat: give indicator panes their own y-axis and zoom

### DIFF
--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -198,6 +198,16 @@ fn dec_from_f64(x: f64) -> Decimal {
 /// so.
 const LANE_HANDLE_HALF_WIDTH_PX: f32 = 5.0;
 
+/// Pixels of drag on a vertical axis that change its span by a factor of `e`.
+///
+/// One number for the price gutter and for every indicator pane's gutter: the
+/// axes stretch at the same rate, so the gesture feels the same wherever the
+/// numbers being dragged happen to live.
+const AXIS_ZOOM_DRAG_PX: f32 = 150.0;
+/// The same, for a scroll over an axis rather than a drag. Scroll deltas are
+/// coarser than pointer motion, so the divisor is smaller.
+const AXIS_ZOOM_SCROLL_PX: f32 = 200.0;
+
 /// Pixels of drag on the lane's own time strip that double or halve its window.
 ///
 /// Matches the candles' own feel: dragging the time axis zooms it by
@@ -222,19 +232,27 @@ fn plot_split(area: egui::Rect, live_strip_width: f32, pane_count: usize) -> Plo
     let split_y = (plot.bottom() - TIME_STRIP).max(plot.top() + 20.0);
     let body = egui::Rect::from_min_max(plot.min, egui::pos2(split_x, split_y));
     let (chart, indicator_panes) = crate::indicators::split_panes(body, pane_count);
+    // The gutter is banded exactly like the body it labels: the candles' price
+    // scale owns the height of the candles and not a pixel more, so a drag
+    // over a pane's numbers can only ever move that pane.
+    let band = |top: f32, bottom: f32| {
+        egui::Rect::from_min_max(egui::pos2(gutter_x, top), egui::pos2(plot.right(), bottom))
+    };
+    let pane_gutters = indicator_panes
+        .iter()
+        .map(|pane| band(pane.top(), pane.bottom()))
+        .collect();
     PlotAreas {
         chart,
         indicator_panes,
+        pane_gutters,
         live_strip: (strip_width > 0.0).then(|| {
             egui::Rect::from_min_max(
                 egui::pos2(split_x, plot.top()),
                 egui::pos2(gutter_x, split_y),
             )
         }),
-        price_gutter: egui::Rect::from_min_max(
-            egui::pos2(gutter_x, plot.top()),
-            egui::pos2(plot.right(), split_y),
-        ),
+        price_gutter: band(plot.top(), chart.bottom()),
         time_strip: egui::Rect::from_min_max(
             egui::pos2(plot.left(), split_y),
             egui::pos2(split_x, plot.bottom()),
@@ -280,6 +298,9 @@ struct PlotAreas {
     /// Stacked indicator panes below the candles, top to bottom. Empty when
     /// no pane indicator is visible.
     indicator_panes: Vec<egui::Rect>,
+    /// The gutter band beside each pane, in the same order: where that pane's
+    /// value labels are drawn and where its own zoom gesture lives.
+    pane_gutters: Vec<egui::Rect>,
     /// Present only while the strip is shown; sits between `chart` and
     /// `price_gutter` and is not an input region.
     live_strip: Option<egui::Rect>,
@@ -437,6 +458,11 @@ pub struct QuantickApp {
     last_auto_range: Option<(f64, f64)>,
     last_chart_height: f32,
     last_chart_top: f32,
+    // The raw plot area the last frame split into chart, panes and gutters.
+    // Kept so a caller that needs a band it does not otherwise see — the pane
+    // axis tests aiming a drag at a pane's own gutter — asks `plot_split` for
+    // it rather than re-deriving the layout and drifting from it.
+    last_plot_area: Option<egui::Rect>,
     // Pointer position over the plot this frame, for the crosshair.
     hover_pos: Option<egui::Pos2>,
     // Drawing placement/movement state. Anchors are chart coordinates; only
@@ -581,6 +607,7 @@ impl QuantickApp {
             last_auto_range: None,
             last_chart_height: 1.0,
             last_chart_top: 0.0,
+            last_plot_area: None,
             hover_pos: None,
             drawing_hover: None,
             drawing_press_position: None,
@@ -2288,6 +2315,7 @@ impl QuantickApp {
     /// that starts inside the tape moves nothing, and scrolling there zooms the
     /// tape's own window instead of the candles.
     fn handle_navigation(&mut self, ui: &egui::Ui, area: egui::Rect) {
+        self.last_plot_area = Some(area);
         // Remembered for inspector placement and manager centring: the pane
         // where drawings live, already free of both axes and the live lane.
         self.last_chart_area = Some(
@@ -2572,7 +2600,8 @@ impl QuantickApp {
             }
         }
 
-        // Right price gutter: drag or scroll to zoom the price scale.
+        // Right price gutter: drag or scroll to zoom the price scale. It spans
+        // the candles' height only — the bands below belong to the panes.
         let price = ui.interact(
             areas.price_gutter,
             egui::Id::new("price_nav"),
@@ -2581,8 +2610,10 @@ impl QuantickApp {
         if let Some(auto) = auto {
             if price.dragged() {
                 // Drag up → compress span (bigger candles); down → expand.
-                self.price_view
-                    .zoom(f64::from(price.drag_delta().y / 150.0).exp(), auto);
+                self.price_view.zoom(
+                    f64::from(price.drag_delta().y / AXIS_ZOOM_DRAG_PX).exp(),
+                    auto,
+                );
             }
             if price.double_clicked() {
                 self.price_view.reset();
@@ -2590,8 +2621,44 @@ impl QuantickApp {
             if price.hovered() {
                 let scroll = ui.input(|i| i.raw_scroll_delta.y);
                 if scroll.abs() > 0.0 {
-                    self.price_view.zoom(f64::from(-scroll / 200.0).exp(), auto);
+                    self.price_view
+                        .zoom(f64::from(-scroll / AXIS_ZOOM_SCROLL_PX).exp(), auto);
                 }
+            }
+        }
+
+        // Each pane's own axis, in the gutter band beside it: the price
+        // gutter's gesture aimed at the pane under the pointer. Keyed by slot,
+        // so the scale that moves is always the one whose numbers were
+        // grabbed — panes come and go and a positional id would follow the
+        // position, not the indicator.
+        let pane_gutters = areas.pane_gutters.clone();
+        let scroll = ui.input(|i| i.raw_scroll_delta.y);
+        for (view, gutter) in self.indicators.visible_panes_mut().zip(&pane_gutters) {
+            let pane_axis = ui.interact(
+                *gutter,
+                egui::Id::new(("pane_price_nav", view.slot)),
+                egui::Sense::click_and_drag(),
+            );
+            if pane_axis.double_clicked() {
+                view.scale.reset();
+            }
+            // Nothing computed yet is nothing to scale: the pane says "warming
+            // up" and its axis has no range a gesture could stretch.
+            let Some(auto) = view.last_auto else {
+                continue;
+            };
+            if pane_axis.dragged() {
+                // Drag up → compress the pane's span (a taller trace); down →
+                // expand it. Same pixels, same feel as the price axis.
+                view.scale.zoom(
+                    f64::from(pane_axis.drag_delta().y / AXIS_ZOOM_DRAG_PX).exp(),
+                    auto,
+                );
+            }
+            if pane_axis.hovered() && scroll.abs() > 0.0 {
+                view.scale
+                    .zoom(f64::from(-scroll / AXIS_ZOOM_SCROLL_PX).exp(), auto);
             }
         }
     }
@@ -2804,21 +2871,37 @@ impl QuantickApp {
             );
         }
         // Pane indicators stack in the band carved off above, sharing the
-        // candles' x-mapping so bars and their flow read as one chart.
-        for (view, pane) in self.indicators.visible_panes().zip(&pane_rects) {
-            let pane = egui::Rect::from_min_max(
-                egui::pos2(history_rect.left(), pane.top()),
-                egui::pos2(history_rect.right(), pane.bottom()),
-            );
+        // candles' x-mapping so bars and their flow read as one chart. Each
+        // pane records the range it auto-fitted to, so the gesture over its
+        // axis zooms the very range this frame drew.
+        let grid = self.grid();
+        let pane_gutters = areas.pane_gutters.clone();
+        for ((view, pane), gutter) in self
+            .indicators
+            .visible_panes_mut()
+            .zip(&pane_rects)
+            .zip(&pane_gutters)
+        {
+            let auto = indicator_render::pane_auto_range(view, start, end);
+            view.last_auto = auto;
+            let frame = indicator_render::PaneFrame {
+                rect: egui::Rect::from_min_max(
+                    egui::pos2(history_rect.left(), pane.top()),
+                    egui::pos2(history_rect.right(), pane.bottom()),
+                ),
+                gutter: *gutter,
+                background: canvas_background,
+                grid,
+            };
             indicator_render::draw_pane(
                 painter,
-                pane,
+                &frame,
                 view,
                 &plot_x,
+                auto.map(|auto| view.scale.resolve(auto)),
                 start,
                 end,
                 partial_visible.map(|_| closed.len()),
-                canvas_background,
             );
         }
         if let Some(frame) = &orderflow_frame {
@@ -4416,13 +4499,301 @@ mod tests {
         assert_eq!(one.chart.bottom(), pane.top(), "no gap, no overlap");
         assert_eq!(pane.bottom(), none.chart.bottom());
         assert_eq!(one.chart.width(), none.chart.width());
-        // The axes stay where they were: only the candle body shrinks.
-        assert_eq!(one.price_gutter, none.price_gutter);
+        // The axes keep their column; the time strip is untouched.
+        assert_eq!(one.price_gutter.x_range(), none.price_gutter.x_range());
         assert_eq!(one.time_strip, none.time_strip);
 
         let three = plot_split(area, 0.0, 3);
         assert_eq!(three.indicator_panes.len(), 3);
         assert!(three.chart.height() < one.chart.height());
+    }
+
+    /// The gutter is banded like the body it labels. Before it was, the whole
+    /// column belonged to the candles: dragging the numbers beside a CVD pane
+    /// stretched the *price* scale, and the pane — which had no axis at all —
+    /// did not move.
+    #[test]
+    fn every_pane_owns_the_gutter_band_beside_it() {
+        let area = egui::Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(1000.0, 600.0));
+
+        let none = plot_split(area, 0.0, 0);
+        assert!(none.pane_gutters.is_empty());
+        assert_eq!(
+            none.price_gutter.bottom(),
+            none.chart.bottom(),
+            "with no pane the gutter is the candles', top to bottom"
+        );
+
+        let two = plot_split(area, 0.0, 2);
+        assert_eq!(two.pane_gutters.len(), two.indicator_panes.len());
+        assert_eq!(
+            two.price_gutter.bottom(),
+            two.chart.bottom(),
+            "the candles' scale stops where the candles do"
+        );
+        for (pane, gutter) in two.indicator_panes.iter().zip(&two.pane_gutters) {
+            assert_eq!(gutter.y_range(), pane.y_range(), "band beside its pane");
+            assert_eq!(gutter.x_range(), two.price_gutter.x_range(), "one column");
+        }
+        // No pixel answers to two scales: the bands tile the gutter exactly.
+        assert_eq!(two.price_gutter.bottom(), two.pane_gutters[0].top());
+        assert_eq!(two.pane_gutters[0].bottom(), two.pane_gutters[1].top());
+
+        // The strip pays out of the candles, not the gutter: the pane bands
+        // keep the same column when the tape is shown.
+        let with_strip = plot_split(area, crate::live_strip::LIVE_STRIP_WIDTH_PX, 2);
+        assert_eq!(with_strip.pane_gutters, two.pane_gutters);
+    }
+
+    /// A pane indicator with `values` as its single plot, delivered the way
+    /// the worker delivers one.
+    fn add_pane_indicator(app: &mut QuantickApp, title: &str, values: Vec<f64>) -> SlotId {
+        let slot = app.indicators.allocate_slot();
+        rebuild_pane_indicator(app, slot, title, values);
+        slot
+    }
+
+    /// The same indicator, recomputed — an edited input, a hot reload, older
+    /// trades re-cutting the series.
+    fn rebuild_pane_indicator(app: &mut QuantickApp, slot: SlotId, title: &str, values: Vec<f64>) {
+        app.indicators.apply(IndicatorEvent::Rebuilt {
+            slot,
+            descriptor: quantick_indicators::IndicatorDescriptor {
+                title: title.to_owned(),
+                short_title: None,
+                overlay: false,
+                plots: vec![quantick_indicators::PlotSpec {
+                    id: quantick_indicators::PlotId::new(0),
+                    title: title.to_owned(),
+                    style: quantick_indicators::PlotStyle::Line,
+                    base_color: quantick_indicators::Rgba8::opaque(255, 255, 255),
+                    width: 1.0,
+                    offset: 0,
+                    marker: None,
+                }],
+                inputs: Vec::new(),
+                fills: Vec::new(),
+            },
+            columns: vec![values],
+            inputs: Vec::new(),
+            stale: None,
+        });
+    }
+
+    /// The `(lo, hi)` a pane is drawing with right now: its manual range if the
+    /// user has taken control of the axis, else the fit the last frame made.
+    fn pane_range(app: &QuantickApp, slot: SlotId) -> (f64, f64) {
+        let view = app
+            .indicators
+            .all()
+            .iter()
+            .find(|view| view.slot == slot)
+            .expect("the pane is still there");
+        let auto = view.last_auto.expect("a frame fitted this pane");
+        view.scale.resolve(auto)
+    }
+
+    /// Whether a pane is still auto-fitting its values.
+    fn pane_is_auto(app: &QuantickApp, slot: SlotId) -> bool {
+        app.indicators
+            .all()
+            .iter()
+            .find(|view| view.slot == slot)
+            .expect("the pane is still there")
+            .scale
+            .is_auto()
+    }
+
+    /// The gutter band beside pane `index`, computed the way the frame does.
+    fn pane_gutter(app: &QuantickApp, index: usize) -> egui::Rect {
+        let areas = plot_split(
+            app.last_plot_area.expect("a frame has been drawn"),
+            app.live_strip_width(),
+            app.indicators.visible_panes().count(),
+        );
+        areas.pane_gutters[index]
+    }
+
+    /// The headline of this feature: a pane's numbers are its own axis. A drag
+    /// there stretches that pane and nothing else — before the gutter was
+    /// banded, the same pixels moved the *candles'* price scale, and the pane
+    /// had no axis to grab at all.
+    #[test]
+    fn dragging_a_pane_axis_zooms_that_pane_and_nothing_else() {
+        let (mut app, _cmd_rx) = app_with_history(200);
+        let ctx = egui::Context::default();
+        let flow = add_pane_indicator(&mut app, "cvd", (0..200).map(f64::from).collect());
+        let other = add_pane_indicator(&mut app, "delta", (0..200).map(f64::from).collect());
+        run_frame(&mut app, &ctx); // the frame that fits each pane and records it
+
+        let gutter = pane_gutter(&app, 0);
+        let (lo, hi) = pane_range(&app, flow);
+        let untouched = pane_range(&app, other);
+        drag_chart(
+            &mut app,
+            &ctx,
+            gutter.center(),
+            gutter.center() - egui::vec2(0.0, 60.0),
+        );
+
+        let (zoomed_lo, zoomed_hi) = pane_range(&app, flow);
+        assert!(
+            zoomed_hi - zoomed_lo < hi - lo,
+            "drag up compresses the span: {lo}..{hi} -> {zoomed_lo}..{zoomed_hi}"
+        );
+        assert!(
+            (f64::midpoint(zoomed_lo, zoomed_hi) - f64::midpoint(lo, hi)).abs() < 1e-6,
+            "and stretches around the middle rather than sliding the pane"
+        );
+        assert_eq!(pane_range(&app, other), untouched, "one pane, one scale");
+        assert!(
+            app.price_view.is_auto(),
+            "the candles never felt it: their gutter ends where they do"
+        );
+    }
+
+    /// The other half of the isolation: the candles' own gutter must not reach
+    /// down into a pane. Both gestures exist on the same column of pixels, and
+    /// only the band decides which scale they mean.
+    #[test]
+    fn dragging_the_price_gutter_leaves_every_pane_alone() {
+        let (mut app, _cmd_rx) = app_with_history(200);
+        let ctx = egui::Context::default();
+        let flow = add_pane_indicator(&mut app, "cvd", (0..200).map(f64::from).collect());
+        run_frame(&mut app, &ctx);
+
+        let untouched = pane_range(&app, flow);
+        let gutter = plot_split(
+            app.last_plot_area.expect("a frame has been drawn"),
+            app.live_strip_width(),
+            1,
+        )
+        .price_gutter;
+        drag_chart(
+            &mut app,
+            &ctx,
+            gutter.center(),
+            gutter.center() - egui::vec2(0.0, 60.0),
+        );
+
+        assert!(!app.price_view.is_auto(), "the candles took the drag");
+        assert_eq!(
+            pane_range(&app, flow),
+            untouched,
+            "and the pane never felt it"
+        );
+        assert!(pane_is_auto(&app, flow));
+    }
+
+    /// Scroll is the same gesture with a wheel: it zooms the pane under the
+    /// pointer, and the candles keep auto-fitting.
+    #[test]
+    fn scrolling_a_pane_axis_zooms_that_pane() {
+        let (mut app, _cmd_rx) = app_with_history(200);
+        let ctx = egui::Context::default();
+        let flow = add_pane_indicator(&mut app, "cvd", (0..200).map(f64::from).collect());
+        run_frame(&mut app, &ctx);
+
+        let (lo, hi) = pane_range(&app, flow);
+        let over = pane_gutter(&app, 0).center();
+        run_frame_with_events(
+            &mut app,
+            &ctx,
+            vec![
+                egui::Event::PointerMoved(over),
+                egui::Event::MouseWheel {
+                    unit: egui::MouseWheelUnit::Point,
+                    delta: egui::vec2(0.0, 120.0),
+                    modifiers: egui::Modifiers::NONE,
+                },
+            ],
+        );
+
+        let (zoomed_lo, zoomed_hi) = pane_range(&app, flow);
+        assert!(
+            zoomed_hi - zoomed_lo < hi - lo,
+            "scrolling up zooms in: {lo}..{hi} -> {zoomed_lo}..{zoomed_hi}"
+        );
+        assert!(app.price_view.is_auto(), "the candles kept auto-fitting");
+    }
+
+    /// Manual control is manual: the range holds while values keep arriving,
+    /// and a double-click on the axis hands the pane back to auto-fit.
+    #[test]
+    fn a_zoomed_pane_holds_its_range_until_the_axis_is_double_clicked() {
+        let (mut app, _cmd_rx) = app_with_history(200);
+        let ctx = egui::Context::default();
+        let flow = add_pane_indicator(&mut app, "cvd", (0..200).map(f64::from).collect());
+        run_frame(&mut app, &ctx);
+
+        let gutter = pane_gutter(&app, 0);
+        drag_chart(
+            &mut app,
+            &ctx,
+            gutter.center(),
+            gutter.center() - egui::vec2(0.0, 60.0),
+        );
+        let held = pane_range(&app, flow);
+        assert!(!pane_is_auto(&app, flow), "the drag took manual control");
+
+        // The indicator recomputes ten times bigger: auto-fit would jump, a
+        // range the user set does not.
+        rebuild_pane_indicator(
+            &mut app,
+            flow,
+            "cvd",
+            (0..200).map(|row| f64::from(row) * 10.0).collect(),
+        );
+        run_frame(&mut app, &ctx);
+        assert_eq!(pane_range(&app, flow), held, "the range the user set holds");
+
+        click_chart(&mut app, &ctx, gutter.center());
+        click_chart(&mut app, &ctx, gutter.center());
+        run_frame(&mut app, &ctx);
+        assert!(
+            pane_is_auto(&app, flow),
+            "double-click returns the pane to auto-fit"
+        );
+        let refitted = pane_range(&app, flow);
+        assert!(
+            refitted.1 > held.1,
+            "and auto-fit sees the values that arrived meanwhile: {refitted:?} vs {held:?}"
+        );
+    }
+
+    /// The pane reads as a chart: its own round numbers, in the gutter beside
+    /// it. The candles' axis never labels those pixels, and the pane's labels
+    /// never appear over the candles.
+    #[test]
+    fn a_pane_prints_its_own_value_labels_in_the_gutter() {
+        let (mut app, _cmd_rx) = app_with_history(200);
+        let ctx = egui::Context::default();
+        // Values well away from the test's 95..115 price range, so a label can
+        // only have come from the pane's own axis.
+        add_pane_indicator(
+            &mut app,
+            "cvd",
+            (0..200).map(|row| f64::from(row) - 200.0).collect(),
+        );
+        let output = run_frame(&mut app, &ctx);
+        let texts = painted_text(&output);
+
+        let pane_labels: Vec<&String> = texts
+            .iter()
+            .filter(|text| {
+                text.parse::<f64>()
+                    .is_ok_and(|value| (-200.0..=-1.0).contains(&value))
+            })
+            .collect();
+        assert!(
+            pane_labels.len() >= 3,
+            "the pane's own round numbers are drawn, and enough of them to \
+             read as a scale: {texts:?}"
+        );
+        assert!(
+            has_price_axis(&texts),
+            "and the candles keep theirs: {texts:?}"
+        );
     }
 
     /// Each pane zooms from the strip under it, and the split is exactly the

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -204,9 +204,49 @@ const LANE_HANDLE_HALF_WIDTH_PX: f32 = 5.0;
 /// axes stretch at the same rate, so the gesture feels the same wherever the
 /// numbers being dragged happen to live.
 const AXIS_ZOOM_DRAG_PX: f32 = 150.0;
-/// The same, for a scroll over an axis rather than a drag. Scroll deltas are
-/// coarser than pointer motion, so the divisor is smaller.
+/// The same, for a scroll over an axis rather than a drag. One wheel notch
+/// reports far more units than a pointer travels in a frame, so each unit has
+/// to count for less — a larger divisor, not a smaller one.
 const AXIS_ZOOM_SCROLL_PX: f32 = 200.0;
+
+/// The gesture that scales a vertical axis, wherever its numbers live: drag up
+/// to compress the span, down to expand, scroll to zoom, double-click to hand
+/// the axis back to auto-fit.
+///
+/// One implementation for the price gutter and for every indicator pane's, so
+/// a third band that wants an axis — a volume profile, the tape — registers it
+/// rather than copying it, and no two axes can drift apart in feel.
+///
+/// `auto` is the range the last frame fitted; `None` means nothing has been
+/// computed to scale yet, and only the reset stays available.
+fn axis_zoom_gesture(
+    ui: &egui::Ui,
+    id: egui::Id,
+    band: egui::Rect,
+    view: &mut PriceView,
+    auto: Option<(f64, f64)>,
+) {
+    let response = ui.interact(band, id, egui::Sense::click_and_drag());
+    if response.double_clicked() {
+        view.reset();
+    }
+    let Some(auto) = auto else {
+        return;
+    };
+    if response.dragged() {
+        // Drag up → compress the span (a taller trace); down → expand it.
+        view.zoom(
+            f64::from(response.drag_delta().y / AXIS_ZOOM_DRAG_PX).exp(),
+            auto,
+        );
+    }
+    if response.hovered() {
+        let scroll = ui.input(|input| input.raw_scroll_delta.y);
+        if scroll.abs() > 0.0 {
+            view.zoom(f64::from(-scroll / AXIS_ZOOM_SCROLL_PX).exp(), auto);
+        }
+    }
+}
 
 /// Pixels of drag on the lane's own time strip that double or halve its window.
 ///
@@ -2600,66 +2640,28 @@ impl QuantickApp {
             }
         }
 
-        // Right price gutter: drag or scroll to zoom the price scale. It spans
-        // the candles' height only — the bands below belong to the panes.
-        let price = ui.interact(
-            areas.price_gutter,
+        // Right price gutter: the candles' own axis gesture. It spans their
+        // height only — the bands below belong to the panes.
+        axis_zoom_gesture(
+            ui,
             egui::Id::new("price_nav"),
-            egui::Sense::click_and_drag(),
+            areas.price_gutter,
+            &mut self.price_view,
+            auto,
         );
-        if let Some(auto) = auto {
-            if price.dragged() {
-                // Drag up → compress span (bigger candles); down → expand.
-                self.price_view.zoom(
-                    f64::from(price.drag_delta().y / AXIS_ZOOM_DRAG_PX).exp(),
-                    auto,
-                );
-            }
-            if price.double_clicked() {
-                self.price_view.reset();
-            }
-            if price.hovered() {
-                let scroll = ui.input(|i| i.raw_scroll_delta.y);
-                if scroll.abs() > 0.0 {
-                    self.price_view
-                        .zoom(f64::from(-scroll / AXIS_ZOOM_SCROLL_PX).exp(), auto);
-                }
-            }
-        }
 
-        // Each pane's own axis, in the gutter band beside it: the price
-        // gutter's gesture aimed at the pane under the pointer. Keyed by slot,
-        // so the scale that moves is always the one whose numbers were
-        // grabbed — panes come and go and a positional id would follow the
-        // position, not the indicator.
-        let pane_gutters = areas.pane_gutters.clone();
-        let scroll = ui.input(|i| i.raw_scroll_delta.y);
-        for (view, gutter) in self.indicators.visible_panes_mut().zip(&pane_gutters) {
-            let pane_axis = ui.interact(
-                *gutter,
+        // The same gesture, once per pane, over the gutter band beside it.
+        // Keyed by slot, so the scale that moves is always the one whose
+        // numbers were grabbed — panes come and go, and a positional id would
+        // follow the position rather than the indicator.
+        for (view, gutter) in self.indicators.visible_panes_mut().zip(&areas.pane_gutters) {
+            axis_zoom_gesture(
+                ui,
                 egui::Id::new(("pane_price_nav", view.slot)),
-                egui::Sense::click_and_drag(),
+                *gutter,
+                &mut view.scale,
+                view.last_auto,
             );
-            if pane_axis.double_clicked() {
-                view.scale.reset();
-            }
-            // Nothing computed yet is nothing to scale: the pane says "warming
-            // up" and its axis has no range a gesture could stretch.
-            let Some(auto) = view.last_auto else {
-                continue;
-            };
-            if pane_axis.dragged() {
-                // Drag up → compress the pane's span (a taller trace); down →
-                // expand it. Same pixels, same feel as the price axis.
-                view.scale.zoom(
-                    f64::from(pane_axis.drag_delta().y / AXIS_ZOOM_DRAG_PX).exp(),
-                    auto,
-                );
-            }
-            if pane_axis.hovered() && scroll.abs() > 0.0 {
-                view.scale
-                    .zoom(f64::from(-scroll / AXIS_ZOOM_SCROLL_PX).exp(), auto);
-            }
         }
     }
 
@@ -2875,12 +2877,11 @@ impl QuantickApp {
         // pane records the range it auto-fitted to, so the gesture over its
         // axis zooms the very range this frame drew.
         let grid = self.grid();
-        let pane_gutters = areas.pane_gutters.clone();
         for ((view, pane), gutter) in self
             .indicators
             .visible_panes_mut()
             .zip(&pane_rects)
-            .zip(&pane_gutters)
+            .zip(&areas.pane_gutters)
         {
             let auto = indicator_render::pane_auto_range(view, start, end);
             view.last_auto = auto;
@@ -3055,7 +3056,7 @@ impl QuantickApp {
         scale: &PriceScale,
     ) {
         let (lo, hi) = scale.range();
-        let font = egui::FontId::monospace(11.0);
+        let font = egui::FontId::monospace(chart::AXIS_LABEL_FONT_PX);
         for tick in crate::chart::nice_ticks(lo, hi, 8) {
             let y = scale.y(tick);
             if y < chart_rect.top() || y > chart_rect.bottom() {
@@ -3069,7 +3070,7 @@ impl QuantickApp {
                 egui::Stroke::new(1.0_f32, self.grid()),
             );
             painter.text(
-                egui::pos2(axis_x + 6.0, y),
+                egui::pos2(axis_x + chart::AXIS_LABEL_GAP_PX, y),
                 egui::Align2::LEFT_CENTER,
                 format!("{tick:.2}"),
                 font.clone(),
@@ -3129,10 +3130,10 @@ impl QuantickApp {
         // where a price sits on the axis.
         let galley = painter.layout_no_wrap(
             format!("{price:.2}"),
-            egui::FontId::monospace(11.0),
+            egui::FontId::monospace(chart::AXIS_LABEL_FONT_PX),
             LAST_PRICE_CHIP_TEXT,
         );
-        let text_pos = egui::pos2(axis_x + 6.0, y - galley.size().y / 2.0);
+        let text_pos = egui::pos2(axis_x + chart::AXIS_LABEL_GAP_PX, y - galley.size().y / 2.0);
         let bg = egui::Rect::from_min_size(
             text_pos - egui::vec2(3.0, 1.0),
             galley.size() + egui::vec2(6.0, 2.0),
@@ -3259,10 +3260,13 @@ impl QuantickApp {
         let price = scale.price_at(pos.y);
         let galley = painter.layout_no_wrap(
             format!("{price:.2}"),
-            egui::FontId::monospace(11.0),
+            egui::FontId::monospace(chart::AXIS_LABEL_FONT_PX),
             egui::Color32::WHITE,
         );
-        let text_pos = egui::pos2(axis_x + 6.0, pos.y - galley.size().y / 2.0);
+        let text_pos = egui::pos2(
+            axis_x + chart::AXIS_LABEL_GAP_PX,
+            pos.y - galley.size().y / 2.0,
+        );
         let bg = egui::Rect::from_min_size(
             text_pos - egui::vec2(3.0, 1.0),
             galley.size() + egui::vec2(6.0, 2.0),

--- a/crates/app/src/chart.rs
+++ b/crates/app/src/chart.rs
@@ -336,7 +336,15 @@ const AXIS_MAX_TICKS: usize = 8;
 const AXIS_LABEL_MIN_GAP_PX: f32 = 18.0;
 /// Thresholds a tick label is abbreviated at, largest first, with the suffix
 /// that replaces the zeros. Below the smallest the value is printed as it is.
-const AXIS_UNITS: [(f64, &str); 3] = [(1e9, "B"), (1e6, "M"), (1e3, "k")];
+///
+/// Same spellings as the aggression bubbles' own `format_quantity`: one chart,
+/// one way to write a thousand.
+const AXIS_UNITS: [(f64, &str); 3] = [(1e9, "B"), (1e6, "M"), (1e3, "K")];
+/// Gap between the axis rule and a tick label, in pixels. Shared by the price
+/// gutter and every pane's, so the numbers form one column down the chart.
+pub const AXIS_LABEL_GAP_PX: f32 = 6.0;
+/// Tick label font size, in pixels. Shared for the same reason.
+pub const AXIS_LABEL_FONT_PX: f32 = 11.0;
 /// Most decimals a tick label ever shows. Past this the step is so fine that
 /// the digits stop distinguishing neighbouring labels.
 const AXIS_MAX_DECIMALS: usize = 4;
@@ -375,7 +383,7 @@ pub fn axis_labels(lo: f64, hi: f64, height_px: f32) -> Vec<(f64, String)> {
         .map(|tick| {
             // Zero is zero in every unit; "0.0M" is three characters of noise
             // on the one label a flow pane is read against.
-            let label = if tick == 0.0 {
+            let label = if is_zero_tick(tick, step) {
                 "0".to_owned()
             } else {
                 format!("{:.*}{suffix}", decimals, tick / unit)
@@ -383,6 +391,17 @@ pub fn axis_labels(lo: f64, hi: f64, height_px: f32) -> Vec<(f64, String)> {
             (tick, label)
         })
         .collect()
+}
+
+/// Whether `tick` is the sequence's zero.
+///
+/// Not `tick == 0.0`: [`nice_ticks`] walks the range by adding `step`, so a
+/// step that is not exact in binary (0.1, 0.05, …) lands on `-2.8e-17` where
+/// zero should be — which prints as `-0.0` on the one label a flow pane is
+/// read against, and hides zero from the thinning anchor. Anything within a
+/// rounding error of a step is the zero.
+fn is_zero_tick(tick: f64, step: f64) -> bool {
+    tick.abs() <= step.abs() * AXIS_STEP_EPSILON
 }
 
 /// How many labels an axis `height_px` tall asks for.
@@ -406,12 +425,16 @@ fn thin_to_fit(ticks: Vec<f64>, span: f64, height_px: f32) -> Vec<f64> {
     let [first, second, ..] = ticks.as_slice() else {
         return ticks;
     };
-    let gap_px = f64::from(height_px) * ((second - first) / span);
+    let step = second - first;
+    let gap_px = f64::from(height_px) * (step / span);
     if !gap_px.is_finite() || gap_px <= 0.0 || gap_px >= f64::from(AXIS_LABEL_MIN_GAP_PX) {
         return ticks;
     }
     let stride = (f64::from(AXIS_LABEL_MIN_GAP_PX) / gap_px).ceil() as usize;
-    let anchor = ticks.iter().position(|tick| *tick == 0.0).unwrap_or(0);
+    let anchor = ticks
+        .iter()
+        .position(|tick| is_zero_tick(*tick, step))
+        .unwrap_or(0);
     ticks
         .into_iter()
         .enumerate()
@@ -622,6 +645,7 @@ mod tests {
         // A CVD in the millions: one unit for the whole column, because a
         // column mixing "900000" and "1M" is a column you read twice.
         assert_eq!(labels(0.0, 4.0e6), vec!["0", "1M", "2M", "3M", "4M"]);
+        assert_eq!(labels(0.0, 4.0e3), vec!["0", "1K", "2K", "3K", "4K"]);
         // A finer step keeps its decimal rather than rounding two labels onto
         // the same number.
         assert_eq!(labels(0.0, 1.2e6), vec!["0", "0.5M", "1.0M"]);
@@ -689,6 +713,30 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec!["0", "20", "40", "60", "80", "100"]
         );
+    }
+
+    /// `nice_ticks` walks the range by adding `step`, so a sub-unit step lands
+    /// on `-2.8e-17` where zero belongs. Printed naively that is `-0.0` on the
+    /// one label a flow pane is read against — a normalised oscillator or a
+    /// per-contract delta hits it, a CVD in the thousands never does, which is
+    /// why every other test here passes over it.
+    #[test]
+    fn the_zero_label_survives_a_step_that_is_not_exact_in_binary() {
+        for (lo, hi) in [(-0.324, 0.324), (-0.756, 0.756), (-0.19, 0.03)] {
+            let labels: Vec<String> = axis_labels(lo, hi, 163.0)
+                .into_iter()
+                .map(|(_, label)| label)
+                .collect();
+            assert!(
+                labels.iter().any(|label| label == "0"),
+                "{lo}..{hi} must label its zero as zero: {labels:?}"
+            );
+            assert!(
+                !labels.iter().any(|label| label.starts_with('-')
+                    && label.parse::<f64>().is_ok_and(|value| value == 0.0)),
+                "and never as a negative nothing: {labels:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/app/src/chart.rs
+++ b/crates/app/src/chart.rs
@@ -316,6 +316,127 @@ pub fn nice_ticks(lo: f64, hi: f64, target: usize) -> Vec<f64> {
     ticks
 }
 
+/// Pixels of axis height per label *asked for*.
+///
+/// The ask is not a promise: [`nice_ticks`] rounds the step to 1, 2 or 5,
+/// which can hand back half of what was asked or nearly double it. So an axis
+/// asks generously — one label per 20 pixels — and thins the result to fit
+/// ([`AXIS_LABEL_MIN_GAP_PX`]). Asking modestly instead is what left a 163 px
+/// CVD pane drawing a single label: an ask of three rounded down to one, and
+/// there was nothing left to thin.
+const AXIS_LABEL_SPACING_PX: f32 = 20.0;
+/// Fewest labels an axis asks for: below two there is no scale to read, only
+/// a number floating in a band.
+const AXIS_MIN_TICKS: usize = 2;
+/// Most labels an axis asks for, however tall it grows.
+const AXIS_MAX_TICKS: usize = 8;
+/// Least vertical room between two labels, in pixels. Below this the column
+/// reads as texture rather than as numbers, and the axis drops every other
+/// label until it clears.
+const AXIS_LABEL_MIN_GAP_PX: f32 = 18.0;
+/// Thresholds a tick label is abbreviated at, largest first, with the suffix
+/// that replaces the zeros. Below the smallest the value is printed as it is.
+const AXIS_UNITS: [(f64, &str); 3] = [(1e9, "B"), (1e6, "M"), (1e3, "k")];
+/// Most decimals a tick label ever shows. Past this the step is so fine that
+/// the digits stop distinguishing neighbouring labels.
+const AXIS_MAX_DECIMALS: usize = 4;
+/// Relative tolerance for "this many decimals writes the step back exactly".
+/// Steps are 1/2/5 × a power of ten, so the only error to absorb is the one
+/// binary floating point introduces.
+const AXIS_STEP_EPSILON: f64 = 1e-6;
+
+/// Labelled ticks for a vertical axis `height_px` tall spanning `[lo, hi]`:
+/// round numbers, written against the step they advance by and the magnitude
+/// they reach — so a CVD in the millions reads `1.2M` while an oscillator
+/// reads `70`.
+///
+/// Every label shares one unit, because a column mixing `900` and `1.1k` is a
+/// column you have to read twice. The height decides both how many labels are
+/// asked for and how many the column has room to keep.
+#[must_use]
+pub fn axis_labels(lo: f64, hi: f64, height_px: f32) -> Vec<(f64, String)> {
+    let ticks = thin_to_fit(
+        nice_ticks(lo, hi, tick_target(height_px)),
+        hi - lo,
+        height_px,
+    );
+    let step = match ticks.as_slice() {
+        [first, second, ..] => second - first,
+        _ => hi - lo,
+    };
+    let largest = ticks.iter().fold(0.0_f64, |acc, tick| acc.max(tick.abs()));
+    let (unit, suffix) = AXIS_UNITS
+        .into_iter()
+        .find(|(threshold, _)| largest >= *threshold)
+        .unwrap_or((1.0, ""));
+    let decimals = tick_decimals(step / unit);
+    ticks
+        .into_iter()
+        .map(|tick| {
+            // Zero is zero in every unit; "0.0M" is three characters of noise
+            // on the one label a flow pane is read against.
+            let label = if tick == 0.0 {
+                "0".to_owned()
+            } else {
+                format!("{:.*}{suffix}", decimals, tick / unit)
+            };
+            (tick, label)
+        })
+        .collect()
+}
+
+/// How many labels an axis `height_px` tall asks for.
+fn tick_target(height_px: f32) -> usize {
+    let by_room = if height_px.is_finite() && height_px > 0.0 {
+        (height_px / AXIS_LABEL_SPACING_PX) as usize
+    } else {
+        0
+    };
+    by_room.clamp(AXIS_MIN_TICKS, AXIS_MAX_TICKS)
+}
+
+/// Keep every `stride`-th label until the column clears
+/// [`AXIS_LABEL_MIN_GAP_PX`], anchored on zero when zero is one of them — it
+/// is the line a flow pane is read against, and dropping it to keep a tidy
+/// stride would cost the pane its only landmark.
+///
+/// What survives is still round: the ticks are an arithmetic sequence, so
+/// keeping every other one only multiplies the step.
+fn thin_to_fit(ticks: Vec<f64>, span: f64, height_px: f32) -> Vec<f64> {
+    let [first, second, ..] = ticks.as_slice() else {
+        return ticks;
+    };
+    let gap_px = f64::from(height_px) * ((second - first) / span);
+    if !gap_px.is_finite() || gap_px <= 0.0 || gap_px >= f64::from(AXIS_LABEL_MIN_GAP_PX) {
+        return ticks;
+    }
+    let stride = (f64::from(AXIS_LABEL_MIN_GAP_PX) / gap_px).ceil() as usize;
+    let anchor = ticks.iter().position(|tick| *tick == 0.0).unwrap_or(0);
+    ticks
+        .into_iter()
+        .enumerate()
+        .filter(|(index, _)| index % stride == anchor % stride)
+        .map(|(_, tick)| tick)
+        .collect()
+}
+
+/// Decimals that keep two neighbouring labels apart when they advance by
+/// `step`: a step of 250 needs none, 2.5k needs one, 0.05 needs two.
+///
+/// The fewest that write `step` back exactly, so no label is ever rounded
+/// into its neighbour ("2.5" and "5.0" must not both print as "2" and "5").
+fn tick_decimals(step: f64) -> usize {
+    if !step.is_finite() || step <= 0.0 {
+        return 0;
+    }
+    (0..AXIS_MAX_DECIMALS)
+        .find(|decimals| {
+            let factor = 10f64.powi(i32::try_from(*decimals).unwrap_or(0));
+            ((step * factor).round() / factor - step).abs() <= step * AXIS_STEP_EPSILON
+        })
+        .unwrap_or(AXIS_MAX_DECIMALS)
+}
+
 /// A "nice" number near `range`: 1, 2, 5 or 10 × a power of ten. When `round`,
 /// picks the nearest nice value; otherwise the smallest nice value ≥ `range`.
 fn nice_num(range: f64, round: bool) -> f64 {
@@ -486,6 +607,98 @@ mod tests {
         assert!(nice_ticks(100.0, 100.0, 5).is_empty());
         assert!(nice_ticks(110.0, 100.0, 5).is_empty());
         assert!(nice_ticks(100.0, 110.0, 0).is_empty());
+    }
+
+    #[test]
+    fn axis_labels_are_round_numbers_sharing_one_unit() {
+        // An axis 120 px tall: what a fifth of a laptop-sized chart comes to.
+        let labels = |lo: f64, hi: f64| -> Vec<String> {
+            axis_labels(lo, hi, 120.0)
+                .into_iter()
+                .map(|(_, label)| label)
+                .collect()
+        };
+
+        // A CVD in the millions: one unit for the whole column, because a
+        // column mixing "900000" and "1M" is a column you read twice.
+        assert_eq!(labels(0.0, 4.0e6), vec!["0", "1M", "2M", "3M", "4M"]);
+        // A finer step keeps its decimal rather than rounding two labels onto
+        // the same number.
+        assert_eq!(labels(0.0, 1.2e6), vec!["0", "0.5M", "1.0M"]);
+        // An oscillator: plain integers, no suffix, no decimals.
+        assert_eq!(labels(0.0, 100.0), vec!["0", "20", "40", "60", "80", "100"]);
+
+        // A ratio near 1: the step decides the decimals, so no label is
+        // rounded into its neighbour — or into a value it does not sit at.
+        let ratio = axis_labels(0.9, 1.1, 120.0);
+        let printed: Vec<&String> = ratio.iter().map(|(_, label)| label).collect();
+        let unique: std::collections::BTreeSet<_> = printed.iter().collect();
+        assert_eq!(
+            unique.len(),
+            printed.len(),
+            "no repeated labels: {printed:?}"
+        );
+        for (tick, label) in &ratio {
+            let value: f64 = label.parse().expect("a plain number near 1");
+            assert!(
+                (value - tick).abs() < 1e-9,
+                "{label} must not round {tick} away"
+            );
+        }
+    }
+
+    #[test]
+    fn a_degenerate_range_labels_nothing_instead_of_guessing() {
+        assert!(axis_labels(5.0, 5.0, 120.0).is_empty());
+        assert!(axis_labels(f64::NAN, 1.0, 120.0).is_empty());
+        // An axis with no height cannot be measured for room; it still labels
+        // round numbers rather than dividing by zero.
+        assert!(!axis_labels(0.0, 10.0, 0.0).is_empty());
+    }
+
+    /// The bug this ask exists for, measured on a running chart: a 163 px CVD
+    /// pane spanning roughly -30..30 asked for three labels, `nice_ticks`
+    /// rounded that down to one, and the pane read as a band with a number
+    /// floating in it.
+    #[test]
+    fn an_axis_asks_for_labels_generously_and_thins_them_to_fit() {
+        assert_eq!(tick_target(40.0), 2, "a short axis still asks for two");
+        assert_eq!(tick_target(163.0), 8);
+        assert_eq!(tick_target(f32::NAN), AXIS_MIN_TICKS);
+
+        assert_eq!(
+            nice_ticks(-30.7, 29.4, 3).len(),
+            1,
+            "the shape of the bug, kept as evidence: a modest ask rounds to one"
+        );
+        let fitted = axis_labels(-30.7, 29.4, 163.0);
+        assert!(
+            fitted.len() >= 3,
+            "asking generously gets the pane a scale: {fitted:?}"
+        );
+
+        // And the ask is not blindly honoured. Over 0..100 a 163 px axis is
+        // handed eleven labels 16 px apart — texture, not numbers — so every
+        // other one goes, and what stays is still round.
+        assert_eq!(nice_ticks(0.0, 100.0, 8).len(), 11);
+        let thinned = axis_labels(0.0, 100.0, 163.0);
+        assert_eq!(
+            thinned
+                .iter()
+                .map(|(_, label)| label.as_str())
+                .collect::<Vec<_>>(),
+            vec!["0", "20", "40", "60", "80", "100"]
+        );
+    }
+
+    #[test]
+    fn tick_decimals_are_the_fewest_that_write_the_step_back() {
+        assert_eq!(tick_decimals(250.0), 0);
+        assert_eq!(tick_decimals(1.0), 0);
+        // 2500 shown in thousands: "2.5k", never "2k" twice in a column.
+        assert_eq!(tick_decimals(2.5), 1);
+        assert_eq!(tick_decimals(0.05), 2);
+        assert_eq!(tick_decimals(0.0), 0, "a degenerate step asks for nothing");
     }
 
     #[test]

--- a/crates/app/src/indicator_render.rs
+++ b/crates/app/src/indicator_render.rs
@@ -60,6 +60,15 @@ const MARKER_TEXT_GAP_PX: f32 = 2.0;
 /// anchor to the pane's edges instead; this is the substitution, named so it
 /// no longer reads as an unexplained multiple of the bar gap.
 const PANE_MARKER_INSET_PX: f32 = MARKER_GAP_PX * 2.0;
+/// Gap between the axis line and a tick label, in pixels. Matches the price
+/// axis, so both gutters read as one column of numbers.
+const AXIS_LABEL_GAP_PX: f32 = 6.0;
+/// Tick label font size, in pixels.
+const AXIS_LABEL_FONT_PX: f32 = 11.0;
+/// A tick label is dropped when it would be drawn within this many pixels of
+/// the pane's own edge: the frame hairline and the pane's title/headline live
+/// there, and a number crossing either reads as a smudge rather than a value.
+const AXIS_LABEL_EDGE_MARGIN_PX: f32 = 7.0;
 
 fn color32(c: Rgba8) -> Color32 {
     Color32::from_rgba_unmultiplied(c.r, c.g, c.b, c.a)
@@ -133,21 +142,58 @@ pub(crate) fn draw_overlays<'a>(
     }
 }
 
-/// Draw one pane indicator into its own rect: subtle frame, its plots on an
-/// auto-fitted value scale, a zero line when zero is in range, and the
-/// label + last value so the pane reads without a y-axis (v1).
+/// Where one pane paints, and in what colours.
+///
+/// A pane spans two rects that the chart's own layout keeps apart — the plot
+/// area and the slice of the right-hand gutter beside it — so they travel
+/// together rather than as two more positional arguments no caller can read.
+pub(crate) struct PaneFrame {
+    /// The pane's plot area: the candles' x-range, the live lane excluded.
+    pub rect: Rect,
+    /// The gutter band beside `rect`, where this pane's value labels go. It
+    /// is the same band the pane's zoom gesture is registered over, which is
+    /// what makes the numbers the thing you grab.
+    pub gutter: Rect,
+    /// The canvas colour behind the pane.
+    pub background: Color32,
+    /// Gridline and axis-rule colour, shared with the price axis so both
+    /// read as one grid.
+    pub grid: Color32,
+}
+
+/// The value range a pane auto-fits to: its visible values plus breathing
+/// room above and below. `None` while everything visible is still NaN warmup
+/// — there is nothing to scale to yet, and no axis to draw.
+pub(crate) fn pane_auto_range(
+    view: &IndicatorView,
+    start: usize,
+    end: usize,
+) -> Option<(f64, f64)> {
+    let (lo, hi) = value_range(view, start, end)?;
+    let pad = (hi - lo).max(f64::EPSILON) * PANE_PAD_FRAC;
+    Some((lo - pad, hi + pad))
+}
+
+/// Draw one pane indicator into its own rect: subtle frame, its plots on the
+/// given value range, its own y-axis in the gutter beside it, a zero line
+/// when zero is in range, and the label + last value.
+///
+/// `range` is the `(lo, hi)` the pane draws with — [`pane_auto_range`] unless
+/// the user has zoomed this pane's axis — and `None` means the indicator has
+/// computed nothing visible yet.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn draw_pane(
     painter: &egui::Painter,
-    pane: Rect,
+    frame: &PaneFrame,
     view: &IndicatorView,
     x: &PlotX<'_>,
+    range: Option<(f64, f64)>,
     start: usize,
     end: usize,
     partial_slot: Option<usize>,
-    background: Color32,
 ) {
-    painter.rect_filled(pane, egui::Rounding::ZERO, background);
+    let pane = frame.rect;
+    painter.rect_filled(pane, egui::Rounding::ZERO, frame.background);
     painter.line_segment(
         [pane.left_top(), pane.right_top()],
         Stroke::new(
@@ -155,8 +201,18 @@ pub(crate) fn draw_pane(
             theme::TEXT_MUTED.gamma_multiply(PANE_FRAME_ALPHA),
         ),
     );
+    // The rule that closes the pane's right edge is drawn whatever the pane
+    // has to say: the gutter is one column down the whole chart, and a gap in
+    // it at the height of a warming-up pane reads as a broken axis.
+    painter.line_segment(
+        [
+            pos2(frame.gutter.left(), pane.top()),
+            pos2(frame.gutter.left(), pane.bottom()),
+        ],
+        Stroke::new(PANE_RULE_WIDTH_PX, frame.grid),
+    );
 
-    let Some((lo, hi)) = value_range(view, start, end) else {
+    let Some((lo, hi)) = range else {
         painter.text(
             pane.center(),
             egui::Align2::CENTER_CENTER,
@@ -166,11 +222,12 @@ pub(crate) fn draw_pane(
         );
         return;
     };
-    let span = (hi - lo).max(f64::EPSILON);
-    let pad = span * PANE_PAD_FRAC;
-    let scale = PriceScale::from_range(lo - pad, hi + pad, pane.top(), pane.bottom());
+    let scale = PriceScale::from_range(lo, hi, pane.top(), pane.bottom());
 
     let clipped = painter.with_clip_rect(pane);
+    // The axis first, so its grid sits behind the plots rather than over them
+    // — the price axis' own paint order.
+    draw_pane_axis(painter, &clipped, frame, &scale);
     // A zero line anchors flow panes (cvd, delta) visually.
     if lo < 0.0 && hi > 0.0 {
         let y = scale.y(0.0);
@@ -221,6 +278,43 @@ pub(crate) fn draw_pane(
             egui::Align2::RIGHT_TOP,
             format_value(last),
             egui::FontId::monospace(PANE_LABEL_FONT_PX),
+            theme::TEXT_MUTED,
+        );
+    }
+}
+
+/// One pane's y-axis: round-number gridlines across the pane and their
+/// labels in the gutter beside it.
+///
+/// `clipped` is the pane's own clipped painter, so gridlines stop at the pane;
+/// the labels are painted on `painter`, since the gutter is outside that clip.
+fn draw_pane_axis(
+    painter: &egui::Painter,
+    clipped: &egui::Painter,
+    frame: &PaneFrame,
+    scale: &PriceScale,
+) {
+    let pane = frame.rect;
+    let (lo, hi) = scale.range();
+    let font = egui::FontId::monospace(AXIS_LABEL_FONT_PX);
+    for (tick, label) in crate::chart::axis_labels(lo, hi, pane.height()) {
+        let y = scale.y(tick);
+        clipped.line_segment(
+            [pos2(pane.left(), y), pos2(pane.right(), y)],
+            Stroke::new(PANE_RULE_WIDTH_PX, frame.grid),
+        );
+        // A label centred on the pane's own edge would be sliced in half by
+        // the neighbouring pane; the gridline still marks the value.
+        if y - pane.top() < AXIS_LABEL_EDGE_MARGIN_PX
+            || pane.bottom() - y < AXIS_LABEL_EDGE_MARGIN_PX
+        {
+            continue;
+        }
+        painter.text(
+            pos2(frame.gutter.left() + AXIS_LABEL_GAP_PX, y),
+            egui::Align2::LEFT_CENTER,
+            label,
+            font.clone(),
             theme::TEXT_MUTED,
         );
     }
@@ -828,6 +922,8 @@ mod tests {
             stale: None,
             error: None,
             hidden: false,
+            scale: crate::price_view::PriceView::new(),
+            last_auto: None,
         }
     }
 
@@ -903,6 +999,22 @@ mod tests {
             }
         }
         assert_eq!(runs, 2, "two segments, one gap");
+    }
+
+    #[test]
+    fn the_auto_range_pads_the_values_and_has_nothing_to_pad_during_warmup() {
+        let pane = view(vec![vec![0.0, 10.0]], None);
+        let (lo, hi) = pane_auto_range(&pane, 0, 2).expect("two values are a range");
+        assert!(lo < 0.0 && hi > 10.0, "the trace never touches the edges");
+        assert!(
+            (lo + 0.8).abs() < 1e-9 && (hi - 10.8).abs() < 1e-9,
+            "8% of the span on each side: {lo}..{hi}"
+        );
+
+        assert!(
+            pane_auto_range(&view(vec![vec![f64::NAN]], None), 0, 1).is_none(),
+            "nothing computed yet is nothing to scale — and no axis to draw"
+        );
     }
 
     #[test]

--- a/crates/app/src/indicator_render.rs
+++ b/crates/app/src/indicator_render.rs
@@ -60,11 +60,6 @@ const MARKER_TEXT_GAP_PX: f32 = 2.0;
 /// anchor to the pane's edges instead; this is the substitution, named so it
 /// no longer reads as an unexplained multiple of the bar gap.
 const PANE_MARKER_INSET_PX: f32 = MARKER_GAP_PX * 2.0;
-/// Gap between the axis line and a tick label, in pixels. Matches the price
-/// axis, so both gutters read as one column of numbers.
-const AXIS_LABEL_GAP_PX: f32 = 6.0;
-/// Tick label font size, in pixels.
-const AXIS_LABEL_FONT_PX: f32 = 11.0;
 /// A tick label is dropped when it would be drawn within this many pixels of
 /// the pane's own edge: the frame hairline and the pane's title/headline live
 /// there, and a number crossing either reads as a smudge rather than a value.
@@ -296,7 +291,7 @@ fn draw_pane_axis(
 ) {
     let pane = frame.rect;
     let (lo, hi) = scale.range();
-    let font = egui::FontId::monospace(AXIS_LABEL_FONT_PX);
+    let font = egui::FontId::monospace(crate::chart::AXIS_LABEL_FONT_PX);
     for (tick, label) in crate::chart::axis_labels(lo, hi, pane.height()) {
         let y = scale.y(tick);
         clipped.line_segment(
@@ -311,7 +306,7 @@ fn draw_pane_axis(
             continue;
         }
         painter.text(
-            pos2(frame.gutter.left() + AXIS_LABEL_GAP_PX, y),
+            pos2(frame.gutter.left() + crate::chart::AXIS_LABEL_GAP_PX, y),
             egui::Align2::LEFT_CENTER,
             label,
             font.clone(),

--- a/crates/app/src/indicators/mod.rs
+++ b/crates/app/src/indicators/mod.rs
@@ -16,6 +16,7 @@ use quantick_indicators::{
 };
 
 use crate::indicator_worker::{IndicatorEvent, SlotId};
+use crate::price_view::PriceView;
 
 /// Fraction of the chart's height each indicator pane takes (plan §4.3:
 /// fixed fraction v1, draggable dividers later).
@@ -49,6 +50,21 @@ pub(crate) struct IndicatorView {
     /// A failed hot reload's errors: the running version is stale relative
     /// to the file on disk, and the panel says so.
     pub stale: Option<String>,
+    /// This pane's vertical scale: auto-fits its visible values until the
+    /// user drags the pane's own y-axis, then holds the range they set — the
+    /// candles' price axis rule, applied per pane.
+    ///
+    /// Render-side state, like `hidden`, and it lives on the view rather than
+    /// in a slot-keyed map on the side: a removed indicator takes its scale
+    /// with it, so a later pane can never inherit a range someone set for a
+    /// different series.
+    pub scale: PriceView,
+    /// The auto-fitted `(lo, hi)` the last frame drew this pane with.
+    ///
+    /// The gesture that zooms the pane runs before the frame that draws it,
+    /// so it needs the range the renderer actually used — the same handshake
+    /// `last_auto_range` performs for the candles.
+    pub last_auto: Option<(f64, f64)>,
 }
 
 impl IndicatorView {
@@ -132,6 +148,8 @@ impl IndicatorViews {
                         objects: ObjectSnapshot::default(),
                         input_values: inputs,
                         stale,
+                        scale: PriceView::new(),
+                        last_auto: None,
                     });
                 }
             }
@@ -223,6 +241,16 @@ impl IndicatorViews {
     pub(crate) fn visible_panes(&self) -> impl Iterator<Item = &IndicatorView> {
         self.views
             .iter()
+            .filter(|v| !v.descriptor.overlay && !v.hidden && v.error.is_none())
+            .take(MAX_PANES)
+    }
+
+    /// The same panes, in the same order, mutable: the renderer records the
+    /// range it fitted and the axis gesture moves the scale, both on the view
+    /// the pane rect belongs to.
+    pub(crate) fn visible_panes_mut(&mut self) -> impl Iterator<Item = &mut IndicatorView> {
+        self.views
+            .iter_mut()
             .filter(|v| !v.descriptor.overlay && !v.hidden && v.error.is_none())
             .take(MAX_PANES)
     }
@@ -375,6 +403,39 @@ mod tests {
         }
         assert_eq!(views.visible_overlays().count(), 1);
         assert_eq!(views.visible_panes().count(), 1);
+    }
+
+    /// A pane's scale belongs to the indicator, not to the slot's position on
+    /// screen: removing one and adding another must not hand the newcomer a
+    /// range someone set for a different series.
+    #[test]
+    fn a_removed_pane_takes_its_scale_with_it() {
+        let mut views = IndicatorViews::new();
+        let first = views.allocate_slot();
+        views.apply(IndicatorEvent::Rebuilt {
+            slot: first,
+            descriptor: descriptor(false, 1),
+            columns: vec![vec![1.0]],
+            inputs: Vec::new(),
+            stale: None,
+        });
+        let view = views.view_mut(first).expect("the pane is there");
+        view.last_auto = Some((0.0, 10.0));
+        view.scale.zoom(0.5, (0.0, 10.0));
+        assert!(!views.all()[0].scale.is_auto());
+
+        views.remove(first);
+        let second = views.allocate_slot();
+        views.apply(IndicatorEvent::Rebuilt {
+            slot: second,
+            descriptor: descriptor(false, 1),
+            columns: vec![vec![1.0]],
+            inputs: Vec::new(),
+            stale: None,
+        });
+        let fresh = &views.all()[0];
+        assert!(fresh.scale.is_auto(), "a new pane fits its own values");
+        assert!(fresh.last_auto.is_none(), "and has not been drawn yet");
     }
 
     #[test]

--- a/crates/app/src/indicators/mod.rs
+++ b/crates/app/src/indicators/mod.rs
@@ -241,7 +241,7 @@ impl IndicatorViews {
     pub(crate) fn visible_panes(&self) -> impl Iterator<Item = &IndicatorView> {
         self.views
             .iter()
-            .filter(|v| !v.descriptor.overlay && !v.hidden && v.error.is_none())
+            .filter(|v| is_visible_pane(v))
             .take(MAX_PANES)
     }
 
@@ -251,9 +251,20 @@ impl IndicatorViews {
     pub(crate) fn visible_panes_mut(&mut self) -> impl Iterator<Item = &mut IndicatorView> {
         self.views
             .iter_mut()
-            .filter(|v| !v.descriptor.overlay && !v.hidden && v.error.is_none())
+            .filter(|v| is_visible_pane(v))
             .take(MAX_PANES)
     }
+}
+
+/// Whether this indicator gets a pane of its own right now.
+///
+/// One predicate for both iterators, because the two are zipped against the
+/// same rects: `plot_split` carves bands from `visible_panes().count()` and the
+/// input pass walks `visible_panes_mut()`. A condition added to one and not the
+/// other would misalign the zip silently — and a drag would then stretch the
+/// pane next to the one whose numbers were grabbed.
+fn is_visible_pane(view: &IndicatorView) -> bool {
+    !view.descriptor.overlay && !view.hidden && view.error.is_none()
 }
 
 /// Carve the pane band off the bottom of the chart rect: each pane takes


### PR DESCRIPTION
## What

Indicator panes (CVD, delta, any non-overlay indicator) get a real y-axis, and
that axis is draggable: the pane scales like the candles do, from the numbers
beside it.

Before, a pane drew a title and a headline value and nothing else — the module
said so in a comment ("so the pane reads without a y-axis (v1)") — and the
right-hand gutter belonged entirely to the candles. Dragging the numbers beside
a CVD pane stretched the *price* scale of the candles above it, which is the
one thing that gesture must not do.

## How

- `plot_split` bands the gutter like the body it labels: `price_gutter` spans
  the candles' height only, and each visible pane gets the band beside it
  (`pane_gutters`). No pixel answers to two scales.
- `IndicatorView` carries its own `PriceView` — the same auto-fit-until-you-drag
  state the price axis already uses — plus the auto range the last frame fitted.
  The state lives on the view, so a removed indicator takes its scale with it
  and a later pane can never inherit a range set for a different series.
- `chart.rs` (the display-free geometry module, where `nice_ticks` already
  lives) gained `axis_labels`: round numbers for a vertical axis, abbreviated
  to one shared unit (`1.2M`, `500k`, `70`) with the fewest decimals that still
  tell two neighbouring labels apart. It asks for labels by axis height and
  thins the result to fit, because `nice_ticks` rounds the step to 1/2/5 and
  can hand back a fraction of the ask — a 163 px CVD pane asking for three
  labels was handed **one** on a live chart, which is how the bug was found.
- `indicator_render` gained `pane_auto_range` (pure), a `PaneFrame` (plot rect,
  gutter band, canvas colours) and `draw_pane_axis`: gridlines behind the plots,
  labels in the gutter, and the rule closing the pane's right edge — drawn even
  while an indicator is warming up, so the axis column is never broken.
- `handle_navigation` registers one interaction per pane band, keyed by slot:
  drag up compresses, down expands, scroll zooms, double-click returns the pane
  to auto-fit. The drag and scroll constants are now named (`AXIS_ZOOM_DRAG_PX`,
  `AXIS_ZOOM_SCROLL_PX`) and shared with the price gutter, so both axes stretch
  at the same rate.

## Tests

Gesture, proven through real egui pointer events against a real frame:

- `dragging_a_pane_axis_zooms_that_pane_and_nothing_else` — the dragged pane
  compresses around its middle; the other pane and the candles' price view are
  untouched.
- `dragging_the_price_gutter_leaves_every_pane_alone` — the other half of the
  isolation.
- `scrolling_a_pane_axis_zooms_that_pane`.
- `a_zoomed_pane_holds_its_range_until_the_axis_is_double_clicked` — a manual
  range survives a rebuild that would have moved auto-fit.

Layout and state:

- `every_pane_owns_the_gutter_band_beside_it` — the bands tile the gutter
  exactly, and the candles' band stops where the candles do.
- `a_removed_pane_takes_its_scale_with_it`.
- `a_pane_prints_its_own_value_labels_in_the_gutter` — the pane's own round
  numbers are really painted, enough of them to read as a scale, and the price
  axis still paints its own.

Pure geometry (`chart.rs`):

- `axis_labels_are_round_numbers_sharing_one_unit`,
  `an_axis_asks_for_labels_generously_and_thins_them_to_fit` (carries the
  measured bug as evidence), `tick_decimals_are_the_fewest_that_write_the_step_back`,
  `a_degenerate_range_labels_nothing_instead_of_guessing`.

## Validation on a running chart

Launched against Binance/BTCUSDT with the CVD pane on and captured the window:
the axis draws in the gutter, in the same column as the price labels. That run
is also what caught the single-label bug — a pixel scan of the pane band found
one gridline where there should have been several. A capture of the fixed
version was blocked by the window not presenting (fps 19 / frame_avg 50 ms /
cpu 1.3 ms — the documented "surface not presenting" signature), so the fix is
proven by the headless frame test rather than a second screenshot.

## Arch-review

Reviewed twice — once by the author, once by an independent reviewer over the
same diff. Everything at Blocker or Should-fix severity is fixed in this branch:

- **The zero label was not always zero.** `nice_ticks` walks its range by adding
  `step`, so a sub-unit step lands on `-2.8e-17` where zero belongs — printed as
  `-0.0` on the one label a flow pane is read against, and invisible to the
  thinning anchor. A normalised oscillator or a per-contract delta hits this; a
  CVD in the thousands never does, which is why the first round of tests passed
  straight over it. Fixed with `is_zero_tick` (tolerance of one rounding error
  of a step) and covered by `the_zero_label_survives_a_step_that_is_not_exact_in_binary`.
- **The axis gesture was written twice** — and the two copies had already
  diverged (the price gutter's double-click sat inside its `if let Some(auto)`,
  the pane's outside). Extracted as `axis_zoom_gesture`, so the next band that
  wants an axis registers the gesture instead of copying it.
- **Constants claiming to match the price axis that the price axis did not
  use**: the label gap and font were named in `indicator_render` while
  `draw_price_axis`, `draw_last_price` and the crosshair kept `6.0` and
  `monospace(11.0)` literals. Both now live in `chart.rs` and all six call sites
  read them.
- **The "is this pane visible" predicate was duplicated** across
  `visible_panes` / `visible_panes_mut`. That is now load-bearing: the bands
  come from one and the input pass walks the other, so a condition added to one
  alone would misalign the zip and drag the wrong pane, with no test going red.
  One `is_visible_pane` for both.
- Axis units now spell thousands `K`, matching the aggression bubbles'
  `format_quantity` on the same chart.
- Dropped a per-frame `Vec<Rect>` clone that the borrow checker never needed.

### Deferred, deliberately

- **Unifying `draw_pane_axis` with `draw_price_axis`.** They are the same
  renderer with different formatting, and one `draw_value_axis` would cover
  both — but that changes how prices are written on the candles' axis, which is
  outside what this change was asked to do.
- **Storing the whole `PlotAreas` instead of `last_plot_area`.** Would save one
  `plot_split` per frame and let the pane-axis tests read the bands directly,
  but it means cloning two `Vec`s into app state; the current field costs one
  `Rect` and keeps production reading the same `plot_split` the tests do.

## Not in this change

- Draggable pane-height dividers: panes still take a fixed `PANE_HEIGHT_FRAC`
  each. Deliberate — pane *scale* zoom was chosen over resizing.
- Log scale for panes.
