### PR TITLE
feat: paper trading v2 - brackets by drag, trades ledger, chart marks, full report, export

### DIFF
--- a/crates/app/config/feeds.toml
+++ b/crates/app/config/feeds.toml
@@ -150,8 +150,10 @@ US30 = 9103
 # `quantick-trades` format into this folder — a future bot runner, another
 # tool — shows up in the Trades ledger, the report and the export, no wiring
 # needed. Relative paths resolve against quantick's working directory; the
-# QUANTICK_TRADES_DIR environment variable overrides the setting for one run.
-# The section is optional; absent, trades save under `paper-trades`.
+# QUANTICK_TRADES_DIR environment variable overrides the setting for one run,
+# and the folder picker in the Trading tab (remembered in paper-state.toml)
+# wins over this base. The section is optional; absent, trades save under
+# `paper-trades`.
 #
 # [paper]
 # trades_dir = "paper-trades"

--- a/crates/app/config/feeds.toml
+++ b/crates/app/config/feeds.toml
@@ -140,3 +140,18 @@ bridge_command = ["python", "bridge/mt5/quantick_bridge.py"]
 XAUUSD = 9101
 US500 = 9102
 US30 = 9103
+
+# ---------------------------------------------------------------------------
+# Paper trading.
+#
+# Closed simulated trades are journaled the moment they close, one CSV per
+# session under a folder per symbol, and exports land beside them. This is
+# also the integration port for other producers: anything writing the
+# `quantick-trades` format into this folder — a future bot runner, another
+# tool — shows up in the Trades ledger, the report and the export, no wiring
+# needed. Relative paths resolve against quantick's working directory; the
+# QUANTICK_TRADES_DIR environment variable overrides the setting for one run.
+# The section is optional; absent, trades save under `paper-trades`.
+#
+# [paper]
+# trades_dir = "paper-trades"

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -2109,6 +2109,7 @@ impl QuantickApp {
                             (DockTab::Bubbles, "Bubble settings"),
                             (DockTab::Session, "Session"),
                             (DockTab::Trading, "Paper trading"),
+                            (DockTab::Trades, "Trades"),
                         ] {
                             if ui.button(label).clicked() {
                                 self.dock.open_tab(tab);
@@ -3215,6 +3216,7 @@ impl QuantickApp {
                 tabs,
                 active_tab,
                 replay_view,
+                tz,
                 ..
             } = self;
             // The Trading tab speaks for the market on screen: one tab, one
@@ -3237,6 +3239,7 @@ impl QuantickApp {
                     replay_view,
                     replay: replay.as_ref(),
                     paper,
+                    tz: *tz,
                 },
             )
         };
@@ -3245,6 +3248,20 @@ impl QuantickApp {
         }
         if let Some(action) = dock_response.replay_action {
             self.apply_replay_action(action);
+        }
+        // The ledger's jump-to-trade: center the flow pane on the round
+        // trip's midpoint, the object manager's own "select and centre".
+        if let Some((opened, closed)) = dock_response.navigate_to_trade {
+            let pane = &mut self.active_tab_mut().flow_pane;
+            if let (Some(entry), Some(exit), Some(area)) = (
+                pane.slot_at_time(opened),
+                pane.slot_at_time(closed),
+                pane.last_chart_area,
+            ) {
+                let slots = pane.slots();
+                let mid = (entry + exit) as f32 / 2.0;
+                pane.viewport.center_on_bar(mid, area.width(), slots);
+            }
         }
         // The pinned inspector is chrome: declared before the central canvas
         // so the chart pays its width, exactly like the dock.

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -1975,6 +1975,24 @@ const PREVIOUS_TAB_SHORTCUT: egui::KeyboardShortcut = egui::KeyboardShortcut::ne
     egui::Modifiers::CTRL.plus(egui::Modifiers::SHIFT),
     egui::Key::Tab,
 );
+/// Simulated buy at market (`docs/ux/paper-trading.md` §9). All the
+/// trading hotkeys are Shift+letter and stand down while any text field
+/// owns the keyboard — a capital letter typed into a symbol box must
+/// never become an order.
+const PAPER_BUY_SHORTCUT: egui::KeyboardShortcut =
+    egui::KeyboardShortcut::new(egui::Modifiers::SHIFT, egui::Key::B);
+/// Simulated sell at market.
+const PAPER_SELL_SHORTCUT: egui::KeyboardShortcut =
+    egui::KeyboardShortcut::new(egui::Modifiers::SHIFT, egui::Key::S);
+/// Reverse the simulated position.
+const PAPER_REVERSE_SHORTCUT: egui::KeyboardShortcut =
+    egui::KeyboardShortcut::new(egui::Modifiers::SHIFT, egui::Key::R);
+/// Flatten: close the position and cancel every working order.
+const PAPER_FLATTEN_SHORTCUT: egui::KeyboardShortcut =
+    egui::KeyboardShortcut::new(egui::Modifiers::SHIFT, egui::Key::F);
+/// Cancel every working order without trading.
+const PAPER_CANCEL_SHORTCUT: egui::KeyboardShortcut =
+    egui::KeyboardShortcut::new(egui::Modifiers::SHIFT, egui::Key::X);
 /// Height of the menu bar, in pixels (§5 zone 1).
 const MENU_BAR_HEIGHT: f32 = 28.0;
 
@@ -1987,6 +2005,30 @@ impl QuantickApp {
         }
         if ctx.input_mut(|i| i.consume_shortcut(&DOCK_SHORTCUT)) {
             self.dock.toggle_visible();
+        }
+        // Trading hotkeys, swallowed only while no text field owns the
+        // keyboard. Market entries use the ticket's quantity and offsets,
+        // exactly like the toolbar buttons they twin.
+        if !ctx.wants_keyboard_input() {
+            if ctx.input_mut(|i| i.consume_shortcut(&PAPER_BUY_SHORTCUT)) {
+                self.active_tab_mut()
+                    .paper
+                    .market(quantick_engine::Side::Buy);
+            }
+            if ctx.input_mut(|i| i.consume_shortcut(&PAPER_SELL_SHORTCUT)) {
+                self.active_tab_mut()
+                    .paper
+                    .market(quantick_engine::Side::Sell);
+            }
+            if ctx.input_mut(|i| i.consume_shortcut(&PAPER_REVERSE_SHORTCUT)) {
+                self.active_tab_mut().paper.reverse_position();
+            }
+            if ctx.input_mut(|i| i.consume_shortcut(&PAPER_FLATTEN_SHORTCUT)) {
+                self.active_tab_mut().paper.flatten();
+            }
+            if ctx.input_mut(|i| i.consume_shortcut(&PAPER_CANCEL_SHORTCUT)) {
+                self.active_tab_mut().paper.cancel_all_orders();
+            }
         }
 
         let mut tab_action = None;

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -515,6 +515,13 @@ pub struct QuantickApp {
     // Fixed UTC offset the time axis is displayed in (default UTC−03:00).
     tz: TzOffset,
 
+    /// Where trades save this run — resolved once at boot (environment >
+    /// the user's stored pick > config) and updated by the panel's folder
+    /// picker; new tabs journal here too.
+    trades_dir: std::path::PathBuf,
+    /// The in-flight trades-folder dialog, if any. One at a time.
+    trades_dir_picker: Option<std::sync::mpsc::Receiver<Option<std::path::PathBuf>>>,
+
     frames: FrameStats,
     /// CPU time per frame (update + tessellation + paint, no vsync wait), from
     /// eframe. Separates "we are slow" from "we are waiting for the display".
@@ -562,6 +569,10 @@ impl QuantickApp {
         spec: BarSpec,
         feed: FeedHandle,
     ) -> Self {
+        let trades_dir = {
+            let stored = crate::paper_state::load(&crate::paper_state::default_path());
+            PaperTrading::resolve_trades_dir(&config.paper.trades_dir, stored.as_deref())
+        };
         let tab = Tab::new(
             FIRST_TAB_ID,
             pane_ids(FIRST_TAB_ID),
@@ -569,7 +580,7 @@ impl QuantickApp {
             symbol.into(),
             spec,
             feed,
-            PaperTrading::resolve_trades_dir(&config.paper.trades_dir),
+            trades_dir.clone(),
         );
         let mut app = Self {
             tabs: vec![tab],
@@ -630,6 +641,8 @@ impl QuantickApp {
             last_style_change: None,
             show_perf: true,
             tz: TzOffset::default(),
+            trades_dir,
+            trades_dir_picker: None,
             frames: FrameStats::new(120),
             cpu_frames: FrameStats::new(120),
             last_frame: None,
@@ -768,6 +781,51 @@ impl QuantickApp {
         app
     }
 
+    /// Ask the operating system for a trades folder, off the UI thread —
+    /// the panel's "choose where trades are saved". One dialog at a time.
+    fn open_trades_dir_picker(&mut self) {
+        if self.trades_dir_picker.is_some() {
+            return;
+        }
+        let (sender, receiver) = std::sync::mpsc::channel();
+        // Start where trades actually go right now — under an env override
+        // that is the override's folder, not the stored base.
+        let start = self.active_tab().paper.trades_dir().to_path_buf();
+        std::thread::Builder::new()
+            .name("quantick-trades-dir-picker".into())
+            .spawn(move || {
+                let mut dialog = rfd::FileDialog::new().set_title("Choose where trades are saved");
+                if start.is_dir() {
+                    dialog = dialog.set_directory(&start);
+                }
+                let _ = sender.send(dialog.pick_folder());
+            })
+            .expect("spawn trades-dir picker thread");
+        self.trades_dir_picker = Some(receiver);
+    }
+
+    /// Land the picked folder: every tab journals there from now on, and
+    /// the choice is remembered across restarts (`paper-state.toml`) —
+    /// files already written stay where they are.
+    fn poll_trades_dir_picker(&mut self) {
+        let Some(receiver) = &self.trades_dir_picker else {
+            return;
+        };
+        let Ok(choice) = receiver.try_recv() else {
+            return;
+        };
+        self.trades_dir_picker = None;
+        let Some(dir) = choice else { return };
+        crate::paper_state::save(
+            &crate::paper_state::default_path(),
+            &dir.display().to_string(),
+        );
+        self.trades_dir = dir;
+        for tab in &mut self.tabs {
+            tab.paper.set_trades_dir(self.trades_dir.clone());
+        }
+    }
+
     /// The active tab beside the config it reads.
     ///
     /// Split here, once, because almost every tab operation needs both and
@@ -857,7 +915,7 @@ impl QuantickApp {
             "opening a market in a new tab"
         );
         let spec = self.active_tab().flow_pane.state.spec().clone();
-        let trades_dir = PaperTrading::resolve_trades_dir(&self.config.paper.trades_dir);
+        let trades_dir = self.trades_dir.clone();
         self.tabs.push(Tab::new(
             id,
             pane_ids(id),
@@ -3343,6 +3401,10 @@ impl QuantickApp {
                 pane.viewport.center_on_bar(mid, area.width(), slots);
             }
         }
+        if dock_response.pick_trades_dir {
+            self.open_trades_dir_picker();
+        }
+        self.poll_trades_dir_picker();
         // The pinned inspector is chrome: declared before the central canvas
         // so the chart pays its width, exactly like the dock.
         self.draw_drawing_inspector_panel(ctx, now);

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -5352,6 +5352,70 @@ plot(close)
         }
     }
 
+    /// The closed-trade marks obey their own switch: a closed round trip
+    /// paints marks and a connector, `closed trade marks` off erases them,
+    /// and the live paper layer is untouched either way — hiding history
+    /// must never hide the position machinery.
+    #[test]
+    fn the_trade_paint_layer_switch_stops_the_marks() {
+        let ctx = egui::Context::default();
+        let screen = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(900.0, 600.0));
+        let (mut app, evt_tx, _cmd_rx, _book_tx) = test_app();
+        let dir =
+            std::env::temp_dir().join(format!("quantick-trade-paint-gate-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        app.active_tab_mut().paper.redirect_history_dir(dir.clone());
+        evt_tx
+            .try_send(FeedEvent::Backfilled(vec![trade(2)]))
+            .unwrap();
+        app.active_tab_mut().drain_feed_with_clock(|| 0);
+        app.apply_toolbar_action(ToolbarAction::PaperBuy);
+        evt_tx.try_send(FeedEvent::Live(trade(4))).unwrap();
+        app.active_tab_mut().drain_feed_with_clock(|| 0);
+        app.apply_toolbar_action(ToolbarAction::PaperClose);
+        evt_tx.try_send(FeedEvent::Live(trade(6))).unwrap();
+        app.active_tab_mut().drain_feed_with_clock(|| 0);
+        assert_eq!(
+            app.active_tab().paper.session_trades().len(),
+            1,
+            "one closed round trip to paint"
+        );
+
+        let shapes = |app: &mut QuantickApp| -> usize {
+            with_flow_pane(app, |pane, chrome| {
+                let output = ctx.run(
+                    egui::RawInput {
+                        screen_rect: Some(screen),
+                        ..Default::default()
+                    },
+                    |ctx| {
+                        egui::CentralPanel::default().show(ctx, |ui| {
+                            let area = ui.available_rect_before_wrap();
+                            pane.draw_chart(ui.painter(), area, chrome);
+                        });
+                    },
+                );
+                output.shapes.len()
+            })
+        };
+        // One frame to settle the ranges a draw computes for the next one.
+        let _ = shapes(&mut app);
+        let marks_on = shapes(&mut app);
+        switch_layer(&mut app, ChartLayer::TradePaint, false);
+        let marks_off = shapes(&mut app);
+        assert!(
+            marks_off < marks_on,
+            "the marks kept painting with their layer off ({marks_off} vs {marks_on})"
+        );
+        assert!(
+            app.active_tab()
+                .flow_pane
+                .layer_visible(ChartLayer::PaperTrading, &app.style),
+            "hiding closed-trade history leaves the live paper layer alone"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
     /// The gesture itself: a right-click on the canvas opens the menu, and the
     /// primary button — which pans, zooms and places drawings — never does.
     ///

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -731,6 +731,34 @@ impl QuantickApp {
                 "market replay autostart"
             );
         }
+        // Same convenience for the dock: open a named tab, so a scripted
+        // validation run shows a panel without a click.
+        if let Ok(name) = std::env::var("QUANTICK_DOCK_TAB") {
+            let tab = match name.trim() {
+                "l2" => Some(DockTab::L2),
+                "bubbles" => Some(DockTab::Bubbles),
+                "session" => Some(DockTab::Session),
+                "trading" => Some(DockTab::Trading),
+                "trades" => Some(DockTab::Trades),
+                _ => None,
+            };
+            match tab {
+                Some(tab) => app.dock.open_tab(tab),
+                None => tracing::warn!(
+                    target: "quantick::app",
+                    schema_version = 1_u8,
+                    event_code = "DOCK_TAB_AUTOSTART_UNKNOWN",
+                    tab = %name,
+                    action = "dock_left_as_is",
+                    "QUANTICK_DOCK_TAB names no dock tab"
+                ),
+            }
+        }
+        // And for the performance report window — the Report… button's own
+        // path, so a scripted run can show it.
+        if std::env::var("QUANTICK_PAPER_REPORT_AUTOSTART").is_ok_and(|value| value == "1") {
+            app.active_tab_mut().paper.autostart_report();
+        }
         // An env var is not a user edit: what the autostart hooks switched on
         // must not be written back as though the user had asked for it every
         // launch from now on. Same rule the indicator state follows.
@@ -4657,6 +4685,12 @@ plot(close)
     #[test]
     fn the_toolbar_close_action_exits_the_open_position() {
         let (mut app, evt_tx, _cmd_rx, _book_tx) = test_app();
+        // The close journals; without this the test writes a real
+        // `paper-trades/` folder into the crate's source tree.
+        let dir =
+            std::env::temp_dir().join(format!("quantick-paper-app-close-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        app.active_tab_mut().paper.redirect_history_dir(dir.clone());
         evt_tx
             .try_send(FeedEvent::Backfilled(vec![trade(2)]))
             .unwrap();
@@ -4684,6 +4718,7 @@ plot(close)
             app.active_tab().paper.close_button_label().is_none(),
             "flat removes the toolbar exit"
         );
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     /// A source reset (replay seek, feed switch) flattens the simulated

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -5427,6 +5427,62 @@ plot(close)
         let _ = std::fs::remove_dir_all(&dir);
     }
 
+    /// Through the real frame pipeline — real pointer events, the pane's own
+    /// scale — a click on the ✕ of a working order's chart tag cancels the
+    /// order. It must never read as a drag on the order's line: the hit-test
+    /// is geometric at press time, because a cached pixel rect goes stale
+    /// the moment a live chart autoscales between paint and press.
+    #[test]
+    fn clicking_the_chart_tag_close_cancels_the_order() {
+        let ctx = egui::Context::default();
+        let (mut app, evt_tx, _cmd_rx, _book_tx) = test_app();
+        evt_tx
+            .try_send(FeedEvent::Backfilled(vec![
+                trade(2),
+                trade(6),
+                trade(10),
+                trade(14),
+                trade(18),
+            ]))
+            .unwrap();
+        app.active_tab_mut().drain_feed_with_clock(|| 0);
+        // A resting buy limit in the middle of the backfilled price range,
+        // so its line and tag are on screen.
+        let price = Decimal::new(1005, 1);
+        app.active_tab_mut()
+            .paper
+            .apply_sim_command_for_tests(quantick_sim::Command::PlaceLimit {
+                side: quantick_engine::Side::Buy,
+                quantity: Decimal::ONE,
+                price,
+                bracket: quantick_sim::Bracket::none(),
+            });
+        assert_eq!(app.active_tab().paper.working_orders().len(), 1);
+        run_frame(&mut app, &ctx);
+        run_frame(&mut app, &ctx);
+
+        let chart = app
+            .active_tab()
+            .flow_pane
+            .last_chart_area
+            .expect("the pane laid out");
+        let tag_right = app
+            .active_tab()
+            .flow_pane
+            .last_lane_divider_x
+            .unwrap_or(chart.right());
+        let y = price_y(&app, PaneSide::Flow, 100.5);
+        let close = crate::paper_trading::close_button_rect(
+            tag_right,
+            crate::paper_trading::clamp_tag_center(y, chart.top(), chart.bottom()),
+        );
+        drag_chart(&mut app, &ctx, close.center(), close.center());
+        assert!(
+            app.active_tab().paper.working_orders().is_empty(),
+            "the click cancelled the order instead of dragging it"
+        );
+    }
+
     /// The gesture itself: a right-click on the canvas opens the menu, and the
     /// primary button — which pans, zooms and places drawings — never does.
     ///

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -35,6 +35,7 @@ use crate::loading::{self, LoadingTask};
 use crate::metrics::{self, FrameStats};
 use crate::notice_card;
 use crate::pane::{self, ChartPane, DRAWING_ANCHOR_RADIUS_PX, PaneSide};
+use crate::paper_trading::PaperTrading;
 use crate::replay_view::{ReplayAction, ReplayView};
 use crate::state::BarSpec;
 use crate::statusbar;
@@ -568,6 +569,7 @@ impl QuantickApp {
             symbol.into(),
             spec,
             feed,
+            PaperTrading::resolve_trades_dir(&config.paper.trades_dir),
         );
         let mut app = Self {
             tabs: vec![tab],
@@ -855,8 +857,16 @@ impl QuantickApp {
             "opening a market in a new tab"
         );
         let spec = self.active_tab().flow_pane.state.spec().clone();
-        self.tabs
-            .push(Tab::new(id, pane_ids(id), feed_id, symbol, spec, feed));
+        let trades_dir = PaperTrading::resolve_trades_dir(&self.config.paper.trades_dir);
+        self.tabs.push(Tab::new(
+            id,
+            pane_ids(id),
+            feed_id,
+            symbol,
+            spec,
+            feed,
+            trades_dir,
+        ));
         self.active_tab = self.tabs.len() - 1;
         let config = self.config.clone();
         self.active_tab_mut().refresh_chip_label(&config);
@@ -4074,6 +4084,7 @@ mod tests {
                 bubble_preset: None,
             }],
             metatrader: Default::default(),
+            paper: Default::default(),
         }
     }
 
@@ -7288,6 +7299,7 @@ plot(close)
                 },
             ],
             metatrader: Default::default(),
+            paper: Default::default(),
         };
         let mut app = QuantickApp::new(
             config,
@@ -7798,17 +7810,16 @@ plot(close)
         PriceScale::from_range(lo, hi, chart.top(), chart.bottom()).y(price)
     }
 
-    /// Order entry belongs to the flow pane. Both panes draw the simulated
-    /// lines — same instrument, same prices — but only the flow pane hands
-    /// the pointer to the simulator: the time pane is the context view, and a
-    /// press on its copy of a line is an ordinary chart gesture.
+    /// Order entry follows the focused pane — both charts are trading
+    /// surfaces, and the press that focuses a pane is the press that acts.
     ///
-    /// Proven through the consequence, not the flag: the position's entry line
-    /// consumes a press without moving (it is history, not an order), so a
-    /// vertical drag that starts on it pans nothing on the flow pane — and
-    /// pans normally on the time pane, where the simulator never sees it.
+    /// Proven through the consequence, not the flag: with a fully bracketed
+    /// position the entry line consumes a press without moving (it is
+    /// history, not an order), so a vertical drag that starts on it pans
+    /// nothing — on *either* pane, because the press itself moves the focus
+    /// (and with it the simulator's pointer) to the pane it landed in.
     #[test]
-    fn only_the_flow_pane_hands_the_pointer_to_the_simulator() {
+    fn the_focused_pane_hands_the_pointer_to_the_simulator() {
         let ctx = egui::Context::default();
         let (mut app, _commands) = split_app(&ctx, 200);
         app.apply_toolbar_action(ToolbarAction::PaperBuy);
@@ -7819,10 +7830,18 @@ plot(close)
             app.active_tab().paper.status_cell().is_some(),
             "this proof needs an open simulated position to grab"
         );
+        // Both legs set, so the entry-line press blocks instead of starting
+        // a bracket-creating drag — the no-pan consequence stays provable.
+        app.active_tab_mut()
+            .paper
+            .apply_sim_command_for_tests(quantick_sim::Command::SetBracket {
+                stop_loss: Some(fill.price - rust_decimal::Decimal::from(10)),
+                take_profit: Some(fill.price + rust_decimal::Decimal::from(10)),
+            });
         let entry = rust_decimal::prelude::ToPrimitive::to_f64(&fill.price)
             .expect("the fill price is finite");
 
-        for (side, panned) in [(PaneSide::Time, true), (PaneSide::Flow, false)] {
+        for side in [PaneSide::Time, PaneSide::Flow] {
             app.active_tab_mut().pane_mut(side).price_view.reset();
             let chart = app
                 .active_tab()
@@ -7836,11 +7855,15 @@ plot(close)
             );
             drag_chart(&mut app, &ctx, start, start + egui::vec2(0.0, 40.0));
 
+            assert!(
+                app.active_tab().pane(side).price_view.is_auto(),
+                "{side:?}: the entry line owns the gesture on the pane the \
+                 press focused — the chart must not pan under it"
+            );
             assert_eq!(
-                !app.active_tab().pane(side).price_view.is_auto(),
-                panned,
-                "{side:?}: a drag on the entry line must {} pan this pane",
-                if panned { "" } else { "not " }
+                app.active_tab().focused_side(),
+                side,
+                "the press that traded is the press that focused"
             );
         }
     }
@@ -9708,6 +9731,7 @@ plot(close)
                 ports,
                 ..Default::default()
             },
+            paper: Default::default(),
         }
     }
 

--- a/crates/app/src/chart_layers.rs
+++ b/crates/app/src/chart_layers.rs
@@ -76,6 +76,8 @@ pub(crate) enum ChartLayer {
     Crosshair,
     /// Simulated orders, the position line and their chips.
     PaperTrading,
+    /// Entry/exit marks for closed simulated trades and their connectors.
+    TradePaint,
     /// User drawings (lines, boxes, Fibs).
     Drawings,
 }
@@ -83,8 +85,10 @@ pub(crate) enum ChartLayer {
 impl ChartLayer {
     /// Every layer, in menu order. A variant missing from here has no switch
     /// and cannot be turned off at all, so a new one belongs in this list and
-    /// in the menu test that counts it.
-    pub(crate) const ALL: [Self; 12] = [
+    /// in the menu test that counts it. The two paper layers sit together:
+    /// live orders and closed-trade marks are switched apart, because hiding
+    /// history must never hide the position you are in.
+    pub(crate) const ALL: [Self; 13] = [
         Self::Heatmap,
         Self::Bubbles,
         Self::LiveStrip,
@@ -96,6 +100,7 @@ impl ChartLayer {
         Self::SeamDivider,
         Self::Crosshair,
         Self::PaperTrading,
+        Self::TradePaint,
         Self::Drawings,
     ];
 
@@ -114,6 +119,7 @@ impl ChartLayer {
             Self::SeamDivider => "seam_divider",
             Self::Crosshair => "crosshair",
             Self::PaperTrading => "paper_trading",
+            Self::TradePaint => "trade_paint",
             Self::Drawings => "drawings",
         }
     }
@@ -138,6 +144,7 @@ impl ChartLayer {
             Self::SeamDivider => "venue/prints seam",
             Self::Crosshair => "crosshair",
             Self::PaperTrading => "paper orders & position",
+            Self::TradePaint => "closed trade marks",
             Self::Drawings => "drawings",
         }
     }
@@ -177,6 +184,11 @@ impl ChartLayer {
             Self::PaperTrading => {
                 "simulated entries, exits and the open position. Hiding them draws nothing and \
                  cancels nothing — the orders stay working and the dock still shows them"
+            }
+            Self::TradePaint => {
+                "entry and exit marks for closed simulated trades, joined by a faint line. \
+                 Hiding them draws nothing and forgets nothing — the trades stay in the \
+                 ledger and on disk"
             }
             Self::Drawings => {
                 "everything drawn by hand. Hidden objects keep their anchors and stop answering \

--- a/crates/app/src/config.rs
+++ b/crates/app/src/config.rs
@@ -417,6 +417,42 @@ pub struct FeedConfig {
     pub bubble_preset: Option<String>,
 }
 
+/// Paper-trading options (`[paper]` in the TOML).
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(default)]
+pub struct PaperSettings {
+    /// Where the simulator saves closed trades — the per-symbol journals,
+    /// and the exports beside them. Relative paths resolve against
+    /// quantick's working directory; the `QUANTICK_TRADES_DIR` environment
+    /// variable still overrides it for one run (an env var is an explicit
+    /// request, like every autostart hook). The same folder is the
+    /// integration port for other producers: anything that writes the
+    /// `quantick-trades` format here — a bot runner, another tool — shows
+    /// up in the Trades ledger, the report and the export.
+    pub trades_dir: String,
+}
+
+impl Default for PaperSettings {
+    fn default() -> Self {
+        Self {
+            trades_dir: "paper-trades".to_string(),
+        }
+    }
+}
+
+impl PaperSettings {
+    fn validate(&self) -> Result<(), String> {
+        if self.trades_dir.trim().is_empty() {
+            return Err(
+                "paper.trades_dir must not be empty - drop the key to use the default \
+                 `paper-trades`"
+                    .to_string(),
+            );
+        }
+        Ok(())
+    }
+}
+
 /// The whole feed/asset configuration.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 pub struct AppConfig {
@@ -429,6 +465,9 @@ pub struct AppConfig {
     /// MetaTrader bridge settings; defaults apply when the section is absent.
     #[serde(default)]
     pub metatrader: MetaTraderSettings,
+    /// Paper-trading settings; defaults apply when the section is absent.
+    #[serde(default)]
+    pub paper: PaperSettings,
 }
 
 impl AppConfig {
@@ -605,6 +644,7 @@ impl AppConfig {
     /// Returns a human-readable message describing the first problem found.
     pub fn validate(&self) -> Result<(), String> {
         self.metatrader.validate()?;
+        self.paper.validate()?;
         if self.feeds.is_empty() {
             return Err("no feeds configured; add at least one [[feeds]] entry".to_string());
         }

--- a/crates/app/src/dock.rs
+++ b/crates/app/src/dock.rs
@@ -256,7 +256,20 @@ impl Dock {
                         .inner_margin(egui::Margin::symmetric(10.0, 8.0)),
                 )
                 .show(ctx, |ui| {
-                    draw_tab_header(ui, tab, &mut self.active);
+                    let mut export = false;
+                    draw_tab_header(ui, tab, &mut self.active, |ui| {
+                        if tab == DockTab::Trades
+                            && ui
+                                .small_button(icons::DOWNLOAD_SIMPLE)
+                                .on_hover_text("export these trades to a CSV file")
+                                .clicked()
+                        {
+                            export = true;
+                        }
+                    });
+                    if export {
+                        env.paper.start_export();
+                    }
                     match tab {
                         DockTab::L2 => {
                             response.restart_book_capture |= env.orderflow.draw_l2_tab(ui);
@@ -296,8 +309,14 @@ impl Dock {
     }
 }
 
-/// Title row shared by every tab, with the collapse affordance.
-fn draw_tab_header(ui: &mut egui::Ui, tab: DockTab, active: &mut Option<DockTab>) {
+/// Title row shared by every tab, with the collapse affordance and one
+/// optional action slot left of it (the Trades tab's export lives there).
+fn draw_tab_header(
+    ui: &mut egui::Ui,
+    tab: DockTab,
+    active: &mut Option<DockTab>,
+    actions: impl FnOnce(&mut egui::Ui),
+) {
     ui.horizontal(|ui| {
         ui.label(
             egui::RichText::new(tab.title())
@@ -314,6 +333,7 @@ fn draw_tab_header(ui: &mut egui::Ui, tab: DockTab, active: &mut Option<DockTab>
             {
                 *active = None;
             }
+            actions(ui);
         });
     });
     ui.separator();

--- a/crates/app/src/dock.rs
+++ b/crates/app/src/dock.rs
@@ -14,7 +14,9 @@ use quantick_engine::Side;
 
 use crate::feed::ReplayLink;
 use crate::orderflow_view::OrderflowView;
-use crate::paper_trading::{LedgerAction, PaperTrading, fmt_decimal, position_word};
+use crate::paper_trading::{
+    LedgerAction, PaperTrading, TradingTabAction, fmt_decimal, position_word,
+};
 use crate::replay_view::{ReplayAction, ReplayView};
 use crate::theme;
 use crate::timezone::TzOffset;
@@ -121,6 +123,9 @@ pub struct DockResponse {
     /// The Trades tab asked to center the chart on a round trip
     /// (`opened_ms`, `closed_ms`).
     pub navigate_to_trade: Option<(i64, i64)>,
+    /// The Trading tab asked for the trades-folder picker — app-wide, so
+    /// the app owns the dialog and the fan-out to every tab.
+    pub pick_trades_dir: bool,
 }
 
 /// The dock's chrome state. Hidden, collapsed to the strip, or open on one
@@ -287,7 +292,13 @@ impl Dock {
                             // with no way to reach them.
                             egui::ScrollArea::vertical()
                                 .auto_shrink([false, true])
-                                .show(ui, |ui| env.paper.draw_trading_tab(ui));
+                                .show(ui, |ui| {
+                                    if let Some(TradingTabAction::PickTradesDir) =
+                                        env.paper.draw_trading_tab(ui)
+                                    {
+                                        response.pick_trades_dir = true;
+                                    }
+                                });
                         }
                         // The ledger manages its own scroll (a virtualised
                         // list with a pinned totals strip).

--- a/crates/app/src/dock.rs
+++ b/crates/app/src/dock.rs
@@ -14,9 +14,10 @@ use quantick_engine::Side;
 
 use crate::feed::ReplayLink;
 use crate::orderflow_view::OrderflowView;
-use crate::paper_trading::{PaperTrading, fmt_decimal, position_word};
+use crate::paper_trading::{LedgerAction, PaperTrading, fmt_decimal, position_word};
 use crate::replay_view::{ReplayAction, ReplayView};
 use crate::theme;
+use crate::timezone::TzOffset;
 use crate::widgets::{IconButton, RAIL_ICON};
 
 /// Width of the always-visible tab strip, in pixels.
@@ -39,11 +40,19 @@ pub enum DockTab {
     Session,
     /// Paper trading: simulated position, order entry, pending orders.
     Trading,
+    /// The trade ledger: closed simulated trades, this session and saved.
+    Trades,
 }
 
 impl DockTab {
     /// Every tab, in strip order.
-    pub const ALL: [Self; 4] = [Self::L2, Self::Bubbles, Self::Session, Self::Trading];
+    pub const ALL: [Self; 5] = [
+        Self::L2,
+        Self::Bubbles,
+        Self::Session,
+        Self::Trading,
+        Self::Trades,
+    ];
 
     /// The Phosphor glyph on the strip.
     #[must_use]
@@ -53,6 +62,7 @@ impl DockTab {
             Self::Bubbles => icons::CIRCLES_THREE,
             Self::Session => icons::FILM_STRIP,
             Self::Trading => icons::TREND_UP,
+            Self::Trades => icons::RECEIPT,
         }
     }
 
@@ -64,6 +74,7 @@ impl DockTab {
             Self::Bubbles => "AGGRESSION BUBBLES",
             Self::Session => "SESSION",
             Self::Trading => "PAPER TRADING · SIM",
+            Self::Trades => "TRADES · SIM",
         }
     }
 
@@ -75,6 +86,7 @@ impl DockTab {
             Self::Bubbles => "Bubble settings — the layer toggle stays in the toolbar",
             Self::Session => "Market replay session",
             Self::Trading => "Paper trading — simulated orders, position and history",
+            Self::Trades => "Closed simulated trades — this session and the saved history",
         }
     }
 
@@ -93,8 +105,10 @@ pub struct DockEnv<'a> {
     pub replay_view: &'a mut ReplayView,
     /// The playing session, if any.
     pub replay: Option<&'a ReplayLink>,
-    /// The paper-trading host the Trading tab drives.
+    /// The paper-trading host the Trading and Trades tabs drive.
     pub paper: &'a mut PaperTrading,
+    /// The display timezone the ledger stamps its close times in.
+    pub tz: TzOffset,
 }
 
 /// What drawing the dock asked the app to do.
@@ -104,6 +118,9 @@ pub struct DockResponse {
     pub restart_book_capture: bool,
     /// The Session tab asked to close the replay.
     pub replay_action: Option<ReplayAction>,
+    /// The Trades tab asked to center the chart on a round trip
+    /// (`opened_ms`, `closed_ms`).
+    pub navigate_to_trade: Option<(i64, i64)>,
 }
 
 /// The dock's chrome state. Hidden, collapsed to the strip, or open on one
@@ -130,7 +147,7 @@ impl Dock {
             active: None,
             // Opening widths per tab, ordered as [`DockTab::ALL`]: the L2 tab
             // carries the densest controls, the Session tab the fewest.
-            widths: [340.0, 320.0, 300.0, 320.0],
+            widths: [340.0, 320.0, 300.0, 320.0, 320.0],
         }
     }
 
@@ -228,6 +245,7 @@ impl Dock {
             });
 
         if let Some(tab) = self.active {
+            let mut open_ticket = false;
             let panel = egui::SidePanel::right(egui::Id::new(("dock_body", tab.index())))
                 .resizable(true)
                 .default_width(self.widths[tab.index()])
@@ -258,9 +276,21 @@ impl Dock {
                                 .auto_shrink([false, true])
                                 .show(ui, |ui| env.paper.draw_trading_tab(ui));
                         }
+                        // The ledger manages its own scroll (a virtualised
+                        // list with a pinned totals strip).
+                        DockTab::Trades => match env.paper.draw_trades_tab(ui, env.tz) {
+                            Some(LedgerAction::Navigate(opened, closed)) => {
+                                response.navigate_to_trade = Some((opened, closed));
+                            }
+                            Some(LedgerAction::OpenTicket) => open_ticket = true,
+                            None => {}
+                        },
                     }
                 });
             self.remember_width(tab, panel.response.rect.width());
+            if open_ticket {
+                self.active = Some(DockTab::Trading);
+            }
         }
         response
     }
@@ -410,6 +440,7 @@ mod tests {
                             replay_view: &mut replay_view,
                             replay: None,
                             paper: &mut paper,
+                            tz: TzOffset::default(),
                         },
                     );
                     assert!(
@@ -430,6 +461,7 @@ mod tests {
                     replay_view: &mut replay_view,
                     replay: None,
                     paper: &mut paper,
+                    tz: TzOffset::default(),
                 },
             );
             assert!(!response.restart_book_capture);
@@ -456,6 +488,7 @@ mod tests {
                             replay_view: &mut ReplayView::new(),
                             replay: None,
                             paper,
+                            tz: TzOffset::default(),
                         },
                     );
                 });

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -51,6 +51,7 @@ mod time_header;
 mod timezone;
 mod toolbar;
 mod toolrail;
+mod trade_paint;
 mod viewport;
 mod widgets;
 

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -36,6 +36,7 @@ mod orderflow_view;
 mod orderflow_worker;
 mod pane;
 mod paper_hud;
+mod paper_state;
 mod paper_trading;
 mod price_view;
 mod replay_view;

--- a/crates/app/src/pane.rs
+++ b/crates/app/src/pane.rs
@@ -605,7 +605,8 @@ impl ChartPane {
             | ChartLayer::BackfillDivider
             | ChartLayer::SeamDivider
             | ChartLayer::Crosshair
-            | ChartLayer::PaperTrading => !self.hidden_layers.contains(&layer),
+            | ChartLayer::PaperTrading
+            | ChartLayer::TradePaint => !self.hidden_layers.contains(&layer),
         }
     }
 
@@ -649,7 +650,8 @@ impl ChartPane {
             | ChartLayer::BackfillDivider
             | ChartLayer::SeamDivider
             | ChartLayer::Crosshair
-            | ChartLayer::PaperTrading => {
+            | ChartLayer::PaperTrading
+            | ChartLayer::TradePaint => {
                 if visible {
                     self.hidden_layers.remove(&layer);
                 } else {
@@ -714,7 +716,8 @@ impl ChartPane {
     }
 
     /// The same visibility as one bit per persisted layer, for change
-    /// detection. `ALL` is a dozen entries, so the mask cannot outgrow `u16`.
+    /// detection. `ALL` is thirteen entries, so the mask cannot outgrow
+    /// `u16`.
     pub fn layer_mask(&self, style: &ChartStyle) -> u16 {
         ChartLayer::ALL
             .into_iter()
@@ -2071,6 +2074,28 @@ impl ChartPane {
         // Drawings sit above market layers and remain anchored to chart space,
         // not the screen, while the viewport moves beneath them.
         self.draw_drawings(painter, chart_rect, right, total, &scale);
+
+        // Closed-trade marks sit between the drawings and the live paper
+        // lines: history under the orders that are still working. Only the
+        // session's trades paint — the tape on screen proves their fills;
+        // rows loaded from earlier sessions stay in the ledger.
+        if self.layer_visible(ChartLayer::TradePaint, chrome.style) {
+            let frame = crate::trade_paint::TradePaintFrame {
+                painter,
+                chart_rect,
+                scale: &scale,
+                background: canvas_background,
+                pointer: self.hover_pos,
+                tz: chrome.tz,
+            };
+            crate::trade_paint::draw(
+                &frame,
+                chrome.paper.session_trades(),
+                chrome.paper.selected_trade_index(),
+                |ms| self.slot_at_time(ms),
+                |slot| self.viewport.x_center(slot, right, total),
+            );
+        }
 
         // Simulated orders and the position sit above the drawings: they are
         // operational state, read against the last price painted next. The

--- a/crates/app/src/pane.rs
+++ b/crates/app/src/pane.rs
@@ -488,6 +488,9 @@ pub struct ChartPane {
     /// the paper host is mutably reachable outside the chrome's shared
     /// borrow.
     paper_hud_anchor: Option<(egui::Rect, PriceScale)>,
+    /// Price under the right-click that opened the layer menu — the trade
+    /// section's anchor. Refreshed by every secondary click on the canvas.
+    context_menu_price: Option<f64>,
 
     /// User drawings live entirely in the app overlay layer, never in market
     /// state, so chart/backtest/bot determinism stays untouched.
@@ -567,6 +570,7 @@ impl ChartPane {
             hover_pos: None,
             history_prefix: Vec::new(),
             paper_hud_anchor: None,
+            context_menu_price: None,
             drawings: Drawings::default(),
             drawing_hover: None,
             drawing_press_position: None,
@@ -763,6 +767,14 @@ impl ChartPane {
     /// state the toolbar's eye writes — so an indicator hidden here shows as
     /// hidden there, and the indicator state file remains its single home.
     pub fn draw_layer_menu(&mut self, ui: &mut egui::Ui, chrome: &mut PaneChrome<'_>) {
+        // The trade section rides on top, on the pane that owns order
+        // entry, anchored at the price the right-click landed on.
+        if chrome.paper_owns_input
+            && let Some(price) = self.context_menu_price
+        {
+            chrome.paper.context_trade_actions(ui, price);
+            ui.separator();
+        }
         ui.label(
             egui::RichText::new("chart layers")
                 .size(11.0)
@@ -1393,6 +1405,19 @@ impl ChartPane {
             egui::Sense::click_and_drag(),
         );
         self.hover_pos = chart.hover_pos();
+        let drawing_scale = auto.map(|(auto_lo, auto_hi)| {
+            let (lo, hi) = self.price_view.resolve((auto_lo, auto_hi));
+            PriceScale::from_range(lo, hi, areas.chart.top(), areas.chart.bottom())
+        });
+        // The price under a right-click, remembered before the menu eats
+        // the pointer: the trade section places orders at it.
+        if chart.secondary_clicked()
+            && let Some(position) = chart.interact_pointer_pos()
+            && areas.chart.contains(position)
+            && let Some(scale) = drawing_scale.as_ref()
+        {
+            self.context_menu_price = Some(scale.price_at(position.y));
+        }
         // Right-click: what is on this canvas, and what is not. Secondary
         // button only, so it shares no gesture with the pan, the zoom or the
         // drawing tools — a pan that ends anywhere never opens it.
@@ -1402,10 +1427,6 @@ impl ChartPane {
         if chart.context_menu_opened() {
             self.hover_pos = None;
         }
-        let drawing_scale = auto.map(|(auto_lo, auto_hi)| {
-            let (lo, hi) = self.price_view.resolve((auto_lo, auto_hi));
-            PriceScale::from_range(lo, hi, areas.chart.top(), areas.chart.bottom())
-        });
         let history_right = self.last_lane_divider_x.unwrap_or(areas.chart.right());
         let drawing_area = egui::Rect::from_min_max(
             areas.chart.min,

--- a/crates/app/src/pane.rs
+++ b/crates/app/src/pane.rs
@@ -1761,7 +1761,7 @@ impl ChartPane {
         &mut self,
         painter: &egui::Painter,
         area: egui::Rect,
-        chrome: &PaneChrome<'_>,
+        chrome: &mut PaneChrome<'_>,
     ) {
         self.paper_hud_anchor = None;
         let canvas_background = background_color(chrome.style);
@@ -2095,9 +2095,27 @@ impl ChartPane {
             } else {
                 None
             };
-            chrome
-                .paper
-                .draw_layer(painter, chart_rect, axis_x, &scale, reserved_chip_y);
+            // Tags anchor inside the interactive plot (left of the live
+            // lane when one is up) — the same right edge the input pass
+            // hands to `handle_chart_input`, so a painted ✕ and its press
+            // agree about where it is.
+            let tag_right = self.last_lane_divider_x.unwrap_or(chart_rect.right());
+            // Hover affordances paint only on the pane whose pointer feeds
+            // the paper input; the other pane keeps display-only tags.
+            let paper_pointer = if chrome.paper_owns_input {
+                self.hover_pos
+            } else {
+                None
+            };
+            chrome.paper.draw_layer(
+                painter,
+                chart_rect,
+                tag_right,
+                axis_x,
+                &scale,
+                reserved_chip_y,
+                paper_pointer,
+            );
             if chrome.paper_owns_input {
                 self.paper_hud_anchor = Some((chart_rect, scale));
             }

--- a/crates/app/src/pane.rs
+++ b/crates/app/src/pane.rs
@@ -1476,7 +1476,7 @@ impl ChartPane {
             && let Some(position) =
                 pointer_position.filter(|position| drawing_area.contains(*position))
             && let Some(scale) = drawing_scale.as_ref()
-            && let Some(cursor) = chrome.paper.hover_cursor(position, scale)
+            && let Some(cursor) = chrome.paper.hover_cursor(position, drawing_area, scale)
         {
             ui.ctx().set_cursor_icon(cursor);
         }

--- a/crates/app/src/paper_state.rs
+++ b/crates/app/src/paper_state.rs
@@ -1,0 +1,150 @@
+//! Where the paper-trading journal lives, when the user picked it in-app.
+//!
+//! One value, one home: the shipped base stays `[paper] trades_dir` in the
+//! config, the `QUANTICK_TRADES_DIR` environment variable stays the
+//! explicit per-run override, and this sidecar records the choice made
+//! with the panel's folder picker — the added-symbols pattern: an in-app
+//! edit must survive a restart without the app rewriting the user's
+//! hand-commented `quantick.toml` (a TOML writer would strip its comments,
+//! which is exactly what the config rules forbid).
+//!
+//! Same store discipline as the chart layers: a versioned TOML next to the
+//! config (override with `QUANTICK_PAPER_STATE`), read once at startup,
+//! written when the choice changes, temp-file-and-rename so a crash
+//! mid-write cannot leave half a file behind. Anything unreadable is
+//! ignored entirely.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+/// Environment override for the paper-state file location.
+const STATE_ENV: &str = "QUANTICK_PAPER_STATE";
+/// Default file, next to the working directory's config.
+const STATE_FILE: &str = "paper-state.toml";
+/// Bumped on breaking layout changes; unknown versions are ignored.
+const FORMAT_VERSION: u32 = 1;
+
+#[derive(Debug, Serialize, Deserialize)]
+struct PaperStateFile {
+    version: u32,
+    /// The folder the user picked for the trade journal, when they did.
+    #[serde(default)]
+    trades_dir: Option<String>,
+}
+
+/// The paper-state file the app opens with and writes back to. Under test
+/// it is a scratch file of its own per process, for the same reason the
+/// chart layers do it: tests must not restore one another's choice, nor
+/// rewrite the repo's copy.
+#[must_use]
+pub(crate) fn default_path() -> PathBuf {
+    if cfg!(test) {
+        return scratch_path();
+    }
+    std::env::var_os(STATE_ENV).map_or_else(|| PathBuf::from(STATE_FILE), PathBuf::from)
+}
+
+/// A store of its own, for tests. See [`default_path`].
+fn scratch_path() -> PathBuf {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static NEXT: AtomicU64 = AtomicU64::new(0);
+    std::env::temp_dir().join(format!(
+        "quantick-paper-state-{}-{}.toml",
+        std::process::id(),
+        NEXT.fetch_add(1, Ordering::Relaxed)
+    ))
+}
+
+/// The stored folder choice; `None` when the file is missing, unreadable,
+/// from an unknown version, or holds no choice.
+#[must_use]
+pub(crate) fn load(path: &Path) -> Option<String> {
+    let text = std::fs::read_to_string(path).ok()?;
+    match toml::from_str::<PaperStateFile>(&text) {
+        Ok(file) if file.version == FORMAT_VERSION => {
+            file.trades_dir.filter(|dir| !dir.trim().is_empty())
+        }
+        Ok(file) => {
+            tracing::warn!(
+                target: "quantick::app",
+                schema_version = 1_u8,
+                event_code = "PAPER_STATE_VERSION",
+                path = %path.display(),
+                version = file.version,
+                action = "keeping_configured_trades_dir",
+                "paper state file is from an unknown version"
+            );
+            None
+        }
+        Err(error) => {
+            tracing::warn!(
+                target: "quantick::app",
+                schema_version = 1_u8,
+                event_code = "PAPER_STATE_UNREADABLE",
+                path = %path.display(),
+                %error,
+                action = "keeping_configured_trades_dir",
+                "paper state file is unreadable"
+            );
+            None
+        }
+    }
+}
+
+/// Remember the picked folder.
+pub(crate) fn save(path: &Path, trades_dir: &str) {
+    let file = PaperStateFile {
+        version: FORMAT_VERSION,
+        trades_dir: Some(trades_dir.to_owned()),
+    };
+    let Ok(text) = toml::to_string_pretty(&file) else {
+        tracing::warn!(
+            target: "quantick::app",
+            schema_version = 1_u8,
+            event_code = "PAPER_STATE_WRITE_FAILED",
+            action = "choice_not_saved",
+            "could not serialize the paper state"
+        );
+        return;
+    };
+    let temp = path.with_extension("toml.tmp");
+    if let Err(error) = std::fs::write(&temp, text).and_then(|()| std::fs::rename(&temp, path)) {
+        let _ = std::fs::remove_file(&temp);
+        tracing::warn!(
+            target: "quantick::app",
+            schema_version = 1_u8,
+            event_code = "PAPER_STATE_WRITE_FAILED",
+            path = %path.display(),
+            %error,
+            action = "choice_not_saved",
+            "could not save the paper state"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_choice_round_trips_through_disk() {
+        let path = scratch_path();
+        assert_eq!(load(&path), None, "a missing file holds no choice");
+        save(&path, "D:/trading/journals");
+        assert_eq!(load(&path), Some("D:/trading/journals".to_owned()));
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn unknown_versions_and_garbage_degrade_to_no_choice() {
+        let path = scratch_path();
+        std::fs::write(&path, "version = 99\ntrades_dir = \"x\"\n").unwrap();
+        assert_eq!(load(&path), None, "unknown version changes nothing");
+        std::fs::write(&path, "not even toml [").unwrap();
+        assert_eq!(load(&path), None, "garbage changes nothing");
+        std::fs::write(&path, "version = 1\ntrades_dir = \"  \"\n").unwrap();
+        assert_eq!(load(&path), None, "a blank choice is no choice");
+        std::fs::remove_file(&path).ok();
+    }
+}

--- a/crates/app/src/paper_trading.rs
+++ b/crates/app/src/paper_trading.rs
@@ -820,6 +820,22 @@ impl PaperTrading {
         false
     }
 
+    /// This session's closed round trips, oldest first — the trades whose
+    /// fills the current tape can prove, and so the only ones the chart
+    /// paints marks for.
+    #[must_use]
+    pub fn session_trades(&self) -> &[ClosedTrade] {
+        self.sim.closed_trades()
+    }
+
+    /// Index (into [`Self::session_trades`]) of the ledger's selected
+    /// trade, for the chart to emphasize; `None` while nothing is selected.
+    #[must_use]
+    pub fn selected_trade_index(&self) -> Option<usize> {
+        self.selected_trade
+            .filter(|index| *index < self.sim.closed_trades().len())
+    }
+
     pub fn handle_chart_input(&mut self, input: &ChartInput<'_>) -> bool {
         // An armed placement takes the next chart click.
         if let Some(armed) = self.armed
@@ -2662,7 +2678,7 @@ fn draw_ledger_row(
 }
 
 /// `38s`, `4m 18s`, `1h 02m` — a trade's age in venue time.
-fn fmt_duration_ms(ms: i64) -> String {
+pub(crate) fn fmt_duration_ms(ms: i64) -> String {
     let seconds = (ms / 1000).max(0);
     if seconds < 60 {
         format!("{seconds}s")

--- a/crates/app/src/paper_trading.rs
+++ b/crates/app/src/paper_trading.rs
@@ -112,6 +112,9 @@ const CURVE_MAX_POINTS: usize = 1000;
 const CURVE_GRID_RESERVE_PX: f32 = 230.0;
 /// Width of the equity curve's y-tick gutter.
 const CURVE_GUTTER_PX: f32 = 52.0;
+/// Longest export path a toast prints whole; past it the folder elides
+/// and the file name stays.
+const EXPORT_PATH_ELIDE_CHARS: usize = 64;
 /// Text color inside colored gutter chips — the same ink as the last-price
 /// chip (`LAST_PRICE_CHIP_TEXT` is private to `app.rs`, so the value is
 /// duplicated here; keep the two identical).
@@ -334,7 +337,6 @@ pub struct PaperTrading {
     /// A failed journal write warns once, not once per trade.
     journal_warned: bool,
     // Order-entry form.
-    side: Side,
     qty_text: String,
     order_type: EntryKind,
     stop_offset_text: String,
@@ -346,6 +348,12 @@ pub struct PaperTrading {
     /// Interactive rects painted by the last `draw_layer` pass (tag ✕s,
     /// bracket handles), pressed against on the next input pass.
     controls: Vec<(PaperControl, egui::Rect)>,
+    /// The working order hovered in the dock this frame — its chart line
+    /// lifts, so one hover reads on both surfaces. Cleared after the chart
+    /// consumed it (`draw_toast` runs last in the frame).
+    hovered_order: Option<OrderId>,
+    /// The in-flight export, if any; resolved by `draw_toast`'s poll.
+    export_rx: Option<std::sync::mpsc::Receiver<Result<(PathBuf, usize), String>>>,
     toast: Option<Toast>,
     report_open: bool,
     /// Report symbol filter: `None` is every symbol, `Some` one folder.
@@ -385,7 +393,6 @@ impl PaperTrading {
                 .map_or_else(|| PathBuf::from(TRADES_DIR), PathBuf::from),
             journal_path: None,
             journal_warned: false,
-            side: Side::Buy,
             qty_text: "1".to_owned(),
             order_type: EntryKind::Market,
             stop_offset_text: String::new(),
@@ -394,6 +401,8 @@ impl PaperTrading {
             drag: PaperDrag::None,
             drag_price: None,
             controls: Vec::new(),
+            hovered_order: None,
+            export_rx: None,
             toast: None,
             report_open: false,
             report_symbol: None,
@@ -714,7 +723,7 @@ impl PaperTrading {
             if !ctx.in_range(y) {
                 continue;
             }
-            let hovered = ctx.hovers_line(y);
+            let hovered = ctx.hovers_line(y) || self.hovered_order == Some(order.id);
             let shown = if dragged { self.snap(price) } else { level };
             ctx.level_line(y, theme::ACCENT, true, LINE_WIDTH_PX, hovered, dragged);
             ctx.gutter_chip(y, theme::ACCENT, &fmt_decimal(shown));
@@ -1210,9 +1219,10 @@ impl PaperTrading {
     // Dock tab
     // ------------------------------------------------------------------
 
-    /// The Trading dock tab: position card, order entry, pending orders,
-    /// session summary. See `docs/ux/paper-trading.md` §3.
+    /// The Trading dock tab: position, ticket, working orders, session
+    /// strip. See `docs/ux/paper-trading.md` §3.
     pub fn draw_trading_tab(&mut self, ui: &mut egui::Ui) {
+        self.hovered_order = None;
         ui.label(
             egui::RichText::new("Simulated fills from the tape - no broker, points not currency.")
                 .color(theme::TEXT_MUTED)
@@ -1234,199 +1244,443 @@ impl PaperTrading {
         self.draw_session_summary(ui);
     }
 
+    /// A quiet action button — the HUD's control grammar, sized to share a
+    /// row evenly.
+    fn quiet_action(label: &str, width: f32) -> egui::Button<'_> {
+        egui::Button::new(
+            egui::RichText::new(label)
+                .color(theme::TEXT_PRIMARY)
+                .small(),
+        )
+        .fill(theme::CONTROL)
+        .stroke(egui::Stroke::new(1.0_f32, theme::BORDER))
+        .rounding(egui::Rounding::same(3.0))
+        .min_size(egui::vec2(width, 22.0))
+    }
+
+    /// The position block: a one-row FLAT card while flat (with the
+    /// session's realized points), the full card while a position is open —
+    /// identity, brackets with their P&L, the R:R read, and the actions.
     fn draw_position_card(&mut self, ui: &mut egui::Ui) {
         let Some(position) = self.sim.position().cloned() else {
-            ui.label(egui::RichText::new("No open position.").color(theme::TEXT_MUTED));
+            ui.horizontal(|ui| {
+                ui.label(
+                    egui::RichText::new("FLAT")
+                        .monospace()
+                        .color(theme::TEXT_MUTED),
+                );
+                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                    let realized = self.sim.realized_points();
+                    ui.label(
+                        egui::RichText::new(format!("{} pts", fmt_signed_points(realized)))
+                            .monospace()
+                            .strong()
+                            .color(points_color(realized)),
+                    )
+                    .on_hover_text("this session's realized points");
+                });
+            });
+            if !self.sim.orders().is_empty()
+                && ui
+                    .button("Cancel all orders")
+                    .on_hover_text("remove every working order without trading")
+                    .clicked()
+            {
+                self.cancel_all_orders();
+            }
             return;
         };
-        let color = match position.side {
-            Side::Buy => theme::BUY,
-            Side::Sell => theme::SELL,
-        };
+        let color = side_color(position.side);
+        let open = self.sim.mark_price().map(|mark| position.open_points(mark));
+
+        // Identity: the HUD's own chip, so the two surfaces read as one.
         ui.horizontal(|ui| {
+            egui::Frame::none()
+                .fill(color)
+                .rounding(egui::Rounding::same(2.0))
+                .inner_margin(egui::Margin::symmetric(5.0, 1.0))
+                .show(ui, |ui| {
+                    ui.label(
+                        egui::RichText::new(format!(
+                            "SIM {} {}",
+                            position_word(position.side),
+                            fmt_decimal(position.quantity)
+                        ))
+                        .color(theme::CHIP_INK)
+                        .strong()
+                        .small(),
+                    );
+                });
             ui.label(
-                egui::RichText::new(format!(
-                    "{} {} @ {}",
-                    position_word(position.side),
-                    fmt_decimal(position.quantity),
-                    fmt_decimal(position.avg_price),
-                ))
-                .color(color)
-                .strong(),
+                egui::RichText::new(format!("@ {}", fmt_decimal(position.avg_price)))
+                    .monospace()
+                    .color(theme::TEXT_PRIMARY),
             );
-            if let Some(mark) = self.sim.mark_price() {
-                let open = position.open_points(mark);
-                ui.label(
-                    egui::RichText::new(format!("{} pts", fmt_signed_points(open)))
-                        .color(points_color(open)),
-                )
-                .on_hover_text("open profit at the last print, in points (price units × quantity)");
+            if let Some(open) = open {
+                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                    ui.label(
+                        egui::RichText::new(format!("{} pts", fmt_signed_points(open)))
+                            .monospace()
+                            .strong()
+                            .color(points_color(open)),
+                    )
+                    .on_hover_text(
+                        "open profit at the last print, in points (price units × quantity)",
+                    );
+                });
             }
         });
+
+        // Brackets: the level, what it pays, ✕ to clear — or the way to set
+        // the missing leg right here, from the ticket's offset.
         let mut bracket_change = None;
-        ui.horizontal(|ui| match position.stop_loss {
-            Some(stop) => {
-                ui.label(format!("stop loss {}", fmt_decimal(stop)));
-                if ui
-                    .small_button("clear")
-                    .on_hover_text("remove the protective stop")
-                    .clicked()
-                {
-                    bracket_change = Some(Command::SetBracket {
-                        stop_loss: None,
-                        take_profit: position.take_profit,
-                    });
+        egui::Grid::new("paper_position_brackets")
+            .num_columns(3)
+            .spacing([8.0, 4.0])
+            .show(ui, |ui| {
+                let legs = [
+                    (
+                        "SL",
+                        position.stop_loss,
+                        theme::SELL,
+                        parse_offset(&self.stop_offset_text).ok().flatten(),
+                        "remove the protective stop",
+                    ),
+                    (
+                        "TP",
+                        position.take_profit,
+                        theme::BUY,
+                        parse_offset(&self.profit_offset_text).ok().flatten(),
+                        "remove the profit target",
+                    ),
+                ];
+                for (word, level, leg_color, offset, clear_hover) in legs {
+                    ui.label(egui::RichText::new(word).color(theme::TEXT_MUTED).small());
+                    match level {
+                        Some(level) => {
+                            ui.label(
+                                egui::RichText::new(format!(
+                                    "{} {} pts",
+                                    fmt_decimal(level),
+                                    fmt_signed_points(position.open_points(level)),
+                                ))
+                                .monospace()
+                                .color(leg_color),
+                            );
+                            if ui.small_button("×").on_hover_text(clear_hover).clicked() {
+                                bracket_change = Some(match word {
+                                    "SL" => Command::SetBracket {
+                                        stop_loss: None,
+                                        take_profit: position.take_profit,
+                                    },
+                                    _ => Command::SetBracket {
+                                        stop_loss: position.stop_loss,
+                                        take_profit: None,
+                                    },
+                                });
+                            }
+                        }
+                        None => match offset {
+                            Some(offset) => {
+                                ui.label(
+                                    egui::RichText::new("—")
+                                        .monospace()
+                                        .color(theme::TEXT_FAINT),
+                                );
+                                if ui
+                                    .small_button(format!("Set {} pts", fmt_decimal(offset)))
+                                    .on_hover_text(
+                                        "place this leg the ticket's offset away from the \
+                                         average entry",
+                                    )
+                                    .clicked()
+                                {
+                                    let (stop_loss, take_profit) = if word == "SL" {
+                                        (
+                                            Some(offset_price(&position, offset, true)),
+                                            position.take_profit,
+                                        )
+                                    } else {
+                                        (
+                                            position.stop_loss,
+                                            Some(offset_price(&position, offset, false)),
+                                        )
+                                    };
+                                    bracket_change = Some(Command::SetBracket {
+                                        stop_loss,
+                                        take_profit,
+                                    });
+                                }
+                            }
+                            None => {
+                                ui.label(
+                                    egui::RichText::new(
+                                        "drag from the entry line, or type an offset below",
+                                    )
+                                    .color(theme::TEXT_SUPPORT)
+                                    .small(),
+                                );
+                                ui.label("");
+                            }
+                        },
+                    }
+                    ui.end_row();
                 }
-            }
-            None => {
+            });
+        if let (Some(stop), Some(target)) = (position.stop_loss, position.take_profit) {
+            let risk = position.avg_price.saturating_sub(stop).abs();
+            let reward = target.saturating_sub(position.avg_price).abs();
+            if risk > Decimal::ZERO {
                 ui.label(
-                    egui::RichText::new(
-                        "stop loss - (drag one on the chart, or use the offsets below)",
-                    )
-                    .color(theme::TEXT_MUTED),
-                );
+                    egui::RichText::new(format!("R:R {}", fmt_points(reward / risk)))
+                        .monospace()
+                        .color(theme::TEXT_MUTED),
+                )
+                .on_hover_text("reward divided by risk, in points, at the current levels");
             }
-        });
-        ui.horizontal(|ui| match position.take_profit {
-            Some(target) => {
-                ui.label(format!("take profit {}", fmt_decimal(target)));
-                if ui
-                    .small_button("clear")
-                    .on_hover_text("remove the profit target")
-                    .clicked()
-                {
-                    bracket_change = Some(Command::SetBracket {
-                        stop_loss: position.stop_loss,
-                        take_profit: None,
-                    });
-                }
-            }
-            None => {
-                ui.label(
-                    egui::RichText::new(
-                        "take profit - (drag one on the chart, or use the offsets below)",
-                    )
-                    .color(theme::TEXT_MUTED),
-                );
-            }
-        });
+        }
         if let Some(command) = bracket_change {
             let events = self.sim.apply(command);
             self.handle_events(events);
         }
+
+        // Actions, two per row at equal width; consequential ones stay
+        // text-first, never a bare glyph.
         ui.add_space(4.0);
+        let half = (ui.available_width() - ui.spacing().item_spacing.x) / 2.0;
+        let word = position_word(position.side);
+        let qty = fmt_decimal(position.quantity);
         ui.horizontal(|ui| {
             if ui
-                .button("Close")
-                .on_hover_text("exit the position at the next print")
+                .add(Self::quiet_action("× Close", half))
+                .on_hover_text(format!("exit the {word} {qty} at the next print (market)"))
                 .clicked()
             {
                 self.close_position();
             }
             if ui
-                .button("Flatten")
-                .on_hover_text("close the position and cancel every pending order")
+                .add(Self::quiet_action(
+                    &format!("{} Reverse", icons::ARROWS_LEFT_RIGHT),
+                    half,
+                ))
+                .on_hover_text(format!(
+                    "close the {word} {qty} and open the opposite side at the same size"
+                ))
                 .clicked()
             {
-                self.flatten();
+                self.reverse_position();
             }
         });
+        ui.horizontal(|ui| {
+            let in_profit = open.is_some_and(|open| open > Decimal::ZERO);
+            if ui
+                .add_enabled(in_profit, Self::quiet_action("Breakeven", half))
+                .on_hover_text(
+                    "move the stop to the average entry - with no fees simulated, \
+                     break-even is the entry exactly",
+                )
+                .on_disabled_hover_text(
+                    "the stop can only move to entry while the position is in profit - \
+                     below it, this would widen your risk",
+                )
+                .clicked()
+            {
+                let events = self.sim.apply(Command::SetBracket {
+                    stop_loss: Some(position.avg_price),
+                    take_profit: position.take_profit,
+                });
+                self.handle_events(events);
+            }
+            if ui
+                .add(Self::quiet_action("Close 50%", half))
+                .on_hover_text(
+                    "close half the open quantity at the next print; the rest keeps \
+                     its average entry and brackets",
+                )
+                .clicked()
+            {
+                let events = self.sim.apply(Command::ClosePartial {
+                    quantity: (position.quantity / Decimal::TWO).normalize(),
+                });
+                self.handle_events(events);
+            }
+        });
+        let full = ui.available_width();
+        if ui
+            .add(Self::quiet_action("Flatten all", full))
+            .on_hover_text("close the position and cancel every working order")
+            .clicked()
+        {
+            self.flatten();
+        }
     }
 
     fn draw_order_entry(&mut self, ui: &mut egui::Ui) {
+        ui.label(caption("ORDER"));
+        // Qty: free decimal text (empty must keep meaning "fix me"), with
+        // steppers beside it; Shift steps by ten.
         ui.horizontal(|ui| {
-            ui.selectable_value(
-                &mut self.side,
-                Side::Buy,
-                egui::RichText::new("BUY").color(theme::BUY).strong(),
-            );
-            ui.selectable_value(
-                &mut self.side,
-                Side::Sell,
-                egui::RichText::new("SELL").color(theme::SELL).strong(),
-            );
-            ui.label(egui::RichText::new("qty").color(theme::TEXT_MUTED));
-            ui.add(egui::TextEdit::singleline(&mut self.qty_text).desired_width(48.0));
-            egui::ComboBox::from_id_salt("paper_order_type")
-                .selected_text(kind_word(self.order_type))
-                .show_ui(ui, |ui| {
-                    ui.selectable_value(&mut self.order_type, EntryKind::Market, "market");
-                    ui.selectable_value(&mut self.order_type, EntryKind::Limit, "limit");
-                    ui.selectable_value(&mut self.order_type, EntryKind::Stop, "stop");
-                });
+            ui.label(egui::RichText::new("Qty").color(theme::TEXT_MUTED).small());
+            let step = if ui.input(|input| input.modifiers.shift) {
+                Decimal::TEN
+            } else {
+                Decimal::ONE
+            };
+            if ui
+                .small_button("−")
+                .on_hover_text("one less (Shift: ten)")
+                .clicked()
+            {
+                self.step_quantity(-step);
+            }
+            ui.add(egui::TextEdit::singleline(&mut self.qty_text).desired_width(56.0));
+            if ui
+                .small_button("+")
+                .on_hover_text("one more (Shift: ten)")
+                .clicked()
+            {
+                self.step_quantity(step);
+            }
+        });
+        // Type: three pills. Picking Limit or Stop is a promise of an
+        // accent line on the chart, so the selected pill wears the accent.
+        ui.horizontal(|ui| {
+            ui.label(egui::RichText::new("Type").color(theme::TEXT_MUTED).small());
+            for kind in [EntryKind::Market, EntryKind::Limit, EntryKind::Stop] {
+                let on = self.order_type == kind;
+                if pill_toggle(ui, kind_word(kind), on, "how the entry meets the market").clicked()
+                    && !on
+                {
+                    self.order_type = kind;
+                    self.armed = None;
+                }
+            }
         });
         ui.horizontal(|ui| {
-            ui.label(egui::RichText::new("stop -pts").color(theme::TEXT_MUTED))
+            ui.label(egui::RichText::new("Stop").color(theme::TEXT_MUTED).small())
                 .on_hover_text(
                     "optional protective stop, this many points on the losing side of the \
                      entry; empty places no stop",
                 );
-            ui.add(egui::TextEdit::singleline(&mut self.stop_offset_text).desired_width(48.0));
-            ui.label(egui::RichText::new("profit +pts").color(theme::TEXT_MUTED))
-                .on_hover_text(
-                    "optional profit target, this many points on the winning side of the \
-                     entry; empty places no target",
-                );
-            ui.add(egui::TextEdit::singleline(&mut self.profit_offset_text).desired_width(48.0));
+            ui.add(egui::TextEdit::singleline(&mut self.stop_offset_text).desired_width(52.0));
+            ui.label(
+                egui::RichText::new("Target")
+                    .color(theme::TEXT_MUTED)
+                    .small(),
+            )
+            .on_hover_text(
+                "optional profit target, this many points on the winning side of the \
+                 entry; empty places no target",
+            );
+            ui.add(egui::TextEdit::singleline(&mut self.profit_offset_text).desired_width(52.0));
+            ui.label(egui::RichText::new("pts").color(theme::TEXT_FAINT).small());
         });
         ui.add_space(4.0);
-        let side = self.side;
-        let side_color = match side {
-            Side::Buy => theme::BUY,
-            Side::Sell => theme::SELL,
-        };
-        match self.order_type {
-            EntryKind::Market => {
-                let label = format!(
-                    "{} {} at market",
-                    side_word_upper(side),
-                    self.qty_text.trim()
-                );
-                let button = ui
-                    .add_enabled(
-                        self.ready(),
-                        egui::Button::new(egui::RichText::new(label).color(side_color).strong()),
-                    )
-                    .on_hover_text("simulated: fills at the next print of the tape")
-                    .on_disabled_hover_text("waiting for the first print - there is no market yet");
-                if button.clicked() {
-                    self.market(side);
-                }
-            }
-            kind @ (EntryKind::Limit | EntryKind::Stop) => {
-                if self.armed.is_some() {
-                    ui.horizontal(|ui| {
-                        ui.label(
-                            egui::RichText::new("click the chart at your price…")
-                                .color(theme::ACCENT),
-                        );
-                        if ui.small_button("cancel").clicked() {
-                            self.armed = None;
-                        }
-                    });
+
+        // The entry pair: the surface where you commit, taller than the
+        // toolbar's buttons. An armed side inverts — a mode you are in must
+        // be visible on the control that put you there.
+        let half = (ui.available_width() - 6.0) / 2.0;
+        let ready = self.ready();
+        let mut fire: Option<Side> = None;
+        let mut arm: Option<Side> = None;
+        let mut disarm = false;
+        ui.horizontal(|ui| {
+            ui.spacing_mut().item_spacing.x = 6.0;
+            for side in [Side::Buy, Side::Sell] {
+                let color = side_color(side);
+                let armed_here = self.armed.is_some_and(|armed| armed.side == side);
+                let armed_other = self.armed.is_some_and(|armed| armed.side != side);
+                let label = match (self.order_type, armed_here) {
+                    (_, true) => "Click a price…".to_owned(),
+                    (EntryKind::Market, _) => self.entry_label(side),
+                    (kind, _) => format!(
+                        "{} {} {}",
+                        side_word_upper(side),
+                        kind_word(kind).to_uppercase(),
+                        self.quantity_preview()
+                            .map_or_else(String::new, fmt_decimal),
+                    ),
+                };
+                let button = if armed_here {
+                    egui::Button::new(egui::RichText::new(label).color(color).strong())
+                        .fill(theme::CONTROL)
+                        .stroke(egui::Stroke::new(1.5_f32, color))
                 } else {
-                    let label = format!(
-                        "Place {} {} on the chart…",
-                        side_word(side),
-                        kind_word(kind)
-                    );
-                    let button = ui
-                        .add_enabled(
-                            self.ready(),
-                            egui::Button::new(egui::RichText::new(label).color(side_color)),
-                        )
-                        .on_hover_text(
-                            "arms a click: the next chart click rests the order at that price \
-                             (Esc cancels)",
-                        )
-                        .on_disabled_hover_text(
-                            "waiting for the first print - there is no market yet",
-                        );
-                    if button.clicked() {
-                        self.armed = Some(ArmedPlacement { side, kind });
+                    egui::Button::new(egui::RichText::new(label).color(theme::CHIP_INK).strong())
+                        .fill(color)
+                        .stroke(egui::Stroke::NONE)
+                }
+                .rounding(egui::Rounding::same(3.0))
+                .min_size(egui::vec2(half, 34.0));
+                let response = ui
+                    .add_enabled(ready && !armed_other, button)
+                    .on_hover_text(self.entry_hover(side))
+                    .on_disabled_hover_text(if armed_other {
+                        "cancel the armed order first (Esc)"
+                    } else {
+                        "waiting for the first print - there is no market yet"
+                    });
+                if response.clicked() {
+                    match (self.order_type, armed_here) {
+                        (_, true) => disarm = true,
+                        (EntryKind::Market, _) => fire = Some(side),
+                        (EntryKind::Limit | EntryKind::Stop, _) => arm = Some(side),
                     }
                 }
             }
+        });
+        if disarm {
+            self.armed = None;
+        }
+        if let Some(side) = fire {
+            self.market(side);
+        }
+        if let Some(side) = arm {
+            self.armed = Some(ArmedPlacement {
+                side,
+                kind: self.order_type,
+            });
+        }
+        ui.label(
+            egui::RichText::new(if self.armed.is_some() {
+                "Click the chart at your price. Esc cancels."
+            } else if self.order_type == EntryKind::Market {
+                "Market orders fill at the next print."
+            } else {
+                "The button arms a click; the next chart click rests the order there."
+            })
+            .color(theme::TEXT_SUPPORT)
+            .small(),
+        );
+    }
+
+    /// Step the quantity field by `delta`, never below a positive value;
+    /// an unparseable field steps from one.
+    fn step_quantity(&mut self, delta: Decimal) {
+        let current = self
+            .qty_text
+            .trim()
+            .parse::<Decimal>()
+            .ok()
+            .filter(|quantity| *quantity > Decimal::ZERO)
+            .unwrap_or(Decimal::ONE);
+        let next = current.saturating_add(delta);
+        if next > Decimal::ZERO {
+            self.qty_text = fmt_decimal(next);
+        }
+    }
+
+    /// Cancel every working order (resting and queued), trading nothing.
+    pub fn cancel_all_orders(&mut self) {
+        let mut ids: Vec<OrderId> = self.sim.orders().iter().map(|order| order.id).collect();
+        ids.extend(self.sim.queued().iter().filter_map(|action| match action {
+            QueuedAction::Entry(order) => Some(order.id),
+            QueuedAction::Close | QueuedAction::ClosePartial { .. } => None,
+        }));
+        for id in ids {
+            let events = self.sim.apply(Command::CancelOrder { id });
+            self.handle_events(events);
         }
     }
 
@@ -1438,6 +1692,8 @@ impl PaperTrading {
             .filter(|action| matches!(action, QueuedAction::Entry(_)))
             .count();
         let queued_closes = self.sim.queued().len() - queued_entries;
+        let orders: Vec<_> = self.sim.orders().to_vec();
+        ui.label(caption(&format!("WORKING ORDERS · {}", orders.len())));
         if queued_entries > 0 {
             ui.label(
                 egui::RichText::new(format!(
@@ -1454,54 +1710,114 @@ impl PaperTrading {
                     .small(),
             );
         }
-        let orders: Vec<_> = self.sim.orders().to_vec();
         if orders.is_empty() && queued_entries == 0 {
-            ui.label(egui::RichText::new("No pending orders.").color(theme::TEXT_MUTED));
+            ui.label(egui::RichText::new("No working orders.").color(theme::TEXT_MUTED));
+            ui.label(
+                egui::RichText::new("Pick Limit or Stop, then click a price on the chart.")
+                    .color(theme::TEXT_SUPPORT)
+                    .small(),
+            );
             return;
         }
         for order in orders {
-            ui.horizontal(|ui| {
-                let price = order.price.map_or_else(String::new, fmt_decimal);
-                ui.label(format!(
-                    "#{} {} {} {} @ {}",
-                    order.id.0,
-                    side_word(order.side),
-                    kind_word(order.kind),
-                    fmt_decimal(order.quantity),
-                    price,
-                ));
-                if ui
-                    .small_button("×")
-                    .on_hover_text("cancel this order")
-                    .clicked()
-                {
-                    let events = self.sim.apply(Command::CancelOrder { id: order.id });
-                    self.handle_events(events);
-                }
+            let response = ui.horizontal(|ui| {
+                // A short accent dash, echoing the dashed chart line.
+                let (dash, _) =
+                    ui.allocate_exact_size(egui::vec2(10.0, 12.0), egui::Sense::hover());
+                ui.painter().line_segment(
+                    [
+                        egui::pos2(dash.left(), dash.center().y),
+                        egui::pos2(dash.right(), dash.center().y),
+                    ],
+                    egui::Stroke::new(2.0_f32, theme::ACCENT),
+                );
+                ui.label(
+                    egui::RichText::new(format!("#{}", order.id.0))
+                        .color(theme::TEXT_FAINT)
+                        .small(),
+                );
+                ui.label(
+                    egui::RichText::new(side_word_upper(order.side))
+                        .monospace()
+                        .color(side_color(order.side)),
+                );
+                ui.label(
+                    egui::RichText::new(format!(
+                        "{} {} @ {}",
+                        kind_short(order.kind),
+                        fmt_decimal(order.quantity),
+                        order.price.map_or_else(String::new, fmt_decimal),
+                    ))
+                    .monospace()
+                    .color(theme::TEXT_PRIMARY),
+                );
+                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                    if ui
+                        .small_button("×")
+                        .on_hover_text("cancel this order")
+                        .clicked()
+                    {
+                        let events = self.sim.apply(Command::CancelOrder { id: order.id });
+                        self.handle_events(events);
+                    }
+                });
             });
+            // One hover, two surfaces: the row lifts its chart line.
+            if response.response.hovered() {
+                self.hovered_order = Some(order.id);
+            }
         }
     }
 
     fn draw_session_summary(&mut self, ui: &mut egui::Ui) {
-        ui.label(format!(
-            "session: {} pts realized · {} closed trade(s)",
-            fmt_signed_points(self.sim.realized_points()),
-            self.sim.closed_trades().len(),
-        ));
         ui.horizontal(|ui| {
-            if ui
-                .button("Report…")
-                .on_hover_text("performance metrics computed from the saved history")
-                .clicked()
-            {
-                self.open_report();
-            }
-        });
-        ui.label(
-            egui::RichText::new(format!("history: {}", self.dir.display()))
+            let realized = self.sim.realized_points();
+            ui.label(
+                egui::RichText::new(format!("{} pts", fmt_signed_points(realized)))
+                    .monospace()
+                    .strong()
+                    .color(points_color(realized)),
+            );
+            ui.label(
+                egui::RichText::new(format!(
+                    "realized · {} trades",
+                    self.sim.closed_trades().len()
+                ))
                 .color(theme::TEXT_MUTED)
                 .small(),
-        );
+            );
+            ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                if ui
+                    .button("Report…")
+                    .on_hover_text("performance metrics computed from the saved history")
+                    .clicked()
+                {
+                    self.open_report();
+                }
+            });
+        });
+        if ui
+            .add(
+                egui::Button::new(
+                    egui::RichText::new(format!("history: {}", self.dir.display()))
+                        .color(theme::TEXT_MUTED)
+                        .small(),
+                )
+                .fill(theme::CONTROL)
+                .stroke(egui::Stroke::new(1.0_f32, theme::BORDER))
+                .rounding(egui::Rounding::same(3.0))
+                .min_size(egui::vec2(ui.available_width(), 20.0)),
+            )
+            .on_hover_text(format!(
+                "open the history folder — {}",
+                std::path::absolute(&self.dir)
+                    .unwrap_or_else(|_| self.dir.clone())
+                    .display()
+            ))
+            .clicked()
+        {
+            reveal_folder(&self.dir);
+        }
     }
 
     // ------------------------------------------------------------------
@@ -1997,8 +2313,13 @@ impl PaperTrading {
     // Toast
     // ------------------------------------------------------------------
 
-    /// The transient message slot; newest wins, expires on its own.
+    /// The transient message slot; newest wins, expires on its own. Runs
+    /// last in the frame, so it also settles the per-frame handshakes: the
+    /// dock-hover link is cleared (the chart already read it) and a
+    /// finished export lands its toast.
     pub fn draw_toast(&mut self, ctx: &egui::Context, now: Instant) {
+        self.hovered_order = None;
+        self.poll_export();
         let Some(toast) = &self.toast else {
             return;
         };
@@ -2026,6 +2347,92 @@ impl PaperTrading {
             message,
             shown_at: Instant::now(),
         });
+    }
+
+    // ------------------------------------------------------------------
+    // Export
+    // ------------------------------------------------------------------
+
+    /// Write everything the ledger lists (this session plus the saved
+    /// history, in the ledger's scope) to one CSV, off the UI thread. The
+    /// toast answers with the path or the failure.
+    pub fn start_export(&mut self) {
+        if self.export_rx.is_some() {
+            self.show_toast("SIM: an export is already running.".to_owned());
+            return;
+        }
+        if self.history_cache.is_none() {
+            self.reload_ledger();
+        }
+        let mut rows: Vec<(String, ClosedTrade)> = Vec::new();
+        if let Some(cache) = &self.history_cache {
+            rows.extend(cache.rows.iter().cloned());
+        }
+        rows.extend(
+            self.sim
+                .closed_trades()
+                .iter()
+                .map(|trade| (self.symbol.clone(), trade.clone())),
+        );
+        rows.sort_by_key(|row| (row.1.closed_ms, row.1.opened_ms));
+        if rows.is_empty() {
+            self.show_toast("SIM: nothing to export yet - close a trade first.".to_owned());
+            return;
+        }
+        let text = export_csv(&rows);
+        let count = rows.len();
+        let stamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|elapsed| i64::try_from(elapsed.as_millis()).unwrap_or(0))
+            .unwrap_or(0);
+        let dir = self.dir.clone();
+        let path = dir.join(format!("export-{}.csv", utc_compact(stamp)));
+        let (sender, receiver) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let result = std::fs::create_dir_all(&dir)
+                .and_then(|()| std::fs::write(&path, text))
+                .map(|()| (path, count))
+                .map_err(|error| error.to_string());
+            let _ = sender.send(result);
+        });
+        self.export_rx = Some(receiver);
+    }
+
+    /// Land the export's result, if it arrived.
+    fn poll_export(&mut self) {
+        let Some(receiver) = &self.export_rx else {
+            return;
+        };
+        let Ok(result) = receiver.try_recv() else {
+            return;
+        };
+        self.export_rx = None;
+        match result {
+            Ok((path, count)) => {
+                tracing::info!(
+                    target: "quantick::app",
+                    schema_version = 1_u8,
+                    event_code = "PAPER_TRADES_EXPORTED",
+                    path = %path.display(),
+                    trades = count,
+                    "exported the simulated trade history"
+                );
+                self.show_toast(format!("Exported {count} trades to {}", elide_path(&path)));
+            }
+            Err(error) => {
+                tracing::warn!(
+                    target: "quantick::app",
+                    schema_version = 1_u8,
+                    event_code = "PAPER_TRADES_EXPORT_FAILED",
+                    %error,
+                    action = "export_not_saved",
+                    "could not write the trade export"
+                );
+                self.show_toast(
+                    "SIM: could not write the export - see the log for the path.".to_owned(),
+                );
+            }
+        }
     }
 
     // ------------------------------------------------------------------
@@ -3631,6 +4038,102 @@ fn fmt_utc_minute(timestamp_ms: i64) -> String {
     format!("{year:04}-{month:02}-{day:02} {hour:02}:{minute:02}")
 }
 
+/// A protective price the ticket's offset away from the average entry:
+/// the losing side for a stop, the winning side for a target. A long's
+/// stop and a short's target sit below the entry; the other two above.
+fn offset_price(position: &Position, offset: Decimal, stop: bool) -> Decimal {
+    let below = (position.side == Side::Buy) == stop;
+    if below {
+        position.avg_price.saturating_sub(offset)
+    } else {
+        position.avg_price.saturating_add(offset)
+    }
+}
+
+/// Open `path` in the platform's file manager — created first, so the
+/// reveal never points at nothing on a fresh install.
+fn reveal_folder(path: &Path) {
+    let _ = std::fs::create_dir_all(path);
+    let launcher = if cfg!(target_os = "windows") {
+        "explorer"
+    } else if cfg!(target_os = "macos") {
+        "open"
+    } else {
+        "xdg-open"
+    };
+    if let Err(error) = std::process::Command::new(launcher).arg(path).spawn() {
+        tracing::warn!(
+            target: "quantick::app",
+            schema_version = 1_u8,
+            event_code = "PAPER_HISTORY_REVEAL_FAILED",
+            path = %path.display(),
+            %error,
+            "could not open the history folder"
+        );
+    }
+}
+
+/// The export CSV: one merged, Excel-facing artifact — the journal stays
+/// the machine-readable source of truth. Human-readable UTC stamps ride
+/// beside the venue epoch, decimals always use `.`, and the running
+/// equity is a column so a spreadsheet shows it without a formula.
+fn export_csv(rows: &[(String, ClosedTrade)]) -> String {
+    let mut text = String::from(
+        "symbol,side,quantity,opened_ms,opened_utc,entry_price,closed_ms,closed_utc,\
+         exit_price,pnl_points,cum_pnl_points,duration_ms,exit_reason,entry_agg_id,\
+         exit_agg_id,mae_points,mfe_points\n",
+    );
+    let mut cumulative = Decimal::ZERO;
+    let opt_u64 = |value: Option<u64>| value.map(|value| value.to_string()).unwrap_or_default();
+    let opt_points = |value: Option<Decimal>| value.map(fmt_decimal).unwrap_or_default();
+    for (symbol, trade) in rows {
+        cumulative = cumulative.saturating_add(trade.pnl_points);
+        let side = match trade.side {
+            Side::Buy => "long",
+            Side::Sell => "short",
+        };
+        text.push_str(&format!(
+            "{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{}\n",
+            symbol.replace(',', "_"),
+            side,
+            fmt_decimal(trade.quantity),
+            trade.opened_ms,
+            fmt_utc_iso(trade.opened_ms),
+            fmt_decimal(trade.entry_price),
+            trade.closed_ms,
+            fmt_utc_iso(trade.closed_ms),
+            fmt_decimal(trade.exit_price),
+            fmt_decimal(trade.pnl_points),
+            fmt_decimal(cumulative),
+            trade.closed_ms.saturating_sub(trade.opened_ms).max(0),
+            trade.exit_reason.as_str(),
+            opt_u64(trade.entry_agg_id),
+            opt_u64(trade.exit_agg_id),
+            opt_points(trade.mae_points),
+            opt_points(trade.mfe_points),
+        ));
+    }
+    text
+}
+
+/// `YYYY-MM-DDTHH:MM:SSZ` in UTC — the export's human-readable stamp.
+fn fmt_utc_iso(timestamp_ms: i64) -> String {
+    let (year, month, day, hour, minute, second) = civil_utc(timestamp_ms);
+    format!("{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}Z")
+}
+
+/// A toast-sized path: printed whole when short, elided to `…/file.csv`
+/// past the limit — the file name always stays whole.
+fn elide_path(path: &Path) -> String {
+    let text = path.display().to_string();
+    if text.chars().count() <= EXPORT_PATH_ELIDE_CHARS {
+        return text;
+    }
+    path.file_name().map_or(text, |name| {
+        format!("…{}{}", std::path::MAIN_SEPARATOR, name.to_string_lossy())
+    })
+}
+
 /// The symbol folders under the history dir, for the report's combo box.
 fn list_symbol_folders(dir: &Path) -> Vec<String> {
     let Ok(entries) = std::fs::read_dir(dir) else {
@@ -3817,6 +4320,60 @@ mod tests {
         assert_eq!(cache.rows[0].0, "LEDGX");
         assert_eq!(cache.rows[0].1, trade);
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn the_export_csv_carries_readable_stamps_and_running_equity() {
+        let trade = |closed_ms: i64, pnl: i64, mae: Option<i64>| ClosedTrade {
+            side: Side::Buy,
+            quantity: Decimal::ONE,
+            entry_price: Decimal::from(100),
+            exit_price: Decimal::from(100 + pnl),
+            opened_ms: closed_ms - 60_000,
+            closed_ms,
+            pnl_points: Decimal::from(pnl),
+            exit_reason: quantick_sim::ExitReason::Manual,
+            entry_agg_id: mae.map(|_| 1),
+            exit_agg_id: mae.map(|_| 2),
+            mae_points: mae.map(Decimal::from),
+            mfe_points: mae.map(Decimal::from),
+        };
+        let rows = vec![
+            ("BTCUSDT".to_owned(), trade(1_773_666_068_000, 5, Some(2))),
+            ("WINQ26".to_owned(), trade(1_773_666_368_000, -2, None)),
+        ];
+        let text = export_csv(&rows);
+        let lines: Vec<&str> = text.lines().collect();
+        assert_eq!(lines.len(), 3, "header plus two rows");
+        assert!(lines[0].starts_with("symbol,side,quantity,opened_ms,opened_utc"));
+        assert!(
+            lines[1].contains("2026-03-16T13:01:08Z"),
+            "human-readable UTC beside the epoch: {}",
+            lines[1]
+        );
+        assert!(lines[1].ends_with(",manual,1,2,2,2"), "{}", lines[1]);
+        assert!(
+            lines[2].contains(",3,"),
+            "running equity 5 + (-2): {}",
+            lines[2]
+        );
+        assert!(
+            lines[2].ends_with(",manual,,,,"),
+            "unknown v1 fields stay empty, never zero: {}",
+            lines[2]
+        );
+    }
+
+    #[test]
+    fn long_export_paths_elide_to_the_file_name() {
+        let short = Path::new("paper-trades/export-1.csv");
+        assert_eq!(elide_path(short), short.display().to_string());
+        let long = Path::new(
+            "C:/some/extremely/long/path/that/never/ends/and/keeps/going/paper-trades/export-20260805-141233.csv",
+        );
+        let elided = elide_path(long);
+        assert!(elided.starts_with('…'), "{elided}");
+        assert!(elided.ends_with("export-20260805-141233.csv"), "{elided}");
     }
 
     #[test]

--- a/crates/app/src/paper_trading.rs
+++ b/crates/app/src/paper_trading.rs
@@ -307,6 +307,15 @@ struct LoadedHistory {
     problem_rows: usize,
 }
 
+/// What the Trading tab asked of its host.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TradingTabAction {
+    /// Open the folder picker for where trades are saved — the choice is
+    /// app-wide (every tab journals there) and remembered, so the app
+    /// owns the dialog and the fan-out.
+    PickTradesDir,
+}
+
 /// What the Trades ledger asked of its host.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LedgerAction {
@@ -411,16 +420,18 @@ impl PaperTrading {
     /// through [`Self::with_trades_dir`] with the configured folder.
     #[must_use]
     pub fn new() -> Self {
-        Self::with_trades_dir(Self::resolve_trades_dir(TRADES_DIR))
+        Self::with_trades_dir(Self::resolve_trades_dir(TRADES_DIR, None))
     }
 
     /// The journal folder for this run: the environment override wins (an
     /// env var is an explicit request for one run, like every autostart
-    /// hook), then `configured` — the `[paper] trades_dir` key, defaulting
-    /// to `paper-trades`.
+    /// hook), then `stored` — the folder the user last picked with the
+    /// panel's button — then `configured`, the `[paper] trades_dir` key,
+    /// defaulting to `paper-trades`.
     #[must_use]
-    pub fn resolve_trades_dir(configured: &str) -> PathBuf {
-        std::env::var_os(TRADES_DIR_ENV).map_or_else(|| PathBuf::from(configured), PathBuf::from)
+    pub fn resolve_trades_dir(configured: &str, stored: Option<&str>) -> PathBuf {
+        std::env::var_os(TRADES_DIR_ENV)
+            .map_or_else(|| chosen_trades_dir(configured, stored), PathBuf::from)
     }
 
     /// A host journaling to `dir`, already resolved from config and
@@ -462,6 +473,29 @@ impl PaperTrading {
     #[cfg(test)]
     pub(crate) fn redirect_history_dir(&mut self, dir: PathBuf) {
         self.dir = dir;
+    }
+
+    /// Where trades save right now.
+    #[must_use]
+    pub fn trades_dir(&self) -> &Path {
+        &self.dir
+    }
+
+    /// Point the journal somewhere new, in-session — the panel's folder
+    /// picker. Files already written stay exactly where they are; the next
+    /// close opens a new session file under the new folder, and the ledger
+    /// and report re-read from the new home.
+    pub fn set_trades_dir(&mut self, dir: PathBuf) {
+        if self.dir == dir {
+            return;
+        }
+        self.dir = dir;
+        self.journal_path = None;
+        self.journal_warned = false;
+        self.history_cache = None;
+        self.report = None;
+        self.report_view = None;
+        self.show_toast(format!("SIM: trades now save to {}", elide_path(&self.dir)));
     }
 
     /// Apply a raw simulator command through the normal event funnel
@@ -1446,7 +1480,7 @@ impl PaperTrading {
 
     /// The Trading dock tab: position, ticket, working orders, session
     /// strip. See `docs/ux/paper-trading.md` §3.
-    pub fn draw_trading_tab(&mut self, ui: &mut egui::Ui) {
+    pub fn draw_trading_tab(&mut self, ui: &mut egui::Ui) -> Option<TradingTabAction> {
         self.hovered_order = None;
         ui.label(
             egui::RichText::new("Simulated fills from the tape - no broker, points not currency.")
@@ -1466,7 +1500,7 @@ impl PaperTrading {
         ui.separator();
         self.draw_pending_orders(ui);
         ui.separator();
-        self.draw_session_summary(ui);
+        self.draw_session_summary(ui)
     }
 
     /// A quiet action button — the HUD's control grammar, sized to share a
@@ -1995,7 +2029,8 @@ impl PaperTrading {
         }
     }
 
-    fn draw_session_summary(&mut self, ui: &mut egui::Ui) {
+    fn draw_session_summary(&mut self, ui: &mut egui::Ui) -> Option<TradingTabAction> {
+        let mut action = None;
         ui.horizontal(|ui| {
             let realized = self.sim.realized_points();
             ui.label(
@@ -2022,31 +2057,45 @@ impl PaperTrading {
                 }
             });
         });
-        if ui
-            .add(
-                egui::Button::new(
-                    egui::RichText::new(format!("trades saved to: {}", self.dir.display()))
-                        .color(theme::TEXT_MUTED)
-                        .small(),
+        ui.horizontal(|ui| {
+            if ui
+                .small_button(icons::FOLDER_OPEN)
+                .on_hover_text(
+                    "choose where trades are saved — applies to every tab and is \
+                     remembered across restarts",
                 )
-                .fill(theme::CONTROL)
-                .stroke(egui::Stroke::new(1.0_f32, theme::BORDER))
-                .rounding(egui::Rounding::same(3.0))
-                .min_size(egui::vec2(ui.available_width(), 20.0)),
-            )
-            .on_hover_text(format!(
-                "click to open the folder — {}\nset it with [paper] trades_dir in \
-                 quantick.toml; QUANTICK_TRADES_DIR overrides it for one run. Anything \
-                 writing the quantick-trades format here (a future bot included) shows \
-                 up in the ledger, the report and the export.",
-                std::path::absolute(&self.dir)
-                    .unwrap_or_else(|_| self.dir.clone())
-                    .display()
-            ))
-            .clicked()
-        {
-            reveal_folder(&self.dir);
-        }
+                .clicked()
+            {
+                action = Some(TradingTabAction::PickTradesDir);
+            }
+            if ui
+                .add(
+                    egui::Button::new(
+                        egui::RichText::new(format!("trades saved to: {}", self.dir.display()))
+                            .color(theme::TEXT_MUTED)
+                            .small(),
+                    )
+                    .fill(theme::CONTROL)
+                    .stroke(egui::Stroke::new(1.0_f32, theme::BORDER))
+                    .rounding(egui::Rounding::same(3.0))
+                    .min_size(egui::vec2(ui.available_width(), 20.0)),
+                )
+                .on_hover_text(format!(
+                    "click to open the folder — {}\nthe folder button beside this picks a \
+                     new one; [paper] trades_dir in quantick.toml sets the base and \
+                     QUANTICK_TRADES_DIR overrides it for one run. Anything writing the \
+                     quantick-trades format here (a future bot included) shows up in the \
+                     ledger, the report and the export.",
+                    std::path::absolute(&self.dir)
+                        .unwrap_or_else(|_| self.dir.clone())
+                        .display()
+                ))
+                .clicked()
+            {
+                reveal_folder(&self.dir);
+            }
+        });
+        action
     }
 
     // ------------------------------------------------------------------
@@ -4383,6 +4432,14 @@ fn elide_path(path: &Path) -> String {
     })
 }
 
+/// The trades folder before the environment has its say: the user's own
+/// in-app pick when one is stored, else the configured base.
+fn chosen_trades_dir(configured: &str, stored: Option<&str>) -> PathBuf {
+    stored
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(configured))
+}
+
 /// The symbol folders under the history dir, for the report's combo box.
 fn list_symbol_folders(dir: &Path) -> Vec<String> {
     let Ok(entries) = std::fs::read_dir(dir) else {
@@ -4510,6 +4567,63 @@ mod tests {
             "the reset exit is a real, journaled trade"
         );
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn the_stored_pick_beats_the_configured_base() {
+        assert_eq!(
+            chosen_trades_dir("paper-trades", None),
+            PathBuf::from("paper-trades"),
+            "no pick falls back to the configured base"
+        );
+        assert_eq!(
+            chosen_trades_dir("paper-trades", Some("D:/journals")),
+            PathBuf::from("D:/journals"),
+            "the in-app pick wins over the configured base"
+        );
+    }
+
+    /// The panel's folder picker retargets everything downstream: the next
+    /// close opens a new session file under the new home, and the ledger
+    /// and report re-read from it. Files already written stay put.
+    #[test]
+    fn switching_the_trades_dir_retargets_journal_ledger_and_report() {
+        let dir_a =
+            std::env::temp_dir().join(format!("quantick-paper-dir-a-{}", std::process::id()));
+        let dir_b =
+            std::env::temp_dir().join(format!("quantick-paper-dir-b-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir_a);
+        let _ = std::fs::remove_dir_all(&dir_b);
+        let mut paper = PaperTrading::new();
+        paper.dir.clone_from(&dir_a);
+        paper.set_symbol("SWITCHX");
+        paper.seed(&print(0, 100));
+        paper.market(Side::Buy);
+        paper.on_trade(&print(1, 100));
+        let events = paper.sim.apply(Command::ClosePosition);
+        paper.handle_events(events);
+        paper.on_trade(&print(2, 103));
+        assert!(paper.journal_path.is_some(), "the close journaled under A");
+        paper.reload_ledger();
+        assert!(paper.history_cache.is_some());
+
+        paper.set_trades_dir(dir_b.clone());
+        assert_eq!(paper.trades_dir(), dir_b.as_path());
+        assert!(
+            paper.journal_path.is_none(),
+            "the next close opens a new session file under B"
+        );
+        assert!(
+            paper.history_cache.is_none(),
+            "the ledger re-reads from the new home"
+        );
+        assert!(paper.toast.is_some(), "the switch is never silent");
+        assert!(
+            dir_a.join("SWITCHX").exists(),
+            "files already written stay where they are"
+        );
+        let _ = std::fs::remove_dir_all(&dir_a);
+        let _ = std::fs::remove_dir_all(&dir_b);
     }
 
     #[test]

--- a/crates/app/src/paper_trading.rs
+++ b/crates/app/src/paper_trading.rs
@@ -111,6 +111,9 @@ const CURVE_MIN_H_PX: f32 = 160.0;
 const CURVE_MAX_H_PX: f32 = 240.0;
 /// Alpha of the equity area fill — ground under the line, not a mark.
 const CURVE_FILL_ALPHA: u8 = 31;
+/// Alpha of the equity curve's gridlines — the chart's own grid token at
+/// half strength, recessive under one quiet line.
+const CURVE_GRID_LINE_ALPHA: u8 = 128;
 /// At most this many curve points are drawn; the *drawing* downsamples
 /// past it (and says so), the metrics always use every trade.
 const CURVE_MAX_POINTS: usize = 1000;
@@ -122,10 +125,6 @@ const CURVE_GUTTER_PX: f32 = 52.0;
 /// Longest export path a toast prints whole; past it the folder elides
 /// and the file name stays.
 const EXPORT_PATH_ELIDE_CHARS: usize = 64;
-/// Text color inside colored gutter chips — the same ink as the last-price
-/// chip (`LAST_PRICE_CHIP_TEXT` is private to `app.rs`, so the value is
-/// duplicated here; keep the two identical).
-const CHIP_TEXT: egui::Color32 = egui::Color32::from_rgb(0x0E, 0x12, 0x1A);
 /// Vertical clearance between a paper chip's centre and the last-price
 /// chip's, in pixels — just over one chip height, so the two can never
 /// overprint. At the instant a market order fills, the entry price *is* the
@@ -2883,7 +2882,7 @@ fn draw_equity_curve(ui: &mut egui::Ui, view: &ReportView) {
                     theme::CONTROL.r(),
                     theme::CONTROL.g(),
                     theme::CONTROL.b(),
-                    128,
+                    CURVE_GRID_LINE_ALPHA,
                 ),
             ),
         );
@@ -3001,11 +3000,12 @@ fn draw_equity_curve(ui: &mut egui::Ui, view: &ReportView) {
                 egui::Stroke::new(1.0_f32, theme::SELL),
             );
             let label = format!("-{} pts", fmt_points(view.report.max_drawdown_points));
-            let galley = painter.layout_no_wrap(label, egui::FontId::monospace(10.0), CHIP_TEXT);
+            let galley =
+                painter.layout_no_wrap(label, egui::FontId::monospace(10.0), theme::CHIP_INK);
             let center = egui::pos2((x_at(peak) + trough_x) / 2.0, (peak_y + trough_y) / 2.0);
             let bg = egui::Rect::from_center_size(center, galley.size() + egui::vec2(8.0, 4.0));
             painter.rect_filled(bg, egui::Rounding::same(2.0), theme::SELL);
-            painter.galley(bg.min + egui::vec2(4.0, 2.0), galley, CHIP_TEXT);
+            painter.galley(bg.min + egui::vec2(4.0, 2.0), galley, theme::CHIP_INK);
         }
     }
 
@@ -3521,9 +3521,11 @@ impl PaintCtx<'_> {
             self.chart_rect.top(),
             self.chart_rect.bottom(),
         );
-        let galley =
-            self.painter
-                .layout_no_wrap(text.to_owned(), egui::FontId::monospace(11.0), CHIP_TEXT);
+        let galley = self.painter.layout_no_wrap(
+            text.to_owned(),
+            egui::FontId::monospace(11.0),
+            theme::CHIP_INK,
+        );
         let text_pos = egui::pos2(self.axis_x + 6.0, chip_y - galley.size().y / 2.0);
         let bg = egui::Rect::from_min_size(
             text_pos - egui::vec2(3.0, 1.0),
@@ -3531,7 +3533,7 @@ impl PaintCtx<'_> {
         );
         self.painter
             .rect_filled(bg, egui::Rounding::same(2.0), color);
-        self.painter.galley(text_pos, galley, CHIP_TEXT);
+        self.painter.galley(text_pos, galley, theme::CHIP_INK);
     }
 
     /// A solid tag on a line, right-anchored inside the plot. While the
@@ -3547,9 +3549,11 @@ impl PaintCtx<'_> {
         line_hovered: bool,
         with_close: bool,
     ) -> Option<egui::Rect> {
-        let galley =
-            self.painter
-                .layout_no_wrap(text.to_owned(), egui::FontId::monospace(11.0), CHIP_TEXT);
+        let galley = self.painter.layout_no_wrap(
+            text.to_owned(),
+            egui::FontId::monospace(11.0),
+            theme::CHIP_INK,
+        );
         let half = TAG_HEIGHT_PX / 2.0;
         let center_y = y.clamp(
             self.chart_rect.top() + half,
@@ -3575,7 +3579,7 @@ impl PaintCtx<'_> {
         self.painter.galley(
             egui::pos2(resting.left() + TAG_PAD_X, center_y - galley.size().y / 2.0),
             galley,
-            CHIP_TEXT,
+            theme::CHIP_INK,
         );
         if !hovered {
             return None;
@@ -3586,7 +3590,7 @@ impl PaintCtx<'_> {
             egui::Align2::CENTER_CENTER,
             "×",
             egui::FontId::monospace(11.0),
-            CHIP_TEXT,
+            theme::CHIP_INK,
         );
         Some(button)
     }

--- a/crates/app/src/paper_trading.rs
+++ b/crates/app/src/paper_trading.rs
@@ -653,8 +653,13 @@ impl PaperTrading {
             }
             _ => "an offset field needs fixing".to_owned(),
         };
+        let hotkey = match side {
+            Side::Buy => "Shift+B",
+            Side::Sell => "Shift+S",
+        };
         format!(
-            "simulated market {} - fills at the next print; {quantity}, {bracket} (Trading tab)",
+            "simulated market {} - fills at the next print; {quantity}, {bracket} \
+             (Trading tab) · {hotkey}",
             side_word(side),
         )
     }
@@ -1164,40 +1169,107 @@ impl PaperTrading {
         None
     }
 
-    /// The armed click: build the command at the clicked price and let the
-    /// simulator answer. Stays armed on a rejection — the toast explains
-    /// where the order may sit, and the user clicks again.
+    /// The armed click: place at the clicked price and disarm on success.
+    /// Stays armed on a rejection — the toast explains where the order may
+    /// sit, and the user clicks again.
     fn place_armed(&mut self, armed: ArmedPlacement, raw_price: f64) {
+        if self.place_resting(armed.side, armed.kind, raw_price) {
+            self.armed = None;
+        }
+    }
+
+    /// Rest a limit/stop entry at `raw_price` with the ticket's quantity
+    /// and offsets; returns whether the simulator accepted it.
+    fn place_resting(&mut self, side: Side, kind: EntryKind, raw_price: f64) -> bool {
         let Some(quantity) = self.parse_quantity() else {
-            return;
+            return false;
         };
         let price = self.snap(raw_price);
-        let Some(bracket) = self.parse_bracket(armed.side, price) else {
-            return;
+        let Some(bracket) = self.parse_bracket(side, price) else {
+            return false;
         };
-        let command = match armed.kind {
+        let command = match kind {
             EntryKind::Limit => Command::PlaceLimit {
-                side: armed.side,
+                side,
                 quantity,
                 price,
                 bracket,
             },
             EntryKind::Stop => Command::PlaceStop {
-                side: armed.side,
+                side,
                 quantity,
                 trigger: price,
                 bracket,
             },
-            // Market never arms; the form fires it directly.
-            EntryKind::Market => return,
+            // Market never rests; the buttons fire it directly.
+            EntryKind::Market => return false,
         };
         let events = self.sim.apply(command);
         let placed = events
             .iter()
             .any(|event| matches!(event, SimEvent::Placed(_)));
         self.handle_events(events);
-        if placed {
-            self.armed = None;
+        placed
+    }
+
+    /// The chart context menu's trade section, anchored at the clicked
+    /// price: market both ways, then the resting types that are valid on
+    /// that side of the market. The invalid ones stay visible but
+    /// disabled, wearing the sim core's own rejection text — the same
+    /// curriculum the toasts teach.
+    pub fn context_trade_actions(&mut self, ui: &mut egui::Ui, raw_price: f64) {
+        ui.label(
+            egui::RichText::new("trade")
+                .size(11.0)
+                .color(theme::TEXT_MUTED),
+        );
+        let Some(mark) = self.sim.mark_price() else {
+            ui.label(
+                egui::RichText::new("no print yet - there is no market to trade against")
+                    .color(theme::TEXT_MUTED)
+                    .small(),
+            );
+            return;
+        };
+        let quantity = self
+            .quantity_preview()
+            .map_or_else(|| "?".to_owned(), fmt_decimal);
+        for side in [Side::Buy, Side::Sell] {
+            if ui
+                .button(format!("{} {quantity} market", side_word_upper(side)))
+                .on_hover_text("fills at the next print, with the ticket's offsets")
+                .clicked()
+            {
+                self.market(side);
+                ui.close_menu();
+            }
+        }
+        ui.separator();
+        let price = self.snap(raw_price);
+        let entries = [
+            (Side::Buy, EntryKind::Limit, price < mark),
+            (Side::Buy, EntryKind::Stop, price > mark),
+            (Side::Sell, EntryKind::Limit, price > mark),
+            (Side::Sell, EntryKind::Stop, price < mark),
+        ];
+        for (side, kind, valid) in entries {
+            let label = format!(
+                "{} {quantity} {} @ {}",
+                side_word_upper(side),
+                kind_word(kind),
+                fmt_decimal(price),
+            );
+            let reason = match kind {
+                EntryKind::Limit => quantick_sim::RejectReason::LimitOnWrongSide(side),
+                _ => quantick_sim::RejectReason::StopOnWrongSide(side),
+            };
+            let response = ui
+                .add_enabled(valid, egui::Button::new(label))
+                .on_disabled_hover_text(reason.to_string());
+            if response.clicked() {
+                self.place_resting(side, kind, raw_price);
+                ui.close_menu();
+            }
         }
     }
 
@@ -1283,7 +1355,7 @@ impl PaperTrading {
             if !self.sim.orders().is_empty()
                 && ui
                     .button("Cancel all orders")
-                    .on_hover_text("remove every working order without trading")
+                    .on_hover_text("remove every working order without trading (Shift+X)")
                     .clicked()
             {
                 self.cancel_all_orders();
@@ -1464,7 +1536,8 @@ impl PaperTrading {
                     half,
                 ))
                 .on_hover_text(format!(
-                    "close the {word} {qty} and open the opposite side at the same size"
+                    "close the {word} {qty} and open the opposite side at the same size \
+                     (Shift+R)"
                 ))
                 .clicked()
             {
@@ -1508,7 +1581,7 @@ impl PaperTrading {
         let full = ui.available_width();
         if ui
             .add(Self::quiet_action("Flatten all", full))
-            .on_hover_text("close the position and cancel every working order")
+            .on_hover_text("close the position and cancel every working order (Shift+F)")
             .clicked()
         {
             self.flatten();

--- a/crates/app/src/paper_trading.rs
+++ b/crates/app/src/paper_trading.rs
@@ -17,8 +17,8 @@ use std::time::{Duration, Instant};
 use eframe::egui;
 use quantick_engine::{Side, Trade};
 use quantick_sim::{
-    Bracket, ClosedTrade, Command, EntryKind, OrderId, PerformanceReport, QueuedAction, SimEvent,
-    Simulator, history,
+    Bracket, ClosedTrade, Command, EntryKind, OrderId, PerformanceReport, Position, QueuedAction,
+    SimEvent, Simulator, history,
 };
 use rust_decimal::Decimal;
 use rust_decimal::prelude::ToPrimitive;
@@ -46,6 +46,43 @@ const TOAST_LIFT_PX: f32 = 96.0;
 /// Price precision for snapped drags before any print reveals the
 /// instrument's own (two decimals, the crypto-major default).
 const SNAP_FALLBACK_DECIMALS: u32 = 2;
+/// The position's entry line leads the paper lines: it is the one that is
+/// history rather than an order, and it matches the drawings' default width.
+const POSITION_LINE_WIDTH_PX: f32 = 1.5;
+/// Resting width of every other paper line (orders, stop, target).
+const LINE_WIDTH_PX: f32 = 1.0;
+/// Width of a paper line while the pointer is within grab range — the same
+/// emphasis step the drawings use.
+const LINE_HOVER_WIDTH_PX: f32 = 1.5;
+/// Width of a paper line while it is being dragged.
+const LINE_DRAG_WIDTH_PX: f32 = 2.0;
+/// The drawings' selection-halo treatment, mirrored for a dragged paper
+/// line so a grabbed stop feels identical to a grabbed drawing (the
+/// originals are private to `drawings`).
+const DRAG_HALO_COLOR: egui::Color32 = egui::Color32::from_rgba_premultiplied(40, 40, 40, 40);
+/// How much wider than the line the halo pass paints.
+const DRAG_HALO_EXTRA_WIDTH_PX: f32 = 3.5;
+/// Height of an in-plot tag (fits mono 11 plus its padding).
+const TAG_HEIGHT_PX: f32 = 20.0;
+/// Gap between a tag's right edge and the plot's right edge — the inside
+/// mirror of the gutter chips' `AXIS_LABEL_GAP_PX`.
+const TAG_GAP_PX: f32 = 6.0;
+/// Horizontal padding inside a tag.
+const TAG_PAD_X: f32 = 6.0;
+/// Width of the ✕ zone a hovered tag reveals. An overlay convenience —
+/// every action here has a ≥ 28 px twin in the chrome.
+const TAG_BUTTON_PX: f32 = 20.0;
+/// How far around a tag the hover that reveals its ✕ still counts.
+const TAG_HOVER_SLACK_PX: f32 = 4.0;
+/// Size of a labelled SL/TP bracket handle on the entry line.
+const HANDLE_SIZE: egui::Vec2 = egui::vec2(20.0, 14.0);
+/// Vertical clearance between the entry line and a bracket handle.
+const HANDLE_GAP_PX: f32 = 4.0;
+/// Horizontal gap between the position tag and its bracket handles.
+const HANDLE_TAG_GAP_PX: f32 = 8.0;
+/// How far (in pixels) a press on the entry line must travel before it
+/// commits to creating one bracket leg — the drawings' drag threshold.
+const CREATE_DECIDE_THRESHOLD_PX: f32 = 4.0;
 /// Text color inside colored gutter chips — the same ink as the last-price
 /// chip (`LAST_PRICE_CHIP_TEXT` is private to `app.rs`, so the value is
 /// duplicated here; keep the two identical).
@@ -89,8 +126,38 @@ enum PaperDrag {
     Order(OrderId),
     /// The press landed on the entry line: an average entry is history, not
     /// an order, so the geometry stays put — but the gesture still belongs
-    /// to the line (the chart must not pan under it).
+    /// to the line (the chart must not pan under it). This is the state for
+    /// a fully bracketed position, whose legs are their own handles.
     Blocked,
+    /// The press landed on the entry line and at least one bracket leg is
+    /// missing: the first committed pull decides which leg the drag creates
+    /// (profit side → take profit, losing side → stop loss).
+    CreatePending,
+    /// Dragging a stop loss into existence from the entry line or its
+    /// handle; release submits it, exactly like repricing an existing one.
+    CreateStopLoss,
+    /// Dragging a take profit into existence (see `CreateStopLoss`).
+    CreateTakeProfit,
+}
+
+/// A painted overlay control from the last paint pass: a tag's ✕ or a
+/// bracket handle. Hit rects are cached one frame behind the paint — the
+/// input pass runs before the draw, and an immediate-mode overlay control is
+/// pressed against where it was actually painted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PaperControl {
+    /// ✕ on the position tag: exit at the next print.
+    ClosePosition,
+    /// ✕ on the stop-loss tag: clear the protective stop.
+    ClearStopLoss,
+    /// ✕ on the take-profit tag: clear the profit target.
+    ClearTakeProfit,
+    /// ✕ on a working order's tag: cancel it.
+    CancelOrder(OrderId),
+    /// Labelled `SL` handle on the entry line: press starts a create-drag.
+    HandleStopLoss,
+    /// Labelled `TP` handle on the entry line.
+    HandleTakeProfit,
 }
 
 /// One transient message; rejections double as the tutorial.
@@ -149,6 +216,9 @@ pub struct PaperTrading {
     // Chart-layer drag.
     drag: PaperDrag,
     drag_price: Option<f64>,
+    /// Interactive rects painted by the last `draw_layer` pass (tag ✕s,
+    /// bracket handles), pressed against on the next input pass.
+    controls: Vec<(PaperControl, egui::Rect)>,
     toast: Option<Toast>,
     report_open: bool,
     report_scope: ReportScope,
@@ -179,6 +249,7 @@ impl PaperTrading {
             armed: None,
             drag: PaperDrag::None,
             drag_price: None,
+            controls: Vec::new(),
             toast: None,
             report_open: false,
             report_scope: ReportScope::Symbol,
@@ -443,119 +514,164 @@ impl PaperTrading {
     // Chart layer
     // ------------------------------------------------------------------
 
-    /// Paint the simulated lines: pending orders (dashed, accent), then the
-    /// position's entry / stop-loss / take-profit (solid, semantic colors).
-    /// Chips share the last-price chip geometry so prices never disagree
-    /// about their pixel; `reserved_chip_y` is the last-price chip's row,
-    /// which every paper chip dodges rather than overprints.
+    /// Paint the simulated lines and their in-plot tags: pending orders
+    /// (dashed, accent), then the position's entry / stop-loss / take-profit
+    /// (solid, semantic colors). Gutter chips keep the last-price chip's
+    /// geometry and carry *the price and nothing else*, so prices never
+    /// disagree about their pixel; the words and the controls live in tags
+    /// right-anchored inside the plot. `pointer` is `Some` only on the pane
+    /// that owns paper input, so hover affordances (a tag's ✕, the bracket
+    /// handles) paint nowhere else. The interactive rects painted here are
+    /// cached for the next input pass — immediate mode presses against what
+    /// was actually drawn.
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "the pane hands over its frame geometry; bundling it here would rename, not simplify"
+    )]
     pub fn draw_layer(
-        &self,
+        &mut self,
         painter: &egui::Painter,
         chart_rect: egui::Rect,
+        tag_right: f32,
         axis_x: f32,
         scale: &PriceScale,
         reserved_chip_y: Option<f32>,
+        pointer: Option<egui::Pos2>,
     ) {
+        let ctx = PaintCtx {
+            painter,
+            chart_rect,
+            tag_right,
+            axis_x,
+            scale,
+            reserved_chip_y,
+            pointer,
+        };
+        let mut controls = Vec::new();
+
         for order in self.sim.orders() {
             let Some(level) = order.price else { continue };
-            let price = if self.drag == PaperDrag::Order(order.id) {
+            let dragged = self.drag == PaperDrag::Order(order.id);
+            let price = if dragged {
                 self.drag_price
                     .unwrap_or_else(|| level.to_f64().unwrap_or_default())
             } else {
                 level.to_f64().unwrap_or_default()
             };
-            let label = format!(
+            let y = ctx.scale.y(price);
+            if !ctx.in_range(y) {
+                continue;
+            }
+            let hovered = ctx.hovers_line(y);
+            let shown = if dragged { self.snap(price) } else { level };
+            ctx.level_line(y, theme::ACCENT, true, LINE_WIDTH_PX, hovered, dragged);
+            ctx.gutter_chip(y, theme::ACCENT, &fmt_decimal(shown));
+            let text = format!(
                 "#{} {} {} {} @ {}",
                 order.id.0,
-                side_word(order.side),
-                kind_word(order.kind),
+                side_word_upper(order.side),
+                kind_short(order.kind),
                 fmt_decimal(order.quantity),
-                fmt_decimal(level),
+                fmt_decimal(shown),
             );
-            draw_price_line(
-                painter,
-                chart_rect,
-                axis_x,
-                scale,
-                price,
-                theme::ACCENT,
-                true,
-                &label,
-                reserved_chip_y,
-            );
-        }
-        if let Some(position) = self.sim.position() {
-            let entry_color = match position.side {
-                Side::Buy => theme::BUY,
-                Side::Sell => theme::SELL,
-            };
-            let entry = position.avg_price.to_f64().unwrap_or_default();
-            let label = format!(
-                "SIM {} {} @ {}",
-                position_word(position.side),
-                fmt_decimal(position.quantity),
-                fmt_decimal(position.avg_price),
-            );
-            draw_price_line(
-                painter,
-                chart_rect,
-                axis_x,
-                scale,
-                entry,
-                entry_color,
-                false,
-                &label,
-                reserved_chip_y,
-            );
-            if let Some(stop) = position.stop_loss {
-                let price = if self.drag == PaperDrag::StopLoss {
-                    self.drag_price
-                        .unwrap_or_else(|| stop.to_f64().unwrap_or_default())
-                } else {
-                    stop.to_f64().unwrap_or_default()
-                };
-                let label = format!(
-                    "SL {} {} pts",
-                    fmt_decimal(stop),
-                    fmt_signed_points(position.open_points(stop)),
-                );
-                draw_price_line(
-                    painter,
-                    chart_rect,
-                    axis_x,
-                    scale,
-                    price,
-                    theme::SELL,
-                    false,
-                    &label,
-                    reserved_chip_y,
-                );
-            }
-            if let Some(target) = position.take_profit {
-                let price = if self.drag == PaperDrag::TakeProfit {
-                    self.drag_price
-                        .unwrap_or_else(|| target.to_f64().unwrap_or_default())
-                } else {
-                    target.to_f64().unwrap_or_default()
-                };
-                let label = format!(
-                    "TP {} {} pts",
-                    fmt_decimal(target),
-                    fmt_signed_points(position.open_points(target)),
-                );
-                draw_price_line(
-                    painter,
-                    chart_rect,
-                    axis_x,
-                    scale,
-                    price,
-                    theme::BUY,
-                    false,
-                    &label,
-                    reserved_chip_y,
-                );
+            if let Some(close) = ctx.chip_tag(y, theme::ACCENT, &text, hovered, !dragged) {
+                controls.push((PaperControl::CancelOrder(order.id), close));
             }
         }
+
+        if let Some(position) = self.sim.position().cloned() {
+            let color = side_color(position.side);
+            let entry_y = ctx.scale.y(position.avg_price.to_f64().unwrap_or_default());
+            if ctx.in_range(entry_y) {
+                ctx.level_line(entry_y, color, false, POSITION_LINE_WIDTH_PX, false, false);
+                ctx.gutter_chip(entry_y, color, &fmt_decimal(position.avg_price));
+                let side_text = format!(
+                    "SIM {} {}",
+                    position_word(position.side),
+                    fmt_decimal(position.quantity),
+                );
+                let points = self
+                    .sim
+                    .mark_price()
+                    .map(|mark| position.open_points(mark))
+                    .map(|open| {
+                        (
+                            format!("{} pts", fmt_signed_points(open)),
+                            points_color(open),
+                        )
+                    });
+                let line_hovered = ctx.hovers_line(entry_y);
+                let (close, tag_rect) =
+                    ctx.position_tag(entry_y, color, &side_text, points, line_hovered);
+                if let Some(close) = close {
+                    controls.push((PaperControl::ClosePosition, close));
+                }
+
+                // Labelled handles for the missing bracket legs, revealed
+                // while the pointer is on the entry line or its tag: the
+                // affordance behind "drag from the position line to create".
+                let over_tag = ctx
+                    .pointer
+                    .is_some_and(|pointer| tag_rect.expand(TAG_HOVER_SLACK_PX).contains(pointer));
+                if self.drag == PaperDrag::None && (line_hovered || over_tag) {
+                    let anchor = tag_rect.left() - HANDLE_TAG_GAP_PX;
+                    let legs = [
+                        (
+                            position.stop_loss.is_none(),
+                            PaperControl::HandleStopLoss,
+                            "SL",
+                            position.side == Side::Buy,
+                            theme::SELL,
+                        ),
+                        (
+                            position.take_profit.is_none(),
+                            PaperControl::HandleTakeProfit,
+                            "TP",
+                            position.side == Side::Sell,
+                            theme::BUY,
+                        ),
+                    ];
+                    for (absent, control, label, below, leg_color) in legs {
+                        if !absent {
+                            continue;
+                        }
+                        let rect = handle_rect(anchor, entry_y, below);
+                        ctx.bracket_handle(rect, label, leg_color);
+                        controls.push((control, rect));
+                    }
+                }
+            }
+
+            self.draw_bracket_leg(
+                &ctx,
+                &LegPaint {
+                    position: &position,
+                    level: position.stop_loss,
+                    other_level: position.take_profit,
+                    word: "SL",
+                    color: theme::SELL,
+                    amend: PaperDrag::StopLoss,
+                    create: PaperDrag::CreateStopLoss,
+                    clear: PaperControl::ClearStopLoss,
+                },
+                &mut controls,
+            );
+            self.draw_bracket_leg(
+                &ctx,
+                &LegPaint {
+                    position: &position,
+                    level: position.take_profit,
+                    other_level: position.stop_loss,
+                    word: "TP",
+                    color: theme::BUY,
+                    amend: PaperDrag::TakeProfit,
+                    create: PaperDrag::CreateTakeProfit,
+                    clear: PaperControl::ClearTakeProfit,
+                },
+                &mut controls,
+            );
+        }
+
         if let Some(armed) = self.armed {
             let hint = format!(
                 "click a price to place your {} {} - Esc cancels",
@@ -571,6 +687,55 @@ impl PaperTrading {
                 egui::FontId::proportional(12.0),
                 theme::ACCENT,
             );
+        }
+        self.controls = controls;
+    }
+
+    /// One protective leg: its resting line and tag, the drag that reprices
+    /// it, or — while a create-drag runs and the leg does not exist yet —
+    /// the dashed preview of where release would put it. The tag gains the
+    /// live R:R read once both legs are known, which is what turns the drag
+    /// into a decision.
+    fn draw_bracket_leg(
+        &self,
+        ctx: &PaintCtx<'_>,
+        leg: &LegPaint<'_>,
+        controls: &mut Vec<(PaperControl, egui::Rect)>,
+    ) {
+        let amending = self.drag == leg.amend;
+        let creating = self.drag == leg.create && leg.level.is_none();
+        let resting = leg.level.map(|level| level.to_f64().unwrap_or_default());
+        let price = if amending || creating {
+            self.drag_price.or(resting)
+        } else {
+            resting
+        };
+        let Some(price) = price else { return };
+        let y = ctx.scale.y(price);
+        if !ctx.in_range(y) {
+            return;
+        }
+        let dragging = amending || creating;
+        let hovered = ctx.hovers_line(y);
+        let shown = if dragging {
+            self.snap(price)
+        } else {
+            leg.level.unwrap_or_else(|| self.snap(price))
+        };
+        // A leg being created previews dashed — it is not an order yet.
+        ctx.level_line(y, leg.color, creating, LINE_WIDTH_PX, hovered, dragging);
+        ctx.gutter_chip(y, leg.color, &fmt_decimal(shown));
+        let mut text = format!(
+            "{} {} {} pts",
+            leg.word,
+            fmt_decimal(shown),
+            fmt_signed_points(leg.position.open_points(shown)),
+        );
+        if dragging && let Some(ratio) = rr_ratio(leg, shown) {
+            text.push_str(&format!(" · R:R {ratio}"));
+        }
+        if let Some(close) = ctx.chip_tag(y, leg.color, &text, hovered, !dragging) {
+            controls.push((leg.clear, close));
         }
     }
 
@@ -605,6 +770,34 @@ impl PaperTrading {
             return true;
         }
 
+        // A painted overlay control (a tag's ✕, a bracket handle) takes the
+        // press before any line under it — it was drawn on top.
+        if input.primary_pressed
+            && self.drag == PaperDrag::None
+            && let Some(pointer) = input.pointer
+            && let Some(scale) = input.scale
+            && let Some(control) = self.control_at(pointer)
+        {
+            match control {
+                PaperControl::ClosePosition => self.close_position(),
+                PaperControl::ClearStopLoss => self.clear_bracket_leg(true),
+                PaperControl::ClearTakeProfit => self.clear_bracket_leg(false),
+                PaperControl::CancelOrder(id) => {
+                    let events = self.sim.apply(Command::CancelOrder { id });
+                    self.handle_events(events);
+                }
+                PaperControl::HandleStopLoss => {
+                    self.drag = PaperDrag::CreateStopLoss;
+                    self.drag_price = Some(scale.price_at(pointer.y));
+                }
+                PaperControl::HandleTakeProfit => {
+                    self.drag = PaperDrag::CreateTakeProfit;
+                    self.drag_price = Some(scale.price_at(pointer.y));
+                }
+            }
+            return true;
+        }
+
         // Grab a line.
         if input.primary_pressed
             && self.drag == PaperDrag::None
@@ -618,36 +811,45 @@ impl PaperTrading {
             return true;
         }
 
-        // Follow the pointer while dragging.
+        // Follow the pointer while dragging. A press that started on the
+        // entry line commits to one bracket leg on its first real pull:
+        // towards the profit side it creates the take profit, towards the
+        // losing side the stop — and a side whose leg already exists stays
+        // blocked (that leg's own line is its handle).
         if input.primary_down && self.drag != PaperDrag::None {
             if let (Some(pointer), Some(scale)) = (input.pointer, input.scale) {
                 let y = pointer.y.clamp(input.chart.top(), input.chart.bottom());
                 self.drag_price = Some(scale.price_at(y));
+                if self.drag == PaperDrag::CreatePending {
+                    self.decide_pending_leg(y, scale);
+                }
             }
             return true;
         }
 
         // Drop: submit the new price; the simulator answers (a rejection
-        // snaps the line back and the toast explains why).
+        // snaps the line back and the toast explains why). Creating a leg
+        // and repricing it are the same command — the bracket is replaced
+        // wholesale either way.
         if input.primary_released && self.drag != PaperDrag::None {
             let drag = std::mem::take(&mut self.drag);
             if let Some(price) = self.drag_price.take() {
                 let price = self.snap(price);
                 let command = match drag {
-                    PaperDrag::StopLoss => {
+                    PaperDrag::StopLoss | PaperDrag::CreateStopLoss => {
                         self.sim.position().map(|position| Command::SetBracket {
                             stop_loss: Some(price),
                             take_profit: position.take_profit,
                         })
                     }
-                    PaperDrag::TakeProfit => {
+                    PaperDrag::TakeProfit | PaperDrag::CreateTakeProfit => {
                         self.sim.position().map(|position| Command::SetBracket {
                             stop_loss: position.stop_loss,
                             take_profit: Some(price),
                         })
                     }
                     PaperDrag::Order(id) => Some(Command::ModifyOrder { id, price }),
-                    PaperDrag::None | PaperDrag::Blocked => None,
+                    PaperDrag::None | PaperDrag::Blocked | PaperDrag::CreatePending => None,
                 };
                 if let Some(command) = command {
                     let events = self.sim.apply(command);
@@ -660,29 +862,94 @@ impl PaperTrading {
         self.drag != PaperDrag::None
     }
 
-    /// The cursor that announces a paper line under the pointer (audit
-    /// M3/M4): vertical-resize over a draggable order/stop/target line,
-    /// not-allowed over the entry line — an average entry is history, not an
-    /// order, and the chart will not pan across it either. `None` away from
-    /// every line, so the caller falls through to the drawings' own cursors.
+    /// Remove one protective leg, keeping the other — the tag ✕'s command.
+    fn clear_bracket_leg(&mut self, stop: bool) {
+        let Some(position) = self.sim.position() else {
+            return;
+        };
+        let command = if stop {
+            Command::SetBracket {
+                stop_loss: None,
+                take_profit: position.take_profit,
+            }
+        } else {
+            Command::SetBracket {
+                stop_loss: position.stop_loss,
+                take_profit: None,
+            }
+        };
+        let events = self.sim.apply(command);
+        self.handle_events(events);
+    }
+
+    /// The overlay control under the pointer, from the last paint pass.
+    fn control_at(&self, pointer: egui::Pos2) -> Option<PaperControl> {
+        self.controls
+            .iter()
+            .find(|(_, rect)| rect.contains(pointer))
+            .map(|(control, _)| *control)
+    }
+
+    /// Turn a pending entry-line press into the leg the pull chose, once it
+    /// travelled far enough to mean it.
+    fn decide_pending_leg(&mut self, pointer_y: f32, scale: &PriceScale) {
+        let Some(position) = self.sim.position() else {
+            self.drag = PaperDrag::Blocked;
+            return;
+        };
+        let entry_y = scale.y(position.avg_price.to_f64().unwrap_or_default());
+        let delta = pointer_y - entry_y;
+        if delta.abs() < CREATE_DECIDE_THRESHOLD_PX {
+            return;
+        }
+        // On screen, up is negative y; up is the profit side for a long.
+        let profit_side = match position.side {
+            Side::Buy => delta < 0.0,
+            Side::Sell => delta > 0.0,
+        };
+        self.drag = if profit_side {
+            if position.take_profit.is_none() {
+                PaperDrag::CreateTakeProfit
+            } else {
+                PaperDrag::Blocked
+            }
+        } else if position.stop_loss.is_none() {
+            PaperDrag::CreateStopLoss
+        } else {
+            PaperDrag::Blocked
+        };
+    }
+
+    /// The cursor that announces what is under the pointer (audit M3/M4):
+    /// a pointing hand over a painted control, vertical-resize over a
+    /// draggable order/stop/target line and over an entry line with a
+    /// missing bracket leg (dragging away from it creates that leg),
+    /// not-allowed over a fully bracketed entry — the average entry itself
+    /// is history and never moves. `None` away from everything, so the
+    /// caller falls through to the drawings' own cursors.
     #[must_use]
     pub fn hover_cursor(
         &self,
         pointer: egui::Pos2,
         scale: &PriceScale,
     ) -> Option<egui::CursorIcon> {
+        if self.control_at(pointer).is_some() {
+            return Some(egui::CursorIcon::PointingHand);
+        }
         match self.line_at(pointer, scale)? {
             PaperDrag::Blocked => Some(egui::CursorIcon::NotAllowed),
-            PaperDrag::StopLoss | PaperDrag::TakeProfit | PaperDrag::Order(_) => {
-                Some(egui::CursorIcon::ResizeVertical)
-            }
-            PaperDrag::None => None,
+            PaperDrag::StopLoss
+            | PaperDrag::TakeProfit
+            | PaperDrag::Order(_)
+            | PaperDrag::CreatePending => Some(egui::CursorIcon::ResizeVertical),
+            PaperDrag::None | PaperDrag::CreateStopLoss | PaperDrag::CreateTakeProfit => None,
         }
     }
 
     /// Which line sits under the pointer, in draw-stack priority: pending
     /// orders first (they draw on top), then take profit, stop loss, and
-    /// the (blocked) entry line.
+    /// the entry line — which starts a bracket-creating drag while a leg is
+    /// missing, and blocks the gesture once both exist.
     fn line_at(&self, pointer: egui::Pos2, scale: &PriceScale) -> Option<PaperDrag> {
         let near = |price: Decimal| {
             let y = scale.y(price.to_f64().unwrap_or_default());
@@ -707,7 +974,12 @@ impl PaperTrading {
             return Some(PaperDrag::StopLoss);
         }
         if near(position.avg_price) {
-            return Some(PaperDrag::Blocked);
+            let creatable = position.stop_loss.is_none() || position.take_profit.is_none();
+            return Some(if creatable {
+                PaperDrag::CreatePending
+            } else {
+                PaperDrag::Blocked
+            });
         }
         None
     }
@@ -1463,48 +1735,348 @@ fn load_report(dir: &Path, symbol: Option<&str>) -> ReportData {
     }
 }
 
-/// One price line with its gutter chip — the last-price chip geometry, so
-/// prices never disagree about their pixel. The line always sits at its true
-/// price; only the chip dodges the reserved last-price row.
-#[expect(clippy::too_many_arguments, reason = "a paint helper, not an API")]
-fn draw_price_line(
-    painter: &egui::Painter,
+/// The frame geometry every paper paint helper reads: one struct so a tag,
+/// a chip and a line can never disagree about where the plot ends.
+struct PaintCtx<'a> {
+    painter: &'a egui::Painter,
     chart_rect: egui::Rect,
+    /// Right edge of the interactive plot (the lane divider when a live
+    /// lane is up, the chart's edge otherwise) — tags anchor inside it.
+    tag_right: f32,
+    /// Left edge of the price axis — lines run to it, gutter chips sit past
+    /// it.
     axis_x: f32,
-    scale: &PriceScale,
-    price: f64,
-    color: egui::Color32,
-    dashed: bool,
-    label: &str,
+    scale: &'a PriceScale,
+    /// The last-price chip's row, which every gutter chip dodges.
     reserved_chip_y: Option<f32>,
-) {
-    let y = scale.y(price);
-    if y < chart_rect.top() || y > chart_rect.bottom() {
-        return;
+    /// The pointer, `Some` only on the pane that owns paper input.
+    pointer: Option<egui::Pos2>,
+}
+
+/// One protective leg's paint inputs (see `draw_bracket_leg`).
+struct LegPaint<'a> {
+    position: &'a Position,
+    level: Option<Decimal>,
+    /// The other leg's level, for the R:R read while dragging.
+    other_level: Option<Decimal>,
+    word: &'static str,
+    color: egui::Color32,
+    amend: PaperDrag,
+    create: PaperDrag,
+    clear: PaperControl,
+}
+
+impl PaintCtx<'_> {
+    fn in_range(&self, y: f32) -> bool {
+        y >= self.chart_rect.top() && y <= self.chart_rect.bottom()
     }
-    let stroke = egui::Stroke::new(1.0_f32, color);
-    if dashed {
-        painter.extend(egui::Shape::dashed_line(
-            &[egui::pos2(chart_rect.left(), y), egui::pos2(axis_x, y)],
-            stroke,
-            ORDER_DASH_PX,
-            ORDER_GAP_PX,
-        ));
-    } else {
-        painter.line_segment(
-            [egui::pos2(chart_rect.left(), y), egui::pos2(axis_x, y)],
-            stroke,
+
+    /// Whether the pointer is within grab range of the line at `y`.
+    fn hovers_line(&self, y: f32) -> bool {
+        self.pointer.is_some_and(|pointer| {
+            self.chart_rect.contains(pointer) && (pointer.y - y).abs() <= LINE_GRAB_RADIUS_PX
+        })
+    }
+
+    /// The line itself: hover thickens it, a drag thickens it further and
+    /// paints the drawings' halo treatment beneath, so a grabbed stop feels
+    /// identical to a grabbed drawing.
+    fn level_line(
+        &self,
+        y: f32,
+        color: egui::Color32,
+        dashed: bool,
+        base_width: f32,
+        hovered: bool,
+        dragged: bool,
+    ) {
+        let width = if dragged {
+            LINE_DRAG_WIDTH_PX
+        } else if hovered {
+            LINE_HOVER_WIDTH_PX.max(base_width)
+        } else {
+            base_width
+        };
+        let points = [
+            egui::pos2(self.chart_rect.left(), y),
+            egui::pos2(self.axis_x, y),
+        ];
+        if dragged {
+            self.painter.line_segment(
+                points,
+                egui::Stroke::new(width + DRAG_HALO_EXTRA_WIDTH_PX, DRAG_HALO_COLOR),
+            );
+        }
+        let stroke = egui::Stroke::new(width, color);
+        if dashed {
+            self.painter.extend(egui::Shape::dashed_line(
+                &points,
+                stroke,
+                ORDER_DASH_PX,
+                ORDER_GAP_PX,
+            ));
+        } else {
+            self.painter.line_segment(points, stroke);
+        }
+    }
+
+    /// The gutter chip: the price and nothing else, on the last-price
+    /// chip's geometry. The line stays at its true price; only the chip
+    /// dodges the reserved last-price row.
+    fn gutter_chip(&self, y: f32, color: egui::Color32, text: &str) {
+        let chip_y = dodged_chip_y(
+            y,
+            self.reserved_chip_y,
+            self.chart_rect.top(),
+            self.chart_rect.bottom(),
+        );
+        let galley =
+            self.painter
+                .layout_no_wrap(text.to_owned(), egui::FontId::monospace(11.0), CHIP_TEXT);
+        let text_pos = egui::pos2(self.axis_x + 6.0, chip_y - galley.size().y / 2.0);
+        let bg = egui::Rect::from_min_size(
+            text_pos - egui::vec2(3.0, 1.0),
+            galley.size() + egui::vec2(6.0, 2.0),
+        );
+        self.painter
+            .rect_filled(bg, egui::Rounding::same(2.0), color);
+        self.painter.galley(text_pos, galley, CHIP_TEXT);
+    }
+
+    /// A solid tag on a line, right-anchored inside the plot. While the
+    /// pointer is on the line or the tag (and `with_close` allows it), the
+    /// tag grows leftward to reveal a ✕ zone; the returned rect is that
+    /// button. Overlay ✕s carry no tooltip of their own — each has a
+    /// full-size, fully labelled twin in the chrome.
+    fn chip_tag(
+        &self,
+        y: f32,
+        fill: egui::Color32,
+        text: &str,
+        line_hovered: bool,
+        with_close: bool,
+    ) -> Option<egui::Rect> {
+        let galley =
+            self.painter
+                .layout_no_wrap(text.to_owned(), egui::FontId::monospace(11.0), CHIP_TEXT);
+        let half = TAG_HEIGHT_PX / 2.0;
+        let center_y = y.clamp(
+            self.chart_rect.top() + half,
+            self.chart_rect.bottom() - half,
+        );
+        let content_w = galley.size().x + 2.0 * TAG_PAD_X;
+        let resting = egui::Rect::from_min_max(
+            egui::pos2(self.tag_right - TAG_GAP_PX - content_w, center_y - half),
+            egui::pos2(self.tag_right - TAG_GAP_PX, center_y + half),
+        );
+        let hovered = with_close
+            && (line_hovered
+                || self
+                    .pointer
+                    .is_some_and(|pointer| resting.expand(TAG_HOVER_SLACK_PX).contains(pointer)));
+        let full = if hovered {
+            egui::Rect::from_min_max(resting.min - egui::vec2(TAG_BUTTON_PX, 0.0), resting.max)
+        } else {
+            resting
+        };
+        self.painter
+            .rect_filled(full, egui::Rounding::same(3.0), fill);
+        self.painter.galley(
+            egui::pos2(resting.left() + TAG_PAD_X, center_y - galley.size().y / 2.0),
+            galley,
+            CHIP_TEXT,
+        );
+        if !hovered {
+            return None;
+        }
+        let button = egui::Rect::from_min_size(full.min, egui::vec2(TAG_BUTTON_PX, TAG_HEIGHT_PX));
+        self.painter.text(
+            button.center(),
+            egui::Align2::CENTER_CENTER,
+            "×",
+            egui::FontId::monospace(11.0),
+            CHIP_TEXT,
+        );
+        Some(button)
+    }
+
+    /// The position's tag wears the card grammar, not a chip: a position is
+    /// a fact about the account, not an order that will fire. Returns the
+    /// hover-revealed ✕ rect and the resting rect (the bracket handles
+    /// anchor left of it).
+    fn position_tag(
+        &self,
+        y: f32,
+        side_color: egui::Color32,
+        side_text: &str,
+        points: Option<(String, egui::Color32)>,
+        line_hovered: bool,
+    ) -> (Option<egui::Rect>, egui::Rect) {
+        let font = egui::FontId::monospace(11.0);
+        let side_galley =
+            self.painter
+                .layout_no_wrap(side_text.to_owned(), font.clone(), side_color);
+        let points_galley = points.map(|(text, color)| {
+            (
+                self.painter.layout_no_wrap(text, font.clone(), color),
+                color,
+            )
+        });
+        let rail = 3.0;
+        let mut content_w = rail + TAG_PAD_X + side_galley.size().x + TAG_PAD_X;
+        if let Some((galley, _)) = &points_galley {
+            content_w += galley.size().x + TAG_PAD_X;
+        }
+        let half = TAG_HEIGHT_PX / 2.0;
+        let center_y = y.clamp(
+            self.chart_rect.top() + half,
+            self.chart_rect.bottom() - half,
+        );
+        let resting = egui::Rect::from_min_max(
+            egui::pos2(self.tag_right - TAG_GAP_PX - content_w, center_y - half),
+            egui::pos2(self.tag_right - TAG_GAP_PX, center_y + half),
+        );
+        let hovered = line_hovered
+            || self
+                .pointer
+                .is_some_and(|pointer| resting.expand(TAG_HOVER_SLACK_PX).contains(pointer));
+        let full = if hovered {
+            egui::Rect::from_min_max(resting.min - egui::vec2(TAG_BUTTON_PX, 0.0), resting.max)
+        } else {
+            resting
+        };
+        self.painter
+            .rect_filled(full, egui::Rounding::same(3.0), theme::INSET);
+        self.painter.rect_stroke(
+            full,
+            egui::Rounding::same(3.0),
+            egui::Stroke::new(1.0_f32, theme::BORDER),
+        );
+        // The side rail rides the card's left edge, ✕ zone and all.
+        self.painter.rect_filled(
+            egui::Rect::from_min_max(
+                full.min + egui::vec2(1.0, 1.0),
+                egui::pos2(full.min.x + 1.0 + rail, full.max.y - 1.0),
+            ),
+            egui::Rounding {
+                nw: 2.0,
+                sw: 2.0,
+                ne: 0.0,
+                se: 0.0,
+            },
+            side_color,
+        );
+        let mut x = resting.left() + rail + TAG_PAD_X;
+        let side_size = side_galley.size();
+        self.painter.galley(
+            egui::pos2(x, center_y - side_size.y / 2.0),
+            side_galley,
+            side_color,
+        );
+        x += side_size.x + TAG_PAD_X;
+        if let Some((galley, color)) = points_galley {
+            let size = galley.size();
+            self.painter
+                .galley(egui::pos2(x, center_y - size.y / 2.0), galley, color);
+        }
+        if !hovered {
+            return (None, resting);
+        }
+        let button = egui::Rect::from_min_size(
+            full.min + egui::vec2(1.0 + rail, 0.0),
+            egui::vec2(TAG_BUTTON_PX - rail, TAG_HEIGHT_PX),
+        );
+        let over_button = self.pointer.is_some_and(|pointer| button.contains(pointer));
+        self.painter.text(
+            button.center(),
+            egui::Align2::CENTER_CENTER,
+            "×",
+            egui::FontId::monospace(11.0),
+            if over_button {
+                theme::TEXT_PRIMARY
+            } else {
+                theme::TEXT_MUTED
+            },
+        );
+        // A hairline between the ✕ zone and the words.
+        self.painter.line_segment(
+            [
+                egui::pos2(button.right(), full.top() + 3.0),
+                egui::pos2(button.right(), full.bottom() - 3.0),
+            ],
+            egui::Stroke::new(1.0_f32, theme::BORDER),
+        );
+        (Some(button), resting)
+    }
+
+    /// A labelled `SL`/`TP` handle on the entry line: quiet control fill,
+    /// the leg's own colour on hover.
+    fn bracket_handle(&self, rect: egui::Rect, label: &str, leg_color: egui::Color32) {
+        let hovered = self.pointer.is_some_and(|pointer| rect.contains(pointer));
+        self.painter
+            .rect_filled(rect, egui::Rounding::same(3.0), theme::CONTROL);
+        self.painter.rect_stroke(
+            rect,
+            egui::Rounding::same(3.0),
+            egui::Stroke::new(1.0_f32, if hovered { leg_color } else { theme::BORDER }),
+        );
+        self.painter.text(
+            rect.center(),
+            egui::Align2::CENTER_CENTER,
+            label,
+            egui::FontId::monospace(9.0),
+            if hovered {
+                theme::TEXT_PRIMARY
+            } else {
+                theme::TEXT_MUTED
+            },
         );
     }
-    let chip_y = dodged_chip_y(y, reserved_chip_y, chart_rect.top(), chart_rect.bottom());
-    let galley = painter.layout_no_wrap(label.to_owned(), egui::FontId::monospace(11.0), CHIP_TEXT);
-    let text_pos = egui::pos2(axis_x + 6.0, chip_y - galley.size().y / 2.0);
-    let bg = egui::Rect::from_min_size(
-        text_pos - egui::vec2(3.0, 1.0),
-        galley.size() + egui::vec2(6.0, 2.0),
-    );
-    painter.rect_filled(bg, egui::Rounding::same(2.0), color);
-    painter.galley(text_pos, galley, CHIP_TEXT);
+}
+
+/// Where a bracket handle sits: right-anchored at `anchor_right`, one gap
+/// off the entry line, on the side its leg protects.
+fn handle_rect(anchor_right: f32, line_y: f32, below: bool) -> egui::Rect {
+    let x = anchor_right - HANDLE_SIZE.x;
+    let y = if below {
+        line_y + HANDLE_GAP_PX
+    } else {
+        line_y - HANDLE_GAP_PX - HANDLE_SIZE.y
+    };
+    egui::Rect::from_min_size(egui::pos2(x, y), HANDLE_SIZE)
+}
+
+/// Reward over risk at the dragged level, against the other leg — the read
+/// that turns a drag into a decision. `None` until both legs are known or
+/// while the risk is zero.
+fn rr_ratio(leg: &LegPaint<'_>, dragged: Decimal) -> Option<String> {
+    let other = leg.other_level?;
+    let entry = leg.position.avg_price;
+    let (stop, target) = if leg.word == "SL" {
+        (dragged, other)
+    } else {
+        (other, dragged)
+    };
+    let risk = entry.saturating_sub(stop).abs();
+    let reward = target.saturating_sub(entry).abs();
+    (risk > Decimal::ZERO).then(|| fmt_points(reward / risk))
+}
+
+/// The side's chrome colour — one mapping for every paper surface.
+fn side_color(side: Side) -> egui::Color32 {
+    match side {
+        Side::Buy => theme::BUY,
+        Side::Sell => theme::SELL,
+    }
+}
+
+/// Three-letter order kind for the compact chart tags (`LMT`, `STP`, `MKT`).
+fn kind_short(kind: EntryKind) -> &'static str {
+    match kind {
+        EntryKind::Market => "MKT",
+        EntryKind::Limit => "LMT",
+        EntryKind::Stop => "STP",
+    }
 }
 
 /// Keep a gutter chip legible when it would land on the last-price chip:
@@ -1878,10 +2450,10 @@ mod tests {
     }
 
     /// The lines say what a press would do before it happens (audit M3/M4):
-    /// draggable levels wear the resize cursor, the entry line wears
-    /// not-allowed, and empty tape asks nothing.
+    /// draggable levels wear the resize cursor, an entry line with a
+    /// missing leg offers the create-drag, and empty tape asks nothing.
     #[test]
-    fn hover_cursors_announce_draggable_and_blocked_lines() {
+    fn hover_cursors_announce_draggable_and_creatable_lines() {
         let mut paper = PaperTrading::new();
         paper.seed(&print(0, 100));
         paper.stop_offset_text = "10".to_owned();
@@ -1895,8 +2467,8 @@ mod tests {
         );
         assert_eq!(
             paper.hover_cursor(egui::pos2(400.0, 200.0), &scale),
-            Some(egui::CursorIcon::NotAllowed),
-            "the entry at 100 sits at y 200 and never moves"
+            Some(egui::CursorIcon::ResizeVertical),
+            "the entry at 100 offers the missing take profit by drag"
         );
         assert_eq!(
             paper.hover_cursor(egui::pos2(400.0, 40.0), &scale),
@@ -1928,26 +2500,119 @@ mod tests {
         );
     }
 
+    /// The TradingView gesture: pull away from the entry line and the
+    /// missing bracket leg is born on release — the profit side makes a
+    /// take profit, the losing side a stop.
     #[test]
-    fn the_entry_line_blocks_the_gesture_but_never_moves() {
+    fn dragging_from_the_entry_line_creates_the_missing_leg() {
         let mut paper = PaperTrading::new();
         paper.seed(&print(0, 100));
         paper.market(Side::Buy);
         paper.on_trade(&print(1, 100));
         let (chart, scale) = chart_and_scale(80.0, 120.0);
-        // The entry at 100 sits at y = 200: grabbing it consumes the gesture
-        // (the chart must not pan under it) but repositions nothing.
+        // Grab the entry at 100 (y = 200), pull up to 105 (y = 150), drop.
         assert!(paper.handle_chart_input(&frame(chart, &scale, 200.0, true, true, false)));
+        assert!(paper.handle_chart_input(&frame(chart, &scale, 150.0, false, true, false)));
         assert!(paper.handle_chart_input(&frame(chart, &scale, 150.0, false, false, true)));
+        let position = paper.sim.position().expect("still long");
         assert_eq!(
-            paper.sim.position().expect("long").avg_price,
-            Decimal::from(100),
-            "an average entry is history, not an order"
+            position.take_profit,
+            Some(Decimal::from(105)),
+            "above a long is the profit side"
         );
+        assert_eq!(
+            position.avg_price,
+            Decimal::from(100),
+            "the entry itself never moves"
+        );
+        // The same pull downward births the stop.
+        assert!(paper.handle_chart_input(&frame(chart, &scale, 200.0, true, true, false)));
+        assert!(paper.handle_chart_input(&frame(chart, &scale, 300.0, false, true, false)));
+        assert!(paper.handle_chart_input(&frame(chart, &scale, 300.0, false, false, true)));
+        let position = paper.sim.position().expect("still long");
+        assert_eq!(position.stop_loss, Some(Decimal::from(90)));
+        assert_eq!(position.take_profit, Some(Decimal::from(105)), "untouched");
+    }
+
+    #[test]
+    fn a_fully_bracketed_entry_line_blocks_the_gesture_but_never_moves() {
+        let mut paper = PaperTrading::new();
+        paper.seed(&print(0, 100));
+        paper.stop_offset_text = "10".to_owned();
+        paper.profit_offset_text = "10".to_owned();
+        paper.market(Side::Buy);
+        paper.on_trade(&print(1, 100));
+        let (chart, scale) = chart_and_scale(80.0, 120.0);
+        assert_eq!(
+            paper.hover_cursor(egui::pos2(400.0, 200.0), &scale),
+            Some(egui::CursorIcon::NotAllowed),
+            "both legs exist, so their own lines are the handles"
+        );
+        // Grabbing the entry still consumes the gesture (the chart must not
+        // pan under it) but repositions nothing.
+        assert!(paper.handle_chart_input(&frame(chart, &scale, 200.0, true, true, false)));
+        assert!(paper.handle_chart_input(&frame(chart, &scale, 150.0, false, true, false)));
+        assert!(paper.handle_chart_input(&frame(chart, &scale, 150.0, false, false, true)));
+        let position = paper.sim.position().expect("long");
+        assert_eq!(position.avg_price, Decimal::from(100));
+        assert_eq!(position.stop_loss, Some(Decimal::from(90)), "untouched");
+        assert_eq!(position.take_profit, Some(Decimal::from(110)), "untouched");
         // Empty space is not ours: the press falls through to the chart.
         assert!(
             !paper.handle_chart_input(&frame(chart, &scale, 40.0, true, true, false)),
             "a press far from every line belongs to the pan"
+        );
+    }
+
+    /// Painted overlay controls (cached from the last paint pass) take the
+    /// press before the lines under them.
+    #[test]
+    fn painted_controls_take_the_press_before_the_lines() {
+        let mut paper = PaperTrading::new();
+        paper.seed(&print(0, 100));
+        let events = paper.sim.apply(Command::PlaceLimit {
+            side: Side::Buy,
+            quantity: Decimal::ONE,
+            price: Decimal::from(95),
+            bracket: Bracket::none(),
+        });
+        paper.handle_events(events);
+        let id = paper.sim.orders()[0].id;
+        let (chart, scale) = chart_and_scale(80.0, 120.0);
+        // A ✕ painted last frame at (700, 120) — far from any line.
+        let button = egui::Rect::from_center_size(egui::pos2(700.0, 120.0), egui::vec2(20.0, 20.0));
+        paper.controls = vec![(PaperControl::CancelOrder(id), button)];
+        let input = ChartInput {
+            chart,
+            scale: Some(&scale),
+            pointer: Some(egui::pos2(700.0, 120.0)),
+            primary_pressed: true,
+            primary_down: true,
+            primary_released: false,
+        };
+        assert!(paper.handle_chart_input(&input), "the ✕ owns the press");
+        assert!(paper.sim.orders().is_empty(), "and it cancelled the order");
+
+        // A bracket handle press starts the create-drag for its leg.
+        paper.market(Side::Buy);
+        paper.on_trade(&print(1, 100));
+        let handle = egui::Rect::from_center_size(egui::pos2(700.0, 210.0), HANDLE_SIZE);
+        paper.controls = vec![(PaperControl::HandleStopLoss, handle)];
+        let press = ChartInput {
+            chart,
+            scale: Some(&scale),
+            pointer: Some(egui::pos2(700.0, 210.0)),
+            primary_pressed: true,
+            primary_down: true,
+            primary_released: false,
+        };
+        assert!(paper.handle_chart_input(&press));
+        assert!(paper.handle_chart_input(&frame(chart, &scale, 300.0, false, true, false)));
+        assert!(paper.handle_chart_input(&frame(chart, &scale, 300.0, false, false, true)));
+        assert_eq!(
+            paper.sim.position().expect("long").stop_loss,
+            Some(Decimal::from(90)),
+            "the handle drag placed the stop"
         );
     }
 

--- a/crates/app/src/paper_trading.rs
+++ b/crates/app/src/paper_trading.rs
@@ -19,7 +19,7 @@ use egui_phosphor::regular as icons;
 use quantick_engine::{Side, Trade};
 use quantick_sim::{
     Bracket, ClosedTrade, Command, EntryKind, OrderId, PerformanceReport, Position, QueuedAction,
-    SimEvent, Simulator, history,
+    SideReport, SimEvent, Simulator, history,
 };
 use rust_decimal::Decimal;
 use rust_decimal::prelude::ToPrimitive;
@@ -92,6 +92,26 @@ const LEDGER_ROW_HEIGHT_PX: f32 = 34.0;
 const SIDE_RAIL_WIDTH_PX: f32 = 3.0;
 /// Height reserved under the ledger for the pinned totals strip.
 const TOTALS_STRIP_PX: f32 = 26.0;
+/// Headline tile geometry: a caption, a 22 px value, a sub-line.
+const TILE_HEIGHT_PX: f32 = 62.0;
+/// Gap between headline tiles.
+const TILE_GUTTER_PX: f32 = 8.0;
+/// The report's hero numbers — the one type size above 16 in the app.
+const HEADLINE_FONT_PX: f32 = 22.0;
+/// The equity curve's readable floor.
+const CURVE_MIN_H_PX: f32 = 160.0;
+/// Stops the curve from eating a resized window.
+const CURVE_MAX_H_PX: f32 = 240.0;
+/// Alpha of the equity area fill — ground under the line, not a mark.
+const CURVE_FILL_ALPHA: u8 = 31;
+/// At most this many curve points are drawn; the *drawing* downsamples
+/// past it (and says so), the metrics always use every trade.
+const CURVE_MAX_POINTS: usize = 1000;
+/// Space kept under the curve for the metric grids before the curve
+/// height clamps.
+const CURVE_GRID_RESERVE_PX: f32 = 230.0;
+/// Width of the equity curve's y-tick gutter.
+const CURVE_GUTTER_PX: f32 = 52.0;
 /// Text color inside colored gutter chips — the same ink as the last-price
 /// chip (`LAST_PRICE_CHIP_TEXT` is private to `app.rs`, so the value is
 /// duplicated here; keep the two identical).
@@ -182,10 +202,72 @@ enum ReportScope {
     All,
 }
 
-/// What the report window shows, loaded fresh from disk when opened.
-struct ReportData {
+/// The report's period filter, measured back from the newest saved trade
+/// in scope — never from a wall clock. The engine has no clock, and a
+/// replayed session's trades may be years old; a wall-clock "7 days" would
+/// report a perfectly good replay as empty.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReportPeriod {
+    Today,
+    Week,
+    Month,
+    Quarter,
+    All,
+}
+
+impl ReportPeriod {
+    /// Every period, in pill order.
+    const ALL: [Self; 5] = [
+        Self::Today,
+        Self::Week,
+        Self::Month,
+        Self::Quarter,
+        Self::All,
+    ];
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Today => "Today",
+            Self::Week => "7d",
+            Self::Month => "30d",
+            Self::Quarter => "90d",
+            Self::All => "All",
+        }
+    }
+
+    /// The anchor-relative phrase the support line reads.
+    fn phrase(self) -> &'static str {
+        match self {
+            Self::Today => "the newest trade's day",
+            Self::Week => "the last 7 days",
+            Self::Month => "the last 30 days",
+            Self::Quarter => "the last 90 days",
+            Self::All => "everything saved",
+        }
+    }
+
+    /// Oldest closing time still inside the period, measured back from
+    /// `anchor_ms`; `None` keeps everything.
+    fn cutoff_ms(self, anchor_ms: i64) -> Option<i64> {
+        const DAY_MS: i64 = 86_400_000;
+        match self {
+            Self::Today => Some(anchor_ms.div_euclid(DAY_MS) * DAY_MS),
+            Self::Week => Some(anchor_ms.saturating_sub(7 * DAY_MS)),
+            Self::Month => Some(anchor_ms.saturating_sub(30 * DAY_MS)),
+            Self::Quarter => Some(anchor_ms.saturating_sub(90 * DAY_MS)),
+            Self::All => None,
+        }
+    }
+}
+
+/// The report as filtered for display: the period's trades in closing
+/// order, their aggregation, and the anchor the period was measured from.
+struct ReportView {
+    period: ReportPeriod,
+    /// Newest closing time in scope — what the period counts back from.
+    anchor_ms: Option<i64>,
+    trades: Vec<ClosedTrade>,
     report: PerformanceReport,
-    history: LoadedHistory,
 }
 
 /// Journal rows loaded from disk, each remembering the symbol folder it
@@ -266,8 +348,16 @@ pub struct PaperTrading {
     controls: Vec<(PaperControl, egui::Rect)>,
     toast: Option<Toast>,
     report_open: bool,
-    report_scope: ReportScope,
-    report: Option<ReportData>,
+    /// Report symbol filter: `None` is every symbol, `Some` one folder.
+    report_symbol: Option<String>,
+    report_period: ReportPeriod,
+    /// Symbol folders on disk, for the report's combo box.
+    report_symbols: Vec<String>,
+    /// The report's history in scope, loaded fresh from disk.
+    report: Option<LoadedHistory>,
+    /// The report filtered to the period — rebuilt when the period or the
+    /// loaded history changes.
+    report_view: Option<ReportView>,
     // Trades ledger.
     ledger_scope: ReportScope,
     /// Earlier sessions' journal rows, read on first draw and on demand —
@@ -306,8 +396,11 @@ impl PaperTrading {
             controls: Vec::new(),
             toast: None,
             report_open: false,
-            report_scope: ReportScope::Symbol,
+            report_symbol: None,
+            report_period: ReportPeriod::All,
+            report_symbols: Vec::new(),
             report: None,
+            report_view: None,
             ledger_scope: ReportScope::Symbol,
             history_cache: None,
             selected_trade: None,
@@ -1666,55 +1759,143 @@ impl PaperTrading {
 
     fn open_report(&mut self) {
         self.report_open = true;
+        if self.report.is_none() && !self.symbol.is_empty() {
+            // First open lands on the chart's own symbol; later opens keep
+            // whatever the user last chose.
+            self.report_symbol = Some(self.symbol.clone());
+        }
         self.reload_report();
     }
 
     fn reload_report(&mut self) {
-        let symbol = match self.report_scope {
-            ReportScope::Symbol => Some(self.symbol.as_str()),
-            ReportScope::All => None,
+        self.report = Some(load_history(&self.dir, self.report_symbol.as_deref(), None));
+        self.report_view = None;
+        self.report_symbols = list_symbol_folders(&self.dir);
+    }
+
+    /// Rebuild the filtered view when the period (or the loaded history)
+    /// changed. The anchor is the newest trade in scope, never a clock.
+    fn ensure_report_view(&mut self) {
+        let fresh = self
+            .report_view
+            .as_ref()
+            .is_some_and(|view| view.period == self.report_period);
+        if fresh {
+            return;
+        }
+        let Some(history) = &self.report else {
+            self.report_view = None;
+            return;
         };
-        self.report = Some(load_report(&self.dir, symbol));
+        let anchor_ms = history.rows.last().map(|(_, trade)| trade.closed_ms);
+        let cutoff = anchor_ms.and_then(|anchor| self.report_period.cutoff_ms(anchor));
+        let trades: Vec<ClosedTrade> = history
+            .rows
+            .iter()
+            .map(|(_, trade)| trade)
+            .filter(|trade| cutoff.is_none_or(|cutoff| trade.closed_ms >= cutoff))
+            .cloned()
+            .collect();
+        let report = PerformanceReport::from_trades(&trades);
+        self.report_view = Some(ReportView {
+            period: self.report_period,
+            anchor_ms,
+            trades,
+            report,
+        });
     }
 
     /// The performance report, computed from what is actually on disk.
+    /// Non-modal by the app's contract — dimming the chart while a
+    /// simulated position is open would be dangerous.
     pub fn draw_report_window(&mut self, ctx: &egui::Context) {
         if !self.report_open {
             return;
         }
+        self.ensure_report_view();
         let mut open = true;
-        let mut scope_changed = false;
+        let mut reload = false;
         egui::Window::new("Simulated performance")
             .open(&mut open)
             .collapsible(false)
-            .resizable(false)
+            .resizable(true)
+            .default_size(egui::vec2(620.0, 560.0))
+            .min_width(520.0)
+            .min_height(420.0)
             .show(ctx, |ui| {
-                ui.horizontal(|ui| {
-                    ui.label(egui::RichText::new("scope").color(theme::TEXT_MUTED));
-                    scope_changed |= ui
-                        .selectable_value(
-                            &mut self.report_scope,
-                            ReportScope::Symbol,
-                            format!("this symbol ({})", self.symbol),
-                        )
-                        .clicked();
-                    scope_changed |= ui
-                        .selectable_value(&mut self.report_scope, ReportScope::All, "all symbols")
-                        .clicked();
-                });
+                reload = self.draw_report_filters(ui);
                 ui.separator();
-                match &self.report {
-                    Some(data) if !data.history.rows.is_empty() => draw_report_body(ui, data),
+                match &self.report_view {
+                    Some(view) if !view.trades.is_empty() => {
+                        draw_report_tiles(ui, &view.report);
+                        ui.add_space(8.0);
+                        draw_equity_curve(ui, view);
+                        ui.add_space(4.0);
+                        egui::ScrollArea::vertical()
+                            .id_salt("paper_report_grids")
+                            .auto_shrink([false, true])
+                            .show(ui, |ui| {
+                                draw_report_grid(ui, &view.report);
+                                draw_side_grid(ui, &view.report);
+                                draw_exit_reason_grid(ui, &view.report);
+                            });
+                    }
                     _ => {
+                        ui.add_space(8.0);
                         ui.label(
-                            egui::RichText::new(
-                                "No saved trades yet - close a simulated trade and it lands here.",
-                            )
-                            .color(theme::TEXT_MUTED),
+                            egui::RichText::new("No saved trades for this filter.")
+                                .color(theme::TEXT_PRIMARY),
                         );
+                        let scope = self
+                            .report_symbol
+                            .as_deref()
+                            .unwrap_or("any symbol")
+                            .to_owned();
+                        ui.label(
+                            egui::RichText::new(format!(
+                                "{scope} has no trades in {}. Try \"All\", or another symbol.",
+                                self.report_period.phrase(),
+                            ))
+                            .color(theme::TEXT_SUPPORT)
+                            .small(),
+                        );
+                        let default_symbol = (!self.symbol.is_empty()).then(|| self.symbol.clone());
+                        if (self.report_period != ReportPeriod::All
+                            || self.report_symbol != default_symbol)
+                            && ui
+                                .button("Clear filters")
+                                .on_hover_text("back to this symbol, all time")
+                                .clicked()
+                        {
+                            self.report_symbol = default_symbol;
+                            self.report_period = ReportPeriod::All;
+                            reload = true;
+                        }
                     }
                 }
                 ui.add_space(6.0);
+                if let Some(history) = &self.report {
+                    if history.unreadable_files > 0 || history.problem_rows > 0 {
+                        ui.label(
+                            egui::RichText::new(format!(
+                                "{} file(s) unreadable, {} row(s) skipped - counted, never \
+                                 silently dropped.",
+                                history.unreadable_files, history.problem_rows,
+                            ))
+                            .color(theme::WARN)
+                            .small(),
+                        );
+                    }
+                    ui.label(
+                        egui::RichText::new(format!(
+                            "{} trade(s) across {} file(s) in scope",
+                            history.rows.len(),
+                            history.files
+                        ))
+                        .color(theme::TEXT_MUTED)
+                        .small(),
+                    );
+                }
                 ui.label(
                     egui::RichText::new(
                         "All figures are simulated, in points (price units × quantity) - \
@@ -1724,12 +1905,92 @@ impl PaperTrading {
                     .small(),
                 );
             });
-        if scope_changed {
+        if reload {
             self.reload_report();
         }
         if !open {
             self.report_open = false;
         }
+    }
+
+    /// The filter row (symbol combo + period pills + refresh) and the
+    /// support line stating the anchor out loud. Returns whether the
+    /// history must be re-read.
+    fn draw_report_filters(&mut self, ui: &mut egui::Ui) -> bool {
+        let mut reload = false;
+        ui.horizontal(|ui| {
+            ui.label(
+                egui::RichText::new("Symbol")
+                    .color(theme::TEXT_MUTED)
+                    .small(),
+            );
+            let selected = self
+                .report_symbol
+                .clone()
+                .unwrap_or_else(|| "All symbols".to_owned());
+            let symbols = self.report_symbols.clone();
+            egui::ComboBox::from_id_salt("paper_report_symbol")
+                .width(140.0)
+                .selected_text(selected)
+                .show_ui(ui, |ui| {
+                    if ui
+                        .selectable_label(self.report_symbol.is_none(), "All symbols")
+                        .clicked()
+                    {
+                        self.report_symbol = None;
+                        reload = true;
+                    }
+                    for symbol in symbols {
+                        let on = self.report_symbol.as_deref() == Some(symbol.as_str());
+                        if ui.selectable_label(on, &symbol).clicked() {
+                            self.report_symbol = Some(symbol);
+                            reload = true;
+                        }
+                    }
+                });
+            ui.separator();
+            ui.label(
+                egui::RichText::new("Period")
+                    .color(theme::TEXT_MUTED)
+                    .small(),
+            );
+            for period in ReportPeriod::ALL {
+                let on = self.report_period == period;
+                if pill_toggle(
+                    ui,
+                    period.label(),
+                    on,
+                    "measured back from the newest saved trade in scope, not the wall clock",
+                )
+                .clicked()
+                    && !on
+                {
+                    self.report_period = period;
+                    self.report_view = None;
+                }
+            }
+            ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                if ui
+                    .small_button(icons::ARROWS_CLOCKWISE)
+                    .on_hover_text("re-read the history folder")
+                    .clicked()
+                {
+                    reload = true;
+                }
+            });
+        });
+        if let Some(view) = &self.report_view {
+            let text = match view.anchor_ms {
+                Some(anchor) => format!(
+                    "{} up to {} (newest saved trade, not the wall clock)",
+                    view.period.phrase(),
+                    fmt_utc_date(anchor),
+                ),
+                None => "no saved trades in this scope".to_owned(),
+            };
+            ui.label(egui::RichText::new(text).color(theme::TEXT_SUPPORT).small());
+        }
+        reload
     }
 
     // ------------------------------------------------------------------
@@ -1904,10 +2165,421 @@ impl PaperTrading {
     }
 }
 
-/// The report body: one metric per row, the explanation on hover, honest
-/// blanks (`—`) where a ratio has no denominator.
-fn draw_report_body(ui: &mut egui::Ui, data: &ReportData) {
-    let report = &data.report;
+/// The three headline tiles: NET (the one coloured number in the window),
+/// WIN RATE, PROFIT FACTOR — each with its denominator under it, so every
+/// tile is a self-explaining fact rather than a floating statistic.
+fn draw_report_tiles(ui: &mut egui::Ui, report: &PerformanceReport) {
+    let width = ((ui.available_width() - 2.0 * TILE_GUTTER_PX) / 3.0).max(80.0);
+    ui.horizontal(|ui| {
+        ui.spacing_mut().item_spacing.x = TILE_GUTTER_PX;
+        draw_tile(
+            ui,
+            width,
+            "NET",
+            fmt_signed_points(report.net_points),
+            "pts",
+            points_color(report.net_points),
+            format!("{} trades", report.trades),
+        );
+        draw_tile(
+            ui,
+            width,
+            "WIN RATE",
+            report
+                .win_rate_pct
+                .map_or_else(|| "—".to_owned(), |rate| fmt_decimal(rate.round_dp(0))),
+            "%",
+            theme::TEXT_PRIMARY,
+            format!(
+                "{} W · {} L · {} scratch",
+                report.wins, report.losses, report.scratches
+            ),
+        );
+        draw_tile(
+            ui,
+            width,
+            "PROFIT FACTOR",
+            report
+                .profit_factor
+                .map_or_else(|| "—".to_owned(), fmt_points),
+            "",
+            theme::TEXT_PRIMARY,
+            format!(
+                "+{} / -{}",
+                fmt_points(report.gross_profit),
+                fmt_points(report.gross_loss)
+            ),
+        );
+    });
+}
+
+/// One headline tile: caption, hero value with its unit, denominator line.
+fn draw_tile(
+    ui: &mut egui::Ui,
+    width: f32,
+    label: &str,
+    value: String,
+    unit: &str,
+    value_color: egui::Color32,
+    subline: String,
+) {
+    let (rect, _) = ui.allocate_exact_size(egui::vec2(width, TILE_HEIGHT_PX), egui::Sense::hover());
+    if !ui.is_rect_visible(rect) {
+        return;
+    }
+    let painter = ui.painter();
+    painter.rect_filled(rect, egui::Rounding::same(4.0), theme::INSET);
+    painter.rect_stroke(
+        rect,
+        egui::Rounding::same(4.0),
+        egui::Stroke::new(1.0_f32, theme::BORDER),
+    );
+    painter.text(
+        rect.min + egui::vec2(12.0, 6.0),
+        egui::Align2::LEFT_TOP,
+        label,
+        egui::FontId::monospace(10.0),
+        theme::TEXT_FAINT,
+    );
+    let value_galley = painter.layout_no_wrap(
+        value,
+        egui::FontId::monospace(HEADLINE_FONT_PX),
+        value_color,
+    );
+    let value_w = value_galley.size().x;
+    let baseline = rect.top() + 38.0;
+    painter.galley(
+        egui::pos2(rect.left() + 12.0, baseline - value_galley.size().y),
+        value_galley,
+        value_color,
+    );
+    if !unit.is_empty() {
+        painter.text(
+            egui::pos2(rect.left() + 12.0 + value_w + 4.0, baseline - 2.0),
+            egui::Align2::LEFT_BOTTOM,
+            unit,
+            egui::FontId::monospace(11.0),
+            theme::TEXT_MUTED,
+        );
+    }
+    painter.text(
+        egui::pos2(rect.left() + 12.0, rect.bottom() - 6.0),
+        egui::Align2::LEFT_BOTTOM,
+        subline,
+        egui::FontId::monospace(10.0),
+        theme::TEXT_FAINT,
+    );
+}
+
+/// The realized equity curve, `E_k` by trade index — the closing order
+/// that defines the drawdown, so calling the axis "time" would misstate
+/// what is plotted. One quiet line; a diverging fill against the zero
+/// baseline answers "was I ever under water?" at a glance; the deepest
+/// drawdown is annotated so the number in the grid below is locatable.
+fn draw_equity_curve(ui: &mut egui::Ui, view: &ReportView) {
+    let n = view.trades.len();
+    if n == 0 {
+        return;
+    }
+    ui.label(caption("REALIZED EQUITY"));
+    let height =
+        (ui.available_height() - CURVE_GRID_RESERVE_PX).clamp(CURVE_MIN_H_PX, CURVE_MAX_H_PX);
+    let (rect, response) = ui.allocate_exact_size(
+        egui::vec2(ui.available_width(), height),
+        egui::Sense::hover(),
+    );
+    if !ui.is_rect_visible(rect) {
+        return;
+    }
+    let painter = ui.painter_at(rect);
+
+    // The walk E_0..E_n, with E_0 = 0 before the first trade.
+    let mut equity = Vec::with_capacity(n + 1);
+    equity.push(0.0_f32);
+    let mut sum = Decimal::ZERO;
+    for trade in &view.trades {
+        sum = sum.saturating_add(trade.pnl_points);
+        equity.push(sum.to_f64().unwrap_or_default() as f32);
+    }
+    let (mut low, mut high) = (0.0_f32, 0.0_f32);
+    for value in &equity {
+        low = low.min(*value);
+        high = high.max(*value);
+    }
+    let span = (high - low).max(f32::EPSILON);
+    let plot = egui::Rect::from_min_max(
+        egui::pos2(rect.left() + CURVE_GUTTER_PX, rect.top() + 4.0),
+        egui::pos2(rect.right() - 4.0, rect.bottom() - 14.0),
+    );
+    let x_at = |k: usize| plot.left() + plot.width() * (k as f32) / (n as f32);
+    let y_at = |value: f32| plot.bottom() - (value - low) / span * plot.height();
+    let zero_y = y_at(0.0);
+
+    // Gridlines + y ticks at the floor, zero and the ceiling.
+    let mut ticks = vec![low, 0.0, high];
+    ticks.dedup_by(|a, b| (*a - *b).abs() < f32::EPSILON);
+    for tick in ticks {
+        let y = y_at(tick);
+        painter.line_segment(
+            [egui::pos2(plot.left(), y), egui::pos2(plot.right(), y)],
+            egui::Stroke::new(
+                1.0_f32,
+                egui::Color32::from_rgba_unmultiplied(
+                    theme::CONTROL.r(),
+                    theme::CONTROL.g(),
+                    theme::CONTROL.b(),
+                    128,
+                ),
+            ),
+        );
+        painter.text(
+            egui::pos2(plot.left() - 6.0, y),
+            egui::Align2::RIGHT_CENTER,
+            fmt_points(Decimal::from_f64_retain(f64::from(tick)).unwrap_or_default()),
+            egui::FontId::monospace(10.0),
+            theme::TEXT_FAINT,
+        );
+    }
+
+    // Diverging fill to the zero baseline: gains ground in BUY, losses in
+    // SELL, split exactly at each crossing.
+    let stride = n.div_ceil(CURVE_MAX_POINTS).max(1);
+    let fill_of = |value: f32| {
+        let color = if value >= 0.0 {
+            theme::BUY
+        } else {
+            theme::SELL
+        };
+        egui::Color32::from_rgba_unmultiplied(color.r(), color.g(), color.b(), CURVE_FILL_ALPHA)
+    };
+    let mut drawn_points = vec![egui::pos2(x_at(0), y_at(equity[0]))];
+    let mut previous = 0usize;
+    let mut next = stride;
+    while previous < n {
+        let k = next.min(n);
+        let (a, b) = (equity[previous], equity[k]);
+        let (x0, x1) = (x_at(previous), x_at(k));
+        if a == 0.0 && b == 0.0 {
+            // Nothing to fill on the baseline itself.
+        } else if (a >= 0.0) == (b >= 0.0) {
+            painter.add(egui::Shape::convex_polygon(
+                vec![
+                    egui::pos2(x0, y_at(a)),
+                    egui::pos2(x1, y_at(b)),
+                    egui::pos2(x1, zero_y),
+                    egui::pos2(x0, zero_y),
+                ],
+                fill_of(if a == 0.0 { b } else { a }),
+                egui::Stroke::NONE,
+            ));
+        } else {
+            // The step crosses zero: split it at the exact crossing.
+            let t = a / (a - b);
+            let xc = x0 + (x1 - x0) * t;
+            painter.add(egui::Shape::convex_polygon(
+                vec![
+                    egui::pos2(x0, y_at(a)),
+                    egui::pos2(xc, zero_y),
+                    egui::pos2(x0, zero_y),
+                ],
+                fill_of(a),
+                egui::Stroke::NONE,
+            ));
+            painter.add(egui::Shape::convex_polygon(
+                vec![
+                    egui::pos2(xc, zero_y),
+                    egui::pos2(x1, y_at(b)),
+                    egui::pos2(x1, zero_y),
+                ],
+                fill_of(b),
+                egui::Stroke::NONE,
+            ));
+        }
+        drawn_points.push(egui::pos2(x1, y_at(b)));
+        previous = k;
+        next += stride;
+    }
+
+    // The zero baseline over the fill, then the line over everything.
+    painter.line_segment(
+        [
+            egui::pos2(plot.left(), zero_y),
+            egui::pos2(plot.right(), zero_y),
+        ],
+        egui::Stroke::new(1.0_f32, theme::BORDER),
+    );
+    painter.add(egui::Shape::line(
+        drawn_points,
+        egui::Stroke::new(1.5_f32, theme::TEXT_PRIMARY),
+    ));
+    if n == 1 {
+        painter.circle_filled(
+            egui::pos2(x_at(1), y_at(equity[1])),
+            2.0,
+            theme::TEXT_PRIMARY,
+        );
+        painter.text(
+            plot.center(),
+            egui::Align2::CENTER_CENTER,
+            "one trade — no curve yet",
+            egui::FontId::monospace(10.0),
+            theme::TEXT_FAINT,
+        );
+    }
+
+    // The deepest drawdown, locatable: its peak level dotted, the drop
+    // solid, the number on a chip at the drop's midpoint.
+    if let Some((peak, trough)) = view.report.max_drawdown_span {
+        let (peak, trough) = (peak as usize, trough as usize);
+        if trough <= n {
+            let peak_y = y_at(equity[peak]);
+            let trough_x = x_at(trough);
+            let trough_y = y_at(equity[trough]);
+            painter.extend(egui::Shape::dashed_line(
+                &[egui::pos2(x_at(peak), peak_y), egui::pos2(trough_x, peak_y)],
+                egui::Stroke::new(1.0_f32, theme::SELL),
+                2.0,
+                3.0,
+            ));
+            painter.line_segment(
+                [egui::pos2(trough_x, peak_y), egui::pos2(trough_x, trough_y)],
+                egui::Stroke::new(1.0_f32, theme::SELL),
+            );
+            let label = format!("-{} pts", fmt_points(view.report.max_drawdown_points));
+            let galley = painter.layout_no_wrap(label, egui::FontId::monospace(10.0), CHIP_TEXT);
+            let center = egui::pos2((x_at(peak) + trough_x) / 2.0, (peak_y + trough_y) / 2.0);
+            let bg = egui::Rect::from_center_size(center, galley.size() + egui::vec2(8.0, 4.0));
+            painter.rect_filled(bg, egui::Rounding::same(2.0), theme::SELL);
+            painter.galley(bg.min + egui::vec2(4.0, 2.0), galley, CHIP_TEXT);
+        }
+    }
+
+    // Axis words: first and last trade index, with the unit between them.
+    painter.text(
+        egui::pos2(plot.left(), rect.bottom()),
+        egui::Align2::LEFT_BOTTOM,
+        "1",
+        egui::FontId::monospace(10.0),
+        theme::TEXT_FAINT,
+    );
+    painter.text(
+        egui::pos2(plot.right(), rect.bottom()),
+        egui::Align2::RIGHT_BOTTOM,
+        n.to_string(),
+        egui::FontId::monospace(10.0),
+        theme::TEXT_FAINT,
+    );
+    painter.text(
+        egui::pos2(plot.center().x, rect.bottom()),
+        egui::Align2::CENTER_BOTTOM,
+        "trades",
+        egui::FontId::monospace(10.0),
+        theme::TEXT_FAINT,
+    );
+    if stride > 1 {
+        painter.text(
+            egui::pos2(plot.left() + 4.0, plot.top() + 2.0),
+            egui::Align2::LEFT_TOP,
+            format!(
+                "curve downsampled to ~{CURVE_MAX_POINTS} points; every metric uses every trade"
+            ),
+            egui::FontId::proportional(10.0),
+            theme::TEXT_SUPPORT,
+        );
+    }
+
+    // Hover: snap to the nearest trade index and answer in the ledger's
+    // vocabulary, so the two surfaces never disagree.
+    if let Some(pointer) = response.hover_pos()
+        && plot.contains(pointer)
+    {
+        let k = (((pointer.x - plot.left()) / plot.width()) * (n as f32))
+            .round()
+            .clamp(0.0, n as f32) as usize;
+        let x = x_at(k);
+        painter.line_segment(
+            [egui::pos2(x, plot.top()), egui::pos2(x, plot.bottom())],
+            egui::Stroke::new(1.0_f32, theme::TEXT_FAINT),
+        );
+        let head = if k == 0 {
+            "start".to_owned()
+        } else {
+            let trade = &view.trades[k - 1];
+            format!(
+                "#{k} · {} {} · {} pts",
+                position_word(trade.side),
+                fmt_decimal(trade.quantity),
+                fmt_signed_points(trade.pnl_points),
+            )
+        };
+        let lines = [
+            head,
+            format!(
+                "equity {} pts",
+                fmt_signed_points(
+                    Decimal::from_f64_retain(f64::from(equity[k])).unwrap_or_default()
+                )
+            ),
+            if k == 0 {
+                String::new()
+            } else {
+                fmt_utc_minute(view.trades[k - 1].closed_ms)
+            },
+        ];
+        draw_hover_card(&painter, rect, pointer, &lines);
+    }
+}
+
+/// A small TAG_BG hover card with up to three lines, clamped into `rect`.
+fn draw_hover_card(
+    painter: &egui::Painter,
+    rect: egui::Rect,
+    pointer: egui::Pos2,
+    lines: &[String],
+) {
+    let font = egui::FontId::monospace(10.0);
+    let galleys: Vec<_> = lines
+        .iter()
+        .filter(|line| !line.is_empty())
+        .map(|line| painter.layout_no_wrap(line.clone(), font.clone(), theme::TEXT_PRIMARY))
+        .collect();
+    if galleys.is_empty() {
+        return;
+    }
+    let width = galleys
+        .iter()
+        .map(|galley| galley.size().x)
+        .fold(0.0_f32, f32::max)
+        + 12.0;
+    let height: f32 = galleys.iter().map(|galley| galley.size().y).sum::<f32>() + 10.0;
+    let mut origin = pointer + egui::vec2(10.0, -height - 6.0);
+    origin.x = origin.x.min(rect.right() - width).max(rect.left());
+    origin.y = origin.y.max(rect.top());
+    let card = egui::Rect::from_min_size(origin, egui::vec2(width, height));
+    painter.rect_filled(card, egui::Rounding::same(4.0), theme::TAG_BG);
+    let mut y = card.top() + 5.0;
+    for galley in galleys {
+        let advance = galley.size().y;
+        painter.galley(
+            egui::pos2(card.left() + 6.0, y),
+            galley,
+            theme::TEXT_PRIMARY,
+        );
+        y += advance;
+    }
+}
+
+/// The metric grid: one metric per row, the explanation on hover, honest
+/// blanks (`—`) where a ratio has no denominator. Every value here has a
+/// structurally fixed sign, so none of them is coloured.
+fn draw_report_grid(ui: &mut egui::Ui, report: &PerformanceReport) {
+    let blank = || "—".to_owned();
+    let pts = |value: Decimal| format!("{} pts", fmt_points(value));
+    let opt_pts = |value: Option<Decimal>| {
+        value.map_or_else(blank, |value| format!("{} pts", fmt_points(value)))
+    };
+    let opt_plain = |value: Option<Decimal>| value.map_or_else(blank, fmt_points);
+    let duration = |value: Option<i64>| value.map_or_else(blank, fmt_duration_ms);
     egui::Grid::new("paper_report_grid")
         .num_columns(2)
         .spacing([16.0, 4.0])
@@ -1919,37 +2591,27 @@ fn draw_report_body(ui: &mut egui::Ui, data: &ReportData) {
                 ui.end_row();
             };
             row(
-                "net P&L",
-                format!("{} pts", fmt_signed_points(report.net_points)),
-                "every closed trade's points, summed",
-            );
-            row(
                 "trades",
                 format!(
                     "{} ({} long / {} short)",
                     report.trades, report.long_trades, report.short_trades
                 ),
-                "closed round trips in the saved history",
-            );
-            row(
-                "win rate",
-                report
-                    .win_rate_pct
-                    .map_or_else(|| "—".to_owned(), |rate| format!("{}%", fmt_points(rate))),
-                "winning trades over all trades; a scratch counts as a trade but not a win",
-            );
-            row(
-                "profit factor",
-                report
-                    .profit_factor
-                    .map_or_else(|| "—".to_owned(), fmt_points),
-                "gross profit divided by gross loss; above 1 means the wins outweigh — \
-                 blank with no losses, because an undefined ratio is not infinity",
+                "closed round trips under the current filter",
             );
             row(
                 "max drawdown",
-                format!("{} pts", fmt_points(report.max_drawdown_points)),
+                pts(report.max_drawdown_points),
                 "deepest drop of realized equity below its running peak, in closing order",
+            );
+            row(
+                "max run-up",
+                pts(report.max_runup_points),
+                "highest rise of realized equity above its running trough — the drawdown's mirror",
+            );
+            row(
+                "recovery factor",
+                opt_plain(report.recovery_factor),
+                "net profit divided by the max drawdown; blank while nothing drew down",
             );
             row(
                 "gross profit / loss",
@@ -1964,10 +2626,53 @@ fn draw_report_body(ui: &mut egui::Ui, data: &ReportData) {
                 "avg win / loss",
                 format!(
                     "{} / {} pts",
-                    report.avg_win.map_or_else(|| "—".to_owned(), fmt_points),
-                    report.avg_loss.map_or_else(|| "—".to_owned(), fmt_points),
+                    opt_plain(report.avg_win),
+                    opt_plain(report.avg_loss),
                 ),
                 "mean winner and mean loser magnitude",
+            );
+            row(
+                "payoff ratio",
+                opt_plain(report.payoff_ratio),
+                "average win divided by average loss — how much a winner pays for a loser",
+            );
+            row(
+                "expectancy",
+                report
+                    .expectancy_points
+                    .map_or_else(blank, |value| format!("{} pts/trade", fmt_points(value))),
+                "net profit per trade: what one average trade pays",
+            );
+            row(
+                "std deviation",
+                opt_pts(report.stddev_points),
+                "sample standard deviation of trade points (N−1); blank below two trades",
+            );
+            row(
+                "longest streaks",
+                format!(
+                    "{} wins / {} losses",
+                    report.max_consecutive_wins, report.max_consecutive_losses
+                ),
+                "longest consecutive runs, in closing order; a scratch breaks both",
+            );
+            row(
+                "avg / median duration",
+                format!(
+                    "{} / {}",
+                    duration(report.avg_duration_ms),
+                    duration(report.median_duration_ms),
+                ),
+                "trade lifetimes in venue time",
+            );
+            row(
+                "winner vs loser duration",
+                format!(
+                    "{} / {}",
+                    duration(report.avg_win_duration_ms),
+                    duration(report.avg_loss_duration_ms),
+                ),
+                "how long winners run against how long losers are held",
             );
             row(
                 "largest win / loss",
@@ -1978,27 +2683,105 @@ fn draw_report_body(ui: &mut egui::Ui, data: &ReportData) {
                 ),
                 "best single trade and worst single trade magnitude",
             );
+            row(
+                "avg winner MAE",
+                report.avg_winner_mae_points.map_or_else(blank, |value| {
+                    format!(
+                        "{} pts (over {} of {})",
+                        fmt_points(value),
+                        report.winners_with_mae,
+                        report.wins
+                    )
+                }),
+                "how far the average winner first ran against you; only trades that \
+                 recorded an excursion count, and the denominator says how many did",
+            );
+            row(
+                "avg loser MFE",
+                report.avg_loser_mfe_points.map_or_else(blank, |value| {
+                    format!(
+                        "{} pts (over {} of {})",
+                        fmt_points(value),
+                        report.losers_with_mfe,
+                        report.losses
+                    )
+                }),
+                "how far the average loser was in profit before it lost; same disclosure",
+            );
         });
-    if data.history.unreadable_files > 0 || data.history.problem_rows > 0 {
-        ui.add_space(4.0);
-        ui.label(
-            egui::RichText::new(format!(
-                "{} file(s) unreadable, {} row(s) skipped - counted, never silently dropped.",
-                data.history.unreadable_files, data.history.problem_rows,
-            ))
-            .color(theme::WARN)
-            .small(),
-        );
+}
+
+/// Long and short, side by side, with the core metrics in each column.
+fn draw_side_grid(ui: &mut egui::Ui, report: &PerformanceReport) {
+    ui.add_space(8.0);
+    ui.label(caption("LONG VS SHORT"));
+    fn opt_plain(value: Option<Decimal>) -> String {
+        value.map_or_else(|| "—".to_owned(), fmt_points)
     }
-    ui.label(
-        egui::RichText::new(format!(
-            "{} trade(s) across {} file(s)",
-            data.history.rows.len(),
-            data.history.files
-        ))
-        .color(theme::TEXT_MUTED)
-        .small(),
-    );
+    /// One side-by-side row's value, computed per column.
+    type SideValue = Box<dyn Fn(&SideReport) -> String>;
+    let side_rows: [(&str, SideValue); 7] = [
+        ("trades", Box::new(|side| side.trades.to_string())),
+        (
+            "net",
+            Box::new(|side| format!("{} pts", fmt_signed_points(side.net_points))),
+        ),
+        (
+            "win rate",
+            Box::new(|side| {
+                side.win_rate_pct
+                    .map_or_else(|| "—".to_owned(), |rate| format!("{}%", fmt_points(rate)))
+            }),
+        ),
+        (
+            "profit factor",
+            Box::new(|side| opt_plain(side.profit_factor)),
+        ),
+        ("avg win", Box::new(|side| opt_plain(side.avg_win))),
+        ("avg loss", Box::new(|side| opt_plain(side.avg_loss))),
+        (
+            "expectancy",
+            Box::new(|side| opt_plain(side.expectancy_points)),
+        ),
+    ];
+    egui::Grid::new("paper_report_sides")
+        .num_columns(3)
+        .spacing([16.0, 4.0])
+        .show(ui, |ui| {
+            ui.label("");
+            ui.label(egui::RichText::new("LONG").color(theme::BUY).small());
+            ui.label(egui::RichText::new("SHORT").color(theme::SELL).small());
+            ui.end_row();
+            for (label, value_of) in &side_rows {
+                ui.label(egui::RichText::new(*label).color(theme::TEXT_MUTED));
+                ui.label(value_of(&report.long));
+                ui.label(value_of(&report.short));
+                ui.end_row();
+            }
+        });
+}
+
+/// How trades that left one way performed — count and net per exit reason.
+fn draw_exit_reason_grid(ui: &mut egui::Ui, report: &PerformanceReport) {
+    if report.by_exit_reason.is_empty() {
+        return;
+    }
+    ui.add_space(8.0);
+    ui.label(caption("BY EXIT REASON"));
+    egui::Grid::new("paper_report_reasons")
+        .num_columns(3)
+        .spacing([16.0, 4.0])
+        .show(ui, |ui| {
+            for reason in &report.by_exit_reason {
+                ui.label(
+                    egui::RichText::new(reason.reason.as_str().replace('_', " "))
+                        .color(theme::TEXT_MUTED),
+                );
+                ui.label(format!("{} trade(s)", reason.trades));
+                ui.label(format!("{} pts", fmt_signed_points(reason.net_points)));
+                ui.end_row();
+            }
+        });
 }
 
 /// Read every history file under `dir` (one symbol's folder, or all of
@@ -2076,18 +2859,16 @@ fn load_history(dir: &Path, symbol: Option<&str>, exclude: Option<&Path>) -> Loa
     }
 }
 
-/// Aggregate the saved history into the report window's data.
-fn load_report(dir: &Path, symbol: Option<&str>) -> ReportData {
-    let history = load_history(dir, symbol, None);
+/// Aggregate loaded history rows — the tests' shortcut from a journal on
+/// disk to a report.
+#[cfg(test)]
+fn report_from_history(history: &LoadedHistory) -> PerformanceReport {
     let trades: Vec<ClosedTrade> = history
         .rows
         .iter()
         .map(|(_, trade)| trade.clone())
         .collect();
-    ReportData {
-        report: PerformanceReport::from_trades(&trades),
-        history,
-    }
+    PerformanceReport::from_trades(&trades)
 }
 
 /// The frame geometry every paper paint helper reads: one struct so a tag,
@@ -2804,10 +3585,10 @@ fn sanitize_symbol(symbol: &str) -> String {
     }
 }
 
-/// `YYYYMMDD-HHMMSS` in UTC from epoch milliseconds — session file names
-/// derive from venue time, so the same replay run names the same file.
-/// Civil-from-days per Howard Hinnant's algorithm; no clock, no chrono.
-fn utc_compact(timestamp_ms: i64) -> String {
+/// Civil UTC date-time from epoch milliseconds: `(year, month, day, hour,
+/// minute, second)`. Civil-from-days per Howard Hinnant's algorithm; no
+/// clock, no chrono.
+fn civil_utc(timestamp_ms: i64) -> (i64, i64, i64, i64, i64, i64) {
     let seconds = timestamp_ms.div_euclid(1000);
     let days = seconds.div_euclid(86_400);
     let time_of_day = seconds.rem_euclid(86_400);
@@ -2821,12 +3602,47 @@ fn utc_compact(timestamp_ms: i64) -> String {
     let day = day_of_year - (153 * mp + 2) / 5 + 1;
     let month = if mp < 10 { mp + 3 } else { mp - 9 };
     let year = year_of_era + era * 400 + i64::from(month <= 2);
-    format!(
-        "{year:04}{month:02}{day:02}-{:02}{:02}{:02}",
+    (
+        year,
+        month,
+        day,
         time_of_day / 3600,
         (time_of_day % 3600) / 60,
         time_of_day % 60,
     )
+}
+
+/// `YYYYMMDD-HHMMSS` in UTC from epoch milliseconds — session file names
+/// derive from venue time, so the same replay run names the same file.
+fn utc_compact(timestamp_ms: i64) -> String {
+    let (year, month, day, hour, minute, second) = civil_utc(timestamp_ms);
+    format!("{year:04}{month:02}{day:02}-{hour:02}{minute:02}{second:02}")
+}
+
+/// `YYYY-MM-DD` in UTC — the report's anchor date.
+fn fmt_utc_date(timestamp_ms: i64) -> String {
+    let (year, month, day, ..) = civil_utc(timestamp_ms);
+    format!("{year:04}-{month:02}-{day:02}")
+}
+
+/// `YYYY-MM-DD HH:MM` in UTC — the equity curve's hover stamp.
+fn fmt_utc_minute(timestamp_ms: i64) -> String {
+    let (year, month, day, hour, minute, _) = civil_utc(timestamp_ms);
+    format!("{year:04}-{month:02}-{day:02} {hour:02}:{minute:02}")
+}
+
+/// The symbol folders under the history dir, for the report's combo box.
+fn list_symbol_folders(dir: &Path) -> Vec<String> {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    let mut folders: Vec<String> = entries
+        .flatten()
+        .filter(|entry| entry.path().is_dir())
+        .filter_map(|entry| entry.file_name().to_str().map(str::to_owned))
+        .collect();
+    folders.sort();
+    folders
 }
 
 #[cfg(test)]
@@ -2903,11 +3719,11 @@ mod tests {
         assert_eq!(parsed.trades[0].pnl_points, Decimal::from(5));
         assert_eq!(parsed.trades[1].pnl_points, Decimal::from(2));
 
-        let data = load_report(&dir, Some("TESTUSDT"));
-        assert_eq!(data.history.rows.len(), 2);
-        assert_eq!(data.report.net_points, Decimal::from(7));
-        assert_eq!(data.history.files, 1);
-        assert_eq!(data.history.unreadable_files, 0);
+        let history = load_history(&dir, Some("TESTUSDT"), None);
+        assert_eq!(history.rows.len(), 2);
+        assert_eq!(report_from_history(&history).net_points, Decimal::from(7));
+        assert_eq!(history.files, 1);
+        assert_eq!(history.unreadable_files, 0);
 
         let _ = std::fs::remove_dir_all(&dir);
     }
@@ -2934,10 +3750,11 @@ mod tests {
             "an armed click dies with the timeline"
         );
         assert!(paper.toast.is_some(), "the flatten is never silent");
-        let data = load_report(&dir, Some("RESETX"));
-        assert_eq!(data.history.rows.len(), 1);
+        let history = load_history(&dir, Some("RESETX"), None);
+        assert_eq!(history.rows.len(), 1);
         assert_eq!(
-            data.report.trades, 1,
+            report_from_history(&history).trades,
+            1,
             "the reset exit is a real, journaled trade"
         );
         let _ = std::fs::remove_dir_all(&dir);
@@ -3000,6 +3817,78 @@ mod tests {
         assert_eq!(cache.rows[0].0, "LEDGX");
         assert_eq!(cache.rows[0].1, trade);
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn report_periods_anchor_to_the_given_trade_never_a_clock() {
+        // 2026-03-16 13:01:08 UTC.
+        let anchor = 1_773_666_068_000_i64;
+        assert_eq!(ReportPeriod::All.cutoff_ms(anchor), None);
+        assert_eq!(
+            ReportPeriod::Today.cutoff_ms(anchor),
+            Some(1_773_619_200_000),
+            "the anchor's own UTC midnight"
+        );
+        assert_eq!(
+            ReportPeriod::Week.cutoff_ms(anchor),
+            Some(anchor - 7 * 86_400_000)
+        );
+    }
+
+    #[test]
+    fn utc_dates_format_from_the_same_civil_math() {
+        assert_eq!(fmt_utc_date(1_773_666_068_000), "2026-03-16");
+        assert_eq!(fmt_utc_minute(1_773_666_068_000), "2026-03-16 13:01");
+    }
+
+    #[test]
+    fn the_report_view_filters_by_period_from_the_newest_trade() {
+        fn trade_at(closed_ms: i64, pnl: i64) -> ClosedTrade {
+            ClosedTrade {
+                side: Side::Buy,
+                quantity: Decimal::ONE,
+                entry_price: Decimal::from(100),
+                exit_price: Decimal::from(100 + pnl),
+                opened_ms: closed_ms - 1000,
+                closed_ms,
+                pnl_points: Decimal::from(pnl),
+                exit_reason: quantick_sim::ExitReason::Manual,
+                entry_agg_id: None,
+                exit_agg_id: None,
+                mae_points: None,
+                mfe_points: None,
+            }
+        }
+        let day = 86_400_000_i64;
+        let mut paper = PaperTrading::new();
+        paper.report = Some(LoadedHistory {
+            rows: vec![
+                ("X".to_owned(), trade_at(10 * day, 5)),
+                ("X".to_owned(), trade_at(18 * day, -2)),
+                ("X".to_owned(), trade_at(20 * day + 3_600_000, 7)),
+            ],
+            files: 1,
+            unreadable_files: 0,
+            problem_rows: 0,
+        });
+        paper.report_period = ReportPeriod::Week;
+        paper.ensure_report_view();
+        let view = paper.report_view.as_ref().expect("view built");
+        assert_eq!(
+            view.anchor_ms,
+            Some(20 * day + 3_600_000),
+            "anchored to the newest saved trade, not a clock"
+        );
+        assert_eq!(view.trades.len(), 2, "the 10-day-old trade is outside 7d");
+        assert_eq!(view.report.net_points, Decimal::from(5));
+
+        paper.report_period = ReportPeriod::All;
+        paper.ensure_report_view();
+        assert_eq!(
+            paper.report_view.as_ref().expect("rebuilt").trades.len(),
+            3,
+            "All sees everything again"
+        );
     }
 
     #[test]

--- a/crates/app/src/paper_trading.rs
+++ b/crates/app/src/paper_trading.rs
@@ -81,8 +81,11 @@ const TAG_PAD_X: f32 = 6.0;
 /// Width of the ✕ zone a hovered tag reveals. An overlay convenience —
 /// every action here has a ≥ 28 px twin in the chrome.
 const TAG_BUTTON_PX: f32 = 20.0;
-/// How far around a tag the hover that reveals its ✕ still counts.
+/// How far around a tag the hover that reveals the bracket handles still
+/// counts.
 const TAG_HOVER_SLACK_PX: f32 = 4.0;
+/// Alpha of the ink hairline between a chip tag's ✕ zone and its words.
+const CLOSE_DIVIDER_ALPHA: u8 = 90;
 /// Size of a labelled SL/TP bracket handle on the entry line.
 const HANDLE_SIZE: egui::Vec2 = egui::vec2(20.0, 14.0);
 /// Vertical clearance between the entry line and a bracket handle.
@@ -120,6 +123,15 @@ const CURVE_MAX_POINTS: usize = 1000;
 /// Space kept under the curve for the metric grids before the curve
 /// height clamps.
 const CURVE_GRID_RESERVE_PX: f32 = 230.0;
+/// The report window's smallest usable size — everything scrolls or
+/// clamps below its defaults, so the window resizes freely down to this.
+const REPORT_MIN_WIDTH_PX: f32 = 440.0;
+/// See [`REPORT_MIN_WIDTH_PX`].
+const REPORT_MIN_HEIGHT_PX: f32 = 360.0;
+/// Height the report keeps for its honesty footer under the grids.
+const REPORT_FOOTER_RESERVE_PX: f32 = 64.0;
+/// The grids' readable floor inside a squeezed window.
+const REPORT_GRID_MIN_H_PX: f32 = 80.0;
 /// Width of the equity curve's y-tick gutter.
 const CURVE_GUTTER_PX: f32 = 52.0;
 /// Longest export path a toast prints whole; past it the folder elides
@@ -398,13 +410,31 @@ impl Default for PaperTrading {
 }
 
 impl PaperTrading {
+    /// A host on the default journal folder (environment override, then
+    /// `paper-trades`) — tests and standalone use. The app itself goes
+    /// through [`Self::with_trades_dir`] with the configured folder.
     #[must_use]
     pub fn new() -> Self {
+        Self::with_trades_dir(Self::resolve_trades_dir(TRADES_DIR))
+    }
+
+    /// The journal folder for this run: the environment override wins (an
+    /// env var is an explicit request for one run, like every autostart
+    /// hook), then `configured` — the `[paper] trades_dir` key, defaulting
+    /// to `paper-trades`.
+    #[must_use]
+    pub fn resolve_trades_dir(configured: &str) -> PathBuf {
+        std::env::var_os(TRADES_DIR_ENV).map_or_else(|| PathBuf::from(configured), PathBuf::from)
+    }
+
+    /// A host journaling to `dir`, already resolved from config and
+    /// environment.
+    #[must_use]
+    pub fn with_trades_dir(dir: PathBuf) -> Self {
         Self {
             sim: Simulator::new(),
             symbol: String::new(),
-            dir: std::env::var_os(TRADES_DIR_ENV)
-                .map_or_else(|| PathBuf::from(TRADES_DIR), PathBuf::from),
+            dir,
             journal_path: None,
             journal_warned: false,
             qty_text: "1".to_owned(),
@@ -437,6 +467,15 @@ impl PaperTrading {
     #[cfg(test)]
     pub(crate) fn redirect_history_dir(&mut self, dir: PathBuf) {
         self.dir = dir;
+    }
+
+    /// Apply a raw simulator command through the normal event funnel
+    /// (tests only) — for arranging sim state the UI would need gestures
+    /// to reach.
+    #[cfg(test)]
+    pub(crate) fn apply_sim_command_for_tests(&mut self, command: Command) {
+        let events = self.sim.apply(command);
+        self.handle_events(events);
     }
 
     /// Follow the app's active symbol. A change retargets the journal; the
@@ -805,7 +844,7 @@ impl PaperTrading {
                 fmt_decimal(order.quantity),
                 fmt_decimal(shown),
             );
-            if let Some(close) = ctx.chip_tag(y, theme::ACCENT, &text, hovered, !dragged) {
+            if let Some(close) = ctx.chip_tag(y, theme::ACCENT, &text, !dragged) {
                 controls.push((PaperControl::CancelOrder(order.id), close));
             }
         }
@@ -832,8 +871,7 @@ impl PaperTrading {
                         )
                     });
                 let line_hovered = ctx.hovers_line(entry_y);
-                let (close, tag_rect) =
-                    ctx.position_tag(entry_y, color, &side_text, points, line_hovered);
+                let (close, tag_rect) = ctx.position_tag(entry_y, color, &side_text, points);
                 if let Some(close) = close {
                     controls.push((PaperControl::ClosePosition, close));
                 }
@@ -965,7 +1003,7 @@ impl PaperTrading {
         if dragging && let Some(ratio) = rr_ratio(leg, shown) {
             text.push_str(&format!(" · R:R {ratio}"));
         }
-        if let Some(close) = ctx.chip_tag(y, leg.color, &text, hovered, !dragging) {
+        if let Some(close) = ctx.chip_tag(y, leg.color, &text, !dragging) {
             controls.push((leg.clear, close));
         }
     }
@@ -1937,7 +1975,7 @@ impl PaperTrading {
         if ui
             .add(
                 egui::Button::new(
-                    egui::RichText::new(format!("history: {}", self.dir.display()))
+                    egui::RichText::new(format!("trades saved to: {}", self.dir.display()))
                         .color(theme::TEXT_MUTED)
                         .small(),
                 )
@@ -1947,7 +1985,10 @@ impl PaperTrading {
                 .min_size(egui::vec2(ui.available_width(), 20.0)),
             )
             .on_hover_text(format!(
-                "open the history folder — {}",
+                "click to open the folder — {}\nset it with [paper] trades_dir in \
+                 quantick.toml; QUANTICK_TRADES_DIR overrides it for one run. Anything \
+                 writing the quantick-trades format here (a future bot included) shows \
+                 up in the ledger, the report and the export.",
                 std::path::absolute(&self.dir)
                     .unwrap_or_else(|_| self.dir.clone())
                     .display()
@@ -2282,9 +2323,9 @@ impl PaperTrading {
             .open(&mut open)
             .collapsible(false)
             .resizable(true)
-            .default_size(egui::vec2(620.0, 560.0))
-            .min_width(520.0)
-            .min_height(420.0)
+            .default_size(egui::vec2(600.0, 520.0))
+            .min_width(REPORT_MIN_WIDTH_PX)
+            .min_height(REPORT_MIN_HEIGHT_PX)
             .show(ctx, |ui| {
                 reload = self.draw_report_filters(ui);
                 ui.separator();
@@ -2294,9 +2335,18 @@ impl PaperTrading {
                         ui.add_space(8.0);
                         draw_equity_curve(ui, view);
                         ui.add_space(4.0);
+                        // The grids fill whatever height the user gave the
+                        // window and scroll inside it. Letting them take
+                        // their content height instead (auto-shrink) made
+                        // the window itself grow to fit and refuse to
+                        // resize down — the "stuck huge" report.
                         egui::ScrollArea::vertical()
                             .id_salt("paper_report_grids")
-                            .auto_shrink([false, true])
+                            .auto_shrink([false, false])
+                            .max_height(
+                                (ui.available_height() - REPORT_FOOTER_RESERVE_PX)
+                                    .max(REPORT_GRID_MIN_H_PX),
+                            )
                             .show(ui, |ui| {
                                 draw_report_grid(ui, &view.report);
                                 draw_side_grid(ui, &view.report);
@@ -3536,9 +3586,10 @@ impl PaintCtx<'_> {
         self.painter.galley(text_pos, galley, theme::CHIP_INK);
     }
 
-    /// A solid tag on a line, right-anchored inside the plot. While the
-    /// pointer is on the line or the tag (and `with_close` allows it), the
-    /// tag grows leftward to reveal a ✕ zone; the returned rect is that
+    /// A solid tag on a line, right-anchored inside the plot. When the tag
+    /// carries a close (`with_close` — everything but a mid-drag preview),
+    /// its ✕ zone is **always painted**: cancelling from the chart must not
+    /// depend on discovering a hover reveal. The returned rect is that
     /// button. Overlay ✕s carry no tooltip of their own — each has a
     /// full-size, fully labelled twin in the chrome.
     fn chip_tag(
@@ -3546,7 +3597,6 @@ impl PaintCtx<'_> {
         y: f32,
         fill: egui::Color32,
         text: &str,
-        line_hovered: bool,
         with_close: bool,
     ) -> Option<egui::Rect> {
         let galley = self.painter.layout_no_wrap(
@@ -3564,12 +3614,7 @@ impl PaintCtx<'_> {
             egui::pos2(self.tag_right - TAG_GAP_PX - content_w, center_y - half),
             egui::pos2(self.tag_right - TAG_GAP_PX, center_y + half),
         );
-        let hovered = with_close
-            && (line_hovered
-                || self
-                    .pointer
-                    .is_some_and(|pointer| resting.expand(TAG_HOVER_SLACK_PX).contains(pointer)));
-        let full = if hovered {
+        let full = if with_close {
             egui::Rect::from_min_max(resting.min - egui::vec2(TAG_BUTTON_PX, 0.0), resting.max)
         } else {
             resting
@@ -3581,7 +3626,7 @@ impl PaintCtx<'_> {
             galley,
             theme::CHIP_INK,
         );
-        if !hovered {
+        if !with_close {
             return None;
         }
         let button = egui::Rect::from_min_size(full.min, egui::vec2(TAG_BUTTON_PX, TAG_HEIGHT_PX));
@@ -3592,20 +3637,36 @@ impl PaintCtx<'_> {
             egui::FontId::monospace(11.0),
             theme::CHIP_INK,
         );
+        // A hairline of ink between the ✕ and the words, so the zone reads
+        // as a button rather than a longer label.
+        self.painter.line_segment(
+            [
+                egui::pos2(button.right(), full.top() + 4.0),
+                egui::pos2(button.right(), full.bottom() - 4.0),
+            ],
+            egui::Stroke::new(
+                1.0_f32,
+                egui::Color32::from_rgba_unmultiplied(
+                    theme::CHIP_INK.r(),
+                    theme::CHIP_INK.g(),
+                    theme::CHIP_INK.b(),
+                    CLOSE_DIVIDER_ALPHA,
+                ),
+            ),
+        );
         Some(button)
     }
 
     /// The position's tag wears the card grammar, not a chip: a position is
-    /// a fact about the account, not an order that will fire. Returns the
-    /// hover-revealed ✕ rect and the resting rect (the bracket handles
-    /// anchor left of it).
+    /// a fact about the account, not an order that will fire. Its ✕ is
+    /// always painted, like every chart close. Returns the ✕ rect and the
+    /// resting rect (the bracket handles anchor left of it).
     fn position_tag(
         &self,
         y: f32,
         side_color: egui::Color32,
         side_text: &str,
         points: Option<(String, egui::Color32)>,
-        line_hovered: bool,
     ) -> (Option<egui::Rect>, egui::Rect) {
         let font = egui::FontId::monospace(11.0);
         let side_galley =
@@ -3631,15 +3692,8 @@ impl PaintCtx<'_> {
             egui::pos2(self.tag_right - TAG_GAP_PX - content_w, center_y - half),
             egui::pos2(self.tag_right - TAG_GAP_PX, center_y + half),
         );
-        let hovered = line_hovered
-            || self
-                .pointer
-                .is_some_and(|pointer| resting.expand(TAG_HOVER_SLACK_PX).contains(pointer));
-        let full = if hovered {
-            egui::Rect::from_min_max(resting.min - egui::vec2(TAG_BUTTON_PX, 0.0), resting.max)
-        } else {
-            resting
-        };
+        let full =
+            egui::Rect::from_min_max(resting.min - egui::vec2(TAG_BUTTON_PX, 0.0), resting.max);
         self.painter
             .rect_filled(full, egui::Rounding::same(3.0), theme::INSET);
         self.painter.rect_stroke(
@@ -3673,9 +3727,6 @@ impl PaintCtx<'_> {
             let size = galley.size();
             self.painter
                 .galley(egui::pos2(x, center_y - size.y / 2.0), galley, color);
-        }
-        if !hovered {
-            return (None, resting);
         }
         let button = egui::Rect::from_min_size(
             full.min + egui::vec2(1.0 + rail, 0.0),
@@ -4829,6 +4880,44 @@ mod tests {
             !paper.handle_chart_input(&frame(chart, &scale, 40.0, true, true, false)),
             "a press far from every line belongs to the pan"
         );
+    }
+
+    /// The ✕ on a working order's chart tag is always painted — cancelling
+    /// from the chart must not depend on discovering a hover reveal — and
+    /// pressing it cancels the order.
+    #[test]
+    fn order_tags_offer_their_close_without_hover() {
+        let ctx = egui::Context::default();
+        let mut paper = PaperTrading::new();
+        paper.seed(&print(0, 100));
+        let events = paper.sim.apply(Command::PlaceLimit {
+            side: Side::Buy,
+            quantity: Decimal::ONE,
+            price: Decimal::from(95),
+            bracket: Bracket::none(),
+        });
+        paper.handle_events(events);
+        let (chart, scale) = chart_and_scale(80.0, 120.0);
+        let _ = ctx.run(egui::RawInput::default(), |ctx| {
+            let painter = ctx.layer_painter(egui::LayerId::background());
+            paper.draw_layer(&painter, chart, 760.0, 760.0, &scale, None, None);
+        });
+        let close = paper
+            .controls
+            .iter()
+            .find(|(control, _)| matches!(control, PaperControl::CancelOrder(_)))
+            .map(|(_, rect)| *rect)
+            .expect("the ✕ is painted with no pointer anywhere near");
+        let input = ChartInput {
+            chart,
+            scale: Some(&scale),
+            pointer: Some(close.center()),
+            primary_pressed: true,
+            primary_down: true,
+            primary_released: false,
+        };
+        assert!(paper.handle_chart_input(&input), "the ✕ owns the press");
+        assert!(paper.sim.orders().is_empty(), "and the order is gone");
     }
 
     /// Painted overlay controls (cached from the last paint pass) take the

--- a/crates/app/src/paper_trading.rs
+++ b/crates/app/src/paper_trading.rs
@@ -88,10 +88,9 @@ const TAG_HOVER_SLACK_PX: f32 = 4.0;
 const CLOSE_DIVIDER_ALPHA: u8 = 90;
 /// Size of a labelled SL/TP bracket handle on the entry line.
 const HANDLE_SIZE: egui::Vec2 = egui::vec2(20.0, 14.0);
-/// Vertical clearance between the entry line and a bracket handle.
-const HANDLE_GAP_PX: f32 = 4.0;
-/// Horizontal gap between the position tag and its bracket handles.
-const HANDLE_TAG_GAP_PX: f32 = 8.0;
+/// Vertical clearance between the entry line and a bracket handle — past
+/// the tag's half height, so handle and tag never overlap.
+const HANDLE_CLEAR_PX: f32 = 12.0;
 /// How far (in pixels) a press on the entry line must travel before it
 /// commits to creating one bracket leg — the drawings' drag threshold.
 const CREATE_DECIDE_THRESHOLD_PX: f32 = 4.0;
@@ -368,9 +367,6 @@ pub struct PaperTrading {
     // Chart-layer drag.
     drag: PaperDrag,
     drag_price: Option<f64>,
-    /// Interactive rects painted by the last `draw_layer` pass (tag ✕s,
-    /// bracket handles), pressed against on the next input pass.
-    controls: Vec<(PaperControl, egui::Rect)>,
     /// The working order hovered in the dock this frame — its chart line
     /// lifts, so one hover reads on both surfaces. Cleared after the chart
     /// consumed it (`draw_toast` runs last in the frame).
@@ -444,7 +440,6 @@ impl PaperTrading {
             armed: None,
             drag: PaperDrag::None,
             drag_price: None,
-            controls: Vec::new(),
             hovered_order: None,
             export_rx: None,
             toast: None,
@@ -788,18 +783,19 @@ impl PaperTrading {
     /// (dashed, accent), then the position's entry / stop-loss / take-profit
     /// (solid, semantic colors). Gutter chips keep the last-price chip's
     /// geometry and carry *the price and nothing else*, so prices never
-    /// disagree about their pixel; the words and the controls live in tags
-    /// right-anchored inside the plot. `pointer` is `Some` only on the pane
-    /// that owns paper input, so hover affordances (a tag's ✕, the bracket
-    /// handles) paint nowhere else. The interactive rects painted here are
-    /// cached for the next input pass — immediate mode presses against what
-    /// was actually drawn.
+    /// disagree about their pixel; the words and the ✕s live in tags
+    /// right-anchored inside the plot. Every interactive rect painted here
+    /// comes from the same pure geometry the press-time hit-test computes
+    /// (`close_button_rect`, `bracket_handle_rect`) — nothing is cached
+    /// across frames, because a live chart autoscales between paint and
+    /// press. `pointer` is `Some` only on the pane that owns paper input,
+    /// so hover affordances paint nowhere else.
     #[expect(
         clippy::too_many_arguments,
         reason = "the pane hands over its frame geometry; bundling it here would rename, not simplify"
     )]
     pub fn draw_layer(
-        &mut self,
+        &self,
         painter: &egui::Painter,
         chart_rect: egui::Rect,
         tag_right: f32,
@@ -817,7 +813,6 @@ impl PaperTrading {
             reserved_chip_y,
             pointer,
         };
-        let mut controls = Vec::new();
 
         for order in self.sim.orders() {
             let Some(level) = order.price else { continue };
@@ -844,9 +839,7 @@ impl PaperTrading {
                 fmt_decimal(order.quantity),
                 fmt_decimal(shown),
             );
-            if let Some(close) = ctx.chip_tag(y, theme::ACCENT, &text, !dragged) {
-                controls.push((PaperControl::CancelOrder(order.id), close));
-            }
+            ctx.chip_tag(y, theme::ACCENT, &text, !dragged);
         }
 
         if let Some(position) = self.sim.position().cloned() {
@@ -871,42 +864,46 @@ impl PaperTrading {
                         )
                     });
                 let line_hovered = ctx.hovers_line(entry_y);
-                let (close, tag_rect) = ctx.position_tag(entry_y, color, &side_text, points);
-                if let Some(close) = close {
-                    controls.push((PaperControl::ClosePosition, close));
-                }
+                let tag_rect = ctx.position_tag(entry_y, color, &side_text, points);
 
                 // Labelled handles for the missing bracket legs, revealed
-                // while the pointer is on the entry line or its tag: the
-                // affordance behind "drag from the position line to create".
+                // while the pointer is on the entry line, its tag, or the
+                // handles themselves — the affordance behind "drag from the
+                // position line to create". Their rects are the hit-test's
+                // own geometry, so a revealed handle is always pressable.
+                let entry_center =
+                    clamp_tag_center(entry_y, ctx.chart_rect.top(), ctx.chart_rect.bottom());
+                let legs = [
+                    (
+                        position.stop_loss.is_none(),
+                        "SL",
+                        position.side == Side::Sell,
+                        theme::SELL,
+                    ),
+                    (
+                        position.take_profit.is_none(),
+                        "TP",
+                        position.side == Side::Buy,
+                        theme::BUY,
+                    ),
+                ];
                 let over_tag = ctx
                     .pointer
                     .is_some_and(|pointer| tag_rect.expand(TAG_HOVER_SLACK_PX).contains(pointer));
-                if self.drag == PaperDrag::None && (line_hovered || over_tag) {
-                    let anchor = tag_rect.left() - HANDLE_TAG_GAP_PX;
-                    let legs = [
-                        (
-                            position.stop_loss.is_none(),
-                            PaperControl::HandleStopLoss,
-                            "SL",
-                            position.side == Side::Buy,
-                            theme::SELL,
-                        ),
-                        (
-                            position.take_profit.is_none(),
-                            PaperControl::HandleTakeProfit,
-                            "TP",
-                            position.side == Side::Sell,
-                            theme::BUY,
-                        ),
-                    ];
-                    for (absent, control, label, below, leg_color) in legs {
+                let over_handle = ctx.pointer.is_some_and(|pointer| {
+                    legs.iter().any(|(absent, _, above, _)| {
+                        *absent
+                            && bracket_handle_rect(ctx.tag_right, entry_center, *above)
+                                .contains(pointer)
+                    })
+                });
+                if self.drag == PaperDrag::None && (line_hovered || over_tag || over_handle) {
+                    for (absent, label, above, leg_color) in legs {
                         if !absent {
                             continue;
                         }
-                        let rect = handle_rect(anchor, entry_y, below);
+                        let rect = bracket_handle_rect(ctx.tag_right, entry_center, above);
                         ctx.bracket_handle(rect, label, leg_color);
-                        controls.push((control, rect));
                     }
                 }
             }
@@ -921,9 +918,7 @@ impl PaperTrading {
                     color: theme::SELL,
                     amend: PaperDrag::StopLoss,
                     create: PaperDrag::CreateStopLoss,
-                    clear: PaperControl::ClearStopLoss,
                 },
-                &mut controls,
             );
             self.draw_bracket_leg(
                 &ctx,
@@ -935,9 +930,7 @@ impl PaperTrading {
                     color: theme::BUY,
                     amend: PaperDrag::TakeProfit,
                     create: PaperDrag::CreateTakeProfit,
-                    clear: PaperControl::ClearTakeProfit,
                 },
-                &mut controls,
             );
         }
 
@@ -957,7 +950,6 @@ impl PaperTrading {
                 theme::ACCENT,
             );
         }
-        self.controls = controls;
     }
 
     /// One protective leg: its resting line and tag, the drag that reprices
@@ -965,12 +957,7 @@ impl PaperTrading {
     /// the dashed preview of where release would put it. The tag gains the
     /// live R:R read once both legs are known, which is what turns the drag
     /// into a decision.
-    fn draw_bracket_leg(
-        &self,
-        ctx: &PaintCtx<'_>,
-        leg: &LegPaint<'_>,
-        controls: &mut Vec<(PaperControl, egui::Rect)>,
-    ) {
+    fn draw_bracket_leg(&self, ctx: &PaintCtx<'_>, leg: &LegPaint<'_>) {
         let amending = self.drag == leg.amend;
         let creating = self.drag == leg.create && leg.level.is_none();
         let resting = leg.level.map(|level| level.to_f64().unwrap_or_default());
@@ -1003,9 +990,7 @@ impl PaperTrading {
         if dragging && let Some(ratio) = rr_ratio(leg, shown) {
             text.push_str(&format!(" · R:R {ratio}"));
         }
-        if let Some(close) = ctx.chip_tag(y, leg.color, &text, !dragging) {
-            controls.push((leg.clear, close));
-        }
+        ctx.chip_tag(y, leg.color, &text, !dragging);
     }
 
     /// Route pointer input to the simulated lines. Returns true when paper
@@ -1038,6 +1023,13 @@ impl PaperTrading {
         self.sim.closed_trades()
     }
 
+    /// The resting entry orders, in placement order — the simulator's own
+    /// view, read-only.
+    #[must_use]
+    pub fn working_orders(&self) -> &[quantick_sim::Order] {
+        self.sim.orders()
+    }
+
     /// Index (into [`Self::session_trades`]) of the ledger's selected
     /// trade, for the chart to emphasize; `None` while nothing is selected.
     #[must_use]
@@ -1047,24 +1039,18 @@ impl PaperTrading {
     }
 
     pub fn handle_chart_input(&mut self, input: &ChartInput<'_>) -> bool {
-        // An armed placement takes the next chart click.
-        if let Some(armed) = self.armed
-            && input.primary_pressed
-            && let Some(pointer) = input.pointer
-            && input.chart.contains(pointer)
-            && let Some(scale) = input.scale
-        {
-            self.place_armed(armed, scale.price_at(pointer.y));
-            return true;
-        }
-
-        // A painted overlay control (a tag's ✕, a bracket handle) takes the
-        // press before any line under it — it was drawn on top.
+        // An overlay control (a tag's ✕, a bracket handle) takes the press
+        // before *everything*: before the armed click — arming an order must
+        // never eat the ✕ under the pointer — and before the line grab,
+        // which is what made "close this order" read as "drag this order".
+        // The hit is geometric, from this frame's own scale and state: a
+        // pixel rect cached from the last paint goes stale the moment a
+        // live chart autoscales, and the press then slips onto the line.
         if input.primary_pressed
             && self.drag == PaperDrag::None
             && let Some(pointer) = input.pointer
             && let Some(scale) = input.scale
-            && let Some(control) = self.control_at(pointer)
+            && let Some(control) = self.control_at(pointer, input.chart, scale)
         {
             match control {
                 PaperControl::ClosePosition => self.close_position(),
@@ -1083,6 +1069,17 @@ impl PaperTrading {
                     self.drag_price = Some(scale.price_at(pointer.y));
                 }
             }
+            return true;
+        }
+
+        // An armed placement takes the next chart click.
+        if let Some(armed) = self.armed
+            && input.primary_pressed
+            && let Some(pointer) = input.pointer
+            && input.chart.contains(pointer)
+            && let Some(scale) = input.scale
+        {
+            self.place_armed(armed, scale.price_at(pointer.y));
             return true;
         }
 
@@ -1170,12 +1167,64 @@ impl PaperTrading {
         self.handle_events(events);
     }
 
-    /// The overlay control under the pointer, from the last paint pass.
-    fn control_at(&self, pointer: egui::Pos2) -> Option<PaperControl> {
-        self.controls
-            .iter()
-            .find(|(_, rect)| rect.contains(pointer))
-            .map(|(control, _)| *control)
+    /// The overlay control under the pointer, computed from this frame's
+    /// scale and simulator state — never a cached pixel rect, which goes
+    /// stale between paint and press the moment a live chart autoscales.
+    /// Priority follows the draw stack: working orders on top, then the
+    /// take profit, the stop, the position's ✕, and last the bracket
+    /// handles beside the entry line.
+    fn control_at(
+        &self,
+        pointer: egui::Pos2,
+        chart: egui::Rect,
+        scale: &PriceScale,
+    ) -> Option<PaperControl> {
+        let tag_right = chart.right();
+        // A line outside the visible price range paints no tag, so it
+        // offers no control either — same gate the paint applies.
+        let visible_center = |price: Decimal| {
+            let y = scale.y(price.to_f64().unwrap_or_default());
+            (y >= chart.top() && y <= chart.bottom())
+                .then(|| clamp_tag_center(y, chart.top(), chart.bottom()))
+        };
+        for order in self.sim.orders().iter().rev() {
+            if let Some(level) = order.price
+                && let Some(center_y) = visible_center(level)
+                && close_button_rect(tag_right, center_y).contains(pointer)
+            {
+                return Some(PaperControl::CancelOrder(order.id));
+            }
+        }
+        let position = self.sim.position()?;
+        if let Some(target) = position.take_profit
+            && let Some(center_y) = visible_center(target)
+            && close_button_rect(tag_right, center_y).contains(pointer)
+        {
+            return Some(PaperControl::ClearTakeProfit);
+        }
+        if let Some(stop) = position.stop_loss
+            && let Some(center_y) = visible_center(stop)
+            && close_button_rect(tag_right, center_y).contains(pointer)
+        {
+            return Some(PaperControl::ClearStopLoss);
+        }
+        let entry_center = visible_center(position.avg_price)?;
+        if close_button_rect(tag_right, entry_center).contains(pointer) {
+            return Some(PaperControl::ClosePosition);
+        }
+        if position.take_profit.is_none()
+            && bracket_handle_rect(tag_right, entry_center, position.side == Side::Buy)
+                .contains(pointer)
+        {
+            return Some(PaperControl::HandleTakeProfit);
+        }
+        if position.stop_loss.is_none()
+            && bracket_handle_rect(tag_right, entry_center, position.side == Side::Sell)
+                .contains(pointer)
+        {
+            return Some(PaperControl::HandleStopLoss);
+        }
+        None
     }
 
     /// Turn a pending entry-line press into the leg the pull chose, once it
@@ -1219,9 +1268,10 @@ impl PaperTrading {
     pub fn hover_cursor(
         &self,
         pointer: egui::Pos2,
+        chart: egui::Rect,
         scale: &PriceScale,
     ) -> Option<egui::CursorIcon> {
-        if self.control_at(pointer).is_some() {
+        if self.control_at(pointer, chart, scale).is_some() {
             return Some(egui::CursorIcon::PointingHand);
         }
         match self.line_at(pointer, scale)? {
@@ -1868,7 +1918,7 @@ impl PaperTrading {
             .filter(|action| matches!(action, QueuedAction::Entry(_)))
             .count();
         let queued_closes = self.sim.queued().len() - queued_entries;
-        let orders: Vec<_> = self.sim.orders().to_vec();
+        let orders: Vec<_> = self.working_orders().to_vec();
         ui.label(caption(&format!("WORKING ORDERS · {}", orders.len())));
         if queued_entries > 0 {
             ui.label(
@@ -3504,7 +3554,6 @@ struct LegPaint<'a> {
     color: egui::Color32,
     amend: PaperDrag,
     create: PaperDrag,
-    clear: PaperControl,
 }
 
 impl PaintCtx<'_> {
@@ -3586,50 +3635,38 @@ impl PaintCtx<'_> {
         self.painter.galley(text_pos, galley, theme::CHIP_INK);
     }
 
-    /// A solid tag on a line, right-anchored inside the plot. When the tag
-    /// carries a close (`with_close` — everything but a mid-drag preview),
-    /// its ✕ zone is **always painted**: cancelling from the chart must not
-    /// depend on discovering a hover reveal. The returned rect is that
-    /// button. Overlay ✕s carry no tooltip of their own — each has a
-    /// full-size, fully labelled twin in the chrome.
-    fn chip_tag(
-        &self,
-        y: f32,
-        fill: egui::Color32,
-        text: &str,
-        with_close: bool,
-    ) -> Option<egui::Rect> {
+    /// A solid tag on a line, right-anchored inside the plot. When it is
+    /// closable (`with_close` — everything but a mid-drag preview) its ✕
+    /// occupies the tag's right edge, painted on `close_button_rect`'s own
+    /// geometry — the exact rect the press-time hit-test computes, so the
+    /// two can never disagree. Overlay ✕s carry no tooltip of their own —
+    /// each has a full-size, fully labelled twin in the chrome.
+    fn chip_tag(&self, y: f32, fill: egui::Color32, text: &str, with_close: bool) {
         let galley = self.painter.layout_no_wrap(
             text.to_owned(),
             egui::FontId::monospace(11.0),
             theme::CHIP_INK,
         );
         let half = TAG_HEIGHT_PX / 2.0;
-        let center_y = y.clamp(
-            self.chart_rect.top() + half,
-            self.chart_rect.bottom() - half,
+        let center_y = clamp_tag_center(y, self.chart_rect.top(), self.chart_rect.bottom());
+        let right = self.tag_right - TAG_GAP_PX;
+        let button_w = if with_close { TAG_BUTTON_PX } else { 0.0 };
+        let content_w = galley.size().x + 2.0 * TAG_PAD_X + button_w;
+        let full = egui::Rect::from_min_max(
+            egui::pos2(right - content_w, center_y - half),
+            egui::pos2(right, center_y + half),
         );
-        let content_w = galley.size().x + 2.0 * TAG_PAD_X;
-        let resting = egui::Rect::from_min_max(
-            egui::pos2(self.tag_right - TAG_GAP_PX - content_w, center_y - half),
-            egui::pos2(self.tag_right - TAG_GAP_PX, center_y + half),
-        );
-        let full = if with_close {
-            egui::Rect::from_min_max(resting.min - egui::vec2(TAG_BUTTON_PX, 0.0), resting.max)
-        } else {
-            resting
-        };
         self.painter
             .rect_filled(full, egui::Rounding::same(3.0), fill);
         self.painter.galley(
-            egui::pos2(resting.left() + TAG_PAD_X, center_y - galley.size().y / 2.0),
+            egui::pos2(full.left() + TAG_PAD_X, center_y - galley.size().y / 2.0),
             galley,
             theme::CHIP_INK,
         );
         if !with_close {
-            return None;
+            return;
         }
-        let button = egui::Rect::from_min_size(full.min, egui::vec2(TAG_BUTTON_PX, TAG_HEIGHT_PX));
+        let button = close_button_rect(self.tag_right, center_y);
         self.painter.text(
             button.center(),
             egui::Align2::CENTER_CENTER,
@@ -3637,12 +3674,12 @@ impl PaintCtx<'_> {
             egui::FontId::monospace(11.0),
             theme::CHIP_INK,
         );
-        // A hairline of ink between the ✕ and the words, so the zone reads
+        // A hairline of ink between the words and the ✕, so the zone reads
         // as a button rather than a longer label.
         self.painter.line_segment(
             [
-                egui::pos2(button.right(), full.top() + 4.0),
-                egui::pos2(button.right(), full.bottom() - 4.0),
+                egui::pos2(button.left(), full.top() + 4.0),
+                egui::pos2(button.left(), full.bottom() - 4.0),
             ],
             egui::Stroke::new(
                 1.0_f32,
@@ -3654,20 +3691,19 @@ impl PaintCtx<'_> {
                 ),
             ),
         );
-        Some(button)
     }
 
     /// The position's tag wears the card grammar, not a chip: a position is
-    /// a fact about the account, not an order that will fire. Its ✕ is
-    /// always painted, like every chart close. Returns the ✕ rect and the
-    /// resting rect (the bracket handles anchor left of it).
+    /// a fact about the account, not an order that will fire. Its ✕ sits at
+    /// the right edge on `close_button_rect`'s own geometry, like every
+    /// chart close. Returns the tag's rect (the handle-reveal hover zone).
     fn position_tag(
         &self,
         y: f32,
         side_color: egui::Color32,
         side_text: &str,
         points: Option<(String, egui::Color32)>,
-    ) -> (Option<egui::Rect>, egui::Rect) {
+    ) -> egui::Rect {
         let font = egui::FontId::monospace(11.0);
         let side_galley =
             self.painter
@@ -3679,21 +3715,17 @@ impl PaintCtx<'_> {
             )
         });
         let rail = 3.0;
-        let mut content_w = rail + TAG_PAD_X + side_galley.size().x + TAG_PAD_X;
+        let mut content_w = rail + TAG_PAD_X + side_galley.size().x + TAG_PAD_X + TAG_BUTTON_PX;
         if let Some((galley, _)) = &points_galley {
             content_w += galley.size().x + TAG_PAD_X;
         }
         let half = TAG_HEIGHT_PX / 2.0;
-        let center_y = y.clamp(
-            self.chart_rect.top() + half,
-            self.chart_rect.bottom() - half,
+        let center_y = clamp_tag_center(y, self.chart_rect.top(), self.chart_rect.bottom());
+        let right = self.tag_right - TAG_GAP_PX;
+        let full = egui::Rect::from_min_max(
+            egui::pos2(right - content_w, center_y - half),
+            egui::pos2(right, center_y + half),
         );
-        let resting = egui::Rect::from_min_max(
-            egui::pos2(self.tag_right - TAG_GAP_PX - content_w, center_y - half),
-            egui::pos2(self.tag_right - TAG_GAP_PX, center_y + half),
-        );
-        let full =
-            egui::Rect::from_min_max(resting.min - egui::vec2(TAG_BUTTON_PX, 0.0), resting.max);
         self.painter
             .rect_filled(full, egui::Rounding::same(3.0), theme::INSET);
         self.painter.rect_stroke(
@@ -3701,7 +3733,7 @@ impl PaintCtx<'_> {
             egui::Rounding::same(3.0),
             egui::Stroke::new(1.0_f32, theme::BORDER),
         );
-        // The side rail rides the card's left edge, ✕ zone and all.
+        // The side rail rides the card's left edge.
         self.painter.rect_filled(
             egui::Rect::from_min_max(
                 full.min + egui::vec2(1.0, 1.0),
@@ -3715,7 +3747,7 @@ impl PaintCtx<'_> {
             },
             side_color,
         );
-        let mut x = resting.left() + rail + TAG_PAD_X;
+        let mut x = full.left() + rail + TAG_PAD_X;
         let side_size = side_galley.size();
         self.painter.galley(
             egui::pos2(x, center_y - side_size.y / 2.0),
@@ -3728,10 +3760,7 @@ impl PaintCtx<'_> {
             self.painter
                 .galley(egui::pos2(x, center_y - size.y / 2.0), galley, color);
         }
-        let button = egui::Rect::from_min_size(
-            full.min + egui::vec2(1.0 + rail, 0.0),
-            egui::vec2(TAG_BUTTON_PX - rail, TAG_HEIGHT_PX),
-        );
+        let button = close_button_rect(self.tag_right, center_y);
         let over_button = self.pointer.is_some_and(|pointer| button.contains(pointer));
         self.painter.text(
             button.center(),
@@ -3744,15 +3773,15 @@ impl PaintCtx<'_> {
                 theme::TEXT_MUTED
             },
         );
-        // A hairline between the ✕ zone and the words.
+        // A hairline between the words and the ✕ zone.
         self.painter.line_segment(
             [
-                egui::pos2(button.right(), full.top() + 3.0),
-                egui::pos2(button.right(), full.bottom() - 3.0),
+                egui::pos2(button.left(), full.top() + 3.0),
+                egui::pos2(button.left(), full.bottom() - 3.0),
             ],
             egui::Stroke::new(1.0_f32, theme::BORDER),
         );
-        (Some(button), resting)
+        full
     }
 
     /// A labelled `SL`/`TP` handle on the entry line: quiet control fill,
@@ -3780,16 +3809,33 @@ impl PaintCtx<'_> {
     }
 }
 
-/// Where a bracket handle sits: right-anchored at `anchor_right`, one gap
-/// off the entry line, on the side its leg protects.
-fn handle_rect(anchor_right: f32, line_y: f32, below: bool) -> egui::Rect {
-    let x = anchor_right - HANDLE_SIZE.x;
-    let y = if below {
-        line_y + HANDLE_GAP_PX
+/// A tag's vertical center: the line's row, kept fully inside the plot.
+pub(crate) fn clamp_tag_center(y: f32, top: f32, bottom: f32) -> f32 {
+    let half = TAG_HEIGHT_PX / 2.0;
+    y.clamp(top + half, bottom - half)
+}
+
+/// The ✕ zone every closable tag reserves at its right edge — a fixed
+/// position derivable without measuring text, which is what lets the
+/// paint and the press-time geometric hit-test share one truth.
+pub(crate) fn close_button_rect(tag_right: f32, center_y: f32) -> egui::Rect {
+    let right = tag_right - TAG_GAP_PX;
+    egui::Rect::from_min_max(
+        egui::pos2(right - TAG_BUTTON_PX, center_y - TAG_HEIGHT_PX / 2.0),
+        egui::pos2(right, center_y + TAG_HEIGHT_PX / 2.0),
+    )
+}
+
+/// A bracket handle's rect: the ✕ column, one clear step above or below
+/// the entry line so it never overlaps the position tag between them.
+fn bracket_handle_rect(tag_right: f32, entry_y: f32, above: bool) -> egui::Rect {
+    let right = tag_right - TAG_GAP_PX;
+    let y = if above {
+        entry_y - HANDLE_CLEAR_PX - HANDLE_SIZE.y
     } else {
-        line_y - HANDLE_GAP_PX - HANDLE_SIZE.y
+        entry_y + HANDLE_CLEAR_PX
     };
-    egui::Rect::from_min_size(egui::pos2(x, y), HANDLE_SIZE)
+    egui::Rect::from_min_size(egui::pos2(right - HANDLE_SIZE.x, y), HANDLE_SIZE)
 }
 
 /// Reward over risk at the dragged level, against the other leg — the read
@@ -4777,19 +4823,19 @@ mod tests {
         paper.stop_offset_text = "10".to_owned();
         paper.market(Side::Buy);
         paper.on_trade(&print(1, 100));
-        let (_chart, scale) = chart_and_scale(80.0, 120.0);
+        let (chart, scale) = chart_and_scale(80.0, 120.0);
         assert_eq!(
-            paper.hover_cursor(egui::pos2(400.0, 300.0), &scale),
+            paper.hover_cursor(egui::pos2(400.0, 300.0), chart, &scale),
             Some(egui::CursorIcon::ResizeVertical),
             "the stop at 90 sits at y 300 and drags"
         );
         assert_eq!(
-            paper.hover_cursor(egui::pos2(400.0, 200.0), &scale),
+            paper.hover_cursor(egui::pos2(400.0, 200.0), chart, &scale),
             Some(egui::CursorIcon::ResizeVertical),
             "the entry at 100 offers the missing take profit by drag"
         );
         assert_eq!(
-            paper.hover_cursor(egui::pos2(400.0, 40.0), &scale),
+            paper.hover_cursor(egui::pos2(400.0, 40.0), chart, &scale),
             None,
             "empty tape belongs to the chart"
         );
@@ -4862,7 +4908,7 @@ mod tests {
         paper.on_trade(&print(1, 100));
         let (chart, scale) = chart_and_scale(80.0, 120.0);
         assert_eq!(
-            paper.hover_cursor(egui::pos2(400.0, 200.0), &scale),
+            paper.hover_cursor(egui::pos2(400.0, 200.0), chart, &scale),
             Some(egui::CursorIcon::NotAllowed),
             "both legs exist, so their own lines are the handles"
         );
@@ -4882,12 +4928,12 @@ mod tests {
         );
     }
 
-    /// The ✕ on a working order's chart tag is always painted — cancelling
-    /// from the chart must not depend on discovering a hover reveal — and
-    /// pressing it cancels the order.
+    /// The ✕ on a working order's chart tag: the hit is pure geometry from
+    /// the live scale — no hover, no prior paint, no cached rect that goes
+    /// stale while a live chart autoscales — it wins over the armed click
+    /// (which used to eat it), and it never reads as a drag on the line.
     #[test]
-    fn order_tags_offer_their_close_without_hover() {
-        let ctx = egui::Context::default();
+    fn the_order_tags_close_is_geometric_and_beats_the_armed_click() {
         let mut paper = PaperTrading::new();
         paper.seed(&print(0, 100));
         let events = paper.sim.apply(Command::PlaceLimit {
@@ -4897,18 +4943,17 @@ mod tests {
             bracket: Bracket::none(),
         });
         paper.handle_events(events);
-        let (chart, scale) = chart_and_scale(80.0, 120.0);
-        let _ = ctx.run(egui::RawInput::default(), |ctx| {
-            let painter = ctx.layer_painter(egui::LayerId::background());
-            paper.draw_layer(&painter, chart, 760.0, 760.0, &scale, None, None);
+        // The trap that used to swallow every chart click.
+        paper.armed = Some(ArmedPlacement {
+            side: Side::Sell,
+            kind: EntryKind::Stop,
         });
-        let close = paper
-            .controls
-            .iter()
-            .find(|(control, _)| matches!(control, PaperControl::CancelOrder(_)))
-            .map(|(_, rect)| *rect)
-            .expect("the ✕ is painted with no pointer anywhere near");
-        let input = ChartInput {
+        let (chart, scale) = chart_and_scale(80.0, 120.0);
+        let close = close_button_rect(
+            chart.right(),
+            clamp_tag_center(scale.y(95.0), chart.top(), chart.bottom()),
+        );
+        let press = ChartInput {
             chart,
             scale: Some(&scale),
             pointer: Some(close.center()),
@@ -4916,53 +4961,43 @@ mod tests {
             primary_down: true,
             primary_released: false,
         };
-        assert!(paper.handle_chart_input(&input), "the ✕ owns the press");
-        assert!(paper.sim.orders().is_empty(), "and the order is gone");
+        assert!(paper.handle_chart_input(&press), "the ✕ owns the press");
+        assert!(
+            paper.sim.orders().is_empty(),
+            "the order is gone and the armed click placed nothing"
+        );
+        assert!(
+            paper.armed.is_some(),
+            "the armed placement neither fired nor died"
+        );
+        assert_eq!(paper.drag, PaperDrag::None, "and nothing started dragging");
     }
 
-    /// Painted overlay controls (cached from the last paint pass) take the
-    /// press before the lines under them.
+    /// A bracket handle press starts the create-drag — its rect is the
+    /// hit-test's own geometry beside the entry tag, above the line for
+    /// the profit side and below it for the losing side.
     #[test]
-    fn painted_controls_take_the_press_before_the_lines() {
+    fn a_bracket_handle_press_starts_the_create_drag() {
         let mut paper = PaperTrading::new();
         paper.seed(&print(0, 100));
-        let events = paper.sim.apply(Command::PlaceLimit {
-            side: Side::Buy,
-            quantity: Decimal::ONE,
-            price: Decimal::from(95),
-            bracket: Bracket::none(),
-        });
-        paper.handle_events(events);
-        let id = paper.sim.orders()[0].id;
-        let (chart, scale) = chart_and_scale(80.0, 120.0);
-        // A ✕ painted last frame at (700, 120) — far from any line.
-        let button = egui::Rect::from_center_size(egui::pos2(700.0, 120.0), egui::vec2(20.0, 20.0));
-        paper.controls = vec![(PaperControl::CancelOrder(id), button)];
-        let input = ChartInput {
-            chart,
-            scale: Some(&scale),
-            pointer: Some(egui::pos2(700.0, 120.0)),
-            primary_pressed: true,
-            primary_down: true,
-            primary_released: false,
-        };
-        assert!(paper.handle_chart_input(&input), "the ✕ owns the press");
-        assert!(paper.sim.orders().is_empty(), "and it cancelled the order");
-
-        // A bracket handle press starts the create-drag for its leg.
         paper.market(Side::Buy);
         paper.on_trade(&print(1, 100));
-        let handle = egui::Rect::from_center_size(egui::pos2(700.0, 210.0), HANDLE_SIZE);
-        paper.controls = vec![(PaperControl::HandleStopLoss, handle)];
+        let (chart, scale) = chart_and_scale(80.0, 120.0);
+        // A long's SL handle sits below the entry line (above = false).
+        let entry_center = clamp_tag_center(scale.y(100.0), chart.top(), chart.bottom());
+        let handle = bracket_handle_rect(chart.right(), entry_center, false);
         let press = ChartInput {
             chart,
             scale: Some(&scale),
-            pointer: Some(egui::pos2(700.0, 210.0)),
+            pointer: Some(handle.center()),
             primary_pressed: true,
             primary_down: true,
             primary_released: false,
         };
-        assert!(paper.handle_chart_input(&press));
+        assert!(
+            paper.handle_chart_input(&press),
+            "the handle owns the press"
+        );
         assert!(paper.handle_chart_input(&frame(chart, &scale, 300.0, false, true, false)));
         assert!(paper.handle_chart_input(&frame(chart, &scale, 300.0, false, false, true)));
         assert_eq!(

--- a/crates/app/src/paper_trading.rs
+++ b/crates/app/src/paper_trading.rs
@@ -31,6 +31,13 @@ use crate::timezone::TzOffset;
 /// Overrides the history folder (cwd-relative otherwise, like every
 /// quantick path).
 const TRADES_DIR_ENV: &str = "QUANTICK_TRADES_DIR";
+/// `=1` runs a fixed sequence of ordinary sim commands driven by print
+/// count, so a screenshot or demo run shows every trading surface without
+/// a click — the autostart family's member for paper trading. The trades
+/// are as real as any simulated trade (journaled, listed, painted); point
+/// `QUANTICK_TRADES_DIR` somewhere scratch to keep a demo out of your
+/// journal.
+const PAPER_DEMO_ENV: &str = "QUANTICK_PAPER_DEMO";
 /// Default history folder, relative to the working directory.
 const TRADES_DIR: &str = "paper-trades";
 /// How long a paper toast stays on screen.
@@ -196,6 +203,11 @@ enum PaperControl {
 struct Toast {
     message: String,
     shown_at: Instant,
+}
+
+/// The scripted demo's only state: how many prints it has seen.
+struct PaperDemo {
+    prints: u64,
 }
 
 /// Report scope: one symbol's history or the whole folder.
@@ -366,6 +378,9 @@ pub struct PaperTrading {
     /// The report filtered to the period — rebuilt when the period or the
     /// loaded history changes.
     report_view: Option<ReportView>,
+    /// The scripted demo (`QUANTICK_PAPER_DEMO=1`), for screenshot and
+    /// validation runs; `None` in normal use.
+    demo: Option<PaperDemo>,
     // Trades ledger.
     ledger_scope: ReportScope,
     /// Earlier sessions' journal rows, read on first draw and on demand —
@@ -410,6 +425,9 @@ impl PaperTrading {
             report_symbols: Vec::new(),
             report: None,
             report_view: None,
+            demo: std::env::var(PAPER_DEMO_ENV)
+                .is_ok_and(|value| value == "1")
+                .then_some(PaperDemo { prints: 0 }),
             ledger_scope: ReportScope::Symbol,
             history_cache: None,
             selected_trade: None,
@@ -442,6 +460,54 @@ impl PaperTrading {
     /// Feed one live print through the simulator and act on what it did.
     pub fn on_trade(&mut self, trade: &Trade) {
         let events = self.sim.on_trade(trade);
+        self.handle_events(events);
+        if self.demo.is_some() {
+            self.run_demo_step();
+        }
+    }
+
+    /// One step of the scripted demo: a fixed command sequence by print
+    /// count — an entry, brackets, a partial, a flatten, a resting order,
+    /// a short round trip — so every surface has something honest to show.
+    fn run_demo_step(&mut self) {
+        let Some(demo) = &mut self.demo else { return };
+        demo.prints += 1;
+        let prints = demo.prints;
+        let Some(mark) = self.sim.mark_price() else {
+            return;
+        };
+        // Scale-free distance: 0.2% of the mark, snapped to its precision.
+        let offset = (mark * Decimal::new(2, 3)).round_dp(mark.scale());
+        let has_position = self.sim.position().is_some();
+        let command = match prints {
+            5 => Command::PlaceMarket {
+                side: Side::Buy,
+                quantity: Decimal::ONE,
+                bracket: Bracket::none(),
+            },
+            12 => Command::SetBracket {
+                stop_loss: Some(mark.saturating_sub(offset)),
+                take_profit: Some(mark.saturating_add(offset.saturating_add(offset))),
+            },
+            80 if has_position => Command::ClosePartial {
+                quantity: Decimal::new(5, 1),
+            },
+            160 => Command::Flatten,
+            220 => Command::PlaceLimit {
+                side: Side::Buy,
+                quantity: Decimal::ONE,
+                price: mark.saturating_sub(offset.saturating_add(offset)),
+                bracket: Bracket::none(),
+            },
+            260 => Command::PlaceMarket {
+                side: Side::Sell,
+                quantity: Decimal::ONE,
+                bracket: Bracket::none(),
+            },
+            340 if has_position => Command::ClosePosition,
+            _ => return,
+        };
+        let events = self.sim.apply(command);
         self.handle_events(events);
     }
 
@@ -2146,6 +2212,15 @@ impl PaperTrading {
     // Report window
     // ------------------------------------------------------------------
 
+    /// The `QUANTICK_PAPER_REPORT_AUTOSTART` hook: the report, scoped to
+    /// every symbol — an autostart runs before the first feed settles, so
+    /// "the current symbol" would be the wrong one anyway.
+    pub(crate) fn autostart_report(&mut self) {
+        self.report_symbol = None;
+        self.open_report();
+    }
+
+    /// Open the report window — the `Report…` button's path.
     fn open_report(&mut self) {
         self.report_open = true;
         if self.report.is_none() && !self.symbol.is_empty() {

--- a/crates/app/src/paper_trading.rs
+++ b/crates/app/src/paper_trading.rs
@@ -15,6 +15,7 @@ use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 use eframe::egui;
+use egui_phosphor::regular as icons;
 use quantick_engine::{Side, Trade};
 use quantick_sim::{
     Bracket, ClosedTrade, Command, EntryKind, OrderId, PerformanceReport, Position, QueuedAction,
@@ -25,6 +26,7 @@ use rust_decimal::prelude::ToPrimitive;
 
 use crate::chart::PriceScale;
 use crate::theme;
+use crate::timezone::TzOffset;
 
 /// Overrides the history folder (cwd-relative otherwise, like every
 /// quantick path).
@@ -83,6 +85,13 @@ const HANDLE_TAG_GAP_PX: f32 = 8.0;
 /// How far (in pixels) a press on the entry line must travel before it
 /// commits to creating one bracket leg — the drawings' drag threshold.
 const CREATE_DECIDE_THRESHOLD_PX: f32 = 4.0;
+/// Fixed ledger row height — two lines plus their padding, held constant so
+/// the trade list can virtualise through `ScrollArea::show_rows`.
+const LEDGER_ROW_HEIGHT_PX: f32 = 34.0;
+/// The side rail on ledger rows — the position HUD card's rail width.
+const SIDE_RAIL_WIDTH_PX: f32 = 3.0;
+/// Height reserved under the ledger for the pinned totals strip.
+const TOTALS_STRIP_PX: f32 = 26.0;
 /// Text color inside colored gutter chips — the same ink as the last-price
 /// chip (`LAST_PRICE_CHIP_TEXT` is private to `app.rs`, so the value is
 /// duplicated here; keep the two identical).
@@ -176,12 +185,48 @@ enum ReportScope {
 /// What the report window shows, loaded fresh from disk when opened.
 struct ReportData {
     report: PerformanceReport,
-    trades: usize,
+    history: LoadedHistory,
+}
+
+/// Journal rows loaded from disk, each remembering the symbol folder it
+/// came from, merged into one closing-order timeline.
+struct LoadedHistory {
+    /// `(symbol, trade)` in closing order across every file read.
+    rows: Vec<(String, ClosedTrade)>,
     files: usize,
     /// Files that were not readable quantick-trades files.
     unreadable_files: usize,
     /// Rows the parser had to report as unreadable (torn tails and such).
     problem_rows: usize,
+}
+
+/// What the Trades ledger asked of its host.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LedgerAction {
+    /// Center the chart on this round trip (`opened_ms`, `closed_ms`).
+    Navigate(i64, i64),
+    /// Switch the dock to the Trading tab — the empty state's call to
+    /// action.
+    OpenTicket,
+}
+
+/// One virtualised ledger line.
+enum LedgerRow<'a> {
+    /// A group caption and its count.
+    Header(&'static str, usize),
+    /// A closed trade from this session's simulator: selectable, and its
+    /// round trip is on the current tape.
+    Session(usize, &'a ClosedTrade),
+    /// A row loaded from an earlier session's journal — display only; its
+    /// tape is not the one on screen.
+    Earlier(&'a str, &'a ClosedTrade),
+}
+
+/// What one painted ledger row reported back.
+#[derive(Default)]
+struct LedgerRowResponse {
+    clicked: bool,
+    navigate: bool,
 }
 
 /// Everything `handle_chart_input` needs from the frame, gathered by the
@@ -223,6 +268,15 @@ pub struct PaperTrading {
     report_open: bool,
     report_scope: ReportScope,
     report: Option<ReportData>,
+    // Trades ledger.
+    ledger_scope: ReportScope,
+    /// Earlier sessions' journal rows, read on first draw and on demand —
+    /// the live session file is excluded (its trades are already in the
+    /// simulator).
+    history_cache: Option<LoadedHistory>,
+    /// Index into the session's closed trades selected in the ledger; the
+    /// chart emphasizes that round trip.
+    selected_trade: Option<usize>,
 }
 
 impl Default for PaperTrading {
@@ -254,6 +308,9 @@ impl PaperTrading {
             report_open: false,
             report_scope: ReportScope::Symbol,
             report: None,
+            ledger_scope: ReportScope::Symbol,
+            history_cache: None,
+            selected_trade: None,
         }
     }
 
@@ -270,6 +327,8 @@ impl PaperTrading {
         if self.symbol != symbol {
             self.symbol = symbol.to_owned();
             self.journal_path = None;
+            self.history_cache = None;
+            self.selected_trade = None;
         }
     }
 
@@ -753,6 +812,9 @@ impl PaperTrading {
         if self.drag != PaperDrag::None {
             self.drag = PaperDrag::None;
             self.drag_price = None;
+            return true;
+        }
+        if self.selected_trade.take().is_some() {
             return true;
         }
         false
@@ -1334,6 +1396,255 @@ impl PaperTrading {
     }
 
     // ------------------------------------------------------------------
+    // Trades ledger tab
+    // ------------------------------------------------------------------
+
+    /// Load the earlier sessions' rows for the ledger, scoped to the
+    /// current symbol or the whole folder. The live session's own file is
+    /// excluded — its trades are already in the simulator.
+    fn reload_ledger(&mut self) {
+        let symbol = match self.ledger_scope {
+            ReportScope::Symbol => Some(self.symbol.as_str()),
+            ReportScope::All => None,
+        };
+        self.history_cache = Some(load_history(
+            &self.dir,
+            symbol,
+            self.journal_path.as_deref(),
+        ));
+    }
+
+    /// The Trades dock tab: the ledger of closed simulated trades — the
+    /// open position pinned on top, this session under it, the saved
+    /// history under that, and a totals strip that never scrolls away.
+    pub fn draw_trades_tab(&mut self, ui: &mut egui::Ui, tz: TzOffset) -> Option<LedgerAction> {
+        if self.history_cache.is_none() {
+            self.reload_ledger();
+        }
+        let mut action = None;
+
+        // Scope row: which symbols the saved history contributes.
+        let mut reload = false;
+        ui.horizontal(|ui| {
+            ui.label(
+                egui::RichText::new(if self.symbol.is_empty() {
+                    "—"
+                } else {
+                    &self.symbol
+                })
+                .monospace()
+                .color(theme::TEXT_MUTED),
+            );
+            ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                if ui
+                    .small_button(icons::ARROWS_CLOCKWISE)
+                    .on_hover_text("re-read the history folder")
+                    .clicked()
+                {
+                    reload = true;
+                }
+                let all = self.ledger_scope == ReportScope::All;
+                if pill_toggle(
+                    ui,
+                    "All symbols",
+                    all,
+                    "include every symbol's saved history, not just this chart's",
+                )
+                .clicked()
+                {
+                    self.ledger_scope = if all {
+                        ReportScope::Symbol
+                    } else {
+                        ReportScope::All
+                    };
+                    reload = true;
+                }
+            });
+        });
+        if reload {
+            self.reload_ledger();
+        }
+
+        ui.horizontal(|ui| {
+            ui.label(caption("TRADE"));
+            ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                ui.label(caption("PTS"));
+            });
+        });
+        ui.separator();
+
+        // The open position rides above the scroll — panning through
+        // history must never hide the trade you are in.
+        if let Some(summary) = self.position_summary() {
+            ui.label(caption("OPEN"));
+            let held_ms = self
+                .sim
+                .mark_timestamp_ms()
+                .zip(self.sim.position().map(|position| position.opened_ms))
+                .map(|(mark, opened)| mark.saturating_sub(opened));
+            draw_open_row(ui, &summary, self.sim.mark_price(), held_ms);
+        }
+
+        let all_scope = self.ledger_scope == ReportScope::All;
+        let session: Vec<(usize, &ClosedTrade)> =
+            self.sim.closed_trades().iter().enumerate().rev().collect();
+        let earlier: Vec<(&str, &ClosedTrade)> = self
+            .history_cache
+            .as_ref()
+            .map(|cache| {
+                cache
+                    .rows
+                    .iter()
+                    .rev()
+                    .map(|(symbol, trade)| (symbol.as_str(), trade))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        if session.is_empty() && earlier.is_empty() {
+            if self.position_summary().is_none() {
+                ui.add_space(12.0);
+                let headline = match self.ledger_scope {
+                    ReportScope::Symbol if !self.symbol.is_empty() => {
+                        format!("No trades for {}.", self.symbol)
+                    }
+                    _ => "No simulated trades yet.".to_owned(),
+                };
+                ui.label(egui::RichText::new(headline).color(theme::TEXT_PRIMARY));
+                ui.label(
+                    egui::RichText::new(
+                        "Close a position and it lands here - this session and every saved one.",
+                    )
+                    .color(theme::TEXT_SUPPORT)
+                    .small(),
+                );
+                ui.add_space(4.0);
+                if ui
+                    .button("Open the ticket")
+                    .on_hover_text("switch to the Trading tab and place an order")
+                    .clicked()
+                {
+                    action = Some(LedgerAction::OpenTicket);
+                }
+            }
+            self.draw_ledger_disclosure(ui);
+            return action;
+        }
+
+        let mut rows = Vec::new();
+        if !session.is_empty() {
+            rows.push(LedgerRow::Header("THIS SESSION", session.len()));
+            rows.extend(
+                session
+                    .iter()
+                    .map(|(index, trade)| LedgerRow::Session(*index, trade)),
+            );
+        }
+        if !earlier.is_empty() {
+            rows.push(LedgerRow::Header("EARLIER SESSIONS", earlier.len()));
+            rows.extend(
+                earlier
+                    .iter()
+                    .map(|(symbol, trade)| LedgerRow::Earlier(symbol, trade)),
+            );
+        }
+
+        // Totals over everything listed, computed before the scroll so the
+        // strip below can never disagree with the rows above it.
+        let mut total_trades = 0usize;
+        let mut total_wins = 0usize;
+        let mut net = Decimal::ZERO;
+        for trade in session
+            .iter()
+            .map(|(_, trade)| *trade)
+            .chain(earlier.iter().map(|(_, trade)| *trade))
+        {
+            total_trades += 1;
+            if trade.pnl_points > Decimal::ZERO {
+                total_wins += 1;
+            }
+            net = net.saturating_add(trade.pnl_points);
+        }
+
+        let list_height = (ui.available_height() - TOTALS_STRIP_PX).max(LEDGER_ROW_HEIGHT_PX);
+        let selected = self.selected_trade;
+        let mut clicked: Option<Option<usize>> = None;
+        let mut navigate = None;
+        egui::ScrollArea::vertical()
+            .id_salt("paper_trades_ledger")
+            .auto_shrink([false, false])
+            .max_height(list_height)
+            .show_rows(ui, LEDGER_ROW_HEIGHT_PX, rows.len(), |ui, range| {
+                for index in range {
+                    match &rows[index] {
+                        LedgerRow::Header(label, count) => draw_group_header(ui, label, *count),
+                        LedgerRow::Session(trade_index, trade) => {
+                            let is_selected = selected == Some(*trade_index);
+                            let response = draw_ledger_row(ui, trade, None, is_selected, true, tz);
+                            if response.navigate {
+                                navigate =
+                                    Some(LedgerAction::Navigate(trade.opened_ms, trade.closed_ms));
+                            } else if response.clicked {
+                                clicked = Some((!is_selected).then_some(*trade_index));
+                            }
+                        }
+                        LedgerRow::Earlier(symbol, trade) => {
+                            let symbol = all_scope.then_some(*symbol);
+                            draw_ledger_row(ui, trade, symbol, false, false, tz);
+                        }
+                    }
+                }
+            });
+        if let Some(selection) = clicked {
+            self.selected_trade = selection;
+        }
+        if navigate.is_some() {
+            action = navigate;
+        }
+
+        ui.separator();
+        ui.horizontal(|ui| {
+            let win_rate = (total_wins * 100)
+                .checked_div(total_trades)
+                .map_or_else(String::new, |rate| format!(" · {rate}% win"));
+            ui.label(
+                egui::RichText::new(format!("{total_trades} trades{win_rate}"))
+                    .monospace()
+                    .color(theme::TEXT_MUTED),
+            );
+            ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                ui.label(
+                    egui::RichText::new(format!("{} pts", fmt_signed_points(net)))
+                        .monospace()
+                        .strong()
+                        .color(points_color(net)),
+                );
+            });
+        });
+        self.draw_ledger_disclosure(ui);
+        action
+    }
+
+    /// The honesty line under the ledger: unreadable files and skipped rows
+    /// are counted, never silently dropped.
+    fn draw_ledger_disclosure(&self, ui: &mut egui::Ui) {
+        let Some(cache) = &self.history_cache else {
+            return;
+        };
+        if cache.unreadable_files == 0 && cache.problem_rows == 0 {
+            return;
+        }
+        ui.label(
+            egui::RichText::new(format!(
+                "{} file(s) unreadable, {} row(s) skipped - counted, never silently dropped.",
+                cache.unreadable_files, cache.problem_rows,
+            ))
+            .color(theme::WARN)
+            .small(),
+        );
+    }
+
+    // ------------------------------------------------------------------
     // Report window
     // ------------------------------------------------------------------
 
@@ -1377,7 +1688,7 @@ impl PaperTrading {
                 });
                 ui.separator();
                 match &self.report {
-                    Some(data) if data.trades > 0 => draw_report_body(ui, data),
+                    Some(data) if !data.history.rows.is_empty() => draw_report_body(ui, data),
                     _ => {
                         ui.label(
                             egui::RichText::new(
@@ -1652,12 +1963,12 @@ fn draw_report_body(ui: &mut egui::Ui, data: &ReportData) {
                 "best single trade and worst single trade magnitude",
             );
         });
-    if data.unreadable_files > 0 || data.problem_rows > 0 {
+    if data.history.unreadable_files > 0 || data.history.problem_rows > 0 {
         ui.add_space(4.0);
         ui.label(
             egui::RichText::new(format!(
                 "{} file(s) unreadable, {} row(s) skipped - counted, never silently dropped.",
-                data.unreadable_files, data.problem_rows,
+                data.history.unreadable_files, data.history.problem_rows,
             ))
             .color(theme::WARN)
             .small(),
@@ -1666,7 +1977,8 @@ fn draw_report_body(ui: &mut egui::Ui, data: &ReportData) {
     ui.label(
         egui::RichText::new(format!(
             "{} trade(s) across {} file(s)",
-            data.trades, data.files
+            data.history.rows.len(),
+            data.history.files
         ))
         .color(theme::TEXT_MUTED)
         .small(),
@@ -1674,9 +1986,10 @@ fn draw_report_body(ui: &mut egui::Ui, data: &ReportData) {
 }
 
 /// Read every history file under `dir` (one symbol's folder, or all of
-/// them), merge chronologically, and aggregate. Missing folders are simply
-/// empty — the report says "no saved trades", not an error.
-fn load_report(dir: &Path, symbol: Option<&str>) -> ReportData {
+/// them), remembering each row's symbol and skipping `exclude` (the live
+/// session's own file — its trades are already in the simulator). Missing
+/// folders are simply empty, not an error.
+fn load_history(dir: &Path, symbol: Option<&str>, exclude: Option<&Path>) -> LoadedHistory {
     let mut folders = Vec::new();
     match symbol {
         Some(symbol) => folders.push(dir.join(sanitize_symbol(symbol))),
@@ -1692,7 +2005,7 @@ fn load_report(dir: &Path, symbol: Option<&str>) -> ReportData {
             }
         }
     }
-    let mut trades = Vec::new();
+    let mut rows = Vec::new();
     let mut files = 0usize;
     let mut unreadable_files = 0usize;
     let mut problem_rows = 0usize;
@@ -1700,6 +2013,10 @@ fn load_report(dir: &Path, symbol: Option<&str>) -> ReportData {
         let Ok(entries) = std::fs::read_dir(&folder) else {
             continue;
         };
+        let folder_symbol = folder
+            .file_name()
+            .map(|name| name.to_string_lossy().into_owned())
+            .unwrap_or_default();
         let mut paths: Vec<PathBuf> = entries
             .flatten()
             .map(|entry| entry.path())
@@ -1710,12 +2027,21 @@ fn load_report(dir: &Path, symbol: Option<&str>) -> ReportData {
             .collect();
         paths.sort();
         for path in paths {
+            if exclude.is_some_and(|exclude| exclude == path) {
+                continue;
+            }
             files += 1;
             match std::fs::read_to_string(&path).map_err(|error| error.to_string()) {
                 Ok(text) => match history::parse(&text) {
                     Ok(parsed) => {
                         problem_rows += parsed.problems.len();
-                        trades.extend(parsed.trades);
+                        let symbol = parsed.symbol.unwrap_or_else(|| folder_symbol.clone());
+                        rows.extend(
+                            parsed
+                                .trades
+                                .into_iter()
+                                .map(|trade| (symbol.clone(), trade)),
+                        );
                     }
                     Err(_) => unreadable_files += 1,
                 },
@@ -1725,13 +2051,26 @@ fn load_report(dir: &Path, symbol: Option<&str>) -> ReportData {
     }
     // Files are per-session; merge into one closing-order timeline so the
     // drawdown walk is honest across sessions.
-    trades.sort_by_key(|trade| (trade.closed_ms, trade.opened_ms));
-    ReportData {
-        report: PerformanceReport::from_trades(&trades),
-        trades: trades.len(),
+    rows.sort_by_key(|row| (row.1.closed_ms, row.1.opened_ms));
+    LoadedHistory {
+        rows,
         files,
         unreadable_files,
         problem_rows,
+    }
+}
+
+/// Aggregate the saved history into the report window's data.
+fn load_report(dir: &Path, symbol: Option<&str>) -> ReportData {
+    let history = load_history(dir, symbol, None);
+    let trades: Vec<ClosedTrade> = history
+        .rows
+        .iter()
+        .map(|(_, trade)| trade.clone())
+        .collect();
+    ReportData {
+        report: PerformanceReport::from_trades(&trades),
+        history,
     }
 }
 
@@ -2079,6 +2418,261 @@ fn kind_short(kind: EntryKind) -> &'static str {
     }
 }
 
+/// Uppercase section caption — the ledger's group labels and column header.
+fn caption(text: &str) -> egui::RichText {
+    egui::RichText::new(text)
+        .size(10.0)
+        .color(theme::TEXT_FAINT)
+}
+
+/// A pill-shaped toggle chip: accent fill while on, quiet control while off.
+fn pill_toggle(ui: &mut egui::Ui, label: &str, on: bool, hover: &str) -> egui::Response {
+    let (fill, ink, stroke) = if on {
+        (theme::ACCENT, theme::CHIP_INK, egui::Stroke::NONE)
+    } else {
+        (
+            theme::CONTROL,
+            theme::TEXT_MUTED,
+            egui::Stroke::new(1.0_f32, theme::BORDER),
+        )
+    };
+    ui.add(
+        egui::Button::new(egui::RichText::new(label).color(ink).small())
+            .fill(fill)
+            .stroke(stroke)
+            .rounding(egui::Rounding::same(9.0)),
+    )
+    .on_hover_text(hover)
+}
+
+/// A group caption inside the virtualised list, sharing the fixed row
+/// height so `show_rows` stays honest about where every row is.
+fn draw_group_header(ui: &mut egui::Ui, label: &str, count: usize) {
+    let width = ui.available_width();
+    let (rect, _) = ui.allocate_exact_size(
+        egui::vec2(width, LEDGER_ROW_HEIGHT_PX),
+        egui::Sense::hover(),
+    );
+    if !ui.is_rect_visible(rect) {
+        return;
+    }
+    ui.painter().text(
+        egui::pos2(rect.left() + 2.0, rect.bottom() - 4.0),
+        egui::Align2::LEFT_BOTTOM,
+        format!("{label} · {count}"),
+        egui::FontId::monospace(10.0),
+        theme::TEXT_FAINT,
+    );
+}
+
+/// The pinned open-position row: sunken, live open points on the right,
+/// the current mark standing in for the exit.
+fn draw_open_row(
+    ui: &mut egui::Ui,
+    summary: &PositionSummary,
+    mark: Option<Decimal>,
+    held_ms: Option<i64>,
+) {
+    let width = ui.available_width();
+    let (rect, _) = ui.allocate_exact_size(
+        egui::vec2(width, LEDGER_ROW_HEIGHT_PX),
+        egui::Sense::hover(),
+    );
+    if !ui.is_rect_visible(rect) {
+        return;
+    }
+    let painter = ui.painter();
+    painter.rect_filled(rect, egui::Rounding::ZERO, theme::INSET);
+    for y in [rect.top(), rect.bottom()] {
+        painter.line_segment(
+            [egui::pos2(rect.left(), y), egui::pos2(rect.right(), y)],
+            egui::Stroke::new(1.0_f32, theme::BORDER),
+        );
+    }
+    painter.rect_filled(
+        egui::Rect::from_min_max(
+            rect.left_top(),
+            egui::pos2(rect.left() + SIDE_RAIL_WIDTH_PX, rect.bottom()),
+        ),
+        egui::Rounding::ZERO,
+        side_color(summary.side),
+    );
+    let exit = mark.map_or_else(|| "…".to_owned(), fmt_decimal);
+    let held = held_ms.map_or_else(String::new, |ms| format!("open {}", fmt_duration_ms(ms)));
+    draw_row_lines(
+        painter,
+        rect,
+        RowLines {
+            side: summary.side,
+            head: format!(
+                "{} {}",
+                position_word(summary.side),
+                fmt_decimal(summary.quantity)
+            ),
+            route: format!("{} → {}", fmt_decimal(summary.avg_price), exit),
+            points: summary.open_points,
+            detail: format!("{held} · at the last print"),
+        },
+    );
+}
+
+/// The two text lines every ledger row shares.
+struct RowLines {
+    side: Side,
+    head: String,
+    route: String,
+    points: Option<Decimal>,
+    detail: String,
+}
+
+fn draw_row_lines(painter: &egui::Painter, rect: egui::Rect, lines: RowLines) {
+    let font = egui::FontId::monospace(11.0);
+    let x = rect.left() + SIDE_RAIL_WIDTH_PX + 6.0;
+    let y1 = rect.top() + 9.0;
+    let y2 = rect.top() + 24.0;
+    let color = side_color(lines.side);
+    let head = painter.layout_no_wrap(lines.head, font.clone(), color);
+    let head_w = head.size().x;
+    painter.galley(egui::pos2(x, y1 - head.size().y / 2.0), head, color);
+    painter.text(
+        egui::pos2(x + head_w + 8.0, y1),
+        egui::Align2::LEFT_CENTER,
+        lines.route,
+        font.clone(),
+        theme::TEXT_MUTED,
+    );
+    if let Some(points) = lines.points {
+        painter.text(
+            egui::pos2(rect.right() - 6.0, y1),
+            egui::Align2::RIGHT_CENTER,
+            fmt_signed_points(points),
+            font,
+            points_color(points),
+        );
+    }
+    painter.text(
+        egui::pos2(x, y2),
+        egui::Align2::LEFT_CENTER,
+        lines.detail,
+        egui::FontId::monospace(10.0),
+        theme::TEXT_FAINT,
+    );
+}
+
+/// One closed trade in the ledger. Session rows select on click and reveal
+/// a jump-to-chart control on hover; rows from earlier sessions are
+/// display-only — their tape is not the one on screen, so the chart has
+/// nothing honest to point at.
+fn draw_ledger_row(
+    ui: &mut egui::Ui,
+    trade: &ClosedTrade,
+    symbol: Option<&str>,
+    selected: bool,
+    session: bool,
+    tz: TzOffset,
+) -> LedgerRowResponse {
+    let width = ui.available_width();
+    let sense = if session {
+        egui::Sense::click()
+    } else {
+        egui::Sense::hover()
+    };
+    let (rect, response) = ui.allocate_exact_size(egui::vec2(width, LEDGER_ROW_HEIGHT_PX), sense);
+    if !ui.is_rect_visible(rect) {
+        return LedgerRowResponse::default();
+    }
+    if selected {
+        ui.painter().rect_filled(
+            rect,
+            egui::Rounding::ZERO,
+            theme::active_tint(theme::ACCENT),
+        );
+    } else if response.hovered() {
+        ui.painter()
+            .rect_filled(rect, egui::Rounding::ZERO, theme::BORDER);
+    }
+    ui.painter().rect_filled(
+        egui::Rect::from_min_max(
+            rect.left_top(),
+            egui::pos2(rect.left() + SIDE_RAIL_WIDTH_PX, rect.bottom()),
+        ),
+        egui::Rounding::ZERO,
+        side_color(trade.side),
+    );
+    let mut detail = format!(
+        "{} · {} · {}",
+        crate::app::fmt_time(trade.closed_ms, tz),
+        fmt_duration_ms(trade.closed_ms.saturating_sub(trade.opened_ms)),
+        trade.exit_reason.as_str().replace('_', " "),
+    );
+    if let Some(symbol) = symbol {
+        detail.push_str(" · ");
+        detail.push_str(symbol);
+    }
+    draw_row_lines(
+        ui.painter(),
+        rect,
+        RowLines {
+            side: trade.side,
+            head: format!(
+                "{} {}",
+                position_word(trade.side),
+                fmt_decimal(trade.quantity)
+            ),
+            route: format!(
+                "{} → {}",
+                fmt_decimal(trade.entry_price),
+                fmt_decimal(trade.exit_price)
+            ),
+            points: Some(trade.pnl_points),
+            detail,
+        },
+    );
+    let mut navigate = false;
+    if session && response.hovered() {
+        let nav_rect = egui::Rect::from_center_size(
+            egui::pos2(rect.right() - 14.0, rect.top() + 24.0),
+            egui::vec2(16.0, 14.0),
+        );
+        let nav = ui
+            .interact(
+                nav_rect,
+                ui.id()
+                    .with(("ledger_nav", trade.opened_ms, trade.closed_ms)),
+                egui::Sense::click(),
+            )
+            .on_hover_text("center the chart on this trade");
+        ui.painter().text(
+            nav_rect.center(),
+            egui::Align2::CENTER_CENTER,
+            icons::ARROW_UP_RIGHT,
+            egui::FontId::proportional(11.0),
+            if nav.hovered() {
+                theme::TEXT_PRIMARY
+            } else {
+                theme::TEXT_MUTED
+            },
+        );
+        navigate = nav.clicked();
+    }
+    LedgerRowResponse {
+        clicked: response.clicked() && !navigate,
+        navigate,
+    }
+}
+
+/// `38s`, `4m 18s`, `1h 02m` — a trade's age in venue time.
+fn fmt_duration_ms(ms: i64) -> String {
+    let seconds = (ms / 1000).max(0);
+    if seconds < 60 {
+        format!("{seconds}s")
+    } else if seconds < 3600 {
+        format!("{}m {:02}s", seconds / 60, seconds % 60)
+    } else {
+        format!("{}h {:02}m", seconds / 3600, (seconds % 3600) / 60)
+    }
+}
+
 /// Keep a gutter chip legible when it would land on the last-price chip:
 /// push it just clear of the reserved row, towards its own side of the
 /// price, clamped into the pane. At the exact fill price (no distance at
@@ -2294,10 +2888,10 @@ mod tests {
         assert_eq!(parsed.trades[1].pnl_points, Decimal::from(2));
 
         let data = load_report(&dir, Some("TESTUSDT"));
-        assert_eq!(data.trades, 2);
+        assert_eq!(data.history.rows.len(), 2);
         assert_eq!(data.report.net_points, Decimal::from(7));
-        assert_eq!(data.files, 1);
-        assert_eq!(data.unreadable_files, 0);
+        assert_eq!(data.history.files, 1);
+        assert_eq!(data.history.unreadable_files, 0);
 
         let _ = std::fs::remove_dir_all(&dir);
     }
@@ -2325,11 +2919,70 @@ mod tests {
         );
         assert!(paper.toast.is_some(), "the flatten is never silent");
         let data = load_report(&dir, Some("RESETX"));
-        assert_eq!(data.trades, 1);
+        assert_eq!(data.history.rows.len(), 1);
         assert_eq!(
             data.report.trades, 1,
             "the reset exit is a real, journaled trade"
         );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn durations_format_by_magnitude() {
+        assert_eq!(fmt_duration_ms(38_000), "38s");
+        assert_eq!(fmt_duration_ms(258_000), "4m 18s");
+        assert_eq!(fmt_duration_ms(3_720_000), "1h 02m");
+        assert_eq!(fmt_duration_ms(-5), "0s", "clock skew never explodes");
+    }
+
+    /// The ledger's cache reads every saved file except the live session's
+    /// own (its trades are already in the simulator), and remembers which
+    /// symbol each row came from.
+    #[test]
+    fn the_ledger_cache_excludes_the_live_session_file() {
+        let dir =
+            std::env::temp_dir().join(format!("quantick-paper-ledger-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let mut paper = PaperTrading::new();
+        paper.dir.clone_from(&dir);
+        paper.set_symbol("LEDGX");
+        paper.seed(&print(0, 100));
+        paper.market(Side::Buy);
+        paper.on_trade(&print(1, 100));
+        let events = paper.sim.apply(Command::ClosePosition);
+        paper.handle_events(events);
+        paper.on_trade(&print(2, 105));
+        assert!(paper.journal_path.is_some(), "the close journaled");
+
+        // An earlier session's file, written by hand beside the live one.
+        let trade = ClosedTrade {
+            side: Side::Sell,
+            quantity: Decimal::ONE,
+            entry_price: Decimal::from(200),
+            exit_price: Decimal::from(195),
+            opened_ms: 10,
+            closed_ms: 20,
+            pnl_points: Decimal::from(5),
+            exit_reason: quantick_sim::ExitReason::Manual,
+            entry_agg_id: Some(1),
+            exit_agg_id: Some(2),
+            mae_points: Some(Decimal::ZERO),
+            mfe_points: Some(Decimal::from(5)),
+        };
+        let mut text = history::write_header("LEDGX");
+        text.push_str(&history::write_trade(&trade));
+        std::fs::write(dir.join("LEDGX").join("20200101-000000.csv"), text)
+            .expect("the earlier session file writes");
+
+        paper.reload_ledger();
+        let cache = paper.history_cache.as_ref().expect("loaded");
+        assert_eq!(
+            cache.rows.len(),
+            1,
+            "the live session's file is excluded, the earlier one loads"
+        );
+        assert_eq!(cache.rows[0].0, "LEDGX");
+        assert_eq!(cache.rows[0].1, trade);
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/crates/app/src/tab.rs
+++ b/crates/app/src/tab.rs
@@ -33,6 +33,7 @@ use crate::style::ChartStyle;
 use crate::theme;
 use crate::timezone::TzOffset;
 use crate::toolrail::ToolRail;
+use std::path::PathBuf;
 
 /// Each UI capture epoch reserves room for reconnect generations. This keeps
 /// late events from an aborted task below the next accepted generation floor.
@@ -243,6 +244,7 @@ impl Tab {
         symbol: String,
         spec: BarSpec,
         feed: FeedHandle,
+        trades_dir: PathBuf,
     ) -> Self {
         let mut loading = LoadingTracker::new();
         // The feed starts backfilling the moment it is spawned, so the tab
@@ -268,7 +270,7 @@ impl Tab {
             latest_trade_latency_ms: None,
             latest_trade_ms: None,
             live_trades: 0,
-            paper: PaperTrading::new(),
+            paper: PaperTrading::with_trades_dir(trades_dir),
             flow_pane: ChartPane::flow(pane_ids.0, spec, symbol.clone()),
             chip_label: String::new(),
             ohlcv_base: None,
@@ -1525,6 +1527,7 @@ impl Tab {
         });
 
         {
+            let focused = self.focused_side();
             let Self {
                 flow_pane,
                 time_pane,
@@ -1554,21 +1557,22 @@ impl Tab {
                 flow_area,
                 PaneSide::Flow,
             ))) {
-                // Order entry belongs to the flow pane: trading happens on the
-                // chart quantick is built around, and the time pane is the
-                // context view beside it. Unsplit this is the only pane there
-                // is, so it is exactly the behaviour before the split existed.
-                chrome.paper_owns_input = side == PaneSide::Flow;
+                // Order entry follows the focused pane (§11): both charts are
+                // trading surfaces — a level is as true on the time pane as on
+                // the flow pane — and focus lands on the press that acts, so
+                // the first click already trades where the accent rule is.
+                // Unsplit, the flow pane is the only pane and nothing changes.
+                chrome.paper_owns_input = side == focused;
                 pane.handle_navigation(ui, rect, &mut chrome);
                 pane.draw_chart(ui.painter(), rect, &mut chrome);
             }
         }
 
-        // The position HUD rides the pane that owns order entry. It draws
-        // here, after the pane loop, because its buttons need the paper host
-        // mutably — inside the loop that borrow is pinned behind the shared
-        // chrome.
-        if let Some((rect, scale)) = self.flow_pane.paper_hud_anchor() {
+        // The position HUD rides the pane that owns order entry (the focused
+        // one). It draws here, after the pane loop, because its buttons need
+        // the paper host mutably — inside the loop that borrow is pinned
+        // behind the shared chrome.
+        if let Some((rect, scale)) = self.focused_pane().paper_hud_anchor() {
             crate::paper_hud::draw(ui.ctx(), rect, &mut self.paper, &scale);
         }
 

--- a/crates/app/src/tab.rs
+++ b/crates/app/src/tab.rs
@@ -1560,7 +1560,7 @@ impl Tab {
                 // is, so it is exactly the behaviour before the split existed.
                 chrome.paper_owns_input = side == PaneSide::Flow;
                 pane.handle_navigation(ui, rect, &mut chrome);
-                pane.draw_chart(ui.painter(), rect, &chrome);
+                pane.draw_chart(ui.painter(), rect, &mut chrome);
             }
         }
 

--- a/crates/app/src/tabstrip.rs
+++ b/crates/app/src/tabstrip.rs
@@ -376,6 +376,7 @@ mod tests {
                 bubble_preset: None,
             }],
             metatrader: MetaTraderSettings::default(),
+            paper: Default::default(),
         }
     }
 

--- a/crates/app/src/trade_paint.rs
+++ b/crates/app/src/trade_paint.rs
@@ -1,0 +1,411 @@
+//! Closed-trade paint: entry/exit marks and their connectors on the chart.
+//!
+//! Only this session's trades are painted — their fills happened on the
+//! tape on screen, which is what makes the marks honest. Trades loaded from
+//! earlier sessions stay in the ledger and the report; the chart has no
+//! proof of their prints, so it does not draw them.
+//!
+//! The encoding is scannable for outcomes: marks and connectors take the
+//! *outcome* colour (win/loss/scratch), while direction is carried by
+//! shape — a filled triangle pointing the trade's way at the entry, a
+//! diamond at the exit. Both anchor to the fill *price* (the honest datum)
+//! on the bar that held the fill's venue time, and every mark wears a ring
+//! in the canvas colour so it survives a same-coloured candle behind it.
+//!
+//! Switched off (the `closed trade marks` layer), nothing here draws;
+//! nothing is forgotten either — the trades stay in the ledger and on disk.
+
+use eframe::egui;
+use quantick_engine::Side;
+use quantick_sim::ClosedTrade;
+use rust_decimal::prelude::ToPrimitive;
+
+use crate::chart::PriceScale;
+use crate::paper_trading::{
+    fmt_decimal, fmt_duration_ms, fmt_signed_points, points_color, position_word,
+};
+use crate::theme;
+use crate::timezone::TzOffset;
+
+/// Entry triangle footprint (width × height), sized to read at 100% and
+/// stay under one candle body.
+const ENTRY_MARKER_W_PX: f32 = 11.0;
+/// Entry triangle height (see `ENTRY_MARKER_W_PX`).
+const ENTRY_MARKER_H_PX: f32 = 8.0;
+/// Half-diagonal of the exit diamond — a 9 px mark, visibly smaller than
+/// the entry triangle because an exit is a point event.
+const EXIT_MARKER_RADIUS_PX: f32 = 4.5;
+/// Gap between a mark's tip and the price pixel the fill owns.
+const MARKER_GAP_PX: f32 = 3.0;
+/// Ring around every mark, in the canvas colour, for legibility over a
+/// same-coloured candle.
+const MARKER_RING_PX: f32 = 1.0;
+/// Connector dash length — distinct from the last-price line's 4/4 rhythm.
+const CONNECTOR_DASH_PX: f32 = 2.0;
+/// Connector gap (see `CONNECTOR_DASH_PX`).
+const CONNECTOR_GAP_PX: f32 = 3.0;
+/// Connector alpha: an annotation crossing candles, not a series.
+const CONNECTOR_ALPHA: u8 = 115;
+/// Emphasis width of a selected trade's connector.
+const SELECTED_CONNECTOR_WIDTH_PX: f32 = 1.5;
+/// The drawings' halo treatment, for the selected trade's marks.
+const SELECTION_HALO_COLOR: egui::Color32 = egui::Color32::from_rgba_premultiplied(40, 40, 40, 40);
+/// How far past a mark's edge the selection halo reaches.
+const SELECTION_HALO_EXTRA_PX: f32 = 3.5;
+/// At most this many trades paint, newest first; past it the paint is
+/// noise (≈ one mark per 4 px on a 1600 px chart). The withheld count is
+/// said out loud, never silently dropped.
+const TRADE_PAINT_LIMIT: usize = 200;
+/// How close (px) the pointer must be to a mark for its tooltip.
+const HOVER_RADIUS_PX: f32 = 8.0;
+
+/// The frame geometry the paint reads, handed over by the pane.
+pub(crate) struct TradePaintFrame<'a> {
+    pub painter: &'a egui::Painter,
+    pub chart_rect: egui::Rect,
+    pub scale: &'a PriceScale,
+    /// The pane's resolved canvas colour — the marks' ring.
+    pub background: egui::Color32,
+    /// The pointer, for the hover tooltip; `None` paints no tooltip.
+    pub pointer: Option<egui::Pos2>,
+    pub tz: TzOffset,
+}
+
+/// One drawable mark, kept for the hover pass.
+struct Mark<'a> {
+    position: egui::Pos2,
+    trade: &'a ClosedTrade,
+}
+
+/// Paint the session's closed trades: connectors under marks, newest
+/// trades first when the cap bites, the selected trade emphasized.
+/// `slot_at_time` and `x_at_slot` are the pane's own mappings, so the
+/// marks land exactly where the candles say that moment is.
+pub(crate) fn draw(
+    frame: &TradePaintFrame<'_>,
+    trades: &[ClosedTrade],
+    selected: Option<usize>,
+    slot_at_time: impl Fn(i64) -> Option<usize>,
+    x_at_slot: impl Fn(usize) -> f32,
+) {
+    let painter = frame.painter.with_clip_rect(frame.chart_rect);
+    let mut marks: Vec<Mark<'_>> = Vec::new();
+    let mut drawn = 0usize;
+    let mut withheld = 0usize;
+    for (index, trade) in trades.iter().enumerate().rev() {
+        let Some(points) = endpoints(frame, trade, &slot_at_time, &x_at_slot) else {
+            continue;
+        };
+        let (entry, exit) = points;
+        let visible = entry.x.max(exit.x) >= frame.chart_rect.left()
+            && entry.x.min(exit.x) <= frame.chart_rect.right();
+        if !visible {
+            continue;
+        }
+        if drawn >= TRADE_PAINT_LIMIT {
+            withheld += 1;
+            continue;
+        }
+        drawn += 1;
+        let is_selected = selected == Some(index);
+        // Win, loss or scratch — the one hue the whole round trip wears;
+        // direction is carried by the entry mark's shape instead.
+        let color = points_color(trade.pnl_points);
+        let connector = if is_selected {
+            egui::Stroke::new(SELECTED_CONNECTOR_WIDTH_PX, color)
+        } else {
+            egui::Stroke::new(
+                1.0_f32,
+                egui::Color32::from_rgba_unmultiplied(
+                    color.r(),
+                    color.g(),
+                    color.b(),
+                    CONNECTOR_ALPHA,
+                ),
+            )
+        };
+        painter.extend(egui::Shape::dashed_line(
+            &[entry, exit],
+            connector,
+            CONNECTOR_DASH_PX,
+            CONNECTOR_GAP_PX,
+        ));
+        draw_entry_mark(&painter, frame.background, entry, trade, color, is_selected);
+        draw_exit_mark(&painter, frame.background, exit, color, is_selected);
+        marks.push(Mark {
+            position: entry,
+            trade,
+        });
+        marks.push(Mark {
+            position: exit,
+            trade,
+        });
+    }
+    if withheld > 0 {
+        painter.text(
+            frame.chart_rect.left_bottom() + egui::vec2(8.0, -24.0),
+            egui::Align2::LEFT_BOTTOM,
+            format!("trade paint: {drawn} of {} shown", drawn + withheld),
+            egui::FontId::proportional(10.0),
+            theme::TEXT_FAINT,
+        );
+    }
+    if let Some(pointer) = frame.pointer
+        && let Some(mark) = marks
+            .iter()
+            .filter(|mark| mark.position.distance(pointer) <= HOVER_RADIUS_PX)
+            .min_by(|a, b| {
+                a.position
+                    .distance(pointer)
+                    .total_cmp(&b.position.distance(pointer))
+            })
+    {
+        draw_tooltip(frame, &painter, pointer, mark.trade);
+    }
+}
+
+/// Screen endpoints of a round trip — entry and exit fills at their prices
+/// on the bars that held their venue times. `None` while the chart has no
+/// bar for those moments (a fresh tape after a reset, an empty pane).
+fn endpoints(
+    frame: &TradePaintFrame<'_>,
+    trade: &ClosedTrade,
+    slot_at_time: &impl Fn(i64) -> Option<usize>,
+    x_at_slot: &impl Fn(usize) -> f32,
+) -> Option<(egui::Pos2, egui::Pos2)> {
+    let entry_slot = slot_at_time(trade.opened_ms)?;
+    let exit_slot = slot_at_time(trade.closed_ms)?;
+    let entry = egui::pos2(
+        x_at_slot(entry_slot),
+        frame
+            .scale
+            .y(trade.entry_price.to_f64().unwrap_or_default()),
+    );
+    let exit = egui::pos2(
+        x_at_slot(exit_slot),
+        frame.scale.y(trade.exit_price.to_f64().unwrap_or_default()),
+    );
+    Some((entry, exit))
+}
+
+/// A filled triangle pointing the trade's way, its apex one gap off the
+/// entry price: under the level for a long, above it for a short.
+fn draw_entry_mark(
+    painter: &egui::Painter,
+    background: egui::Color32,
+    at: egui::Pos2,
+    trade: &ClosedTrade,
+    color: egui::Color32,
+    selected: bool,
+) {
+    let long = trade.side == Side::Buy;
+    let apex_y = if long {
+        at.y + MARKER_GAP_PX
+    } else {
+        at.y - MARKER_GAP_PX
+    };
+    let base_y = if long {
+        apex_y + ENTRY_MARKER_H_PX
+    } else {
+        apex_y - ENTRY_MARKER_H_PX
+    };
+    let half = ENTRY_MARKER_W_PX / 2.0;
+    let points = vec![
+        egui::pos2(at.x, apex_y),
+        egui::pos2(at.x - half, base_y),
+        egui::pos2(at.x + half, base_y),
+    ];
+    if selected {
+        painter.add(egui::Shape::convex_polygon(
+            points.clone(),
+            SELECTION_HALO_COLOR,
+            egui::Stroke::new(SELECTION_HALO_EXTRA_PX, SELECTION_HALO_COLOR),
+        ));
+    }
+    painter.add(egui::Shape::convex_polygon(
+        points,
+        color,
+        egui::Stroke::new(MARKER_RING_PX, background),
+    ));
+}
+
+/// A diamond centred exactly on the exit price — a point event; its
+/// direction is already told by the entry.
+fn draw_exit_mark(
+    painter: &egui::Painter,
+    background: egui::Color32,
+    at: egui::Pos2,
+    color: egui::Color32,
+    selected: bool,
+) {
+    let r = EXIT_MARKER_RADIUS_PX;
+    let points = vec![
+        egui::pos2(at.x, at.y - r),
+        egui::pos2(at.x + r, at.y),
+        egui::pos2(at.x, at.y + r),
+        egui::pos2(at.x - r, at.y),
+    ];
+    if selected {
+        painter.add(egui::Shape::convex_polygon(
+            points.clone(),
+            SELECTION_HALO_COLOR,
+            egui::Stroke::new(SELECTION_HALO_EXTRA_PX, SELECTION_HALO_COLOR),
+        ));
+    }
+    painter.add(egui::Shape::convex_polygon(
+        points,
+        color,
+        egui::Stroke::new(MARKER_RING_PX, background),
+    ));
+}
+
+/// The hover tooltip, in the ledger's own vocabulary so the two surfaces
+/// never disagree about a trade.
+fn draw_tooltip(
+    frame: &TradePaintFrame<'_>,
+    painter: &egui::Painter,
+    pointer: egui::Pos2,
+    trade: &ClosedTrade,
+) {
+    let font = egui::FontId::monospace(11.0);
+    let caption = egui::FontId::monospace(10.0);
+    let head = format!(
+        "{} {} · {} → {} · {} pts",
+        position_word(trade.side),
+        fmt_decimal(trade.quantity),
+        fmt_decimal(trade.entry_price),
+        fmt_decimal(trade.exit_price),
+        fmt_signed_points(trade.pnl_points),
+    );
+    let detail = format!(
+        "{} · {} · {}",
+        trade.exit_reason.as_str().replace('_', " "),
+        crate::app::fmt_time(trade.closed_ms, frame.tz),
+        fmt_duration_ms(trade.closed_ms.saturating_sub(trade.opened_ms)),
+    );
+    let head_galley = painter.layout_no_wrap(head, font, theme::TEXT_PRIMARY);
+    let detail_galley = painter.layout_no_wrap(detail, caption, theme::TEXT_MUTED);
+    let head_height = head_galley.size().y;
+    let width = head_galley.size().x.max(detail_galley.size().x) + 16.0;
+    let height = head_height + detail_galley.size().y + 14.0;
+    let mut origin = pointer + egui::vec2(12.0, -height - 8.0);
+    origin.x = origin
+        .x
+        .min(frame.chart_rect.right() - width)
+        .max(frame.chart_rect.left());
+    origin.y = origin.y.max(frame.chart_rect.top());
+    let rect = egui::Rect::from_min_size(origin, egui::vec2(width, height));
+    painter.rect_filled(rect, egui::Rounding::same(4.0), theme::TAG_BG);
+    painter.galley(
+        rect.min + egui::vec2(8.0, 4.0),
+        head_galley,
+        theme::TEXT_PRIMARY,
+    );
+    painter.galley(
+        rect.min + egui::vec2(8.0, head_height + 8.0),
+        detail_galley,
+        theme::TEXT_MUTED,
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use quantick_sim::ExitReason;
+    use rust_decimal::Decimal;
+
+    fn trade(open_s: i64, close_s: i64, pnl: i64) -> ClosedTrade {
+        ClosedTrade {
+            side: Side::Buy,
+            quantity: Decimal::ONE,
+            entry_price: Decimal::from(100),
+            exit_price: Decimal::from(100 + pnl),
+            opened_ms: open_s * 1000,
+            closed_ms: close_s * 1000,
+            pnl_points: Decimal::from(pnl),
+            exit_reason: ExitReason::TakeProfit,
+            entry_agg_id: Some(1),
+            exit_agg_id: Some(2),
+            mae_points: Some(Decimal::ZERO),
+            mfe_points: Some(Decimal::from(pnl.max(0))),
+        }
+    }
+
+    /// Run one paint pass against a real context; returns the shape count
+    /// and every text galley painted.
+    fn painted(trades: &[ClosedTrade], pointer: Option<egui::Pos2>) -> (usize, Vec<String>) {
+        let ctx = egui::Context::default();
+        let screen = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(800.0, 400.0));
+        let output = ctx.run(
+            egui::RawInput {
+                screen_rect: Some(screen),
+                ..Default::default()
+            },
+            |ctx| {
+                let painter = ctx.layer_painter(egui::LayerId::background());
+                let scale = PriceScale::from_range(80.0, 120.0, 0.0, 400.0);
+                let frame = TradePaintFrame {
+                    painter: &painter,
+                    chart_rect: screen,
+                    scale: &scale,
+                    background: egui::Color32::BLACK,
+                    pointer,
+                    tz: TzOffset::default(),
+                };
+                draw(
+                    &frame,
+                    trades,
+                    None,
+                    |ms| usize::try_from(ms / 1000).ok(),
+                    |slot| ((slot % 100) as f32) * 4.0,
+                );
+            },
+        );
+        let mut texts = Vec::new();
+        let count = output.shapes.len();
+        for shape in output.shapes {
+            if let egui::epaint::Shape::Text(text) = shape.shape {
+                texts.push(text.galley.text().to_owned());
+            }
+        }
+        (count, texts)
+    }
+
+    #[test]
+    fn a_round_trip_paints_marks_and_nothing_paints_empty() {
+        let (empty, _) = painted(&[], None);
+        let (one, texts) = painted(&[trade(10, 20, 5)], None);
+        assert!(
+            one > empty,
+            "a closed trade adds its marks: {one} vs {empty}"
+        );
+        assert!(texts.is_empty(), "no cap note under the limit: {texts:?}");
+    }
+
+    #[test]
+    fn the_cap_discloses_what_it_withheld() {
+        let trades: Vec<ClosedTrade> = (0..260).map(|index| trade(index, index + 1, 1)).collect();
+        let (_, texts) = painted(&trades, None);
+        assert!(
+            texts
+                .iter()
+                .any(|text| text == "trade paint: 200 of 260 shown"),
+            "withheld marks are counted out loud: {texts:?}"
+        );
+    }
+
+    #[test]
+    fn a_hovered_mark_speaks_the_ledgers_words() {
+        // Entry: slot 10 → x 40; price 100 → y 200 on this scale.
+        let (_, texts) = painted(&[trade(10, 20, 5)], Some(egui::pos2(41.0, 202.0)));
+        let tooltip = texts.join(" ");
+        assert!(
+            tooltip.contains("LONG 1 · 100 → 105 · +5 pts"),
+            "the tooltip heads with the ledger row's words: {texts:?}"
+        );
+        assert!(
+            tooltip.contains("take profit"),
+            "and tells the exit reason: {texts:?}"
+        );
+    }
+}

--- a/crates/sim/src/history.rs
+++ b/crates/sim/src/history.rs
@@ -8,16 +8,23 @@
 //! silently dropping.
 //!
 //! ```text
-//! # quantick-trades 1
+//! # quantick-trades 2
 //! # symbol=BTCUSDT
-//! opened_ms,closed_ms,side,quantity,entry_price,exit_price,pnl_points,exit_reason
-//! 1700000000000,1700000060000,long,2,100.5,103.25,5.5,take_profit
+//! opened_ms,closed_ms,side,quantity,entry_price,exit_price,pnl_points,exit_reason,entry_agg_id,exit_agg_id,mae_points,mfe_points
+//! 1700000000000,1700000060000,long,2,100.5,103.25,5.5,take_profit,41,57,1.5,6.0
 //! ```
 //!
 //! `side` is the position's direction (`long`/`short`); `exit_reason` uses
 //! [`ExitReason::as_str`] tokens. Timestamps are venue epoch milliseconds;
 //! prices and quantities are exact decimals; `pnl_points` is points, not
-//! currency.
+//! currency. `entry_agg_id`/`exit_agg_id` are the aggregate ids of the
+//! prints that opened and closed the trade — the audit trail back to the
+//! tape — and `mae_points`/`mfe_points` are the worst-adverse and
+//! best-favorable excursions (see [`ClosedTrade`]).
+//!
+//! Version 1 files (the first 8 columns only) still load: the missing
+//! fields come back as `None`, and writing such a row emits empty fields —
+//! unknown is not zero.
 
 use quantick_engine::Side;
 use rust_decimal::Decimal;
@@ -27,13 +34,16 @@ use crate::simulator::ClosedTrade;
 
 /// Magic token on the first line, naming the format.
 pub const FORMAT_NAME: &str = "quantick-trades";
-/// Version written and the only one accepted — an unknown version is an
-/// error, never a guess.
-pub const FORMAT_VERSION: u32 = 1;
+/// Version written. Version 1 is still read; anything newer than
+/// [`FORMAT_VERSION`] is an error, never a guess.
+pub const FORMAT_VERSION: u32 = 2;
 /// Extension the app uses for history files.
 pub const FILE_EXTENSION: &str = "csv";
-/// The column header, fixed order.
-pub const HEADER: &str =
+/// The version-2 column header, fixed order. The first eight columns are
+/// exactly the version-1 header, so a version bump only ever appends.
+pub const HEADER: &str = "opened_ms,closed_ms,side,quantity,entry_price,exit_price,pnl_points,exit_reason,entry_agg_id,exit_agg_id,mae_points,mfe_points";
+/// The version-1 column header, still accepted on read.
+const HEADER_V1: &str =
     "opened_ms,closed_ms,side,quantity,entry_price,exit_price,pnl_points,exit_reason";
 
 /// A parsed history file.
@@ -56,7 +66,7 @@ pub struct HistoryProblem {
 }
 
 /// The file is not a readable quantick-trades file at all (wrong magic,
-/// wrong version, wrong header) — as opposed to a file with bad rows.
+/// unknown version, wrong header) — as opposed to a file with bad rows.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HistoryError {
     /// 1-based line number.
@@ -77,7 +87,8 @@ pub fn write_header(symbol: &str) -> String {
 }
 
 /// One closed trade as one CSV line (newline included), the exact inverse
-/// of what [`parse`] reads.
+/// of what [`parse`] reads. Fields the trade does not know (a row loaded
+/// from a version-1 file) are written empty, never invented.
 #[must_use]
 pub fn write_trade(trade: &ClosedTrade) -> String {
     let side = match trade.side {
@@ -85,7 +96,7 @@ pub fn write_trade(trade: &ClosedTrade) -> String {
         Side::Sell => "short",
     };
     format!(
-        "{},{},{},{},{},{},{},{}\n",
+        "{},{},{},{},{},{},{},{},{},{},{},{}\n",
         trade.opened_ms,
         trade.closed_ms,
         side,
@@ -94,12 +105,24 @@ pub fn write_trade(trade: &ClosedTrade) -> String {
         trade.exit_price,
         trade.pnl_points,
         trade.exit_reason.as_str(),
+        opt_u64(trade.entry_agg_id),
+        opt_u64(trade.exit_agg_id),
+        opt_decimal(trade.mae_points),
+        opt_decimal(trade.mfe_points),
     )
 }
 
-/// Read a history file back. Fatal errors are reserved for "this is not a
-/// quantick-trades file"; a bad *row* becomes a [`HistoryProblem`] and the
-/// rest of the file still loads.
+fn opt_u64(value: Option<u64>) -> String {
+    value.map(|value| value.to_string()).unwrap_or_default()
+}
+
+fn opt_decimal(value: Option<Decimal>) -> String {
+    value.map(|value| value.to_string()).unwrap_or_default()
+}
+
+/// Read a history file back (version 1 or 2). Fatal errors are reserved for
+/// "this is not a quantick-trades file"; a bad *row* becomes a
+/// [`HistoryProblem`] and the rest of the file still loads.
 pub fn parse(text: &str) -> Result<TradeHistory, HistoryError> {
     let mut lines = text.lines().enumerate();
 
@@ -113,16 +136,17 @@ pub fn parse(text: &str) -> Result<TradeHistory, HistoryError> {
                 "empty file - expected `# {FORMAT_NAME} {FORMAT_VERSION}` on the first line"
             ),
         })?;
-    let expected_magic = format!("# {FORMAT_NAME} {FORMAT_VERSION}");
-    if magic.trim() != expected_magic {
-        return Err(HistoryError {
-            line: magic_line + 1,
-            message: format!(
-                "not a {FORMAT_NAME} version {FORMAT_VERSION} file - first line is `{}`",
-                magic.trim()
-            ),
-        });
-    }
+    let version = parse_magic(magic.trim()).ok_or(HistoryError {
+        line: magic_line + 1,
+        message: format!(
+            "not a {FORMAT_NAME} version 1 or {FORMAT_VERSION} file - first line is `{}`",
+            magic.trim()
+        ),
+    })?;
+    let expected_header = match version {
+        1 => HEADER_V1,
+        _ => HEADER,
+    };
 
     let mut symbol = None;
     let mut header_seen = false;
@@ -141,16 +165,18 @@ pub fn parse(text: &str) -> Result<TradeHistory, HistoryError> {
             continue;
         }
         if !header_seen {
-            if trimmed != HEADER {
+            if trimmed != expected_header {
                 return Err(HistoryError {
                     line: line_number,
-                    message: format!("expected the column header `{HEADER}`, found `{trimmed}`"),
+                    message: format!(
+                        "expected the column header `{expected_header}`, found `{trimmed}`"
+                    ),
                 });
             }
             header_seen = true;
             continue;
         }
-        match parse_row(trimmed) {
+        match parse_row(trimmed, version) {
             Ok(trade) => trades.push(trade),
             Err(message) => problems.push(HistoryProblem {
                 line: line_number,
@@ -161,7 +187,7 @@ pub fn parse(text: &str) -> Result<TradeHistory, HistoryError> {
     if !header_seen {
         return Err(HistoryError {
             line: magic_line + 1,
-            message: format!("no column header - expected `{HEADER}` after the comments"),
+            message: format!("no column header - expected `{expected_header}` after the comments"),
         });
     }
     Ok(TradeHistory {
@@ -171,10 +197,22 @@ pub fn parse(text: &str) -> Result<TradeHistory, HistoryError> {
     })
 }
 
-fn parse_row(row: &str) -> Result<ClosedTrade, String> {
+/// `# quantick-trades N` for a version this parser reads, else `None`.
+fn parse_magic(line: &str) -> Option<u32> {
+    let rest = line.strip_prefix('#')?.trim();
+    let version = rest.strip_prefix(FORMAT_NAME)?.trim();
+    let version: u32 = version.parse().ok()?;
+    (1..=FORMAT_VERSION).contains(&version).then_some(version)
+}
+
+fn parse_row(row: &str, version: u32) -> Result<ClosedTrade, String> {
     let fields: Vec<&str> = row.split(',').collect();
-    if fields.len() != 8 {
-        return Err(format!("expected 8 fields, found {}", fields.len()));
+    let expected = if version == 1 { 8 } else { 12 };
+    if fields.len() != expected {
+        return Err(format!(
+            "expected {expected} fields, found {}",
+            fields.len()
+        ));
     }
     let opened_ms = parse_i64(fields[0], "opened_ms")?;
     let closed_ms = parse_i64(fields[1], "closed_ms")?;
@@ -189,6 +227,16 @@ fn parse_row(row: &str) -> Result<ClosedTrade, String> {
     let pnl_points = parse_decimal(fields[6], "pnl_points")?;
     let exit_reason = ExitReason::parse(fields[7])
         .ok_or_else(|| format!("unknown exit_reason `{}`", fields[7]))?;
+    let (entry_agg_id, exit_agg_id, mae_points, mfe_points) = if version == 1 {
+        (None, None, None, None)
+    } else {
+        (
+            parse_opt_u64(fields[8], "entry_agg_id")?,
+            parse_opt_u64(fields[9], "exit_agg_id")?,
+            parse_opt_decimal(fields[10], "mae_points")?,
+            parse_opt_decimal(fields[11], "mfe_points")?,
+        )
+    };
     Ok(ClosedTrade {
         side,
         quantity,
@@ -198,6 +246,10 @@ fn parse_row(row: &str) -> Result<ClosedTrade, String> {
         closed_ms,
         pnl_points,
         exit_reason,
+        entry_agg_id,
+        exit_agg_id,
+        mae_points,
+        mfe_points,
     })
 }
 
@@ -211,6 +263,28 @@ fn parse_decimal(field: &str, name: &str) -> Result<Decimal, String> {
     field
         .parse()
         .map_err(|_| format!("{name} must be a decimal number, found `{field}`"))
+}
+
+/// An empty field means "not recorded" (a version-1 row passing through),
+/// never zero.
+fn parse_opt_u64(field: &str, name: &str) -> Result<Option<u64>, String> {
+    if field.is_empty() {
+        return Ok(None);
+    }
+    field
+        .parse()
+        .map(Some)
+        .map_err(|_| format!("{name} must be an integer id or empty, found `{field}`"))
+}
+
+fn parse_opt_decimal(field: &str, name: &str) -> Result<Option<Decimal>, String> {
+    if field.is_empty() {
+        return Ok(None);
+    }
+    field
+        .parse()
+        .map(Some)
+        .map_err(|_| format!("{name} must be a decimal number or empty, found `{field}`"))
 }
 
 #[cfg(test)]
@@ -227,6 +301,10 @@ mod tests {
             closed_ms: 1_700_000_060_000,
             pnl_points: Decimal::from(pnl),
             exit_reason: reason,
+            entry_agg_id: Some(41),
+            exit_agg_id: Some(57),
+            mae_points: Some(Decimal::new(15, 1)),
+            mfe_points: Some(Decimal::from(6)),
         }
     }
 
@@ -248,6 +326,40 @@ mod tests {
     }
 
     #[test]
+    fn a_version_1_file_still_loads_with_honest_unknowns() {
+        let text = "# quantick-trades 1\n# symbol=WINQ26\n\
+                    opened_ms,closed_ms,side,quantity,entry_price,exit_price,pnl_points,exit_reason\n\
+                    1700000000000,1700000060000,long,2,100.5,103.25,5.5,take_profit\n";
+        let history = parse(text).expect("version 1 still parses");
+        assert_eq!(history.symbol.as_deref(), Some("WINQ26"));
+        assert_eq!(history.trades.len(), 1);
+        let trade = &history.trades[0];
+        assert_eq!(trade.pnl_points, Decimal::new(55, 1));
+        assert_eq!(trade.entry_agg_id, None, "v1 did not record it");
+        assert_eq!(trade.exit_agg_id, None);
+        assert_eq!(trade.mae_points, None, "unknown is not zero");
+        assert_eq!(trade.mfe_points, None);
+    }
+
+    #[test]
+    fn a_v1_row_re_exports_with_empty_fields_not_invented_values() {
+        let mut trade = sample(Side::Buy, 5, ExitReason::Manual);
+        trade.entry_agg_id = None;
+        trade.exit_agg_id = None;
+        trade.mae_points = None;
+        trade.mfe_points = None;
+        let line = write_trade(&trade);
+        assert!(
+            line.trim_end().ends_with("manual,,,,"),
+            "unknown fields stay empty: {line}"
+        );
+        let mut text = write_header("X");
+        text.push_str(&line);
+        let history = parse(&text).expect("round trips");
+        assert_eq!(history.trades[0], trade);
+    }
+
+    #[test]
     fn a_torn_final_line_costs_one_reported_row_not_the_file() {
         let mut text = write_header("WINQ26");
         text.push_str(&write_trade(&sample(Side::Buy, 5, ExitReason::Manual)));
@@ -260,7 +372,7 @@ mod tests {
             history.problems[0].line, 5,
             "magic + symbol + header + row, then the tear"
         );
-        assert!(history.problems[0].message.contains("8 fields"));
+        assert!(history.problems[0].message.contains("12 fields"));
     }
 
     #[test]
@@ -274,24 +386,31 @@ mod tests {
     #[test]
     fn unknown_version_is_fatal_not_guessed() {
         let error =
-            parse("# quantick-trades 2\nopened_ms\n").expect_err("future versions are refused");
+            parse("# quantick-trades 3\nopened_ms\n").expect_err("future versions are refused");
         assert!(
             error
                 .message
-                .contains("not a quantick-trades version 1 file")
+                .contains("not a quantick-trades version 1 or 2 file")
         );
     }
 
     #[test]
     fn missing_header_is_fatal() {
-        let error = parse("# quantick-trades 1\n# symbol=X\n").expect_err("header required");
+        let error = parse("# quantick-trades 2\n# symbol=X\n").expect_err("header required");
         assert!(error.message.contains("no column header"));
+    }
+
+    #[test]
+    fn a_v2_file_with_the_v1_header_is_fatal() {
+        let error = parse(&format!("# quantick-trades 2\n{HEADER_V1}\n"))
+            .expect_err("the header must match the declared version");
+        assert!(error.message.contains("expected the column header"));
     }
 
     #[test]
     fn unknown_exit_reason_is_a_problem_row() {
         let mut text = write_header("X");
-        text.push_str("1,2,long,1,100,101,1,liquidated\n");
+        text.push_str("1,2,long,1,100,101,1,liquidated,,,,\n");
         let history = parse(&text).expect("file loads");
         assert!(history.trades.is_empty());
         assert!(history.problems[0].message.contains("liquidated"));

--- a/crates/sim/src/lib.rs
+++ b/crates/sim/src/lib.rs
@@ -69,5 +69,5 @@ pub mod report;
 pub use events::{CancelReason, ExitReason, Fill, FillRole, RejectReason, SimEvent};
 pub use order::{Bracket, EntryKind, Order, OrderId};
 pub use position::Position;
-pub use report::PerformanceReport;
+pub use report::{PerformanceReport, ReasonReport, SideReport};
 pub use simulator::{ClosedTrade, Command, QueuedAction, Simulator};

--- a/crates/sim/src/position.rs
+++ b/crates/sim/src/position.rs
@@ -17,6 +17,17 @@ pub struct Position {
     pub avg_price: Decimal,
     /// Venue time of the print that opened the position.
     pub opened_ms: i64,
+    /// Aggregate id of the print that opened the position — the audit trail
+    /// back to the tape, carried into every [`ClosedTrade`] it produces.
+    ///
+    /// [`ClosedTrade`]: crate::ClosedTrade
+    pub opened_agg_id: u64,
+    /// Lowest price the position has been exposed to: its entry fills, every
+    /// mark while it was open, and its exit fills. Together with
+    /// `high_price` this yields the MAE/MFE recorded on close.
+    pub low_price: Decimal,
+    /// Highest price the position has been exposed to (see `low_price`).
+    pub high_price: Decimal,
     /// Protective stop price; exits the whole position at the print that
     /// trades at or through it.
     pub stop_loss: Option<Decimal>,
@@ -31,6 +42,33 @@ impl Position {
     #[must_use]
     pub fn open_points(&self, mark: Decimal) -> Decimal {
         signed_points(self.side, self.avg_price, mark, self.quantity)
+    }
+
+    /// Fold `price` into the exposure range the excursions are measured on.
+    pub(crate) fn observe(&mut self, price: Decimal) {
+        self.low_price = self.low_price.min(price);
+        self.high_price = self.high_price.max(price);
+    }
+
+    /// Per-unit excursions against the average entry once `exit` joins the
+    /// exposure range: `(adverse, favorable)`, both clamped at zero. The
+    /// adverse side is where the position loses (below entry for a long,
+    /// above it for a short); the favorable side is where it wins.
+    #[must_use]
+    pub(crate) fn excursions(&self, exit: Decimal) -> (Decimal, Decimal) {
+        let low = self.low_price.min(exit);
+        let high = self.high_price.max(exit);
+        let (adverse, favorable) = match self.side {
+            Side::Buy => (
+                self.avg_price.saturating_sub(low),
+                high.saturating_sub(self.avg_price),
+            ),
+            Side::Sell => (
+                high.saturating_sub(self.avg_price),
+                self.avg_price.saturating_sub(low),
+            ),
+        };
+        (adverse.max(Decimal::ZERO), favorable.max(Decimal::ZERO))
     }
 }
 

--- a/crates/sim/src/report.rs
+++ b/crates/sim/src/report.rs
@@ -6,8 +6,19 @@
 
 use quantick_engine::Side;
 use rust_decimal::Decimal;
+use rust_decimal::prelude::{FromPrimitive, ToPrimitive};
 
+use crate::events::ExitReason;
 use crate::simulator::ClosedTrade;
+
+/// Every exit reason, in the fixed order the report presents them.
+const EXIT_REASONS: [ExitReason; 5] = [
+    ExitReason::StopLoss,
+    ExitReason::TakeProfit,
+    ExitReason::Manual,
+    ExitReason::Reversal,
+    ExitReason::Reset,
+];
 
 /// The report the UI renders. All point values follow the crate's honesty
 /// rule: points (price units × quantity), not currency.
@@ -28,14 +39,41 @@ pub struct PerformanceReport {
     pub gross_profit: Decimal,
     /// Magnitude of losing trades' points (≥ 0).
     pub gross_loss: Decimal,
-    /// `wins / trades × 100`; `None` when there are no trades.
+    /// `wins / trades × 100`; `None` when there are no trades. A scratch
+    /// counts in the denominator.
     pub win_rate_pct: Option<Decimal>,
+    /// `losses / trades × 100`; `None` when there are no trades.
+    pub loss_rate_pct: Option<Decimal>,
     /// `gross_profit / gross_loss`; `None` when there are no losses — an
     /// undefined ratio is not infinity.
     pub profit_factor: Option<Decimal>,
+    /// `avg_win / avg_loss`; `None` when either side is empty.
+    pub payoff_ratio: Option<Decimal>,
+    /// `net_points / trades`; `None` when there are no trades. Equivalent
+    /// to `win_rate × avg_win − loss_rate × avg_loss`.
+    pub expectancy_points: Option<Decimal>,
     /// Deepest drop of the realized equity curve below its running peak,
     /// walking the trades in the order they closed (≥ 0).
     pub max_drawdown_points: Decimal,
+    /// The deepest drawdown's bounding points on the equity curve
+    /// `E_0..E_n` (`E_0 = 0` before the first trade): indices of the peak
+    /// and the trough, `None` when the curve never drew down.
+    pub max_drawdown_span: Option<(u64, u64)>,
+    /// Highest rise of the equity curve above its running trough (≥ 0) —
+    /// the mirror of the drawdown.
+    pub max_runup_points: Decimal,
+    /// `net_points / max_drawdown_points`; `None` when there was no
+    /// drawdown.
+    pub recovery_factor: Option<Decimal>,
+    /// Longest run of consecutive wins; a scratch breaks both runs.
+    pub max_consecutive_wins: u64,
+    /// Longest run of consecutive losses; a scratch breaks both runs.
+    pub max_consecutive_losses: u64,
+    /// Sample standard deviation of trade points (`N − 1` denominator);
+    /// `None` below two trades. A display metric: the square root is taken
+    /// in `f64` (IEEE-754 sqrt is exactly rounded, so this stays
+    /// deterministic) and rounded to four decimal places.
+    pub stddev_points: Option<Decimal>,
     /// Best single trade's points (0 when there are no wins).
     pub largest_win: Decimal,
     /// Worst single trade's magnitude (0 when there are no losses).
@@ -44,75 +82,292 @@ pub struct PerformanceReport {
     pub avg_win: Option<Decimal>,
     /// `gross_loss / losses` (magnitude); `None` when there are no losses.
     pub avg_loss: Option<Decimal>,
+    /// Mean of `closed_ms − opened_ms` in milliseconds, rounded toward
+    /// zero; `None` when there are no trades.
+    pub avg_duration_ms: Option<i64>,
+    /// Median trade duration in milliseconds (mean of the middle two on an
+    /// even count); `None` when there are no trades.
+    pub median_duration_ms: Option<i64>,
+    /// Mean duration of winning trades; `None` when there are no wins.
+    pub avg_win_duration_ms: Option<i64>,
+    /// Mean duration of losing trades; `None` when there are no losses.
+    pub avg_loss_duration_ms: Option<i64>,
+    /// Mean MAE of winning trades, over the winners that recorded one
+    /// (version-1 history rows did not); `None` when none did.
+    pub avg_winner_mae_points: Option<Decimal>,
+    /// Winners with a recorded MAE — the denominator the report discloses.
+    pub winners_with_mae: u64,
+    /// Mean MFE of losing trades, over the losers that recorded one;
+    /// `None` when none did.
+    pub avg_loser_mfe_points: Option<Decimal>,
+    /// Losers with a recorded MFE.
+    pub losers_with_mfe: u64,
+    /// The long side on its own.
+    pub long: SideReport,
+    /// The short side on its own.
+    pub short: SideReport,
+    /// Per-exit-reason totals in a fixed order, empty reasons skipped.
+    pub by_exit_reason: Vec<ReasonReport>,
+}
+
+/// The core metrics for one side of the book (long-only or short-only).
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct SideReport {
+    pub trades: u64,
+    pub net_points: Decimal,
+    pub win_rate_pct: Option<Decimal>,
+    pub profit_factor: Option<Decimal>,
+    pub avg_win: Option<Decimal>,
+    pub avg_loss: Option<Decimal>,
+    pub expectancy_points: Option<Decimal>,
+}
+
+/// How trades that left one way performed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReasonReport {
+    pub reason: ExitReason,
+    pub trades: u64,
+    pub net_points: Decimal,
+}
+
+/// Win/loss/net accumulator shared by the whole-book and per-side walks.
+#[derive(Default)]
+struct Tally {
+    trades: u64,
+    wins: u64,
+    losses: u64,
+    net: Decimal,
+    gross_profit: Decimal,
+    gross_loss: Decimal,
+}
+
+impl Tally {
+    fn add(&mut self, points: Decimal) {
+        self.trades += 1;
+        self.net = self.net.saturating_add(points);
+        if points > Decimal::ZERO {
+            self.wins += 1;
+            self.gross_profit = self.gross_profit.saturating_add(points);
+        } else if points < Decimal::ZERO {
+            self.losses += 1;
+            self.gross_loss = self.gross_loss.saturating_add(-points);
+        }
+    }
+
+    fn side_report(&self) -> SideReport {
+        SideReport {
+            trades: self.trades,
+            net_points: self.net,
+            win_rate_pct: ratio(
+                Decimal::from(self.wins).saturating_mul(Decimal::ONE_HUNDRED),
+                Decimal::from(self.trades),
+            ),
+            profit_factor: ratio(self.gross_profit, self.gross_loss),
+            avg_win: ratio(self.gross_profit, Decimal::from(self.wins)),
+            avg_loss: ratio(self.gross_loss, Decimal::from(self.losses)),
+            expectancy_points: ratio(self.net, Decimal::from(self.trades)),
+        }
+    }
+}
+
+/// `numerator / denominator` when the denominator is positive, else `None`.
+/// The numerator may be signed (expectancy, recovery factor).
+fn ratio(numerator: Decimal, denominator: Decimal) -> Option<Decimal> {
+    (denominator > Decimal::ZERO).then(|| numerator / denominator)
+}
+
+/// Mean of `sum` over `count` in integer milliseconds, rounded toward zero.
+fn mean_ms(sum: i128, count: u64) -> Option<i64> {
+    (count > 0).then(|| i64::try_from(sum / i128::from(count)).unwrap_or(i64::MAX))
 }
 
 impl PerformanceReport {
-    /// Aggregate `trades` in the order given — drawdown depends on it, and
-    /// the caller keeps history in closing order.
+    /// Aggregate `trades` in the order given — drawdown, run-up and streaks
+    /// depend on it, and the caller keeps history in closing order.
     #[must_use]
     pub fn from_trades(trades: &[ClosedTrade]) -> Self {
-        let mut wins = 0u64;
-        let mut losses = 0u64;
+        let mut all = Tally::default();
+        let mut long = Tally::default();
+        let mut short = Tally::default();
         let mut scratches = 0u64;
-        let mut long_trades = 0u64;
-        let mut short_trades = 0u64;
-        let mut gross_profit = Decimal::ZERO;
-        let mut gross_loss = Decimal::ZERO;
         let mut largest_win = Decimal::ZERO;
         let mut largest_loss = Decimal::ZERO;
+
         let mut equity = Decimal::ZERO;
         let mut peak = Decimal::ZERO;
+        let mut peak_index = 0u64;
+        let mut trough = Decimal::ZERO;
         let mut max_drawdown = Decimal::ZERO;
+        let mut max_drawdown_span = None;
+        let mut max_runup = Decimal::ZERO;
 
-        for trade in trades {
-            match trade.side {
-                Side::Buy => long_trades += 1,
-                Side::Sell => short_trades += 1,
-            }
+        let mut consecutive_wins = 0u64;
+        let mut consecutive_losses = 0u64;
+        let mut max_consecutive_wins = 0u64;
+        let mut max_consecutive_losses = 0u64;
+
+        let mut durations: Vec<i64> = Vec::with_capacity(trades.len());
+        let mut duration_sum = 0i128;
+        let mut win_duration_sum = 0i128;
+        let mut loss_duration_sum = 0i128;
+
+        let mut winner_mae_sum = Decimal::ZERO;
+        let mut winners_with_mae = 0u64;
+        let mut loser_mfe_sum = Decimal::ZERO;
+        let mut losers_with_mfe = 0u64;
+
+        let mut reason_tallies: [(u64, Decimal); EXIT_REASONS.len()] = Default::default();
+
+        for (index, trade) in trades.iter().enumerate() {
             let points = trade.pnl_points;
+            all.add(points);
+            match trade.side {
+                Side::Buy => long.add(points),
+                Side::Sell => short.add(points),
+            }
+
+            let duration = trade.closed_ms.saturating_sub(trade.opened_ms).max(0);
+            durations.push(duration);
+            duration_sum += i128::from(duration);
+
             if points > Decimal::ZERO {
-                wins += 1;
-                gross_profit = gross_profit.saturating_add(points);
                 largest_win = largest_win.max(points);
+                win_duration_sum += i128::from(duration);
+                consecutive_wins += 1;
+                consecutive_losses = 0;
+                max_consecutive_wins = max_consecutive_wins.max(consecutive_wins);
+                if let Some(mae) = trade.mae_points {
+                    winner_mae_sum = winner_mae_sum.saturating_add(mae);
+                    winners_with_mae += 1;
+                }
             } else if points < Decimal::ZERO {
-                losses += 1;
-                let magnitude = -points;
-                gross_loss = gross_loss.saturating_add(magnitude);
-                largest_loss = largest_loss.max(magnitude);
+                largest_loss = largest_loss.max(-points);
+                loss_duration_sum += i128::from(duration);
+                consecutive_losses += 1;
+                consecutive_wins = 0;
+                max_consecutive_losses = max_consecutive_losses.max(consecutive_losses);
+                if let Some(mfe) = trade.mfe_points {
+                    loser_mfe_sum = loser_mfe_sum.saturating_add(mfe);
+                    losers_with_mfe += 1;
+                }
             } else {
                 scratches += 1;
+                // A scratch breaks both runs: it is neither.
+                consecutive_wins = 0;
+                consecutive_losses = 0;
             }
+
+            // The equity curve E_0..E_n, where this trade lands at k.
+            let k = u64::try_from(index).unwrap_or(u64::MAX).saturating_add(1);
             equity = equity.saturating_add(points);
-            peak = peak.max(equity);
-            max_drawdown = max_drawdown.max(peak.saturating_sub(equity));
+            if equity > peak {
+                peak = equity;
+                peak_index = k;
+            }
+            let drawdown = peak.saturating_sub(equity);
+            if drawdown > max_drawdown {
+                max_drawdown = drawdown;
+                max_drawdown_span = Some((peak_index, k));
+            }
+            trough = trough.min(equity);
+            max_runup = max_runup.max(equity.saturating_sub(trough));
+
+            if let Some(slot) = EXIT_REASONS
+                .iter()
+                .position(|reason| *reason == trade.exit_reason)
+            {
+                reason_tallies[slot].0 += 1;
+                reason_tallies[slot].1 = reason_tallies[slot].1.saturating_add(points);
+            }
         }
 
-        let total = wins + losses + scratches;
-        let ratio = |numerator: Decimal, denominator: Decimal| {
-            (denominator > Decimal::ZERO).then(|| numerator / denominator)
+        let total = Decimal::from(all.trades);
+        let avg_win = ratio(all.gross_profit, Decimal::from(all.wins));
+        let avg_loss = ratio(all.gross_loss, Decimal::from(all.losses));
+
+        durations.sort_unstable();
+        let median_duration_ms = match durations.len() {
+            0 => None,
+            n if n % 2 == 1 => Some(durations[n / 2]),
+            n => Some(durations[n / 2 - 1].midpoint(durations[n / 2])),
         };
+
+        let by_exit_reason = EXIT_REASONS
+            .iter()
+            .zip(reason_tallies)
+            .filter(|(_, (count, _))| *count > 0)
+            .map(|(reason, (count, net))| ReasonReport {
+                reason: *reason,
+                trades: count,
+                net_points: net,
+            })
+            .collect();
+
         Self {
-            trades: total,
-            wins,
-            losses,
+            trades: all.trades,
+            wins: all.wins,
+            losses: all.losses,
             scratches,
-            long_trades,
-            short_trades,
-            net_points: gross_profit.saturating_sub(gross_loss),
-            gross_profit,
-            gross_loss,
+            long_trades: long.trades,
+            short_trades: short.trades,
+            net_points: all.net,
+            gross_profit: all.gross_profit,
+            gross_loss: all.gross_loss,
             win_rate_pct: ratio(
-                Decimal::from(wins).saturating_mul(Decimal::ONE_HUNDRED),
-                Decimal::from(total),
+                Decimal::from(all.wins).saturating_mul(Decimal::ONE_HUNDRED),
+                total,
             ),
-            profit_factor: ratio(gross_profit, gross_loss),
+            loss_rate_pct: ratio(
+                Decimal::from(all.losses).saturating_mul(Decimal::ONE_HUNDRED),
+                total,
+            ),
+            profit_factor: ratio(all.gross_profit, all.gross_loss),
+            payoff_ratio: match (avg_win, avg_loss) {
+                (Some(win), Some(loss)) => ratio(win, loss),
+                _ => None,
+            },
+            expectancy_points: ratio(all.net, total),
             max_drawdown_points: max_drawdown,
+            max_drawdown_span,
+            max_runup_points: max_runup,
+            recovery_factor: ratio(all.net, max_drawdown),
+            max_consecutive_wins,
+            max_consecutive_losses,
+            stddev_points: stddev(trades, all.net, total),
             largest_win,
             largest_loss,
-            avg_win: ratio(gross_profit, Decimal::from(wins)),
-            avg_loss: ratio(gross_loss, Decimal::from(losses)),
+            avg_win,
+            avg_loss,
+            avg_duration_ms: mean_ms(duration_sum, all.trades),
+            median_duration_ms,
+            avg_win_duration_ms: mean_ms(win_duration_sum, all.wins),
+            avg_loss_duration_ms: mean_ms(loss_duration_sum, all.losses),
+            avg_winner_mae_points: ratio(winner_mae_sum, Decimal::from(winners_with_mae)),
+            winners_with_mae,
+            avg_loser_mfe_points: ratio(loser_mfe_sum, Decimal::from(losers_with_mfe)),
+            losers_with_mfe,
+            long: long.side_report(),
+            short: short.side_report(),
+            by_exit_reason,
         }
     }
+}
+
+/// Sample standard deviation of trade points; see the field doc for the
+/// determinism note on the `f64` square root.
+fn stddev(trades: &[ClosedTrade], net: Decimal, total: Decimal) -> Option<Decimal> {
+    if trades.len() < 2 {
+        return None;
+    }
+    let mean = net / total;
+    let mut sum_squares = Decimal::ZERO;
+    for trade in trades {
+        let deviation = trade.pnl_points.saturating_sub(mean);
+        sum_squares = sum_squares.saturating_add(deviation.saturating_mul(deviation));
+    }
+    let variance = sum_squares / Decimal::from(trades.len() - 1);
+    let root = variance.to_f64()?.sqrt();
+    Decimal::from_f64(root).map(|value| value.round_dp(4))
 }
 
 #[cfg(test)]
@@ -130,6 +385,36 @@ mod tests {
             closed_ms: 1,
             pnl_points: Decimal::from(pnl),
             exit_reason: ExitReason::Manual,
+            entry_agg_id: None,
+            exit_agg_id: None,
+            mae_points: None,
+            mfe_points: None,
+        }
+    }
+
+    /// A trade with everything the extended metrics read.
+    fn full(
+        side: Side,
+        pnl: i64,
+        opened_ms: i64,
+        closed_ms: i64,
+        mae: Option<i64>,
+        mfe: Option<i64>,
+        reason: ExitReason,
+    ) -> ClosedTrade {
+        ClosedTrade {
+            side,
+            quantity: Decimal::ONE,
+            entry_price: Decimal::ONE_HUNDRED,
+            exit_price: Decimal::ONE_HUNDRED + Decimal::from(pnl),
+            opened_ms,
+            closed_ms,
+            pnl_points: Decimal::from(pnl),
+            exit_reason: reason,
+            entry_agg_id: Some(1),
+            exit_agg_id: Some(2),
+            mae_points: mae.map(Decimal::from),
+            mfe_points: mfe.map(Decimal::from),
         }
     }
 
@@ -139,10 +424,21 @@ mod tests {
         assert_eq!(report.trades, 0);
         assert_eq!(report.net_points, Decimal::ZERO);
         assert_eq!(report.win_rate_pct, None);
+        assert_eq!(report.loss_rate_pct, None);
         assert_eq!(report.profit_factor, None);
+        assert_eq!(report.payoff_ratio, None);
+        assert_eq!(report.expectancy_points, None);
         assert_eq!(report.avg_win, None);
         assert_eq!(report.avg_loss, None);
         assert_eq!(report.max_drawdown_points, Decimal::ZERO);
+        assert_eq!(report.max_drawdown_span, None);
+        assert_eq!(report.max_runup_points, Decimal::ZERO);
+        assert_eq!(report.recovery_factor, None);
+        assert_eq!(report.stddev_points, None);
+        assert_eq!(report.avg_duration_ms, None);
+        assert_eq!(report.median_duration_ms, None);
+        assert_eq!(report.by_exit_reason, Vec::new());
+        assert_eq!(report.long, SideReport::default());
     }
 
     #[test]
@@ -164,16 +460,197 @@ mod tests {
         assert_eq!(report.gross_profit, Decimal::from(12));
         assert_eq!(report.gross_loss, Decimal::from(17));
         assert_eq!(report.win_rate_pct, Some(Decimal::from(50)));
+        assert_eq!(report.loss_rate_pct, Some(Decimal::from(50)));
         assert_eq!(
             report.profit_factor,
             Some(Decimal::from(12) / Decimal::from(17))
         );
         // Equity walks 10, 5, 7, -5; the peak of 10 to the trough of -5.
         assert_eq!(report.max_drawdown_points, Decimal::from(15));
+        assert_eq!(report.max_drawdown_span, Some((1, 4)));
+        assert_eq!(report.max_runup_points, Decimal::from(10));
+        assert_eq!(
+            report.recovery_factor,
+            Some(Decimal::from(-5) / Decimal::from(15))
+        );
         assert_eq!(report.largest_win, Decimal::from(10));
         assert_eq!(report.largest_loss, Decimal::from(12));
         assert_eq!(report.avg_win, Some(Decimal::from(6)));
         assert_eq!(report.avg_loss, Some(Decimal::from(17) / Decimal::from(2)));
+        assert_eq!(
+            report.payoff_ratio,
+            Some(Decimal::from(6) / (Decimal::from(17) / Decimal::from(2)))
+        );
+        assert_eq!(
+            report.expectancy_points,
+            Some(Decimal::from(-5) / Decimal::from(4))
+        );
+    }
+
+    #[test]
+    fn the_extended_fixture_matches_the_hand_computation() {
+        // Close order: W +10, W +2, L -5, L -12, scratch, W +6.
+        let minute = 60_000i64;
+        let trades = [
+            full(
+                Side::Buy,
+                10,
+                0,
+                minute,
+                Some(2),
+                Some(12),
+                ExitReason::TakeProfit,
+            ),
+            full(
+                Side::Buy,
+                2,
+                0,
+                minute / 2,
+                Some(1),
+                Some(4),
+                ExitReason::Manual,
+            ),
+            full(
+                Side::Sell,
+                -5,
+                0,
+                2 * minute,
+                Some(6),
+                Some(1),
+                ExitReason::StopLoss,
+            ),
+            full(
+                Side::Sell,
+                -12,
+                0,
+                4 * minute,
+                Some(14),
+                None,
+                ExitReason::StopLoss,
+            ),
+            full(
+                Side::Buy,
+                0,
+                0,
+                minute / 6,
+                Some(3),
+                Some(3),
+                ExitReason::Manual,
+            ),
+            full(
+                Side::Buy,
+                6,
+                0,
+                minute / 3,
+                None,
+                Some(8),
+                ExitReason::Reversal,
+            ),
+        ];
+        let report = PerformanceReport::from_trades(&trades);
+
+        assert_eq!(report.trades, 6);
+        assert_eq!((report.wins, report.losses, report.scratches), (3, 2, 1));
+        assert_eq!(report.net_points, Decimal::ONE);
+        assert_eq!(report.max_consecutive_wins, 2, "W W then broken by a loss");
+        assert_eq!(report.max_consecutive_losses, 2);
+
+        // Equity: 10, 12, 7, -5, -5, 1 → peak 12 at k=2, trough -5 at k=4.
+        assert_eq!(report.max_drawdown_points, Decimal::from(17));
+        assert_eq!(report.max_drawdown_span, Some((2, 4)));
+        assert_eq!(report.max_runup_points, Decimal::from(12));
+        assert_eq!(
+            report.recovery_factor,
+            Some(Decimal::ONE / Decimal::from(17))
+        );
+
+        // Durations: 60, 30, 120, 240, 10, 20 seconds.
+        assert_eq!(report.avg_duration_ms, Some(80_000));
+        assert_eq!(report.median_duration_ms, Some(45_000), "(30s + 60s) / 2");
+        assert_eq!(
+            report.avg_win_duration_ms,
+            Some(36_666),
+            "(60s + 30s + 20s) / 3, rounded toward zero"
+        );
+        assert_eq!(report.avg_loss_duration_ms, Some(180_000));
+
+        // Winners' MAE: 2 and 1 known, the +6 winner did not record one.
+        assert_eq!(report.winners_with_mae, 2);
+        assert_eq!(
+            report.avg_winner_mae_points,
+            Some(Decimal::from(3) / Decimal::from(2))
+        );
+        // Losers' MFE: only the -5 loser recorded one.
+        assert_eq!(report.losers_with_mfe, 1);
+        assert_eq!(report.avg_loser_mfe_points, Some(Decimal::ONE));
+
+        // Long side: +10, +2, 0, +6 → 4 trades, 3 wins, 1 scratch.
+        assert_eq!(report.long.trades, 4);
+        assert_eq!(report.long.net_points, Decimal::from(18));
+        assert_eq!(report.long.win_rate_pct, Some(Decimal::from(75)));
+        assert_eq!(report.long.profit_factor, None, "no long losses");
+        assert_eq!(report.long.avg_win, Some(Decimal::from(6)));
+        assert_eq!(report.long.avg_loss, None);
+        assert_eq!(
+            report.long.expectancy_points,
+            Some(Decimal::from(18) / Decimal::from(4))
+        );
+        // Short side: -5, -12.
+        assert_eq!(report.short.trades, 2);
+        assert_eq!(report.short.net_points, Decimal::from(-17));
+        assert_eq!(report.short.win_rate_pct, Some(Decimal::ZERO));
+        assert_eq!(report.short.profit_factor, Some(Decimal::ZERO));
+        assert_eq!(
+            report.short.expectancy_points,
+            Some(Decimal::from(-17) / Decimal::from(2))
+        );
+
+        // Exit reasons in fixed order, empty ones skipped.
+        assert_eq!(
+            report.by_exit_reason,
+            vec![
+                ReasonReport {
+                    reason: ExitReason::StopLoss,
+                    trades: 2,
+                    net_points: Decimal::from(-17),
+                },
+                ReasonReport {
+                    reason: ExitReason::TakeProfit,
+                    trades: 1,
+                    net_points: Decimal::from(10),
+                },
+                ReasonReport {
+                    reason: ExitReason::Manual,
+                    trades: 2,
+                    net_points: Decimal::from(2),
+                },
+                ReasonReport {
+                    reason: ExitReason::Reversal,
+                    trades: 1,
+                    net_points: Decimal::from(6),
+                },
+            ]
+        );
+
+        // Sample stddev of {10, 2, -5, -12, 0, 6}: variance 11118/180,
+        // sqrt ≈ 7.859176, rounded to four places.
+        assert_eq!(report.stddev_points, Some(Decimal::new(78_592, 4)));
+    }
+
+    #[test]
+    fn a_scratch_breaks_both_streaks() {
+        let trades = [
+            trade(Side::Buy, 4),
+            trade(Side::Buy, 0),
+            trade(Side::Buy, 5),
+            trade(Side::Buy, 6),
+        ];
+        let report = PerformanceReport::from_trades(&trades);
+        assert_eq!(
+            report.max_consecutive_wins, 2,
+            "the scratch broke the first run"
+        );
+        assert_eq!(report.max_consecutive_losses, 0);
     }
 
     #[test]
@@ -181,8 +658,11 @@ mod tests {
         let trades = [trade(Side::Buy, 3), trade(Side::Buy, 4)];
         let report = PerformanceReport::from_trades(&trades);
         assert_eq!(report.profit_factor, None);
+        assert_eq!(report.payoff_ratio, None, "no losses to pay off against");
         assert_eq!(report.win_rate_pct, Some(Decimal::ONE_HUNDRED));
         assert_eq!(report.max_drawdown_points, Decimal::ZERO);
+        assert_eq!(report.max_drawdown_span, None);
+        assert_eq!(report.recovery_factor, None, "no drawdown to recover from");
     }
 
     #[test]
@@ -193,5 +673,22 @@ mod tests {
         assert_eq!(report.wins, 1);
         assert_eq!(report.scratches, 1);
         assert_eq!(report.win_rate_pct, Some(Decimal::from(50)));
+    }
+
+    #[test]
+    fn a_single_trade_has_no_stddev_but_has_durations() {
+        let trades = [full(
+            Side::Buy,
+            7,
+            1_000,
+            31_000,
+            Some(1),
+            Some(9),
+            ExitReason::Manual,
+        )];
+        let report = PerformanceReport::from_trades(&trades);
+        assert_eq!(report.stddev_points, None, "one sample has no spread");
+        assert_eq!(report.avg_duration_ms, Some(30_000));
+        assert_eq!(report.median_duration_ms, Some(30_000));
     }
 }

--- a/crates/sim/src/simulator.rs
+++ b/crates/sim/src/simulator.rs
@@ -158,6 +158,13 @@ impl Simulator {
         self.mark.map(|mark| mark.price)
     }
 
+    /// Venue time of the last print seen (live or seeded), if any — the
+    /// only "now" an open trade's age can honestly be measured against.
+    #[must_use]
+    pub fn mark_timestamp_ms(&self) -> Option<i64> {
+        self.mark.map(|mark| mark.timestamp_ms)
+    }
+
     #[must_use]
     pub fn position(&self) -> Option<&Position> {
         self.position.as_ref()

--- a/crates/sim/src/simulator.rs
+++ b/crates/sim/src/simulator.rs
@@ -27,6 +27,23 @@ pub struct ClosedTrade {
     /// number the simulator cannot compute honestly is not shown.
     pub pnl_points: Decimal,
     pub exit_reason: ExitReason,
+    /// Aggregate id of the print that opened the position — the audit trail
+    /// back to the tape. `None` only on rows loaded from a version-1 history
+    /// file, which did not record it; the simulator always fills it.
+    pub entry_agg_id: Option<u64>,
+    /// Aggregate id of the print that closed this quantity (see
+    /// `entry_agg_id` for why it is optional).
+    pub exit_agg_id: Option<u64>,
+    /// Maximum adverse excursion in points (≥ 0): the worst the position ran
+    /// against its average entry over every price it was exposed to — entry
+    /// fills, marks while open, the exit fill — scaled by this trade's
+    /// closed quantity. Measured against the average entry at close time,
+    /// so a position that averaged in reports its excursion against the
+    /// final average. `None` only for version-1 history rows: unknown is
+    /// not zero.
+    pub mae_points: Option<Decimal>,
+    /// Maximum favorable excursion in points (≥ 0); see `mae_points`.
+    pub mfe_points: Option<Decimal>,
 }
 
 /// A user command, applied between prints. Commands and prints interleave
@@ -70,6 +87,13 @@ pub enum Command {
     /// own; the fill (or its quiet dissolution, if a bracket got there
     /// first) is the answer.
     ClosePosition,
+    /// Close up to `quantity` of the open position at the next print. Closes
+    /// at most what is open — a partial close never reverses — and the
+    /// remainder keeps its average entry price, protective prices and
+    /// opening time. Like [`Command::ClosePosition`] it emits no event of
+    /// its own and dissolves quietly if the position is gone by the time
+    /// the print arrives.
+    ClosePartial { quantity: Decimal },
     /// Cancel every pending order and close the position at the next print.
     Flatten,
 }
@@ -83,6 +107,9 @@ pub enum QueuedAction {
     /// arrives (a bracket fired first), the close dissolves — there is
     /// nothing left for it to close.
     Close,
+    /// A user partial close, clamped to the open quantity at fill time.
+    /// Dissolves like [`QueuedAction::Close`] when the position is gone.
+    ClosePartial { quantity: Decimal },
 }
 
 /// The last print seen — the only "now" the simulator knows.
@@ -229,6 +256,9 @@ impl Simulator {
                         );
                     }
                 }
+                QueuedAction::ClosePartial { quantity } => {
+                    self.close_partial_at(quantity, price, trade, &mut events);
+                }
             }
         }
 
@@ -255,7 +285,11 @@ impl Simulator {
         }
         self.resting = kept;
 
-        // 4) The mark updates last.
+        // 4) The mark updates last; a position that survived the print has
+        //    been exposed to its price, which the excursions must remember.
+        if let Some(position) = self.position.as_mut() {
+            position.observe(price);
+        }
         self.mark = Some(Mark {
             timestamp_ms: trade.timestamp_ms,
             agg_id: trade.agg_id,
@@ -287,33 +321,23 @@ impl Simulator {
         // A position can only exist after a print, so the mark is present
         // whenever the position is.
         if let (Some(position), Some(mark)) = (self.position.take(), self.mark) {
-            let exit_side = opposite(position.side);
             events.push(SimEvent::Filled(Fill {
                 timestamp_ms: mark.timestamp_ms,
                 agg_id: mark.agg_id,
-                side: exit_side,
+                side: opposite(position.side),
                 price: mark.price,
                 quantity: position.quantity,
                 role: FillRole::Reset,
             }));
-            let closed = ClosedTrade {
-                side: position.side,
-                quantity: position.quantity,
-                entry_price: position.avg_price,
-                exit_price: mark.price,
-                opened_ms: position.opened_ms,
-                closed_ms: mark.timestamp_ms,
-                pnl_points: signed_points(
-                    position.side,
-                    position.avg_price,
-                    mark.price,
-                    position.quantity,
-                ),
-                exit_reason: ExitReason::Reset,
-            };
-            self.realized_points = self.realized_points.saturating_add(closed.pnl_points);
-            events.push(SimEvent::Closed(closed.clone()));
-            self.closed.push(closed);
+            self.record_close(
+                &position,
+                position.quantity,
+                mark.price,
+                mark.timestamp_ms,
+                mark.agg_id,
+                ExitReason::Reset,
+                &mut events,
+            );
         }
         self.mark = None;
         events
@@ -454,6 +478,14 @@ impl Simulator {
                 self.queue.push(QueuedAction::Close);
                 Ok(Vec::new())
             }
+            Command::ClosePartial { quantity } => {
+                require_positive_quantity(quantity)?;
+                if self.position.is_none() {
+                    return Err(RejectReason::NoPosition);
+                }
+                self.queue.push(QueuedAction::ClosePartial { quantity });
+                Ok(Vec::new())
+            }
             Command::Flatten => {
                 let mut events = Vec::new();
                 for action in std::mem::take(&mut self.queue) {
@@ -564,14 +596,13 @@ impl Simulator {
         let bracket = Self::admissible_bracket(order.side, at, order.bracket, events);
         match self.position.take() {
             None => {
-                self.position = Some(Position {
-                    side: order.side,
-                    quantity: order.quantity,
-                    avg_price: at,
-                    opened_ms: print.timestamp_ms,
-                    stop_loss: bracket.stop_loss,
-                    take_profit: bracket.take_profit,
-                });
+                self.position = Some(opened_position(
+                    order.side,
+                    order.quantity,
+                    at,
+                    print,
+                    bracket,
+                ));
             }
             Some(mut position) if position.side == order.side => {
                 // Average in. The newest entry's bracket wins where it sets
@@ -585,6 +616,7 @@ impl Simulator {
                     position.avg_price = weighted / total;
                 }
                 position.quantity = total;
+                position.observe(at);
                 if bracket.stop_loss.is_some() {
                     position.stop_loss = bracket.stop_loss;
                 }
@@ -595,40 +627,27 @@ impl Simulator {
             }
             Some(mut position) => {
                 // Netting: the opposite entry closes quantity first, then
-                // opens the remainder as a new position.
+                // opens the remainder as a new position. No exit fill of its
+                // own — the entry execution above covers both legs.
                 let close_quantity = position.quantity.min(order.quantity);
-                let closed = ClosedTrade {
-                    side: position.side,
-                    quantity: close_quantity,
-                    entry_price: position.avg_price,
-                    exit_price: at,
-                    opened_ms: position.opened_ms,
-                    closed_ms: print.timestamp_ms,
-                    pnl_points: signed_points(
-                        position.side,
-                        position.avg_price,
-                        at,
-                        close_quantity,
-                    ),
-                    exit_reason: ExitReason::Reversal,
-                };
-                self.realized_points = self.realized_points.saturating_add(closed.pnl_points);
-                events.push(SimEvent::Closed(closed.clone()));
-                self.closed.push(closed);
+                self.record_close(
+                    &position,
+                    close_quantity,
+                    at,
+                    print.timestamp_ms,
+                    print.agg_id,
+                    ExitReason::Reversal,
+                    events,
+                );
                 if position.quantity > close_quantity {
                     position.quantity = position.quantity.saturating_sub(close_quantity);
+                    position.observe(at);
                     self.position = Some(position);
                 } else {
                     let remainder = order.quantity.saturating_sub(close_quantity);
                     if remainder > Decimal::ZERO {
-                        self.position = Some(Position {
-                            side: order.side,
-                            quantity: remainder,
-                            avg_price: at,
-                            opened_ms: print.timestamp_ms,
-                            stop_loss: bracket.stop_loss,
-                            take_profit: bracket.take_profit,
-                        });
+                        self.position =
+                            Some(opened_position(order.side, remainder, at, print, bracket));
                     }
                 }
             }
@@ -655,19 +674,113 @@ impl Simulator {
             quantity: position.quantity,
             role,
         }));
+        self.record_close(
+            &position,
+            position.quantity,
+            at,
+            print.timestamp_ms,
+            print.agg_id,
+            reason,
+            events,
+        );
+    }
+
+    /// Close up to `quantity` of the position at `at` against the print that
+    /// caused it, keeping the remainder (average entry, protective prices
+    /// and opening time untouched). Dissolves when there is no position.
+    fn close_partial_at(
+        &mut self,
+        quantity: Decimal,
+        at: Decimal,
+        print: &Trade,
+        events: &mut Vec<SimEvent>,
+    ) {
+        let Some(mut position) = self.position.take() else {
+            return;
+        };
+        let close_quantity = position.quantity.min(quantity);
+        events.push(SimEvent::Filled(Fill {
+            timestamp_ms: print.timestamp_ms,
+            agg_id: print.agg_id,
+            side: opposite(position.side),
+            price: at,
+            quantity: close_quantity,
+            role: FillRole::Close,
+        }));
+        self.record_close(
+            &position,
+            close_quantity,
+            at,
+            print.timestamp_ms,
+            print.agg_id,
+            ExitReason::Manual,
+            events,
+        );
+        if position.quantity > close_quantity {
+            position.quantity = position.quantity.saturating_sub(close_quantity);
+            position.observe(at);
+            self.position = Some(position);
+        }
+    }
+
+    /// Record `close_quantity` of `position` exiting at `at`: the
+    /// [`ClosedTrade`] with its excursion and tape-audit fields, the
+    /// realized-points total, and the `Closed` event. The caller owns the
+    /// fill event and whatever remains of the position.
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "one exit has one natural argument list; bundling it into a struct would name nothing"
+    )]
+    fn record_close(
+        &mut self,
+        position: &Position,
+        close_quantity: Decimal,
+        at: Decimal,
+        closed_ms: i64,
+        exit_agg_id: u64,
+        reason: ExitReason,
+        events: &mut Vec<SimEvent>,
+    ) {
+        let (adverse, favorable) = position.excursions(at);
         let closed = ClosedTrade {
             side: position.side,
-            quantity: position.quantity,
+            quantity: close_quantity,
             entry_price: position.avg_price,
             exit_price: at,
             opened_ms: position.opened_ms,
-            closed_ms: print.timestamp_ms,
-            pnl_points: signed_points(position.side, position.avg_price, at, position.quantity),
+            closed_ms,
+            pnl_points: signed_points(position.side, position.avg_price, at, close_quantity),
             exit_reason: reason,
+            entry_agg_id: Some(position.opened_agg_id),
+            exit_agg_id: Some(exit_agg_id),
+            mae_points: Some(adverse.saturating_mul(close_quantity)),
+            mfe_points: Some(favorable.saturating_mul(close_quantity)),
         };
         self.realized_points = self.realized_points.saturating_add(closed.pnl_points);
         events.push(SimEvent::Closed(closed.clone()));
         self.closed.push(closed);
+    }
+}
+
+/// A brand-new position opened by an entry fill at `at`: its exposure range
+/// starts at the fill price, and its audit trail starts at the causing print.
+fn opened_position(
+    side: Side,
+    quantity: Decimal,
+    at: Decimal,
+    print: &Trade,
+    bracket: Bracket,
+) -> Position {
+    Position {
+        side,
+        quantity,
+        avg_price: at,
+        opened_ms: print.timestamp_ms,
+        opened_agg_id: print.agg_id,
+        low_price: at,
+        high_price: at,
+        stop_loss: bracket.stop_loss,
+        take_profit: bracket.take_profit,
     }
 }
 
@@ -1360,6 +1473,193 @@ mod tests {
             events,
             vec![SimEvent::Rejected(RejectReason::PriceNotPositive)]
         );
+    }
+
+    #[test]
+    fn close_partial_keeps_the_remainder_and_its_average() {
+        let mut sim = seeded(100);
+        sim.apply(Command::PlaceMarket {
+            side: Side::Buy,
+            quantity: dec(5),
+            bracket: Bracket::none(),
+        });
+        sim.on_trade(&print(1, 100));
+        assert!(
+            sim.apply(Command::ClosePartial { quantity: dec(2) })
+                .is_empty()
+        );
+
+        let events = sim.on_trade(&print(2, 103));
+        let filled = fills(&events);
+        assert_eq!(filled.len(), 1);
+        assert_eq!(filled[0].role, FillRole::Close);
+        assert_eq!(filled[0].quantity, dec(2));
+        let closed = sim.closed_trades().last().expect("partial recorded");
+        assert_eq!(closed.quantity, dec(2));
+        assert_eq!(closed.pnl_points, dec(6), "(103 - 100) × 2");
+        assert_eq!(closed.exit_reason, ExitReason::Manual);
+        let position = sim.position().expect("3 remain");
+        assert_eq!(position.quantity, dec(3));
+        assert_eq!(position.avg_price, dec(100), "the average is untouched");
+        assert_eq!(position.opened_ms, 1000, "so is the opening time");
+        assert_eq!(sim.realized_points(), dec(6));
+    }
+
+    #[test]
+    fn close_partial_clamps_to_the_open_quantity_and_never_reverses() {
+        let mut sim = seeded(100);
+        sim.apply(Command::PlaceMarket {
+            side: Side::Buy,
+            quantity: dec(2),
+            bracket: Bracket::none(),
+        });
+        sim.on_trade(&print(1, 100));
+        sim.apply(Command::ClosePartial { quantity: dec(5) });
+        let events = sim.on_trade(&print(2, 101));
+        assert_eq!(
+            fills(&events)[0].quantity,
+            dec(2),
+            "clamped to what is open"
+        );
+        assert!(
+            sim.position().is_none(),
+            "closed, not reversed into a short"
+        );
+        assert_eq!(sim.closed_trades().last().expect("closed").quantity, dec(2));
+    }
+
+    #[test]
+    fn close_partial_dissolves_when_a_bracket_got_there_first() {
+        let mut sim = seeded(100);
+        sim.apply(Command::PlaceMarket {
+            side: Side::Buy,
+            quantity: dec(1),
+            bracket: Bracket {
+                stop_loss: Some(dec(98)),
+                take_profit: None,
+            },
+        });
+        sim.on_trade(&print(1, 100));
+        sim.apply(Command::ClosePartial { quantity: dec(1) });
+        let events = sim.on_trade(&print(2, 97));
+        let filled = fills(&events);
+        assert_eq!(
+            filled.len(),
+            1,
+            "the stop exit only — the partial dissolved"
+        );
+        assert_eq!(filled[0].role, FillRole::StopLoss);
+        assert_eq!(sim.closed_trades().len(), 1);
+    }
+
+    #[test]
+    fn close_partial_needs_a_position_and_a_positive_quantity() {
+        let mut sim = seeded(100);
+        let events = sim.apply(Command::ClosePartial { quantity: dec(1) });
+        assert_eq!(events, vec![SimEvent::Rejected(RejectReason::NoPosition)]);
+
+        sim.apply(Command::PlaceMarket {
+            side: Side::Buy,
+            quantity: dec(1),
+            bracket: Bracket::none(),
+        });
+        sim.on_trade(&print(1, 100));
+        let events = sim.apply(Command::ClosePartial {
+            quantity: Decimal::ZERO,
+        });
+        assert_eq!(
+            events,
+            vec![SimEvent::Rejected(RejectReason::QuantityNotPositive)]
+        );
+    }
+
+    #[test]
+    fn excursions_and_agg_ids_come_from_the_tape() {
+        let mut sim = seeded(100);
+        sim.apply(Command::PlaceMarket {
+            side: Side::Buy,
+            quantity: dec(1),
+            bracket: Bracket::none(),
+        });
+        sim.on_trade(&print(1, 100));
+        sim.on_trade(&print(2, 96));
+        sim.on_trade(&print(3, 104));
+        sim.apply(Command::ClosePosition);
+        sim.on_trade(&print(4, 103));
+        let closed = sim.closed_trades().last().expect("closed");
+        assert_eq!(closed.entry_agg_id, Some(1), "the print that opened it");
+        assert_eq!(closed.exit_agg_id, Some(4), "the print that closed it");
+        assert_eq!(closed.mae_points, Some(dec(4)), "worst mark was 96");
+        assert_eq!(closed.mfe_points, Some(dec(4)), "best mark was 104");
+    }
+
+    #[test]
+    fn a_stop_gap_counts_toward_the_adverse_excursion() {
+        let mut sim = seeded(100);
+        sim.apply(Command::PlaceMarket {
+            side: Side::Buy,
+            quantity: dec(1),
+            bracket: Bracket {
+                stop_loss: Some(dec(98)),
+                take_profit: None,
+            },
+        });
+        sim.on_trade(&print(1, 100));
+        sim.on_trade(&print(2, 95));
+        let closed = sim.closed_trades().last().expect("stopped");
+        assert_eq!(
+            closed.mae_points,
+            Some(dec(5)),
+            "the gap fill at 95 is part of the excursion"
+        );
+        assert_eq!(closed.mfe_points, Some(dec(0)));
+        assert_eq!(closed.exit_agg_id, Some(2));
+    }
+
+    #[test]
+    fn averaging_in_measures_excursions_against_the_final_average() {
+        let mut sim = seeded(100);
+        sim.apply(Command::PlaceMarket {
+            side: Side::Buy,
+            quantity: dec(1),
+            bracket: Bracket::none(),
+        });
+        sim.on_trade(&print(1, 100));
+        sim.apply(Command::PlaceMarket {
+            side: Side::Buy,
+            quantity: dec(1),
+            bracket: Bracket::none(),
+        });
+        sim.on_trade(&print(2, 104));
+        sim.apply(Command::ClosePosition);
+        sim.on_trade(&print(3, 104));
+        let closed = sim.closed_trades().last().expect("closed");
+        assert_eq!(closed.entry_price, dec(102), "the volume-weighted average");
+        assert_eq!(closed.entry_agg_id, Some(1), "the print that opened it");
+        assert_eq!(
+            closed.mae_points,
+            Some(dec(4)),
+            "(102 - 100) per unit against the final average, × 2"
+        );
+        assert_eq!(closed.mfe_points, Some(dec(4)));
+    }
+
+    #[test]
+    fn reset_stamps_the_mark_as_the_exit_print() {
+        let mut sim = seeded(100);
+        sim.apply(Command::PlaceMarket {
+            side: Side::Buy,
+            quantity: dec(2),
+            bracket: Bracket::none(),
+        });
+        sim.on_trade(&print(1, 100));
+        sim.on_trade(&print(2, 104));
+        sim.reset();
+        let closed = sim.closed_trades().last().expect("reset closes");
+        assert_eq!(closed.entry_agg_id, Some(1));
+        assert_eq!(closed.exit_agg_id, Some(2), "the mark it flattened at");
+        assert_eq!(closed.mae_points, Some(dec(0)));
+        assert_eq!(closed.mfe_points, Some(dec(8)), "(104 - 100) × 2");
     }
 
     /// The determinism contract, exercised end to end: one fixed tape, one

--- a/docs/ux/paper-trading.md
+++ b/docs/ux/paper-trading.md
@@ -202,8 +202,7 @@ Timeline honesty on rebuilds:
 
 ## 7. History on disk, and the export
 
-Closed trades append to `paper-trades/<SYMBOL>/<session>.csv` (cwd-relative
-like every quantick path, `QUANTICK_TRADES_DIR` override), in the
+Closed trades append to `<trades_dir>/<SYMBOL>/<session>.csv`, in the
 `quantick-trades 2` CSV format defined by `quantick_sim::history` — the
 first eight columns are exactly version 1's, then the tape-audit ids
 (`entry_agg_id`, `exit_agg_id`) and the excursions (`mae_points`,
@@ -213,6 +212,19 @@ Append-friendly, self-contained rows, torn tails reported not dropped. The
 `<session>` name derives from the first closed trade's venue timestamp, so
 the same replay run produces the same file name. Files are created lazily
 (no empty files), appended on each close, and never rewritten.
+
+**Where that folder is, is configuration**: `[paper] trades_dir` in
+`quantick.toml` (default `paper-trades`, relative to the working
+directory), overridden for one run by `QUANTICK_TRADES_DIR` — and the
+Trading tab's session strip says it out loud ("trades saved to: …", click
+to open). The folder is also the feature's **integration port**: the
+`quantick-trades` CSV format in `quantick_sim::history` is the contract,
+so any producer that writes it there — the future bot runner, a converter,
+another tool — appears in the Trades ledger (`EARLIER SESSIONS`), the
+report and the export with no extra wiring. The sim crate itself is the
+shared engine: a bot embeds the same `Simulator` and emits the same
+`ClosedTrade`s, so its trades wear the same mould everywhere by
+construction (one engine, three consumers).
 
 The **export** (the Trades tab's download icon) is a different artifact:
 one merged, spreadsheet-facing CSV of everything the ledger lists, written

--- a/docs/ux/paper-trading.md
+++ b/docs/ux/paper-trading.md
@@ -213,11 +213,16 @@ Append-friendly, self-contained rows, torn tails reported not dropped. The
 the same replay run produces the same file name. Files are created lazily
 (no empty files), appended on each close, and never rewritten.
 
-**Where that folder is, is configuration**: `[paper] trades_dir` in
-`quantick.toml` (default `paper-trades`, relative to the working
-directory), overridden for one run by `QUANTICK_TRADES_DIR` — and the
-Trading tab's session strip says it out loud ("trades saved to: …", click
-to open). The folder is also the feature's **integration port**: the
+**Where that folder is, is configuration — and one click**: the Trading
+tab's session strip says it out loud ("trades saved to: …", click to
+open) and its folder button opens a picker; the choice applies to every
+tab at once, the next close opens a new session file under the new home
+(files already written stay put), and it is remembered across restarts in
+the `paper-state.toml` sidecar — the added-symbols pattern, so the app
+never rewrites the user's hand-commented `quantick.toml`. The shipped
+base stays `[paper] trades_dir` in `quantick.toml` (default
+`paper-trades`, relative to the working directory), and
+`QUANTICK_TRADES_DIR` still overrides everything for one run. The folder is also the feature's **integration port**: the
 `quantick-trades` CSV format in `quantick_sim::history` is the contract,
 so any producer that writes it there — the future bot runner, a converter,
 another tool — appears in the Trades ledger (`EARLIER SESSIONS`), the

--- a/docs/ux/paper-trading.md
+++ b/docs/ux/paper-trading.md
@@ -1,6 +1,8 @@
 # Paper trading — UX specification
 
-Status: **design target** for the `feat/trade-sim` milestone. Companion of
+Status: shipped by the `feat/trade-sim` milestone, **extended by
+`feat/paper-trading-v2`** (drag-to-create brackets, the trades ledger,
+closed-trade marks, the filterable report, export). Companion of
 [quantick UI Design Model](ui-design-model.md) — this feature claims the
 zones the growth map already reserved for order/position surfaces; it invents
 no new chrome. The deterministic core lives in `crates/sim`
@@ -46,14 +48,19 @@ Non-negotiables, inherited from `CLAUDE.md` and the sim crate's contract:
 | Surface | Zone | Content |
 |---|---|---|
 | Toolbar | action group | `BUY` / `SELL` market buttons (with quantity), gated like every capability control |
-| Right dock | new tab **Trading** | the chart-trader panel: position card, order entry, pending orders, session history |
-| Canvas | own layer above drawings | entry / SL / TP / pending-order price lines with gutter chips, draggable |
+| Right dock | tab **Trading** | the chart-trader panel: position card, order ticket, working orders, session strip |
+| Right dock | tab **Trades** | the ledger: open position pinned, this session's closed trades, saved history, totals |
+| Canvas | own layer above drawings | entry / SL / TP / pending-order price lines with in-plot tags, draggable |
+| Canvas | own layer under the live lines | closed-trade marks and connectors (`closed trade marks` in the layer menu) |
 | Status bar | new cell | `SIM ±N pts` (realized + open), hidden when the simulator has never traded |
 | Floating window | `SettingsDialog` mold | the performance report, open–read–close |
 
-Explicitly **not** claimed: the chart's right-click gesture (reserved by the
-layer-visibility menu work) and the `AMBER` color (reserved by contract for
-provenance — replay/backfill/inferred data). Pending orders use `ACCENT`.
+The chart's right-click gesture belongs to the layer-visibility menu; paper
+trading joins that menu rather than competing with it — a **trade** section
+on top (anchored at the clicked price, on the pane that owns order entry),
+and the two paper layer switches among the others. `AMBER` stays reserved by
+contract for provenance (replay/backfill/inferred data); pending orders use
+`ACCENT`.
 
 ## 3. The Trading dock tab (chart trader)
 
@@ -61,25 +68,34 @@ Top to bottom, grouped by the §3.2 question each block answers:
 
 1. **Header** — "Paper trading — simulated fills from the tape". One line,
    always visible; the didactic anchor of the whole feature.
-2. **Position card** (only when a position is open) — side and quantity
-   (`LONG 2`), average entry, open P&L in points (live, colored
-   `BUY`/`SELL` by sign), SL and TP values with per-side *clear* buttons,
-   and `Close` / `Flatten` buttons. A hint line explains the difference the
-   first time both exist ("Close exits the position; Flatten also cancels
-   every pending order").
-3. **Order entry** — side toggle (Buy/Sell, colored), quantity drag-value
-   (default 1), order type (`Market` / `Limit` / `Stop`), optional SL/TP
-   offsets, and the action button:
-   - `Market` → the button reads `Buy 1 at market` and fires immediately.
-   - `Limit`/`Stop` → the button arms **click-to-place**: the crosshair
-     shows a price-tag hint ("click a price below the market to rest your
-     buy limit"), the next chart click places the order at that price,
-     `Esc` disarms. This teaches *where* each order type may sit, because
-     the simulator rejects wrong-side placements with advice (§5).
-4. **Pending orders** — one row per resting order (`#3 BUY LMT 2 @ 95`),
-   with cancel buttons, in the `toolbar.rs` indicator-menu row mold.
-5. **Session** — realized points, closed-trade count, and buttons
-   `Report…` and `History folder` (reveals the path).
+2. **Position block** — always present. Flat, it is one quiet row: `FLAT`
+   plus the session's realized points (the answer to "am I in?" costs
+   nothing). Open, it is the HUD card's sibling: the `SIM LONG 2` side
+   chip, average entry, live open points; a bracket grid showing each
+   leg's price and what it pays, with `×` to clear or `Set n pts` to place
+   the missing leg straight from the ticket's offset; the `R:R` read when
+   both legs exist; and the actions — `× Close`, `⇄ Reverse`, `Breakeven`
+   (disabled with its reason until the position is in profit — with no
+   fees simulated, break-even is the entry exactly), `Close 50%` (a
+   partial close; the rest keeps its average and brackets) and
+   `Flatten all`.
+3. **Order ticket** — quantity as free decimal text with `−`/`+` steppers
+   (`Shift` steps by ten; empty keeps meaning "fix me"), order type as
+   three pills (`market` / `limit` / `stop`), optional Stop/Target offsets
+   in points, then the entry pair: two full-width `BUY`/`SELL` chips,
+   taller than the toolbar's — this is the surface where you commit.
+   - `Market` → the buttons disclose consequences (`SELL 5 (reverses to
+     short 4)`) and fire at the next print.
+   - `Limit`/`Stop` → a press arms **click-to-place**; the armed side
+     inverts (quiet fill, its own colour as a ring, `Click a price…`) and
+     the other side disables with the reason. `Esc` disarms. The support
+     line under the pair narrates the mode.
+4. **Working orders** — one row per order: an `ACCENT` dash, `#id`, the
+   side in its colour, `LMT 2 @ 95`, and `×` to cancel. Hovering a row
+   lifts that order's line on the chart — one hover, two surfaces.
+5. **Session strip** — realized points and trade count, `Report…`, and the
+   history folder as a full-width quiet button that reveals the path in
+   the file manager.
 
 ## 4. The chart layer
 
@@ -89,27 +105,72 @@ lines span the chart width and end in a gutter chip (the third instance of
 the `draw_last_price` chip geometry, so prices never disagree about their
 pixel).
 
-| Line | Style | Chip label |
+The gutter chip carries **the price and nothing else** (still dodging the
+last-price row); the words and the controls live in a tag right-anchored
+*inside* the plot. The tag grammar is semantic: an order that will fire
+wears a solid chip; the position — a fact about the account, not an order —
+wears a card (`INSET` fill, hairline border, a side-colour rail).
+
+| Line | Style | In-plot tag |
 |---|---|---|
-| Position entry | solid, `BUY`/`SELL` by side | `SIM LONG 2 @ 103.2` |
-| Stop loss | solid, `SELL` red | `SL 97.0 −12.4 pts` |
-| Take profit | solid, `BUY` teal | `TP 110.0 +13.6 pts` |
-| Pending order | dashed, `ACCENT` | `#3 BUY LMT 2 @ 95.0` |
+| Position entry | solid 1.5 px, `BUY`/`SELL` by side | card: `SIM LONG 2` + live open pts, hover `×` closes |
+| Stop loss | solid 1 px, `SELL` | chip: `SL 97.0 −12.4 pts`, hover `×` clears |
+| Take profit | solid 1 px, `BUY` | chip: `TP 110.0 +13.6 pts`, hover `×` clears |
+| Pending order | dashed 1 px, `ACCENT` | chip: `#3 BUY LMT 2 @ 95.0`, hover `×` cancels |
 
 Interaction, reusing the drawing-drag grammar (`DrawingDrag` mechanics, same
 hit radius constants, raw-input reads, gesture-consumption flag so the chart
-never pans under a grabbed line):
+never pans under a grabbed line; hover thickens a line, a drag adds the
+drawings' halo):
 
 - SL, TP and pending-order lines are **draggable**; on release the new price
   is submitted as a command and the simulator answers — either the line
   settles at the new price or a rejection toast explains why it snapped
-  back ("a long's stop loss must sit below the price it protects…").
-- The position entry line is **not** draggable — an average entry is
-  history, not an order. Grabbing it is a no-op that still consumes the
-  gesture (the `Blocked` pattern).
+  back ("a long's stop loss must sit below the price it protects…"). While
+  an SL/TP drags, its tag reads the points distance and the live `R:R`
+  against the other leg — the read that turns a drag into a decision.
+- **Dragging away from the entry line creates the missing bracket leg** —
+  the TradingView gesture: pull to the profit side and a take profit is
+  born dashed under the pointer, pull to the losing side for the stop;
+  release submits it. Labelled `SL`/`TP` handles appear on hover beside
+  the position tag as the clickable alternative (the label removes the
+  long/short flip ambiguity). A side whose leg already exists stays
+  blocked — that leg's own line is its handle. The entry price itself
+  still never moves: with both legs placed, grabbing the line is the old
+  `Blocked` no-op.
 - Order state lives in the simulator, **not** in `Drawings` — a bar-spec
   change or history rebuild clears annotations, but simulated orders belong
   to the session, not to the bar series.
+
+### Closed-trade marks
+
+Every round trip closed *this session* paints on the chart, under the live
+lines: a filled triangle pointing the trade's way at the entry fill, a
+diamond at the exit, joined by a faint dotted connector — all in the
+**outcome's** colour (win/loss/scratch), direction carried by shape, each
+mark ringed in the canvas colour. Marks anchor to the fill price on the bar
+holding the fill's venue time. Only the session's trades paint — the tape
+on screen proves their fills; rows loaded from earlier sessions stay in the
+ledger. The paint caps at the 200 newest visible trades and says so out
+loud. Hovering a mark answers with the ledger row's own words; the ledger's
+selected trade gains the halo. The `closed trade marks` layer switches all
+of it off independently of `paper orders & position` — hiding history must
+never hide the position you are in.
+
+## 4b. The Trades ledger (dock tab **Trades**)
+
+The ledger of closed simulated trades: the open position pinned above the
+scroll with its live open points, `THIS SESSION` under it, `EARLIER
+SESSIONS` (read from the history folder, the live session's own file
+excluded) under that — newest first, in fixed-height two-line rows (side
+rail, `LONG 2`, `103.25 → 110.00`, signed points; close time · duration ·
+exit reason), virtualised so a long history costs nothing. A totals strip
+that never scrolls away sums what is listed. Scope pills switch this
+symbol / all symbols; a session row's click selects it (Esc clears) and
+highlights its round trip on the chart, and a hover control centers the
+chart on the trade. Rows from earlier sessions are display-only — their
+tape is not the one on screen. The header's download icon exports
+everything listed (§7).
 
 ## 5. Rejections are the curriculum
 
@@ -139,35 +200,77 @@ Timeline honesty on rebuilds:
 - Backfill and paged history only *seed* the last-seen price; they never
   fill orders — trading against the past would be look-ahead.
 
-## 7. History on disk
+## 7. History on disk, and the export
 
 Closed trades append to `paper-trades/<SYMBOL>/<session>.csv` (cwd-relative
 like every quantick path, `QUANTICK_TRADES_DIR` override), in the
-`quantick-trades 1` CSV format defined by `quantick_sim::history` —
-append-friendly, self-contained rows, torn tails reported not dropped. The
+`quantick-trades 2` CSV format defined by `quantick_sim::history` — the
+first eight columns are exactly version 1's, then the tape-audit ids
+(`entry_agg_id`, `exit_agg_id`) and the excursions (`mae_points`,
+`mfe_points`). Version-1 files still load; their missing fields come back
+as *unknown* and re-export as empty cells — unknown is not zero.
+Append-friendly, self-contained rows, torn tails reported not dropped. The
 `<session>` name derives from the first closed trade's venue timestamp, so
 the same replay run produces the same file name. Files are created lazily
 (no empty files), appended on each close, and never rewritten.
 
+The **export** (the Trades tab's download icon) is a different artifact:
+one merged, spreadsheet-facing CSV of everything the ledger lists, written
+off the UI thread to `paper-trades/export-<stamp>.csv` — human-readable
+UTC stamps beside the venue epochs, a running-equity column, decimals
+always with `.` (a pt-BR Excel would reinterpret a comma), symbols as a
+column so concatenation survives. The toast answers with the path or the
+failure; the journal stays the machine-readable source of truth.
+
 ## 8. The performance report
 
-An `egui::Window` in the `SettingsDialog` mold, titled **"Simulated
-performance"**, opened from the Trading tab (and Tools menu). Scope combo:
-current symbol / all symbols — both read the history folder fresh on open,
-so the report always reflects what is actually on disk, this session or any
-before it.
+A resizable, non-modal `egui::Window` titled **"Simulated performance"**,
+opened from the Trading tab (and the View menu). The filter row picks the
+symbol (any folder on disk, or all) and the period — `Today / 7d / 30d /
+90d / All` — **measured back from the newest saved trade in scope, never a
+wall clock**: the engine has none, and a replayed session's trades may be
+years old. The support line states the anchor out loud ("the last 7 days
+up to 2026-08-04 (newest saved trade, not the wall clock)").
 
-Content, from `quantick_sim::PerformanceReport`: net points, trade count,
-win rate, profit factor, max drawdown, gross profit/loss, averages and
-largest win/loss, long/short split — each metric with a one-line plain
-explanation under it (didactic first), and honest blanks: a ratio whose
-denominator doesn't exist shows `—`, never `∞`. Unreadable rows found while
-loading are counted and disclosed ("2 rows could not be read"), never
-silently skipped.
+Three headline tiles answer first — `NET` (the window's one coloured
+number), `WIN RATE`, `PROFIT FACTOR` — each with its denominator under it.
+Then the realized equity curve by **trade index** (the closing order that
+defines the drawdown; calling that axis "time" would misstate the plot):
+one quiet line, a diverging fill against the zero baseline, the deepest
+drawdown annotated with its own chip, hover snapped to the nearest trade in
+the ledger's vocabulary, drawing-only downsampling past a thousand points
+that says so. Under it, the metric grid — drawdown, run-up, recovery
+factor, gross and averages, payoff, expectancy, sample stddev, streaks
+(a scratch breaks both), durations, largest trades, and the excursion
+averages with their disclosed denominators ("over 12 of 14 winners") —
+plus long-vs-short and per-exit-reason tables. Honest blanks everywhere a
+denominator is missing; unreadable files and rows counted and disclosed;
+empty states name the filter that caused them and offer to clear it.
 
-## 9. Out of scope (this milestone)
+## 9. Trading hotkeys and the chart's trade menu
+
+`Shift+B` / `Shift+S` buy/sell at market with the ticket's quantity and
+offsets; `Shift+R` reverses; `Shift+F` flattens (close + cancel all);
+`Shift+X` cancels every working order without trading. All of them stand
+down while any text field owns the keyboard — a capital letter typed into
+a symbol box must never become an order.
+
+The pane's right-click menu (on the pane that owns order entry) opens with
+a **trade** section anchored at the clicked price: buy/sell at market, and
+the resting types that are valid on that side of the market — `Buy limit @
+p` below it, `Buy stop @ p` above it, mirrored for sells. The invalid two
+stay visible but disabled, wearing the sim core's own rejection text
+(disabled ≠ hidden; the curriculum again).
+
+## 10. Out of scope (recorded decisions)
 
 - Real order routing of any kind.
 - Fees, margin, multi-account, per-instrument currency P&L.
 - Automated strategies (the growth map's bot row remains future work).
-- Persisting open positions across restarts.
+- Persisting open positions across restarts. Deliberately kept out even in
+  v2: an honest restore would need the same feed and symbol back, a
+  `restored — not proven by the current tape` label until the first print,
+  and a flatten offer at startup — designed, recorded here, not built.
+- Shaded risk bands between entry and SL/TP: considered and rejected —
+  the line-and-tag grammar carries the same information without painting
+  over the candles.


### PR DESCRIPTION
Brings the paper trading shipped in #118 up to mainstream-platform standard. Three specialist passes (a trader-persona feature audit, a visual spec bound to the chip language, and a codebase map) defined the gap list; this branch closes every MUST and the cheap SHOULDs, one reviewable commit per slice.

## What shipped

**`crates/sim`** (`918f734`)
- `ClosedTrade` records the tape audit trail (`entry_agg_id`/`exit_agg_id`) and the excursions (`mae_points`/`mfe_points`, measured over every price the position was exposed to, honest under averaging-in).
- `Command::ClosePartial` — clamped, never reversing, remainder keeps its average.
- History format `quantick-trades 2` (append-only column growth; v1 still parses, unknown fields load as `None` — unknown is not zero).
- `PerformanceReport` grows loss rate, payoff, expectancy, streaks (a scratch breaks both), max run-up, recovery factor, sample stddev, durations (avg/median, winners vs losers), MAE/MFE averages with disclosed denominators, per-side and per-exit-reason breakdowns, and the drawdown's span on the equity curve. All hand-computed-fixture tested.

**Chart trading** (`042e58f`)
- The TradingView gesture: dragging away from the entry line (or its labelled `SL`/`TP` hover handles) creates the missing bracket leg, previewed dashed with live points distance and R:R; release submits, rejections snap back and teach.
- Labels restructured: gutter chips carry the price only; words and controls moved into right-anchored in-plot tags (position = card grammar, orders/legs = chips), each revealing a hover `×` to close / clear / cancel without a trip to the panel.

**Trades ledger** (`4a0be0f`) — a fifth dock tab: open position pinned with live open points, this session and every saved session grouped newest-first in virtualised two-line rows, pinned totals, scope pills (symbol / all), row click selecting the round trip on the chart, jump-to-trade, honest unreadable-file disclosure. The live session's own journal file is excluded from the read — its trades are already in the simulator.

**Closed-trade marks** (`bb9fcc6`) — entry triangles / exit diamonds joined by a faint connector, outcome-coloured with direction carried by shape, anchored to fill prices on the bars holding the fills' venue times. Session trades only (the tape on screen proves their fills). Capped at the 200 newest visible with the withheld count said out loud. Its own right-click layer, `closed trade marks`, independent of `paper orders & position`.

**Report v2** (`2f19a84`) — resizable window; symbol combo + period pills (`Today/7d/30d/90d/All`) anchored to the newest saved trade in scope, never a wall clock (a replay of old data must not report empty), with the anchor stated out loud; NET / WIN RATE / PROFIT FACTOR headline tiles (only NET is coloured); realized equity curve by trade index with a diverging zero-baseline fill, annotated deepest drawdown, ledger-vocabulary hover, and drawing-only downsampling that says so; extended metric grid + long/short + per-exit-reason tables; empty states that name their filter.

**Panel v2, export, reveal** (`12ca6e3`) — FLAT one-row card; position card with the HUD's identity chip, bracket grid (`×` to clear, `Set` from the ticket's offset — closes UX-audit blocker B1), live R:R, Breakeven (disabled with its reason until in profit), Close 50%, Flatten all; qty steppers (Shift = 10), type pills, 34 px entry pair with armed-side inversion; working-order rows whose hover lifts the chart line. Export writes one merged spreadsheet-facing CSV off the UI thread (ISO stamps beside venue epochs, running equity, `.` decimals) with the toast answering path-or-failure; the history line became a reveal-folder button.

**Hotkeys + trade menu + contract** (`31ecd51`) — `Shift+B/S/R/F/X`, standing down while any text field owns the keyboard; a right-click `trade` section anchored at the clicked price with only the valid resting types enabled (invalid ones disabled wearing the sim's own rejection text); `docs/ux/paper-trading.md` fully revised.

**Validation hooks** (`5d1ce68`) — `QUANTICK_DOCK_TAB`, `QUANTICK_PAPER_REPORT_AUTOSTART`, `QUANTICK_PAPER_DEMO` join the autostart family so scripted screenshot/demo runs need no clicks; plus a test-hygiene fix (the toolbar-close test was writing a real `paper-trades/` folder into the crate source tree).

## Evidence

- 46 test suites green (fmt / clippy -D warnings / build / test). 50 sim tests incl. the double-run determinism harness; hand-computed report fixture; v1↔v2 journal round trips; drag-to-create, painted-control, ledger-cache, period-anchor, export-format and layer-gate tests.
- End-to-end against the WINJ26 replay tape (scripted demo): journal came out as `quantick-trades 2` with the partial close keeping its 182030 average, the agg-id trail (6→81, 261→341) and recorded excursions.
- Visual pass: implemented to the design spec (chip/card/quiet-control grammar, tokens only — no new colour, radius or type size beyond the report's declared 22 px hero). Window screenshots of the demo run are pending only on the desktop presenting (captures while the session is idle return white); a watcher is armed and shots will be attached as a comment.

## arch-review

Run over `git diff main...HEAD`; three findings fixed in `7f2bd49` (chip-ink token unification, named curve-grid alpha, the TradePaint layer-gate regression test). One declared, not changed: the ledger rebuilds its row index per frame while the tab is open — O(listed trades) pointer collect + totals walk, tens of µs at 10k rows, two orders of magnitude under the frame budget; a cache-with-invalidation would cost more complexity than it buys today.

**Docking** — the next feature attaches without surgery: `trade_paint` is a new module + one registration line; layers, dock tabs and sim commands grow through the repo's own extension points (variant + `ALL` + arm).
**Performance** — the per-print hot path gained two comparisons (excursion tracking) and one branch (demo off); every new per-frame cost lives behind an open surface and is declared above.
**Proof** — the determinism double-run, the report fixture, the journal round trips, the bracket-creation drags and the layer gate would each fail if their behaviour regressed.

## Deliberately deferred (with trader-audit severity)

P&L stays in points (deliberate #118 decision; no per-instrument tick-value table exists). Deferred SHOULDs, recorded in `docs/ux/paper-trading.md` §10 where contractual: P&L histogram, expectancy-in-R (needs initial-stop tracking), per-hour breakdown, order event log, position restore across restarts (honest-restore design recorded, not built), sim settings dialog / qty presets / sounds / daily loss limit / trailing / volume-aware partial fills, sortable-resizable ledger columns, row copy menu, keyboard table nav, bars-held column. Rejected: shaded risk bands between entry and SL/TP (lines + tags carry the same information without painting over candles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)