### PR TITLE
feat(app): on-chart indicator legend, and a settings dialog that stays put

### DIFF
--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -26,6 +26,7 @@ use crate::drawings::{
     self, DeleteOutcome, MAX_DRAWING_FILL_ALPHA, MAX_DRAWING_WIDTH_PX, MIN_DRAWING_WIDTH_PX,
 };
 use crate::feed::{self, FeedCommand, FeedHandle};
+use crate::indicator_legend;
 use crate::indicator_panel::{self, SettingsDialog, SettingsOutcome};
 use crate::indicator_worker::{IndicatorCommand, IndicatorEvent, IndicatorSource, SlotId};
 use crate::indicators::library::ScriptLibrary;
@@ -1044,42 +1045,19 @@ impl QuantickApp {
                 self.add_native_indicator(SavedKind::NativeCvd);
             }
             ToolbarAction::ToggleIndicatorHidden(slot) => {
-                self.focused_pane_mut()
-                    .indicators
-                    .toggle_hidden(SlotId(slot));
-                self.mark_indicator_state_dirty();
+                let target = self.target_slot(SlotId(slot));
+                self.toggle_indicator_hidden_at(target);
             }
             ToolbarAction::RemoveIndicator(slot) => {
                 let target = self.target_slot(SlotId(slot));
-                // UI first (the entry vanishes this frame), worker second;
-                // events already in flight for the slot are dropped on apply.
-                let pane = self.focused_pane_mut();
-                pane.indicators.remove(target.slot);
-                pane.indicator_worker
-                    .send(IndicatorCommand::Remove(target.slot));
-                self.slot_kinds.retain(|(owner, _)| *owner != target);
-                self.script_files.retain(|(owner, ..)| *owner != target);
-                self.mark_indicator_state_dirty();
+                self.remove_indicator_at(target);
             }
             ToolbarAction::AddScriptIndicator(index) => {
                 self.add_script_indicator(index);
             }
             ToolbarAction::OpenIndicatorSettings(slot) => {
                 let target = self.target_slot(SlotId(slot));
-                if let Some(view) = self
-                    .focused_pane()
-                    .indicators
-                    .all()
-                    .iter()
-                    .find(|v| v.slot == target.slot)
-                {
-                    self.indicator_settings = Some(SettingsDialog {
-                        slot: target.slot,
-                        title: view.label().to_owned(),
-                        draft: view.input_values.clone(),
-                    });
-                    self.indicator_settings_target = target;
-                }
+                self.open_indicator_settings_at(target);
             }
             // The toolbar acts on the market it is showing: the active tab's
             // simulator, whose tape the buttons' price came from.
@@ -1091,6 +1069,102 @@ impl QuantickApp {
                 .active_tab_mut()
                 .paper
                 .market(quantick_engine::Side::Sell),
+        }
+    }
+
+    /// Flip a slot's render-side eye, wherever the slot lives. Addressed by
+    /// [`TabSlot`], never by focus: the legend acts on the pane it is drawn
+    /// on, and the toolbar path builds its target from focus before calling.
+    fn toggle_indicator_hidden_at(&mut self, target: TabSlot) {
+        let Some(tab) = self.tabs.iter_mut().find(|tab| tab.id == target.tab) else {
+            return;
+        };
+        tab.pane_mut(target.side)
+            .indicators
+            .toggle_hidden(target.slot);
+        self.mark_indicator_state_dirty();
+    }
+
+    /// Remove a slot, wherever it lives. UI first (the entry vanishes this
+    /// frame), worker second; events already in flight for the slot are
+    /// dropped on apply.
+    fn remove_indicator_at(&mut self, target: TabSlot) {
+        let Some(tab) = self.tabs.iter_mut().find(|tab| tab.id == target.tab) else {
+            return;
+        };
+        let pane = tab.pane_mut(target.side);
+        pane.indicators.remove(target.slot);
+        pane.indicator_worker
+            .send(IndicatorCommand::Remove(target.slot));
+        self.slot_kinds.retain(|(owner, _)| *owner != target);
+        self.script_files.retain(|(owner, ..)| *owner != target);
+        self.mark_indicator_state_dirty();
+    }
+
+    /// Open the settings dialog for a slot, wherever it lives.
+    fn open_indicator_settings_at(&mut self, target: TabSlot) {
+        let Some(view) = self
+            .tabs
+            .iter()
+            .find(|tab| tab.id == target.tab)
+            .map(|tab| tab.pane(target.side))
+            .and_then(|pane| {
+                pane.indicators
+                    .all()
+                    .iter()
+                    .find(|view| view.slot == target.slot)
+            })
+        else {
+            return;
+        };
+        self.indicator_settings = Some(SettingsDialog {
+            slot: target.slot,
+            title: view.label().to_owned(),
+            draft: view.input_values.clone(),
+        });
+        self.indicator_settings_target = target;
+    }
+
+    /// Draw each visible pane's indicator legend and run what its rows asked
+    /// for. Actions resolve against the pane the legend was drawn on — the
+    /// legend must never act on the chart beside it (the audit's MAJOR-4
+    /// trap, avoided by construction).
+    fn draw_indicator_legends(&mut self, ctx: &egui::Context) {
+        let tab_id = self.active_tab().id;
+        let split = self.active_tab().layout == CanvasLayout::TimeAndFlow
+            && self.active_tab().time_pane.is_some();
+        let mut pending: Vec<(PaneSide, indicator_legend::LegendAction)> = Vec::new();
+        for side in [PaneSide::Flow, PaneSide::Time] {
+            if side == PaneSide::Time && !split {
+                continue;
+            }
+            let pane = self.active_tab().pane(side);
+            // The rect is last frame's, like every anchor the input path
+            // reads; a pane not yet drawn has none and draws no legend.
+            let Some(rect) = pane.last_chart_area else {
+                continue;
+            };
+            for action in indicator_legend::draw(ctx, pane.id, rect, pane.indicators.all()) {
+                pending.push((side, action));
+            }
+        }
+        for (side, action) in pending {
+            let at = |slot| TabSlot {
+                tab: tab_id,
+                side,
+                slot,
+            };
+            match action {
+                indicator_legend::LegendAction::ToggleHidden(slot) => {
+                    self.toggle_indicator_hidden_at(at(slot));
+                }
+                indicator_legend::LegendAction::OpenSettings(slot) => {
+                    self.open_indicator_settings_at(at(slot));
+                }
+                indicator_legend::LegendAction::Remove(slot) => {
+                    self.remove_indicator_at(at(slot));
+                }
+            }
         }
     }
 
@@ -1124,26 +1198,36 @@ impl QuantickApp {
                 *indicator_settings = None;
                 return;
             };
+            // Follow the live label: an applied edit can retitle the
+            // indicator (`EMA(9)` → `EMA(21)`), and a dialog that stays open
+            // must not keep announcing the old one.
+            dialog.title = view.label().to_owned();
             indicator_panel::draw(ctx, dialog, &view.descriptor.inputs)
         };
         match outcome {
             SettingsOutcome::Open => {}
-            SettingsOutcome::Cancel => self.indicator_settings = None,
-            SettingsOutcome::Apply => {
-                let dialog = self.indicator_settings.take().expect("dialog is open");
-                // The slot the dialog was opened on, not whatever has focus
-                // now: clicking Apply must not retarget the edit.
-                if let Some(tab) = self.tabs.iter_mut().find(|tab| tab.id == target.tab) {
-                    tab.pane_mut(target.side)
-                        .indicator_worker
-                        .send(IndicatorCommand::SetInputs {
-                            slot: dialog.slot,
-                            values: dialog.draft,
-                        });
-                }
-                self.mark_indicator_state_dirty();
-            }
+            SettingsOutcome::Close => self.indicator_settings = None,
+            SettingsOutcome::Apply => self.apply_indicator_settings_draft(),
         }
+    }
+
+    /// Send the open dialog's draft to the worker and keep the dialog open
+    /// (audit M2): tuning is a nudge-and-look loop, and a dialog that dies
+    /// on every Apply makes each attempt four clicks. The slot is the one
+    /// the dialog was opened on, not whatever has focus now — clicking
+    /// Apply must not retarget the edit.
+    fn apply_indicator_settings_draft(&mut self) {
+        let target = self.indicator_settings_target;
+        let Some(dialog) = self.indicator_settings.as_ref() else {
+            return;
+        };
+        let (slot, values) = (dialog.slot, dialog.draft.clone());
+        if let Some(tab) = self.tabs.iter_mut().find(|tab| tab.id == target.tab) {
+            tab.pane_mut(target.side)
+                .indicator_worker
+                .send(IndicatorCommand::SetInputs { slot, values });
+        }
+        self.mark_indicator_state_dirty();
     }
 
     /// Load a library script behind a fresh slot. A file that no longer
@@ -3024,6 +3108,7 @@ impl QuantickApp {
         self.draw_toolbar(ctx);
         self.draw_source_picker(ctx);
         self.draw_indicator_settings(ctx);
+        self.draw_indicator_legends(ctx);
         self.poll_script_files();
         self.maintain_indicator_state();
         self.maintain_chart_layers();
@@ -7794,6 +7879,91 @@ plot(close)
                 .iter()
                 .all(|(owner, _)| owner.side == PaneSide::Time),
             "and it is the time pane's"
+        );
+    }
+
+    /// Apply keeps the dialog open (audit M2): tuning is a nudge-and-look
+    /// loop, and each Apply must land without re-opening anything. The nudge
+    /// really lands — the EMA's length changes and the view retitles.
+    #[test]
+    fn apply_keeps_the_settings_dialog_open_and_lands_the_draft() {
+        let ctx = egui::Context::default();
+        let (mut app, _commands) = split_app(&ctx, 200);
+        let point = pane_point(&app, PaneSide::Flow);
+        click_chart(&mut app, &ctx, point);
+        app.apply_toolbar_action(ToolbarAction::AddEmaIndicator);
+        settle_indicators(&mut app);
+        let slot = app.active_tab().flow_pane.indicators.all()[0].slot;
+        app.apply_toolbar_action(ToolbarAction::OpenIndicatorSettings(slot.0));
+        assert!(app.indicator_settings.is_some(), "the dialog opened");
+
+        if let Some(dialog) = app.indicator_settings.as_mut()
+            && let Some(quantick_indicators::InputValue::Int(len)) = dialog.draft.first_mut()
+        {
+            *len = 21;
+        }
+        app.apply_indicator_settings_draft();
+        assert!(
+            app.indicator_settings.is_some(),
+            "Apply keeps the dialog open for the next nudge"
+        );
+        settle_indicators(&mut app);
+        let label = app.active_tab().flow_pane.indicators.all()[0]
+            .label()
+            .to_owned();
+        assert!(
+            label.contains("21"),
+            "the applied draft rebuilt the indicator: {label}"
+        );
+    }
+
+    /// A legend row acts on the pane it is drawn on, never the focused one —
+    /// the routing that keeps the audit's "commands target one pane, chrome
+    /// speaks for another" contradiction from reappearing here.
+    #[test]
+    fn legend_actions_land_on_their_own_pane_not_the_focused_one() {
+        let ctx = egui::Context::default();
+        let (mut app, _commands) = split_app(&ctx, 200);
+        // An EMA on the time pane...
+        let point = pane_point(&app, PaneSide::Time);
+        click_chart(&mut app, &ctx, point);
+        app.apply_toolbar_action(ToolbarAction::AddEmaIndicator);
+        settle_indicators(&mut app);
+        let slot = app
+            .active_tab()
+            .time_pane
+            .as_ref()
+            .expect("time pane")
+            .indicators
+            .all()[0]
+            .slot;
+        // ...while focus returns to the flow pane.
+        let point = pane_point(&app, PaneSide::Flow);
+        click_chart(&mut app, &ctx, point);
+        assert_eq!(app.active_tab().focused_side(), PaneSide::Flow);
+
+        let target = TabSlot {
+            tab: app.active_tab().id,
+            side: PaneSide::Time,
+            slot,
+        };
+        app.toggle_indicator_hidden_at(target);
+        assert!(
+            app.active_tab()
+                .time_pane
+                .as_ref()
+                .expect("time pane")
+                .indicators
+                .all()[0]
+                .hidden,
+            "the time pane's own slot was toggled, focus notwithstanding"
+        );
+        app.open_indicator_settings_at(target);
+        assert!(app.indicator_settings.is_some());
+        assert_eq!(
+            app.indicator_settings_target.side,
+            PaneSide::Time,
+            "the dialog's Apply will land on the legend's pane"
         );
     }
 

--- a/crates/app/src/chart.rs
+++ b/crates/app/src/chart.rs
@@ -352,6 +352,24 @@ const AXIS_MAX_DECIMALS: usize = 4;
 /// Steps are 1/2/5 × a power of ten, so the only error to absorb is the one
 /// binary floating point introduces.
 const AXIS_STEP_EPSILON: f64 = 1e-6;
+/// Decimals a compact readout shows below the smallest abbreviation unit.
+const COMPACT_VALUE_DECIMALS: usize = 2;
+
+/// One value for a compact readout (the indicator legend's last-value cell):
+/// the axis units' own spellings — `1.20M`, `3.40K` — so the legend and the
+/// axis beside it can never write a thousand two ways. Non-finite values are
+/// an honest `—`, never a `NaN` on screen.
+#[must_use]
+pub fn compact_value(value: f64) -> String {
+    if !value.is_finite() {
+        return "—".to_owned();
+    }
+    let (unit, suffix) = AXIS_UNITS
+        .into_iter()
+        .find(|(threshold, _)| value.abs() >= *threshold)
+        .unwrap_or((1.0, ""));
+    format!("{:.COMPACT_VALUE_DECIMALS$}{suffix}", value / unit)
+}
 
 /// Labelled ticks for a vertical axis `height_px` tall spanning `[lo, hi]`:
 /// round numbers, written against the step they advance by and the magnitude
@@ -495,6 +513,19 @@ mod tests {
     use super::*;
     use rust_decimal::Decimal;
     use std::str::FromStr as _;
+
+    /// The legend's value cell speaks the axis' own abbreviations, and a
+    /// missing value is a blank, never a `NaN`.
+    #[test]
+    fn compact_values_share_the_axis_spellings() {
+        assert_eq!(compact_value(70.0), "70.00");
+        assert_eq!(compact_value(-3.25), "-3.25");
+        assert_eq!(compact_value(1_234.0), "1.23K");
+        assert_eq!(compact_value(-2_500_000.0), "-2.50M");
+        assert_eq!(compact_value(7.2e9), "7.20B");
+        assert_eq!(compact_value(f64::NAN), "—");
+        assert_eq!(compact_value(f64::INFINITY), "—");
+    }
 
     fn bar(low: &str, high: &str) -> Bar {
         let l = Decimal::from_str(low).unwrap();

--- a/crates/app/src/indicator_legend.rs
+++ b/crates/app/src/indicator_legend.rs
@@ -1,0 +1,303 @@
+//! The on-chart indicator legend (audit S1; spec'd in
+//! `docs/ux/ui-design-model.md` §9 and never built): one row per indicator
+//! on the pane, pinned to the chart's top-left — colour dot, name, last
+//! value, and the eye / gear / remove controls beside it. Double-clicking
+//! the name opens settings, the TradingView gesture the audit's pain 3
+//! found nowhere to happen.
+//!
+//! Error and stale rows say so *on the chart*, red and amber, with the full
+//! message on hover. An errored indicator used to disappear from the render
+//! with its message computed and never shown (B1) — against the project's
+//! data-honesty rule; this surface is where that statement now lives.
+
+use eframe::egui;
+use egui_phosphor::regular as icons;
+use quantick_indicators::Rgba8;
+
+use crate::chart;
+use crate::indicator_worker::SlotId;
+use crate::indicators::IndicatorView;
+use crate::theme;
+
+/// Gap between the pane's corner and the legend, in pixels.
+const LEGEND_MARGIN_PX: f32 = 8.0;
+/// Diameter of a row's colour dot, in pixels.
+const DOT_DIAMETER_PX: f32 = 8.0;
+/// How much of a hidden row's dot colour survives — enough to still name
+/// the plot, faded enough to read as off.
+const HIDDEN_DOT_FADE: f32 = 0.4;
+
+/// What a legend row asked of the app this frame. The caller applies each
+/// against the pane the legend was drawn for — never the focused pane, so a
+/// row can never act on the chart beside it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum LegendAction {
+    /// Flip the render-side eye (no recompute).
+    ToggleHidden(SlotId),
+    /// Open the settings dialog.
+    OpenSettings(SlotId),
+    /// Remove the indicator.
+    Remove(SlotId),
+}
+
+/// Draw the legend over `chart_rect`. A no-op with no indicators — an empty
+/// legend frame would be chart chrome with nothing to say.
+pub(crate) fn draw(
+    ctx: &egui::Context,
+    pane_id: u64,
+    chart_rect: egui::Rect,
+    views: &[IndicatorView],
+) -> Vec<LegendAction> {
+    let mut actions = Vec::new();
+    if views.is_empty() {
+        return actions;
+    }
+    egui::Area::new(egui::Id::new(("indicator_legend", pane_id)))
+        .fixed_pos(chart_rect.left_top() + egui::vec2(LEGEND_MARGIN_PX, LEGEND_MARGIN_PX))
+        .order(egui::Order::Middle)
+        .show(ctx, |ui| {
+            egui::Frame::none()
+                .fill(theme::TAG_BG)
+                .rounding(egui::Rounding::same(4.0))
+                .inner_margin(egui::Margin::symmetric(6.0, 4.0))
+                .show(ui, |ui| {
+                    for view in views {
+                        draw_row(ui, view, &mut actions);
+                    }
+                });
+        });
+    actions
+}
+
+/// One legend row. Status precedence matches the toolbar menu's dot:
+/// errored beats stale beats hidden — a broken indicator must never read as
+/// merely hidden.
+fn draw_row(ui: &mut egui::Ui, view: &IndicatorView, actions: &mut Vec<LegendAction>) {
+    ui.horizontal(|ui| {
+        draw_status_dot(ui, view);
+        let name_color = if view.error.is_some() {
+            theme::SELL
+        } else if view.stale.is_some() {
+            theme::ACCENT
+        } else if view.hidden {
+            theme::TEXT_MUTED
+        } else {
+            theme::TEXT_PRIMARY
+        };
+        let name = ui
+            .add(
+                egui::Label::new(egui::RichText::new(view.label()).color(name_color).small())
+                    .sense(egui::Sense::click()),
+            )
+            .on_hover_text("double-click to open settings");
+        if name.double_clicked() {
+            actions.push(LegendAction::OpenSettings(view.slot));
+        }
+        // The last committed value of the first plot — the number a trader
+        // reads an overlay by. Withheld while hidden or errored: a value
+        // from a line that is not on screen answers nothing.
+        if !view.hidden
+            && view.error.is_none()
+            && let Some(value) = view.columns.first().and_then(|column| column.last())
+        {
+            ui.label(
+                egui::RichText::new(chart::compact_value(*value))
+                    .monospace()
+                    .small()
+                    .color(theme::TEXT_MUTED),
+            );
+        }
+        if let Some(error) = &view.error {
+            ui.label(egui::RichText::new("error").small().color(theme::SELL))
+                .on_hover_text(error.to_string());
+        } else if let Some(stale) = &view.stale {
+            ui.label(egui::RichText::new("stale").small().color(theme::ACCENT))
+                .on_hover_text(stale.clone());
+        }
+        if ui
+            .small_button(if view.hidden {
+                icons::EYE
+            } else {
+                icons::EYE_SLASH
+            })
+            .on_hover_text("hide/show without removing (no recompute)")
+            .clicked()
+        {
+            actions.push(LegendAction::ToggleHidden(view.slot));
+        }
+        if ui
+            .small_button(icons::GEAR)
+            .on_hover_text("settings")
+            .clicked()
+        {
+            actions.push(LegendAction::OpenSettings(view.slot));
+        }
+        if ui
+            .small_button(icons::TRASH)
+            .on_hover_text("remove this indicator")
+            .clicked()
+        {
+            actions.push(LegendAction::Remove(view.slot));
+        }
+    });
+}
+
+/// The row's colour dot: the first plot's own colour, so the row and the
+/// line it names can never disagree; error and stale wear the same glyphs
+/// as the toolbar menu's status dot.
+fn draw_status_dot(ui: &mut egui::Ui, view: &IndicatorView) {
+    if view.error.is_some() {
+        ui.label(
+            egui::RichText::new(icons::WARNING_CIRCLE)
+                .small()
+                .color(theme::SELL),
+        );
+        return;
+    }
+    if view.stale.is_some() {
+        ui.label(
+            egui::RichText::new(icons::WARNING)
+                .small()
+                .color(theme::ACCENT),
+        );
+        return;
+    }
+    let color = view
+        .descriptor
+        .plots
+        .first()
+        .map_or(theme::TEXT_MUTED, |plot| rgba(plot.base_color));
+    let color = if view.hidden {
+        color.gamma_multiply(HIDDEN_DOT_FADE)
+    } else {
+        color
+    };
+    let (rect, _) = ui.allocate_exact_size(
+        egui::vec2(DOT_DIAMETER_PX, DOT_DIAMETER_PX),
+        egui::Sense::hover(),
+    );
+    ui.painter()
+        .circle_filled(rect.center(), DOT_DIAMETER_PX / 2.0, color);
+}
+
+fn rgba(color: Rgba8) -> egui::Color32 {
+    egui::Color32::from_rgba_unmultiplied(color.r, color.g, color.b, color.a)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::indicator_worker::IndicatorEvent;
+    use crate::indicators::IndicatorViews;
+    use quantick_indicators::{EvalError, IndicatorDescriptor, PlotId, PlotSpec, PlotStyle};
+
+    fn descriptor(title: &str) -> IndicatorDescriptor {
+        IndicatorDescriptor {
+            title: title.to_owned(),
+            short_title: None,
+            overlay: true,
+            plots: vec![PlotSpec {
+                id: PlotId::new(0),
+                title: "p0".to_owned(),
+                style: PlotStyle::Line,
+                base_color: Rgba8::opaque(0x26, 0xA6, 0x9A),
+                width: 1.0,
+                offset: 0,
+                marker: None,
+            }],
+            inputs: Vec::new(),
+            fills: Vec::new(),
+        }
+    }
+
+    fn views_with(build: impl FnOnce(&mut IndicatorViews, SlotId)) -> IndicatorViews {
+        let mut views = IndicatorViews::new();
+        let slot = views.allocate_slot();
+        build(&mut views, slot);
+        views
+    }
+
+    fn painted(ctx: &egui::Context, views: &IndicatorViews) -> String {
+        let chart = egui::Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(800.0, 400.0));
+        let mut text = String::new();
+        for _ in 0..2 {
+            let output = ctx.run(egui::RawInput::default(), |ctx| {
+                let actions = draw(ctx, 0, chart, views.all());
+                assert!(actions.is_empty(), "no clicks, no actions");
+            });
+            text.clear();
+            for shape in output.shapes {
+                if let egui::epaint::Shape::Text(galley) = shape.shape {
+                    text.push_str(galley.galley.text());
+                    text.push(' ');
+                }
+            }
+        }
+        text
+    }
+
+    /// A healthy row reaches pixels: name and last value, in the axis'
+    /// compact spelling.
+    #[test]
+    fn the_legend_names_the_indicator_and_its_last_value() {
+        let ctx = egui::Context::default();
+        let views = views_with(|views, slot| {
+            views.apply(IndicatorEvent::Rebuilt {
+                slot,
+                descriptor: descriptor("EMA(9, close)"),
+                columns: vec![vec![101.5, 1_234.0]],
+                inputs: Vec::new(),
+                stale: None,
+            });
+        });
+        let text = painted(&ctx, &views);
+        assert!(text.contains("EMA(9, close)"), "painted: {text}");
+        assert!(text.contains("1.23K"), "painted: {text}");
+    }
+
+    /// B1: an errored indicator states its error on the chart, message
+    /// reachable — it must never simply disappear.
+    #[test]
+    fn an_errored_indicator_states_its_error_on_the_chart() {
+        let ctx = egui::Context::default();
+        let views = views_with(|views, slot| {
+            views.apply(IndicatorEvent::Rebuilt {
+                slot,
+                descriptor: descriptor("zigzag.pine"),
+                columns: vec![vec![1.0]],
+                inputs: Vec::new(),
+                stale: None,
+            });
+            views.apply(IndicatorEvent::Error {
+                slot,
+                error: EvalError {
+                    bar_index: 7,
+                    message: "PINE_NO_SECURITY: security() is not supported".to_owned(),
+                },
+            });
+        });
+        let text = painted(&ctx, &views);
+        assert!(text.contains("zigzag.pine"), "painted: {text}");
+        assert!(text.contains("error"), "painted: {text}");
+    }
+
+    /// A stale row wears the amber word; a flat list draws nothing at all.
+    #[test]
+    fn stale_rows_say_stale_and_an_empty_list_paints_nothing() {
+        let ctx = egui::Context::default();
+        let views = views_with(|views, slot| {
+            views.apply(IndicatorEvent::Rebuilt {
+                slot,
+                descriptor: descriptor("cvd.pine"),
+                columns: vec![vec![2.0]],
+                inputs: Vec::new(),
+                stale: Some("edit has errors; running the previous version".to_owned()),
+            });
+        });
+        let text = painted(&ctx, &views);
+        assert!(text.contains("stale"), "painted: {text}");
+
+        let empty = IndicatorViews::new();
+        assert!(painted(&ctx, &empty).is_empty(), "no rows, no chrome");
+    }
+}

--- a/crates/app/src/indicator_panel.rs
+++ b/crates/app/src/indicator_panel.rs
@@ -3,8 +3,9 @@
 //! Every widget the user sees maps to exactly one spec variant — the crate
 //! declares, the app renders, nothing is hand-tailored per indicator. Apply
 //! sends the draft to the worker (construct anew → replace → replay), so a
-//! running indicator never observes a value changing mid-stream; Cancel
-//! drops the draft.
+//! running indicator never observes a value changing mid-stream — and the
+//! dialog stays open, because tuning is a nudge-and-look loop (audit M2);
+//! Close drops any un-applied edits.
 
 use eframe::egui;
 use quantick_indicators::{InputSpec, InputValue, Rgba8, SourceId};
@@ -14,6 +15,12 @@ use crate::theme;
 
 /// Drag sensitivity of a float input that declares no `step`.
 const DEFAULT_FLOAT_DRAG_SPEED: f64 = 0.1;
+
+/// Where the dialog first opens: beside the drawing inspector's own default
+/// (`DRAWING_INSPECTOR_DEFAULT_POSITION`), clear of the toolbar and of the
+/// INDICATORS menu that spawns it — a deliberate position instead of egui's
+/// centre default landing under the still-open menu (audit M3/QW2).
+const SETTINGS_DEFAULT_POSITION: egui::Pos2 = egui::pos2(120.0, 150.0);
 
 /// An open settings dialog: which slot, and the in-flight draft values.
 pub(crate) struct SettingsDialog {
@@ -29,9 +36,9 @@ pub(crate) struct SettingsDialog {
 pub(crate) enum SettingsOutcome {
     /// Keep showing the dialog.
     Open,
-    /// Discard the draft.
-    Cancel,
-    /// Send the draft to the worker and close.
+    /// Close the dialog, dropping any un-applied edits.
+    Close,
+    /// Send the draft to the worker; the dialog stays open.
     Apply,
 }
 
@@ -45,6 +52,7 @@ pub(crate) fn draw(
     let mut open = true;
     egui::Window::new(format!("Settings — {}", dialog.title))
         .id(egui::Id::new(("indicator-settings", dialog.slot.0)))
+        .default_pos(SETTINGS_DEFAULT_POSITION)
         .open(&mut open)
         .collapsible(false)
         .resizable(false)
@@ -66,16 +74,24 @@ pub(crate) fn draw(
             }
             ui.separator();
             ui.horizontal(|ui| {
-                if ui.button("Apply").clicked() {
+                if ui
+                    .button("Apply")
+                    .on_hover_text("apply and keep tuning - the dialog stays open")
+                    .clicked()
+                {
                     outcome = SettingsOutcome::Apply;
                 }
-                if ui.button("Cancel").clicked() {
-                    outcome = SettingsOutcome::Cancel;
+                if ui
+                    .button("Close")
+                    .on_hover_text("close without applying the current edits")
+                    .clicked()
+                {
+                    outcome = SettingsOutcome::Close;
                 }
             });
         });
     if !open {
-        outcome = SettingsOutcome::Cancel;
+        outcome = SettingsOutcome::Close;
     }
     outcome
 }

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -20,6 +20,7 @@ mod config;
 mod dock;
 mod drawings;
 mod feed;
+mod indicator_legend;
 mod indicator_panel;
 mod indicator_render;
 mod indicator_worker;

--- a/crates/app/src/toolbar.rs
+++ b/crates/app/src/toolbar.rs
@@ -644,6 +644,10 @@ fn draw_indicators_menu(ui: &mut egui::Ui, model: &ToolbarModel, actions: &mut V
                     .clicked()
                 {
                     actions.push(ToolbarAction::OpenIndicatorSettings(entry.slot));
+                    // The menu closes so it cannot occlude the dialog it
+                    // just spawned (egui paints menus above windows) —
+                    // audit M3.
+                    ui.close_menu();
                 }
                 if ui
                     .small_button(icons::TRASH)
@@ -651,6 +655,10 @@ fn draw_indicators_menu(ui: &mut egui::Ui, model: &ToolbarModel, actions: &mut V
                     .clicked()
                 {
                     actions.push(ToolbarAction::RemoveIndicator(entry.slot));
+                    // Closing beats redrawing the menu around a vanished
+                    // row. The eye deliberately keeps the menu open:
+                    // toggling several indicators is one errand.
+                    ui.close_menu();
                 }
             });
         }


### PR DESCRIPTION
## Summary

Third of the four P0 items from the August 2026 UX audit (`docs/ux/ux-audit-2026-08.md` §4, pain 3): editing indicator properties felt strange because the on-screen object was inert — no legend to identify or reach it, script errors computed and never rendered, the INDICATORS menu occluding the dialog it spawned, and Apply closing the dialog after every nudge.

Resolves, from `docs/ux/ux-audit-2026-08/indicators.md`:

- **M1 + most of B1** (via **S1**) — `indicator_legend.rs` (new module): one row per indicator at the pane's top-left — colour dot taken from the first plot so the row and the line can never disagree, name, last value in the axis' own compact vocabulary (`chart::compact_value`). An errored indicator now *states* its error on the chart, red, with the full message on hover; stale rows say `stale` in amber. Eye / gear / remove sit on each row, and double-clicking the name opens settings — the TradingView gesture that had nowhere to happen.
- **M3** (QW) — the gear (and remove) close the menu, so it can no longer occlude the dialog it spawned. The eye deliberately keeps the menu open: toggling several indicators is one errand.
- **M2 (partial)** — Apply keeps the dialog open for the next nudge (`Apply` / `Close` buttons, hover-explained); the title re-syncs from the live label each frame, so an applied retitle (`EMA(9)` → `EMA(21)`) never goes stale — which also retires **m4** before Apply-stays-open could expose it.
- **QW2** — the dialog opens at a deliberate default position beside the drawing inspector's, instead of egui's centre default underneath the menu.

## Design notes

- Legend actions return as data (the toolbar's own pattern) and the app applies them through new `TabSlot`-addressed methods (`toggle_indicator_hidden_at` / `open_indicator_settings_at` / `remove_indicator_at`) — the legend acts on the pane it is drawn on, **never the focused pane**, so the audit's "commands target one pane, chrome speaks for another" contradiction (MAJOR-4's shape) cannot reappear here. The toolbar path builds its target from focus before calling the same methods.
- The legend draws per visible pane of the active tab, anchored on the pane's cached chart rect (the inspector-placement cache that already exists).

## Merge-time notes

- Shares the chart's top-left with #122's position HUD — whichever merges second stacks the two with a one-line offset at the call site.
- On this branch alone, the paper armed-placement hint also sits top-left; #122 moves it to bottom-left, so the overlap resolves when both are in.

## Verification

- All four checks green locally (676 app tests + workspace).
- arch-review over the diff: one Should-fix (magic fade constant on the hidden row's dot) applied as `HIDDEN_DOT_FADE`. Consider items deferred and noted: the menu-close-on-gear behaviour has no test (egui menu interplay is not simulatable with the repo's current harness), and legend button clicks are proven at the action-routing level rather than by synthetic pointer events.
- New tests: legend paints name + compact value, errored row states `error` on the chart (B1), stale row + empty-list-paints-nothing, `compact_value` matrix, Apply-keeps-the-dialog-open end to end (the draft really lands: the EMA retitles to 21), and legend-actions-land-on-their-own-pane-not-the-focused-one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
