### PR TITLE
feat(app): venue history for any time-cutting pane, and a humane time route

### DIFF
--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -8478,6 +8478,91 @@ plot(close)
         );
     }
 
+    /// S1 end to end on the single-pane route: `bars → time` on the flow
+    /// pane asks the venue for candle history and wears the reply as its
+    /// prefix — the fix for the audit's BLOCKER-1, where the toolbar route
+    /// produced a 1-second chart and then an empty one. The venue prefix
+    /// belongs to what a pane shows, never to which pane object it is.
+    #[test]
+    fn the_flow_pane_cutting_time_bars_earns_the_venue_prefix() {
+        let ctx = egui::Context::default();
+        let (evt_tx, evt_rx) = mpsc::channel(64);
+        let (book_tx, book_rx) = mpsc::channel(64);
+        let (cmd_tx, mut cmd_rx) = mpsc::channel(16);
+        let mut app = QuantickApp::new(
+            test_config(),
+            "binance",
+            "TESTUSDT",
+            BarSpec::Tick(1),
+            FeedHandle {
+                events: evt_rx,
+                book_events: book_rx,
+                notices: feed::silent_notices(),
+                capabilities: feed::fixed_capabilities(FeedCapabilities {
+                    book_capture: false,
+                    history_paging: true,
+                    traded_volume: true,
+                    ohlcv_history: true,
+                    ohlcv_generation: 0,
+                }),
+                commands: cmd_tx,
+                replay: None,
+            },
+        );
+        let _ = book_tx;
+        let trades: Vec<_> = (0..200).map(minute_trade).collect();
+        evt_tx.try_send(FeedEvent::Backfilled(trades)).unwrap();
+        app.drain_tabs();
+        run_frame(&mut app, &ctx);
+        assert_eq!(
+            drain_ohlcv_requests(&mut cmd_rx),
+            0,
+            "a tick chart asks for no candles"
+        );
+
+        // The toolbar route: `bars → time`. The kind's default interval is a
+        // real timeframe (QW2), so the spec that lands is one minute.
+        app.active_tab_mut().flow_pane.kind = crate::state::BarKind::Time;
+        run_frame(&mut app, &ctx);
+        run_frame(&mut app, &ctx);
+        run_frame(&mut app, &ctx);
+        assert_eq!(
+            *app.active_tab().flow_pane.state.spec(),
+            BarSpec::Time(crate::time_header::DEFAULT_INTERVAL_MS),
+            "bars → time opens on 1m, not one second"
+        );
+        assert!(
+            drain_ohlcv_requests(&mut cmd_rx) >= 1,
+            "the time-cutting flow pane asks the venue for history"
+        );
+
+        evt_tx
+            .try_send(FeedEvent::OhlcvHistory {
+                interval_ms: crate::feed::OHLCV_BASE_INTERVAL_MS,
+                bars: venue_history(120),
+                complete: true,
+            })
+            .unwrap();
+        app.drain_tabs();
+        let tab = app.active_tab();
+        assert_eq!(
+            tab.flow_pane.seam_slot(),
+            120,
+            "the venue candles stand in front of the bars cut from prints"
+        );
+
+        // And leaving the time kind hands the prefix back: a tick chart is
+        // the tape's alone.
+        app.active_tab_mut().flow_pane.kind = crate::state::BarKind::Tick;
+        run_frame(&mut app, &ctx);
+        run_frame(&mut app, &ctx);
+        assert_eq!(
+            app.active_tab().flow_pane.seam_slot(),
+            0,
+            "a pane that stopped cutting by time carries no venue candles"
+        );
+    }
+
     /// "Load older" moves the first engine bar backwards in time, and the
     /// prefix was trimmed against where that bar used to be.
     ///

--- a/crates/app/src/pane.rs
+++ b/crates/app/src/pane.rs
@@ -432,8 +432,10 @@ pub struct ChartPane {
     /// [`Self::closed_bar`], the rebuild payload and the draw — and survives
     /// every rebuild the engine does.
     ///
-    /// Only ever non-empty on a time pane. The flow pane is the tape's, and a
-    /// venue candle has no tape in it.
+    /// Non-empty on any pane cutting by a foldable time interval — the
+    /// split's time pane, and the flow pane whenever its spec is
+    /// `BarSpec::Time` (audit S1). A venue candle has no tape in it, so over
+    /// the prefix the flow layers simply draw nothing.
     pub history_prefix: Vec<quantick_engine::Bar>,
 
     /// User drawings live entirely in the app overlay layer, never in market
@@ -469,7 +471,9 @@ impl ChartPane {
         let mut tick_n = 50;
         let mut volume_units = 5.0;
         let mut dollar_notional = 500_000.0;
-        let mut time_interval_ms = 1_000;
+        // `bars → time` opens on a real timeframe, not a one-second chart
+        // (audit QW2): the same 1m the split's time pane opens on.
+        let mut time_interval_ms = crate::time_header::DEFAULT_INTERVAL_MS;
         let mut imbalance_target = 100;
         match &spec {
             BarSpec::Tick(n) => tick_n = *n,
@@ -903,13 +907,11 @@ impl ChartPane {
     /// drawings keep their bars, the indicator columns keep their candles
     /// until the rebuild lands. Returns whether anything changed.
     pub fn install_history_prefix(&mut self, bars: Vec<quantick_engine::Bar>) -> bool {
-        // Only a time pane ever carries one, and a time pane has no tape. Held
-        // as an assertion rather than a comment because the draw path reads
-        // the two as mutually exclusive.
-        debug_assert!(
-            bars.is_empty() || self.orderflow.is_none(),
-            "a venue prefix belongs to a pane with no tape"
-        );
+        // Any time-cutting pane may carry one (audit S1) — the flow pane
+        // showing time bars included. On a pane with a tape the flow layers
+        // simply have nothing to draw over the prefix: a venue candle has no
+        // prints in it, and the projection maps only the engine's own bars
+        // (see `draw_chart`'s timeline).
         if !prefix_differs(&self.history_prefix, &bars) {
             return false;
         }
@@ -1773,11 +1775,13 @@ impl ChartPane {
         // to `lane_width_px` rather than restated, because the two decide the
         // same thing: with them apart, the newest prints would be clustered and
         // sized as lane prints and then squeezed into a single candle slot.
-        // Flow-pane only: a pane with a tape never carries a venue prefix, so
-        // the state half *is* the window here.
+        // Only the engine's own bars carry tape, so the timeline starts at
+        // the first *state* bar's global slot: when the window straddles the
+        // venue seam (a time-cutting flow pane, audit S1), that is the seam
+        // itself, not the window's first slot.
         let timeline = VisibleBarTimeline::new(
             self.state.timeline_revision(),
-            closed_start,
+            closed_start.max(prefix.len()),
             visible_state,
             partial_visible,
         );

--- a/crates/app/src/state.rs
+++ b/crates/app/src/state.rs
@@ -137,16 +137,34 @@ impl BarSpec {
         }
     }
 
-    /// A human-readable summary, e.g. `tick(50)` or `dollar(500000)`.
+    /// A human-readable summary, e.g. `tick(50)` or `time(1m)`.
     #[must_use]
     pub fn summary(&self) -> String {
         match self {
             BarSpec::Tick(n) => format!("tick({n})"),
             BarSpec::Volume(u) => format!("volume({u})"),
             BarSpec::Dollar(d) => format!("dollar({d})"),
-            BarSpec::Time(ms) => format!("time({ms}ms)"),
+            BarSpec::Time(ms) => format!("time({})", fmt_time_interval(*ms)),
             BarSpec::Imbalance(target) => format!("imbalance({target})"),
         }
+    }
+}
+
+/// A time-bar interval for humans: `1m`, `5m`, `1h` for round units, `90s`
+/// for whole seconds, raw milliseconds otherwise. The same vocabulary the
+/// timeframe chips speak, so the status bar, the toolbar and the chips can
+/// never disagree about what `60000` means (the audit's MAJOR-6: two time
+/// controls speaking different languages).
+#[must_use]
+pub fn fmt_time_interval(ms: i64) -> String {
+    if ms >= 3_600_000 && ms % 3_600_000 == 0 {
+        format!("{}h", ms / 3_600_000)
+    } else if ms >= 60_000 && ms % 60_000 == 0 {
+        format!("{}m", ms / 60_000)
+    } else if ms >= 1_000 && ms % 1_000 == 0 {
+        format!("{}s", ms / 1_000)
+    } else {
+        format!("{ms}ms")
     }
 }
 
@@ -428,6 +446,26 @@ mod tests {
         assert!(!BarKind::Tick.needs_traded_volume());
         assert!(!BarKind::Time.needs_traded_volume());
         assert!(!BarKind::Imbalance.needs_traded_volume());
+    }
+
+    /// One vocabulary for every surface that names a timeframe: the summary
+    /// speaks the chips' own labels, falling back to finer units only where
+    /// no coarser one writes the value back exactly.
+    #[test]
+    fn time_summaries_speak_the_chips_language() {
+        assert_eq!(fmt_time_interval(60_000), "1m");
+        assert_eq!(fmt_time_interval(300_000), "5m");
+        assert_eq!(fmt_time_interval(900_000), "15m");
+        assert_eq!(fmt_time_interval(3_600_000), "1h");
+        assert_eq!(
+            fmt_time_interval(90_000),
+            "90s",
+            "90s is not a round minute"
+        );
+        assert_eq!(fmt_time_interval(1_000), "1s");
+        assert_eq!(fmt_time_interval(1_500), "1500ms");
+        assert_eq!(BarSpec::Time(60_000).summary(), "time(1m)");
+        assert_eq!(BarSpec::Time(500).summary(), "time(500ms)");
     }
 
     #[test]

--- a/crates/app/src/tab.rs
+++ b/crates/app/src/tab.rs
@@ -304,7 +304,7 @@ impl Tab {
         self.ohlcv_pending = false;
         self.ohlcv_capable = false;
         self.loading.set_active(LoadingTask::VenueHistory, false);
-        if let Some(pane) = self.time_pane.as_mut() {
+        for pane in std::iter::once(&mut self.flow_pane).chain(self.time_pane.as_mut()) {
             pane.install_history_prefix(Vec::new());
         }
         self.events = handle.events;
@@ -370,15 +370,32 @@ impl Tab {
         self.attach(handle);
     }
 
+    /// Whether any pane on this tab cuts bars by a foldable time interval —
+    /// the gate for venue candle history. Capability-shaped, like every other
+    /// gate in the app (audit S1): the prefix belongs to what a pane *shows*
+    /// (`BarSpec::Time` at a whole number of venue candles), never to which
+    /// pane object it is. `bars → time` on the flow pane earns the same 90
+    /// days the split's time pane gets.
+    fn any_pane_wants_venue_history(&self) -> bool {
+        std::iter::once(&self.flow_pane)
+            .chain(self.time_pane.as_ref())
+            .any(|pane| {
+                pane.state
+                    .spec()
+                    .time_interval_ms()
+                    .is_some_and(crate::resample::is_foldable)
+            })
+    }
+
     /// Ask the venue for its candle history, if there is anything to ask.
     ///
     /// Gated on the capability, never on the provider: a feed that serves no
     /// candles, and a recording — which is a fixed span of prints with no
     /// venue behind it — are both simply not asked. One request at a time, and
-    /// a base already held is not re-fetched: changing the pane's interval is
+    /// a base already held is not re-fetched: changing a pane's interval is
     /// a different fold over the same bars.
     fn request_ohlcv_history(&mut self, config: &AppConfig) {
-        if self.time_pane.is_none()
+        if !self.any_pane_wants_venue_history()
             || self.replay.is_some()
             || self.ohlcv_pending
             || self.ohlcv_base.is_some()
@@ -527,32 +544,38 @@ impl Tab {
         self.refold_history_prefix();
     }
 
-    /// Rebuild the time pane's prefix from the base at the pane's interval.
+    /// Rebuild every pane's prefix from the base at that pane's interval.
     ///
-    /// Free of the venue: a chip click lands here, not on the network.
-    /// Reports whether the prefix actually changed — an installed prefix
+    /// Free of the venue: a chip click lands here, not on the network. One
+    /// base, one fold per time-cutting pane — the flow pane showing time
+    /// bars folds exactly as the split's time pane does (audit S1).
+    /// Reports whether any prefix actually changed — an installed prefix
     /// rebuilds the indicators, so the caller can skip sending a second one.
     pub fn refold_history_prefix(&mut self) -> bool {
         let Some(base) = self.ohlcv_base.as_ref() else {
             return false;
         };
-        let Some(pane) = self.time_pane.as_mut() else {
-            return false;
-        };
-        // A pane not cutting by time has no interval to fold to, and a
-        // sub-minute one has no whole number of venue candles in it: both get
-        // no prefix, which is the honest answer rather than an invented one.
-        let Some(interval) = pane.state.spec().time_interval_ms() else {
-            return pane.install_history_prefix(Vec::new());
-        };
-        let folded = crate::resample::fold(base, interval);
-        let prefix = trim_to_seam(
-            folded,
-            pane.state.bars().first(),
-            pane.state.partial(),
-            interval,
-        );
-        pane.install_history_prefix(prefix)
+        let mut changed = false;
+        for pane in std::iter::once(&mut self.flow_pane).chain(self.time_pane.as_mut()) {
+            // A pane not cutting by time has no interval to fold to, and a
+            // sub-minute one has no whole number of venue candles in it: both
+            // get no prefix, which is the honest answer rather than an
+            // invented one.
+            let prefix = match pane.state.spec().time_interval_ms() {
+                Some(interval) => {
+                    let folded = crate::resample::fold(base, interval);
+                    trim_to_seam(
+                        folded,
+                        pane.state.bars().first(),
+                        pane.state.partial(),
+                        interval,
+                    )
+                }
+                None => Vec::new(),
+            };
+            changed |= pane.install_history_prefix(prefix);
+        }
+        changed
     }
 
     /// Whether this tab has trouble worth showing on its chip while it sits in
@@ -1078,13 +1101,15 @@ impl Tab {
                 // The venue prefix folds to the new interval before the view
                 // is reanchored: the market time the user was looking at has
                 // to resolve against the series they will be looking at.
+                // Either pane: `bars → time` on the flow pane is exactly the
+                // spec change this refold exists for (audit S1).
                 //
                 // Installing a prefix rebuilds the indicators over the whole
                 // composed series, so the plain rebuild is only sent when the
                 // refold did not — two rebuilds of ~130k bars per settled drag
                 // frame, with no coalescing in the worker, is the cost of
                 // sending both.
-                let refolded = side == PaneSide::Time && self.refold_history_prefix();
+                let refolded = self.refold_history_prefix();
                 if !refolded {
                     self.pane_mut(side).send_indicator_rebuild();
                 }

--- a/crates/app/src/toolbar.rs
+++ b/crates/app/src/toolbar.rs
@@ -953,8 +953,7 @@ mod tests {
     #[test]
     fn the_time_kind_widens_the_param_slot_and_folds_sooner() {
         assert!(param_width(BarKind::Time) > param_width(BarKind::Tick));
-        let exactly_drag =
-            CollapsePlan::FULL.width(FLAT_TRADE_W, param_width(BarKind::Tick));
+        let exactly_drag = CollapsePlan::FULL.width(FLAT_TRADE_W, param_width(BarKind::Tick));
         assert_eq!(
             stage(collapse_plan(
                 exactly_drag,

--- a/crates/app/src/toolbar.rs
+++ b/crates/app/src/toolbar.rs
@@ -39,8 +39,10 @@ const W_SOURCE_FULL: f32 = 350.0;
 const W_SOURCE_SHRUNK: f32 = 260.0;
 /// BARS without the parameter widget.
 const W_BARS: f32 = 160.0;
-/// The bar-parameter label + drag value.
+/// The bar-parameter label + drag value (every kind but time).
 const W_BAR_PARAM: f32 = 150.0;
+/// The time kind's parameter row: four preset chips plus the custom drag.
+const W_TIME_PARAM: f32 = 260.0;
 /// The `+ older ▾` split button.
 const W_HISTORY: f32 = 100.0;
 /// The simulated BUY/SELL pair.
@@ -93,8 +95,10 @@ impl CollapsePlan {
     /// Estimated width of the toolbar under this plan. The `⋯` slot is
     /// always reserved: it appears exactly when something folds, so counting
     /// it conditionally would make the first fold width-neutral and leave
-    /// the planner skipping straight past it.
-    fn width(self) -> f32 {
+    /// the planner skipping straight past it. `param_width` comes in as a
+    /// parameter because the time kind's chip row is wider than the other
+    /// kinds' single drag (see [`param_width`]).
+    fn width(self, param_width: f32) -> f32 {
         let mut width = W_SLACK + W_ICON + W_BARS + W_LAYERS;
         width += if self.feed_full_name {
             W_SOURCE_FULL
@@ -102,7 +106,7 @@ impl CollapsePlan {
             W_SOURCE_SHRUNK
         };
         if self.param_inline {
-            width += W_BAR_PARAM;
+            width += param_width;
         }
         if self.history_inline {
             width += W_HISTORY;
@@ -124,7 +128,7 @@ impl CollapsePlan {
 /// The last plan is accepted even when it still overflows — there is nothing
 /// left to fold, and the symbol and LAYERS are never candidates.
 #[must_use]
-pub fn collapse_plan(available: f32) -> CollapsePlan {
+pub fn collapse_plan(available: f32, param_width: f32) -> CollapsePlan {
     let mut plan = CollapsePlan::FULL;
     let steps: [fn(&mut CollapsePlan); 6] = [
         |plan| plan.look_inline = false,
@@ -135,12 +139,23 @@ pub fn collapse_plan(available: f32) -> CollapsePlan {
         |plan| plan.feed_full_name = false,
     ];
     for fold in steps {
-        if plan.width() <= available {
+        if plan.width(param_width) <= available {
             return plan;
         }
         fold(&mut plan);
     }
     plan
+}
+
+/// Estimated width of the selected kind's parameter row, for the collapse
+/// plan: the time kind carries the preset chips (audit QW1), so its row is
+/// wider than the single label + drag every other kind shows.
+#[must_use]
+pub fn param_width(kind: BarKind) -> f32 {
+    match kind {
+        BarKind::Time => W_TIME_PARAM,
+        _ => W_BAR_PARAM,
+    }
 }
 
 /// The amber label that replaces SOURCE while a recording plays.
@@ -272,7 +287,7 @@ pub fn draw(ctx: &egui::Context, model: &mut ToolbarModel) -> Vec<ToolbarAction>
                 .inner_margin(egui::Margin::symmetric(8.0, 0.0)),
         )
         .show(ctx, |ui| {
-            let plan = collapse_plan(ui.available_width());
+            let plan = collapse_plan(ui.available_width(), param_width(*model.kind));
             ui.horizontal_centered(|ui| {
                 ui.spacing_mut().item_spacing.x = 6.0;
                 draw_source(ui, model, plan);
@@ -415,15 +430,28 @@ fn draw_bar_param(ui: &mut egui::Ui, model: &mut ToolbarModel) {
             );
         }
         BarKind::Time => {
-            ui.label("interval ms");
-            ui.add(
-                egui::DragValue::new(model.time_interval_ms)
-                    .range(
-                        crate::state::MIN_TIME_INTERVAL_MS as f64
-                            ..=crate::state::MAX_TIME_INTERVAL_MS as f64,
-                    )
-                    .speed(crate::state::TIME_INTERVAL_DRAG_SPEED),
-            );
+            // The same four presets the time pane's header offers — one
+            // list, two surfaces (§11) — with the drag as the custom escape
+            // hatch. `bars → time` must not require knowing that a minute is
+            // 60000 (audit QW1).
+            ui.horizontal(|ui| {
+                for (label, preset_ms) in crate::time_header::PRESETS {
+                    let selected = *model.time_interval_ms == preset_ms;
+                    if ui.selectable_label(selected, label).clicked() && !selected {
+                        *model.time_interval_ms = preset_ms;
+                    }
+                }
+                ui.add(
+                    egui::DragValue::new(model.time_interval_ms)
+                        .range(
+                            crate::state::MIN_TIME_INTERVAL_MS as f64
+                                ..=crate::state::MAX_TIME_INTERVAL_MS as f64,
+                        )
+                        .speed(crate::state::TIME_INTERVAL_DRAG_SPEED)
+                        .suffix(" ms"),
+                )
+                .on_hover_text("custom interval, in milliseconds");
+            });
         }
         BarKind::Imbalance => {
             ui.label("target trades");
@@ -436,13 +464,14 @@ fn draw_bar_param(ui: &mut egui::Ui, model: &mut ToolbarModel) {
     }
 }
 
-/// Short parameter readout for the merged kind combo, e.g. `tick · 50`.
+/// Short parameter readout for the merged kind combo, e.g. `tick · 50` or
+/// `time · 1m` — the chips' own vocabulary, never raw milliseconds (QW3).
 fn param_summary(model: &ToolbarModel) -> String {
     match model.kind {
         BarKind::Tick => model.tick_n.to_string(),
         BarKind::Volume => format!("{:.1}", model.volume_units),
         BarKind::Dollar => format!("{:.0}", model.dollar_notional),
-        BarKind::Time => format!("{} ms", model.time_interval_ms),
+        BarKind::Time => crate::state::fmt_time_interval(*model.time_interval_ms),
         BarKind::Imbalance => model.imbalance_target.to_string(),
     }
 }
@@ -759,14 +788,14 @@ mod tests {
 
     #[test]
     fn a_wide_toolbar_folds_nothing() {
-        let plan = collapse_plan(10_000.0);
+        let plan = collapse_plan(10_000.0, W_BAR_PARAM);
         assert_eq!(stage(plan), Some(0));
         assert!(!plan.overflow_needed());
     }
 
     #[test]
     fn a_hopeless_width_ends_fully_folded() {
-        let plan = collapse_plan(0.0);
+        let plan = collapse_plan(0.0, W_BAR_PARAM);
         assert_eq!(stage(plan), Some(6));
         assert!(plan.overflow_needed());
     }
@@ -778,7 +807,7 @@ mod tests {
         // and every plan must be one of the canonical §6 states.
         let mut width = 100.0;
         while width <= 2000.0 {
-            let plan = collapse_plan(width);
+            let plan = collapse_plan(width, W_BAR_PARAM);
             let stage = stage(plan).expect("plans fold strictly in the §6 order");
             assert!(
                 stage <= last_stage,
@@ -793,10 +822,27 @@ mod tests {
     #[test]
     fn look_folds_first_and_alone_at_a_mildly_tight_width() {
         // One pixel short of the full plan: exactly LOOK moves to overflow.
-        let full_width = CollapsePlan::FULL.width();
-        let plan = collapse_plan(full_width - 1.0);
+        let full_width = CollapsePlan::FULL.width(W_BAR_PARAM);
+        let plan = collapse_plan(full_width - 1.0, W_BAR_PARAM);
         assert_eq!(stage(plan), Some(1));
         assert!(plan.overflow_needed());
+    }
+
+    /// The time kind's chip row widens the parameter slot, and the plan
+    /// reads that width: what exactly fits a drag-only kind folds once the
+    /// chips are on screen.
+    #[test]
+    fn the_time_kind_widens_the_param_slot_and_folds_sooner() {
+        assert!(param_width(BarKind::Time) > param_width(BarKind::Tick));
+        let exactly_drag = CollapsePlan::FULL.width(param_width(BarKind::Tick));
+        assert_eq!(
+            stage(collapse_plan(exactly_drag, param_width(BarKind::Tick))),
+            Some(0)
+        );
+        assert!(
+            stage(collapse_plan(exactly_drag, param_width(BarKind::Time))).expect("canonical") > 0,
+            "the wider chip row must fold something at the same window width"
+        );
     }
 
     #[test]
@@ -884,6 +930,86 @@ mod tests {
                 });
             }
         }
+    }
+
+    /// With the time kind selected, the preset chips reach actual toolbar
+    /// pixels — the audit's pain 2 began with `bars → time` offering a bare
+    /// millisecond drag (QW1), and the summary speaks the chips' vocabulary
+    /// (QW3).
+    #[test]
+    fn the_time_kind_paints_the_preset_chips() {
+        let ctx = egui::Context::default();
+        let mut feed_id = "binance".to_owned();
+        let mut symbol = "BTCUSDT".to_owned();
+        let mut kind = BarKind::Time;
+        let mut tick_n = 50_u64;
+        let mut volume_units = 5.0_f64;
+        let mut dollar_notional = 500_000.0_f64;
+        let mut time_interval_ms = 60_000_i64;
+        let mut imbalance_target = 100_u64;
+        let mut history_step = 2_000_usize;
+        // Wide enough that the §6 plan folds nothing — the point is the
+        // inline chip row, not the overflow menu.
+        let input = || egui::RawInput {
+            screen_rect: Some(egui::Rect::from_min_size(
+                egui::Pos2::ZERO,
+                egui::vec2(1900.0, 400.0),
+            )),
+            ..Default::default()
+        };
+        let mut painted = String::new();
+        for _ in 0..2 {
+            let output = ctx.run(input(), |ctx| {
+                let mut model = ToolbarModel {
+                    feeds: vec![("binance".to_owned(), "Binance".to_owned())],
+                    feed_id: &mut feed_id,
+                    feed_display_name: "Binance".to_owned(),
+                    symbols: vec!["BTCUSDT".to_owned()],
+                    symbol: &mut symbol,
+                    replay: None,
+                    kind: &mut kind,
+                    tick_n: &mut tick_n,
+                    volume_units: &mut volume_units,
+                    dollar_notional: &mut dollar_notional,
+                    time_interval_ms: &mut time_interval_ms,
+                    imbalance_target: &mut imbalance_target,
+                    history_step: &mut history_step,
+                    history_trades: 1_000,
+                    capabilities: FeedCapabilities {
+                        book_capture: true,
+                        history_paging: true,
+                        traded_volume: true,
+                        ohlcv_history: true,
+                        ohlcv_generation: 0,
+                    },
+                    heatmap_on: false,
+                    bubbles_on: false,
+                    live_strip_on: false,
+                    dock_visible: true,
+                    appearance_open: false,
+                    paper_ready: true,
+                    indicators: Vec::new(),
+                    scripts: Vec::new(),
+                };
+                let actions = draw(ctx, &mut model);
+                assert!(actions.is_empty(), "no clicks, no actions");
+            });
+            painted.clear();
+            for shape in output.shapes {
+                if let egui::epaint::Shape::Text(text) = shape.shape {
+                    painted.push_str(text.galley.text());
+                    painted.push(' ');
+                }
+            }
+        }
+        for chip in ["1m", "5m", "15m", "1h"] {
+            assert!(
+                painted.contains(chip),
+                "the {chip} preset never reached the toolbar; painted: {painted}"
+            );
+        }
+        assert_eq!(kind, BarKind::Time, "an un-clicked frame changes nothing");
+        assert_eq!(time_interval_ms, 60_000);
     }
 
     /// The same layout for a venue that prints no volume — the shape a live


### PR DESCRIPTION
## Summary

Second of the four P0 items from the August 2026 UX audit (`docs/ux/ux-audit-2026-08.md` §3, pain 2): the obvious route to a timeframe chart — the toolbar's `bars → time` — opened at one second and, corrected to a real timeframe, produced a one-bar chart, because the 90-day venue candle history was keyed to *which pane object* showed it rather than to *what the pane shows*.

Resolves, from `docs/ux/ux-audit-2026-08/tabs-timeframe.md`:

- **BLOCKER-1** (via **S1 + QW2**) — the venue prefix is now capability-shaped: any pane whose spec is `BarSpec::Time` at a foldable interval earns it, the flow pane included. `bars → time` opens at 1m (the split's own default) and stands on the same ~90 days of venue candles the split's time pane gets. Leaving the time kind hands the prefix back — a tick chart is the tape's alone.
- **MAJOR-6** (via **QW3**) — the two time controls spoke different languages (`1m` chips vs `time(60000ms)` readouts): one shared formatter (`state::fmt_time_interval`) makes the status bar and the toolbar speak the chips' vocabulary — `time(1m)`, `time(5m)`, falling back to `90s`/`ms` only where no coarser unit writes the value back exactly.
- **QW1** — the BARS group's time parameter is the same 1m/5m/15m/1h preset row the time pane's header offers (one list, `time_header::PRESETS`), with the ms drag kept as the custom escape hatch; the collapse plan measures the wider chip row (`param_width`).

## Design notes

- The one structural change behind S1 is the boundary in `install_history_prefix`: the old `debug_assert` ("a venue prefix belongs to a pane with no tape") is retired, and the orderflow projection's timeline now starts at the first *engine* bar's global slot (`closed_start.max(prefix.len())`) — venue candles carry no tape, so flow layers simply have nothing to draw over the prefix, and stay correctly placed when the window straddles the seam.
- Sub-minute intervals still get no prefix (an honest absence — `resample::is_foldable` is unchanged), and the request gate stays capability-driven (`ohlcv_history`), never provider-driven.
- One base fetch per tab, folds per pane: a chip click is still a local refold, never a network round trip.

## Verification

- All four checks green locally (674 app tests + workspace).
- arch-review over the diff: no Blocker/Should-fix. Two Consider findings, deferred deliberately: (1) the seam-straddle timeline index fix has no direct test — proving it needs a projection-level harness with a prefixed flow pane; the invariant is documented at the call site. (2) a spec change now refolds every time-cutting pane, so the unchanged pane pays one wasted O(base) fold on a rare, user-initiated path — declared rather than optimized, per the priority table (panel edits: clarity wins).
- New tests: flow-pane-earns-the-prefix end to end (request gating, 1m default spec, seam at 120, prefix handed back on leaving the time kind), `fmt_time_interval` matrix + `time(1m)` summaries, toolbar chip row painted with no actions on an un-clicked frame, and the param-width fold test.
- Interacts with #122 only at merge time (`collapse_plan` gained a different parameter on each branch — `trade_width` there, `param_width` here; the resolution is to accept both).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
