### PR TITLE
docs(ux): August 2026 UX audit — synthesis, per-area reports, prioritized roadmap

### DIFF
--- a/docs/ux/ux-audit-2026-08.md
+++ b/docs/ux/ux-audit-2026-08.md
@@ -1,0 +1,227 @@
+# UX audit — August 2026
+
+An atomic usability audit of the whole `crates/app` surface: every tab, tool,
+panel, dialog and gesture, carried out by six independent reviewers over the
+code on `main`. Each claim carries a `file:line` reference. This document is
+the synthesis; the six full per-area reports live in
+[`ux-audit-2026-08/`](ux-audit-2026-08/).
+
+**Audit base:** `main @ 2856238` (2026-08-04). PR #120 (chart layer
+visibility) merged after the audit snapshot, so findings about the toolbar
+layer toggles may be partially addressed — re-verify those before acting.
+
+**Trigger:** user-reported friction — (1) could not close an open simulated
+trade and could not tell which trade was open; (2) the way a timeframe chart
+opens feels strange; (3) editing indicator properties feels strange.
+
+**Totals:** 136 findings — 12 blockers, 50 majors, 52 minors, 22 nits.
+
+---
+
+## 1. Executive summary
+
+The verdict in one sentence: **quantick's problem is not aesthetics — it is
+missing surface.** The design system exists and is disciplined (tokens, amber
+reserved for data honesty, capability gating with written reasons on every
+disabled control). What is missing is the half of the interface that answers
+questions: closing what is open, reading what is on screen, editing what was
+added.
+
+Three patterns cut across every area:
+
+1. **Entry controls without exit controls.** BUY/SELL always visible;
+   Close/Flatten buried in a dock that opens collapsed. The `bars → time`
+   combo visible; the good timeframe chart hidden under *File → Layout*.
+2. **The app contradicts itself.** The drawing inspector opens on selection,
+   applies live, has tabs — while indicators use a blind dialog that the menu
+   occludes. The status bar follows focus; the BARS group ignores it. Layer
+   toggles target the flow pane; indicator commands target the focused pane.
+3. **Nothing persists.** Tabs, layout, bar spec, drawings, dock, timezone —
+   everything resets on every launch. The `ui-state.toml` (§14) already named
+   in code comments would resolve half of the "I rebuild my workspace every
+   time" pain.
+
+Genuinely strong and not to be regressed: capability gating with written
+reasons; the tape cell's arrival-vs-staleness split; gesture-coalesced undo in
+drawings; the simulator's didactic rejection messages; amber as a disciplined
+provenance-only token.
+
+## 2. Pain point 1 — closing / seeing the open trade
+
+Confirmed on both halves, three blockers. Full detail:
+[`paper-trading.md`](ux-audit-2026-08/paper-trading.md).
+
+Root causes:
+
+- **Entry and exit live in structurally different places.** BUY/SELL are on
+  the toolbar (`toolbar.rs:484-509`); Close/Flatten exist only inside the
+  Trading dock tab (`paper_trading.rs:677-692`), and the dock starts
+  collapsed (`dock.rs:124-132`). Nothing bridges the gap — no toolbar link,
+  no clickable status cell, no chart menu, no shortcut, no badge on the dock
+  icon while a position is open.
+- **The position chip is overpainted by the last-price chip** at identical
+  x/font (`paper_trading.rs:1300` vs `chart.rs:345,347`, paint order at
+  `pane.rs:1709-1714`) — and entry price equals last price at the exact
+  moment a market order fills, so the one persistent "you are long" statement
+  is born mangled.
+- **The status cell cannot distinguish open from flat** (`statusbar.rs:297`).
+- **Pressing SELL while long is an undisclosed close-or-reverse**
+  (`simulator.rs:601-627`), keyed to a quantity field the toolbar never shows.
+- **Bonus blocker:** the UI instructs "drag a stop on the chart, or use the
+  offsets below" for an open position — both routes are dead
+  (`paper_trading.rs:640-669`); brackets can only be attached before entry.
+
+Redesign (approved direction):
+
+- `✕ Close 1 LONG` on the toolbar whenever a position is open; state-aware
+  BUY/SELL labels (`SELL 1 (closes)` / `SELL 5 (reverses to short 4)`).
+- A persistent position HUD pinned to the chart's top-left: side, qty, avg
+  price, open P&L, Close/Reverse; directional caret when the entry price is
+  off-screen.
+- Status cell reads `SIM LONG 1 · +2.0 pts` open / `SIM +7.0 pts · flat`
+  otherwise, and clicks through to the Trading tab.
+- Fix the chip paint-order collision; make the bracket hint true (Apply →
+  `SetBracket` on the open position; drag-to-create SL/TP from the entry
+  line); a closed-trades ledger in the Trading tab; fill markers on candles.
+
+## 3. Pain point 2 — how the timeframe chart opens
+
+Full detail: [`tabs-timeframe.md`](ux-audit-2026-08/tabs-timeframe.md).
+
+Root cause: **two routes that are not the same feature, and the obvious one is
+broken.**
+
+| | Route A — toolbar `bars → time` | Route B — `File → Layout → Time + Flow` |
+|---|---|---|
+| Opens at | **1 second** (`pane.rs:449`) | 1 minute, with 1m/5m/15m/1h chips |
+| Venue history | **never** (`tab.rs:375-382`); fixing the interval to 60000 ms leaves ~1 bar | 90 days (~130k candles) |
+| Full window | yes (but empty) | **never** — always a split, max 75% (`pane.rs:115`) |
+
+Aggravators: opening the split does not focus the new pane
+(`tab.rs:636-664`); the BARS group ignores focus and always writes to the flow
+pane (`app.rs:946-951`) while the status bar reads the focused pane;
+sub-minute intervals silently discard the entire venue prefix
+(`resample.rs:24`, `tab.rs:540-542`); chips say "1m" while toolbar/status say
+`time(60000ms)`.
+
+Redesign (approved direction):
+
+- **S1 — venue candle history belongs to any pane whose spec is
+  `BarSpec::Time`**, not to "the time pane object". This is the real fix.
+- Timeframe preset chips in the toolbar (same list as the header); opening
+  default 1m, not 1s; human labels everywhere.
+- **A third layout: `Time` alone** (full-window timeframe chart).
+- Layout moves from File to View with a label that says "timeframe"; opening
+  the split focuses the pane it creates.
+
+### The default-bar-type decision
+
+The user suggested time bars as the default. Decision (2026-08-05): **keep
+the flow pane as the factory default** — alternative bars are the product's
+identity, the flow layers only render on the flow pane, and switching the
+default would not fix the broken route (the app would simply *open* on a
+one-bar chart). Instead: fix Route A + ship the `Time` layout + persist the
+workspace so the user's own choice becomes their default; optionally expose
+`default_bars = "time:1m"` in `feeds.toml` as per-feed configuration.
+
+## 4. Pain point 3 — editing indicator properties
+
+Full detail: [`indicators.md`](ux-audit-2026-08/indicators.md).
+
+Four independent root causes:
+
+1. **No legend — the on-screen object is inert.** No overlay legend exists
+   (`indicator_render.rs:116`), the pane title has no `Sense`
+   (`indicator_render.rs:263-269`). The TradingView convention (double-click
+   the name → settings) has nowhere to happen. The project's own spec
+   (`docs/ux/ui-design-model.md` §9) describes exactly this legend; it was
+   never built.
+2. **The menu occludes the dialog it spawns.** The gear does not close the
+   menu (`toolbar.rs:641-647`) and egui paints menus above windows.
+3. **No live preview, and Apply closes.** Four clicks per tuning attempt
+   (`indicator_panel.rs:56-71`).
+4. **The app contradicts itself.** The drawing inspector already implements
+   the right model (select → inspector → live apply → undo); indicators break
+   every part of it.
+
+Also blockers: script errors are computed and never rendered (an errored
+indicator just disappears — against the data-honesty rule); the 4th pane
+indicator silently does not draw (`indicators/mod.rs:241-246`).
+
+Redesign (approved direction): build the chart legend (error/stale rows
+included, double-click opens settings); reuse the drawing-inspector host for
+indicator properties with Inputs/Style/Visibility tabs; make `PlotSpec`
+editable as a UI-side override; immediate quick wins (close menu on gear,
+deliberate dialog position, Apply without closing, delete confirm/undo,
+show the scripts folder + rescan).
+
+## 5. Remaining areas — headline findings
+
+- **Drawing tools** ([`drawing-tools.md`](ux-audit-2026-08/drawing-tools.md)):
+  blockers — drawings do not survive a restart (no `save()` on the app);
+  all chart navigation is dead while a tool is armed. Majors — no trend line,
+  no line styles, style neither presetable nor remembered, no right-click
+  menu, no delete-all, no magnet/snap, tool shortcuts stay live while the
+  rail is hidden.
+- **Chart canvas** ([`chart-canvas.md`](ux-audit-2026-08/chart-canvas.md)):
+  blocker — projection caps drop tape data silently (log-only, against the
+  CLAUDE.md honesty rule). Majors — zero inspection of any flow mark (a
+  bubble with ten encodings answers no questions), crosshair is a mode that
+  costs object selection, prices hardcoded to 2 decimals in three places,
+  no canvas gesture is discoverable (one cursor on the whole canvas), no
+  back-to-live control, overloaded double-click, wheel zoom anchored to the
+  right edge instead of the pointer.
+- **App chrome** ([`app-chrome.md`](ux-audit-2026-08/app-chrome.md)):
+  blockers — a bad config file kills the process before any window opens;
+  Binance/Hyperliquid can never escalate to an actionable `Attention` notice.
+  Majors — feed/symbol switching destroys the chart with no warning or undo,
+  the status bar has no overflow strategy, the default 1100 px window already
+  folds three toolbar groups (full toolbar needs 1172 px), two picker idioms
+  for the same job.
+
+## 6. Prioritized roadmap
+
+| Prio | Item | Resolves |
+|---|---|---|
+| P0 | Close/state on toolbar + position HUD + honest status cell + chip-collision fix + dock badge | Pain 1 |
+| P0 | Venue history for any `BarSpec::Time` pane + timeframe chips in toolbar + 1m default + human labels | Pain 2 |
+| P0 | Indicator chart legend (with visible error/stale) + menu closes on gear + Apply stays open + positioned dialog | Pain 3 |
+| P0 | One-to-three-line quick-win batch: cursors on axes and sim lines, jump-to-live chip, ScrollAreas (Trading tab, object manager), tape/bars tooltips, focus-gated Ctrl+W, rail-hidden shortcut gate, hide-all preview guard, persistent Fib errors, delete-all drawings | ~20 findings |
+| P1 | **`ui-state.toml` (§14):** tabs, layout, split, focus, bar spec, dock, timezone, window + drawings persisted per (feed, symbol, spec) | Biggest single lever |
+| P1 | `Time` layout alone + Layout in View menu + focus follows creation + resolve BARS×focus | Pain 2 structural |
+| P1 | Unified inspector (drawings + indicators) with plot Style tab | Pain 3 structural |
+| P1 | Brackets on open positions (Apply + drag-to-create) + trades ledger + fill markers | Sim as a practice tool |
+| P1 | Crosshair as hover + OHLC readout + bubble inspection tooltip + pointer-anchored zoom + step-aware price decimals | Canvas readability |
+| P1 | Config error in a window + Attention path for Binance/Hyperliquid + confirmed market switching | Chrome blockers |
+| P2 | Trend line/ray/vertical/text tools; dash/dot line styles + style presets; right-click context menu; magnet/snap | Charting parity |
+| P2 | Unified Settings surface (~19 env vars); Insert menu; Indicators dock tab; resizable panes; status-bar overflow plan; live window title; Help → shortcuts | Finish |
+
+## 7. Visual direction — "clean" without changing the soul
+
+The current dark theme is solid. Five principles guide the redesign:
+
+1. **Everything on screen answers questions.** Legend for indicators, tooltip
+   for bubbles, OHLC at the crosshair, HUD for the position. If a pixel
+   encodes data, the data is reachable with the mouse.
+2. **Every gesture announces itself.** The cursor changes over anything
+   draggable; hover highlights; interactive things look interactive.
+3. **One editing model for the whole app.** Select → inspector appears →
+   changes apply live → undo. Drawings already do this; indicators and the
+   sim join them.
+4. **Dense by default, quiet by choice.** Keep the terminal density, add
+   cross-layer control (per-layer opacity/focus) and bubble presets whose
+   thresholds are all alive — no encoding that cannot be read.
+5. **Honesty even in the cut.** Capped tape gets an amber status cell like
+   every other admission; discarded sub-minute history explains itself.
+
+## 8. Methodology
+
+Six independent parallel audits (paper trading, tabs/timeframe, indicators,
+drawing tools, chart canvas, app chrome) by separate reviewers over the code
+at `main @ 2856238`, without running the app — pixel-level claims are
+inferences from constants and are marked as such in the reports. Severities:
+Blocker / Major / Minor / Nit; Nielsen heuristics cited per finding. The
+per-area reports under [`ux-audit-2026-08/`](ux-audit-2026-08/) contain the
+full atomic inventories (every control with `file:line`), the exact user
+flows as implemented, all findings, and quick-win vs structural
+recommendations.

--- a/docs/ux/ux-audit-2026-08/app-chrome.md
+++ b/docs/ux/ux-audit-2026-08/app-chrome.md
@@ -1,0 +1,327 @@
+# App chrome — full audit report
+
+Read-only analysis of everything around the chart canvas: menu bar, toolbar, status bar, tab strip, source picker, replay browser/transport, notice cards, loading indicators, theming, and window chrome.
+
+## 1. INVENTORY
+
+### 1.1 Window chrome & startup
+
+| # | Element | Location | Trigger | Effect |
+|---|---|---|---|---|
+| 1 | Window title `quantick` | `main.rs:146` | startup | Static title. Never reflects feed/symbol/replay state. |
+| 2 | Window icon | `main.rs:136-147` | startup | Bundled `assets/icon.png`. |
+| 3 | Initial window size 1100×650 | `main.rs:141` | startup | See F-06 — at this width the toolbar already folds 3 groups. |
+| 4 | Minimum window size 900×560 | `main.rs:144` | resize | Floor chosen so the drawing rail doesn't clip (documented). |
+| 5 | Config load failure → `process::exit(1)` | `main.rs:95-106` | malformed `QUANTICK_CONFIG`/`quantick.toml` | Logs `CONFIG_ERROR` to stderr and exits **before any window opens**. |
+| 6 | Startup-selection failure → `process::exit(1)` | `main.rs:107-115` | bad `QUANTICK_DEFAULT_FEED`/`_SYMBOL` | Same: stderr + exit, no window. |
+| 7 | Tracing init | `main.rs:63-88` | startup | stderr; `QUANTICK_LOG_FORMAT=json` for NDJSON. |
+| 8 | Theme install | `main.rs:158-161`, `theme.rs:75-107` | startup | Phosphor font + dark tokens applied to egui `Visuals`. One theme only. |
+
+### 1.2 Menu bar (zone 1, 28 px — `app.rs:1755-1928`)
+
+| # | Item | Location | Trigger | Effect |
+|---|---|---|---|---|
+| 9 | **File → New Tab…** | `app.rs:1776` | click / `Ctrl+T` | Opens `SourcePicker`. |
+| 10 | **File → Close Tab** | `app.rs:1784-1798` | click / `Ctrl+W` | Closes active tab; disabled on last tab with explanation. |
+| 11 | **File → Layout → Single** | `app.rs:1802` | click | `set_layout(Single)`. |
+| 12 | **File → Layout → Time + Flow** | `app.rs:1803` | click | Builds/reveals the time pane (deferred one frame, shows `BarRebuild` spinner). |
+| 13 | **File → Market Replay…** | `app.rs:1815-1824` | click / `Ctrl+R` | Opens the replay browser window. |
+| 14 | **File → Close Replay** | `app.rs:1825-1831` | click (only rendered while replaying) | Returns to the live feed. Entry vanishes when not replaying. |
+| 15 | **File → Exit** | `app.rs:1833` | click | `ViewportCommand::Close`. No confirmation. |
+| 16 | **View → Hide/Show panels** | `app.rs:1838-1852` | click / `Ctrl+B` | Toggles the whole dock. Label flips with state. |
+| 17 | **View → Drawing toolbar → Left/Right/Top/Bottom** | `app.rs:1853-1868` | click | Re-docks the drawing rail; `selectable_label` marks current. |
+| 18 | **View → Hide/Show drawing toolbar** | `app.rs:1869-1877` | click | Toggles the rail. |
+| 19 | **View → L2 settings** | `app.rs:1878-1888` | click | `dock.open_tab(L2)`. |
+| 20 | **View → Bubble settings** | idem | click | `dock.open_tab(Bubbles)`. |
+| 21 | **View → Session** | idem | click | `dock.open_tab(Session)`. |
+| 22 | **View → Paper trading** | idem | click | `dock.open_tab(Trading)`. |
+| 23 | **View → Perf readings** (checkbox) | `app.rs:1890` | click | Shows/hides fps + frame ms + trade count on the status bar. Default **off** (see F-09). |
+| 24 | **View → Timezone → (38 offsets)** | `app.rs:1893-1905` | click | Sets `self.tz`; scroll area capped at 280 px. Duplicate of the status-bar combo (#68). |
+| 25 | **Tools → Appearance…** | `app.rs:1908` | click | Opens the candle/canvas style window. |
+| 26 | **Help → Replay file format…** | `app.rs:1914` | click | Opens the replay browser **with the format section expanded**. |
+
+### 1.3 Tab strip (shares the menu row — `tabstrip.rs:53-102`)
+
+| # | Element | Location | Trigger | Effect |
+|---|---|---|---|---|
+| 27 | Tab chip `SYMBOL · venue` | `tabstrip.rs:56-65`; label built in `tab.rs:710-716` | click | Activates that tab. Amber text while that tab is replaying (`tabstrip.rs:59-61`). |
+| 28 | Attention dot (amber, 3 px) | `tabstrip.rs:67-74`; predicate `tab.rs:560-564` | background tab reconnecting or holding an `Attention` notice | Painted top-right of the chip. Suppressed on the active tab. |
+| 29 | Chip close `×` | `tabstrip.rs:77-91` | hover / active / last-tab | Closes the tab; disabled on the last tab. |
+| 30 | `+` button | `tabstrip.rs:94-100` | click / `Ctrl+T` | Opens the source picker. Tooltip "Open another market (Ctrl+T)". |
+
+### 1.4 Source picker dialog (`tabstrip.rs:234-359`, driven by `app.rs:3118-3163`)
+
+| # | Element | Location | Trigger | Effect |
+|---|---|---|---|---|
+| 31 | Window "Open market" | `tabstrip.rs:243-247` | `Ctrl+T` / `+` / File → New Tab | Non-collapsible, **non-resizable**, no anchor. |
+| 32 | Feed combo | `tabstrip.rs:249-266` | click | Sets draft feed; unimplemented providers labelled `"… (soon)"` (`config.rs:60`). |
+| 33 | Symbol combo | `tabstrip.rs:272-278` | click | Sets draft symbol; auto-corrected by `ensure_symbol_valid` when the feed changes. |
+| 34 | "added here" list + `×` per symbol | `tabstrip.rs:283-316` | click | Removes a user-added symbol from the catalog. Disabled while a tab shows it. |
+| 35 | "Add symbol…" field + **Add** | `tabstrip.rs:319-338` | Enter / click | Trimmed, taken verbatim, added to the catalog, persisted to `quantick-symbols.toml`, opened in a new tab. |
+| 36 | Refusal line | `tabstrip.rs:341-343`, set from `app.rs:3155-3159` | failed `config.validate()` | Red small text under the field; dialog stays open. |
+| 37 | **Open** / **Cancel** | `tabstrip.rs:346-353` | click | Opens the chosen market in a new tab / dismisses. Window `×` also cancels. |
+
+### 1.5 Toolbar (zone 2, 44 px — `toolbar.rs:265-317`)
+
+**SOURCE group** (`toolbar.rs:320-358`)
+
+| # | Element | Location | Trigger | Effect |
+|---|---|---|---|---|
+| 38 | `feed` label + feed combo | `toolbar.rs:342-349` | click | Writes `tab.feed_id`; feed switch applied later in the frame via `maybe_switch_feed` (`tab.rs:889`) — **resets the chart**. |
+| 39 | `symbol` label + symbol combo | `toolbar.rs:350-357` | click | Writes `tab.symbol`; same reset path. |
+| 40 | Amber replay label (replaces 38+39) | `toolbar.rs:321-330` | while replaying | `source: <session>` in amber, hover shows file path + side source (`app.rs:896-907`). No combos while replaying — deliberate. |
+
+**BARS group** (`toolbar.rs:362-437`)
+
+| # | Element | Location | Trigger | Effect |
+|---|---|---|---|---|
+| 41 | `bars` kind combo (Tick/Volume/Dollar/Time/Imbalance) | `toolbar.rs:370-387` | click | Sets `pane.kind`; rebuild deferred to `apply_spec_changes` (`app.rs:2986`) with a `BarRebuild` spinner. Size-based kinds disabled without `traded_volume`, with the reason on hover. |
+| 42 | Bar parameter (`N trades` / `units` / `notional` / `interval ms` / `target trades`) | `toolbar.rs:395-437` | drag / type | Sets the spec parameter. Folds into the kind combo as `tick · 50` when collapsed. |
+
+**HISTORY group** (`toolbar.rs:452-477`)
+
+| # | Element | Location | Trigger | Effect |
+|---|---|---|---|---|
+| 43 | `+ older` button | `toolbar.rs:454-460` | click | `request_older_history()`. Disabled without `history_paging`: "this feed only streams forward…". |
+| 44 | Caret `▾` menu → page size drag (500–50 000) | `toolbar.rs:461-477` | drag | Trades pulled per click. |
+| 45 | "N trades backfilled so far" | `toolbar.rs:476` | — | Read-only counter inside the caret menu only. |
+
+**TRADE group** (`toolbar.rs:483-510`)
+
+| # | Element | Location | Trigger | Effect |
+|---|---|---|---|---|
+| 46 | **BUY** (teal, bold) | `toolbar.rs:484-496` | click | Simulated market buy at the Trading tab's quantity. Disabled until the sim has seen a price. |
+| 47 | **SELL** (red, bold) | `toolbar.rs:498-509` | click | Mirror of #46. |
+
+**LAYERS group** (right-aligned — `toolbar.rs:515-572`)
+
+| # | Element | Location | Trigger | Effect |
+|---|---|---|---|---|
+| 48 | Indicators menu (chart-line glyph) | `toolbar.rs:577-660` | click | Accent-coloured when any indicator is active. Contains: Add EMA(9), Add CVD pane, script list, and per-indicator rows with status dot, eye, gear, trash. |
+| 49 | Bubbles toggle (three-circles, BUY accent) | `toolbar.rs:518-536` | left / right-click | Toggles the layer / opens the Bubbles dock tab. Disabled without `traded_volume`. |
+| 50 | Heatmap toggle (fire, ACCENT) | `toolbar.rs:538-553` | left / right | Toggles display only (capture keeps running) / opens the L2 tab. Disabled without `book_capture`. |
+| 51 | Live-strip toggle (wall, ACCENT) | `toolbar.rs:558-571` | left / right | Toggles the strip / opens the **L2** tab (same target as #50 — see F-12). Never capability-gated. |
+
+**LOOK / PANELS / OVERFLOW**
+
+| # | Element | Location | Trigger | Effect |
+|---|---|---|---|---|
+| 52 | Appearance icon (paint brush) | `toolbar.rs:303-309` | click | Toggles the style window; `active()` while open. |
+| 53 | Panels icon (sidebar) | `toolbar.rs:294-300` | click | `dock.toggle_visible()`; tooltip names Ctrl+B. |
+| 54 | Overflow `⋯` | `toolbar.rs:664-728` | click when anything folded | Holds Appearance, Show/hide panels, Load older + page size, Buy/Sell at market (SIM), bar parameter — in the fixed §6 order. |
+| 55 | Collapse planner | `toolbar.rs:127-144` | resize | Folds in order: LOOK → PANELS → HISTORY → TRADE → param → feed-name-to-initial. Symbol and LAYERS never fold. |
+
+
+### 1.6 Status bar (zone 7, 28 px — `statusbar.rs:203-363`)
+
+**Provenance (left)**
+
+| # | Segment | Location | Content / colour |
+|---|---|---|---|
+| 56 | State dot (8 px) | `statusbar.rs:227-232` | Faint = connecting, WARN = reconnecting, BUY = live, AMBER = replay (`statusbar.rs:46-53`). |
+| 57 | State word | `statusbar.rs:233-237` | `connecting` / `reconnecting` / `live` / `replay`. |
+| 58 | Venue name | `statusbar.rs:238` | Feed display name, or the literal `"recording"` while replaying (`app.rs:1686-1690`). |
+| 59 | Symbol (monospace) | `statusbar.rs:239-243` | — |
+| 60 | Tape cell | `statusbar.rs:255-263`, text in `tape_text` (`statusbar.rs:167-186`) | `arrival 230 ms` / `stale 12 s` (age > 10 s, `metrics.rs:27`) / `10× 45%` replaying / `arrival —`. Turns WARN past `HIGH_LAG_MS` (5 s) or when stale. **No tooltip anywhere on this cell.** |
+
+**Content (middle)**
+
+| # | Segment | Location | Content |
+|---|---|---|---|
+| 61 | Bar spec | `statusbar.rs:268-272` | e.g. `tick(50)`. |
+| 62 | Bar progress | `statusbar.rs:273-280` | e.g. `37/50 ticks`, amber, hover "how far the forming bar is from closing". |
+| 63 | Bar counts | `statusbar.rs:281-289`, `bars_text:190-199` | `240+61 bars`, or `26000v+240+61 bars` with a venue prefix. **No tooltip explaining the split.** |
+| 64 | Honesty label | `statusbar.rs:290-296`; source `tab.rs:1332-1359` | Amber: `side: inferred (tick rule)`, `side: not recorded`, `prints: quote-derived`. Hover carries the full disclosure. |
+| 65 | Sim P&L cell | `statusbar.rs:297-308` | `SIM ±N pts`, coloured by sign, hover "…simulated fills, not a broker account". Absent until the simulator is touched. |
+| 66 | "history · double-click for live" | `statusbar.rs:309-315` | TEXT_FAINT, only when the viewport is detached. |
+| 67 | "price: manual · double-click the axis to auto-fit" | `statusbar.rs:316-322` | TEXT_FAINT, only when the price axis is manual. |
+
+**Machinery (right, right-to-left)**
+
+| # | Segment | Location | Content |
+|---|---|---|---|
+| 68 | Timezone combo | `statusbar.rs:328-334` | 38 fixed offsets; default UTC−03:00 (`timezone.rs:88-92`). The bar's only control. |
+| 69 | Clock glyph | `statusbar.rs:335` | Decoration for #68. |
+| 70 | fps · frame ms · cpu ms | `statusbar.rs:347-356` | Only when `show_perf`; WARN past `SLOW_FRAME_MS` (20 ms). |
+| 71 | `N trades` | `statusbar.rs:358-362` | Only when `show_perf`. |
+
+### 1.7 Notice card (`notice_card.rs`)
+
+| # | Element | Location | Trigger | Effect |
+|---|---|---|---|---|
+| 72 | Card body (420 px, clamped to chart) | `notice_card.rs:164-219` | `should_draw` (`notice_card.rs:72-78`) | `Attention` → always. `Working`/`Reconnecting` → only while `bars == 0`. `Connected`/`Clear` → never. |
+| 73 | Severity dot + border | `notice_card.rs:181-197` | — | AMBER for `Attention`, TEXT_MUTED for progress. |
+| 74 | Headline + next step | `notice_card.rs:199-210` | — | Wrapped to the clamped width; step only exists on `Attention`. |
+| 75 | **Try again** button | `notice_card.rs:214-218` → `app.rs:3038-3042` → `tab.restart_feed` (`tab.rs:1427`) | click | Respawns the live feed and restarts book capture. Present only on `Attention`. |
+| 76 | Actual notice texts | `feed/mt5_bridge.rs:227-232, 365-371, 474-479, 493-499`; `feed/metatrader.rs:192-195, 256-258, 368, 487-493` | — | MetaTrader path is rich and actionable. **Binance/Hyperliquid only ever emit `Working`/`Reconnecting`/`Connected`** (`feed/binance.rs:154-161`, `feed/hyperliquid.rs:141-148`). |
+
+### 1.8 Loading (`loading.rs`)
+
+| # | Element | Location | Trigger | Label |
+|---|---|---|---|---|
+| 77 | `History` | `loading.rs:45-47, 67` | backfill / load-older / source reset | "loading history…" |
+| 78 | `BarRebuild` | `loading.rs:48-49` | bar kind/param change, time-pane build | "rebuilding bars…" |
+| 79 | `BookSync` | `loading.rs:50-51`; mirrored `app.rs:2998` | book connecting/buffering/resyncing | "syncing order book…" |
+| 80 | `ReplaySession` | `loading.rs:52-53`; mirrored `app.rs:2997` | session parsing on a worker | "loading replay session…" |
+| 81 | `VenueHistory` | `loading.rs:54-55` | candle history in flight | "loading venue history…" |
+| 82 | Overlay backdrop | `loading.rs:166-212` | any active task | Stacked rows, amber spinners, centred at the top of the chart, 150/255 black backdrop. |
+| 83 | `inline()` spinner | `loading.rs:158-161` | embedded | Used by the replay browser for the folder dialog and session load. |
+| 84 | Counting semantics | `loading.rs:103-127` | — | `begin`/`end` counted; `restart` collapses to 1; `set_active` level-triggered. Saturating — cannot underflow into "loading forever". |
+
+### 1.9 Replay browser (`replay_view.rs:280-540`)
+
+| # | Element | Location | Trigger | Effect |
+|---|---|---|---|---|
+| 85 | Window "Market Replay" | `replay_view.rs:287-293` | `Ctrl+R` / File / Session tab / Help | Centre-anchored, resizable, 560×460. |
+| 86 | Folder text field | `replay_view.rs:320-327` | Enter | Rescans. Seeded from `QUANTICK_REPLAY_DIR`. |
+| 87 | **Browse…** | `replay_view.rs:329-331` | click | Native folder dialog on a worker thread (`replay_view.rs:235-252`) — never blocks a frame. |
+| 88 | Refresh `↻` | `replay_view.rs:332-338` | click | Rescans. |
+| 89 | "waiting for the folder dialog" spinner | `replay_view.rs:340-344` | while the picker is out | Inline loading row. |
+| 90 | Session list | `replay_view.rs:349-419` | click / double-click | Selects / selects+loads. Shows label + size + per-entry notes. |
+| 91 | Empty states | `replay_view.rs:359-383` | no library / no sessions | "Choose the folder holding your recorded sessions." / "No sessions in this folder." + format hint. |
+| 92 | Problems collapsing header | `replay_view.rs:421-457` | rejected files | Per-file subject + detail + advice; auto-opens when no session loaded. |
+| 93 | Format help link | `replay_view.rs:459-491` | click | Toggles a scrollable monospace dump of `format::FORMAT_HELP`. |
+| 94 | Speed chips (Start at) | `replay_view.rs:508-515` | click | Sets the opening speed. |
+| 95 | "and play" checkbox | `replay_view.rs:517-518` | click | Autoplay vs open paused. |
+| 96 | **Play session** (amber fill) | `replay_view.rs:525-536` | click | Loads on a worker; disabled with "Pick a session from the list first". |
+| 97 | Error frame | `replay_view.rs:496-505` | parse failure | Red-tinted panel with `{e}\n{advice}`. |
+
+### 1.10 Replay transport (30 px, above the status bar — `replay_view.rs:544-633`)
+
+| # | Element | Location | Trigger | Effect |
+|---|---|---|---|---|
+| 98 | Skip-back | `replay_view.rs:560-566` | click | `Restart`. Tooltip "Back to the first print". |
+| 99 | Play/Pause (amber glyph) | `replay_view.rs:568-582` | click / **Space** | Reads live status before deciding, so a click can't invert a stale state. Space only when nothing has focus (`replay_view.rs:629-631`). |
+| 100 | `REPLAY` badge | `replay_view.rs:584, 655-668` | — | Amber pill, black text. |
+| 101 | Session label | `replay_view.rs:585` | — | — |
+| 102 | Session clock `HH:MM:SS` | `replay_view.rs:586-590`, `clock_text:725-728` | — | In the **session's own timezone**, not the app's `tz` (see F-13). |
+| 103 | Speed chips | `replay_view.rs:592-597` | click | `SetSpeed`. |
+| 104 | Seek track | `replay_view.rs:618-622, 677-721` | drag / click | Emits **one** seek per gesture on release. |
+| 105 | `N / M prints` | `replay_view.rs:607-615` | — | Space-grouped thousands (`thousands:735-745`). |
+| 106 | Close `×` | `replay_view.rs:600-606` | click | Back to the live feed. |
+
+### 1.11 Dock, theming, shared widgets
+
+| # | Element | Location | Notes |
+|---|---|---|---|
+| 107 | 36 px dock tab strip (L2, Bubbles, Session, Trading) | `dock.rs:173-192` | Always visible when the dock is visible; clicking the active tab collapses. |
+| 108 | Dock body, width remembered per tab | `dock.rs:194-220, 162-164` | Clamped 280–360 px. |
+| 109 | Session tab | `dock.rs:250-290` | Duplicates the replay entry point (#13) and Close Replay (#14). |
+| 110 | Design tokens | `theme.rs:20-52` | CANVAS/CHROME/INSET/CONTROL/BORDER/TEXT×3/BUY/SELL/ACCENT/AMBER/WARN/TAG_BG/TEXT_SUPPORT. Amber reserved for provenance honesty. |
+| 111 | Tooltip delay 350 ms | `theme.rs:79` | Prevents a trail of labels on a rail sweep. |
+| 112 | `IconButton` four-state grammar | `widgets.rs:106-141, 217-267` | disabled > pressed > active > hover > idle; disabled = 40 % opacity **plus** a hover explanation; focus ring on top. |
+| 113 | Appearance window "candle appearance" | `candle_view.rs:115-164` | Presets, live preview, body/outline/wick/live/canvas sections, "restore Order flow defaults", footer promising redraw-only. |
+
+## 2. FLOWS
+
+### (a) First launch
+
+1. `config::load()` → env override, then `./quantick.toml`, then the compiled-in `feeds.toml`. **Any parse error kills the process before a window exists** (`main.rs:95-115`).
+2. The live feed spawns **before** the window (`main.rs:134`), so backfill is already in flight at first paint.
+3. First frame: menu bar + one tab chip `BTCUSDT · Binance` + toolbar + empty canvas + status bar reading `● connecting  Binance  BTCUSDT  arrival —`, `tick(50)`, `0+0 bars`.
+4. Because `bars == 0`, the notice card shows `Working { "connecting to Binance" }` — headline only, no button.
+5. Backfill lands as one `Backfilled` batch; the overlay shows "loading history…" while it is out. `FeedNotice::Connected` flips the dot to green and clears the card.
+6. **Nothing about window state persists.** eframe is built with `default-features = false` and no `persistence` feature (`crates/app/Cargo.toml:29-34`), and `impl eframe::App` (`app.rs:2860`) defines only `update` — no `save`. Window size/position, dock state, open tabs, timezone, perf toggle and candle style all reset every launch. Only indicator state, added symbols, bubble presets and drawing presets have their own sidecar files.
+
+### (b) Switching feed and symbol
+
+- Two independent combos in the toolbar (#38, #39). Writing either mutates `tab.feed_id`/`tab.symbol` immediately; `maybe_switch_feed` (`tab.rs:889-935`) runs later in the same frame, respawns the feed and resets every pane.
+- Picking a feed that doesn't offer the current symbol silently retargets it: `ensure_symbol_valid` (`app.rs:969-973`, `tab.rs:720-724`) snaps to the feed's first symbol. **No confirmation, no undo** — and the reset discards loaded history and drawings (`note_overlay_cleared`).
+- During replay the combos are replaced by the amber session label, so a stale selection can't respawn a live feed under the recording.
+- The picker (#31-37) is the *other* path, and it opens a **new tab** instead of switching — two different mental models for "choose a market".
+
+### (c) Starting a replay session
+
+`Ctrl+R` / File → Market Replay… / dock Session tab → browser window → folder (env-seeded, typed, or **Browse…**) → scan (`library::scan`) → list + a collapsible "N file(s) were not loaded" with per-file advice → pick speed + autoplay → **Play session** → parse on a worker (inline spinner + `ReplaySession` overlay row) → on success the window closes and `ReplayAction::Open` fires; on failure the window stays open with `{error}\n{advice}` in a red frame.
+
+Once playing: the SOURCE group becomes the amber session label, the status dot turns amber, the tape cell becomes `10× 45%`, a 30 px transport appears above the status bar, and the tab chip's label turns amber. Exit via the transport `×`, File → Close Replay, or the Session tab's Close replay.
+
+### (d) Connection health and data honesty
+
+Four independent surfaces, and they genuinely say different things:
+
+- **Dot + word** — transport state, driven by explicit `Connected`/`Reconnecting` notices rather than inferred from trade arrival (`feed/mod.rs:296-309`).
+- **Tape cell** — `arrival` is a frozen observation from when the newest print landed; `stale N s` is wall-clock minus the newest event's timestamp, recomputed every frame. This is the only thing that catches a socket that stays open and delivers nothing (`statusbar.rs:157-186`, `metrics.rs:18-27`).
+- **Honesty label** — amber, in the middle section: `prints: quote-derived` beats `side: inferred` (`tab.rs:1328-1352`).
+- **Notice card** — the only surface that says *why* and offers a fix, and only MetaTrader populates it.
+
+Capability gating is consistently by capability, never by provider name: `traded_volume` disables the volume/dollar bar kinds and the bubble layer; `book_capture` disables the heatmap; `history_paging` disables `+ older`. Every disabled control keeps its glyph at 40 % and explains itself on hover.
+
+### (e) Settings / preferences
+
+There is no preferences surface. Settings are scattered across: the appearance window (candles/canvas), the dock tabs (L2, bubbles, trading), the View menu (perf, timezone, rail dock), the status-bar timezone combo, and **~19 environment variables** (`QUANTICK_CONFIG`, `_DEFAULT_FEED`, `_DEFAULT_SYMBOL`, `_BACKFILL`, `_BOOK_DEPTH`, `_REPLAY_DIR`, `_REPLAY_AUTOSTART`, `_REPLAY_SPEED`, `_SYMBOLS`, `_INDICATORS_DIR`, `_INDICATORS_STATE`, `_INDICATORS_AUTOSTART`, `_INDICATOR_SCRIPTS_AUTOSTART`, `_BUBBLES`, `_BOOK_AUTOSTART`, `_LIVE_STRIP_AUTOSTART`, `_BUBBLES_AUTOSTART`, `_DRAWING_PRESETS`, `_TRADES_DIR`, `_LOG_FORMAT`). None are discoverable from the UI.
+
+
+## 3. UX FINDINGS
+
+### Blocker
+
+**F-01 · A bad config file kills the app with no visible message.** `main.rs:95-115` — both `config::load()` and `apply_startup_selection_from_env()` log to stderr and `process::exit(1)` before `run_native`. Launched from a desktop shortcut or a file-manager double-click, the app flashes nothing and dies; the user has no way to learn that `quantick.toml` line 14 is malformed. The app already owns exactly the right widget for this — `FeedNotice::Attention` + the notice card's "Try again". *Heuristic: visibility of system status; help users recognize and recover from errors.*
+
+**F-02 · Binance and Hyperliquid can never ask for help.** `feed/binance.rs:154-161` and `feed/hyperliquid.rs:141-148` only ever call `connection_notice`, which yields `Working`/`Reconnecting`/`Connected` (`feed/mod.rs:296-309`). A wrong symbol, a geo-blocked endpoint, a DNS failure or a 451 all present identically: `● reconnecting` forever, a `Reconnecting` card that disappears the moment one bar exists, and **no Try again button** (the button only exists on `Attention`, `notice_card.rs:148-151`). *Heuristic: error recovery; help users diagnose.*
+
+### Major
+
+**F-03 · Changing feed or symbol silently destroys the chart, with no warning and no undo.** `toolbar.rs:343-357` writes straight through `&mut` borrows; `tab.rs:889-935` then respawns the feed and resets every pane, discarding loaded history and clearing drawings (`app.rs:2986-2989`). Two adjacent combos in the busiest part of the toolbar, one click apart, both destructive. *Heuristic: user control and freedom; error prevention.*
+
+**F-04 · Changing the feed can silently change the symbol.** `ensure_symbol_valid` (`app.rs:969-973`) snaps the symbol to the feed's first entry when the new feed doesn't offer the current one. Switching from `metatrader-b3 / WINQ26` to Binance lands you on `BTCUSDT` with no acknowledgement. *Heuristic: visibility of system status.*
+
+**F-05 · The status bar has no overflow strategy.** `statusbar.rs:211-221`: a single `horizontal_centered` row. The middle section can carry up to seven items simultaneously (#61-67), including a 46-character hint. The module's own comment concedes the risk (`statusbar.rs:291-293`) but nothing enforces it — no eliding, no clipping, no priority order, no equivalent of the toolbar's `collapse_plan`. At 900 px with a detached viewport, a manual price axis, a sim position and perf readings on, the timezone combo is the first thing to go. *Heuristic: consistency; aesthetic and minimalist design.*
+
+**F-06 · The shipped default window size already folds three toolbar groups.** `CollapsePlan::FULL.width()` = **1172 px** (`toolbar.rs:35-51, 97-120`), against a default inner width of 1100 (`main.rs:141`) minus 16 px margin = 1084 px available. The planner folds LOOK, then PANELS, then HISTORY before it fits. Out of the box, Appearance, Show/hide panels and Load older all live behind `⋯`. At the 900 px minimum, TRADE and the bar parameter fold too. Nobody sees the designed toolbar without resizing first. *Heuristic: recognition rather than recall.*
+
+**F-07 · Two different picker idioms for the same job.** The toolbar has bare feed+symbol combos that *switch the current tab* (destructively). The `+` picker has labelled combos, an add-symbol field, a remove list, and Open/Cancel — and it *opens a new tab*. Same catalog, same two fields, opposite outcomes, no cross-reference. The picker is also the **only** place a symbol can be added or removed. *Heuristic: consistency and standards.*
+
+### Minor
+
+**F-08 · The tape cell has no tooltip.** `statusbar.rs:255-263` — `arrival 230 ms`, `stale 12 s` and `10× 45%` all render in the same slot with no hover text. Same for the bar-count cell (#63): `26000v+240+61 bars` is unexplained.
+
+**F-09 · Perf readings default off, and the toggle is buried.** `View → Perf readings` (`app.rs:1890`) is the only path. The app logs `APP_SLOW_FRAMES` when frames exceed 20 ms (`app.rs:1601-1614`), so the app knows it is struggling while the user sees nothing on screen.
+
+**F-10 · Duplicate timezone pickers with no shared affordance.** `app.rs:1893-1905` (scrolling menu) and `statusbar.rs:328-334` (combo) both enumerate the same 38 offsets. Neither is searchable; neither shows city names.
+
+**F-11 · Replay has four entry points and three exits.** Entries: `Ctrl+R`, File → Market Replay…, Session dock tab, Help → Replay file format…. Exits: transport `×`, File → Close Replay, Session tab → Close replay. Defensible for discoverability, but the Session dock tab is almost entirely a shortcut to a window that already has a global shortcut.
+
+**F-12 · The live-strip toggle right-clicks into the L2 tab.** `toolbar.rs:570` — same target as the heatmap toggle (`toolbar.rs:552`). The tooltip promises "right-click for settings", and the tab that opens is titled `L2 · LIQUIDITY MAP`.
+
+**F-13 · The replay clock and the chart's time axis can disagree.** `replay_view.rs:725-728` renders the transport clock in the session's own recorded timezone, while the time axis uses the app-wide `tz` (default UTC−03:00). Two visible clocks showing different times for the same instant, with nothing labelling either.
+
+**F-14 · The `+ older` counter is hidden behind a caret menu.** `toolbar.rs:476` — "N trades backfilled so far" only appears after opening the `▾` menu.
+
+**F-15 · The window title never changes.** `main.rs:146` — always `quantick`. With multiple tabs, an alt-tab or taskbar preview says nothing about which market, which venue, or whether a recording is playing.
+
+**F-16 · No keyboard shortcut reference and no About.** Help contains one item. Shortcuts are discoverable only via individual tooltips or menu items, and several — Space for play/pause, double-click to re-follow live — appear in no menu at all.
+
+### Nit
+
+**F-17 · Window title casing is inconsistent.** `"Market Replay"`, `"Open market"`, `"candle appearance"`, `"Drawn objects"` — four windows, three casing conventions.
+**F-18 · Two different close glyphs.** Dock header and tab chips use Latin-1 `×`; the replay transport uses Phosphor `icons::X`.
+**F-19 · Mixed hyphen conventions in copy.** Tooltips use ASCII hyphens while notices use em/en dashes.
+**F-20 · Toolbar labels are lowercase, menu items are sentence case.** `feed`, `symbol`, `bars` against `New Tab…`, `Market Replay…`; the `⋯` menu mixes both.
+
+## 4. QUICK WINS vs STRUCTURAL
+
+### Quick wins
+
+1. **Show config errors in a window** (F-01). Instead of `process::exit(1)`, launch `run_native` with a minimal error viewport carrying the parse error and the resolved config path. ~30 lines in `main.rs`.
+2. **Give Binance and Hyperliquid an `Attention` path** (F-02). The variant, the card and the Try-again wiring all already exist; the reconnect loops just need a retry-count threshold that upgrades `Reconnecting` to `Attention` with the last transport error and a next step. Mirror `mt5_bridge.rs:474-479`.
+3. **Tooltip the tape and bar-count cells** (F-08). Two `.on_hover_text()` calls; the prose already exists verbatim in the source comments.
+4. **Widen the default window to ~1200 px, or re-measure the width constants** (F-06). Add a test pinning `CollapsePlan::FULL.width() <= default_inner_width - 16.0`.
+5. **Move "N trades backfilled" out of the caret menu** (F-14).
+6. **Live window title** (F-15): `SYMBOL · venue — quantick`, plus a `REPLAY` prefix, via `ViewportCommand::Title` whenever the chip label changes (`tab.rs:710-716` is already the one place that recomposes it).
+7. **Fix the live-strip right-click target** (F-12) — either a dedicated dock tab or a tooltip that names L2 honestly.
+8. **Help → Keyboard shortcuts** (F-16): a static window listing the ten bindings already defined in `app.rs:1729-1748`.
+9. **Copy pass** (F-17/19/20): one casing convention for window titles, em dashes everywhere.
+
+### Structural
+
+1. **A collapse plan for the status bar** (F-05). Port the `CollapsePlan` idea from `toolbar.rs:97-144`: rank the middle-section items by importance (spec > honesty label > counts > progress > sim P&L > navigation hints), measure, and drop the tail into a `⋯` hover or elide it. Contained entirely in `statusbar.rs`.
+2. **Make market switching non-destructive, or make it ask** (F-03/F-04). Options: (a) confirm before a switch that would discard history and drawings, with the count in the prompt; (b) unify on the picker — toolbar combos open a new tab like `+`, in-place switching behind an explicit action. Option (b) also resolves F-07.
+3. **UI-state persistence.** Enabling eframe's `persistence` feature + `save()` covers window geometry; a `ui-state.toml` sidecar — the pattern the codebase already uses four times — covers open tabs, dock state, timezone, perf toggle and candle style. `app.rs:384` already carries the §14 marker.
+4. **One settings surface.** ~19 env vars and no preferences dialog. A Tools → Settings window grouping data (backfill depth, book depth, replay folder), paths (indicators dir, trades dir, symbols file) and display (timezone, perf) — reading/writing the same sidecar as #3.
+5. **Unify the source-selection model** (F-07). One picker component used by both the toolbar (as a popup) and `+`, with the mode (switch this tab / open a new tab) as an explicit choice inside it.
+
+## 5. What is genuinely strong (don't regress it)
+
+Capability gating is by capability rather than provider name throughout, and every gated control stays visible at 40 % opacity with a written reason instead of disappearing (`widgets.rs:106-141`). The arrival-vs-staleness split in the tape cell is a real insight most trading apps get wrong. The notice card's "never cover a working chart" rule is enforced by a tested predicate (`notice_card.rs:72-78`). Amber is disciplined as a provenance-only token and never used decoratively. The replay seek commits once per gesture for a stated performance reason. And every chrome module ships an off-screen layout test that catches duplicated widget ids and panicking widgets before they reach the chart.
+

--- a/docs/ux/ux-audit-2026-08/chart-canvas.md
+++ b/docs/ux/ux-audit-2026-08/chart-canvas.md
@@ -1,0 +1,187 @@
+# Chart canvas — full audit report
+
+Read-only analysis of `crates/app/src/{chart,candle_view,price_view,viewport,orderflow_view,orderflow_render,live_strip,bubble_presets,pane,time_header,timezone}.rs`, `orderflow/*`, plus the input/layout code that actually owns the canvas gestures (`app.rs`, `tab.rs`, `toolbar.rs`, `toolrail.rs`, `statusbar.rs`).
+
+One structural note up front: `chart.rs`, `viewport.rs`, `price_view.rs` and `live_strip.rs` are pure, well-tested geometry with no UI in them. Every user-facing gesture on the canvas lives in `pane.rs::handle_navigation` (`pane.rs:1048-1389`) and every pixel is painted from `pane.rs::draw_chart` (`pane.rs:1391-1751`). `orderflow/interaction.rs` is named for *market* interaction (aggression vs. resting liquidity), not pointer interaction — it contains no UI.
+
+## 1. INVENTORY
+
+### Time-axis navigation
+
+| # | Element | Location | Trigger | Effect |
+|---|---|---|---|---|
+| 1 | Chart-body pan (time) | `pane.rs:1256-1266` | Left-drag horizontally anywhere on the candle body | `Viewport::pan_pixels` (`viewport.rs:84`); right edge moves by `dx / candle_width`. Drag right reveals history. |
+| 2 | Auto-resume follow | `viewport.rs:96` | Pan back until right edge is within 0.5 bars of newest | `follow = true`; chart re-pins to live. No user action, no announcement. |
+| 3 | Pan into empty future | `viewport.rs:18, 91-92` | Drag left past the newest bar | Right edge may travel `FUTURE_MARGIN_BARS = 40` slots past newest. Fixed bar count, not a pixel or viewport fraction. |
+| 4 | Chart-body zoom (time) | `pane.rs:1280-1292` | Mouse wheel over the candle body | `viewport.zoom(2^(scroll/300))`. **Anchored to the right edge** (`viewport.rs:63`), not to the pointer. |
+| 5 | Time-strip drag zoom | `pane.rs:1326-1335` | Left-drag horizontally on the bottom time strip | `viewport.zoom(exp(dx/120))`, `LANE_ZOOM_DRAG_PX` at `pane.rs:242`. |
+| 6 | Time-strip scroll zoom | `pane.rs:1336-1341` | Wheel over the bottom time strip | Same `2^(scroll/300)`. |
+| 7 | Zoom clamp | `viewport.rs:14-16` | — | Candle slot clamped to 2 px … 64 px. |
+| 8 | Jump to live + reset price | `pane.rs:1276-1279` | **Double-click the chart body** | `viewport.snap_to_live()` **and** `price_view.reset()` — one gesture, two resets, not separable. |
+
+### Price-axis navigation
+
+| # | Element | Location | Trigger | Effect |
+|---|---|---|---|---|
+| 9 | Chart-body pan (price) | `pane.rs:1267-1274` | Left-drag vertically on the candle body | `PriceView::pan` (`price_view.rs:42`); takes the axis out of auto-fit permanently. |
+| 10 | Price-gutter drag zoom | `pane.rs:222-228` (`axis_zoom_gesture`) | Left-drag vertically on the right price gutter | `price_view.zoom(exp(dy/150))`, `AXIS_ZOOM_DRAG_PX` at `pane.rs:191`. Drag up compresses the span, down expands it. |
+| 11 | Price-gutter scroll zoom | `pane.rs:229-234` | Wheel over the price gutter | `zoom(exp(-scroll/200))`, `AXIS_ZOOM_SCROLL_PX` at `pane.rs:195`. |
+| 12 | Price-axis reset | `pane.rs:216-218` | **Double-click the price gutter** | `price_view.reset()` → back to auto-fit. |
+| 13 | Auto-fit | `chart.rs:38-63`, `chart.rs:124-135` | Default state | Fits visible bars' high/low with `AUTO_PAD_FRAC = 0.05` (`chart.rs:139`). Falls back to last frame's window, then to the newest bar, so an empty view never blanks. |
+
+### Per-pane y-axis (PR #117)
+
+| # | Element | Location | Trigger | Effect |
+|---|---|---|---|---|
+| 14 | Indicator-pane axis zoom | `pane.rs:1380-1388` | Drag / scroll / double-click on that pane's own gutter band | Same `axis_zoom_gesture` as the price gutter. Keyed by `(pane_id, slot)` so a split's two charts don't share a drag. |
+| 15 | Pane gutter banding | `app.rs:192-198` | — | Each pane's gutter spans exactly its own height, so a drag can only ever move the pane whose numbers it is over. |
+
+### Live lane (reserved band)
+
+| # | Element | Location | Trigger | Effect |
+|---|---|---|---|---|
+| 16 | Lane divider resize | `pane.rs:1299-1319` | Drag the divider, grab area ±5 px (`pane.rs:184`) | `resize_live_lane` (`orderflow_view.rs:246`). Cursor becomes `ResizeHorizontal` — **the only cursor change on the entire canvas**. |
+| 17 | Lane time zoom (wheel) | `pane.rs:1285-1288` | Wheel while the pointer is right of the divider | `zoom_live_lane`; the candles do not zoom. Boundary from `gesture_hits_lane` (`app.rs:222`). |
+| 18 | Lane time-strip zoom | `pane.rs:1344-1362` | Drag / wheel on the time-strip segment under the lane | `zoom_live_lane(exp(dx/120))`. |
+| 19 | Lane window readout | `pane.rs:1809-1825` | Always, when a lane exists | Prints `tape · 37.5 s` under the lane. The only readout of what lane zoom is worth. |
+| 20 | Lane immunity to pan/zoom | `viewport.rs:388-399` (test) | — | Panning and zooming candles never moves the tape. |
+
+### Crosshair and readouts
+
+| # | Element | Location | Trigger | Effect |
+|---|---|---|---|---|
+| 21 | Crosshair | `pane.rs:2007-2059` | **Only while `Tool::Crosshair` is armed** (`pane.rs:2015`), key `2` (`toolrail.rs:457`) | Vertical + horizontal hairline, plus a price tag on the axis. |
+| 22 | Crosshair price tag | `pane.rs:2042-2058` | Same | `{price:.2}` on `theme::TAG_BG`. **No time tag on the x axis.** |
+| 23 | Last-price line | `pane.rs:1904-1909` | Always | Dashed 4/4 px across the body, coloured by the carrying bar's direction (`candle_view.rs:35`), alpha 0.55. |
+| 24 | Last-price chip | `pane.rs:1913-1924` | Always | Filled chip on the gutter, `{price:.2}`, dark text. |
+| 25 | Price gridlines + labels | `pane.rs:1841-1860` | Always | `nice_ticks(lo, hi, 8)` (`chart.rs:295`), label `{tick:.2}`. |
+| 26 | Time-strip labels | `pane.rs:1775-1799` | Always | `HH:MM:SS` (`app.rs:354`), step `= (visible/6).max(1)` in **bar indices**, not pixels. No date component. |
+| 27 | Timezone selector | `statusbar.rs:328-334` | Combo in the status bar | 38 fixed offsets (`timezone.rs:45-84`), default UTC−03:00 (`timezone.rs:88-92`). Relabels the time axis only; engine stays UTC. |
+
+### Canvas chrome and honesty marks
+
+| # | Element | Location | Trigger | Effect |
+|---|---|---|---|---|
+| 28 | Seam divider | `pane.rs:2069-2092` | Venue prefix present and on screen | Dashed amber rule + `venue` label. |
+| 29 | Backfill divider | `pane.rs:2099-2139` | Backfill boundary on screen | Solid amber rule + `backfill` / `live` labels. |
+| 30 | Empty-view message | `pane.rs:1732-1740` | No bars in the candle pane | `"no bars in view — double-click to return to the live edge"`. |
+| 31 | Connecting message | `pane.rs:1413-1419` | `total == 0` | `"connecting to <symbol> …"`. |
+| 32 | L2 status badge | `orderflow_view.rs:498-521` | **Only while `depth_visible()`** (`:501`) | Top-right plate with the capture state. |
+| 33 | Status-bar follow hint | `statusbar.rs:309-315` | Only when `!follows_live` | `"history · double-click for live"`. |
+| 34 | Status-bar price hint | `statusbar.rs:316-322` | Only when `!price_auto` | `"price: manual · double-click the axis to auto-fit"`. |
+| 35 | Focused-pane rule | `tab.rs:1541-1547` | Split layout | 1 px accent line under the focused pane's top edge. |
+| 36 | Pane focus by click | `tab.rs:1553-1575` | Any primary press inside a pane | Sets `focus`; read from the raw pointer so the same press that starts a pan also focuses. |
+| 37 | Canvas divider | `tab.rs:1582-1599` | Drag between the two panes | Resize, clamped to 25 % minimum each (`pane.rs:115, 162`). |
+| 38 | Timeframe chips | `time_header.rs:85-108` | Click 1m/5m/15m/1h, or drag the ms `DragValue` | Time pane interval. |
+
+### Layer toggles — all off-canvas, in the toolbar
+
+| # | Element | Location | Trigger | Effect |
+|---|---|---|---|---|
+| 39 | Bubbles toggle | `toolbar.rs:518-536` | Left-click icon | `set_bubbles_enabled`. Disabled when the feed reports no traded volume (`:524`). Right-click opens the Bubbles dock tab. |
+| 40 | Heatmap toggle | `toolbar.rs:538-553` | Left-click icon | `set_depth_visible`; capture keeps running (`orderflow_view.rs:183-198`). Disabled without `book_capture`. Right-click opens the L2 tab. |
+| 41 | Live-strip toggle | `toolbar.rs:558-571` | Left-click icon | `live_strip_visible`; never capability-gated (`pane.rs:584-595`). |
+| 42 | Live strip content | `orderflow_view.rs:541-643` | Strip visible | Mirrored buy/sell aggression histogram for the forming bar, normalized by its own biggest bucket (`live_strip.rs:91-96`), plus best bid/ask touch lines. |
+
+### Bubble anatomy (one mark, up to ten simultaneous encodings)
+
+`draw_bubble` at `orderflow_render.rs:522-669`. Radius = quantity (`bubble_radius:2252`); fill colour = side (`:192-198`); vertical lean = side, sliding with buy share (`:1300-1305`); halo alpha = normalized size (`:348-350`); hollow ring vs solid disc = buy side below `readable_min_radius` (`:560-562`); pie split = buy share of a closed-bar summary (`:610-623`); consumption front = ate resting liquidity (`:647-656`); impact-ring brightness = matched fraction (`:657-668`); trail = ate liquidity (`:1337-1358`); text = quantity and/or `×N` (`:1382-1405`). Three further channels (sphere shading, rim, separator ring) carry no data. The on-canvas legend (`:1415-1445`) explains at most six things and needs `chart_rect.width() >= 150.0` to draw at all (`:1451`).
+
+### Gestures that do **not** exist
+
+- **No right-click anywhere on the canvas.** `secondary_clicked` appears only at `toolbar.rs:534/551/569` and `toolrail.rs:974`. No context menu on a candle, bubble, axis, drawing or the lane.
+- **No hover or click on any order-flow mark.** Every flow draw function takes a bare `&egui::Painter`; the only `egui::Sense` in `orderflow_render.rs` is at line 1529, inside the *settings-panel preview*. No hit-test, no nearest-bubble search, no tooltip.
+- **No candle OHLC readout** of any kind — no hover tooltip, no corner legend.
+- **No keyboard chart navigation.** Shortcuts are tabs/dock/replay (`app.rs:1729-1748`) and tool arming (`toolrail.rs:454-463`). No arrow-key pan, no `+`/`−`, no Home/End.
+- **No middle-drag pan, no horizontal wheel, no Ctrl/Shift wheel modifiers.** Only `raw_scroll_delta.y`.
+
+
+## 2. FLOWS
+
+**(a) Navigating history and returning to live.** Left-drag right on the candle body; each pixel moves the right edge by `1/candle_width` bars (`pane.rs:1266`). At the default 8 px slot, a full 1200 px drag buys 150 bars. Older trades are fetched separately through the toolbar's HISTORY group, not by reaching the left edge. To return: double-click the chart body (`pane.rs:1276`) — or drag back until the edge falls within half a bar of the newest, which silently re-arms follow (`viewport.rs:96`). There is no button, and the only on-screen hint is a small grey line in the status bar (`statusbar.rs:311`) that appears only after you have already left. When history is prepended or the series is re-cut, the window is held steady by `shift_right_edge` / `reanchor` (`viewport.rs:129, 153`) — this part is handled carefully.
+
+**(b) Zooming time and price.** Time: wheel over the body, or drag/wheel the bottom time strip. Price: drag or wheel the right gutter. The two axes never zoom together and there is no gesture that does both. Time zoom is right-edge-anchored, so the bars under the cursor slide away as you zoom.
+
+**(c) Resetting a manually-zoomed y-axis.** Double-click the gutter (`pane.rs:216`). For an indicator pane, double-click *that pane's own* gutter band (`pane.rs:1380`). Double-clicking the chart body also resets price, but drags the viewport to live as a side effect (`pane.rs:1276-1279`). Discovery relies entirely on the status-bar line at `statusbar.rs:318`, which only appears once the axis is already manual.
+
+**(d) Reading order-flow information from a bubble.** There is no flow. A bubble carries up to ten simultaneous encodings and **none of them is queryable**. The only numeric readout is the optional in-bubble label (`orderflow_render.rs:1382-1405`), which requires `radius >= label_min_radius` *and* the text to fit within `1.78 r × 1.45 r`. Everything else — exact quantity, price, timestamp, trade count, what it consumed — is unreachable from the chart.
+
+**(e) Toggling visual layers.** Not on the canvas at all. Three icon buttons in the toolbar's LAYERS group (`toolbar.rs:515-572`); left-click toggles, right-click opens the corresponding dock tab for settings. Bubbles and heatmap are capability-gated with disabled-state explanations, which is good practice. But the toggles always act on the **flow pane's** tape (`app.rs:910-911, 985-995` → `tab.rs:614`), whereas the indicator commands beside them act on the **focused** pane (`app.rs:1007`).
+
+## 3. UX FINDINGS
+
+### Blocker
+
+**F1 — Capped projections drop market data silently.** `max_aggression_primitives = 700` and `max_visible_cells = 12000` (`orderflow/config.rs:810-811`) discard primitives whenever the frame exceeds them, size-ranked (`projection.rs:360`, `1071-1082`). The drop counts *are* computed (`projection.rs:349-356`) and *are* logged — as a `tracing::warn!` with `event_code = "HEATMAP_PROJECTION_CAPPED"` (`app.rs:1648-1662`) — but they never reach the canvas or the status bar. The trader sees a complete-looking tape that is a subset of the flow. This contradicts the project's own non-negotiable rule in CLAUDE.md: *"inferred or incomplete data is labeled as such, never silently patched."* Every other honesty case in this codebase gets an amber mark (`pane.rs:2084`, `2122`, `statusbar.rs:294`); this one gets a log line nobody reads.
+
+### Major
+
+**F2 — Zero inspection of order-flow marks.** (Heuristic: recognition rather than recall; match between system and real world.) The product's whole reason to exist is order-flow reading, and the richest mark on the screen answers no questions. A trader who spots an unusually large bubble cannot learn its size, its price, or when it printed. Evidence: `draw_aggression_bubbles` (`orderflow_render.rs:1286-1407`), `draw_heatmap_background` (`:896-992`), `draw_liquidity_events` (`:1058-1277`) and `OrderflowView::draw_live_strip` (`orderflow_view.rs:532-644`) all take `&Painter` only and cannot register interaction by construction. The projection already carries every field a tooltip would need (`AggressionPrimitive` in `orderflow/projection.rs`, including `agg_ids`, `trade_count`, `first/last_timestamp_ms`, `matched_fraction`) and each primitive already has `x`, `y`, `size` in screen space — the data for a hit-test is sitting there unused.
+
+**F3 — The crosshair is a mode, and an expensive one.** `pane.rs:2015` returns early unless `Tool::Crosshair` is armed. The rail defaults to `Tool::Pointer`, so a fresh chart has **no cursor price readout at all**. Three compounding problems: (i) nothing on screen says the crosshair exists; (ii) at narrow rail widths the Crosshair button folds into the More overflow (`toolrail.rs:1576-1580`), so the only route to a price readout is buried in a menu; (iii) arming Crosshair costs you drawing selection and movement, because that whole branch requires `Tool::Pointer` (`pane.rs:1120`). The user must choose between reading prices and editing objects. Every mainstream charting product treats the crosshair as a hover state, not a tool.
+
+**F4 — Price labels are hardcoded to two decimals, in three places.** `pane.rs:1856` (axis), `pane.rs:1914` (last-price chip), `pane.rs:2045` (crosshair tag). Two failure modes, both live in this product's own markets: on B3 index futures (WIN ≈ 137000, integer ticks) every label wastes three characters on `.00` in a narrow gutter; on a fine-tick instrument `nice_ticks` can return a step below 0.01, and then **two different gridlines print the identical number**. The fix already exists in the codebase and is not being used: `chart::axis_labels` (`chart.rs:365`) derives decimals from the step (`tick_decimals`, `chart.rs:451`), applies unit suffixes, and thins labels to `AXIS_LABEL_MIN_GAP_PX` (`thin_to_fit`, `chart.rs:424`). `draw_price_axis` bypasses all of it and calls raw `nice_ticks` (`pane.rs:1841`). The result is that the **price axis is the only axis in the app without step-aware decimals or collision thinning** — every indicator pane gets better treatment than the price.
+
+**F5 — No gesture on the canvas is discoverable.** (Heuristic: visibility of system status; affordance.) `axis_zoom_gesture` (`pane.rs:208-235`) registers a full `click_and_drag` region over the price gutter and sets **no cursor, no hover highlight, nothing**. Same for the time strip (`pane.rs:1326`). The code is aware of the problem — the lane divider's comment at `pane.rs:178-183` states outright *"the resize cursor is the only thing that says so"* — and that is literally true: the lane divider is the sole element on the canvas that changes the pointer. So the price zoom, the time-strip zoom, the two double-click resets and the lane zoom are all invisible until someone tells you. The status-bar hints (`statusbar.rs:309-322`) are reactive and remote: they appear at the bottom of the window only *after* you have already left auto-fit, and they teach the way out, never the way in.
+
+**F6 — No "back to live" control.** With bars still visible but old, nothing on the canvas offers a return; the empty-view message (`pane.rs:1736`) only fires in the degenerate case where the pane holds no bars at all. Panning back through a long session is a long drag with no scrollbar, no minimap, and no go-to-date.
+
+**F7 — Double-click is overloaded and collides with object editing.** `pane.rs:1276-1279` resets viewport *and* price together, so a user who has carefully framed a price range and just wants to jump to live loses the framing; there is no way to reset time alone. Worse, with `Tool::Pointer` armed a click over a drawing selects it (`pane.rs:1151-1169`) — and no drawing tool implements `double_clicked` anywhere (confirmed: no matches in `crates/app/src/drawings`). So double-clicking a trendline, the natural "open properties" gesture in every charting product, instead **snaps the whole chart to the live edge**.
+
+**F8 — Wheel zoom is anchored to the right edge, not the pointer.** `viewport.rs:63-69`: *"Anchored to the right edge — the newest bar stays put."* When examining a cluster 200 bars back, scrolling to zoom in pushes that cluster off screen. This is the single most-used chart gesture and it fights the user in exactly the situation the product is designed for.
+
+**F9 — Visual overload has no cross-layer control.** With everything on, the canvas paints roughly thirty distinct layer types in one frame. Every de-cluttering mechanism is *within* a layer — temporal clustering (`orderflow/config.rs:30`), dust merge (`:452-462`), primitive caps (`:810-811`), noise floors (`:802-803`). There is no global opacity, no "dim everything but this layer", no focus mode. Layer opacity exists only inside the Bubbles dock tab, three clicks away. There is also no spatial de-confliction at all: no overlap test, no label-collision avoidance, no repulsion — two bubbles at the same price and time simply overdraw, mitigated only by a constant 3.5 px side nudge (`config.rs:384`) and a darker rim. Against the stated goal of a clean look, and with `live lane pie` (spheres, halo 0.20, pie splits, `×N` labels) shipped as the default for both MT5 feeds (`config/bubbles.toml:9`, `crates/app/config/feeds.toml:61-86`), the default state is the busiest one.
+
+**F10 — Ten encodings on one mark, six-row legend, no key for the rest.** `legend_entries` (`orderflow_render.rs:1415-1445`) explains at most six things: liquidity grouping, buy aggression, sell aggression, aligned depletion, unattributed reduction, L2 gap. Nothing on canvas explains the **size scale, the pie split, the hollow ring, the halo, the impact ring, the trail, the side-offset nudge, `×N`, or the live lane itself**. Those explanations exist — as `on_hover_text` on settings widgets (`orderflow_view.rs:1046-1130`) — where a person reading the chart will never see them.
+
+### Minor
+
+**F11 — Two shipped presets have a dead label switch.** `default` sets `max_radius = 15.0` but `label_min_radius = 16.0` with `show_quantity_labels = true` (`config/bubbles.toml:19, 42`), and `live_lane.radius_scale = 1.0` (`:47`) so the lane cannot rescue it either. No bubble can ever reach the threshold; the toggle does nothing, silently. `dense tape btc` repeats it (`max 14.0` / `label_min 20.0` with `show_trade_count = true`, `:216, 239, 238`), and `3d spheres` sits exactly on the boundary (`16.0` / `16.0`, `:177, 200`). A control that reports "on" and produces nothing is worse than a missing one.
+
+**F12 — Layer toggles ignore pane focus.** `app.rs:910-911` and `985-995` read and write `active_tab().tape()`, which is hard-wired to the flow pane (`tab.rs:614`), while the indicator entries in the same toolbar act on `focused_pane()` (`app.rs:1007`). Focus the time pane, click the bubbles icon: the icon lights, the pane under your eyes does not change. Two adjacent toolbar groups with two different targeting rules.
+
+**F13 — Time axis prints no date and can repeat itself.** `fmt_time` yields `HH:MM:SS` only (`app.rs:354-359`). A time pane can hold 1h bars over months of venue history (`pane.rs:331`), and the axis never says which day. Separately, the label step is `(visible/6).max(1)` in **bar indices** (`pane.rs:1783`) with no pixel-gap thinning; on tick or volume bars several consecutive bars share the same second, so the strip prints the identical timestamp repeatedly. The price axis has `thin_to_fit` for exactly this class of problem (`chart.rs:424`); the time axis has nothing.
+
+**F14 — The live-strip histogram has no scale.** Bars are normalized by the forming bar's own largest bucket (`live_strip.rs:91-96`), so the reference changes continuously and is never shown. Equal widths in two frames mean different quantities, and no number appears anywhere in the strip. Reasonable as a shape-reading device, but currently unlabelled in a codebase that is otherwise strict about labelling.
+
+**F15 — The status badge reports only L2, and vanishes with the heatmap.** `orderflow_view.rs:501` gates on `depth_visible()`. Hide the map while capture is still syncing and the canvas goes quiet about the book entirely. Nothing on canvas ever reports the aggression layer's health.
+
+**F16 — Future margin is a fixed 40 bars regardless of zoom.** `viewport.rs:18`. At 64 px slots that is 2560 px of empty space; at 2 px it is 80 px. The right-hand breathing room changes by a factor of 32 across the zoom range.
+
+**F17 — Minimum zoom-out is a hard wall for tick bars.** `MIN_CANDLE_WIDTH = 2.0` (`viewport.rs:14`) caps a 2000 px window at ~1000 visible bars. A tick-bar session of 100k bars can never be surveyed, and there is no "fit all", no go-to-date and no overview scrollbar to compensate.
+
+### Nit
+
+**F18 — Crosshair has no time tag.** `pane.rs:2042-2058` tags the price axis only.
+**F19 — `PriceScale::from_range` substitutes ±0.5 on a degenerate span** (`chart.rs:69-75`). On a 137000-priced instrument that yields an arbitrary one-unit window.
+**F20 — `orderflow/interaction.rs` is named for market interaction, not pointer interaction.** A reader looking for canvas input handling opens the wrong file; the real handler is `pane.rs::handle_navigation`.
+
+
+## 4. QUICK WINS vs STRUCTURAL
+
+### Quick wins
+
+1. **Surface the capping (F1).** The counters already exist in `book.dropped_*` (`app.rs:1657-1659`). Add an amber status-bar cell — `"tape capped · 340 prints hidden"` — beside the existing `side_note` (`statusbar.rs:290-296`), which is the established pattern for this exact kind of admission.
+2. **Route the price axis through `chart::axis_labels` (F4).** Replace the raw `nice_ticks` + `{tick:.2}` at `pane.rs:1841-1859` with the existing `axis_labels(lo, hi, height)`. Decimals become step-derived and labels get thinned. Then feed the same derived decimal count into the last-price chip (`:1914`) and the crosshair tag (`:2045`) so all three agree. No new machinery, and it fixes the duplicate-label bug outright.
+3. **Set cursors on the interactive axis bands (F5).** `axis_zoom_gesture` already has the `Response`; add `ResizeVertical` on hover over the price gutter and `ResizeHorizontal` on the time strip, mirroring what the lane divider already does at `pane.rs:1310-1312`.
+4. **Add a "jump to live" chip (F6).** Render it at the right end of the time strip whenever `!viewport.follows_live()`; one click calls the existing `snap_to_live()`. The state is already computed and already plumbed to the status bar (`app.rs:1717`).
+5. **Fix the dead label thresholds in the shipped presets (F11).** Lower `label_min_radius` below each preset's `max_radius` in `config/bubbles.toml`, or clamp it in `apply_to` (`bubble_presets.rs:97-103`) so an impossible threshold can never ship.
+6. **Add a date to the time axis (F13).** Print a day marker on the first label after a date change, in the style the seam divider already uses.
+7. **Point the layer toggles at the focused pane, or grey them out when the focused pane has no tape (F12).** `app.rs:985-995`; a `ChartPane` with `orderflow: None` is already the explicit signal.
+8. **Draw the crosshair time tag (F18).** `slot_open_time` (`pane.rs:536`) already answers the question; add a tag on the time strip mirroring the price tag's geometry.
+9. **Split the chart-body double-click (F7).** Reset time only; leave price to its own gutter double-click, which is already documented in the status-bar hint at `statusbar.rs:318`.
+
+### Structural
+
+1. **A hover-inspection layer for flow marks (F2, F10).** Each `AggressionPrimitive` already carries `x`, `y`, `size` in screen space plus `quantity`, `trade_count`, `first/last_timestamp_ms` and `matched_fraction`. Build a per-frame spatial index of the projected primitives and hit-test the pointer against it, then show a tooltip with the exact figures. This turns ten opaque visual channels into readable data and would retire most of F10 at the same time. The main design question is where it lives — the flow renderers are painter-only by contract, so the hit-test belongs in `OrderflowView` beside the published frame rather than inside `orderflow_render.rs`.
+2. **Make the crosshair a hover state, not a tool (F3).** Decouple `draw_crosshair` from `toolrail.tool()` and drive it from `hover_pos` (already maintained at `pane.rs:1074`), with an explicit setting to turn it off. Keep a "magnet" or snapping mode as the tool if the rail slot is wanted. This alone removes the crosshair-vs-selection trade-off and the overflow-menu burial.
+3. **Pointer-anchored zoom (F8).** `Viewport::zoom` needs an anchor argument: keep the bar under the cursor fixed by adjusting `right_bar` as `candle_width` changes. Small, self-contained, and fully unit-testable in `viewport.rs` where the existing zoom tests already live.
+4. **An OHLC readout.** A corner legend that follows the crosshair (symbol, O/H/L/C, volume, delta) is the standard companion to F3 and is missing entirely today.
+5. **Cross-layer visual control (F9).** A per-layer opacity or a "focus this layer" affordance in the LAYERS group, so the trader can pull the heatmap back without turning it off. Currently the only lever is binary on/off in the toolbar or a slider three clicks deep in a dock tab.
+6. **Long-history navigation (F17).** A time-axis overview strip, a go-to-date control, or a "fit visible session" command. Today a 100k-bar tick session is only traversable by dragging.
+7. **Time-axis label thinning (F13).** Port the pixel-gap logic from `chart.rs::thin_to_fit` to the time strip so labels are spaced by pixels rather than bar counts, and so repeated timestamps collapse.
+
+## One note on what is working well
+
+The layout contract is genuinely good and worth preserving: `plot_split` (`app.rs:181`) carves the regions once so the input handler and the renderer can never disagree about a boundary; `axis_zoom_gesture` (`pane.rs:208`) is a single implementation shared by the price gutter and every indicator pane, so no two axes can drift apart in feel; interaction ids are namespaced per pane (`pane.rs:492`) so a split's two charts cannot share a drag; and the empty-view fallback chain in `price_window` (`chart.rs:124-135`) means a re-cut series never produces a blank frame. The capability gating on the bubbles and heatmap toggles, complete with `disabled_explanation` text (`toolbar.rs:529, 546`), is exactly the right pattern — it just needs to reach the canvas findings above.
+

--- a/docs/ux/ux-audit-2026-08/drawing-tools.md
+++ b/docs/ux/ux-audit-2026-08/drawing-tools.md
@@ -1,0 +1,283 @@
+# Drawing tools — full audit report
+
+Scope: `crates/app/src/drawings/**`, `crates/app/src/toolrail.rs`, and the wiring in `crates/app/src/app.rs`, `crates/app/src/pane.rs`, `crates/app/src/tab.rs`. Read-only; no files were modified. Reference spec: `docs/drawing-toolbar-ux.md`.
+
+## 1. INVENTORY
+
+### 1.1 Drawing tools (the whole registry)
+
+Registered in one macro list at `crates/app/src/drawings/mod.rs:393-399`. Five entries, four rail slots (the two Fib tools fold into one family slot).
+
+| # | Name | id | File | Icon | Points | Shortcut | Fill? | Extra tab | Payload |
+|---|---|---|---|---|---|---|---|---|---|
+| 1 | Horizontal line | `horizontal-line` | `drawings/horizontal_line.rs:11` | `MINUS` | 1 | `H` | no | — | `NoPayload` |
+| 2 | Rectangle | `rectangle` | `drawings/rectangle.rs:10` | `RECTANGLE` | 2 | `R` | yes | — | `NoPayload` |
+| 3 | Parallel channel | `parallel-channel` | `drawings/parallel_channel.rs:20` | `PARALLELOGRAM` | 3 | `C` | yes | — | `NoPayload` |
+| 4 | Fib retracement | `fib-retracement` | `drawings/fib_retracement.rs:11` | `ROWS` | 2 | `F` | no | "Levels" | `FibPayload` |
+| 5 | Fib extension | `fib-extension` | `drawings/fib_extension.rs:11` | `ROWS_PLUS_TOP` | 3 | `Shift+F` | no | "Levels" | `FibPayload` |
+
+Non-drawing modes on the same rail: **Pointer** (`toolrail.rs:98`, key `1`, also the Esc fallback) and **Crosshair** (`toolrail.rs:99`, key `2`).
+
+Notably absent from the registry: trend line (diagonal), vertical line, ray, arrow, text/note/callout, measure/ruler, long-short position, pitchfork, elliott/wave, price range, brush. The parallel channel's first two clicks *are* a trend line, but there is no way to keep only that.
+
+### 1.2 Tool rail controls
+
+Rail geometry: 44 px thick (`toolrail.rs:18`), 32 px button hit target, 18 px glyph (`widgets.rs:29`, asserted at `widgets.rs:332-333`). Four docks (Left default, Right, Top, Bottom — `toolrail.rs:133-139`).
+
+**Leading cluster** (`toolrail.rs:560-589`):
+
+| Control | file:line | Trigger | Effect |
+|---|---|---|---|
+| Grip (6-dot glyph) | `toolrail.rs:608` | drag | Docks the rail at the nearest window edge on release (`nearest`, normalised distance, `toolrail.rs:151`). Live drop-preview band painted at `toolrail.rs:1128`. `Esc` mid-drag aborts and keeps the dock (`toolrail.rs:647`). Cursor Grab→Grabbing. |
+| Pointer button | `draw_button`, `toolrail.rs:857` | click / `1` / `Esc` | Arms Pointer (select, move, pan, zoom). |
+| Crosshair button | same | click / `2` | Arms crosshair mode; the crosshair lines + axis price tag only paint in this mode (`pane.rs:2015`). |
+| Separator hairline | `toolrail.rs:674` | — | Decoration. |
+| Per-tool button ×3 | `toolrail.rs:857` | click / letter key | Arms that drawing tool. Active state = accent marker on the edge facing the window border (`marker_edge`, `toolrail.rs:173`). |
+| Fib family split button | `draw_family_slot`, `toolrail.rs:909` | left-click body | Arms the last-armed member, or member[0] before any use (`family_member`, `toolrail.rs:900`). |
+| Fib family caret zone | `toolrail.rs:934-940`, click test at `:970` | click in the 10×10 px bottom-right corner, **or** right-click anywhere on the button | Opens the family flyout. |
+| Draft badge | `paint_draft_badge`, `toolrail.rs:876` | automatic | Shows `2/3` on the armed multi-point tool while a draft is open. Occupies the same corner as the caret and suppresses its glyph (`:941`). |
+| More menu (`DOTS_THREE`) | `draw_more_menu`, `toolrail.rs:714` | click | Lists exactly what the current stage swallowed, by name + shortcut. At Minimal it also carries repeat / hide-all / lock-all as text items. |
+
+**Trailing cluster** (`toolrail.rs:593-602`, laid from the far end backwards):
+
+| Control | file:line | Trigger | Effect |
+|---|---|---|---|
+| Repeat pin (`ARROW_CLOCKWISE`) | `toolrail.rs:701` | click | Toggles: keep the drawing tool armed after an object completes. Default off = one-shot back to Pointer (`pane.rs:899`). |
+| Hide-all eye | `toolrail.rs:832-854` | click | `set_all_hidden` — a *layer* over each object's own eye; restoring preserves per-object state (`mod.rs:778`, test `mod.rs:1143`). One undo entry. |
+| Lock-all | `toolrail.rs:808-830` | click | `set_all_locked` on every object, one undo entry, never deletes (`mod.rs:793`). |
+| Separator | `toolrail.rs:674` | — | Decoration. |
+| Objects button (`LIST`) + count badge | `toolrail.rs:779` | click | Toggles the object manager. Badge = `drawings.items().len()` of the **focused pane**. |
+
+**Responsive staging** (`stage_for`, `toolrail.rs:285`): Full ≥ 417 px, Compact 345–416 px (only Pointer, Crosshair, the armed tool, More survive), Minimal < 345 px (Crosshair and the globals fold into More). Pure function of extent, hysteresis-free.
+
+**Menu path**: View → Drawing toolbar → Left/Right/Top/Bottom (radio), plus Show/Hide drawing toolbar — `app.rs:1853-1877`.
+
+### 1.3 Inspector — title bar (`draw_inspector_title_bar`, `app.rs:2152`)
+
+| Control | file:line | Trigger | Effect |
+|---|---|---|---|
+| Grip glyph + title | `app.rs:2174-2196` | drag (floating only) | Moves the window; sets `inspector_moved` so automatic placement stops. |
+| Title bar double-click | `app.rs:2240` | double-click | Clears `inspector_moved`, re-runs automatic placement. |
+| Eye | `app.rs:2229` | click | Hide/show *this* drawing. |
+| Pin | `app.rs:2212` | click | Switches between floating window and right-side dock panel; sets `inspector_pin_touched` so the auto-pin rule stops firing. |
+| Close (X) | `app.rs:2201` | click | Clears the selection (keeps the drawing). |
+
+### 1.4 Inspector — body (`drawing_inspector_body`, `app.rs:2263`)
+
+| Control | file:line | Effect |
+|---|---|---|
+| "Lock drawing" / "Unlock drawing" | `drawings/action_bar.rs:30` | Toggles lock. Textual by contract. |
+| "Delete drawing" + `Del` shortcut hint | `drawings/action_bar.rs:37` | Requests delete through the one command path (`request_delete_selected`, `app.rs:1947`). |
+| Locked / hidden explanatory lines | `app.rs:2278-2293` | Status text only. |
+| "Delete locked drawing?" + Cancel / Delete anyway | `app.rs:2294-2305` | Only shown when the object is locked and a delete was requested. |
+| Tab: Style | `app.rs:2313` | — |
+| Tab: *extra* (Fib only, "Levels") | `app.rs:2316` | Mounted by the tool, central code never learns its contents. |
+| Tab: Coordinates | `app.rs:2319` | — |
+| Style → colour swatch | `app.rs:2349` | `color_edit_button_srgba` on `style.color`. |
+| Style → "line width (px)" slider | `app.rs:2353` | 0.5 … 6.0 (`mod.rs:24-25`). |
+| Style → "fill opacity" slider | `app.rs:2363` | 0 … 160, only for tools where `supports_fill()` (rectangle, channel). |
+| Coordinates → per-anchor `bar` DragValue | `app.rs:2383` | Labels A/B/C/D (`app.rs:2376`), speed 0.25 bars/pt. Disabled when locked. |
+| Coordinates → per-anchor price DragValue | `app.rs:2389` | Speed = visible range / 200 (`PRICE_DRAG_STEPS`, `app.rs:102`). |
+
+### 1.5 Fib "Levels" tab (`drawings/fib.rs:687`) — the only tool-owned inspector
+
+Built-in preset buttons (`fib.rs:701-709`); custom-preset combo + Apply / Delete / "Set as default" (`fib.rs:714-752`); preset-name field + "Save preset" with an inline "Overwrite? Yes/No" confirmation and "Clear default" (`fib.rs:753-789`). Per level row (`fib.rs:798-882`): visible checkbox, ratio text field (accepts `.618`, `0,618`, `61.8%` — `parse_ratio`, `fib.rs:381`), custom label field, colour override + `x` to inherit, "fill" to next visible level, `×` delete (disabled at one level). Then "+ Add level" / "Sort" / "Restore" (`fib.rs:899-918`), band-opacity slider, labels-mode combo, label-position combo, extend combo, "log scale" checkbox (disabled with hover reason when any anchor price ≤ 0), and "Invert A ↔ B" (`fib.rs:922-974`).
+
+### 1.6 Object manager (`draw_drawing_manager`, `app.rs:2687`)
+
+Non-modal window "Drawn objects", opens beside the rail in all four docks (`manager_target_position`, `app.rs:2665`). Listed **top-most first**, matching hit-test order (`app.rs:2721`). Per row: selectable label `"{tool name} {index+1}"` (weak when hidden), inline "locked"/"hidden" tags, and right-aligned **Hide/Show · Lock/Unlock · Front · Delete** small buttons (`app.rs:2741-2767`). Footer: **Show all** and **Unlock all** (`app.rs:2771-2778`). Selecting a row also centres the viewport on the object's mean bar (`app.rs:2783-2794`).
+
+### 1.7 Selection visuals and handles
+
+Painted by the wrapper, never by the tool (`DrawingTool::paint`, `mod.rs:311-341`): a halo pass underneath at `width + 3.5 px` in premultiplied ~16 % white (`mod.rs:37`), then the object in its own colour, then white anchor discs of radius 4 px with an accent ring — **only when unlocked** (`pane.rs:1974`, "a locked object shows no resize handles: the affordance would lie").
+
+Hit radii: stroke/body select radius **10 px** (`pane.rs:41`), anchor grab radius **12 px** (`pane.rs:43`), drag-to-place threshold **4 px** (`pane.rs:45`).
+
+### 1.8 Drag behaviours (`pane.rs:1119-1250`)
+
+- **Anchor drag** — press within 12 px of an anchor of the selected object (selected object wins ties, `drawing_anchor_at`, `pane.rs:1014`) → `DrawingDrag::Anchor`, moves that one point, clamped to the history rect, cursor `ResizeNwSe`.
+- **Body drag** — press on the stroke/interior → `DrawingDrag::Translate`, rigid translation of every anchor.
+- **Blocked** — press on locked geometry → `DrawingDrag::Blocked`, cursor `NotAllowed`, nothing moves.
+- One drag = one undo entry (`begin_gesture` at press, `commit_gesture` at release, `pane.rs:1188/1248`).
+- Chrome gate: a press under a floating panel never grabs the drawing beneath (`over_chrome`, `pane.rs:1099`); a drag that *started* on canvas keeps running across panels.
+
+### 1.9 Keyboard map
+
+| Key | Where | Effect |
+|---|---|---|
+| `1` / `2` | `toolrail.rs:454-458` | Pointer / Crosshair |
+| `H` `R` `C` `F` `Shift+F` | declared per tool, dispatched `toolrail.rs:460` | Arm that tool |
+| `Esc` | escape stack, `app.rs:2009-2027` | rail drag → paper interaction → delete confirmation → cancel draft (+ disarm) → deselect → Pointer |
+| `Backspace` (during placement) | `app.rs:2031` | Drop the last draft anchor; the last one cancels the draft |
+| `Delete` / `Backspace` (otherwise) | `app.rs:2034` | Delete the selected drawing |
+| `Ctrl+Z` / `Ctrl+Y` / `Ctrl+Shift+Z` | `app.rs:1994-1996` | Undo / redo (drawings only, 64 entries, `mod.rs:30`) |
+| `Alt+L` | `app.rs:1997` | Toggle lock on the selection |
+| `Alt+H` | `app.rs:1998` | Toggle hide on the selection |
+| `Ctrl+D` | `app.rs:1999` | Duplicate, offset +2 bars, unlocked, becomes the selection (`mod.rs:655`) |
+| `←→↑↓` (+`Shift` = ×10) | `app.rs:1986-1989`, applied `app.rs:2064-2079` | Nudge: 1 bar horizontally, 1 px worth of price vertically; one undo entry per press |
+| `Alt+click` on chart | `pane.rs:1157` | Cycle down the z-order through overlapping objects, wrapping |
+
+All chart shortcuts are suspended while any widget holds keyboard focus (`app.rs:1965`, `toolrail.rs:447`).
+
+### 1.10 Magnet / snap
+
+**None.** `drawing_point_at` (`pane.rs:779`) converts a pixel to a raw fractional bar and a raw scale price. No snap to OHLC, to bar centres, or to the instrument's tick size — even though the codebase already has tick snapping for paper trading (`paper_trading.rs:556`).
+
+### 1.11 Preset persistence
+
+`PresetStore` (`drawings/presets.rs:43`) writes a versioned TOML (`quantick-drawing-presets.toml`, env override `QUANTICK_DRAWING_PRESETS`). Stores, per tool id, named **payload** exports plus one "default for new objects". A future file version starts empty rather than guessing (`presets.rs:63-71`). Overwriting requires explicit consent (`presets.rs:134`).
+
+
+## 2. FLOWS (as implemented today)
+
+**(a) Pick a tool and place.** Click the rail button or press its letter → the tool is armed. `handle_drawing_placement` (`pane.rs:807`) then owns the pointer inside the *history* rect (chart minus the live lane). Cursor becomes a crosshair glyph. Each **press** places one anchor (`pane.rs:846-852`); if this was the first press of a fresh draft and the pointer travelled ≥ 4 px before release, a second anchor lands on release (`pane.rs:861-870`). So:
+
+- Horizontal line (1 pt): one press. Lands on mouse-**down**, not on release.
+- Rectangle / Fib retracement (2 pts): click-click **or** press-drag-release.
+- Parallel channel / Fib extension (3 pts): press-drag-release for the baseline, then one more click; or three clicks.
+
+On completion the object is appended, becomes the selection (`mod.rs:626-632`), and the tool reverts to Pointer unless the repeat pin is on (`pane.rs:896-903`). A live preview follows the pointer using the hovered anchor (`pane.rs:1978-2001`). A new object's payload is seeded from the user's default preset if one is set; its **style is always the stock default** (`mod.rs:618`).
+
+**(b) Select.** Pointer armed → click. Topmost hit within 10 px of the geometry wins (`drawing_at`, `pane.rs:920`, walks `.rev()`); `Alt+click` walks downward through the stack. A click on nothing deselects. Hover pre-feedback: `Move` over a body, `ResizeNwSe` over an anchor of the selection, `NotAllowed` over locked geometry (`pane.rs:1124-1150`). Selecting also opens the inspector, since the inspector is a pure function of the selection.
+
+**(c) Edit properties.** Only through the inspector. It opens floating, auto-placed by an eight-candidate least-overlap algorithm clamped inside the chart pane (`inspector_target_position`, `app.rs:2485`), or pinned as a right-side panel. On a chart narrower than 1180 px a fresh selection opens **pinned** (`app.rs:2597-2607`). Colour/width/fill live in the Style tab; a whole slider or colour gesture coalesces into one undo entry via `inspector_edit_baseline` → `record_edit_of` (`app.rs:2415-2427`, `mod.rs:559`).
+
+**(d) Move / resize.** Body drag translates; anchor drag (12 px grab) moves one point; arrows nudge; the Coordinates tab edits bar and price numerically. Locked objects reject all four.
+
+**(e) Delete.** Four triggers — inspector button, `Delete`/`Backspace`, manager row "Delete", and the forced path — all funnel through `Drawings::delete_selected` (`mod.rs:714`). Unlocked → deletes and raises an 8-second toast with an Undo button (`app.rs:1951`, `TOAST_UNDO_MS` = 8000). Locked → `NeedsConfirmation`, and the "Delete locked drawing?" prompt appears **in the inspector body**. **There is no delete-all / "remove drawings" command anywhere** — the rail's globals are hide-all and lock-all only.
+
+**(f) Presets.** Fib tools only. Built-in ratio sets are one-click. Custom presets: type a name → "Save preset" → if the name exists, an inline "Overwrite? Yes/No" appears. "Set as default" makes new objects of that tool start from it. Presets carry the payload only — **never colour, width, or fill**.
+
+**(g) Persistence.**
+- **Across restarts: no.** `impl eframe::App for QuantickApp` defines only `update` (`app.rs:2860-2867`); there is no `save`. Drawings live in `ChartPane::drawings` in memory. Rail dock, rail visibility, the repeat pin and the inspector pin state are equally volatile — the spec acknowledges this and defers it to an unbuilt `ui-state.toml` (`docs/drawing-toolbar-ux.md` §3.5). By contrast, indicators *do* persist (`indicators/state_file.rs`, saved at `app.rs:1487`), and drawing *presets* persist.
+- **Across bar-type / timeframe / feed switches: destroyed.** `clear_overlay` (`tab.rs:324`) wipes items, draft, selection **and the entire undo history** (`mod.rs:673-681`). The user gets a toast — "Drawings cleared - the bars were rebuilt under them." — deliberately with **no Undo button**, because nothing can bring them back (`app.rs:1500-1513`).
+- **Across tab switches: preserved** (per-tab, per-pane state).
+
+## 3. UX FINDINGS
+
+### Blockers
+
+**B1 — Chart markup does not survive a restart.**
+`app.rs:2860-2867` has no `save`. Every trendline, level and Fib a trader draws is gone when the app closes. This is the single most damaging gap: it makes the drawing tools unusable for the multi-session workflow they exist for, and it is *inconsistent inside the same app*, since indicators (`indicators/state_file.rs`) and drawing presets (`drawings/presets.rs`) both persist. Heuristic: user control and freedom; consistency and standards.
+
+**B2 — All chart navigation is dead while a tool is armed.**
+`pane.rs:1058`: `if self.handle_drawing_placement(...) { return; }` returns before the chart's `interact`, the scroll-zoom branch, the double-click reset, and the axis handles. With any drawing tool armed you cannot pan, cannot scroll-wheel zoom, cannot drag either axis, cannot double-click to reset. Placing the second anchor of a channel on a bar that is currently off-screen is impossible without disarming, panning, and re-arming — losing the draft to the Esc that disarms. TradingView keeps wheel-zoom and scroll live throughout placement. Heuristic: flexibility and efficiency of use.
+
+### Major
+
+**M3 — No trend line.** The registry (`mod.rs:393-399`) ships five tools and omits the diagonal trend line, the most-used object in technical analysis, plus vertical line, ray, arrow, text/note and measure. The parallel channel's first two clicks draw exactly the missing primitive but cannot be stopped there (`required_points() == 3`, `parallel_channel.rs:36`). For an order-flow charting app this reads as an unfinished tool set rather than a deliberate "small and focused" scope.
+
+**M4 — No line style.** `DrawingStyle` is `{ color, width_px, fill_alpha }` (`mod.rs:407-412`). No dashed, no dotted. Traders routinely encode meaning in dash style (projected level vs confirmed level); here every object is a solid line. The Fib anchor guides *are* dashed but with a hardcoded constant (`fib.rs:39`) the user cannot reach.
+
+**M5 — Style is neither preset-able nor remembered.** `place_with` always assigns `DrawingStyle::default()` (`mod.rs:618`) — the same light blue, 1.5 px, for every tool and every object. Presets export only the tool **payload** (`DrawingPayload::export_preset`, `mod.rs:53`), so:
+- The three `NoPayload` tools (horizontal line, rectangle, channel) have **no preset capability at all** — `export_preset` returns `None`, and they render no extra tab.
+- Even for Fib, "Set as default" cannot carry a colour.
+The result: every new drawing must be recoloured by hand, one at a time, and a chart with ten objects is monochrome. Heuristic: recognition over recall; user control.
+
+**M6 — No right-click context menu on a drawing.** The only `secondary_clicked` handlers in the whole app are the rail family slot (`toolrail.rs:974`) and three toolbar layer buttons (`toolbar.rs:534/551/569`). Right-clicking an object — the primary edit path every TradingView user reaches for first (Settings / Clone / Remove / Visual order / Lock / Hide) — does nothing. Every action requires the inspector or a memorised chord. Heuristic: match between system and the real world; consistency with platform conventions.
+
+**M7 — No way to clear all drawings.** Grep for `Delete all` / `Remove all` / `Clear all` / `delete_all` across `crates/app/src` returns nothing. The rail offers hide-all and lock-all (`toolrail.rs:807`), the manager offers "Show all" and "Unlock all" (`app.rs:2771-2778`), but removing a marked-up chart means deleting objects one by one. TradingView's "Remove drawings" is a single command.
+
+**M8 — A new drawing is invisible when hide-all is engaged, but its preview is not.**
+`is_visible` returns false while `all_hidden` (`mod.rs:519-521`), yet the draft preview at `pane.rs:1978` is painted **unconditionally**. So with hide-all on, the user sees the rubber-band preview follow the cursor, clicks to complete — and the object vanishes. Nothing warns them; the rail's eye is merely in its active state. This will read as "the tool is broken". Heuristic: visibility of system status.
+
+**M9 — Tool shortcuts stay live while the rail is hidden.**
+`ToolRail::handle_keys` (`toolrail.rs:446`) has no `visible` check and is called unconditionally each frame (`app.rs:2891`), while `draw` returns early when hidden (`toolrail.rs:478`). Pressing `H` with the toolbar hidden arms the horizontal-line tool with **no on-screen indication anywhere** (the status bar shows no armed tool — grep for `tool` in `statusbar.rs` returns nothing), and the next click on the chart drops a line instead of selecting or panning. This directly contradicts the invariant the codebase itself asserts in `toolrail.rs:1244` (`hiding_the_toolbox_cannot_leave_an_invisible_drawing_tool_armed`) — the test covers `toggle_visible` but not the keyboard path.
+
+**M10 — No crosshair or price readout while placing.**
+`draw_crosshair` returns immediately unless `Tool::Crosshair` is armed (`pane.rs:2015`). While placing a Fib or a horizontal line there are no guide lines and no axis price tag; the user is eyeballing the level against the price gutter. Every charting platform shows the crosshair *during* drawing precisely because that is when precision matters most.
+
+**M11 — No magnet/snap of any kind.** `drawing_point_at` (`pane.rs:779`) yields raw fractional bar and raw pixel-derived price. A horizontal line placed at a swing high will sit a few cents off it, and the price is not even snapped to the instrument's tick size, though the machinery exists next door (`paper_trading.rs:556`). For a level-marking workflow this is the difference between a usable line and a decorative one.
+
+**M12 — Fib validation messages flash for one frame.**
+In `draw_levels_tab`, `error` is a frame-local (`fib.rs:793`) set inside `response.lost_focus()` / `.changed()` branches and rendered at `fib.rs:896-898`. The next frame the branch is false and the label disappears. "Ratios read like 0.618 or 61.8%.", "That ratio already exists." and "At least one level stays visible." are therefore visible for roughly 16 ms — effectively never. The user sees their typed ratio silently revert with no explanation (`fib.rs:832` rewrites the buffer regardless). Heuristic: help users recognise, diagnose and recover from errors.
+
+**M13 — The object manager has no scroll area and cannot be resized.**
+`app.rs:2704-2714`: `.resizable(false)`, default width 320 px, and the row loop at `:2721` sits directly in the window body with no `ScrollArea` (contrast the pinned inspector, which wraps its body at `app.rs:2563`). With 30 objects the window grows past the screen and the "Show all"/"Unlock all" footer becomes unreachable. Each row also packs four small buttons plus two tags into 320 px, so labels crowd immediately.
+
+**M14 — On a common laptop the inspector permanently steals 320–360 px of chart.**
+`INSPECTOR_AUTO_PIN_CHART_WIDTH_PX = 1180.0` (`app.rs:89`) and the auto-pin fires whenever the chart pane is narrower (`app.rs:2597-2607`). On a 1366×768 screen, after the 44 px rail and the right dock, the chart is well under 1180 px, so *every* selection docks the inspector and the chart loses another quarter of its width. The rule is defensible in isolation, but its practical effect on the most common laptop resolution should be verified against a real window rather than assumed.
+
+**M15 — Undo history is destroyed by a bar-spec change.**
+`clear()` empties `undo` and `redo` (`mod.rs:673-681`). The toast is honest ("the bars were rebuilt under them") and deliberately offers no Undo (`app.rs:1505-1512`), which is the right *data* decision — but the user experience is that flipping a timeframe chip to compare views annihilates the session's markup with no confirmation beforehand. There is no "are you sure, this will discard N drawings" gate on a reversible-looking action. Heuristic: error prevention over error messaging.
+
+### Minor
+
+**m16 — The family caret is a 10 × 10 px target that becomes invisible but stays live.**
+`TOOLBOX_CARET_ZONE_PX = 10.0` (`toolrail.rs:32`) inside a 32 px button — well under any pointer-target guidance. Worse, when a draft badge occupies the corner the caret **glyph** is suppressed (`toolrail.rs:941`) but the **click zone** is not (`toolrail.rs:970` does not consult `badge_shown`): clicking the bottom-right of the armed Fib button mid-draft opens the flyout with no affordance having suggested it would.
+
+**m17 — Selectable but not draggable inside the live lane.**
+`horizontal_line::hit_test` accepts any x in `chart_rect` (`horizontal_line.rs:62`) and click-selection uses the full chart rect (`pane.rs:1151`), but drag initiation is gated on `drawing_area` = history only (`pane.rs:1178`). Clicking a line over the live lane selects it; pressing and dragging there does nothing at all — no move, no pan, no cursor change.
+
+**m18 — Z-order is one-directional.** `bring_to_front` exists (`mod.rs:758`, manager "Front" button) with no send-to-back and no arbitrary reordering. Recovering from a mis-ordered stack means promoting every other object.
+
+**m19 — Object identity is the z-index and renumbers itself.** Manager rows are labelled `"{tool} {index+1}"` (`app.rs:2728`). Pressing "Front" on "Rectangle 2" renames it and renumbers its neighbours. There is no rename, no stable id, no way to tell two rectangles apart except by selecting each and watching the chart.
+
+**m20 — The manager silently speaks for whichever pane has focus.** It reads `focused_pane()` (`app.rs:2715`, `tab.rs:569`), as does the rail's count badge (`toolrail.rs:790`). On a split time/flow canvas the list contents and the badge number change when focus moves, with no header naming the pane.
+
+**m21 — The locked-delete confirmation is not next to its trigger.** `request_delete_selected`'s doc claims it "raises the confirmation next to the trigger" (`app.rs:1944-1946`), but the prompt only ever renders in the inspector body (`app.rs:2294-2305`). Deleting a locked object from a manager row shows the confirmation in a different window, possibly on the far side of the chart.
+
+**m22 — "Delete" on a custom preset has no confirmation** (`fib.rs:739-744`) while *saving over* one does (`fib.rs:765-775`). The destructive action is the unguarded one, and the deletion is written to disk immediately (`presets.rs:142-152`).
+
+**m23 — Most of the keyboard grammar is undiscoverable.** Hover texts carry `(H)`, `(R)`, `(C)`, `(F)`, `(Shift+F)`, `(1)`, `(2)`, and the action bar shows `Del` (`action_bar.rs:39`). Nothing in the UI mentions `Ctrl+D`, `Alt+L`, `Alt+H`, arrow nudge, `Shift`+arrow, `Backspace`-to-step-back-an-anchor, or `Alt+click` z-cycling. There is no shortcuts help panel anywhere in the app.
+
+**m24 — `Alt+H` (hide) sits beside `H` (horizontal line).** Safe in code (`toolrail.rs:451-453` bails on any command/alt modifier) but a poor mnemonic pair; `Alt+L` (lock) has the same issue against a future "line" tool.
+
+**m25 — The repeat-pin icon is `ARROW_CLOCKWISE`** (`toolrail.rs:702`), which reads as reload/refresh rather than "keep tool active". Only the tooltip disambiguates.
+
+**m26 — 4 px drag-to-place threshold is very low** (`pane.rs:45`). A slightly unsteady click on a rectangle produces a 5-pixel rectangle rather than the intended click-click flow.
+
+**m27 — Duplicate offset of 2 bars is often invisible** (`DUPLICATE_OFFSET_BARS`, `app.rs:110`). Zoomed out, the copy lands on top of the original; the only clue that `Ctrl+D` worked is the manager count.
+
+### Nits
+
+**n28** — The one-point horizontal line commits on mouse-**down** (`pane.rs:846-852`); moving before release does not adjust it. Every other tool's anchors feel drag-adjustable; this one does not.
+**n29** — Anchor labels are hardcoded `["A","B","C","D"]` with a `"?"` fallback (`app.rs:2376-2380`); fine for today's 3-point maximum, a latent gap for the next tool.
+**n30** — No copy/paste of drawings, between panes, tabs or symbols; `Ctrl+D` in place is the only duplication path.
+**n31** — Undo depth 64 (`mod.rs:30`) is per pane and shared with style edits; a long styling session can push out the geometry history.
+**n32** — `Ctrl+Z` is bound exclusively to drawings (`app.rs:2038`); pressing it after any other kind of change silently rolls back an unrelated drawing edit instead.
+
+
+## 4. QUICK WINS vs STRUCTURAL
+
+### Quick wins (localised, low blast radius)
+
+1. **Gate `handle_keys` on rail visibility** — one condition in `toolrail.rs:446` (`if !self.visible { return; }`), plus a test alongside `toolrail.rs:1244` that drives the keyboard rather than `toggle_visible`. Closes M9.
+2. **Don't paint the draft while `all_hidden`** — guard `pane.rs:1978` with `!self.drawings.all_hidden()`, or better, have `place_with` refuse (or auto-release hide-all with a toast). Closes M8.
+3. **Make Fib validation errors persist** — move `error: Option<&'static str>` from a frame-local (`fib.rs:793`) into `FibPayload` or into `ui.data_mut` temp storage keyed by the row, cleared on the next successful edit. Closes M12.
+4. **Wrap the manager body in `ScrollArea::vertical()` and set `.resizable(true)`** — two lines at `app.rs:2704-2714`, mirroring the pinned inspector at `app.rs:2563`. Closes M13.
+5. **Add "Delete all drawings" with a count-bearing confirmation** — a trailing-cluster rail button or a manager footer entry beside "Show all"/"Unlock all" (`app.rs:2771`), routed through a new `Drawings::delete_all` that records one undo entry (so the toast's Undo genuinely works). Closes M7.
+6. **Confirm the custom-preset delete** — reuse the exact inline "Overwrite? Yes/No" pattern already sitting ten lines above it (`fib.rs:765-775`). Closes m22.
+7. **Draw the crosshair whenever a drawing tool is armed** — relax `pane.rs:2015` from `!= Tool::Crosshair` to "crosshair mode *or* a drawing tool is armed". Closes M10 with no new state.
+8. **Stop the caret zone from firing when the badge hides its glyph** — add `&& !badge_shown` to the `caret_clicked` test at `toolrail.rs:970`, and widen `TOOLBOX_CARET_ZONE_PX` from 10 to ~14. Closes m16.
+9. **Show the armed tool in the status bar** — one segment in `statusbar.rs` reading `toolrail.tool().name()`. Mitigates M9 and gives the rail-hidden case an anchor.
+10. **Add a "Shortcuts" entry under Help** (`app.rs:1913-1918`) listing the full grammar from §1.9. Closes m23.
+11. **Raise `DRAWING_DRAG_THRESHOLD_PX` to ~8** (`pane.rs:45`) and **make `DUPLICATE_OFFSET_BARS` zoom-aware** (`app.rs:110`). Closes m26, m27.
+12. **Confirm before a bar-spec change discards N drawings** — the count is already known at `tab.rs:326`; raising a "Switching the bar type will discard N drawings" gate before `clear_overlay` turns M15 from an apology into a prevention.
+
+### Structural (real design work)
+
+**S1 — Persist drawings, and the UI state around them.** The spec already names the vehicle (`docs/drawing-toolbar-ux.md` §3.5: a `ui-state.toml` sibling of `indicators-state.toml`). Drawings need a versioned, per-(feed, symbol, bar-spec) store keyed so that anchors are only ever restored onto the data that made them — which is the same honesty rule `clear_overlay` enforces today, just applied at load instead of at switch. This requires serialisation for `Drawing`, which means `DrawingPayload` grows `export`/`import` obligations beyond presets (the Fib payload already has both). It also unlocks a much better answer to M15: instead of destroying markup on a bar-type switch, *park* it under its old spec and restore it when the user switches back. Closes B1 and defuses M15.
+
+**S2 — Let navigation and placement coexist.** `handle_drawing_placement` currently claims the whole gesture by returning early (`pane.rs:1058`). It should consume only the primary-button click stream and let scroll-zoom, middle/right-drag pan and the axis handles fall through. This is a rework of the early-return into a "consumed inputs" mask threaded through `handle_navigation`. Closes B2.
+
+**S3 — Promote style into the tool contract.** Today `DrawingStyle` is a fixed struct the preset system deliberately excludes (`mod.rs:51-53`). Making style presetable means: (a) adding `line_style: LineStyle` (solid/dash/dot) with rendering support in each tool's `paint`; (b) letting a preset carry the common envelope alongside the payload; (c) a per-tool "default style for new objects", so `place_with` stops hardcoding `DrawingStyle::default()` (`mod.rs:618`). This one change closes M4 and M5 and makes the existing preset machinery useful to the three tools that currently cannot touch it.
+
+**S4 — A right-click context menu on drawings, and on the empty chart.** A shared menu, built from the same intents the action bar already reports (`action_bar::ActionBarIntent`) plus Clone / Bring to front / Send to back / Settings…, attached to the chart's secondary click and dispatched against `drawing_at`. The action-bar doc comment already anticipates this host ("inspector, object manager, future context menu", `action_bar.rs:3-5`), so the command layer is ready; what is missing is the surface. Closes M6, and gives m18 and m19 a natural home.
+
+**S5 — Fill out the tool set, starting with the trend line.** The registry is a genuinely clean extension port (proven end-to-end by the fake-tool test at `mod.rs:1489`), so each new tool is one file plus one name. Priority order by trader expectation: trend line → ray → vertical line → text/note → measure → long/short position. The trend line is nearly free: it is the parallel channel's first two anchors. Closes M3.
+
+**S6 — A magnet mode.** A rail toggle (the natural neighbour of the repeat pin) that snaps the placement/drag point to the nearest OHLC of the bar under the cursor, with a weak mode that snaps only to the tick grid. `drawing_point_at` (`pane.rs:779`) is the single choke point, and the pane already holds the bars and the tick size. Closes M11, and materially raises the precision of every existing tool.
+
+**S7 — Stable object identity.** Give `Drawing` an id and an optional user name, so the manager stops labelling by z-index (`app.rs:2728`), rename becomes possible, and persistence (S1) has something to key on. Closes m19, supports m18.
+
+## 5. Where the code is already strong
+
+Worth preserving through any redesign: the command funnel (every delete trigger routes through `Drawings::delete_selected`, `mod.rs:714`, so lock rules cannot drift per surface); gesture-coalesced undo (one drag or one slider sweep = one entry, `mod.rs:544-555`, `app.rs:2415-2427`); undo snapshots that shift with prepended history (`mod.rs:704-709`) so undo never re-anchors an object onto bars that moved; the pointer-opacity contract for floating chrome, gated at press time only so a drag survives crossing a panel (`pane.rs:1094-1101`); hide-all as a layer that preserves per-object visibility (`mod.rs:778`, test at `:1143`); the honest refusal to reattach anchors to rebuilt bars; and the registry itself, which is one of the cleaner extension ports in the codebase.
+
+## Priority summary
+
+- **Blockers:** B1 (no persistence across restarts), B2 (navigation dead while a tool is armed).
+- **Highest-value quick wins:** #1 (hidden-rail shortcuts), #2 (invisible new drawing under hide-all), #7 (crosshair while placing), #5 (delete-all), #3 (invisible Fib errors).
+- **Biggest structural gaps vs TradingView conventions:** no right-click menu (M6), no trend line (M3), no line style / style presets (M4+M5), no magnet (M11).
+

--- a/docs/ux/ux-audit-2026-08/indicators.md
+++ b/docs/ux/ux-audit-2026-08/indicators.md
@@ -1,0 +1,277 @@
+# Indicators — full audit report
+
+Scope: adding, configuring, rendering and scripting indicators. Read-only analysis of `crates/app/src/{indicator_panel.rs, indicators/, indicator_render.rs, indicator_worker.rs, pane.rs, toolbar.rs, app.rs}` plus the input/descriptor contracts in `crates/indicators` and `crates/pine`.
+
+**Headline:** the indicator engine is complete and well-tested; the indicator *surface* is one nested icon menu. The project's own UX spec (`docs/ux/ui-design-model.md` §9) describes a chart legend, an Indicators dock tab and an Insert menu — none of the three exist in code. The user's "editing properties feels strange" traces to four concrete, verifiable causes documented in §3.1 (part 2).
+
+---
+
+## 1. INVENTORY — every user-facing element
+
+### 1.1 Entry point (the only one)
+
+| # | Element | Location | Trigger | Effect |
+|---|---|---|---|---|
+| 1 | INDICATORS icon (`CHART_LINE` glyph, 16 px, no text label) | `crates/app/src/toolbar.rs:579-586` | Left-click | Opens the indicator menu. Tinted `theme::ACCENT` when ≥1 indicator is active on the focused pane, `theme::TEXT_MUTED` otherwise (`toolbar.rs:581-585`) |
+| 2 | Icon tooltip: *"indicators: add or manage overlay and pane indicators"* | `toolbar.rs:659` | Hover | Only text in the whole UI that names the feature |
+
+The icon lives in the LAYERS group (`toolbar.rs:48-49, 515-516`), immediately beside the bubbles / heatmap / live-strip **toggles**. LAYERS is never folded into the `⋯` overflow (`toolbar.rs:127-137` — the collapse steps never touch it), so the icon is always present. There is **no** menu-bar path: `File`, `View`, `Tools`, `Help` (`app.rs:1773-1918`) contain nothing about indicators. There is **no** keyboard shortcut (the shortcut table is `app.rs:1729-1748`). There is **no** left-rail entry (`toolrail.rs` mentions indicators only inside a test comment).
+
+### 1.2 Inside the INDICATORS menu — "add" section
+
+| # | Element | Location | Trigger | Effect |
+|---|---|---|---|---|
+| 3 | `＋ Add EMA(9) on close` | `toolbar.rs:587-593` | Click | `ToolbarAction::AddEmaIndicator` → `add_native_indicator(SavedKind::NativeEma)` (`app.rs:1001-1003`, `1293-1308`). Hardcoded len 9 / source close (`DEFAULT_EMA_LEN`, `app.rs:68`). Closes the menu |
+| 4 | `＋ Add CVD pane` | `toolbar.rs:594-597` | Click | `ToolbarAction::AddCvdIndicator` → native CVD (`app.rs:1004-1006`). Closes the menu |
+| 5 | `scripts` section header (11 px, muted, non-interactive) | `toolbar.rs:598-604` | — | Shown only when the library is non-empty |
+| 6..N | One button per script, `FILE_CODE` glyph + file name | `toolbar.rs:605-610` | Click | `ToolbarAction::AddScriptIndicator(index)` → `add_script_indicator` (`app.rs:1117-1180`). Closes the menu |
+
+Shipped library (`crates/app/src/indicators/library.rs:24-40`): `ema.pine`, `cvd.pine`, `delta_histogram.pine`, `vwap_cumulative.pine`, `zigzag.pine`, `range_box.pine`, plus every `*.pine` found in the scripts folder.
+
+### 1.3 Inside the INDICATORS menu — "manage" section
+
+One `ui.horizontal` row per active indicator, in add order (`toolbar.rs:615-656`), preceded by a separator when non-empty (`toolbar.rs:612-614`):
+
+| # | Element | Location | Trigger | Effect |
+|---|---|---|---|---|
+| 7 | Status dot (non-interactive label) | `toolbar.rs:617-628` | — | `WARNING_CIRCLE`/red if errored → `WARNING`/accent if stale → `EYE_SLASH`/muted if hidden → `CIRCLE`/green otherwise. Precedence hardcoded in that order. **No tooltip, no click target** |
+| 8 | Indicator label (non-interactive) | `toolbar.rs:629` | — | `descriptor.short_title` or `title` (`indicators/mod.rs:90-95`). Not clickable, no hover |
+| 9 | Eye `small_button` | `toolbar.rs:630-640` | Click | `ToggleIndicatorHidden(slot)` → `indicators.toggle_hidden` (`app.rs:1007-1012`). Render-side only, no recompute. Tooltip: *"hide/show without removing (no recompute)"*. **Does not close the menu** |
+| 10 | Gear `small_button` | `toolbar.rs:641-647` | Click | `OpenIndicatorSettings(slot)` → builds a `SettingsDialog` from `view.input_values.clone()` (`app.rs:1028-1044`). Tooltip: *"settings (applying recomputes from scratch)"*. **Does not close the menu** |
+| 11 | Trash `small_button` | `toolbar.rs:648-654` | Click | `RemoveIndicator(slot)` → immediate removal, UI first then worker (`app.rs:1013-1024`). Tooltip: *"remove this indicator"*. **No confirmation, no undo. Does not close the menu** |
+
+The row carries no colour swatch, no last value, no source/pane indication, and no drag handle.
+
+### 1.4 The settings dialog
+
+`indicator_panel.rs:39-81`, drawn from `app.rs:2901` via `draw_indicator_settings` (`app.rs:1061-1108`).
+
+| # | Element | Location | Notes |
+|---|---|---|---|
+| 12 | Window titled `Settings — {label}` | `indicator_panel.rs:46` | Label snapshotted at open time (`app.rs:1039`); goes stale if inputs change the title |
+| 13 | Window id keyed by slot | `indicator_panel.rs:47` | egui remembers position per slot |
+| 14 | Title-bar `✕` | `indicator_panel.rs:48, 77-79` | Maps to `Cancel` — draft discarded |
+| 15 | `.collapsible(false)` | `indicator_panel.rs:49` | No collapse |
+| 16 | `.resizable(false)` | `indicator_panel.rs:50` | Cannot be resized; **no `ScrollArea`** |
+| 17 | 2-column `Grid`, label left / widget right | `indicator_panel.rs:52-60` | One row per declared input |
+| 18 | *"this indicator declares no settings"* (muted) | `indicator_panel.rs:61-66` | Shown when `specs.is_empty()` |
+| 19 | `Apply` button | `indicator_panel.rs:69-71` | Sends `SetInputs` **and closes** (`app.rs:1093-1105`) |
+| 20 | `Cancel` button | `indicator_panel.rs:72-74` | Drops the draft |
+
+No `OK`, no `Reset to defaults`, no per-input revert, no input descriptions/tooltips, no grouping, no tabs.
+
+### 1.5 Property editors — every input widget
+
+Generated purely from `InputSpec` (`crates/indicators/src/input.rs:129-208`). One `match` arm each (`indicator_panel.rs:86-176`):
+
+| # | Input type | Widget | Location | Constraints honoured |
+|---|---|---|---|---|
+| 21 | `Int` | `DragValue` | `indicator_panel.rs:88-111` | `min`/`max` → `.range()`; `step` → `.speed()`. **`options` ignored** despite the spec documenting a dropdown (`input.rs:148-150`) |
+| 22 | `Float` | `DragValue` | `indicator_panel.rs:112-133` | Same; falls back to `DEFAULT_FLOAT_DRAG_SPEED = 0.1` (`indicator_panel.rs:16`). **`options` ignored** |
+| 23 | `Bool` | `checkbox(current, "")` | `indicator_panel.rs:134-137` | Empty checkbox text → the label in column 1 is not a click target |
+| 24 | `Color` | `color_edit_button_srgba_unmultiplied` | `indicator_panel.rs:138-144` | Full RGBA |
+| 25 | `Str` | `text_edit_singleline`, or `ComboBox` when `options` non-empty | `indicator_panel.rs:145-158` | The combo branch is unreachable today — `pine` always emits `options: Vec::new()` (`compile.rs:1441`) |
+| 26 | `Source` | `ComboBox` over `SourceId::ALL` | `indicator_panel.rs:159-168` | All 14 series, including flow series (`input.rs:50-65`). **No filtering by `is_price_scaled`** |
+| 27 | Fallback | *"(unrenderable input)"* | `indicator_panel.rs:171-174` | Spec/value variant mismatch |
+
+**Not editable at all:** plot colour, line width, plot style, offset, marker, fills. These live in `PlotSpec` on the descriptor and can only be changed by editing the `.pine` source. TradingView's entire "Style" tab has no equivalent.
+
+### 1.6 Chart-side rendering
+
+| # | Element | Location | Notes |
+|---|---|---|---|
+| 28 | Overlay plots on the price chart | `indicator_render.rs:116` (`draw_overlays`), called `pane.rs:1610-1619` | **No legend, no label, no colour key, no value readout, no interaction of any kind** |
+| 29 | Overlay draw objects (lines/boxes/labels) | `indicator_render.rs:623+`, called `pane.rs:1622-1631` | Non-interactive |
+| 30 | Pane background + top hairline + right rule | `indicator_render.rs:191-208` | — |
+| 31 | Pane title, top-left, 11 px muted | `indicator_render.rs:263-269` | `painter.text` only — **no `Sense`, not clickable, not hoverable** |
+| 32 | Pane headline value, top-right, monospace muted | `indicator_render.rs:270-278`, `last_value` at `318-330` | Preview value first, else last non-NaN committed |
+| 33 | `"{label} — warming up"`, pane centre | `indicator_render.rs:210-219` | Shown while every visible value is NaN |
+| 34 | Pane y-axis gridlines + gutter labels | `indicator_render.rs:286-316` | Edge labels suppressed within 7 px (`AXIS_LABEL_EDGE_MARGIN_PX`) |
+| 35 | Pane zero line | `indicator_render.rs:227-236` | Only when 0 ∈ range |
+| 36 | Warmup gaps (NaN breaks polylines) | `indicator_render.rs:1-10` | Data-honesty rule, correctly implemented |
+
+### 1.7 Pane management
+
+| # | Element | Location | Notes |
+|---|---|---|---|
+| 37 | Pane creation | `indicators/mod.rs:266-268` | **Implicit**: a pane appears iff `!descriptor.overlay && !hidden && error.is_none()`. The user never chooses |
+| 38 | Pane height | `indicators/mod.rs:23` (`PANE_HEIGHT_FRAC = 0.20`), split at `273-291` | Fixed 20% of chart height each. **No draggable divider, no collapse, no resize** |
+| 39 | Pane cap | `indicators/mod.rs:26` (`MAX_PANES = 3`), enforced by `.take(MAX_PANES)` at `241-256` | The 4th pane indicator is **silently not drawn** |
+| 40 | Pane y-axis zoom | `pane.rs:1380-1388` → `axis_zoom_gesture` (`pane.rs:208-235`) | Drag/scroll over the pane's gutter zooms its scale; double-click resets to auto-fit. Same feel as the price axis |
+| 41 | Pane removal | Only via the trash button (#11) or by hiding (#9) | No per-pane close control |
+
+### 1.8 Script library / Pine loading
+
+| # | Element | Location | Notes |
+|---|---|---|---|
+| 42 | Scripts folder | `library.rs:18-20` | `QUANTICK_INDICATORS_DIR`, else `./indicators`. Created on first scan (`library.rs:74`) |
+| 43 | Library scan | `library.rs:70-89, 107-157` | **Startup only** — a `.pine` file added while the app runs never appears in the menu until restart |
+| 44 | Embedded starters | `library.rs:24-40` | 6 scripts, shadowed by a same-named user file (`library.rs:150-154`) |
+| 45 | Hot reload | `app.rs:1231-1289` | 1 s mtime poll (`SCRIPT_RELOAD_POLL_INTERVAL`, `app.rs:70`). Success → recompile + replay; failure → `stale` flag, last good version keeps running |
+| 46 | Read failure on add | `app.rs:1138-1177` | Builds an error slot so the click is never a no-op |
+| 47 | Persistence | `indicators/state_file.rs`, `app.rs:1331-1489` | `indicators-state.toml`, 1 s debounce. **Flow pane of the startup tab only** — indicators on a time pane or a later-opened tab are session-only (documented at `app.rs:1402-1409`) |
+
+There is **no** in-app script editor, no "open scripts folder" command, no "reload library", no `.pine` file picker, and no Pine dialect reference in `Help` (the `Help` menu has one item: replay file format, `app.rs:1913-1918`).
+
+*(continues in 2/3: FLOWS + root-cause diagnosis)*
+
+
+## 2. FLOWS
+
+### (a) Adding an indicator
+
+1. Locate an unlabelled 16 px line-chart glyph at the right end of the toolbar, sitting among three layer *toggles*.
+2. Click → menu opens.
+3. Pick `＋ Add EMA(9) on close`, `＋ Add CVD pane`, or a `.pine` file name.
+4. Menu closes. The indicator lands on the **focused pane** (`app.rs:999-1000`, `1303`) — the flow pane unless a split canvas is active and the time pane was clicked last.
+5. Placement is decided for you: EMA on close → overlay (`native/ema.rs:41`, `overlay: source.is_price_scaled()`); CVD → pane.
+6. A pane indicator shows `"CVD — warming up"` until it has non-NaN values.
+
+Zero preview, zero search/filter, zero categorisation, zero description of what a script does before loading it. The library is a flat list of file names. Note: the app does **not** open with EMA+CVD by default — that is gated behind `QUANTICK_INDICATORS_AUTOSTART=1` (`app.rs:630-640`); a fresh user opens with nothing unless `indicators-state.toml` restores a set.
+
+### (b) Editing properties — the flow the user called strange
+
+1. Click the unlabelled toolbar icon.
+2. Scroll past the add entries (2 natives + N scripts) to reach the separator.
+3. Find the row by its text label.
+4. Hit a `small_button` gear roughly 14 px wide.
+5. **The menu stays open** — the gear branch never calls `ui.close_menu()` (`toolbar.rs:641-647`), unlike every add branch which does (`toolbar.rs:592, 596, 608`).
+6. A floating `egui::Window` appears at egui's automatic cascade position (no `.default_pos`, no `.pivot` — `area.rs:411` `automatic_area_position`), i.e. upper-left of the viewport, far from the right-side toolbar where the click happened.
+7. **The still-open menu paints over it**: egui menus use `Order::Foreground` (`egui-0.29.1/src/menu.rs:184`) while `Window` defaults to `Order::Middle` (`area.rs:139`).
+8. Edit values. **Nothing on the chart changes** — every widget writes into `dialog.draft` (`indicator_panel.rs:56-57`), a clone taken at open time.
+9. Click `Apply` → `SetInputs` to the worker → construct anew, replace, replay from scratch (`indicator_worker.rs:379-412`). **The dialog closes.**
+10. To try a different value, repeat from step 1.
+
+Additional behaviours:
+- Only one dialog can be open (`app.rs:403`, `indicator_settings: Option<…>`). Opening a second **silently discards the first draft** (`app.rs:1037` overwrites).
+- The dialog is app-global with a `TabSlot` target (`app.rs:1062`, `1073-1082`). Switching tabs leaves it floating over an unrelated chart, still editing the other tab's indicator.
+- It closes itself if the indicator is removed underneath (`app.rs:1083-1087`).
+- Apply retargets nothing: the slot captured at open time wins (`app.rs:1095-1096`).
+- If the worker clamps a value (e.g. EMA `len.max(1)`), it honestly mirrors what was bound — but the dialog has already closed, so the user never sees the correction.
+- Half the shipped library declares **zero inputs**: `cvd.pine`, `delta_histogram.pine`, `vwap_cumulative.pine`, and the native CVD (`native/cvd.rs:34`). The gear on those opens a window whose entire content is *"this indicator declares no settings"* plus an `Apply` that fires a pointless full recompute.
+
+### (c) Removing an indicator
+
+Toolbar icon → menu → find row → trash `small_button`. Immediate, no confirmation, no undo, no toast. Contrast with drawings, which get a confirmation for locked objects and an Undo toast (`app.rs:1947-1959`).
+
+### (d) Moving an indicator between panes
+
+**Not possible.** Overlay-vs-pane is the descriptor's `overlay` flag, and pane order is add order. The only way to move an EMA off the price chart is to change its `Source` input to a flow series, which flips `overlay` via `is_price_scaled()` (`native/ema.rs:41`) — the indicator vanishes from the chart and reappears as a pane with no explanation. There is no "move to pane", no reorder, no drag.
+
+### (e) Loading a custom `.pine` script
+
+1. Find the folder: `./indicators` beside the working directory, or `QUANTICK_INDICATORS_DIR`. **Nothing in the UI states this path.**
+2. Drop the `.pine` file there.
+3. **Restart the app** — the scan runs once at startup (`library.rs:70`).
+4. Toolbar icon → menu → the file name now appears under `scripts`.
+5. Click it. Compile errors produce an error slot; the message goes to the worker and into `view.error`, and is then displayed **nowhere**.
+6. Once loaded, saving the file hot-reloads within ~1 s. A save with errors sets `stale` and keeps the last good version running — again with no visible message.
+
+---
+
+## 3.1 ROOT-CAUSE DIAGNOSIS: "editing indicator properties feels strange"
+
+Four independent causes, each with code evidence. Together they fully explain the report.
+
+**Cause 1 — the entry point is not where any user looks.** TradingView's convention is: the indicator writes its name into the chart legend, and you double-click that name. quantick draws **no legend at all** for overlays (`indicator_render.rs:116` paints plots and nothing else), and the pane title is `painter.text` with no `Sense` (`indicator_render.rs:263-269`). The object on screen is inert. The only route is an unlabelled toolbar glyph → menu → 14 px gear. The project's own spec called for exactly the TradingView affordance — *"Legend (chart overlay, top-left) — one row per active indicator: colour dot, short title, last value; eye / gear / remove appear on hover"* (`docs/ux/ui-design-model.md:304-306`) — and it was never built.
+
+**Cause 2 — the menu does not get out of the way.** The gear does not close the menu, and egui paints menus above windows. The user clicks a gear and gets a dialog partly hidden behind the popup they just clicked in, at the opposite corner of the screen from where they clicked. That alone reads as broken.
+
+**Cause 3 — no live preview, and Apply closes.** Every parameter edit is blind: you set 21, click Apply, the window vanishes, and only then do you see the result. Tuning a length — the single most common indicator interaction — costs four clicks and a menu traversal *per attempt*. TradingView applies changes live as you type/drag, keeps the dialog open, and offers OK/Cancel to commit or revert.
+
+**Cause 4 — the app contradicts itself.** quantick already has an excellent property editor: the drawing inspector (`app.rs:2152-2560`). It opens **automatically on selection**, has **tabs** (Style / Extra / Coordinates, `app.rs:2317-2323`), applies **live** with undo coalescing (`app.rs:2346-2352`, `2404-2427`), can be **pinned as a dock panel or floated**, has a title bar with hide/pin/close, and even has a deliberate default position constant (`DRAWING_INSPECTOR_DEFAULT_POSITION`, `app.rs:65`). A user who has edited a trendline in quantick has learned "select the thing → the inspector appears → changes are live". Indicators break every part of that learned model. The strangeness is not abstract — it is measured against the app's own other half.
+
+
+## 3.2 FINDINGS BY SEVERITY
+
+### BLOCKER
+
+**B1. Indicator errors are computed, tested, and never shown.** `view.error: Option<EvalError>` carries a message with file:line:col and a stable code (`PINE_NO_SECURITY`, etc. — heavily tested at `indicator_worker.rs:725-735`). The UI reads only `.is_some()` (`app.rs:923`); `IndicatorMenuEntry` (`toolbar.rs:210-221`) carries booleans, so the message is structurally unreachable from the toolbar. An errored indicator is filtered out of both render paths (`indicators/mod.rs:237, 267`) and simply disappears from the chart, leaving a red dot inside a menu the user has no reason to open. Same for `stale`, whose message is likewise never rendered. *Heuristic: visibility of system status; help users recognize and recover from errors.* Directly violates the plan's own requirement — *"Error display: full PineError rendering (file:line:col + message + code)"* (`docs/indicator-system-plan.md:574-576`) — and the project's data-honesty rule.
+
+**B2. The 4th pane indicator silently does not exist.** `visible_panes()` ends in `.take(MAX_PANES)` (`indicators/mod.rs:241-246`). The menu shows a healthy green dot, the state file records it, the worker computes it every bar, and nothing draws. No notice, no disabled add entry, no explanation. *Heuristic: visibility of system status.* The cap itself is defensible (`indicators/mod.rs:25-26` calls it "the honest alternative to shrinking panes into unreadability"); the silence is not.
+
+### MAJOR
+
+**M1. No chart legend for overlay indicators.** An EMA overlay is an unlabelled coloured line. Two overlays are two unlabelled lines. There is no way to tell which is which, read a value at the cursor, hide one, or reach its settings. Spec'd at `ui-design-model.md:304-308`, absent from the code. *Recognition rather than recall.*
+
+**M2. Settings are draft-only with no live preview, and Apply closes the dialog.** See Cause 3. `indicator_panel.rs:56-57, 69-71` + `app.rs:1093-1105`. *User control and freedom; flexibility and efficiency of use.*
+
+**M3. The still-open menu occludes the dialog it spawned.** `toolbar.rs:641-647` (no `close_menu`) + egui's `Order::Foreground` menus vs `Order::Middle` windows. *Consistency; aesthetic and minimalist design.*
+
+**M4. Opening a second settings dialog silently discards the first draft.** `app.rs:403, 1037`. No warning, no queueing. *Error prevention.*
+
+**M5. Delete has no confirmation and no undo.** `app.rs:1013-1024`. An indicator with a hand-tuned parameter set is one mis-click from gone; the state file is rewritten 1 s later (`INDICATOR_STATE_SAVE_DEBOUNCE`). Drawings in the same app get a confirmation path and an Undo toast. *User control and freedom; consistency.*
+
+**M6. Plot style is not editable anywhere.** Colour, width, plot type, offset and markers live in `PlotSpec` and can only be changed by editing the `.pine` file. There is no Style tab, and native EMA/CVD have no source file to edit at all. Half of TradingView's settings dialog is missing.
+
+**M7. A new `.pine` file requires an app restart.** `library.rs:70` scans once; the doc comment states this as intentional, but there is no "rescan" command and no message telling the user why their new file is absent. Combined with M8, the custom-script flow is effectively undiscoverable without reading the source.
+
+**M8. The scripts folder is never named in the UI.** `QUANTICK_INDICATORS_DIR` / `./indicators` (`library.rs:18-20`) appear only in code and a log line. No "open scripts folder" action, no path in the menu, no Pine dialect reference under `Help` (which has exactly one entry, `app.rs:1913-1918`). *Help and documentation.*
+
+**M9. Panes cannot be resized, reordered or collapsed.** Fixed 20% each (`indicators/mod.rs:23`, `273-291`). Three panes take 60% of the chart, non-negotiably. Spec'd as *"draggable dividers; a pane collapses to its header. Pane headers carry name + live value + collapse chevron"* (`ui-design-model.md:310-313`) and as a v1 limitation in the plan (`indicator-system-plan.md:552-553`).
+
+**M10. `Source` offers all 14 series with no guidance.** `indicator_panel.rs:159-168` lists `SourceId::ALL` flat. Picking a flow series on an overlay EMA silently relocates it from the price chart to a new pane (`native/ema.rs:41`) — or, if three panes already exist, to nowhere (B2). `SourceId::is_price_scaled()` exists (`input.rs:93-105`) and is not used by the UI to warn or group.
+
+### MINOR
+
+**m1.** `Int`/`Float` `options` silently ignored. `input.rs:148-150` documents *"rendered as a dropdown"*; `indicator_panel.rs:89-96, 113-119` swallow `options` in a `..` pattern. Latent today — `pine` always emits empty options (`compile.rs:1404, 1416, 1441`), which also makes the `Str` combo branch dead — but the doc comment is a lie waiting for the first native that uses it.
+
+**m2.** The dialog cannot scroll or resize. `.resizable(false)` with no `ScrollArea` (`indicator_panel.rs:50-60`). Shipped scripts declare ≤2 inputs so nothing breaks today; a 15-input script puts `Apply` off-screen.
+
+**m3.** Bool label is not a click target. `ui.checkbox(current, "")` (`indicator_panel.rs:136`) leaves a bare ~16 px box.
+
+**m4.** Dialog title goes stale. Snapshotted at open (`app.rs:1039`); `EMA(9)` retitled `EMA(21)` still reads `Settings — EMA(9)`. Masked today because Apply closes.
+
+**m5.** `Apply` on a zero-input indicator triggers a full rebuild for nothing (`app.rs:1093-1105`). Affects 4 of the 8 shipped indicators.
+
+**m6.** Status-dot precedence is invisible (`toolbar.rs:617-628`) — a hidden **and** errored indicator reads as merely errored. No tooltip.
+
+**m7.** The dialog does not follow tab switches (`app.rs:1062, 1073-1082`), so it floats over whatever chart is now on screen.
+
+**m8.** No search or filter in the library list — a folder with 40 scripts becomes a 40-item flat menu (`toolbar.rs:605-610`).
+
+**m9.** Recompute progress is never shown. `IndicatorView::rows()` is commented *"the M4 progress readout reads it live"* (`indicators/mod.rs:74`) but is `allow(dead_code)` outside tests. A rebind over long history shows a frozen plot with no feedback; the plan called for progress (`indicator-system-plan.md:733`).
+
+### NIT
+
+**n1.** The INDICATORS icon is visually identical in weight and placement to the layer toggles beside it, but it is a menu, not a toggle.
+**n2.** `＋ Add EMA(9) on close` hardcodes its parameters in the label; no way to add an EMA of a different length in one step.
+**n3.** Stale M1/M2 comments describe UI that has since shipped: `toolbar.rs:574-576`, `app.rs:66-67`.
+
+---
+
+## 4. QUICK WINS vs STRUCTURAL
+
+### Quick wins (small, local, high leverage)
+
+1. **Call `ui.close_menu()` in the gear/eye/trash branches** — `toolbar.rs:640, 647, 654`. Three lines. Kills the occlusion problem (M3) outright.
+2. **Give the dialog a deliberate position** — `.default_pos(...)` in `indicator_panel.rs:46-50`, mirroring `DRAWING_INSPECTOR_DEFAULT_POSITION` (`app.rs:65`); ideally near the pointer that opened it.
+3. **Make Apply not close** — split into `Apply` (send, stay open) and `Close`, or apply live on `.changed()` as the drawing inspector does (`app.rs:2346-2352`). The worker already handles rebind-and-replay atomically, so live apply is close to free; debounce if a rebind over long history proves expensive.
+4. **Add `ScrollArea` + `.resizable(true)`** to the dialog (`indicator_panel.rs:50`). Two lines, removes m2 permanently.
+5. **Put the error and stale text on the menu row** — widen `IndicatorMenuEntry` (`toolbar.rs:210-221`) from `errored: bool` / `stale: bool` to `Option<String>` and hang it off the status dot with `.on_hover_text`. Fixes the worst of B1 for a handful of lines; the strings already exist on `IndicatorView`.
+6. **Disable the pane-adding entries at the cap, with a reason** — `add_enabled(panes < MAX_PANES, …).on_disabled_hover_text("three panes is the maximum — remove or hide one first")`, plus a distinct dot for an over-cap row. Fixes B2 cheaply.
+7. **Move the label into the checkbox** — `ui.checkbox(current, title)` with an empty left cell (`indicator_panel.rs:134-137`). Fixes m3.
+8. **Confirm or undo on delete** — reuse the existing `DrawingToast`/undo machinery (`app.rs:1947-1959`) for M5.
+9. **Render `Int`/`Float` `options` as a combo, or delete the field and its doc claim** (`indicator_panel.rs:88-133` + `input.rs:148-150`). Fixes m1 either way.
+10. **Show the scripts folder path in the menu** under the `scripts` header, plus a "Rescan library" item re-running `ScriptLibrary::scan()` (`library.rs:70`). Fixes M7/M8 without a file watcher.
+11. **Tooltip or group the source dropdown** by `is_price_scaled()` (`input.rs:93-105`) — "Price" vs "Flow". Partial M10.
+12. **Warn when an edit relocates an indicator** — after `SetInputs`, if `descriptor.overlay` flipped, raise the existing notice/toast. Completes M10.
+
+### Structural (deeper redesigns — each already specified in `docs/ux/ui-design-model.md` §9)
+
+**S1. Build the chart legend.** Highest-value change and the direct fix for the reported complaint. One row per active indicator at the chart's top-left: colour dot, short title, last value; eye / gear / remove on hover; **double-click the name opens settings**. Red row for an error (click for full file:line:col + code), amber for stale. Fixes M1, most of B1, the Cause-1 entry-point problem, and gives overlays the identity they lack — in one surface, and the surface TradingView users already know. New module beside `indicator_render.rs`; needs `IndicatorView` to expose `error`/`stale` text and the first plot's `base_color`, both already present.
+
+**S2. Reuse the drawing inspector for indicators.** Instead of a bespoke floating window, mount indicator properties in the same pinnable/floatable inspector host drawings use (`app.rs:2548+`), with tabs **Inputs / Style / Visibility**. Resolves Cause 4 by construction — one property-editing model for the whole app — and unlocks S3 for free. Requires generalising the inspector host from `Drawing` to a small trait; title bar, pin/float, docking and undo-coalescing are already written and tested.
+
+**S3. Make `PlotSpec` editable (the Style tab).** Per-plot colour, width, style and a visibility checkbox, stored as a UI-side style override layered over the descriptor so a hot reload does not stamp on it. The missing half of the settings dialog (M6) and the one thing a Pine-file edit cannot substitute for on native indicators.
+
+**S4. Draggable pane dividers + collapse chevrons + pane headers.** Replace the fixed `PANE_HEIGHT_FRAC` with per-pane fractions persisted in `indicators-state.toml` (or the `ui-state.toml` the design model reserves, `ui-design-model.md:500-501`). Make the pane header a real widget: name + live value + collapse chevron + gear, which also gives pane indicators an in-place settings entry point. Fixes M9 and reinforces S1.
+
+**S5. An Indicators dock tab.** `DockTab` currently has L2 / Bubbles / Session / Trading (`dock.rs:30-43`). Adding `Indicators` gives room for the library browser with descriptions and search, reordering, add-to-pane targeting, and a persistent error log — the "full manager" the spec describes (`ui-design-model.md:307-309`), with the legend as the fast path. Where M7/M8/m8 get proper answers rather than tooltip-sized ones.
+
+**S6. An `Insert` menu.** `Insert → Indicator…` (opens the dock tab), `Insert → EMA / CVD / …` for natives, plus the drawing tools (`ui-design-model.md:317-319, 334`). Discoverability for anyone who never guesses what the line-chart glyph does, and the natural home for a keyboard shortcut. Fixes n1 by giving the feature a labelled path that does not compete with the layer toggles.
+
+**S7. Move-to-pane / reorder.** Let a user send an overlay to its own pane and back, and reorder panes — independent of the `overlay` flag the descriptor declares. Needs a UI-side placement override on `IndicatorView` plus a display-order field; today placement is fully derived (`indicators/mod.rs:266-268`) and the user has no vote (flow (d)).
+
+**Uncertain / needs a running build:** the exact visual overlap between the open menu popup and the settings window (M3) — the egui paint ordering is unambiguous in the 0.29 source, the geometry of the overlap is not.
+

--- a/docs/ux/ux-audit-2026-08/paper-trading.md
+++ b/docs/ux/ux-audit-2026-08/paper-trading.md
@@ -1,0 +1,394 @@
+# Paper trading — full audit report
+
+**Scope:** `crates/app/src/paper_trading.rs` (1716 lines) plus its wiring in `toolbar.rs`, `dock.rs`, `pane.rs`, `statusbar.rs`, `app.rs`, `tab.rs`, and the data surface of `crates/sim`. Read-only analysis; no files modified. The design contract is `docs/ux/paper-trading.md`, and several findings below are places where the implementation silently diverges from it.
+
+---
+
+## 1. INVENTORY — every user-facing element
+
+### 1.1 Toolbar (top panel, always visible)
+
+| # | Element | Location | Trigger / appearance | Effect |
+|---|---|---|---|---|
+| T1 | `BUY` button (teal `#26A69A`, bold) | `toolbar.rs:484-496` | Always visible in the TRADE group, between HISTORY and the right-hand groups (`toolbar.rs:285-288`) | Pushes `ToolbarAction::PaperBuy` → `PaperTrading::market(Side::Buy)` (`app.rs:1047-1050`) |
+| T2 | `SELL` button (red `#EF5350`, bold) | `toolbar.rs:497-509` | Same group, right of BUY | `ToolbarAction::PaperSell` → `market(Side::Sell)` (`app.rs:1051-1054`) |
+| T3 | BUY hover text | `toolbar.rs:489-492` | Hover on T1 | "simulated market buy - fills at the next print; quantity and brackets live in the Trading tab" |
+| T4 | SELL hover text | `toolbar.rs:502-505` | Hover on T2 | Same wording, sell side |
+| T5 | Disabled explanation (both) | `toolbar.rs:493`, `506` | Hover while `paper_ready == false` | "waiting for the first print - there is no market yet" |
+| T6 | Overflow `Buy at market (SIM)` | `toolbar.rs:708-714` | Inside the `⋯` menu once the window narrows past the TRADE fold (`toolbar.rs:110-112`) | Same as T1, then closes the menu |
+| T7 | Overflow `Sell at market (SIM)` | `toolbar.rs:715-721` | Same | Same as T2 |
+
+There is **no** close, flatten, reverse or cancel control anywhere on the toolbar.
+
+### 1.2 Right dock — strip and entry points
+
+| # | Element | Location | Trigger / appearance | Effect |
+|---|---|---|---|---|
+| D1 | Trading tab icon (Phosphor `TREND_UP`) | `dock.rs:52`, drawn `dock.rs:183-191` | Fourth of four unlabeled 36 px icons on the always-visible right strip | `Dock::select(DockTab::Trading)` — opens the body, or collapses it if already active (`dock.rs:153-159`) |
+| D2 | Strip hover text | `dock.rs:74` | Hover on D1 | "Paper trading — simulated orders, position and history" |
+| D3 | Body title `PAPER TRADING · SIM` | `dock.rs:63`, drawn `dock.rs:226-245` | Top of the open body | Static label |
+| D4 | Collapse `×` | `dock.rs:236-242` | Right of D3 | Sets `active = None`; hover: "collapse the dock to its tab strip" |
+| D5 | View menu → `Paper trading` | `app.rs:1882` (inside the `DockTab` loop at `1878-1890`) | Menu bar | `dock.open_tab(DockTab::Trading)` |
+
+**The dock opens collapsed.** `Dock::new()` sets `active: None` (`dock.rs:124-132`), and I found no persistence of dock state, so every launch starts with the Trading body closed and only the icon strip showing.
+
+### 1.3 Trading tab body — `draw_trading_tab` (`paper_trading.rs:573-593`)
+
+**Header block**
+
+| # | Element | Location | Notes |
+|---|---|---|---|
+| P1 | Muted small label "Simulated fills from the tape - no broker, points not currency." | `574-578` | Always shown |
+| P2 | Its hover text (fill-model explanation) | `579-583` | Explains market/limit/stop fill semantics |
+
+**Position card — `draw_position_card` (`595-694`)**
+
+| # | Element | Location | Trigger / appearance | Effect |
+|---|---|---|---|---|
+| P3 | "No open position." (muted) | `597` | Whole card is replaced by this line when flat — and the function **returns**, so Close/Flatten do not exist while flat | — |
+| P4 | Position line `LONG 1 @ 103.25` | `605-614` | Colored `theme::BUY` for long, `theme::SELL` for short, bold | Static |
+| P5 | Open P&L `+2 pts` | `615-620` | Right of P4, colored by sign via `points_color` (`1351-1357`) | Static; only rendered when `mark_price()` is `Some` |
+| P6 | P&L hover | `621` | "open profit at the last print, in points (price units × quantity)" | — |
+| P7 | `stop loss 90` label | `627` | Only when `position.stop_loss` is `Some` | Static |
+| P8 | SL `clear` small button | `628-637`, hover "remove the protective stop" | Next to P7 | `Command::SetBracket { stop_loss: None, take_profit: <unchanged> }` |
+| P9 | Muted "stop loss - (drag one on the chart, or use the offsets below)" | `640-646` | When SL is `None` | **Instructional text only — both routes it names are non-functional. See Finding B1.** |
+| P10 | `take profit 110` label | `649` | When TP is `Some` | Static |
+| P11 | TP `clear` small button | `650-659`, hover "remove the profit target" | Next to P10 | `SetBracket { take_profit: None }` |
+| P12 | Muted "take profit - (drag one on the chart, or use the offsets below)" | `662-669` | When TP is `None` | Same problem as P9 |
+| P13 | **`Close` button** | `677-684`, hover "exit the position at the next print" | Bottom of the card | `Command::ClosePosition` — queues a market close for the next print |
+| P14 | **`Flatten` button** | `685-692`, hover "close the position and cancel every pending order" | Right of P13 | `Command::Flatten` |
+
+P13/P14 are **the only dedicated exit controls in the entire application.**
+
+**Order entry — `draw_order_entry` (`696-791`)**
+
+| # | Element | Location | Trigger / appearance | Effect |
+|---|---|---|---|---|
+| P15 | `BUY` selectable toggle | `698-702` | Teal, bold | Sets `self.side = Buy` |
+| P16 | `SELL` selectable toggle | `703-707` | Red, bold | Sets `self.side = Sell` |
+| P17 | `qty` label | `708` | Muted | — |
+| P18 | Quantity text field | `709` | `TextEdit::singleline`, 48 px, default `"1"` (`155`) | Free text; parsed only at submit (`parse_quantity`, `1059-1070`) |
+| P19 | Order-type combo | `710-716` | Options `market` / `limit` / `stop`, lowercase | Sets `self.order_type` |
+| P20 | `stop -pts` label + hover | `719-723` | Muted | Hover: "optional protective stop, this many points on the losing side of the entry; empty places no stop" |
+| P21 | Stop-offset field | `724` | 48 px text | Applied **only at entry placement** (`parse_bracket`, called from `235` and `524`) |
+| P22 | `profit +pts` label + hover | `725-729` | Muted | Hover: "optional profit target…" |
+| P23 | Profit-offset field | `730` | 48 px text | Same restriction as P21 |
+| P24 | `BUY 1 at market` action button | `739-755` | Only when order type is `market`; text is `"{SIDE} {qty_text} at market"`, colored by side | `self.market(side)` |
+| P25 | P24 hover / disabled hover | `750-751` | — | "simulated: fills at the next print of the tape" / "waiting for the first print…" |
+| P26 | `Place buy limit on the chart…` button | `767-788` | Only when type is `limit` or `stop`, and nothing armed | Sets `self.armed = Some(ArmedPlacement { side, kind })` |
+| P27 | P26 hover / disabled hover | `778-783` | — | "arms a click: the next chart click rests the order at that price (Esc cancels)" |
+| P28 | "click the chart at your price…" (accent) | `758-762` | Replaces P26 while armed | Static |
+| P29 | `cancel` small button | `763-765` | Right of P28 | `self.armed = None` |
+
+**Pending orders — `draw_pending_orders` (`793-843`)**
+
+| # | Element | Location | Trigger / appearance | Effect |
+|---|---|---|---|---|
+| P30 | "N market order(s) await the next print" | `801-809` | When queued entries exist | Static |
+| P31 | "closing at the next print…" | `810-816` | When a queued close exists (after clicking Close/Flatten) | Static — the only feedback that Close was registered before the next print lands |
+| P32 | "No pending orders." | `818-821` | When nothing rests | Static |
+| P33 | Order row `#1 buy limit 1 @ 95` | `823-832` | One per resting order | Static |
+| P34 | `×` cancel button per row | `833-840`, hover "cancel this order" | Right of P33 | `Command::CancelOrder { id }` |
+
+**Session summary — `draw_session_summary` (`845-865`)**
+
+| # | Element | Location | Notes |
+|---|---|---|---|
+| P35 | "session: +7 pts realized · 2 closed trade(s)" | `846-850` | The only in-session trade count |
+| P36 | `Report…` button | `852-858`, hover "performance metrics computed from the saved history" | Opens the report window; reloads from disk (`871-874`) |
+| P37 | Muted "history: paper-trades" | `860-864` | A **non-interactive label**, relative to cwd. The spec (`docs/ux/paper-trading.md:81-82`) called for a `History folder` button |
+
+### 1.4 Report window — `draw_report_window` (`885-937`)
+
+| # | Element | Location | Notes |
+|---|---|---|---|
+| R1 | `egui::Window` "Simulated performance" | `891-895` | Non-collapsible, non-resizable, with the standard close `×` |
+| R2 | `scope` label | `897` | Muted |
+| R3 | `this symbol (BTCUSDT)` selectable | `898-904` | Reloads from disk on change (`931-933`) |
+| R4 | `all symbols` selectable | `905-907` | Same |
+| R5 | Empty state "No saved trades yet - close a simulated trade and it lands here." | `913-919` | When `trades == 0` |
+| R6 | Footer disclaimer (points, not currency) | `922-929` | Muted small |
+| R7-R14 | Metric rows, each with a hover explanation | `draw_report_body`, `1125-1184` | net P&L, trades (long/short split), win rate, profit factor, max drawdown, gross profit/loss, avg win/loss, largest win/loss. Honest `—` where a ratio has no denominator |
+| R15 | Warning line "N file(s) unreadable, M row(s) skipped" | `1186-1196` | `theme::WARN`, only when > 0 |
+| R16 | "N trade(s) across M file(s)" | `1197-1204` | Muted small |
+
+There is **no per-trade list** anywhere in this window — only aggregates.
+
+*(continues in 2/4)*
+
+
+### 1.5 Chart layer — `draw_layer` (`279-396`), painted by both panes at `pane.rs:1709`
+
+| # | Element | Location | Appearance |
+|---|---|---|---|
+| C1 | Pending-order line | `286-312` | Dashed (4 px on / 4 px off, `40-42`), `theme::ACCENT` `#8AB4F8`, spanning chart-left to `axis_x` |
+| C2 | Pending-order gutter chip | via `draw_price_line:1300-1307` | `#1 buy limit 1 @ 95`, 11 px monospace, dark ink `#0E121A` on an accent-filled rect |
+| C3 | Position entry line | `313-334` | Solid, `theme::BUY` for long / `theme::SELL` for short |
+| C4 | Entry chip | `319-324` | `SIM LONG 1 @ 103.25` |
+| C5 | Stop-loss line | `335-357` | Solid, always `theme::SELL` red |
+| C6 | SL chip | `342-346` | `SL 90 -10 pts` (the points figure is the P&L if it fills) |
+| C7 | Take-profit line | `358-380` | Solid, always `theme::BUY` teal |
+| C8 | TP chip | `365-369` | `TP 110 +10 pts` |
+| C9 | Armed-placement hint | `382-395` | 12 px accent text at the chart's **top-left corner**: "click a price to place your buy limit - Esc cancels" |
+
+Every line early-returns when its `y` falls outside the chart rect (`1283-1285`) — off-screen prices draw nothing at all.
+
+### 1.6 Chart interactions — `handle_chart_input` (`417-482`)
+
+| # | Gesture | Location | Behavior |
+|---|---|---|---|
+| I1 | Armed click | `419-427` | First press inside the chart places the limit/stop at `scale.price_at(pointer.y)`, snapped to the mark's own decimal precision (`snap`, `556-565`) |
+| I2 | Grab a line | `430-440` | Press within `LINE_GRAB_RADIUS_PX = 10.0` (`38`) of a line starts a drag |
+| I3 | Drag | `443-449` | `drag_price` follows the pointer, clamped to the chart's vertical bounds; the line repaints at the dragged price (`288-292`, `336-341`, `359-364`) |
+| I4 | Release | `453-479` | Submits `SetBracket` (SL/TP) or `ModifyOrder`; a rejection snaps the line back and toasts |
+| I5 | Hit priority | `line_at`, `487-514` | Pending orders (reverse order) → take profit → stop loss → entry |
+| I6 | Entry line = `Blocked` | `510-512` | Consumes the gesture, moves nothing, **sets no cursor** |
+| I7 | Escape | `cancel_interaction`, `405-415`; wired at `app.rs:2012` | Cancels the armed placement first, then a grabbed line — one layer per press |
+
+**No hover state, no cursor change, no highlight** exists for any of these lines. `pane.rs:1120` gates the entire cursor-feedback block behind `!paper_gesture`, and `handle_chart_input` never calls `set_cursor_icon`.
+
+**No context menu.** The spec explicitly does not claim right-click (`docs/ux/paper-trading.md:54-56`).
+
+### 1.7 Status bar
+
+| # | Element | Location | Notes |
+|---|---|---|---|
+| S1 | `SIM +2 pts` cell | producer `status_cell:249-269`; model `app.rs:1716`; rendered `statusbar.rs:297-308` | Monospace, colored by sign (teal/red/muted). Sits in the middle content section, after the bar spec, bar counts and the side-inference note |
+| S2 | Its hover | `statusbar.rs:304-307` | "paper-trading P&L (realized + open) in points - simulated fills, not a broker account" |
+
+Returns `None` only while the simulator has never been touched (`250-256`); once any trade closes, the cell shows permanently whether or not a position is open. It is **not clickable**.
+
+### 1.8 Toasts — `draw_toast` (`944-965`)
+
+Bottom-center, lifted 96 px (`TOAST_LIFT_PX`, `45`), 4-second life (`TOAST_MS`, `35`), single slot, newest wins (`show_toast`, `967-972`). Messages:
+
+| Trigger | Location | Text |
+|---|---|---|
+| Rejection | `983` | `SIM: <RejectReason>` — didactic, verbatim from the sim core |
+| Bracket dropped at fill | `984-986` | `SIM: dropped at the fill - <reason>` |
+| Entry fill | `987-996` | `SIM fill: buy 1 @ 103.25` |
+| Trade closed | `997-1006` | `SIM closed: LONG 1 → +2 pts (manual)` |
+| Timeline reset with a position | `212-214` | "SIM position flattened - the timeline was rebuilt under it." |
+| Timeline reset with orders only | `216-218` | "SIM orders cancelled - the timeline was rebuilt under them." |
+| Bad quantity | `1063-1067` | "SIM: quantity must be a positive number - got `x`" |
+| Bad stop offset | `1079-1082` | "SIM: the stop offset must be a positive number of points - got `x`" |
+| Bad profit offset | `1087-1090` | Same, profit side |
+| Journal write failure | `1053-1055` | "SIM: could not save the trade history - see the log for the path." |
+
+### 1.9 Keyboard
+
+**Escape is the only paper-trading key**, and only for cancelling an armed placement or a grabbed line (`app.rs:2004-2013`). No shortcut opens the Trading tab, closes a position, or flattens. For contrast, the app binds Ctrl+R (replay browser), Ctrl+B (dock), Ctrl+T (new tab), Ctrl+W (close tab), Ctrl+Tab (switch tab) at `app.rs:1730-1747`.
+
+---
+
+## 2. FLOWS — as the code implements them
+
+### (a) Enabling / opening paper trading
+
+There is nothing to enable. The simulator exists per tab from construction (`tab.rs:266`) and ingests every trade unconditionally (`tab.rs:1210`). The toolbar BUY/SELL become enabled the moment `mark_price()` is `Some` — which happens on the first backfilled print via `seed` (`tab.rs:1116`), before any live trade. To reach the panel: click the `TREND_UP` icon, fourth on the right strip, or View → Paper trading.
+
+### (b) Placing a market order
+
+Two entry points, both one click:
+
+1. **Toolbar `BUY`/`SELL`** → `market(side)` (`230-244`). Reads `qty_text` and both offset fields from the Trading tab's form — state the toolbar never displays. On a parse failure the order is silently dropped except for a toast.
+2. **Trading tab `BUY 1 at market`** (P24), when the type combo is on `market`.
+
+Either way: `Command::PlaceMarket` queues; nothing happens until the **next print**. The order appears as "1 market order(s) await the next print" (P30) only if the Trading tab is open. On the fill, a toast fires and the entry/SL/TP lines appear on the chart.
+
+### (c) Placing a limit / stop order
+
+Only from the Trading tab, and only via click-to-place:
+
+1. Set the type combo (P19) to `limit` or `stop`.
+2. The action button becomes "Place buy limit on the chart…" (P26). Click it → `armed`.
+3. The button is replaced by "click the chart at your price…" (P28) plus a `cancel` button (P29), and a 12 px accent hint appears at the chart's top-left (C9).
+4. Click anywhere in the flow pane's chart. The price is taken from the pointer's `y`, snapped to the mark's decimal places.
+5. A wrong-side placement is rejected, **stays armed**, and toasts advice (`544-550`) — deliberate, so the user clicks again.
+6. On success the order rests as a dashed accent line and a row in the pending list.
+
+There is no way to type an exact limit price, and no way to place a limit/stop from the toolbar.
+
+### (d) Seeing the open position
+
+Four surfaces, three of which are conditional:
+
+1. **Chart** — solid colored line at the average entry with a gutter chip `SIM LONG 1 @ 103.25`. Disappears completely if the price scrolls out of view.
+2. **Status bar** — `SIM +2 pts`, small monospace, mid-row, indistinguishable from realized-only P&L.
+3. **Trading tab position card** — the full picture, but only if the dock body is open on that tab.
+4. **Toast** — 4 seconds at the fill, then gone.
+
+### (e) Closing an open trade — every path that exists
+
+| Path | Where | Cost to discover |
+|---|---|---|
+| `Close` button (P13) | Trading tab, position card | Requires knowing the dock exists, recognizing `TREND_UP`, clicking it |
+| `Flatten` button (P14) | Same place, same card | Same |
+| **Reversal via the toolbar** — clicking `SELL` while long | `toolbar.rs:497`, netting at `simulator.rs:601-627` | Undocumented in the UI. Closes if quantities match; **opens an opposite position for the remainder if they do not** |
+| SL/TP firing | Automatic, on the tape | Not a user action |
+| Timeline reset | `on_timeline_reset:199-220` — replay seek, symbol/feed switch, restart | Flattens at the last mark, labeled `reset`, journaled, toasted |
+| Tab close | `app.rs:9045-9073` | Ends the session |
+
+There is **no** close/flatten on the toolbar, on the chart, in a context menu, or on a keyboard shortcut.
+
+### (f) Viewing closed trades / history / metrics
+
+- In-session: one line, `session: +7 pts realized · 2 closed trade(s)` (P35). No list.
+- `Report…` (P36) opens the aggregate window, reading fresh from disk. Aggregates only — win rate, profit factor, drawdown, averages. **No individual trade is ever displayed**, despite `sim.closed_trades()` (`simulator.rs:153`) and `history::parse` both returning full per-trade records (side, qty, entry, exit, both timestamps, points, exit reason — `simulator.rs:14-30`).
+- The on-disk path is shown as dead text (P37).
+- Closed trades are never drawn on the chart.
+
+
+## 3. UX FINDINGS
+
+### Root cause of the reported failure
+
+The user said: *"I couldn't figure out how to close the open trade, and it wasn't clear which trade was open."* Both halves have concrete causes in the layout, and they compound:
+
+**Why they couldn't close it.** Entry and exit live in structurally different places. `BUY`/`SELL` sit on the toolbar, permanently visible, at `toolbar.rs:285-288`. `Close`/`Flatten` exist only inside `draw_position_card` (`paper_trading.rs:677-692`), which only runs inside `DockTab::Trading` (`dock.rs:216`), and the dock **starts collapsed** — `Dock::new()` sets `active: None` (`dock.rs:126-131`). So a user who has never opened the dock has, on screen, a control that opens positions and no control that closes them. Nothing bridges the gap: the toolbar has no link to the Trading tab, the status bar `SIM` cell is not clickable, the chart lines have no menu, and there is no keyboard shortcut. The one affordance that exists — the fourth icon on the strip, Phosphor `TREND_UP` (`dock.rs:52`) — is an unlabeled upward-trending arrow that reads as "trend" or "indicator", not "my position", and it carries **no badge or state change when a position is open**. A user reasoning by elimination might press `SELL` to close, which works only if the quantity happens to match; otherwise they are now short.
+*Violates: #7 Flexibility and efficiency of use; #6 Recognition rather than recall.*
+
+**Why it wasn't clear which trade was open.** The persistent chart evidence is broken by a paint-order collision. `draw_price_line` places the entry chip at `axis_x + 6.0` in `FontId::monospace(11.0)` (`paper_trading.rs:1300-1301`). `draw_last_price` places its chip at `axis_x + AXIS_LABEL_GAP_PX` where `AXIS_LABEL_GAP_PX = 6.0` (`chart.rs:345`) in `AXIS_LABEL_FONT_PX = 11.0` (`chart.rs:347`) — **identical x, identical height** — and it is drawn *after* the paper layer (`pane.rs:1709` then `1713-1714`) with an opaque `rect_filled`. Because a market order fills at the very next print, the entry price *equals* the last price at the moment the position opens. So the chip that says `SIM LONG 1 @ 103.25` is overpainted across its first ~6 characters by `103.25`, leaving something like `…G 1 @ 103.25` — visually just another price tag. The one persistent, chart-anchored statement of "you are long" is mangled precisely when the user most needs it.
+
+Everything else that could have carried the message doesn't:
+- The fill toast lasts 4 seconds, bottom-center (`35`, `953-955`), while the user is looking at the chart and the right-hand dock.
+- The status cell reads `SIM +2 pts` (`249-269`) — a bare number that appears identically when flat with closed history, and says nothing about side, size or entry.
+- The entry line vanishes entirely once the price scrolls out of range (`1283-1285`) — no edge marker, no caret.
+- No fill markers are drawn on the candles at all.
+
+---
+
+### Blockers
+
+**B1 — An open position cannot be given a stop loss or take profit, and the UI instructs the user to do exactly that.**
+When `stop_loss` is `None`, the card shows "stop loss - (drag one on the chart, or use the offsets below)" (`640-646`; TP twin at `662-669`). Both routes are dead:
+- *Drag one on the chart*: `line_at` (`487-514`) only returns `PaperDrag::StopLoss` when `position.stop_loss` is already `Some`. With no stop there is no line, so there is nothing to grab. Dragging cannot **create** a level, only move an existing one.
+- *Use the offsets below*: `parse_bracket` (`1075`) is called from exactly two places — `market()` (`235`) and `place_armed()` (`524`). Both are *entry* paths. Typing into the offset fields with a position already open does nothing, and there is no apply button.
+
+`Command::SetBracket` is issued from only four sites (`459`, `465`, `633`, `656`): two drag-releases that require a pre-existing line, and two `clear` buttons that can only set `None`. **The only way to attach protection is to have typed the offsets before entering.** A user who entered from the toolbar (where offsets are invisible) has an unprotectable position and a label telling them otherwise.
+*Violates: #1 Visibility of system status; #2 Match between system and the real world; #10 Help and documentation (instructions that are false).*
+
+**B2 — The exit control is not reachable from any surface the user is looking at.** Detailed above. This is the reported failure and it is a genuine dead end, not a discoverability nuisance: nothing on the toolbar, chart, status bar, or keyboard leads to `Close`.
+*Violates: #7 Flexibility and efficiency of use.*
+
+**B3 — The open-position chip is overpainted by the last-price chip at the exact moment a position opens.** Detailed above; `paper_trading.rs:1300-1307` vs `pane.rs:1713-1714` with `chart.rs:345,347`.
+*Violates: #1 Visibility of system status.*
+
+---
+
+### Major
+
+**M1 — The status cell cannot distinguish "open" from "flat."** `status_cell` (`249-269`) sums realized and open P&L into one figure and returns `Some` as soon as anything has ever happened. `SIM +12 pts` after a closed winner and `SIM +12 pts` with an open winner are byte-identical. The one always-visible paper surface answers the wrong question.
+
+**M2 — Pressing `SELL` while long is an undisclosed close-or-reverse.** `simulator.rs:601-627`: selling 5 while long 2 closes 2 (reason `Reversal`) and **opens a short 3** (confirmed by the crate's own test at `simulator.rs:1058-1077`). The toolbar `SELL` button uses `qty_text` from the Trading tab (`230-244`), which the toolbar never shows. A user who cannot find `Close` will reach for `SELL`; whether that closes the trade or flips it depends on a number they cannot see. No preview, no warning, no confirmation.
+*Violates: #5 Error prevention; #1 Visibility of system status.*
+
+**M3 — The entry line creates an invisible 20 px band where the chart silently refuses to pan.** `line_at` returns `PaperDrag::Blocked` within 10 px of `avg_price` (`510-512`); `handle_chart_input` returns `true`; `pane.rs:1263` excludes the pan. Locked *drawings* at least set `CursorIcon::NotAllowed` (`pane.rs:1239-1241`), but the paper path sets no cursor — the whole cursor-feedback block is gated behind `!paper_gesture` (`pane.rs:1120`). The result is a horizontal stripe across the chart, near the current price, where dragging does nothing and nothing explains why.
+*Violates: #1 Visibility of system status; #9 Help users recognize and diagnose.*
+
+**M4 — SL/TP/order lines are draggable with zero affordance.** Same root cause as M3: no hover highlight, no cursor change, no handle. Drawings get `Move` and `ResizeNwSe` cursors on hover (`pane.rs:1134-1148`); paper lines get nothing. The only mention of draggability is inside the false hint of B1.
+*Violates: #6 Recognition rather than recall.*
+
+**M5 — An armed limit/stop placement is inert while any drawing tool is armed, and its hint never goes away.** `handle_navigation` returns early when `handle_drawing_placement` reports an armed tool (`pane.rs:1057-1059`), so `paper.handle_chart_input` never runs. The chart-corner hint (`382-395`) and the panel's "click the chart at your price…" (`758-762`) keep instructing, while every click draws a trendline. Compounding it, `cancel_interaction` sits **above** the drawing draft in the escape stack (`app.rs:2012` vs `2016`), so one Escape silently kills the paper arm when the user meant to cancel the drawing.
+*Violates: #1 Visibility of system status; #3 User control and freedom.*
+
+**M6 — Lines are drawn on both panes but only interactive on one.** `pane.rs:1709` paints the paper layer for every pane; `tab.rs:1525` sets `paper_owns_input = side == PaneSide::Flow`. In a split layout the time pane shows pixel-identical SL/TP lines that cannot be grabbed, with nothing marking them read-only.
+*Violates: #4 Consistency and standards.*
+
+**M7 — The position disappears from the chart when its price scrolls out of view.** `draw_price_line` early-returns (`1283-1285`) with no edge indicator. Combined with M1, a user who pans away has no on-screen evidence a position exists.
+
+---
+
+### Minor
+
+**m1 — No closed-trade list exists anywhere.** `sim.closed_trades()` (`simulator.rs:153`) and `history::parse` both return complete records — side, quantity, entry, exit, both timestamps, points, exit reason (`simulator.rs:14-30`) — and every one of those fields is discarded before reaching the screen. The user sees a count (`846-850`) and aggregates (`1113-1205`). They cannot answer "what were my last three trades and why did they close?", which is the core question a practice simulator exists to answer.
+
+**m2 — No fill markers on the candles.** Nothing shows *where* an entry or exit happened. The data is present.
+
+**m3 — The Trading tab body does not scroll.** `dock.rs:204-218` places the tab body directly into the `SidePanel`; the L2 tab supplies its own `ScrollArea` (`orderflow_view.rs:1160`) but the Trading branch (`dock.rs:216`) does not. With several pending orders, the session summary and `Report…` button are clipped with no scrollbar and become unreachable.
+
+**m4 — The history path is dead text.** `860-864` renders `history: paper-trades` as a muted label — relative to the working directory, not selectable, not clickable. The spec asked for a `History folder` button (`docs/ux/paper-trading.md:81-82`).
+
+**m5 — The report is only reachable from inside the Trading tab.** `docs/ux/paper-trading.md:155` promises "opened from the Trading tab (and Tools menu)". I found no menu entry — the only opener is P36, two levels behind a collapsed dock.
+
+**m6 — Quantity is free text validated at submit.** `TextEdit::singleline` at `709`; `parse_quantity` toasts on failure (`1059-1070`). The spec called for a DragValue (`docs/ux/paper-trading.md:70`). Typing `1,5` or `1.` fails only when the button is pressed — and if pressed from the *toolbar*, the field that caused the failure isn't even on screen.
+*Violates: #5 Error prevention.*
+
+**m7 — The toolbar buttons never disclose the quantity or brackets they will use.** `toolbar.rs:489-492` says "quantity and brackets live in the Trading tab" — pure recall. A user who set qty 10 and a 5-point stop an hour ago gets no hint from the button they are about to press.
+
+**m8 — Single-slot toast, 4 s, bottom-center.** `show_toast` (`967-972`) overwrites; `TOAST_MS = 4_000`; anchored `CENTER_BOTTOM, -96 px` (`953-955`). A fill and a `BracketDropped` in the same frame means one message is lost — and the dropped-bracket case is exactly the one that must not be missed, since it silently leaves the position unprotected.
+
+**m9 — `Close` vs `Flatten` is explained only on hover.** Two same-weight buttons side by side (`677-692`). "Flatten" is trading jargon. The spec asked for a hint line when both exist (`docs/ux/paper-trading.md:67-69`); it was not implemented.
+
+**m10 — Paper lines ignore the user's candle colors.** `draw_layer` uses the `theme::BUY`/`theme::SELL` constants (`600-603`, `353`, `376`), while `draw_last_price` reads `chrome.style.candles.bull_outline` (`pane.rs:1895-1899`). A user who recolors their candles gets a long-entry line that no longer matches their bulls.
+
+---
+
+### Nits
+
+**n1 — Three label registers in one panel.** `side_word` → `"buy"` (`1322`), `side_word_upper` → `"BUY"` (`1329`), `position_word` → `"LONG"` (`1336`). The pending row reads `#1 buy limit 1 @ 95`, the market button reads `BUY 1 at market`, the toggle reads `BUY`, the chip reads `SIM LONG 1 @ …`.
+
+**n2 — `stop -pts` is ambiguous** (`719`) — parses as "stop minus points" as easily as "stop offset in points".
+
+**n3 — A short position shows two red lines.** The entry is `theme::SELL` (`600-603`) and the stop is always `theme::SELL` (`353`); only the chip text disambiguates. Color-only coding also fails for red-green deficiency (`#26A69A` vs `#EF5350`).
+
+**n4 — No confirmation on `Flatten`.** Defensible for a simulator, but it is the most destructive control in the panel and sits one pixel-gap from `Close`.
+
+**n5 — The report scope label reads `this symbol ()` before a symbol is set** (`902`, with `symbol` initialized empty at `149`). `set_symbol` runs every frame from `tab.rs:1103-1104`, so this is likely unreachable in practice.
+
+---
+
+### What the implementation gets right
+
+Worth preserving through any redesign: rejections carry didactic, actionable text straight from the sim core (`983`, `docs/ux/paper-trading.md:113-121`); disabled controls explain themselves rather than hiding (`toolbar.rs:493`, `751`); the fill model's honesty is stated in the panel header and its hover (`574-583`); timeline resets flatten loudly and journal the exit rather than pretending continuity (`199-220`); unreadable history rows are counted and disclosed rather than dropped (`1186-1196`); and ratios without denominators show `—`, never `∞` (`1142`, `1149`).
+
+
+## 4. RECOMMENDATIONS
+
+### Quick wins
+
+1. **Fix the chip collision (B3).** Either paint the paper layer *after* `draw_last_price` (swap `pane.rs:1709` and `1713-1714`), or offset the paper chips — right of the last-price chip's width, or vertically by one chip height when the two `y` values are within a chip's height of each other.
+2. **Put `Close` on the toolbar (B2).** Add `paper_position: Option<PositionSummary>` to `ToolbarModel` and a `ToolbarAction::PaperClose`. While a position is open the TRADE group becomes `BUY | SELL | ✕ Close 1 LONG`. All the state already flows to `app.rs:960`.
+3. **Make the toolbar buttons state-aware (M2).** While long 1, label the sell button `SELL 1 (closes)` and the buy button `BUY 1 (adds)`; while long 1 with qty 5 in the form, `SELL 5 (reverses to short 4)`. Turns the hidden footgun into a readable one.
+4. **Badge the dock strip icon and make the status cell clickable.** An accent dot on `TREND_UP` while a position is open (`dock.rs:183-191`), and `dock.open_tab(DockTab::Trading)` on a click of the `SIM` cell (`statusbar.rs:297-308`).
+5. **Rewrite the status cell (M1).** `SIM LONG 1 · +2.0 pts` when open, `SIM +7.0 pts · flat` otherwise. One string change in `status_cell` (`249-269`) plus the model tuple.
+6. **Make the false hint true (B1).** Ship an `Apply` button beside the offset fields that issues `SetBracket` against the open position — the command exists and takes absolute prices; `parse_bracket(side, position.avg_price)` already computes them. Until that lands, the text at `640-646` and `662-669` must stop naming two routes that do not work.
+7. **Give the paper gesture a cursor (M3, M4).** Have `handle_chart_input` (or a companion `hover_kind`) report `ResizeVertical` over a draggable line and `NotAllowed` over the entry, and let `pane.rs` set it before the `!paper_gesture` gate at `1120`.
+8. **Wrap the Trading tab body in a `ScrollArea`** (`dock.rs:216`), matching the L2 tab (m3).
+9. **Add `Report…` to the View menu** next to the dock-tab entries at `app.rs:1878-1890` (m5).
+10. **Add a flatten shortcut** (e.g. Ctrl+Shift+F) beside the existing bindings at `app.rs:1730-1747`, and name it in the `Flatten` tooltip.
+11. **Make the history path a button** that opens the folder, and show the absolute path on hover (m4).
+12. **Swap the quantity field for a `DragValue`** (m6) so invalid text is unrepresentable; keep the offsets as text so empty can mean "none".
+13. **Disarm the drawing tool when a paper placement is armed** (M5), and make the escape stack cancel whichever mode is currently *visible* rather than a fixed order.
+
+### Structural redesigns
+
+**S1 — A persistent position HUD pinned to the chart.**
+The single change that fixes both halves of the user's complaint without opening the dock. A compact opaque pill anchored to the chart's top-left (below the armed hint), present whenever a position is open and independent of scroll position:
+
+> `SIM LONG 1 @ 103.25 · +2.0 pts` `[✕ Close]` `[⇄ Reverse]`
+
+Behavior: opaque to the pointer like the drawings inspector; `Close` issues `ClosePosition` directly; `Reverse` issues a market order at twice the position size with a one-line confirmation; hovering the pill highlights the entry line and, when the entry price is outside the visible range, replaces the price with a directional caret (`▲ 103.25 above`) so M7 is answered too. Clicking the pill body opens the Trading tab for the full card.
+
+**S2 — Chart-native bracket creation and management.**
+Extend the existing drag grammar so it can *create* levels, closing B1 in the vocabulary the docs already promised. Hovering the entry line reveals two small handles in the gutter; dragging one downward from a long entry creates a stop loss, upward creates a take profit (mirrored for shorts), with a live preview chip showing the resulting points risk. Hovering an existing SL/TP line reveals an inline `✕` that clears it — the same action as the card's `clear` button, at the place the user is already looking. Every drop still routes through `SetBracket` and still gets refused with advice on a wrong-side placement, so the didactic contract is unchanged.
+
+**S3 — A trades ledger in the Trading tab.**
+Below the session summary, a scrollable table: time, side, qty, entry, exit, reason, points — one row per `ClosedTrade`, current session above the on-disk history, colored by sign. Clicking a row scrolls the chart to span `opened_ms..closed_ms` and highlights that round trip. This is the surface that turns a P&L counter into a practice tool, and every field it needs is already parsed and then thrown away (m1).
+
+**S4 — Fill markers on the candles.**
+Small triangles at each entry and exit (price × time from `ClosedTrade`), joined by a faint line for the round trip, colored by outcome. Answers "where did I get in, and why did it close there?" — the question the whole feature exists for. Gate it behind a LAYERS toggle so it obeys the house rule that every visual layer has one.
+
+**S5 — Resolve the two-pane ownership split (M6).**
+Either let both panes drag (the simulator is per-tab and a price level is as true on the 5-minute context as on the flow chart — which is the reasoning `pane.rs:1703-1708` already gives for *drawing* on both), or render the context pane's lines visibly read-only: dimmed stroke, no chip. The current state, identical pixels with different behavior, is the one option that teaches the user nothing.
+
+## 5. Confidence and caveats
+
+Everything above is grounded in the code as it stands on `main`; the app was not run, so pixel-level claims are inferences from constants:
+
+- **B3** rests on `axis_x` being the same value in both calls (it is), both offsets 6.0, both fonts 11 px. The overlap is certain; its *visual severity* was estimated, not measured.
+- **B2's "dock starts collapsed"** rests on `Dock::new()` (`dock.rs:124-132`) and the absence of any restore path on `Dock`.
+- **M2's reversal arithmetic** is confirmed by the crate's own test (`simulator.rs:1058-1077`).
+
+**Top three, if only three things ship:** (1) `Close` on the toolbar whenever a position is open; (2) the chip-collision fix so `SIM LONG 1 @ …` is legible at the moment of entry; (3) the status cell stating side and size, not just a points figure. Those three, together, are the reported bug.
+

--- a/docs/ux/ux-audit-2026-08/tabs-timeframe.md
+++ b/docs/ux/ux-audit-2026-08/tabs-timeframe.md
@@ -1,0 +1,303 @@
+# Tabs, workspace & timeframe — full audit report
+
+(1/3) — UX AUDIT: Tabs, Workspace Layout & the Timeframe Chart Flow
+
+**Scope:** `crates/app/src/{tab.rs, tabstrip.rs, dock.rs, resample.rs, time_header.rs, state.rs, pane.rs, toolbar.rs, main.rs}`, the tab/layout/bar-type sections of `app.rs`, and `crates/app/config/feeds.toml`. Read-only; no files edited.
+
+---
+
+## 0. Headline
+
+The user's complaint — *"the way the timeframe chart opens feels strange"* — has a concrete, reproducible root cause, and it is **not** primarily about discoverability.
+
+There are two different ways to get time bars in quantick, and **they are not the same feature**:
+
+| | Route A — toolbar `bars → time` | Route B — `File → Layout → Time + Flow` |
+|---|---|---|
+| Which chart | the **flow pane** (the main chart) | a **second pane**, left half of the canvas |
+| Opening interval | **1000 ms (1 second)** — `pane.rs:449` | **60 000 ms (1m)** — `time_header.rs:37` |
+| Presets (1m/5m/15m/1h) | **none** — raw ms drag only | yes — `time_header.rs:28-33` |
+| Venue candle history (90 days) | **never** — `tab.rs:375-382` | yes |
+| Bars on screen at open | ~20 (from a 1000-trade backfill) | ~130 000 |
+| Can it fill the window | yes | **no** — capped at 75% (`pane.rs:115`) |
+
+A user who picks the obvious control (`bars → time` in the toolbar, sitting next to tick/volume/dollar/imbalance) gets a **1-second chart with roughly 20 bars and no history**. If they then drag the interval to 60 000 ms hoping for a 1-minute chart, they get a chart with **one bar** — 1000 backfilled trades on a liquid market is seconds to a couple of minutes of tape, and the flow pane has no venue prefix to stand in front of it. That is the "strange".
+
+The good timeframe experience exists, but it is reachable only through a *layout* command in the **File** menu, it always arrives as a **split**, and it can never occupy the whole window.
+
+---
+
+## 1. Inventory — every user-facing control
+
+### 1.1 Tab strip
+Drawn inside the menu-bar row (`app.rs:1919-1922`), module `tabstrip.rs`.
+
+| # | Control | Location | Trigger | Effect |
+|---|---|---|---|---|
+| 1 | Tab chip `SYMBOL · venue` | `tabstrip.rs:62` | left click | `TabAction::Activate(i)` → `app.rs:3251` sets `active_tab` |
+| 2 | Chip label amber tint | `tabstrip.rs:59-61` | state: `chip.replaying` | marks a tab playing a recording |
+| 3 | Attention dot (3 px amber, chip top-right) | `tabstrip.rs:67-74` | state: `Tab::needs_attention()` (`tab.rs:560`) | background tab reconnecting or asking for user action |
+| 4 | Close `×` | `tabstrip.rs:80-90` | click; visible on hover, on the active chip, or always when disabled | `TabAction::Close(i)` → `close_tab` (`app.rs:806`). Tooltip "Close tab (Ctrl+W)"; disabled tooltip "The last tab stays open — a window with no market has nothing to show" |
+| 5 | `+` | `tabstrip.rs:94-100` | click | `TabAction::New` → opens SourcePicker (`app.rs:3257`). Tooltip "Open another market (Ctrl+T)" |
+
+**Absent:** rename, drag-to-reorder, middle-click close, right-click context menu, duplicate-tab, `Ctrl+1..9` direct selection. `tabstrip.rs` registers no `context_menu` and no drag sense.
+
+### 1.2 Source picker (`+` dialog)
+`egui::Window "Open market"`, `tabstrip.rs:234-359`. Not collapsible, not resizable.
+
+| # | Control | Location | Notes |
+|---|---|---|---|
+| 6 | Feed combo | `tabstrip.rs:249-266` | lists `config.feeds`; unimplemented providers get a `(soon)` suffix |
+| 7 | Symbol combo | `tabstrip.rs:272-278` | corrected to a valid symbol when the feed changes (`ensure_symbol_valid`, `:195`) |
+| 8 | "added here" list + per-symbol `×` | `tabstrip.rs:294-315` | removes a user-added symbol; disabled while a tab holds that market |
+| 9 | "Add symbol…" field (120 px, hint `WINQ26`) | `tabstrip.rs:321-325` | Enter submits |
+| 10 | "Add" button | `tabstrip.rs:328` | trims, takes verbatim, refuses empty (`:208-224`) |
+| 11 | Refusal message | `tabstrip.rs:341-343` | amber, under the field |
+| 12 | "Open" | `tabstrip.rs:347-349` | `PickerOutcome::Chosen` → `open_tab` (`app.rs:746`) |
+| 13 | "Cancel" / window `×` | `tabstrip.rs:350-357` | both cancel |
+
+### 1.3 Menu bar — File (`app.rs:1773-1836`)
+
+| # | Item | Location | Effect |
+|---|---|---|---|
+| 14 | New Tab… (Ctrl+T) | `app.rs:1774-1783` | opens the source picker |
+| 15 | Close Tab (Ctrl+W) | `app.rs:1784-1798` | disabled at one tab, with hover text |
+| 16 | **Layout ▸** submenu | `app.rs:1800-1813` | container only |
+| 17 | Layout ▸ **Single** | `app.rs:1802` | `set_layout(Single)` (`tab.rs:636`) |
+| 18 | Layout ▸ **Time + Flow** | `app.rs:1803` | `set_layout(TimeAndFlow)`; builds the time pane next frame (`tab.rs:670`) |
+| 19 | Market Replay… (Ctrl+R) | `app.rs:1815-1824` | |
+| 20 | Close Replay | `app.rs:1825-1831` | only present while replaying |
+| 21 | Exit | `app.rs:1833-1835` | |
+
+### 1.4 Menu bar — View / Tools / Help
+Items 22-33: Hide/Show panels (Ctrl+B) `:1843`; Drawing toolbar ▸ Left/Right/Top/Bottom `:1853-1868`; Hide/Show drawing toolbar `:1874`; L2 settings, Bubble settings, Session, Paper trading `:1878-1888`; Perf readings checkbox `:1890`; Timezone ▸ `:1893-1905`; Tools → Appearance… `:1908`; Help → Replay file format… `:1914`.
+
+Note: `docs/ux/ui-design-model.md` §10 specifies an **Insert** menu (indicators, drawing tools). It does not exist in `draw_menu_bar` (`app.rs:1772-1918`) — indicators live in the toolbar's LAYERS group instead. Doc/code drift.
+
+### 1.5 Toolbar BARS group (`toolbar.rs:362-437`; model wired at `app.rs:946-951`)
+
+| # | Control | Location | Options / range |
+|---|---|---|---|
+| 34 | `bars` kind combo | `toolbar.rs:370-387` | five entries from `BarKind::ALL` (`state.rs:37`): **tick, volume, dollar, time, imbalance** — labels at `state.rs:47-55` |
+| 35 | volume / dollar entries gated | `toolbar.rs:377-384` | disabled without `capabilities.traded_volume`; disabled hover "this source quotes prices but prints no traded volume" |
+| 36 | `N trades` DragValue | `toolbar.rs:398-399` | 1..=5000 |
+| 37 | `units` DragValue | `toolbar.rs:402-407` | 0.1..=1000, speed 0.1 |
+| 38 | `notional` DragValue | `toolbar.rs:410-415` | 1000..=1e9, speed 1000 |
+| 39 | **`interval ms` DragValue** | `toolbar.rs:418-426` | 100..=86 400 000 ms, speed 100 — **the only time control on the flow pane** |
+| 40 | `target trades` DragValue | `toolbar.rs:429-434` | 2..=5000 |
+| 41 | Folded form: parameter merges into combo text | `toolbar.rs:364-368`, `:440-448` | e.g. `time · 60000 ms`; the widget moves to the `⋯` overflow |
+
+**This group always writes to `tab.flow_pane`** (`app.rs:946-951`) regardless of which pane has focus.
+
+### 1.6 Time pane header (`time_header.rs:66-114`)
+Drawn **only while the canvas is split** (`tab.rs:1472-1491`). 24 px strip carved off the top of the time pane (`pane.rs:170-176`).
+
+| # | Control | Location |
+|---|---|---|
+| 42 | `time` label (faint) | `time_header.rs:84` |
+| 43 | `1m` chip (60 000 ms) | `time_header.rs:29` |
+| 44 | `5m` chip (300 000 ms) | `time_header.rs:30` |
+| 45 | `15m` chip (900 000 ms) | `time_header.rs:31` |
+| 46 | `1h` chip (3 600 000 ms) | `time_header.rs:32` |
+| 47 | custom interval DragValue, suffix `" ms"` | `time_header.rs:97-108`; tooltip "custom interval for this pane" |
+
+### 1.8 Canvas
+| # | Control | Location |
+|---|---|---|
+| 48 | Draggable divider (4 px rule, 5 px grab margin) | `tab.rs:1582-1604`; clamped to 25%..75% (`pane.rs:115,162`) |
+| 49 | Click-to-focus a pane | `tab.rs:1553-1575` (raw pointer press, layer-checked) |
+| 50 | 1 px accent focus rule under the focused pane's top edge | `tab.rs:1541-1547` |
+
+### 1.8 Keyboard shortcuts
+Declared `app.rs:1729-1748`, consumed `app.rs:3094-3115`.
+
+`Ctrl+T` new tab · `Ctrl+W` close tab · `Ctrl+Tab` next tab · `Ctrl+Shift+Tab` previous tab · `Ctrl+R` replay browser · `Ctrl+B` dock.
+
+**No shortcut exists for:** switching layout, switching bar kind, switching timeframe, jumping to tab N, or focusing the other pane. `handle_tab_keys` is not gated on widget focus (unlike `handle_drawing_keys`, `app.rs:1965`), so Ctrl+W/Ctrl+T fire while a text field has focus.
+
+
+## 2. Flows
+
+### (a) What the app opens with
+1. `config::load()` — `QUANTICK_CONFIG` env path, then `./quantick.toml`, then the embedded `crates/app/config/feeds.toml` (`main.rs:95`).
+2. Feed/symbol: `default_feed = "binance"`, `default_symbol = "BTCUSDT"` (`feeds.toml:13-14`), overridable by `QUANTICK_DEFAULT_FEED` / `QUANTICK_DEFAULT_SYMBOL` (`config.rs:31,37`).
+3. **Bar spec: `BarSpec::Tick(50)` — hardcoded** at `main.rs:56` (`INITIAL_TICK_SIZE`) and `main.rs:166`. **There is no config key and no env var for the opening bar type.**
+4. Layout: `CanvasLayout::Single` (`tab.rs:276`), i.e. flow pane only, no time pane built.
+5. Bubbles: `active = "dense tape btc"` in the committed `config/bubbles.toml:9` (working tree currently dirty to `"live lane pie"`). Binance declares no per-feed `bubble_preset`, so the file's `active` stands.
+6. Backfill: 1000 trades (`feed/mod.rs:36`, `DEFAULT_BACKFILL_TARGET`), overridable via `QUANTICK_BACKFILL`. At tick(50) that is **~20 bars on screen** at first paint.
+7. Dock: visible, collapsed to its 36 px strip, no tab open (`dock.rs:124-131`).
+
+### (b) Getting a time-bar chart today — both routes, click by click
+
+**Route A — toolbar (the discoverable one, and the broken one)**
+1. Click the `bars` combo (toolbar, left of centre).
+2. Click `time`.
+   → `pane.current_spec()` (`pane.rs:502`) returns `BarSpec::Time(self.time_interval_ms)`, and `time_interval_ms` was initialised to **1000** at `pane.rs:449` because the opening spec was `Tick(50)`.
+   → **You now have a 1-second chart.**
+3. To reach 1 minute: drag or click-to-type the `interval ms` DragValue and enter `60000`. At speed 100 (`state.rs:174`) that is a ~600-pixel drag.
+   → The chart now holds roughly **one bar**. The flow pane never receives the venue candle prefix: `request_ohlcv_history` returns early when `time_pane.is_none()` (`tab.rs:375-382`), and `refold_history_prefix` installs only onto `self.time_pane` (`tab.rs:534,550`). `pane.rs:412-414` states the invariant outright: *"Only ever non-empty on a time pane."*
+   → Bubbles, the heatmap and the live lane keep rendering, because `orderflow` is `Some` for any flow pane by construction (`pane.rs:431`).
+
+**Total: 2 clicks to a wrong chart, plus a numeric entry to reach a chart that is empty.**
+
+**Route B — the split (the good one, and the hidden one)**
+1. Click `File`.
+2. Hover/click `Layout`.
+3. Click `Time + Flow`.
+   → `set_layout` (`tab.rs:636`) arms `pending_time_pane` and raises the `rebuilding bars` overlay; the pane is built on the **next** frame (`apply_pending_layout`, `tab.rs:670`), seeded from retained trades, then `request_ohlcv_history` asks for **90 days** of 1-minute candles (`feed/mod.rs:46`, `TIME_HISTORY_SPAN_MS`) — roughly 130 000 bars, ~45 MB per tab per §11.
+   → Canvas splits **time left / flow right**, 50/50 (`pane.rs:117`).
+   → The time pane opens at **1m** (`time_header.rs:37`) with the 1m/5m/15m/1h chips in its own 24 px header.
+   → **Focus is not moved to the new pane.** `set_layout` only forces focus on the way *back* to Single (`tab.rs:648-650`). So the status bar and the toolbar still describe the flow pane until the user clicks the time pane.
+
+**Total: 3 clicks to a correct timeframe chart that occupies at most 75% of the canvas and can never be alone.**
+
+### (c) Changing an existing chart's bar type or timeframe
+- **Flow pane:** toolbar `bars` combo + its one parameter. Applied one frame after the selectors settle (`tab.rs:1040-1089`), which debounces a drag to one rebuild per gesture. The viewport is re-anchored by *market time*, not bar index (`tab.rs:1067,1083-1085`), and the pane's drawings are cleared with a toast because bar-index anchors do not survive a re-cut (`tab.rs:324-333`).
+- **Time pane:** its own header chips or ms drag (`tab.rs:1479-1489`). A chip click is a local re-fold of candles already held (`resample.rs:41`), never a network round trip. Dropping below 60 000 ms makes the venue prefix vanish silently — `is_foldable` (`resample.rs:24`) refuses anything that is not a whole number of minutes, and `refold_history_prefix` then installs an empty prefix (`tab.rs:540-542`). The only feedback is the `v` segment of the status bar's bar count going to zero (`statusbar.rs:198`).
+- **Cross-pane trap:** the toolbar's BARS group writes to `flow_pane` unconditionally (`app.rs:946-951`), while the status bar's spec/bar-count section reads the **focused** pane (`app.rs:1677`).
+
+### (d) Tab lifecycle
+- **Create:** `+`, `Ctrl+T`, or File → New Tab… → source picker → Open → `open_tab` (`app.rs:746`) → `adopt_tab` (`app.rs:775`). The new tab **inherits the previous tab's flow-pane bar spec** (`app.rs:789`) but **not** its layout — it always opens `Single` (`tab.rs:276`, asserted at `app.rs:8959-8963`).
+- **Close:** `×`, `Ctrl+W`, File → Close Tab. The last tab cannot be closed. Closing flattens the tab's simulated position through `Tab::close` (`tab.rs:1252`), drops the feed handle and workers, and prunes slot bookkeeping (`app.rs:806-850`). **No confirmation, no undo** — drawings, indicators and viewport go with it.
+- **Switch:** click a chip, or `Ctrl+Tab` / `Ctrl+Shift+Tab` (wrapping, `app.rs:853`). Background tabs keep draining every frame (`app.rs:3065-3077`); only the active one renders.
+- **Duplicates allowed:** the same market may be open twice by design (`app.rs:740-745`).
+
+### (e) Persistence across restarts
+**Almost nothing persists.**
+
+- **Persisted:** indicator slots — kind, hidden flag and input values — for the **flow pane of the first tab only** (`app.rs:1400-1489`), debounced, in the file at `state_file::default_path()`. User-added symbols persist to `quantick-symbols.toml` (`symbols_file.rs`). Bubble presets persist to `config/bubbles.toml` via the panel's save.
+- **Not persisted:** open tabs, active tab, per-tab feed/symbol, **canvas layout**, split fraction, focused pane, bar spec, timeframe, dock width and active dock tab, viewport position, drawings.
+
+`tab.rs:207-210` and `app.rs:383-385` both name this explicitly as the deferred §14 `ui-state.toml` question. Every restart returns to Binance/BTCUSDT/tick(50)/Single.
+
+
+## 3. UX findings
+
+### BLOCKER-1 — `bars → time` produces a 1-second chart, then an empty one
+**Evidence:** `pane.rs:449` (`time_interval_ms = 1_000` default) + `pane.rs:502` + `tab.rs:375-382` (no venue prefix off the time pane) + `feed/mod.rs:36` (1000-trade backfill).
+**Heuristic:** *Match between system and the real world*; *Help users recognize, diagnose and recover from errors*.
+The word "time" in a bar-type list, on a charting app, promises a timeframe chart. It delivers 1-second bars, and correcting the interval to a real timeframe empties the chart because the flow pane has no history source that reaches back further than 1000 trades. **This is the user's reported complaint.** Nothing on screen explains why a 1-minute chart shows one bar.
+
+### BLOCKER-2 — a plain, full-window time chart is not reachable at all
+**Evidence:** `CanvasLayout` has exactly two variants (`tab.rs:47-54`); `MIN_PANE_FRACTION = 0.25` (`pane.rs:115`) caps the time pane at 75%; `time_header::draw` is only called when `split` is true (`tab.rs:1462,1472-1491`).
+**Heuristic:** *User control and freedom*; *Flexibility and efficiency of use*.
+The chart with presets and 90 days of history can never be the only chart. A user who wants "just a 5-minute chart" must accept a permanently split canvas with a flow chart they did not ask for taking at least a quarter of the window.
+
+### MAJOR-3 — the good timeframe entry point is filed under **File → Layout**
+**Evidence:** `app.rs:1800-1813`.
+**Heuristic:** *Recognition rather than recall*; *Match between system and the real world*.
+"File" is where documents live; layout is a view concern, and the View menu right beside it already owns toolbar docking, panels and timezone. Worse, neither label — "Single", "Time + Flow" — contains the words *timeframe*, *time bars*, *minutes* or *candles*. A user hunting for a timeframe chart will scan the toolbar's `bars` combo (Route A, broken) and never open File.
+
+### MAJOR-4 — focus lies: the toolbar's BARS group ignores it
+**Evidence:** `app.rs:946-951` writes to `tab.flow_pane` unconditionally; `app.rs:1677` reads the focused pane for the status bar; `tab.rs:1541-1547` paints a focus accent.
+**Heuristic:** *Consistency and standards*; *Visibility of system status*.
+Every other focus-following surface follows focus — status bar content, indicator targeting, drawing chrome. BARS does not. Concretely: click the time pane (accent moves, status bar reads `time(60000ms)`), then change the toolbar's `bars` combo to `volume` — **the chart on the right changes** and the status bar keeps reading `time(60000ms)`. §11 does state "two selectors, two panes, no modes" as the intent, but the intent needs a visual anchor the current chrome does not provide: the BARS group is nowhere near the flow pane and carries no indication of what it governs.
+
+### MAJOR-5 — opening the split does not focus the pane it just created
+**Evidence:** `set_layout` (`tab.rs:636-664`) sets focus only in the `Single` branch.
+**Heuristic:** *Visibility of system status*.
+The user explicitly asked for the time chart; the chrome keeps speaking for the other one. Status bar, indicator insertion and the drawing rail all still act on the flow pane until an extra click lands on the new pane.
+
+### MAJOR-6 — the two time controls speak different languages
+**Evidence:** `time_header.rs:29-33` ("1m", "5m", "15m", "1h") vs `toolbar.rs:418-426` and `state.rs:147` (`time({ms}ms)`).
+**Heuristic:** *Consistency and standards*.
+The time pane offers human timeframes; the toolbar and the status bar both speak raw milliseconds. A user who learned "1m" in one place has to know it is 60000 in the other. The status bar renders `time(60000ms)` even when the chart came from clicking the chip labelled `1m`.
+
+### MAJOR-7 — sub-minute intervals silently delete 130 000 bars of history
+**Evidence:** `resample.rs:24` (`is_foldable`), `tab.rs:540-542` (installs an empty prefix), `statusbar.rs:198` (the `v` count drops to 0).
+**Heuristic:** *Visibility of system status*; the project's own **Data honesty** rule.
+The ms drag accepts values down to 100 (`state.rs:159`). Dragging from 60000 to 59900 throws the entire venue prefix away. The refusal is honest in intent — the code refuses to invent a fold — but nothing on screen says *why* the chart just lost three months. `OHLCV_INCOMPLETE` is logged (`tab.rs:481`); this case logs nothing at all.
+
+### MAJOR-8 — no config or env control over the opening bar type
+**Evidence:** `main.rs:56,166`; `config.rs` exposes only `QUANTICK_CONFIG`, `QUANTICK_DEFAULT_FEED`, `QUANTICK_DEFAULT_SYMBOL`.
+**Heuristic:** *Flexibility and efficiency of use*.
+Feed and symbol are configuration on principle (`feeds.toml` header says so). The bar type — arguably the more personal choice — is a constant in `main.rs`. Combined with zero workspace persistence, every launch is tick(50) forever.
+
+### MINOR-9 — closing a tab is instant and irreversible
+**Evidence:** `app.rs:806-850`; `tabstrip.rs:88-90`.
+**Heuristic:** *Error prevention*; *User control and freedom*.
+The `×` sits a few pixels from the chip label and appears on hover. One click discards that tab's drawings, indicator slots, viewport and simulated position (flattened and journaled, but gone). No confirmation, no undo, no reopen-closed-tab.
+
+### MINOR-10 — hover-revealed `×` shifts the whole strip
+**Evidence:** `tabstrip.rs:77-91` — the button is only added to the layout when `show_close`.
+**Heuristic:** *Aesthetic and minimalist design* / stability of the pointing target.
+Hovering chip 1 inserts a button into the horizontal layout, pushing chips 2..n and the `+` to the right. The `+` moves out from under a pointer travelling toward it. Reserving the space (or always drawing the `×` faintly) removes the jitter.
+
+### MINOR-11 — no way to reorder, rename or duplicate a tab
+**Evidence:** `tabstrip.rs:53-102` registers no drag sense and no context menu.
+Duplicates are explicitly allowed (`app.rs:740-745`), which makes "two views of one book" a supported workflow with two identical chips and no way to tell them apart or to reorder them. "Duplicate this tab" — the natural gesture for that workflow — does not exist; the user must re-pick the market in the source picker.
+
+### MINOR-12 — the time pane header likely clips at the minimum pane width
+**Evidence:** `time_header.rs:21` (24 px strip), `:25` (8 px horizontal padding), `:84-108` — label + four chips + a DragValue showing up to `86400000 ms`; `pane.rs:115` allows the pane down to 25% of the canvas; `main.rs:145` allows a 900 px window.
+At 900 px with the dock strip (36 px) and the tool rail open, a 25% time pane is roughly 200 px, against ~250 px of header content. **Not visually verified** — flagged from geometry, needs a screenshot at minimum window width.
+
+### MINOR-13 — `Ctrl+Tab` and `Ctrl+W` are not focus-gated
+**Evidence:** `app.rs:3094-3115` has no `ctx.memory(|m| m.focused().is_some())` guard, unlike `handle_drawing_keys` (`app.rs:1965`).
+Typing in the source picker's "Add symbol…" field with `Ctrl+W` held (or any app that maps Tab navigation) can close a tab. Also: whether `Ctrl+Tab` survives egui's own Tab focus-navigation handling is **not determinable from the code** and needs a live test.
+
+### NIT-14 — bar-kind labels are lowercase and unqualified
+`state.rs:47-55`: `tick`, `volume`, `dollar`, `time`, `imbalance`. `time` is the only one whose meaning changes with a unit the combo does not show. `time` reading `time (1s)` or `time (1m)` inline would cost nothing.
+
+### NIT-15 — doc drift: the Insert menu specified in §10 does not exist
+`docs/ux/ui-design-model.md:334` lists **Insert** — indicators, drawing tools. `draw_menu_bar` (`app.rs:1772-1918`) has File, View, Tools, Help only.
+
+## 4. Should time bars be the default? — the honest tradeoff
+
+**The user's suggestion is directionally right about the symptom and wrong about the cure.**
+
+### What genuinely argues for it
+- **First-run comprehension.** tick(50) on BTCUSDT with a 1000-trade backfill is ~20 bars covering seconds of tape. That is a thin, unfamiliar first chart even for a flow trader — it looks like the app failed to load.
+- **The time pane is the only chart with real history.** 90 days of venue candles vs. 1000 trades. On depth of data alone, the timeframe chart is the better default.
+- **It is the shared vocabulary.** Every user arrives from a platform where "chart" means "timeframe chart", and orientation ("where is price, what happened today") is a timeframe question.
+
+### What argues against it, and I find this decisive
+- **It contradicts the product's stated identity.** `CLAUDE.md`: *"Real-time alternative bar charts… Build bars, show bars, expose bars to code."* `tab.rs:50-52` calls `Single` *"The flow pane alone — quantick's default and its identity."* Opening on a 1-minute candle chart makes quantick indistinguishable from TradingView at first glance and buries the one thing it does that others do not.
+- **The flow layers are the point, and they need the flow pane.** Bubbles, heatmap and the live lane render only on the flow pane (`pane.rs:351-354`, §11). Defaulting to time bars either abandons them at startup or forces them onto a time chart the design explicitly keeps them off.
+- **It would not fix the reported bug.** The user's pain is that Route A yields a 1-second, historyless chart. Making the *startup* spec `Time(60000)` leaves that trap exactly where it is — and adds a new one: the flow pane still gets no venue prefix (`tab.rs:375-382`), so quantick would now **open** on a 1-minute chart with one bar. That is strictly worse than today.
+
+### Recommendation
+**Do not change the default chart type. Fix the two structural defects instead**, then let the user's own choice persist:
+
+1. **Give the flow pane the venue prefix whenever its spec is `BarSpec::Time`.** This is the real bug. `request_ohlcv_history`'s `time_pane.is_none()` guard should become "no pane in this tab is cutting by time", and `refold_history_prefix` should fold onto every time-cutting pane. Once done, `bars → time` yields a real chart, and everything downstream stops feeling strange.
+2. **Persist the workspace** (§14 `ui-state.toml`): tabs, layout, split fraction, focus, bar spec. Then a user who prefers timeframe charts gets one on every launch without the project changing its identity — the correct resolution of "make it the default", because it makes it *their* default.
+3. If a shipped default is still wanted after that, expose it as **configuration** (`default_bars = "time:1m"` in `feeds.toml`, alongside `default_feed`) rather than moving the hardcoded constant. That respects the file's own stated principle and lets the B3/MT5 presets differ from the BTC one.
+
+## 5. Quick wins vs. structural
+
+### Quick wins (localized, low blast radius)
+
+| Fix | Where | What |
+|---|---|---|
+| **QW1 — Timeframe presets in the toolbar** | `toolbar.rs:417-427` | Replace the bare `interval ms` DragValue with the same 1m/5m/15m/1h chips the time pane has, plus the drag as the custom escape hatch. Reuses `time_header::PRESETS` — one list, two surfaces, as the module already documents. Kills the "1 second" surprise. |
+| **QW2 — Sane opening interval for `bars → time`** | `pane.rs:449` | Change the flow pane's default `time_interval_ms` from `1_000` to `time_header::DEFAULT_INTERVAL_MS` (60 000). One constant. Note this alone is *not* enough — without the prefix fix (S1) it produces a one-bar chart, so ship QW2 and S1 together. |
+| **QW3 — Human timeframe labels everywhere** | `state.rs:147`, `toolbar.rs:445` | Format `BarSpec::Time` as `1m` / `5m` / `1h` when the interval is a round unit, falling back to ms otherwise. Status bar and toolbar then agree with the chips. |
+| **QW4 — Move Layout to the View menu** | `app.rs:1800-1813` | Cut the submenu from File, paste into View next to "Drawing toolbar". Relabel "Time + Flow" as "Time + Flow (timeframe chart)" or add a hover text naming what it opens. |
+| **QW5 — Focus the pane you just opened** | `tab.rs:636-650` | `set_layout(TimeAndFlow)` sets `self.focus = PaneSide::Time`. The user asked for that chart; the chrome should speak for it. |
+| **QW6 — Say why the venue history vanished** | `tab.rs:540-542` | When a time pane's interval drops below a minute, emit a notice/badge instead of an empty prefix in silence. The honest refusal deserves an honest explanation. |
+| **QW7 — Reserve the close-button width** | `tabstrip.rs:77-91` | Always allocate the `×` slot; render it transparent when not hovered. Removes strip jitter. |
+| **QW8 — Focus-gate the tab shortcuts** | `app.rs:3094` | Add the `ctx.memory(focused().is_some())` guard `handle_drawing_keys` already uses. |
+| **QW9 — Label the BARS group's target while split** | `toolbar.rs:363` | While the canvas is split, render the group's caption as `bars (flow)` instead of `bars`. One string, and MAJOR-4's trap becomes visible. |
+
+### Structural (design decisions, real work)
+
+**S1 — Venue candle history belongs to any time-cutting pane, not to "the time pane".**
+Today the 90-day prefix is keyed to *which pane object* it is (`tab.rs:375-382`, `tab.rs:534`, `pane.rs:412-414`), not to *what the pane is showing*. The correct rule is capability-shaped, matching how the rest of the app gates on `FeedCapabilities` rather than on identity: **a pane whose spec is `BarSpec::Time` with a foldable interval gets the prefix.** This is the single highest-value change in this audit — it is what makes the toolbar route produce a real chart, and it is a prerequisite for any "time bars by default" discussion.
+
+**S2 — A third layout: `Time` alone.**
+`CanvasLayout` needs a variant where the time pane owns the whole canvas (`tab.rs:47-54`), with the header strip drawn in Single-time mode too (`tab.rs:1462`). This is what "I just want a 5-minute chart" actually means, and it is currently unrepresentable. Cost: `draw_canvas` must handle a single *non-flow* pane, and the flow-layer toolbar toggles must disable themselves when no flow pane is on screen — which the capability-gating pattern already supports.
+
+**S3 — Workspace persistence (`ui-state.toml`, §14).**
+Open tabs, active tab, per-tab layout, split fraction, focus, and per-pane bar spec. `tab.rs:207-210` and `app.rs:1400-1409` both already name this as the blocker for persisting anything beyond the first tab's flow-pane indicators. It converts "should time bars be the default?" from a product argument into a user preference, and it removes the daily re-setup tax that likely contributed to the original complaint.
+
+**S4 — Decide whether BARS follows focus, and make the answer visible.**
+Two defensible resolutions: (i) BARS follows focus like everything else, and the time pane's header becomes a redundant convenience; or (ii) BARS stays bound to the flow pane, and the toolbar says so (QW9) while the time pane's header gains equal visual weight. The current state — focus-following status bar over a focus-ignoring control — is the one option that is indefensible.
+
+**S5 — Tab strip affordances: reorder, duplicate, reopen-closed.**
+Duplicate-tab in particular is the missing gesture for the explicitly-supported "two views of one book" workflow (`app.rs:740-745`); today it requires re-picking the market in a dialog, and it does not inherit the source tab's layout or drawings.
+
+## 6. What could not be determined from code
+
+- Whether `Ctrl+Tab` actually reaches `handle_tab_keys` or is swallowed by egui's focus navigation (`app.rs:3099`). Needs a live run.
+- Whether the time pane header clips at the minimum pane width (MINOR-12). Geometry suggests yes at a 900 px window; needs a screenshot.
+- Real-world timing of the 90-day / ~130 000-candle fetch on opening the split — the `loading venue history` overlay covers it (`loading.rs:72`), but how long the user stares at it per venue is unmeasured here.
+


### PR DESCRIPTION
## What

Adds the complete August 2026 UX audit to `docs/ux/`:

- `docs/ux/ux-audit-2026-08.md` — synthesis: executive summary, root-cause analysis of the three user-reported pain points (closing/seeing an open simulated trade; the timeframe-chart opening flow; indicator property editing), the default-bar-type decision, per-area headline findings, a prioritized P0/P1/P2 roadmap, and the visual design principles.
- `docs/ux/ux-audit-2026-08/` — the six full per-area reports (paper trading, tabs/timeframe, indicators, drawing tools, chart canvas, app chrome): atomic inventories with `file:line` for every control, exact user flows as implemented, all 136 findings with severities and Nielsen heuristics, and quick-win vs structural recommendations.

## Why

Reference material for the upcoming UX work: each P0/P1 roadmap line is intended to become its own branch/PR, and the reports carry the evidence and the concrete fix for each finding.

## Notes

- Docs-only change; no code touched.
- Audit base is `main @ 2856238`; PR #120 (chart layer visibility) merged after the snapshot, so layer-toggle findings should be re-verified before acting — noted in the doc itself.
- Arch-review: clean (purely additive, zero existing files edited).

🤖 Generated with [Claude Code](https://claude.com/claude-code)