### PR TITLE
docs(skills): agent skill ecosystem for autonomous UI validation

### DIFF
--- a/.claude/skills/goal/SKILL.md
+++ b/.claude/skills/goal/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: goal
+description: Define and enforce a goal for the current session — capture the objective, classify it, derive acceptance criteria including the standard quantick gates (arch-review, visual-qa, trader-ux-review, ui-harness hooks) that match the kind of work, keep every action aligned, and verify everything before finishing. Use when the user types /goal <objective> or asks to set a goal for the session/task.
+---
+
+# Goal
+
+Argument: the session objective (e.g. `/goal make the heatmap render at
+60fps`). If missing, ask the user what the goal is before doing anything
+else.
+
+The goal is the orchestrator: it decides which of the other skills are part
+of *done* so the user never has to list them. One session, one goal, one
+branch, one worktree, one PR.
+
+## Steps
+
+1. **Capture the goal**: restate the objective in one sentence and confirm
+   it with the user only if it is genuinely ambiguous.
+
+2. **Classify it and inject the standard gates.** Derive 3–7 verifiable
+   criteria specific to the objective, then add the gates for its kind:
+
+   | The goal… | Injected acceptance criteria |
+   | --- | --- |
+   | Any code change | four checks green after rebasing on latest `main`; **performance impact declared** — classify every touched path by rate (per-trade / per-depth / per-frame / rare, the `arch-review` table) as part of the plan, not the review; `arch-review` run with every Blocker/Should-fix resolved or deferred in the PR body; **PR opened** — the goal is not done before the PR exists, and merging is never part of the goal |
+   | Touches a hot path (per-trade, per-depth, per-frame) | evidence that performance is flat or better, not a belief: `APP_HEALTH_SUMMARY` fps/frame_avg under a dense tape vs. a `main` control run, or a bench over a fixture — measured before the PR, numbers in its body |
+   | Touches anything user-visible | follow `ui-harness`: every new/changed surface reachable by env hook (hook added in the same change); `visual-qa` pass with all surfaces PASS or defects explicitly accepted; `trader-ux-review` with no unresolved Blocker |
+   | Adds a capability (feed, bar type, indicator, layer, panel, crate) | follow `new-extension`: port named, registration-only edits, defaults preserve today's behaviour, fake second implementation tested, blast radius (added vs. edited files) stated in the PR body |
+   | Engine / determinism territory | test-first: fixture + expected output written before the code; golden test guards determinism |
+   | Docs/skills only | four checks still run (they are cheap when nothing compiled changed); arch-review waived |
+
+   Present the merged checklist to the user before starting work.
+
+3. **Persist it**: write the goal and its criteria to `.claude/GOAL.md` so
+   the goal survives context compaction. Overwrite any previous goal.
+
+4. **Set up the ground**: fresh worktree from updated `main` under
+   `../quantick-worktrees/` per CLAUDE.md — never work in the main
+   checkout, and check the worktree for a live writer before the first
+   write.
+
+5. **Stay on track**: refuse scope creep. A necessary detour is stated
+   explicitly and tied back to the goal (or taken to the user). Keep the
+   checklist in the todo list so progress is visible.
+
+6. **Verify before finishing**: check off each criterion with evidence —
+   command output, test result, screenshot path, review verdict. A
+   criterion without evidence is unmet. Report goal, criteria and pass/fail
+   for each. Only then archive `.claude/GOAL.md` (move to
+   `.claude/GOAL-archive-<slug>.md`).
+
+## What done means
+
+Done = the PR is open with green CI and the evidence in its body. Not
+merged — merging is the user's call, always. Do not ask permission to push
+or open the PR; opening it *is* the goal's final step.

--- a/.claude/skills/new-extension/SKILL.md
+++ b/.claude/skills/new-extension/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: new-extension
+description: Recipe for adding a new capability to quantick as an additive package — a new feed, bar type, indicator, chart layer, panel or crate that docks via a port instead of surgery on existing code. Use when a goal adds a capability, when scaffolding a new module, or when deciding where a new feature should live. Turns arch-review's docking test from a review gate into a build recipe.
+---
+
+# New extension — ship a package, not a patch
+
+`arch-review` asks after the fact: *could a second implementation be added
+as a new file plus one registration line?* This skill is the same idea
+before the fact — design the feature so the review question answers itself.
+
+## 1. Pick the docking port
+
+Find where things of this kind already plug in, and use that port. The
+repo's existing ports:
+
+| You are adding a… | Port | Registration point |
+| --- | --- | --- |
+| Market data source | `FeedEvent` channel + `FeedCapabilities` | new `feed-*` crate; config entry in `crates/app/config/feeds.toml` |
+| Bar/aggregation type | engine aggregator trait | new module in `engine`, one registration |
+| Indicator / kernel | `Indicator` trait (commit/preview + rollback) | `indicators` crate, or a `.pine` script compiled by `pine` |
+| Chart layer / overlay | chart layer registry (`QUANTICK_CHART_LAYERS` set) | new layer module in `app` |
+| Panel / dock tab | dock tab set | new module in `app`, one tab registration |
+| Look / preset | config file (`bubbles.toml`, drawing presets) | data only — no code |
+| Sim/backtest behaviour | `sim` fill model + metrics | `sim` crate, consumed by chart and runner alike |
+
+**No port fits?** Then the goal has two parts: first carve the port (a
+trait, a registry, a capability flag) as its own reviewable slice, then
+dock the feature into it. Never inline the feature and promise the
+abstraction later. If unsure the port is right, state the second concrete
+implementation you can imagine — if you cannot name one, the abstraction is
+speculative; keep the feature local and small instead.
+
+## 2. Obey the frame
+
+- **Dependency direction is law**: `app` → `pine` → `indicators` →
+  `engine`; `app` also → `orderbook`/`replay`/`sim`/`feed-*`; `feed-*` →
+  `engine`/`orderbook` only. Feeds never see each other. If your feature
+  needs a reverse edge, the feature is in the wrong crate.
+- **Capabilities, not identities**: downstream behaviour gates on what a
+  component *can do* (`FeedCapabilities`), never on which one it is. Adding
+  a `match` arm on a source/type enum in consumer code means the port is
+  broken — fix the port.
+- **One engine**: chart, backtest and bot consume the same aggregator path.
+  A per-consumer copy of bar logic is never a package, it is a fork.
+
+## 3. Additive by default
+
+- New options default to today's behaviour; the diff to existing files is
+  registration lines, not rewrites.
+- Config *presence* never activates anything — the user (or an explicit
+  hook) turns it on.
+- Everything tunable is named config or a unit-suffixed constant from birth
+  (`_MS`, `_PX`, `_TICKS`) — retrofitting costs a review round.
+- Measure blast radius before opening the PR: files added vs. files
+  edited. Mostly edits → you missed a port or need to carve one; say which
+  in the PR body.
+
+## 4. Performance is part of the port
+
+Declare at design time — not at review — which rate class the package runs
+in (`arch-review` table: per-trade, per-depth, per-frame, rare), and build
+to that budget from the first line:
+
+- **Per-trade / per-depth**: zero allocation, no locks, bounded work per
+  event. If the design needs an allocation per tick, the design is wrong —
+  restructure before writing code.
+- **Per-frame**: recompute only what changed since the last event; cache
+  projections and invalidate on event, never rebuild stable data at 60 Hz.
+  Batch draws into the existing meshes — no per-element draw calls.
+- **Rare (config, startup, panel edits)**: clarity wins freely.
+
+A hot-path package proves its budget before the PR: a bench over a fixture
+or an `APP_HEALTH_SUMMARY` comparison against `main` under a dense tape.
+"It felt smooth" is not evidence. Overflow-prone feed arithmetic saturates,
+never panics.
+
+## 5. Born testable, born drivable
+
+- **Prove the port**: a test with a second (fake) implementation exercises
+  the registration path. One implementer never proves a trait is a port.
+- **Prove the behaviour**: engine-adjacent work is test-first — fixture
+  trades in, expected output out, golden-tested for determinism.
+- **Prove it on screen**: any user-visible surface registers a
+  `QUANTICK_*` hook per `ui-harness` in the same commit, and passes a
+  `visual-qa` + `trader-ux-review` pass before the PR.
+
+## 6. Definition of done for a package
+
+Port named · registration is the only edit to existing behaviour · defaults
+preserve today · capabilities not identities · rate class declared and its
+budget proven (bench or health-summary vs. `main`) · fake second
+implementation tested · golden test if determinism is touchable ·
+ui-harness hook if visible · four checks green · arch-review clean.

--- a/.claude/skills/trader-ux-review/SKILL.md
+++ b/.claude/skills/trader-ux-review/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: trader-ux-review
+description: Review a feature or flow through the eyes of the traders who use quantick — fixed personas, order-flow-specific heuristics, and trader-severity ratings. Answers "can a trader actually operate with this?", not "does it render?" (that is visual-qa). Use for any change a trader touches mid-session — panels, popups, hotkeys, trading actions, chart interactions — or when the user asks for a UX review.
+---
+
+# Trader UX review — the user is watching a live tape, not your feature
+
+A trader's attention is the scarcest resource in this product. Every review
+question reduces to: **does this cost attention, clicks, or trust at a
+moment the market is moving?**
+
+Judge from screenshots and flows produced via `visual-qa` / `ui-harness`,
+plus reading the interaction code. Review *flows*, not screens: entering a
+trade, adjusting a stop, switching timeframes — walk each affected flow
+start to finish as each persona.
+
+## The personas
+
+Review as all three; they disagree, and the disagreements are the findings.
+
+**Rafa — order-flow scalper (WIN, tick/volume bars, seconds matter).**
+Eyes locked on tape + book + bubbles. Decides in under a second, acts by
+hotkey, never by menu. Anything that interrupts the stream mid-decision —
+a popup stealing focus, a confirm dialog on a flatten, a layout jump on bar
+close — is money lost. Judges every control by "can I hit it without
+looking?" and every piece of information by "is it true *now*?".
+
+**Marina — swing/context trader (BTC + índice, multiple timeframes).**
+Works across tabs and split panes; compares, measures, draws. Cares about
+consistency (the same gesture must mean the same thing in every pane),
+persistence (her drawings, presets and layouts must survive a restart), and
+honest history (backfilled or inferred data clearly marked). Tolerates
+menus; does not tolerate relearning.
+
+**Duda — newcomer on paper trading (learning the platform).**
+First week. Doesn't know the hotkeys or the jargon. Needs discoverability
+(can she find the action without the manual?), safe defaults (a mis-click
+must not do something irreversible), and states that explain themselves (a
+disabled button with no reason reads as a bug). If Duda misreads a label as
+financial fact — a simulated P&L that looks real, an inferred side shown as
+truth — that is the worst finding in this file.
+
+## Heuristics (order-flow specific)
+
+- **Interruption budget: zero.** Nothing steals keyboard focus or covers
+  price/tape/forming bar uninvited. Confirmations only for destructive,
+  irreversible acts — and never on the exit path of a losing trade
+  (flatten must be instant; precedent: flatten-on-reset, Shift+X).
+- **Action cost.** Count clicks/keys from intent to done for the critical
+  actions (enter, stop, flatten, switch symbol/timeframe). Critical = 1
+  gesture. Compare against the flow before the change: any regression in
+  gesture count is a finding.
+- **Glance cost.** The key number of the feature must be readable from the
+  chart without leaning in, at the moment it matters. Where does the eye
+  have to travel?
+- **Trust.** Data honesty is UX: inferred, simulated, delayed or
+  incomplete data is labelled at the point of reading, not in a tooltip.
+  Sim results say sim; tape-proven fills say how they filled.
+- **Stability under fire.** Fast tape, bar close, feed reconnect: does the
+  layout hold still? Do controls stay where muscle memory expects them?
+- **Latency is UX.** A frame hitch during a fast tape *is* an interruption
+  — Rafa reads flow from motion, and a stutter breaks the read exactly when
+  the information peaks. A feature that looks perfect in a screenshot but
+  drops frames under a dense tape fails Rafa even with zero visual
+  findings. Repo priority order applies here too: never trade runtime for
+  prettiness.
+- **One language.** Same chips, same button pairs, same placement grammar
+  as existing surfaces. A trader configures once and expects the dialect
+  everywhere.
+
+## Severity — in trader terms
+
+- **Blocker** — can cost money or the moment: focus theft mid-tape, an
+  extra gesture on flatten/stop, simulated or inferred data readable as
+  real, an irreversible act one mis-click away.
+- **Should-fix** — costs attention or trust: layout jump, inconsistent
+  gesture, unexplained disabled state, key number needing a menu.
+- **Consider** — polish that would make a persona faster but blocks no one.
+
+## Output
+
+Per affected flow: the persona walk (what each persona hits, in one or two
+sentences each — only where they diverge), then findings ranked by
+severity, each with the flow, the persona who suffers, the evidence
+(screenshot or `file:line`), and the concrete fix. Close with one line per
+persona: can Rafa trade through it, can Marina keep her workspace, can Duda
+figure it out alone? A clean review says so briefly — never pad.
+
+Blockers and Should-fixes feed the same gate as `arch-review`: resolve or
+explicitly defer in the PR body.

--- a/.claude/skills/ui-harness/SKILL.md
+++ b/.claude/skills/ui-harness/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: ui-harness
+description: How an agent drives and observes the quantick desktop app without a human clicking — env-var hooks to reach every UI surface, the screenshot capture workflow, and the rule that every new surface must register a hook. Use when launching the app for validation, capturing screenshots, adding a new UI surface, or when another skill (visual-qa, trader-ux-review) needs to see the app.
+---
+
+# UI harness — drive the app without a mouse
+
+The contract that makes autonomous visual work possible:
+
+> **Every user-visible surface (panel, layer, tab, popup, demo flow) must be
+> reachable from a fresh launch via environment hooks alone — zero clicks.**
+
+A PR that adds a surface without a hook leaves that surface untestable by
+agents; that is a Should-fix in review. Hooks follow the existing family:
+`QUANTICK_<SURFACE>_AUTOSTART=1` reuses the exact code path of the manual
+toggle — never a parallel activation path — and defaults to off, so a hook
+never changes behaviour for a user who did not set it.
+
+## Hook registry
+
+Verified on `main` (grep `env::var` in `crates/app/src` to re-verify — code
+is the source of truth, this table is the index):
+
+| Hook | Reaches |
+| --- | --- |
+| `QUANTICK_CONFIG=<toml>` | full feed/symbol config override (use a scratchpad toml; **never** edit the user's root `quantick.toml`) |
+| `QUANTICK_DEFAULT_FEED` / `QUANTICK_DEFAULT_SYMBOL` | startup feed/symbol |
+| `QUANTICK_BOOK_AUTOSTART=1` | L2 heatmap layer |
+| `QUANTICK_LIVE_STRIP_AUTOSTART=1` | live strip |
+| `QUANTICK_BUBBLES_AUTOSTART=1` | aggression layer (bubbles + live-column footprint) |
+| `QUANTICK_INDICATORS_AUTOSTART` / `QUANTICK_INDICATOR_SCRIPTS_AUTOSTART` | indicator panes / pine scripts |
+| `QUANTICK_REPLAY_DIR` + `QUANTICK_REPLAY_AUTOSTART=1` + `QUANTICK_REPLAY_SPEED` | recorded session playback (deterministic tape → deterministic screen) |
+| `QUANTICK_BUBBLES=<bubbles.toml>` | bubble preset override without touching tracked config |
+| `QUANTICK_CHART_LAYERS` | chart layer visibility set |
+| `QUANTICK_BACKFILL` / `QUANTICK_BOOK_DEPTH` | history paging / depth size |
+| `QUANTICK_TRADES_DIR` | paper-trading journal location (point at scratch) |
+
+Landing with PR #127 (paper trading v2): `QUANTICK_DOCK_TAB`
+(`l2|bubbles|session|trading|trades`), `QUANTICK_PAPER_REPORT_AUTOSTART=1`,
+`QUANTICK_PAPER_DEMO=1` (scripted deterministic trade sequence). Once merged,
+move them into the table above.
+
+For a screen that represents the user's real setup, enable the trio:
+`QUANTICK_BOOK_AUTOSTART` + `QUANTICK_BUBBLES_AUTOSTART` +
+`QUANTICK_LIVE_STRIP_AUTOSTART`, with a preset from `config/bubbles.toml`
+(never bare defaults).
+
+## Launch and capture workflow
+
+1. **Own target dir**: build with `CARGO_TARGET_DIR=F:\src\quantick-agent-target`
+   so the user's running exe is never locked and rust-analyzer never poisons
+   fingerprints.
+2. **Fresh exe, proven fresh**: `cargo build -p quantick-app` immediately
+   before capturing, then compare the exe `LastWriteTime` against your last
+   edit. `cargo test` green does **not** imply the exe was rebuilt.
+3. **Launch via PowerShell `Start-Process`** with hooks set and
+   `RUST_LOG=quantick=info`, stderr to a log file. A bash background job
+   produces a window whose GL surface never presents (pure-white captures).
+4. **Capture by PID, never by window title**: use
+   `heatmap-design-ref/capture_window.ps1` (PrintWindow with
+   PW_RENDERFULLCONTENT) adapted to filter by the PID you launched — title
+   matching grabs the wrong window when other instances or editors are open.
+5. **Gate on health before trusting a capture**: `APP_HEALTH_SUMMARY` prints
+   every 2 s. `fps≈59 / frame_avg≈16.7` → surface presents, capture is real.
+   `fps≈19 / frame_avg≈52 / frame_cpu≈3` → occluded or idle desktop, capture
+   will be blank; wait for fps ≥ 50 in the log and recapture. Blank capture
+   is an environment state, not a render regression — run a `main` control
+   build before blaming the change.
+6. **Verify by pixel when the eye can be fooled**: read the PNG (e.g.
+   `System.Drawing`) to count/locate marks, match dash signatures, or compare
+   two frames; use `readable_min_radius` from `config/bubbles.toml` as the
+   "too small to read" reference.
+7. **Be a guest on the desktop**: never fight the user — if the window gets
+   minimized or the mouse is active (`GetLastInputInfo` idle ≈ 0), stop
+   driving, keep the evidence you have. Do not inject input with `SendInput`.
+   Never bind a second MT5 listener on the user's port (9100) — use
+   `QUANTICK_CONFIG` with an alternate `listen_addr`. Close every instance
+   you opened when done.
+
+## Adding a new hook
+
+New surface → new `QUANTICK_*` env hook in the same commit: read the var next
+to the existing autostart block in `crates/app/src/app.rs`, call the same
+function the manual toggle calls, default off. Then add one row to the
+registry table above. That row is part of the feature's definition of done.

--- a/.claude/skills/visual-qa/SKILL.md
+++ b/.claude/skills/visual-qa/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: visual-qa
+description: Autonomous visual QA of the quantick desktop app — drive every affected surface via ui-harness hooks, capture screenshots across a state matrix, read the images against an objective defect checklist, and report PASS/FAIL with evidence. Use when a change touches UI, when the user asks "how does it look", or as a goal acceptance criterion for any visual work.
+---
+
+# Visual QA — the agent looks so the human doesn't have to
+
+Purpose: catch visual defects (clipped buttons, overlapping popups,
+unreadable text, lying states) without the user ever opening the app.
+Everything here runs on the `ui-harness` skill — load it first; launch,
+capture and capture-trust rules live there and are not repeated here.
+
+## 1. Scope the pass
+
+From the diff, list every surface the change can affect — not just the one
+it targets. A dock tab edit can move a neighbouring splitter; a new popup
+can cover the tape. When in doubt a surface is in scope.
+
+## 2. State matrix
+
+Capture each in-scope surface in the states that actually break layouts,
+not just the happy path:
+
+| State | Why it breaks things |
+| --- | --- |
+| Default open (BTC dense tape preset) | the baseline the user sees first |
+| Feature active via its hook | the change itself |
+| Popup / menu open **over live data** | occlusion of price, tape, or the working bar |
+| Empty data (no session, no fills, no depth) | placeholder honesty, collapsed layouts |
+| Dense data (fast tape replay, deep book) | overflow, truncation, overlap |
+| Narrow window (~1000 px) and the user's normal size | clipping, wrapped labels, lost buttons |
+| Disabled state (capability absent, e.g. replay = no depth) | is the *why* visible, or just a dead control? |
+
+Prefer replay (`QUANTICK_REPLAY_*`, WINJ26 sessions) for anything that must
+be reproducible: deterministic tape → the same screen twice, so a defect
+found once can be re-captured after the fix. Presets come from
+`config/bubbles.toml` — never bare defaults.
+
+## 3. Read the captures — defect checklist
+
+Look at each image and answer explicitly. "It renders" is not a verdict.
+
+- **Integrity**: any control clipped, overlapping, or pushed off-window?
+  Splitters and neighbouring panes intact?
+- **Readability**: text ≥ the size the app itself calls readable
+  (`readable_min_radius` is the reference for marks); contrast holds on the
+  dark canvas; numbers not truncated (`1234…` on a price is a fail).
+- **Occlusion**: does any popup, tooltip or inspector cover the live price,
+  the tape, or the forming bar? (The repo precedent: the drawing inspector
+  is opaque to the pointer and placed to not cover the action.)
+- **State honesty**: disabled controls explain themselves; inferred or
+  incomplete data is visibly labelled (data-honesty rule); an empty panel
+  says why it is empty.
+- **Motion sanity**: for live surfaces, two captures ~1.2 s apart in the
+  same PowerShell call — did the flow advance without layout jumps? The
+  live region must keep moving (never frozen — see the rejected
+  live-tail-compact precedent).
+- **Consistency**: same chip/button language as the P0 surfaces — one
+  visual system, no new one-off widget style.
+- **Performance is a visual property**: every capture session already logs
+  `APP_HEALTH_SUMMARY` — read it, don't just screenshot past it. Under the
+  dense-data state: fps ≥ ~59 and no `APP_SLOW_FRAMES` bursts attributable
+  to the change. fps ~50s with the feature on and ~59 on a `main` control
+  run (same hooks, same tape) is a **FAIL** of this pass, not an
+  environment note — the checklist for occluded-window false alarms is in
+  `ui-harness`; rule those out first, then blame the change.
+
+Verify by pixel where the eye is unreliable (counting marks, dash
+signatures, colour checks) — the technique is in `ui-harness`.
+
+## 4. Report
+
+One verdict per surface × state, most severe first:
+
+- **FAIL** — defect, with the screenshot path, what is wrong in one
+  sentence, and the crop/coordinates that show it.
+- **PASS** — with the screenshot path that proves it. A PASS without
+  evidence is an unproven claim, treat it as not run.
+- **BLOCKED** — could not observe (desktop idle, no live feed); say what is
+  missing and what was validated by other means (headless frame, pixel
+  test). Never report BLOCKED as PASS.
+
+Fix FAILs, then re-run only the failed cells of the matrix and attach the
+before/after pair. The pass is done when every cell is PASS or has an
+explicitly accepted defect noted for the PR body.


### PR DESCRIPTION
## What

Five project skills that turn `/goal` into an orchestrator: when a goal is set, the session already knows which gates define *done* for that kind of work — no need to spell them out each time.

- **`goal`** (now tracked in the repo — it previously lived only as an untracked local file): classifies the objective and injects standard acceptance criteria — performance declared per touched path, arch-review resolved, visual gates when UI is touched, and "done = PR opened, never merged".
- **`ui-harness`**: the contract that every UI surface must be reachable via `QUANTICK_*` env hooks with zero clicks, plus the registry of existing hooks and the launch/capture workflow (own target dir, capture by PID, health-summary gating).
- **`visual-qa`**: autonomous visual pass — state matrix (popups over live data, empty vs. dense, narrow window, disabled states), objective defect checklist, fps read from `APP_HEALTH_SUMMARY`, PASS/FAIL with screenshot evidence.
- **`trader-ux-review`**: three fixed personas (order-flow scalper, swing trader, paper-trading newcomer) and order-flow heuristics — zero interruption budget, gesture-count regressions, data honesty, latency-is-UX — with trader-terms severities.
- **`new-extension`**: the recipe for additive packages — docking ports table, dependency direction, additive-by-default rules, rate-class performance budgets, and a definition of done.

## Why

Autonomous agents were already driving the app via env hooks ad hoc (heatmap, paper trading validation); this formalizes the pattern so every future surface is born drivable, visually testable and reviewed through a trader's eyes without a human in the loop.

## Verification

- `cargo fmt --all -- --check` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo build --workspace` ✓
- `cargo test --workspace` ✓

Docs-only change: 5 files added, 0 existing files edited. Arch-review: additive by definition (blast radius zero), English-only rule respected, no contradictions with CLAUDE.md — no findings.

Note: `QUANTICK_DOCK_TAB` / `QUANTICK_PAPER_*` hooks are documented as landing with PR #127; the ui-harness registry row moves up once that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)