### PR TITLE
feat(app): speak the chip language on the new P0 surfaces

### DIFF
--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -54,6 +54,9 @@ const AXIS_GUTTER: f32 = 64.0;
 const TIME_STRIP: f32 = 24.0;
 /// Id of the tab the window opens with.
 const FIRST_TAB_ID: u64 = 0;
+/// How far the indicator legend drops below the position HUD when both
+/// claim the chart's top-left corner.
+const LEGEND_BELOW_HUD_OFFSET_PX: f32 = 64.0;
 
 /// The (flow, time) pane ids for tab `id`.
 ///
@@ -1153,9 +1156,14 @@ impl QuantickApp {
             let pane = self.active_tab().pane(side);
             // The rect is last frame's, like every anchor the input path
             // reads; a pane not yet drawn has none and draws no legend.
-            let Some(rect) = pane.last_chart_area else {
+            let Some(mut rect) = pane.last_chart_area else {
                 continue;
             };
+            // The position HUD owns the very corner while a position is
+            // open; the legend rides just below it.
+            if side == PaneSide::Flow && self.active_tab().paper.position_summary().is_some() {
+                rect.min.y += LEGEND_BELOW_HUD_OFFSET_PX;
+            }
             for action in indicator_legend::draw(ctx, pane.id, rect, pane.indicators.all()) {
                 pending.push((side, action));
             }

--- a/crates/app/src/indicator_legend.rs
+++ b/crates/app/src/indicator_legend.rs
@@ -56,11 +56,15 @@ pub(crate) fn draw(
         .fixed_pos(chart_rect.left_top() + egui::vec2(LEGEND_MARGIN_PX, LEGEND_MARGIN_PX))
         .order(egui::Order::Middle)
         .show(ctx, |ui| {
+            // The HUD's card grammar, quieter: sunken fill, hairline border,
+            // no rail — the rows' own colour dots carry the identity.
             egui::Frame::none()
-                .fill(theme::TAG_BG)
+                .fill(theme::INSET)
+                .stroke(egui::Stroke::new(1.0_f32, theme::BORDER))
                 .rounding(egui::Rounding::same(4.0))
-                .inner_margin(egui::Margin::symmetric(6.0, 4.0))
+                .inner_margin(egui::Margin::symmetric(8.0, 5.0))
                 .show(ui, |ui| {
+                    ui.spacing_mut().item_spacing = egui::vec2(6.0, 3.0);
                     for view in views {
                         draw_row(ui, view, &mut actions);
                     }

--- a/crates/app/src/pane.rs
+++ b/crates/app/src/pane.rs
@@ -275,21 +275,17 @@ fn live_chip_rect(history_strip: egui::Rect) -> egui::Rect {
     )
 }
 
-/// Paint the jump-to-live chip. Accent, not amber: it is a control, not a
-/// provenance statement.
+/// Paint the jump-to-live chip: solid accent, dark ink — the chip language
+/// of the price gutter, because this too is a statement about the axis.
+/// Accent, not amber: it is a control, not a provenance statement.
 fn draw_live_chip(painter: &egui::Painter, rect: egui::Rect) {
-    painter.rect_filled(rect, egui::Rounding::same(3.0), theme::TAG_BG);
-    painter.rect_stroke(
-        rect,
-        egui::Rounding::same(3.0),
-        egui::Stroke::new(1.0_f32, theme::ACCENT),
-    );
+    painter.rect_filled(rect, egui::Rounding::same(3.0), theme::ACCENT);
     painter.text(
         rect.center(),
         egui::Align2::CENTER_CENTER,
         "» live",
         egui::FontId::proportional(11.0),
-        theme::ACCENT,
+        theme::CHIP_INK,
     );
 }
 

--- a/crates/app/src/paper_hud.rs
+++ b/crates/app/src/paper_hud.rs
@@ -85,24 +85,44 @@ pub fn draw(
         .fixed_pos(chart_rect.left_top() + egui::vec2(HUD_MARGIN_PX, HUD_MARGIN_PX))
         .order(egui::Order::Middle)
         .show(ctx, |ui| {
-            egui::Frame::none()
-                .fill(theme::TAG_BG)
-                .stroke(egui::Stroke::new(1.0_f32, side_color))
+            // A sunken card with a hairline border; the position's side is
+            // said once, loudly, by the rail on the left edge and the solid
+            // side tag — the chip language of the price gutter.
+            let card = egui::Frame::none()
+                .fill(theme::INSET)
+                .stroke(egui::Stroke::new(1.0_f32, theme::BORDER))
                 .rounding(egui::Rounding::same(4.0))
-                .inner_margin(egui::Margin::symmetric(8.0, 6.0))
+                .inner_margin(egui::Margin {
+                    left: 12.0,
+                    right: 10.0,
+                    top: 7.0,
+                    bottom: 7.0,
+                })
                 .show(ui, |ui| {
+                    ui.spacing_mut().item_spacing.y = 5.0;
                     ui.horizontal(|ui| {
+                        egui::Frame::none()
+                            .fill(side_color)
+                            .rounding(egui::Rounding::same(2.0))
+                            .inner_margin(egui::Margin::symmetric(5.0, 1.0))
+                            .show(ui, |ui| {
+                                ui.label(
+                                    egui::RichText::new(format!("SIM {word} {qty}"))
+                                        .color(theme::CHIP_INK)
+                                        .strong()
+                                        .small(),
+                                );
+                            });
                         ui.label(
-                            egui::RichText::new(format!(
-                                "SIM {word} {qty} @ {}",
-                                fmt_decimal(summary.avg_price),
-                            ))
-                            .color(side_color)
-                            .strong(),
+                            egui::RichText::new(format!("@ {}", fmt_decimal(summary.avg_price)))
+                                .monospace()
+                                .color(theme::TEXT_PRIMARY),
                         );
                         if let Some(open) = summary.open_points {
                             ui.label(
                                 egui::RichText::new(format!("{} pts", fmt_signed_points(open)))
+                                    .monospace()
+                                    .strong()
                                     .color(points_color(open)),
                             )
                             .on_hover_text(
@@ -112,11 +132,25 @@ pub fn draw(
                         }
                     });
                     if let Some(caret) = caret_text(&summary, drift) {
-                        ui.label(egui::RichText::new(caret).small().color(theme::TEXT_MUTED));
+                        ui.label(
+                            egui::RichText::new(caret)
+                                .small()
+                                .color(theme::TEXT_SUPPORT),
+                        );
                     }
                     ui.horizontal(|ui| {
+                        let quiet = |label: &str| {
+                            egui::Button::new(
+                                egui::RichText::new(label)
+                                    .color(theme::TEXT_PRIMARY)
+                                    .small(),
+                            )
+                            .fill(theme::CONTROL)
+                            .stroke(egui::Stroke::new(1.0_f32, theme::BORDER))
+                            .rounding(egui::Rounding::same(3.0))
+                        };
                         if ui
-                            .button("× Close")
+                            .add(quiet("× Close"))
                             .on_hover_text(format!(
                                 "exit the {word} {qty} at the next print (market)"
                             ))
@@ -125,7 +159,7 @@ pub fn draw(
                             paper.close_position();
                         }
                         if ui
-                            .button("Reverse")
+                            .add(quiet(&format!("{} Reverse", icons::ARROWS_LEFT_RIGHT)))
                             .on_hover_text(format!(
                                 "close the {word} {qty} and open {opposite} {qty} \
                                  at the next print"
@@ -136,6 +170,22 @@ pub fn draw(
                         }
                     });
                 });
+            // The side rail: 3 px of the position's colour down the card's
+            // left edge, inside the border, rounded with the card.
+            let rect = card.response.rect;
+            ui.painter().rect_filled(
+                egui::Rect::from_min_max(
+                    rect.min + egui::vec2(1.0, 1.0),
+                    egui::pos2(rect.min.x + 4.0, rect.max.y - 1.0),
+                ),
+                egui::Rounding {
+                    nw: 3.0,
+                    sw: 3.0,
+                    ne: 0.0,
+                    se: 0.0,
+                },
+                side_color,
+            );
         });
 }
 

--- a/crates/app/src/theme.rs
+++ b/crates/app/src/theme.rs
@@ -50,6 +50,10 @@ pub const TAG_BG: Color32 = Color32::from_rgb(0x37, 0x3F, 0x50);
 /// (the inspector's locked/hidden notes). [`TEXT_FAINT`] stays reserved for
 /// decoration and disabled states, where 4.5:1 contrast is not required.
 pub const TEXT_SUPPORT: Color32 = Color32::from_rgb(0x86, 0x92, 0xA4);
+/// `chip/ink` — dark text inside a solid semantic-color chip: the last-price
+/// chip's ink, shared by every surface that speaks the chip language (trade
+/// buttons, the position HUD's side tag, the jump-to-live chip).
+pub const CHIP_INK: Color32 = Color32::from_rgb(0x0E, 0x12, 0x1A);
 
 /// Alpha of an "active" tint: a layer accent at 22% over the chrome.
 const ACTIVE_TINT_ALPHA: u8 = 56; // ≈ 22% of 255

--- a/crates/app/src/toolbar.rs
+++ b/crates/app/src/toolbar.rs
@@ -495,9 +495,24 @@ fn draw_bar_param(ui: &mut egui::Ui, model: &mut ToolbarModel) {
             // hatch. `bars → time` must not require knowing that a minute is
             // 60000 (audit QW1).
             ui.horizontal(|ui| {
+                ui.spacing_mut().item_spacing.x = 3.0;
                 for (label, preset_ms) in crate::time_header::PRESETS {
                     let selected = *model.time_interval_ms == preset_ms;
-                    if ui.selectable_label(selected, label).clicked() && !selected {
+                    // The selected timeframe wears the chip language (solid
+                    // accent, dark ink) — the unselected ones stay quiet.
+                    let (fill, ink) = if selected {
+                        (theme::ACCENT, theme::CHIP_INK)
+                    } else {
+                        (theme::CONTROL, theme::TEXT_MUTED)
+                    };
+                    let chip = ui.add(
+                        egui::Button::new(egui::RichText::new(label).color(ink).small())
+                            .fill(fill)
+                            .stroke(egui::Stroke::NONE)
+                            .rounding(egui::Rounding::same(9.0))
+                            .min_size(egui::vec2(28.0, 18.0)),
+                    );
+                    if chip.clicked() && !selected {
                         *model.time_interval_ms = preset_ms;
                     }
                 }
@@ -571,43 +586,47 @@ fn draw_history_menu(ui: &mut egui::Ui, model: &mut ToolbarModel) {
 /// seen a price, never on the provider — paper trading works on any feed.
 fn draw_trade(ui: &mut egui::Ui, model: &ToolbarModel, actions: &mut Vec<ToolbarAction>) {
     let paper = &model.paper;
-    let buy = ui
-        .add_enabled(
-            paper.ready,
-            egui::Button::new(
-                egui::RichText::new(&paper.buy_label)
-                    .color(theme::BUY)
-                    .strong(),
-            ),
+    // The entries speak the chip language: solid side colour, dark ink —
+    // the same grammar as the price chips in the gutter, because the button
+    // and the entry line it will create are one statement.
+    let entry = |ui: &mut egui::Ui, label: &str, fill: egui::Color32, enabled: bool| {
+        ui.add_enabled(
+            enabled,
+            egui::Button::new(egui::RichText::new(label).color(theme::CHIP_INK).strong())
+                .fill(fill)
+                .stroke(egui::Stroke::NONE)
+                .rounding(egui::Rounding::same(3.0))
+                .min_size(egui::vec2(52.0, 24.0)),
         )
+    };
+    let buy = entry(ui, &paper.buy_label, theme::BUY, paper.ready)
         .on_hover_text(&paper.buy_hover)
         .on_disabled_hover_text("waiting for the first print - there is no market yet");
     if buy.clicked() {
         actions.push(ToolbarAction::PaperBuy);
     }
-    let sell = ui
-        .add_enabled(
-            paper.ready,
-            egui::Button::new(
-                egui::RichText::new(&paper.sell_label)
-                    .color(theme::SELL)
-                    .strong(),
-            ),
-        )
+    let sell = entry(ui, &paper.sell_label, theme::SELL, paper.ready)
         .on_hover_text(&paper.sell_hover)
         .on_disabled_hover_text("waiting for the first print - there is no market yet");
     if sell.clicked() {
         actions.push(ToolbarAction::PaperSell);
     }
     // The exit control, on the same surface as the entries: an open position
-    // must never require a dock dive to leave (audit pain 1, B2).
+    // must never require a dock dive to leave (audit pain 1, B2). Outlined,
+    // not filled — leaving is deliberate, never the loudest thing on the bar.
     if let Some(close) = &paper.close_label {
         let button = ui
-            .add(egui::Button::new(
-                egui::RichText::new(format!("× {close}"))
-                    .color(theme::TEXT_PRIMARY)
-                    .strong(),
-            ))
+            .add(
+                egui::Button::new(
+                    egui::RichText::new(format!("× {close}"))
+                        .color(theme::TEXT_PRIMARY)
+                        .strong(),
+                )
+                .fill(theme::CONTROL)
+                .stroke(egui::Stroke::new(1.0_f32, theme::BORDER))
+                .rounding(egui::Rounding::same(3.0))
+                .min_size(egui::vec2(0.0, 24.0)),
+            )
             .on_hover_text("exit the open simulated position at the next print (market)");
         if button.clicked() {
             actions.push(ToolbarAction::PaperClose);


### PR DESCRIPTION
## Summary

Visual pass over the four P0 surfaces (#122–#125), requested after seeing them integrated: they shipped functional but on default-widget styling. The audit's visual direction (`docs/ux/ux-audit-2026-08.md` §7) is "clean without changing the soul" — so instead of inventing a new look, this pass extends the one signature the app already owns: **the gutter chip** — solid semantic colour, dark ink.

- **BUY/SELL** are solid side-colour blocks with dark ink (the button and the entry line it creates are one statement); **× Close** is outlined — leaving is deliberate, never the loudest thing on the bar.
- **Position HUD**: a sunken card (`INSET` + hairline `BORDER`, 4 px rounding) with a side-colour rail down its left edge and a solid `SIM LONG 1` tag; numbers monospace; quiet outlined Close/Reverse.
- **Indicator legend**: the same card grammar one step quieter — no rail, the rows' own colour dots carry identity.
- **Timeframe presets** are pills; the selected one is a solid accent chip.
- **`» live`** is a solid accent chip, matching the axis chips it sits under.
- `CHIP_INK` joins the theme tokens (it was duplicated privately in `pane.rs` and `paper_trading.rs`); the legend stacks below the HUD when both claim the chart's top-left (the follow-up promised in #122/#124).

No new hues — every colour is an existing token; the discipline (amber = provenance only) is untouched.

## Verification

- All four checks green locally (697 app tests + workspace).
- Validated visually against the live app (integrated preview, screenshots reviewed): toolbar blocks, HUD card with rail and tag, legend, pills and the live chip all render as designed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
