### PR TITLE
fix: keep order entry on the flow pane

### DIFF
--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -6753,6 +6753,63 @@ plot(close)
             .center()
     }
 
+    /// Where `price` sits on `side`'s axis, computed the way that pane's own
+    /// frame computes it.
+    fn price_y(app: &QuantickApp, side: PaneSide, price: f64) -> f32 {
+        let pane = app.active_tab().pane(side);
+        let chart = pane.last_chart_area.expect("the pane reported its rect");
+        let auto = pane.last_auto_range.expect("the pane fitted a range");
+        let (lo, hi) = pane.price_view.resolve(auto);
+        PriceScale::from_range(lo, hi, chart.top(), chart.bottom()).y(price)
+    }
+
+    /// Order entry belongs to the flow pane. Both panes draw the simulated
+    /// lines — same instrument, same prices — but only the flow pane hands
+    /// the pointer to the simulator: the time pane is the context view, and a
+    /// press on its copy of a line is an ordinary chart gesture.
+    ///
+    /// Proven through the consequence, not the flag: the position's entry line
+    /// consumes a press without moving (it is history, not an order), so a
+    /// vertical drag that starts on it pans nothing on the flow pane — and
+    /// pans normally on the time pane, where the simulator never sees it.
+    #[test]
+    fn only_the_flow_pane_hands_the_pointer_to_the_simulator() {
+        let ctx = egui::Context::default();
+        let (mut app, _commands) = split_app(&ctx, 200);
+        app.apply_toolbar_action(ToolbarAction::PaperBuy);
+        let fill = trade(4);
+        app.active_tab_mut().ingest_live_trade_at(&fill, 0);
+        run_frame(&mut app, &ctx);
+        assert!(
+            app.active_tab().paper.status_cell().is_some(),
+            "this proof needs an open simulated position to grab"
+        );
+        let entry = rust_decimal::prelude::ToPrimitive::to_f64(&fill.price)
+            .expect("the fill price is finite");
+
+        for (side, panned) in [(PaneSide::Time, true), (PaneSide::Flow, false)] {
+            app.active_tab_mut().pane_mut(side).price_view.reset();
+            let chart = app
+                .active_tab()
+                .pane(side)
+                .last_chart_area
+                .expect("the pane reported its rect");
+            let start = egui::pos2(chart.center().x, price_y(&app, side, entry));
+            assert!(
+                chart.contains(start),
+                "{side:?}: the entry line must cross this pane to be grabbed"
+            );
+            drag_chart(&mut app, &ctx, start, start + egui::vec2(0.0, 40.0));
+
+            assert_eq!(
+                !app.active_tab().pane(side).price_view.is_auto(),
+                panned,
+                "{side:?}: a drag on the entry line must {} pan this pane",
+                if panned { "" } else { "not " }
+            );
+        }
+    }
+
     /// (a) The split really puts two charts on the canvas: two panes with
     /// their own laid-out rects, side by side, and a divider between them.
     #[test]

--- a/crates/app/src/pane.rs
+++ b/crates/app/src/pane.rs
@@ -326,12 +326,15 @@ pub struct PaneChrome<'a> {
     pub paper: &'a mut PaperTrading,
     /// Whether this pane is the one paper trading takes its pointer from.
     ///
-    /// The simulator holds one grabbed line and one armed placement for the
-    /// whole tab, so exactly one pane may drive them: running both would let
-    /// the second pane inherit a drag the first started and re-clamp it into
-    /// the wrong rectangle. [`crate::tab::Tab::draw_canvas`] sets this on the
-    /// focused pane, which is the honest owner — a press focuses the pane it
-    /// landed in on that same frame, and focus cannot move mid-drag.
+    /// Set for the flow pane, and only for it: order entry belongs to the
+    /// chart trading happens on. The time pane is the *context* view (§11) —
+    /// a 90-day 1-minute chart is not a surface to place a stop on, and its
+    /// price span is nothing like the one an order is sized against.
+    ///
+    /// It is also what keeps the gesture coherent: the simulator holds one
+    /// grabbed line and one armed placement for the whole tab, so exactly one
+    /// pane may drive them. Running both would let the second pane inherit a
+    /// drag the first started and re-clamp it into the wrong rectangle.
     pub paper_owns_input: bool,
 }
 

--- a/crates/app/src/tab.rs
+++ b/crates/app/src/tab.rs
@@ -1491,9 +1491,6 @@ impl Tab {
         });
 
         {
-            // Read before the panes borrow `self`: which side owns the
-            // simulator's pointer this frame.
-            let focus = self.focused_side();
             let Self {
                 flow_pane,
                 time_pane,
@@ -1521,10 +1518,11 @@ impl Tab {
                 flow_area,
                 PaneSide::Flow,
             ))) {
-                // One simulator per tab, so one pane drives it: the focused
-                // one. Unsplit that is always the flow pane, which is exactly
-                // the behaviour before the split existed.
-                chrome.paper_owns_input = side == focus;
+                // Order entry belongs to the flow pane: trading happens on the
+                // chart quantick is built around, and the time pane is the
+                // context view beside it. Unsplit this is the only pane there
+                // is, so it is exactly the behaviour before the split existed.
+                chrome.paper_owns_input = side == PaneSide::Flow;
                 pane.handle_navigation(ui, rect, &mut chrome);
                 pane.draw_chart(ui.painter(), rect, &chrome);
             }


### PR DESCRIPTION
Cherry-pick of 6f31609, which landed on feat/timeframe-split-tabs seconds after PR #112 was merged and was stranded outside main. Order entry routes to the flow pane only — the context (time) pane draws the order lines as a readout but never handles their input: order entry belongs to the chart trading happens on, and a 90-day context chart's price span is not what an order is sized against. Comes with its failing-first test (only_the_flow_pane_hands_the_pointer_to_the_simulator).

Four checks green (1111 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)