### PR TITLE
feat(app): close and see the open simulated position from every surface

### DIFF
--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -996,7 +996,14 @@ impl QuantickApp {
             live_strip_on: tab.flow_pane.live_strip_visible,
             dock_visible,
             appearance_open: show_style,
-            paper_ready: tab.paper.ready(),
+            paper: toolbar::PaperTradeModel {
+                ready: tab.paper.ready(),
+                buy_label: tab.paper.entry_label(quantick_engine::Side::Buy),
+                sell_label: tab.paper.entry_label(quantick_engine::Side::Sell),
+                buy_hover: tab.paper.entry_hover(quantick_engine::Side::Buy),
+                sell_hover: tab.paper.entry_hover(quantick_engine::Side::Sell),
+                close_label: tab.paper.close_button_label(),
+            },
             indicators,
             scripts,
         };
@@ -1091,6 +1098,7 @@ impl QuantickApp {
                 .active_tab_mut()
                 .paper
                 .market(quantick_engine::Side::Sell),
+            ToolbarAction::PaperClose => self.active_tab_mut().paper.close_position(),
         }
     }
 
@@ -3028,7 +3036,10 @@ impl QuantickApp {
         self.maintain_indicator_state();
         self.maintain_chart_layers();
         let status = self.status_model();
-        statusbar::draw(ctx, &status, &mut self.tz);
+        let status_response = statusbar::draw(ctx, &status, &mut self.tz);
+        if status_response.open_trading_tab {
+            self.dock.open_tab(DockTab::Trading);
+        }
         // The browser window and, while the *active* tab plays a session, its
         // transport bar. A background tab's recording keeps advancing on its
         // own feed thread; what it does not get is the strip, which speaks for
@@ -4433,6 +4444,41 @@ plot(close)
         assert!(
             app.status_model().sim_pnl.is_some(),
             "the status bar model carries the cell"
+        );
+    }
+
+    /// The toolbar's exit control end to end: with a position open the model
+    /// grows the ✕ button, the close action queues, the next print fills it,
+    /// and the status cell switches from naming the position to `flat`.
+    #[test]
+    fn the_toolbar_close_action_exits_the_open_position() {
+        let (mut app, evt_tx, _cmd_rx, _book_tx) = test_app();
+        evt_tx
+            .try_send(FeedEvent::Backfilled(vec![trade(2)]))
+            .unwrap();
+        app.active_tab_mut().drain_feed_with_clock(|| 0);
+        app.apply_toolbar_action(ToolbarAction::PaperBuy);
+        evt_tx.try_send(FeedEvent::Live(trade(4))).unwrap();
+        app.active_tab_mut().drain_feed_with_clock(|| 0);
+        let (text, _) = app.active_tab().paper.status_cell().expect("open");
+        assert!(text.contains("LONG"), "the cell names the side: {text}");
+        assert!(
+            app.active_tab().paper.close_button_label().is_some(),
+            "an open position grows the toolbar exit"
+        );
+
+        app.apply_toolbar_action(ToolbarAction::PaperClose);
+        evt_tx.try_send(FeedEvent::Live(trade(6))).unwrap();
+        app.active_tab_mut().drain_feed_with_clock(|| 0);
+        assert!(
+            app.active_tab().paper.position_summary().is_none(),
+            "the close filled at the next print"
+        );
+        let (text, _) = app.active_tab().paper.status_cell().expect("history");
+        assert!(text.contains("flat"), "the cell says flat: {text}");
+        assert!(
+            app.active_tab().paper.close_button_label().is_none(),
+            "flat removes the toolbar exit"
         );
     }
 

--- a/crates/app/src/dock.rs
+++ b/crates/app/src/dock.rs
@@ -10,10 +10,11 @@
 
 use eframe::egui;
 use egui_phosphor::regular as icons;
+use quantick_engine::Side;
 
 use crate::feed::ReplayLink;
 use crate::orderflow_view::OrderflowView;
-use crate::paper_trading::PaperTrading;
+use crate::paper_trading::{PaperTrading, fmt_decimal, position_word};
 use crate::replay_view::{ReplayAction, ReplayView};
 use crate::theme;
 use crate::widgets::{IconButton, RAIL_ICON};
@@ -24,6 +25,8 @@ pub const TAB_STRIP_WIDTH: f32 = 36.0;
 pub const DOCK_MIN_WIDTH: f32 = 280.0;
 /// Widest dock body the model allows.
 pub const DOCK_MAX_WIDTH: f32 = 360.0;
+/// Radius of the open-position badge on the Trading strip icon, in pixels.
+const BADGE_RADIUS_PX: f32 = 3.5;
 
 /// One dock tab.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -180,11 +183,44 @@ impl Dock {
             )
             .show(ctx, |ui| {
                 ui.spacing_mut().item_spacing.y = 6.0;
+                let position = env.paper.position_summary();
                 for tab in DockTab::ALL {
+                    // Only the Trading-with-position hover is dynamic; the
+                    // static texts stay borrowed rather than re-allocated
+                    // sixty times a second.
+                    let position_hover = match (tab, &position) {
+                        (DockTab::Trading, Some(summary)) => Some(format!(
+                            "{} — {} {} open",
+                            tab.hover_text(),
+                            position_word(summary.side),
+                            fmt_decimal(summary.quantity),
+                        )),
+                        _ => None,
+                    };
                     let button = IconButton::new(tab.icon(), RAIL_ICON)
                         .active(self.active == Some(tab))
-                        .hover_text(tab.hover_text())
+                        .hover_text(
+                            position_hover
+                                .as_deref()
+                                .unwrap_or_else(|| tab.hover_text()),
+                        )
                         .show(ui);
+                    // An open position must be findable from the chrome even
+                    // with the tab closed: the badge wears the side's own
+                    // color (amber stays reserved for provenance).
+                    if tab == DockTab::Trading
+                        && let Some(summary) = &position
+                    {
+                        let color = match summary.side {
+                            Side::Buy => theme::BUY,
+                            Side::Sell => theme::SELL,
+                        };
+                        let center = egui::pos2(
+                            button.rect.right() - BADGE_RADIUS_PX - 1.0,
+                            button.rect.top() + BADGE_RADIUS_PX + 1.0,
+                        );
+                        ui.painter().circle_filled(center, BADGE_RADIUS_PX, color);
+                    }
                     if button.clicked() {
                         self.select(tab);
                     }
@@ -390,5 +426,56 @@ mod tests {
             );
             assert!(!response.restart_book_capture);
         });
+    }
+
+    /// The strip wears a badge exactly while a position is open — the one
+    /// signal that survives the dock being collapsed.
+    #[test]
+    fn an_open_position_badges_the_trading_strip_icon() {
+        let ctx = egui::Context::default();
+        let mut dock = Dock::new();
+        let mut paper = PaperTrading::new();
+
+        let circles = |dock: &mut Dock, paper: &mut PaperTrading| {
+            let mut count = 0;
+            for _ in 0..2 {
+                count = 0;
+                let output = ctx.run(egui::RawInput::default(), |ctx| {
+                    let _ = dock.draw(
+                        ctx,
+                        &mut DockEnv {
+                            orderflow: &mut OrderflowView::new("TESTUSDT"),
+                            replay_view: &mut ReplayView::new(),
+                            replay: None,
+                            paper,
+                        },
+                    );
+                });
+                for shape in output.shapes {
+                    if matches!(shape.shape, egui::epaint::Shape::Circle(_)) {
+                        count += 1;
+                    }
+                }
+            }
+            count
+        };
+
+        let flat = circles(&mut dock, &mut paper);
+        let print = |agg_id: u64| quantick_engine::Trade {
+            agg_id,
+            timestamp_ms: i64::try_from(agg_id).expect("small test ids") * 1000,
+            price: rust_decimal::Decimal::from(100),
+            quantity: rust_decimal::Decimal::ONE,
+            side: Side::Buy,
+        };
+        paper.seed(&print(0));
+        paper.market(Side::Buy);
+        paper.on_trade(&print(1));
+        assert!(paper.position_summary().is_some(), "the buy filled");
+        let open = circles(&mut dock, &mut paper);
+        assert!(
+            open > flat,
+            "an open position must add the badge circle: {open} vs {flat}"
+        );
     }
 }

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -34,6 +34,7 @@ mod orderflow_render;
 mod orderflow_view;
 mod orderflow_worker;
 mod pane;
+mod paper_hud;
 mod paper_trading;
 mod price_view;
 mod replay_view;

--- a/crates/app/src/pane.rs
+++ b/crates/app/src/pane.rs
@@ -436,6 +436,13 @@ pub struct ChartPane {
     /// venue candle has no tape in it.
     pub history_prefix: Vec<quantick_engine::Bar>,
 
+    /// Where the position HUD anchors this frame: the chart rect and price
+    /// scale, cached by the draw while the paper layer is painted on the
+    /// pane that owns order entry. The HUD itself draws in `tab.rs`, where
+    /// the paper host is mutably reachable outside the chrome's shared
+    /// borrow.
+    paper_hud_anchor: Option<(egui::Rect, PriceScale)>,
+
     /// User drawings live entirely in the app overlay layer, never in market
     /// state, so chart/backtest/bot determinism stays untouched.
     pub drawings: Drawings,
@@ -511,6 +518,7 @@ impl ChartPane {
             last_plot_area: None,
             hover_pos: None,
             history_prefix: Vec::new(),
+            paper_hud_anchor: None,
             drawings: Drawings::default(),
             drawing_hover: None,
             drawing_press_position: None,
@@ -1661,12 +1669,20 @@ impl ChartPane {
         }
     }
 
+    /// The HUD anchor cached by the last draw, if the paper layer was
+    /// painted on the pane that owns order entry.
+    #[must_use]
+    pub fn paper_hud_anchor(&self) -> Option<(egui::Rect, PriceScale)> {
+        self.paper_hud_anchor
+    }
+
     pub fn draw_chart(
         &mut self,
         painter: &egui::Painter,
         area: egui::Rect,
         chrome: &PaneChrome<'_>,
     ) {
+        self.paper_hud_anchor = None;
         let canvas_background = background_color(chrome.style);
         painter.rect_filled(area, egui::Rounding::ZERO, canvas_background);
 
@@ -1983,7 +1999,25 @@ impl ChartPane {
         // Switched off, they are only unpainted: the orders keep working and
         // the dock keeps listing them (see the layer's hint).
         if self.layer_visible(ChartLayer::PaperTrading, chrome.style) {
-            chrome.paper.draw_layer(painter, chart_rect, axis_x, &scale);
+            // The last-price chip's row, computed up front so the paper
+            // chips can dodge it: at the instant a market order fills the
+            // entry *is* the last price, and two chips on one pixel mangle
+            // the only persistent position statement.
+            let reserved_chip_y = if self.layer_visible(ChartLayer::LastPrice, chrome.style) {
+                partial
+                    .or_else(|| closed.last())
+                    .and_then(|bar| bar.close.to_f64())
+                    .map(|price| scale.y(price))
+                    .filter(|y| *y >= chart_rect.top() && *y <= chart_rect.bottom())
+            } else {
+                None
+            };
+            chrome
+                .paper
+                .draw_layer(painter, chart_rect, axis_x, &scale, reserved_chip_y);
+            if chrome.paper_owns_input {
+                self.paper_hud_anchor = Some((chart_rect, scale));
+            }
         }
 
         // Above the flow layers: everything else on the canvas is read against

--- a/crates/app/src/paper_hud.rs
+++ b/crates/app/src/paper_hud.rs
@@ -1,0 +1,218 @@
+//! The persistent position HUD (`docs/ux/ux-audit-2026-08.md` §2): the
+//! chart's own answer to "am I in a trade, and which one?".
+//!
+//! Pinned to the top-left of the pane that owns order entry, visible exactly
+//! while a position is open: side, size, average entry, open points, and the
+//! two exit affordances (close, reverse). When the entry price sits outside
+//! the visible price window a directional caret says which way it left —
+//! panning away from the position must never hide that it exists.
+//!
+//! The pane caches where the HUD anchors (`ChartPane::paper_hud_anchor`);
+//! the draw itself happens in `tab.rs`, where the paper host is mutably
+//! reachable outside the pane chrome's shared borrow.
+
+use eframe::egui;
+use egui_phosphor::regular as icons;
+use quantick_engine::Side;
+use rust_decimal::prelude::ToPrimitive;
+
+use crate::chart::PriceScale;
+use crate::paper_trading::{
+    PaperTrading, PositionSummary, fmt_decimal, fmt_signed_points, points_color, position_word,
+};
+use crate::theme;
+
+/// Gap between the pane's corner and the HUD card, in pixels.
+const HUD_MARGIN_PX: f32 = 8.0;
+
+/// Where the entry price sits relative to the visible price window.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EntryDrift {
+    OnScreen,
+    /// The entry price is above the window's top edge.
+    Above,
+    /// The entry price is below the window's bottom edge.
+    Below,
+}
+
+/// Classify the entry line's screen row against the pane's edges.
+fn entry_drift(entry_y: f32, top: f32, bottom: f32) -> EntryDrift {
+    if entry_y < top {
+        EntryDrift::Above
+    } else if entry_y > bottom {
+        EntryDrift::Below
+    } else {
+        EntryDrift::OnScreen
+    }
+}
+
+/// The caret row's text, `None` while the entry line is on screen.
+fn caret_text(summary: &PositionSummary, drift: EntryDrift) -> Option<String> {
+    let (glyph, word) = match drift {
+        EntryDrift::OnScreen => return None,
+        EntryDrift::Above => (icons::CARET_UP, "above"),
+        EntryDrift::Below => (icons::CARET_DOWN, "below"),
+    };
+    Some(format!(
+        "{glyph} entry {} {word} the view",
+        fmt_decimal(summary.avg_price),
+    ))
+}
+
+/// Draw the HUD over `chart_rect`. A no-op while flat.
+pub fn draw(
+    ctx: &egui::Context,
+    chart_rect: egui::Rect,
+    paper: &mut PaperTrading,
+    scale: &PriceScale,
+) {
+    let Some(summary) = paper.position_summary() else {
+        return;
+    };
+    let side_color = match summary.side {
+        Side::Buy => theme::BUY,
+        Side::Sell => theme::SELL,
+    };
+    let entry_y = scale.y(summary.avg_price.to_f64().unwrap_or_default());
+    let drift = entry_drift(entry_y, chart_rect.top(), chart_rect.bottom());
+    let word = position_word(summary.side);
+    let opposite = position_word(match summary.side {
+        Side::Buy => Side::Sell,
+        Side::Sell => Side::Buy,
+    });
+    let qty = fmt_decimal(summary.quantity);
+    egui::Area::new(egui::Id::new("paper_position_hud"))
+        .fixed_pos(chart_rect.left_top() + egui::vec2(HUD_MARGIN_PX, HUD_MARGIN_PX))
+        .order(egui::Order::Middle)
+        .show(ctx, |ui| {
+            egui::Frame::none()
+                .fill(theme::TAG_BG)
+                .stroke(egui::Stroke::new(1.0_f32, side_color))
+                .rounding(egui::Rounding::same(4.0))
+                .inner_margin(egui::Margin::symmetric(8.0, 6.0))
+                .show(ui, |ui| {
+                    ui.horizontal(|ui| {
+                        ui.label(
+                            egui::RichText::new(format!(
+                                "SIM {word} {qty} @ {}",
+                                fmt_decimal(summary.avg_price),
+                            ))
+                            .color(side_color)
+                            .strong(),
+                        );
+                        if let Some(open) = summary.open_points {
+                            ui.label(
+                                egui::RichText::new(format!("{} pts", fmt_signed_points(open)))
+                                    .color(points_color(open)),
+                            )
+                            .on_hover_text(
+                                "open profit at the last print, in points \
+                                 (price units × quantity)",
+                            );
+                        }
+                    });
+                    if let Some(caret) = caret_text(&summary, drift) {
+                        ui.label(egui::RichText::new(caret).small().color(theme::TEXT_MUTED));
+                    }
+                    ui.horizontal(|ui| {
+                        if ui
+                            .button("× Close")
+                            .on_hover_text(format!(
+                                "exit the {word} {qty} at the next print (market)"
+                            ))
+                            .clicked()
+                        {
+                            paper.close_position();
+                        }
+                        if ui
+                            .button("Reverse")
+                            .on_hover_text(format!(
+                                "close the {word} {qty} and open {opposite} {qty} \
+                                 at the next print"
+                            ))
+                            .clicked()
+                        {
+                            paper.reverse_position();
+                        }
+                    });
+                });
+        });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use quantick_engine::Trade;
+    use rust_decimal::Decimal;
+
+    #[test]
+    fn drift_reads_the_entry_row_against_the_pane_edges() {
+        assert_eq!(entry_drift(50.0, 0.0, 400.0), EntryDrift::OnScreen);
+        assert_eq!(entry_drift(-1.0, 0.0, 400.0), EntryDrift::Above);
+        assert_eq!(entry_drift(401.0, 0.0, 400.0), EntryDrift::Below);
+    }
+
+    #[test]
+    fn the_caret_names_the_price_and_the_direction() {
+        let summary = PositionSummary {
+            side: Side::Buy,
+            quantity: Decimal::ONE,
+            avg_price: Decimal::new(1055, 1),
+            open_points: None,
+        };
+        assert_eq!(caret_text(&summary, EntryDrift::OnScreen), None);
+        let above = caret_text(&summary, EntryDrift::Above).expect("off-screen carets");
+        assert!(
+            above.contains("105.5") && above.contains("above"),
+            "{above}"
+        );
+        let below = caret_text(&summary, EntryDrift::Below).expect("off-screen carets");
+        assert!(below.contains("below"), "{below}");
+    }
+
+    fn print(agg_id: u64, price: i64) -> Trade {
+        Trade {
+            agg_id,
+            timestamp_ms: i64::try_from(agg_id).expect("small test ids") * 1000,
+            price: Decimal::from(price),
+            quantity: Decimal::ONE,
+            side: Side::Buy,
+        }
+    }
+
+    /// The HUD reaches real pixels while a position is open, and paints
+    /// nothing at all while flat.
+    #[test]
+    fn the_hud_paints_the_position_and_only_the_position() {
+        let ctx = egui::Context::default();
+        let chart = egui::Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(800.0, 400.0));
+        let scale = PriceScale::from_range(90.0, 110.0, 0.0, 400.0);
+        let mut paper = PaperTrading::new();
+
+        let painted = |paper: &mut PaperTrading| {
+            let mut text = String::new();
+            for _ in 0..2 {
+                let output = ctx.run(egui::RawInput::default(), |ctx| {
+                    draw(ctx, chart, paper, &scale);
+                });
+                text.clear();
+                for shape in output.shapes {
+                    if let egui::epaint::Shape::Text(galley) = shape.shape {
+                        text.push_str(galley.galley.text());
+                        text.push(' ');
+                    }
+                }
+            }
+            text
+        };
+
+        assert!(painted(&mut paper).is_empty(), "flat paints no HUD");
+        paper.seed(&print(0, 100));
+        paper.market(Side::Buy);
+        paper.on_trade(&print(1, 100));
+        let text = painted(&mut paper);
+        assert!(text.contains("SIM LONG 1 @ 100"), "painted: {text}");
+        assert!(text.contains("Close"), "painted: {text}");
+        assert!(text.contains("Reverse"), "painted: {text}");
+    }
+}

--- a/crates/app/src/paper_trading.rs
+++ b/crates/app/src/paper_trading.rs
@@ -50,6 +50,12 @@ const SNAP_FALLBACK_DECIMALS: u32 = 2;
 /// chip (`LAST_PRICE_CHIP_TEXT` is private to `app.rs`, so the value is
 /// duplicated here; keep the two identical).
 const CHIP_TEXT: egui::Color32 = egui::Color32::from_rgb(0x0E, 0x12, 0x1A);
+/// Vertical clearance between a paper chip's centre and the last-price
+/// chip's, in pixels — just over one chip height, so the two can never
+/// overprint. At the instant a market order fills, the entry price *is* the
+/// last price, and without this the one persistent "you are long" statement
+/// is born unreadable.
+const CHIP_CLEAR_PX: f32 = 16.0;
 
 /// The next chart click places this entry (`Limit` or `Stop` only — a
 /// market order needs no price and fires straight from its button).
@@ -57,6 +63,20 @@ const CHIP_TEXT: egui::Color32 = egui::Color32::from_rgb(0x0E, 0x12, 0x1A);
 pub struct ArmedPlacement {
     side: Side,
     kind: EntryKind,
+}
+
+/// The open position, read-only, as every chrome surface reports it — the
+/// HUD, the dock badge and the status cell all describe the same trade.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PositionSummary {
+    /// Which way the position points.
+    pub side: Side,
+    /// Contracts/units held.
+    pub quantity: Decimal,
+    /// Average entry price.
+    pub avg_price: Decimal,
+    /// Open profit at the current mark; `None` before any mark exists.
+    pub open_points: Option<Decimal>,
 }
 
 /// Which simulated line the pointer is dragging.
@@ -243,28 +263,179 @@ impl PaperTrading {
         self.handle_events(events);
     }
 
-    /// The status-bar cell: `SIM ±N pts` (realized + open), and the sign
-    /// for its color. `None` while the simulator has never been touched.
+    /// The status-bar cell, honest about open versus flat: `SIM LONG 1 ·
+    /// +2 pts` while a position is open (side, size and its open profit),
+    /// `SIM +7 pts · flat` otherwise (the session's realized points). `None`
+    /// while the simulator has never been touched.
     #[must_use]
     pub fn status_cell(&self) -> Option<(String, std::cmp::Ordering)> {
-        let untouched = self.sim.position().is_none()
-            && self.sim.closed_trades().is_empty()
+        if let Some(position) = self.sim.position() {
+            let open = self
+                .sim
+                .mark_price()
+                .map(|mark| position.open_points(mark))
+                .unwrap_or_default();
+            return Some((
+                format!(
+                    "SIM {} {} · {} pts",
+                    position_word(position.side),
+                    fmt_decimal(position.quantity),
+                    fmt_signed_points(open),
+                ),
+                open.cmp(&Decimal::ZERO),
+            ));
+        }
+        let untouched = self.sim.closed_trades().is_empty()
             && self.sim.orders().is_empty()
             && self.sim.queued().is_empty();
         if untouched {
             return None;
         }
-        let open = self
-            .sim
-            .position()
-            .and_then(|position| self.sim.mark_price().map(|mark| position.open_points(mark)));
-        let total = self
-            .sim
-            .realized_points()
-            .saturating_add(open.unwrap_or_default());
+        let realized = self.sim.realized_points();
         Some((
-            format!("SIM {} pts", fmt_signed_points(total)),
-            total.cmp(&Decimal::ZERO),
+            format!("SIM {} pts · flat", fmt_signed_points(realized)),
+            realized.cmp(&Decimal::ZERO),
+        ))
+    }
+
+    /// The open position as the chrome reports it: side, size, entry, and
+    /// the open profit at the current mark. `None` while flat.
+    #[must_use]
+    pub fn position_summary(&self) -> Option<PositionSummary> {
+        let position = self.sim.position()?;
+        Some(PositionSummary {
+            side: position.side,
+            quantity: position.quantity,
+            avg_price: position.avg_price,
+            open_points: self.sim.mark_price().map(|mark| position.open_points(mark)),
+        })
+    }
+
+    /// Exit the open position at the next print — the toolbar's close
+    /// button, the HUD's, and the Trading tab's all funnel here.
+    pub fn close_position(&mut self) {
+        let events = self.sim.apply(Command::ClosePosition);
+        self.handle_events(events);
+    }
+
+    /// Close the position and cancel every pending order.
+    pub fn flatten(&mut self) {
+        let events = self.sim.apply(Command::Flatten);
+        self.handle_events(events);
+    }
+
+    /// Flip the open position: one market order for twice its size, which
+    /// closes it and opens the opposite side at the same quantity. The
+    /// form's protective offsets apply to the new entry, exactly as they do
+    /// to any market order.
+    pub fn reverse_position(&mut self) {
+        let Some(position) = self.sim.position().cloned() else {
+            return;
+        };
+        let side = match position.side {
+            Side::Buy => Side::Sell,
+            Side::Sell => Side::Buy,
+        };
+        let reference = self.sim.mark_price().unwrap_or_default();
+        let Some(bracket) = self.parse_bracket(side, reference) else {
+            return;
+        };
+        let events = self.sim.apply(Command::PlaceMarket {
+            side,
+            quantity: position.quantity.saturating_add(position.quantity),
+            bracket,
+        });
+        self.handle_events(events);
+    }
+
+    /// The form quantity, parsed without side effects — the label builders
+    /// peek at it every frame and must not toast.
+    fn quantity_preview(&self) -> Option<Decimal> {
+        match self.qty_text.trim().parse::<Decimal>() {
+            Ok(quantity) if quantity > Decimal::ZERO => Some(quantity),
+            _ => None,
+        }
+    }
+
+    /// State-aware entry label: what pressing this side's button would do to
+    /// the open position — `SELL 1 (closes)`, `SELL 5 (reverses to short
+    /// 4)`. Whether a press closes or flips hangs on a quantity field the
+    /// toolbar never shows, so the button itself must say. Falls back to the
+    /// bare side word while the form quantity does not parse — the click
+    /// will toast the correction.
+    #[must_use]
+    pub fn entry_label(&self, side: Side) -> String {
+        let word = side_word_upper(side);
+        let Some(qty) = self.quantity_preview() else {
+            return word.to_owned();
+        };
+        let qty_text = fmt_decimal(qty);
+        let Some(position) = self.sim.position() else {
+            return format!("{word} {qty_text}");
+        };
+        if position.side == side {
+            return format!(
+                "{word} {qty_text} (adds to {})",
+                fmt_decimal(position.quantity.saturating_add(qty)),
+            );
+        }
+        match qty.cmp(&position.quantity) {
+            std::cmp::Ordering::Less => format!(
+                "{word} {qty_text} (closes {qty_text} of {})",
+                fmt_decimal(position.quantity),
+            ),
+            std::cmp::Ordering::Equal => format!("{word} {qty_text} (closes)"),
+            std::cmp::Ordering::Greater => format!(
+                "{word} {qty_text} (reverses to {} {})",
+                match side {
+                    Side::Buy => "long",
+                    Side::Sell => "short",
+                },
+                fmt_decimal(qty.saturating_sub(position.quantity)),
+            ),
+        }
+    }
+
+    /// The entry buttons' hover text: the quantity and protective offsets
+    /// the press will use, which the toolbar itself has no widgets for.
+    #[must_use]
+    pub fn entry_hover(&self, side: Side) -> String {
+        let quantity = match self.quantity_preview() {
+            Some(qty) => format!("quantity {}", fmt_decimal(qty)),
+            None => "the quantity is not a positive number".to_owned(),
+        };
+        let bracket = match (
+            parse_offset(&self.stop_offset_text),
+            parse_offset(&self.profit_offset_text),
+        ) {
+            (Ok(None), Ok(None)) => "no protective bracket set".to_owned(),
+            (Ok(stop), Ok(profit)) => {
+                let mut parts = Vec::new();
+                if let Some(stop) = stop {
+                    parts.push(format!("stop {} pts", fmt_decimal(stop)));
+                }
+                if let Some(profit) = profit {
+                    parts.push(format!("target {} pts", fmt_decimal(profit)));
+                }
+                format!("{} on fill", parts.join(" / "))
+            }
+            _ => "an offset field needs fixing".to_owned(),
+        };
+        format!(
+            "simulated market {} - fills at the next print; {quantity}, {bracket} (Trading tab)",
+            side_word(side),
+        )
+    }
+
+    /// `Close 1 LONG` while a position is open — the toolbar's exit button
+    /// label. `None` while flat, which is what removes the button.
+    #[must_use]
+    pub fn close_button_label(&self) -> Option<String> {
+        let position = self.sim.position()?;
+        Some(format!(
+            "Close {} {}",
+            fmt_decimal(position.quantity),
+            position_word(position.side),
         ))
     }
 
@@ -275,13 +446,15 @@ impl PaperTrading {
     /// Paint the simulated lines: pending orders (dashed, accent), then the
     /// position's entry / stop-loss / take-profit (solid, semantic colors).
     /// Chips share the last-price chip geometry so prices never disagree
-    /// about their pixel.
+    /// about their pixel; `reserved_chip_y` is the last-price chip's row,
+    /// which every paper chip dodges rather than overprints.
     pub fn draw_layer(
         &self,
         painter: &egui::Painter,
         chart_rect: egui::Rect,
         axis_x: f32,
         scale: &PriceScale,
+        reserved_chip_y: Option<f32>,
     ) {
         for order in self.sim.orders() {
             let Some(level) = order.price else { continue };
@@ -308,6 +481,7 @@ impl PaperTrading {
                 theme::ACCENT,
                 true,
                 &label,
+                reserved_chip_y,
             );
         }
         if let Some(position) = self.sim.position() {
@@ -331,6 +505,7 @@ impl PaperTrading {
                 entry_color,
                 false,
                 &label,
+                reserved_chip_y,
             );
             if let Some(stop) = position.stop_loss {
                 let price = if self.drag == PaperDrag::StopLoss {
@@ -353,6 +528,7 @@ impl PaperTrading {
                     theme::SELL,
                     false,
                     &label,
+                    reserved_chip_y,
                 );
             }
             if let Some(target) = position.take_profit {
@@ -376,6 +552,7 @@ impl PaperTrading {
                     theme::BUY,
                     false,
                     &label,
+                    reserved_chip_y,
                 );
             }
         }
@@ -385,9 +562,11 @@ impl PaperTrading {
                 side_word(armed.side),
                 kind_word(armed.kind),
             );
+            // Bottom-left: the top-left corner belongs to the position HUD,
+            // and arming an entry with a position open is a normal flow.
             painter.text(
-                chart_rect.left_top() + egui::vec2(8.0, 8.0),
-                egui::Align2::LEFT_TOP,
+                chart_rect.left_bottom() + egui::vec2(8.0, -8.0),
+                egui::Align2::LEFT_BOTTOM,
                 hint,
                 egui::FontId::proportional(12.0),
                 theme::ACCENT,
@@ -679,16 +858,14 @@ impl PaperTrading {
                 .on_hover_text("exit the position at the next print")
                 .clicked()
             {
-                let events = self.sim.apply(Command::ClosePosition);
-                self.handle_events(events);
+                self.close_position();
             }
             if ui
                 .button("Flatten")
                 .on_hover_text("close the position and cancel every pending order")
                 .clicked()
             {
-                let events = self.sim.apply(Command::Flatten);
-                self.handle_events(events);
+                self.flatten();
             }
         });
     }
@@ -1267,7 +1444,8 @@ fn load_report(dir: &Path, symbol: Option<&str>) -> ReportData {
 }
 
 /// One price line with its gutter chip — the last-price chip geometry, so
-/// prices never disagree about their pixel.
+/// prices never disagree about their pixel. The line always sits at its true
+/// price; only the chip dodges the reserved last-price row.
 #[expect(clippy::too_many_arguments, reason = "a paint helper, not an API")]
 fn draw_price_line(
     painter: &egui::Painter,
@@ -1278,6 +1456,7 @@ fn draw_price_line(
     color: egui::Color32,
     dashed: bool,
     label: &str,
+    reserved_chip_y: Option<f32>,
 ) {
     let y = scale.y(price);
     if y < chart_rect.top() || y > chart_rect.bottom() {
@@ -1297,14 +1476,38 @@ fn draw_price_line(
             stroke,
         );
     }
+    let chip_y = dodged_chip_y(y, reserved_chip_y, chart_rect.top(), chart_rect.bottom());
     let galley = painter.layout_no_wrap(label.to_owned(), egui::FontId::monospace(11.0), CHIP_TEXT);
-    let text_pos = egui::pos2(axis_x + 6.0, y - galley.size().y / 2.0);
+    let text_pos = egui::pos2(axis_x + 6.0, chip_y - galley.size().y / 2.0);
     let bg = egui::Rect::from_min_size(
         text_pos - egui::vec2(3.0, 1.0),
         galley.size() + egui::vec2(6.0, 2.0),
     );
     painter.rect_filled(bg, egui::Rounding::same(2.0), color);
     painter.galley(text_pos, galley, CHIP_TEXT);
+}
+
+/// Keep a gutter chip legible when it would land on the last-price chip:
+/// push it just clear of the reserved row, towards its own side of the
+/// price, clamped into the pane. At the exact fill price (no distance at
+/// all) the chip steps down, below the last-price chip. When the reserved
+/// row itself hugs a pane edge the clamp can land the chip back inside the
+/// band — accepted: a chip pinned at the edge beats one pushed out of the
+/// pane, and the next print separates them.
+fn dodged_chip_y(y: f32, reserved: Option<f32>, top: f32, bottom: f32) -> f32 {
+    let Some(reserved) = reserved else {
+        return y;
+    };
+    let delta = y - reserved;
+    if delta.abs() >= CHIP_CLEAR_PX {
+        return y;
+    }
+    let dodged = if delta >= 0.0 {
+        reserved + CHIP_CLEAR_PX
+    } else {
+        reserved - CHIP_CLEAR_PX
+    };
+    dodged.clamp(top, bottom)
 }
 
 /// Empty means "none"; otherwise a strictly positive decimal.
@@ -1333,7 +1536,8 @@ fn side_word_upper(side: Side) -> &'static str {
     }
 }
 
-fn position_word(side: Side) -> &'static str {
+/// `LONG`/`SHORT` — shared with the HUD so every surface uses one register.
+pub(crate) fn position_word(side: Side) -> &'static str {
     match side {
         Side::Buy => "LONG",
         Side::Sell => "SHORT",
@@ -1348,7 +1552,8 @@ fn kind_word(kind: EntryKind) -> &'static str {
     }
 }
 
-fn points_color(points: Decimal) -> egui::Color32 {
+/// Green gains, red losses, muted zero — shared with the HUD.
+pub(crate) fn points_color(points: Decimal) -> egui::Color32 {
     match points.cmp(&Decimal::ZERO) {
         std::cmp::Ordering::Greater => theme::BUY,
         std::cmp::Ordering::Less => theme::SELL,
@@ -1357,7 +1562,7 @@ fn points_color(points: Decimal) -> egui::Color32 {
 }
 
 /// Exact value, trailing zeros stripped — prices and quantities.
-fn fmt_decimal(value: Decimal) -> String {
+pub(crate) fn fmt_decimal(value: Decimal) -> String {
     value.normalize().to_string()
 }
 
@@ -1368,7 +1573,7 @@ fn fmt_points(value: Decimal) -> String {
 
 /// Signed points: an explicit `+` on gains so a green `12` can never be
 /// misread as a count.
-fn fmt_signed_points(value: Decimal) -> String {
+pub(crate) fn fmt_signed_points(value: Decimal) -> String {
     if value > Decimal::ZERO {
         format!("+{}", fmt_points(value))
     } else {
@@ -1696,6 +1901,125 @@ mod tests {
             !paper.handle_chart_input(&frame(chart, &scale, 40.0, true, true, false)),
             "a press far from every line belongs to the pan"
         );
+    }
+
+    /// One long, then every label the entry buttons can wear: the button
+    /// must disclose close-or-reverse, because the quantity deciding it
+    /// lives in a tab the toolbar never shows.
+    #[test]
+    fn entry_labels_disclose_what_the_press_would_do() {
+        let mut paper = PaperTrading::new();
+        assert_eq!(
+            paper.entry_label(Side::Buy),
+            "BUY 1",
+            "flat is a plain entry"
+        );
+        paper.qty_text = "x".to_owned();
+        assert_eq!(
+            paper.entry_label(Side::Sell),
+            "SELL",
+            "an unparseable quantity promises nothing"
+        );
+        paper.qty_text = "2".to_owned();
+        paper.seed(&print(0, 100));
+        paper.market(Side::Buy);
+        paper.on_trade(&print(1, 100));
+
+        paper.qty_text = "1".to_owned();
+        assert_eq!(paper.entry_label(Side::Buy), "BUY 1 (adds to 3)");
+        assert_eq!(paper.entry_label(Side::Sell), "SELL 1 (closes 1 of 2)");
+        paper.qty_text = "2".to_owned();
+        assert_eq!(paper.entry_label(Side::Sell), "SELL 2 (closes)");
+        paper.qty_text = "5".to_owned();
+        assert_eq!(
+            paper.entry_label(Side::Sell),
+            "SELL 5 (reverses to short 3)"
+        );
+    }
+
+    /// The status cell answers the reported question — "am I in a trade?" —
+    /// not just "how many points".
+    #[test]
+    fn the_status_cell_distinguishes_open_from_flat() {
+        let mut paper = PaperTrading::new();
+        assert!(paper.status_cell().is_none(), "untouched owes no line");
+        paper.seed(&print(0, 100));
+        paper.market(Side::Buy);
+        paper.on_trade(&print(1, 100));
+        let (text, _) = paper.status_cell().expect("a position is state");
+        assert_eq!(text, "SIM LONG 1 · 0 pts");
+        paper.on_trade(&print(2, 105));
+        let (text, sign) = paper.status_cell().expect("still open");
+        assert_eq!(text, "SIM LONG 1 · +5 pts");
+        assert_eq!(sign, std::cmp::Ordering::Greater);
+
+        paper.close_position();
+        paper.on_trade(&print(3, 107));
+        let (text, sign) = paper.status_cell().expect("history keeps the cell");
+        assert_eq!(text, "SIM +7 pts · flat");
+        assert_eq!(sign, std::cmp::Ordering::Greater);
+        assert!(paper.close_button_label().is_none(), "flat has no close");
+    }
+
+    #[test]
+    fn the_close_button_names_the_position_it_exits() {
+        let mut paper = PaperTrading::new();
+        paper.qty_text = "3".to_owned();
+        paper.seed(&print(0, 100));
+        paper.market(Side::Sell);
+        paper.on_trade(&print(1, 100));
+        assert_eq!(paper.close_button_label().as_deref(), Some("Close 3 SHORT"));
+        let summary = paper.position_summary().expect("open");
+        assert_eq!(summary.side, Side::Sell);
+        assert_eq!(summary.quantity, Decimal::from(3));
+        assert_eq!(summary.avg_price, Decimal::from(100));
+    }
+
+    /// Reverse flips side and size in one market order, and the form's
+    /// protective offsets ride along to the new entry.
+    #[test]
+    fn reverse_flips_the_position_with_the_forms_bracket() {
+        let mut paper = PaperTrading::new();
+        paper.qty_text = "2".to_owned();
+        paper.seed(&print(0, 100));
+        paper.market(Side::Buy);
+        paper.on_trade(&print(1, 100));
+        paper.stop_offset_text = "5".to_owned();
+        paper.reverse_position();
+        paper.on_trade(&print(2, 100));
+        let position = paper.sim.position().expect("reversed, not flat");
+        assert_eq!(position.side, Side::Sell);
+        assert_eq!(position.quantity, Decimal::from(2));
+        assert_eq!(
+            position.stop_loss,
+            Some(Decimal::from(105)),
+            "the new short is protected by the form's offset"
+        );
+    }
+
+    /// The chip dodge: lines keep their price, chips clear the last-price
+    /// row by the minimum, and the fill-moment tie steps down.
+    #[test]
+    fn paper_chips_dodge_the_last_price_chip_never_the_line() {
+        // No reservation, or far enough away: the chip stays at its line.
+        assert_eq!(dodged_chip_y(100.0, None, 0.0, 400.0), 100.0);
+        assert_eq!(dodged_chip_y(100.0, Some(200.0), 0.0, 400.0), 100.0);
+        // Inside the band: pushed just clear, towards its own side.
+        assert_eq!(
+            dodged_chip_y(210.0, Some(200.0), 0.0, 400.0),
+            200.0 + CHIP_CLEAR_PX
+        );
+        assert_eq!(
+            dodged_chip_y(190.0, Some(200.0), 0.0, 400.0),
+            200.0 - CHIP_CLEAR_PX
+        );
+        // The fill moment: entry == last price, and the chip steps down.
+        assert_eq!(
+            dodged_chip_y(200.0, Some(200.0), 0.0, 400.0),
+            200.0 + CHIP_CLEAR_PX
+        );
+        // Never dodged out of the pane.
+        assert_eq!(dodged_chip_y(398.0, Some(399.0), 0.0, 400.0), 383.0);
     }
 
     #[test]

--- a/crates/app/src/statusbar.rs
+++ b/crates/app/src/statusbar.rs
@@ -198,9 +198,18 @@ pub fn bars_text(venue: usize, backfilled: usize, live: usize) -> String {
     format!("{venue}v+{backfilled}+{live} bars")
 }
 
-/// Draw the status bar as the window's bottom panel. `tz` is the bar's only
-/// control; picking an offset relabels the time axis immediately.
-pub fn draw(ctx: &egui::Context, model: &StatusModel, tz: &mut TzOffset) {
+/// What a click on the bar asked of the app this frame.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct StatusResponse {
+    /// The SIM cell was clicked: open the Trading dock tab, where the
+    /// position it summarizes is managed.
+    pub open_trading_tab: bool,
+}
+
+/// Draw the status bar as the window's bottom panel. `tz` is the bar's
+/// resident control; the SIM cell clicks through to the Trading tab.
+pub fn draw(ctx: &egui::Context, model: &StatusModel, tz: &mut TzOffset) -> StatusResponse {
+    let mut response = StatusResponse::default();
     egui::TopBottomPanel::bottom("status_bar")
         .exact_height(STATUS_BAR_HEIGHT)
         .frame(
@@ -213,12 +222,13 @@ pub fn draw(ctx: &egui::Context, model: &StatusModel, tz: &mut TzOffset) {
                 ui.spacing_mut().item_spacing.x = CELL_SPACING_PX;
                 draw_provenance(ui, model);
                 ui.separator();
-                draw_content(ui, model);
+                response.open_trading_tab = draw_content(ui, model);
                 ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                     draw_machinery(ui, model, tz)
                 });
             });
         });
+    response
 }
 
 /// Left section: state dot, venue, symbol, lag.
@@ -264,7 +274,9 @@ fn draw_provenance(ui: &mut egui::Ui, model: &StatusModel) {
 }
 
 /// Middle section: bar spec, counts, honesty labels and navigation hints.
-fn draw_content(ui: &mut egui::Ui, model: &StatusModel) {
+/// Returns whether the SIM cell was clicked.
+fn draw_content(ui: &mut egui::Ui, model: &StatusModel) -> bool {
+    let mut sim_clicked = false;
     ui.label(
         egui::RichText::new(&model.spec_summary)
             .monospace()
@@ -300,11 +312,19 @@ fn draw_content(ui: &mut egui::Ui, model: &StatusModel) {
             std::cmp::Ordering::Less => theme::SELL,
             std::cmp::Ordering::Equal => theme::TEXT_MUTED,
         };
-        ui.label(egui::RichText::new(text).monospace().color(color))
+        // A click-through, not just a readout: the cell summarizes a
+        // position managed two levels away, so it carries the way there.
+        let cell = ui
+            .add(
+                egui::Label::new(egui::RichText::new(text).monospace().color(color))
+                    .sense(egui::Sense::click()),
+            )
+            .on_hover_cursor(egui::CursorIcon::PointingHand)
             .on_hover_text(
-                "paper-trading P&L (realized + open) in points - simulated fills, \
-                 not a broker account",
+                "paper-trading, in points - simulated fills, not a broker \
+                 account; click to open the Trading tab",
             );
+        sim_clicked = cell.clicked();
     }
     if !model.follows_live {
         ui.label(
@@ -320,6 +340,7 @@ fn draw_content(ui: &mut egui::Ui, model: &StatusModel) {
                 .color(theme::TEXT_FAINT),
         );
     }
+    sim_clicked
 }
 
 /// Right section, laid out right-to-left: timezone picker at the far edge,
@@ -477,7 +498,14 @@ mod tests {
                 show_perf: true,
             };
             for _ in 0..2 {
-                let _ = ctx.run(egui::RawInput::default(), |ctx| draw(ctx, &model, &mut tz));
+                let _ = ctx.run(egui::RawInput::default(), |ctx| {
+                    let response = draw(ctx, &model, &mut tz);
+                    assert_eq!(
+                        response,
+                        StatusResponse::default(),
+                        "an un-clicked frame asks nothing of the app"
+                    );
+                });
             }
         }
         assert_eq!(
@@ -523,7 +551,9 @@ mod tests {
         // Two passes: egui settles its layout on the second.
         let mut painted = String::new();
         for _ in 0..2 {
-            let output = ctx.run(egui::RawInput::default(), |ctx| draw(ctx, &model, &mut tz));
+            let output = ctx.run(egui::RawInput::default(), |ctx| {
+                let _ = draw(ctx, &model, &mut tz);
+            });
             painted.clear();
             for shape in output.shapes {
                 if let egui::epaint::Shape::Text(text) = shape.shape {

--- a/crates/app/src/tab.rs
+++ b/crates/app/src/tab.rs
@@ -1539,6 +1539,14 @@ impl Tab {
             }
         }
 
+        // The position HUD rides the pane that owns order entry. It draws
+        // here, after the pane loop, because its buttons need the paper host
+        // mutably — inside the loop that borrow is pinned behind the shared
+        // chrome.
+        if let Some((rect, scale)) = self.flow_pane.paper_hud_anchor() {
+            crate::paper_hud::draw(ui.ctx(), rect, &mut self.paper, &scale);
+        }
+
         let (Some(time_area), Some(divider)) = (time_area, divider) else {
             return;
         };

--- a/crates/app/src/toolbar.rs
+++ b/crates/app/src/toolbar.rs
@@ -43,12 +43,16 @@ const W_BARS: f32 = 160.0;
 const W_BAR_PARAM: f32 = 150.0;
 /// The `+ older ▾` split button.
 const W_HISTORY: f32 = 100.0;
-/// The simulated BUY/SELL pair.
-const W_TRADE: f32 = 110.0;
 /// The LAYERS icon group (bubbles, heatmap, live strip, indicators).
 const W_LAYERS: f32 = 128.0;
 /// One 28 px icon button (LOOK, PANELS, or the overflow `⋯`).
 const W_ICON: f32 = 28.0;
+/// Estimated width of one glyph in a TRADE button label, in pixels.
+const TRADE_GLYPH_PX: f32 = 7.0;
+/// One TRADE button's own horizontal padding, in pixels.
+const TRADE_BUTTON_PAD_PX: f32 = 16.0;
+/// The close button's `× ` prefix, in pixels.
+const TRADE_CLOSE_PREFIX_PX: f32 = 14.0;
 
 /// Which groups stay inline at the current width. Everything folded is
 /// reachable through the `⋯` overflow menu instead — never hidden.
@@ -93,8 +97,10 @@ impl CollapsePlan {
     /// Estimated width of the toolbar under this plan. The `⋯` slot is
     /// always reserved: it appears exactly when something folds, so counting
     /// it conditionally would make the first fold width-neutral and leave
-    /// the planner skipping straight past it.
-    fn width(self) -> f32 {
+    /// the planner skipping straight past it. `trade_width` comes in as a
+    /// parameter because the TRADE group's state-aware labels grow and
+    /// shrink with the position (see [`trade_width`]).
+    fn width(self, trade_width: f32) -> f32 {
         let mut width = W_SLACK + W_ICON + W_BARS + W_LAYERS;
         width += if self.feed_full_name {
             W_SOURCE_FULL
@@ -108,7 +114,7 @@ impl CollapsePlan {
             width += W_HISTORY;
         }
         if self.trade_inline {
-            width += W_TRADE;
+            width += trade_width;
         }
         if self.look_inline {
             width += W_ICON;
@@ -124,7 +130,7 @@ impl CollapsePlan {
 /// The last plan is accepted even when it still overflows — there is nothing
 /// left to fold, and the symbol and LAYERS are never candidates.
 #[must_use]
-pub fn collapse_plan(available: f32) -> CollapsePlan {
+pub fn collapse_plan(available: f32, trade_width: f32) -> CollapsePlan {
     let mut plan = CollapsePlan::FULL;
     let steps: [fn(&mut CollapsePlan); 6] = [
         |plan| plan.look_inline = false,
@@ -135,12 +141,25 @@ pub fn collapse_plan(available: f32) -> CollapsePlan {
         |plan| plan.feed_full_name = false,
     ];
     for fold in steps {
-        if plan.width() <= available {
+        if plan.width(trade_width) <= available {
             return plan;
         }
         fold(&mut plan);
     }
     plan
+}
+
+/// Estimated TRADE width for the collapse plan. The state-aware labels
+/// (`SELL 5 (reverses to short 4)`, the close button) change with the
+/// position, so the fold decision must read them rather than a constant.
+#[must_use]
+pub fn trade_width(paper: &PaperTradeModel) -> f32 {
+    let button = |label: &str| TRADE_BUTTON_PAD_PX + label.chars().count() as f32 * TRADE_GLYPH_PX;
+    let mut width = button(&paper.buy_label) + button(&paper.sell_label);
+    if let Some(close) = &paper.close_label {
+        width += button(close) + TRADE_CLOSE_PREFIX_PX;
+    }
+    width
 }
 
 /// The amber label that replaces SOURCE while a recording plays.
@@ -194,14 +213,50 @@ pub struct ToolbarModel<'a> {
     pub dock_visible: bool,
     /// Whether the appearance dialog is open.
     pub appearance_open: bool,
-    /// Whether the paper-trading simulator has seen a price — the TRADE
-    /// buttons disable themselves (with the reason) until it has.
-    pub paper_ready: bool,
+    /// The TRADE group: readiness, state-aware entry labels and the close
+    /// button, all computed by the paper host (`PaperTrading`).
+    pub paper: PaperTradeModel,
     /// Active indicators, for the INDICATORS menu (add order).
     pub indicators: Vec<IndicatorMenuEntry>,
     /// Loadable script names, embedded first (the INDICATORS menu's "add"
     /// section; indices map straight to [`ToolbarAction::AddScriptIndicator`]).
     pub scripts: Vec<String>,
+}
+
+/// What the TRADE group shows this frame, computed by the paper host so the
+/// toolbar stays decoupled from the simulator's types. The labels disclose
+/// what the press would do to the open position (`SELL 1 (closes)`), because
+/// the quantity deciding it lives in a tab the toolbar never shows.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PaperTradeModel {
+    /// Whether the simulator has seen a price — the buttons disable
+    /// themselves (with the reason) until it has.
+    pub ready: bool,
+    /// The buy button's state-aware label.
+    pub buy_label: String,
+    /// The sell button's state-aware label.
+    pub sell_label: String,
+    /// The buy button's hover text (quantity and bracket disclosure).
+    pub buy_hover: String,
+    /// The sell button's hover text.
+    pub sell_hover: String,
+    /// `Close 1 LONG` while a position is open; `None` removes the button.
+    pub close_label: Option<String>,
+}
+
+impl PaperTradeModel {
+    /// A flat, ready TRADE group — the tests' baseline.
+    #[cfg(test)]
+    fn flat(ready: bool) -> Self {
+        Self {
+            ready,
+            buy_label: "BUY 1".to_owned(),
+            sell_label: "SELL 1".to_owned(),
+            buy_hover: "simulated market buy".to_owned(),
+            sell_hover: "simulated market sell".to_owned(),
+            close_label: None,
+        }
+    }
 }
 
 /// One active indicator as the INDICATORS menu shows it. Raw slot numbers
@@ -256,6 +311,8 @@ pub enum ToolbarAction {
     PaperBuy,
     /// Simulated market sell at the Trading tab's quantity (paper trading).
     PaperSell,
+    /// Exit the open simulated position at the next print.
+    PaperClose,
 }
 
 /// Draw the toolbar as the 44 px top panel and return what was asked of the
@@ -272,7 +329,7 @@ pub fn draw(ctx: &egui::Context, model: &mut ToolbarModel) -> Vec<ToolbarAction>
                 .inner_margin(egui::Margin::symmetric(8.0, 0.0)),
         )
         .show(ctx, |ui| {
-            let plan = collapse_plan(ui.available_width());
+            let plan = collapse_plan(ui.available_width(), trade_width(&model.paper));
             ui.horizontal_centered(|ui| {
                 ui.spacing_mut().item_spacing.x = 6.0;
                 draw_source(ui, model, plan);
@@ -476,36 +533,53 @@ fn draw_history_menu(ui: &mut egui::Ui, model: &mut ToolbarModel) {
     ui.small(format!("{} trades backfilled so far", model.history_trades));
 }
 
-/// TRADE: the simulated market entries (`docs/ux/paper-trading.md`).
-/// Quantity, brackets and everything else live in the Trading dock tab;
-/// these two buttons are the "act now" pair. Gated on the simulator having
+/// TRADE: the simulated market entries and, while a position is open, its
+/// exit (`docs/ux/paper-trading.md`). Quantity and brackets live in the
+/// Trading dock tab; the labels disclose them. Gated on the simulator having
 /// seen a price, never on the provider — paper trading works on any feed.
 fn draw_trade(ui: &mut egui::Ui, model: &ToolbarModel, actions: &mut Vec<ToolbarAction>) {
+    let paper = &model.paper;
     let buy = ui
         .add_enabled(
-            model.paper_ready,
-            egui::Button::new(egui::RichText::new("BUY").color(theme::BUY).strong()),
+            paper.ready,
+            egui::Button::new(
+                egui::RichText::new(&paper.buy_label)
+                    .color(theme::BUY)
+                    .strong(),
+            ),
         )
-        .on_hover_text(
-            "simulated market buy - fills at the next print; quantity and brackets \
-             live in the Trading tab",
-        )
+        .on_hover_text(&paper.buy_hover)
         .on_disabled_hover_text("waiting for the first print - there is no market yet");
     if buy.clicked() {
         actions.push(ToolbarAction::PaperBuy);
     }
     let sell = ui
         .add_enabled(
-            model.paper_ready,
-            egui::Button::new(egui::RichText::new("SELL").color(theme::SELL).strong()),
+            paper.ready,
+            egui::Button::new(
+                egui::RichText::new(&paper.sell_label)
+                    .color(theme::SELL)
+                    .strong(),
+            ),
         )
-        .on_hover_text(
-            "simulated market sell - fills at the next print; quantity and brackets \
-             live in the Trading tab",
-        )
+        .on_hover_text(&paper.sell_hover)
         .on_disabled_hover_text("waiting for the first print - there is no market yet");
     if sell.clicked() {
         actions.push(ToolbarAction::PaperSell);
+    }
+    // The exit control, on the same surface as the entries: an open position
+    // must never require a dock dive to leave (audit pain 1, B2).
+    if let Some(close) = &paper.close_label {
+        let button = ui
+            .add(egui::Button::new(
+                egui::RichText::new(format!("× {close}"))
+                    .color(theme::TEXT_PRIMARY)
+                    .strong(),
+            ))
+            .on_hover_text("exit the open simulated position at the next print (market)");
+        if button.clicked() {
+            actions.push(ToolbarAction::PaperClose);
+        }
     }
 }
 
@@ -706,17 +780,29 @@ fn draw_overflow(
         if !plan.trade_inline {
             ui.separator();
             let buy = ui
-                .add_enabled(model.paper_ready, egui::Button::new("Buy at market (SIM)"))
+                .add_enabled(
+                    model.paper.ready,
+                    egui::Button::new(format!("{} at market (SIM)", model.paper.buy_label)),
+                )
                 .on_disabled_hover_text("waiting for the first print - there is no market yet");
             if buy.clicked() {
                 actions.push(ToolbarAction::PaperBuy);
                 ui.close_menu();
             }
             let sell = ui
-                .add_enabled(model.paper_ready, egui::Button::new("Sell at market (SIM)"))
+                .add_enabled(
+                    model.paper.ready,
+                    egui::Button::new(format!("{} at market (SIM)", model.paper.sell_label)),
+                )
                 .on_disabled_hover_text("waiting for the first print - there is no market yet");
             if sell.clicked() {
                 actions.push(ToolbarAction::PaperSell);
+                ui.close_menu();
+            }
+            if let Some(close) = &model.paper.close_label
+                && ui.button(format!("× {close} (SIM)")).clicked()
+            {
+                actions.push(ToolbarAction::PaperClose);
                 ui.close_menu();
             }
         }
@@ -731,6 +817,10 @@ fn draw_overflow(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The flat TRADE pair's width — the old `W_TRADE` constant, kept as the
+    /// tests' baseline now that the group is measured from its labels.
+    const FLAT_TRADE_W: f32 = 110.0;
 
     /// How many §6 collapse steps a plan has taken. `None` when the plan is
     /// not one of the seven canonical states — folding out of order.
@@ -759,14 +849,14 @@ mod tests {
 
     #[test]
     fn a_wide_toolbar_folds_nothing() {
-        let plan = collapse_plan(10_000.0);
+        let plan = collapse_plan(10_000.0, FLAT_TRADE_W);
         assert_eq!(stage(plan), Some(0));
         assert!(!plan.overflow_needed());
     }
 
     #[test]
     fn a_hopeless_width_ends_fully_folded() {
-        let plan = collapse_plan(0.0);
+        let plan = collapse_plan(0.0, FLAT_TRADE_W);
         assert_eq!(stage(plan), Some(6));
         assert!(plan.overflow_needed());
     }
@@ -778,7 +868,7 @@ mod tests {
         // and every plan must be one of the canonical §6 states.
         let mut width = 100.0;
         while width <= 2000.0 {
-            let plan = collapse_plan(width);
+            let plan = collapse_plan(width, FLAT_TRADE_W);
             let stage = stage(plan).expect("plans fold strictly in the §6 order");
             assert!(
                 stage <= last_stage,
@@ -793,10 +883,33 @@ mod tests {
     #[test]
     fn look_folds_first_and_alone_at_a_mildly_tight_width() {
         // One pixel short of the full plan: exactly LOOK moves to overflow.
-        let full_width = CollapsePlan::FULL.width();
-        let plan = collapse_plan(full_width - 1.0);
+        let full_width = CollapsePlan::FULL.width(FLAT_TRADE_W);
+        let plan = collapse_plan(full_width - 1.0, FLAT_TRADE_W);
         assert_eq!(stage(plan), Some(1));
         assert!(plan.overflow_needed());
+    }
+
+    /// An open position widens TRADE (state-aware labels + the close
+    /// button), and the plan reads that width: what exactly fits flat folds
+    /// once a position opens.
+    #[test]
+    fn an_open_position_widens_trade_and_folds_sooner() {
+        let flat = PaperTradeModel::flat(true);
+        let open = PaperTradeModel {
+            buy_label: "BUY 1 (adds to 2)".to_owned(),
+            sell_label: "SELL 1 (closes 1 of 2)".to_owned(),
+            close_label: Some("Close 2 LONG".to_owned()),
+            ..PaperTradeModel::flat(true)
+        };
+        let flat_w = trade_width(&flat);
+        let open_w = trade_width(&open);
+        assert!(open_w > flat_w, "{open_w} vs {flat_w}");
+        let exactly_flat = CollapsePlan::FULL.width(flat_w);
+        assert_eq!(stage(collapse_plan(exactly_flat, flat_w)), Some(0));
+        assert!(
+            stage(collapse_plan(exactly_flat, open_w)).expect("canonical") > 0,
+            "the wider TRADE must fold something at the same window width"
+        );
     }
 
     #[test]
@@ -856,7 +969,7 @@ mod tests {
                         live_strip_on: false,
                         dock_visible: true,
                         appearance_open: false,
-                        paper_ready: true,
+                        paper: PaperTradeModel::flat(true),
                         // Non-empty on purpose: the entry rows (status dot,
                         // eye, trash) are only drawn when the menu has
                         // something in it, and an empty vec never exercises
@@ -935,7 +1048,7 @@ mod tests {
                         appearance_open: false,
                         // Not yet ready: the TRADE pair must lay out in its
                         // disabled state without asking anything of the app.
-                        paper_ready: false,
+                        paper: PaperTradeModel::flat(false),
                         indicators: Vec::new(),
                         scripts: Vec::new(),
                     };
@@ -944,5 +1057,89 @@ mod tests {
                 });
             }
         }
+    }
+
+    /// With a position open, the exit control reaches actual toolbar pixels
+    /// — the audit's pain 1 was precisely this button not existing anywhere
+    /// the user looks.
+    #[test]
+    fn an_open_position_paints_the_close_button() {
+        let ctx = egui::Context::default();
+        let mut feed_id = "binance".to_owned();
+        let mut symbol = "BTCUSDT".to_owned();
+        let mut kind = BarKind::Tick;
+        let mut tick_n = 50_u64;
+        let mut volume_units = 5.0_f64;
+        let mut dollar_notional = 500_000.0_f64;
+        let mut time_interval_ms = 1_000_i64;
+        let mut imbalance_target = 100_u64;
+        let mut history_step = 2_000_usize;
+        let mut painted = String::new();
+        // Wide enough that the §6 plan folds nothing — the point is the
+        // inline button, not the overflow menu.
+        let input = || egui::RawInput {
+            screen_rect: Some(egui::Rect::from_min_size(
+                egui::Pos2::ZERO,
+                egui::vec2(1900.0, 400.0),
+            )),
+            ..Default::default()
+        };
+        for _ in 0..2 {
+            let output = ctx.run(input(), |ctx| {
+                let mut model = ToolbarModel {
+                    feeds: vec![("binance".to_owned(), "Binance".to_owned())],
+                    feed_id: &mut feed_id,
+                    feed_display_name: "Binance".to_owned(),
+                    symbols: vec!["BTCUSDT".to_owned()],
+                    symbol: &mut symbol,
+                    replay: None,
+                    kind: &mut kind,
+                    tick_n: &mut tick_n,
+                    volume_units: &mut volume_units,
+                    dollar_notional: &mut dollar_notional,
+                    time_interval_ms: &mut time_interval_ms,
+                    imbalance_target: &mut imbalance_target,
+                    history_step: &mut history_step,
+                    history_trades: 1_000,
+                    capabilities: FeedCapabilities {
+                        book_capture: true,
+                        history_paging: true,
+                        traded_volume: true,
+                        ohlcv_history: true,
+                        ohlcv_generation: 0,
+                    },
+                    heatmap_on: false,
+                    bubbles_on: false,
+                    live_strip_on: false,
+                    dock_visible: true,
+                    appearance_open: false,
+                    paper: PaperTradeModel {
+                        buy_label: "BUY 1 (adds to 2)".to_owned(),
+                        sell_label: "SELL 1 (closes 1 of 2)".to_owned(),
+                        close_label: Some("Close 2 LONG".to_owned()),
+                        ..PaperTradeModel::flat(true)
+                    },
+                    indicators: Vec::new(),
+                    scripts: Vec::new(),
+                };
+                let actions = draw(ctx, &mut model);
+                assert!(actions.is_empty(), "no clicks, no actions");
+            });
+            painted.clear();
+            for shape in output.shapes {
+                if let egui::epaint::Shape::Text(text) = shape.shape {
+                    painted.push_str(text.galley.text());
+                    painted.push(' ');
+                }
+            }
+        }
+        assert!(
+            painted.contains("Close 2 LONG"),
+            "the exit control never reached the toolbar; painted: {painted}"
+        );
+        assert!(
+            painted.contains("SELL 1 (closes 1 of 2)"),
+            "the state-aware label never reached the toolbar; painted: {painted}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

First of the four P0 items from the August 2026 UX audit (`docs/ux/ux-audit-2026-08.md` §6, pain 1): the simulator had entry controls on the toolbar but every exit lived two levels deep in a collapsed dock, and the one persistent "you are long" statement was overpainted at the exact moment it mattered.

Resolves, from `docs/ux/ux-audit-2026-08/paper-trading.md`:

- **B2** — exit unreachable from any surface the user looks at: the toolbar grows a `× Close 1 LONG` button while a position is open (inline and in the overflow menu), the new position HUD carries Close/Reverse, and the status cell clicks through to the Trading tab.
- **B3** — position chip overpainted by the last-price chip at the fill instant: paper chips now dodge the reserved last-price row (`dodged_chip_y`, pure + tested); the line itself never moves off its true price.
- **M1** — status cell could not distinguish open from flat: now `SIM LONG 1 · +2 pts` open, `SIM +7 pts · flat` otherwise.
- **M2 (disclosure)** — SELL-while-long was an undisclosed close-or-reverse: state-aware labels (`SELL 1 (closes)`, `SELL 5 (reverses to short 4)`, `BUY 1 (adds to 2)`) driven by the same quantity the press will use; hover discloses quantity and bracket offsets.
- **M7** — position vanished when its price scrolled off-screen: the HUD persists with a directional caret naming the entry price and which way it left.
- Plus the dock badge: the Trading strip icon wears a side-colored dot while a position is open (amber stays provenance-only).

## Design notes

- `paper_hud.rs` is a new module; the pane only caches an anchor (rect + scale) and `tab.rs` draws the HUD where the paper host is mutably reachable — no new dependency edges, no logic forks.
- The toolbar collapse plan now measures the TRADE group from its actual labels (`trade_width`), since they grow and shrink with the position.
- Reverse is one market order for twice the size — the sim's own reversal semantics, with the form's protective offsets applied to the new entry.

## Verification

- `cargo fmt --all -- --check` / `cargo clippy --workspace --all-targets -- -D warnings` / `cargo build --workspace` / `cargo test --workspace` all green locally (682 app tests + workspace).
- arch-review run over the diff; both Should-fix findings applied (per-frame hover allocation in the dock strip; named width constants in `trade_width`). Deferred as Consider, noted here: click-driven tests for the status-cell click-through and HUD buttons (no repo precedent for simulating chrome clicks on these surfaces; the no-click halves are asserted), and the chip-dodge clamp edge case at pane edges is documented in code as accepted.
- New tests: entry-label matrix, open/flat status cell, close label, reverse-with-bracket, chip dodge, HUD drift/caret + real-paint, toolbar close-button paint, TRADE width folding, dock badge paint, and an end-to-end BUY → Close → flat app test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
