### PR TITLE
feat(app): three-way canvas layout with focus-follow and per-feed startup defaults

### DIFF
--- a/crates/app/config/feeds.toml
+++ b/crates/app/config/feeds.toml
@@ -23,6 +23,16 @@ default_symbol = "BTCUSDT"
 #                   applied whenever this feed is selected. Leave it out and
 #                   the panel keeps whatever preset is active. An unknown name
 #                   is reported and ignored.
+#   default_layout — optional: the canvas layout a tab on this feed opens
+#                   showing — "flow" (the default), "time" (a full-window
+#                   timeframe chart) or "time+flow" (the split). Startup-only:
+#                   it never overrides a layout chosen from View → Layout.
+#   default_bars  — optional: the bar spec a tab on this feed opens on, as
+#                   "kind:parameter" — time:1m, tick:50, volume:5,
+#                   dollar:500000, imbalance:100. Sets the flow pane's opening
+#                   spec; with a time-showing default_layout and a time spec,
+#                   the timeframe pane opens on that interval too. A spec that
+#                   does not parse is refused at load, like any config error.
 [[feeds]]
 id = "binance"
 name = "Binance"

--- a/crates/app/config/feeds.toml
+++ b/crates/app/config/feeds.toml
@@ -38,6 +38,9 @@ id = "binance"
 name = "Binance"
 provider = "binance"
 symbols = ["BTCUSDT", "ETHUSDT"]
+# The default open: timeframe context beside the flow chart, side by side
+# (user decision 2026-08-06). Remove the key to open on the flow pane alone.
+default_layout = "time+flow"
 
 # Hyperliquid perpetuals, over unauthenticated public REST/WebSocket endpoints.
 # These were the five largest non-delisted markets by 24h notional volume in

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -781,12 +781,7 @@ impl QuantickApp {
         // takes. An env var is an explicit request for this run, so it wins
         // over a feed's declared `default_layout`.
         if let Ok(name) = std::env::var("QUANTICK_LAYOUT") {
-            let layout = match name.trim() {
-                "flow" => Some(CanvasLayout::Single),
-                "time" => Some(CanvasLayout::Time),
-                "time+flow" => Some(CanvasLayout::TimeAndFlow),
-                _ => None,
-            };
+            let layout = crate::config::DeclaredLayout::parse(&name).map(CanvasLayout::from);
             match layout {
                 Some(layout) => app.active_tab_mut().set_layout(layout),
                 None => tracing::warn!(

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -656,6 +656,9 @@ impl QuantickApp {
         app.active_tab_mut().ensure_book_capture(&config);
         // A feed that declares its own look opens wearing it.
         app.active_tab_mut().apply_feed_bubble_preset(&config);
+        // Same for a declared opening layout: a feed the user reads by
+        // timeframe can open straight on the timeframe chart.
+        app.active_tab_mut().apply_feed_declared_layout(&config);
         // The map itself stays hidden until asked for — a layer nobody
         // requested must cost no projection. Capture is already running either
         // way, so this is a display choice and nothing else.
@@ -773,6 +776,28 @@ impl QuantickApp {
         // path, so a scripted run can show it.
         if std::env::var("QUANTICK_PAPER_REPORT_AUTOSTART").is_ok_and(|value| value == "1") {
             app.active_tab_mut().paper.autostart_report();
+        }
+        // Open on a named canvas layout, through the same path the View menu
+        // takes. An env var is an explicit request for this run, so it wins
+        // over a feed's declared `default_layout`.
+        if let Ok(name) = std::env::var("QUANTICK_LAYOUT") {
+            let layout = match name.trim() {
+                "flow" => Some(CanvasLayout::Single),
+                "time" => Some(CanvasLayout::Time),
+                "time+flow" => Some(CanvasLayout::TimeAndFlow),
+                _ => None,
+            };
+            match layout {
+                Some(layout) => app.active_tab_mut().set_layout(layout),
+                None => tracing::warn!(
+                    target: "quantick::app",
+                    schema_version = 1_u8,
+                    event_code = "LAYOUT_AUTOSTART_UNKNOWN",
+                    layout = %name,
+                    action = "layout_left_as_is",
+                    "QUANTICK_LAYOUT names no canvas layout (flow, time, time+flow)"
+                ),
+            }
         }
         // An env var is not a user edit: what the autostart hooks switched on
         // must not be written back as though the user had asked for it every
@@ -899,7 +924,10 @@ impl QuantickApp {
     ///
     /// The bar spec is inherited from the tab you were on: opening a second
     /// market to compare it against the first is the reason to do this, and
-    /// landing on a different aggregation would defeat that.
+    /// landing on a different aggregation would defeat that. A feed that
+    /// declares its own `default_bars`/`default_layout` overrides the
+    /// inheritance — the declaration exists because that market reads
+    /// differently, which is exactly when inheriting would mislead.
     fn adopt_tab(&mut self, feed_id: String, symbol: String, feed: FeedHandle) {
         let id = self.next_tab_id;
         self.next_tab_id += 1;
@@ -914,7 +942,10 @@ impl QuantickApp {
             action = "activate_new_tab",
             "opening a market in a new tab"
         );
-        let spec = self.active_tab().flow_pane.state.spec().clone();
+        let spec = self
+            .config
+            .startup_spec_for(&feed_id)
+            .unwrap_or_else(|| self.active_tab().flow_pane.state.spec().clone());
         let trades_dir = self.trades_dir.clone();
         self.tabs.push(Tab::new(
             id,
@@ -930,6 +961,7 @@ impl QuantickApp {
         self.active_tab_mut().refresh_chip_label(&config);
         self.active_tab_mut().ensure_book_capture(&config);
         self.active_tab_mut().apply_feed_bubble_preset(&config);
+        self.active_tab_mut().apply_feed_declared_layout(&config);
         // The new tab opens on the layers the user left showing, over the
         // preset it just put on: opening a second market is not a request to
         // bring back the chrome they switched off.
@@ -1075,10 +1107,19 @@ impl QuantickApp {
             .collect();
         let dock_visible = self.dock.visible();
         let show_style = self.show_style;
-        // The SOURCE and BARS groups write straight into the active tab: a
-        // feed or symbol change is that tab's market switch, and the bar spec
-        // is its flow pane's.
+        // The SOURCE group writes straight into the active tab: a feed or
+        // symbol change is that tab's market switch. The BARS group writes
+        // into the *focused pane* — the pane the status bar reads and every
+        // indicator command lands on (§11) — so the three chrome surfaces
+        // can never disagree about which chart a command describes, and in
+        // the Time layout the group governs the chart actually on screen.
         let tab = self.active_tab_mut();
+        let focused = tab.focused_side();
+        let live_strip_on = tab.flow_pane.live_strip_visible;
+        let pane = match focused {
+            PaneSide::Time => tab.time_pane.as_mut().unwrap_or(&mut tab.flow_pane),
+            PaneSide::Flow => &mut tab.flow_pane,
+        };
         let mut model = toolbar::ToolbarModel {
             feeds,
             feed_id: &mut tab.feed_id,
@@ -1086,18 +1127,18 @@ impl QuantickApp {
             symbols,
             symbol: &mut tab.symbol,
             replay,
-            kind: &mut tab.flow_pane.kind,
-            tick_n: &mut tab.flow_pane.tick_n,
-            volume_units: &mut tab.flow_pane.volume_units,
-            dollar_notional: &mut tab.flow_pane.dollar_notional,
-            time_interval_ms: &mut tab.flow_pane.time_interval_ms,
-            imbalance_target: &mut tab.flow_pane.imbalance_target,
+            kind: &mut pane.kind,
+            tick_n: &mut pane.tick_n,
+            volume_units: &mut pane.volume_units,
+            dollar_notional: &mut pane.dollar_notional,
+            time_interval_ms: &mut pane.time_interval_ms,
+            imbalance_target: &mut pane.imbalance_target,
             history_step: &mut tab.history_step,
             history_trades: tab.history_trades,
             capabilities,
             heatmap_on,
             bubbles_on,
-            live_strip_on: tab.flow_pane.live_strip_visible,
+            live_strip_on,
             dock_visible,
             appearance_open: show_style,
             paper: toolbar::PaperTradeModel {
@@ -2164,21 +2205,6 @@ impl QuantickApp {
                             ui.close_menu();
                         }
                         ui.separator();
-                        ui.menu_button("Layout", |ui| {
-                            for (layout, label) in [
-                                (CanvasLayout::Single, "Single"),
-                                (CanvasLayout::TimeAndFlow, "Time + Flow"),
-                            ] {
-                                if ui
-                                    .selectable_label(self.active_tab().layout == layout, label)
-                                    .clicked()
-                                {
-                                    self.active_tab_mut().set_layout(layout);
-                                    ui.close_menu();
-                                }
-                            }
-                        });
-                        ui.separator();
                         if ui
                             .add(
                                 egui::Button::new("Market Replay…")
@@ -2202,6 +2228,26 @@ impl QuantickApp {
                         }
                     });
                     ui.menu_button("View", |ui| {
+                        // What the canvas shows is a view concern, so the
+                        // switch lives here rather than under File, and each
+                        // entry names the charts it shows — "Timeframe", not
+                        // layout jargon (audit §3).
+                        ui.menu_button("Layout", |ui| {
+                            for (layout, label) in [
+                                (CanvasLayout::Single, "Flow"),
+                                (CanvasLayout::Time, "Timeframe"),
+                                (CanvasLayout::TimeAndFlow, "Timeframe + Flow"),
+                            ] {
+                                if ui
+                                    .selectable_label(self.active_tab().layout == layout, label)
+                                    .clicked()
+                                {
+                                    self.active_tab_mut().set_layout(layout);
+                                    ui.close_menu();
+                                }
+                            }
+                        });
+                        ui.separator();
                         let panels_label = if self.dock.visible() {
                             "Hide panels"
                         } else {
@@ -4144,6 +4190,8 @@ mod tests {
                 provider: ProviderKind::Binance,
                 symbols: vec!["TESTUSDT".to_string(), "ETHUSDT".to_string()],
                 bubble_preset: None,
+                default_layout: None,
+                default_bars: None,
             }],
             metatrader: Default::default(),
             paper: Default::default(),
@@ -7407,6 +7455,8 @@ plot(close)
                     provider: ProviderKind::Binance,
                     symbols: vec!["AAA".to_string()],
                     bubble_preset: None,
+                    default_layout: None,
+                    default_bars: None,
                 },
                 FeedConfig {
                     id: "b".to_string(),
@@ -7414,6 +7464,8 @@ plot(close)
                     provider: ProviderKind::Binance,
                     symbols: vec!["BBB".to_string()],
                     bubble_preset: None,
+                    default_layout: None,
+                    default_bars: None,
                 },
             ],
             metatrader: Default::default(),
@@ -7518,6 +7570,8 @@ plot(close)
             provider: ProviderKind::MetaTrader,
             symbols: vec!["WINQ26".to_string()],
             bubble_preset: Some("live lane pie".to_string()),
+            default_layout: None,
+            default_bars: None,
         });
         let mut app = app_on(config, "binance", "TESTUSDT");
         let opened_with = app.active_tab().tape().active_preset_for_test().to_string();
@@ -8230,6 +8284,211 @@ plot(close)
             app.active_tab().flow_pane.state.spec(),
             &flow_spec,
             "and must leave the chart beside it alone"
+        );
+    }
+
+    /// The Time layout is the timeframe chart alone: built and seeded like
+    /// the split's pane, full window (no divider), header included, and the
+    /// chrome speaks for it.
+    #[test]
+    fn the_time_layout_shows_the_timeframe_chart_alone() {
+        let ctx = egui::Context::default();
+        let (mut app, _commands) = app_with_history(200);
+        run_frame(&mut app, &ctx);
+        app.active_tab_mut().set_layout(CanvasLayout::Time);
+        run_frame(&mut app, &ctx);
+        run_frame(&mut app, &ctx);
+
+        let tab = app.active_tab();
+        let time = tab.time_pane.as_ref().expect("the pane was built");
+        assert_eq!(
+            time.state.trades().len(),
+            200,
+            "and seeded, so it opens showing the market"
+        );
+        assert_eq!(
+            tab.focused_side(),
+            PaneSide::Time,
+            "the chrome speaks for the one visible chart"
+        );
+        assert!(
+            tab.canvas_divider_rect().is_none(),
+            "one pane, no divider to drag"
+        );
+        let chip = tab.time_header_chip(0).expect("chips recorded");
+        assert!(
+            chip.is_positive(),
+            "the header still offers its timeframes at full width"
+        );
+    }
+
+    /// Switching layouts focuses the pane the switch reveals, so the first
+    /// command after a switch already lands on the chart that just appeared
+    /// (audit: opening the split did not focus the pane it created).
+    #[test]
+    fn switching_layouts_focuses_the_pane_the_switch_reveals() {
+        let ctx = egui::Context::default();
+        let (mut app, _commands) = app_with_history(50);
+        run_frame(&mut app, &ctx);
+
+        app.active_tab_mut().set_layout(CanvasLayout::TimeAndFlow);
+        run_frame(&mut app, &ctx);
+        run_frame(&mut app, &ctx);
+        assert_eq!(
+            app.active_tab().focused_side(),
+            PaneSide::Time,
+            "coming from Single, the split reveals the time pane"
+        );
+
+        app.active_tab_mut().set_layout(CanvasLayout::Single);
+        assert_eq!(app.active_tab().focused_side(), PaneSide::Flow);
+
+        app.active_tab_mut().set_layout(CanvasLayout::Time);
+        assert_eq!(app.active_tab().focused_side(), PaneSide::Time);
+
+        app.active_tab_mut().set_layout(CanvasLayout::TimeAndFlow);
+        assert_eq!(
+            app.active_tab().focused_side(),
+            PaneSide::Flow,
+            "coming from Time, the split reveals the flow pane"
+        );
+    }
+
+    /// The BARS group edits the focused pane — the same pane the status bar
+    /// reads and indicator commands land on. In the Time layout that is the
+    /// timeframe chart on screen; the hidden flow pane is untouched.
+    #[test]
+    fn the_bars_selectors_govern_the_focused_pane() {
+        let ctx = egui::Context::default();
+        let (mut app, _commands) = app_with_history(200);
+        run_frame(&mut app, &ctx);
+        app.active_tab_mut().set_layout(CanvasLayout::Time);
+        run_frame(&mut app, &ctx);
+        run_frame(&mut app, &ctx);
+        let flow_spec = app.active_tab().flow_pane.state.spec().clone();
+
+        // The exact selector fields the toolbar's BARS group borrows for the
+        // focused pane, written through the same deferred-spec path.
+        let pane = app.active_tab_mut().focused_pane_mut();
+        pane.kind = crate::state::BarKind::Time;
+        pane.time_interval_ms = 300_000;
+        app.active_tab_mut().apply_spec_changes();
+        app.active_tab_mut().apply_spec_changes();
+
+        assert_eq!(
+            app.active_tab()
+                .time_pane
+                .as_ref()
+                .expect("time pane")
+                .state
+                .spec(),
+            &BarSpec::Time(300_000),
+            "the change lands on the chart on screen"
+        );
+        assert_eq!(
+            app.active_tab().flow_pane.state.spec(),
+            &flow_spec,
+            "and not on the hidden one"
+        );
+    }
+
+    /// A feed declaring `default_layout` and `default_bars` opens wearing
+    /// them: the declared canvas, the declared spec on the flow pane, the
+    /// declared interval on the timeframe pane — and the venue asked for the
+    /// candle history the pane needs.
+    #[test]
+    fn a_feed_declaring_layout_and_bars_opens_wearing_them() {
+        let ctx = egui::Context::default();
+        let (_evt_tx, evt_rx) = mpsc::channel(64);
+        let (_book_tx, book_rx) = mpsc::channel(64);
+        let (cmd_tx, mut cmd_rx) = mpsc::channel(16);
+        let mut config = test_config();
+        config.feeds[0].default_layout = Some(crate::config::DeclaredLayout::Time);
+        config.feeds[0].default_bars = Some("time:5m".to_string());
+        // The declared spec reaches Tab::new the same way main.rs resolves it.
+        let spec = config.startup_spec_for("binance").expect("declared spec");
+        let mut app = QuantickApp::new(
+            config,
+            "binance",
+            "TESTUSDT",
+            spec,
+            FeedHandle {
+                events: evt_rx,
+                book_events: book_rx,
+                notices: feed::silent_notices(),
+                capabilities: feed::fixed_capabilities(FeedCapabilities {
+                    book_capture: false,
+                    history_paging: true,
+                    traded_volume: true,
+                    ohlcv_history: true,
+                    ohlcv_generation: 0,
+                }),
+                commands: cmd_tx,
+                replay: None,
+            },
+        );
+
+        assert_eq!(app.active_tab().layout, CanvasLayout::Time);
+        assert_eq!(
+            app.active_tab().flow_pane.state.spec(),
+            &BarSpec::Time(300_000),
+            "the flow pane opened on the declared spec"
+        );
+        run_frame(&mut app, &ctx);
+        run_frame(&mut app, &ctx);
+        assert_eq!(
+            app.active_tab()
+                .time_pane
+                .as_ref()
+                .expect("built the frame after startup")
+                .state
+                .spec(),
+            &BarSpec::Time(300_000),
+            "the timeframe pane opens on the declared interval too"
+        );
+        assert_eq!(app.active_tab().focused_side(), PaneSide::Time);
+        assert_eq!(
+            drain_ohlcv_requests(&mut cmd_rx),
+            1,
+            "the timeframe chart asked the venue for its history"
+        );
+    }
+
+    /// A new tab on a feed that declares its own defaults takes them; one on
+    /// a feed that declares nothing keeps inheriting from the tab you were on.
+    #[test]
+    fn a_new_tab_takes_the_feeds_declared_defaults_over_inheritance() {
+        let mut config = test_config();
+        config.feeds.push(FeedConfig {
+            id: "mt".to_string(),
+            name: "MetaTrader 5".to_string(),
+            provider: ProviderKind::MetaTrader,
+            symbols: vec!["WINQ26".to_string()],
+            bubble_preset: None,
+            default_layout: Some(crate::config::DeclaredLayout::TimeAndFlow),
+            default_bars: Some("tick:7".to_string()),
+        });
+        let mut app = app_on(config, "binance", "TESTUSDT");
+        assert_eq!(app.active_tab().layout, CanvasLayout::Single);
+
+        app.adopt_tab("mt".to_string(), "WINQ26".to_string(), stub_feed().0);
+        assert_eq!(
+            app.active_tab().flow_pane.state.spec(),
+            &BarSpec::Tick(7),
+            "the declaration wins over the inherited spec"
+        );
+        assert_eq!(app.active_tab().layout, CanvasLayout::TimeAndFlow);
+
+        app.adopt_tab("binance".to_string(), "ETHUSDT".to_string(), stub_feed().0);
+        assert_eq!(
+            app.active_tab().flow_pane.state.spec(),
+            &BarSpec::Tick(7),
+            "a feed declaring nothing still inherits from the tab you were on"
+        );
+        assert_eq!(
+            app.active_tab().layout,
+            CanvasLayout::Single,
+            "and opens on the factory canvas"
         );
     }
 
@@ -9836,6 +10095,8 @@ plot(close)
                     provider: ProviderKind::MetaTrader,
                     symbols: vec!["US500".to_string()],
                     bubble_preset: None,
+                    default_layout: None,
+                    default_bars: None,
                 },
                 FeedConfig {
                     id: "b3".to_string(),
@@ -9843,6 +10104,8 @@ plot(close)
                     provider: ProviderKind::MetaTrader,
                     symbols: vec!["WIN$N".to_string()],
                     bubble_preset: None,
+                    default_layout: None,
+                    default_bars: None,
                 },
             ],
             metatrader: crate::config::MetaTraderSettings {

--- a/crates/app/src/config.rs
+++ b/crates/app/src/config.rs
@@ -412,6 +412,23 @@ pub enum DeclaredLayout {
     TimeAndFlow,
 }
 
+impl DeclaredLayout {
+    /// Parse the same names the serde renames above accept, for callers
+    /// outside serde (the `QUANTICK_LAYOUT` env hook). One vocabulary, one
+    /// place: a name added here must be added to the renames, and the
+    /// `layout_names_agree_between_serde_and_parse` test holds the two
+    /// together.
+    #[must_use]
+    pub fn parse(text: &str) -> Option<Self> {
+        match text.trim() {
+            "flow" => Some(DeclaredLayout::Flow),
+            "time" => Some(DeclaredLayout::Time),
+            "time+flow" => Some(DeclaredLayout::TimeAndFlow),
+            _ => None,
+        }
+    }
+}
+
 /// One selectable feed: a named backend and the symbols it offers.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 pub struct FeedConfig {
@@ -1959,6 +1976,29 @@ mod tests {
         let (undeclared, _) = sample();
         assert_eq!(undeclared.feeds[0].default_layout, None);
         assert_eq!(undeclared.startup_spec_for("binance"), None);
+    }
+
+    /// The TOML names and [`DeclaredLayout::parse`] are one vocabulary: what
+    /// a config file may say, the `QUANTICK_LAYOUT` hook accepts, and
+    /// nothing else on either side.
+    #[test]
+    fn layout_names_agree_between_serde_and_parse() {
+        for (name, expected) in [
+            ("flow", DeclaredLayout::Flow),
+            ("time", DeclaredLayout::Time),
+            ("time+flow", DeclaredLayout::TimeAndFlow),
+        ] {
+            assert_eq!(DeclaredLayout::parse(name), Some(expected), "{name}");
+            let toml = format!("layout = \"{name}\"");
+            #[derive(Deserialize)]
+            struct Probe {
+                layout: DeclaredLayout,
+            }
+            let probe: Probe = toml::from_str(&toml).expect(name);
+            assert_eq!(probe.layout, expected, "{name}");
+        }
+        assert_eq!(DeclaredLayout::parse("grid"), None);
+        assert_eq!(DeclaredLayout::parse(" time "), Some(DeclaredLayout::Time));
     }
 
     /// A `default_bars` no control could produce is refused at load, naming

--- a/crates/app/src/config.rs
+++ b/crates/app/src/config.rs
@@ -393,6 +393,25 @@ impl MetaTraderSettings {
     }
 }
 
+/// The canvas layout a feed declares its tabs open on (`default_layout` in
+/// the TOML), named for what each layout shows.
+///
+/// A config-side twin of `crate::tab::CanvasLayout` rather than that enum
+/// itself, so the TOML vocabulary — part of the user-facing config contract —
+/// cannot drift when the canvas grows a layout a config should not name.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+pub enum DeclaredLayout {
+    /// The flow pane alone — the factory default.
+    #[serde(rename = "flow")]
+    Flow,
+    /// A full-window timeframe chart.
+    #[serde(rename = "time")]
+    Time,
+    /// Timeframe left, flow right, on the draggable divider.
+    #[serde(rename = "time+flow")]
+    TimeAndFlow,
+}
+
 /// One selectable feed: a named backend and the symbols it offers.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 pub struct FeedConfig {
@@ -415,6 +434,23 @@ pub struct FeedConfig {
     /// and ignored rather than silently altering the panel.
     #[serde(default)]
     pub bubble_preset: Option<String>,
+    /// The canvas layout a tab on this feed opens showing.
+    ///
+    /// Startup-scoped, like `default_feed`: it decides what a *new* tab looks
+    /// like and never overrides a layout the user has since chosen. Absent,
+    /// nothing changes — the factory default stays the flow pane, quantick's
+    /// identity (UX audit §3).
+    #[serde(default)]
+    pub default_layout: Option<DeclaredLayout>,
+    /// The bar spec a tab on this feed opens on, as `kind:parameter` —
+    /// `time:1m`, `tick:50`, `volume:5`, `dollar:500000`, `imbalance:100`
+    /// (see `crate::state::BarSpec::parse`). It sets the flow pane's opening
+    /// spec; when [`default_layout`](Self::default_layout) shows a time pane
+    /// and this names a time spec, that pane opens on its interval too.
+    /// Absent, the factory default spec applies, exactly as before the field
+    /// existed.
+    #[serde(default)]
+    pub default_bars: Option<String>,
 }
 
 /// Paper-trading options (`[paper]` in the TOML).
@@ -575,6 +611,33 @@ impl AppConfig {
         self.feed(id).map(|f| f.provider)
     }
 
+    /// The bar spec feed `id` declares its tabs open on, if it declares one.
+    ///
+    /// `validate` already proved the string parses, so `None` normally means
+    /// "nothing declared". A spec that stopped parsing anyway (a config
+    /// mutated in a test, say) is reported and treated as undeclared rather
+    /// than trusted half-way.
+    #[must_use]
+    pub fn startup_spec_for(&self, id: &str) -> Option<crate::state::BarSpec> {
+        let bars = self.feed(id)?.default_bars.as_deref()?;
+        match crate::state::BarSpec::parse(bars) {
+            Ok(spec) => Some(spec),
+            Err(message) => {
+                tracing::warn!(
+                    target: "quantick::app",
+                    schema_version = 1_u8,
+                    event_code = "DEFAULT_BARS_INVALID",
+                    feed = %id,
+                    spec = %bars,
+                    reason = %message,
+                    action = "open_factory_default_spec",
+                    "feed declares a default_bars that does not parse; ignoring"
+                );
+                None
+            }
+        }
+    }
+
     /// Data-honesty label for how feed `id` decides the aggressor side of a
     /// trade, or `None` when the venue reports true sides. Shown verbatim on
     /// the status bar; this sits next to the provider → code-path map because
@@ -683,6 +746,15 @@ impl AppConfig {
                 .is_some_and(|name| name.trim().is_empty())
             {
                 return Err(format!("feed '{}' names an empty bubble_preset", feed.id));
+            }
+            // The same live-control rules apply to a declared opening spec: a
+            // config must not open a chart no control could have produced,
+            // and the only symptom of a typo here would be a silently
+            // factory-default chart.
+            if let Some(bars) = &feed.default_bars {
+                crate::state::BarSpec::parse(bars).map_err(|message| {
+                    format!("feed '{}' has an invalid default_bars: {message}", feed.id)
+                })?;
             }
         }
         // Needs the catalog, so it waits until the catalog is known good.
@@ -1851,6 +1923,79 @@ mod tests {
             name = "X"
             provider = "kraken"
             symbols = ["Y"]
+        "#;
+        let err = parse(text, ConfigSource::Embedded, &AddedSymbols::default()).unwrap_err();
+        assert!(matches!(err, ConfigError::Parse { .. }), "{err}");
+    }
+
+    /// The declared opening layout and bar spec are read from the feed entry,
+    /// in the same vocabulary the View menu and the BARS group speak.
+    #[test]
+    fn declared_layout_and_bars_are_read_and_resolved() {
+        let text = r#"
+            default_feed = "b"
+            default_symbol = "AAA"
+            [[feeds]]
+            id = "b"
+            name = "B"
+            provider = "binance"
+            symbols = ["AAA"]
+            default_layout = "time+flow"
+            default_bars = "time:5m"
+        "#;
+        let config = parse(text, ConfigSource::Embedded, &AddedSymbols::default()).unwrap();
+        assert_eq!(
+            config.feeds[0].default_layout,
+            Some(DeclaredLayout::TimeAndFlow)
+        );
+        assert_eq!(
+            config.startup_spec_for("b"),
+            Some(crate::state::BarSpec::Time(300_000))
+        );
+        assert_eq!(config.startup_spec_for("nope"), None);
+
+        // Absent, both fields change nothing — the factory defaults stand,
+        // exactly as before the fields existed.
+        let (undeclared, _) = sample();
+        assert_eq!(undeclared.feeds[0].default_layout, None);
+        assert_eq!(undeclared.startup_spec_for("binance"), None);
+    }
+
+    /// A `default_bars` no control could produce is refused at load, naming
+    /// the feed — its only runtime symptom would be a silently
+    /// factory-default chart.
+    #[test]
+    fn an_invalid_default_bars_is_refused_at_load() {
+        for bad in ["time:0", "tick:0", "bananas:9", "time:25h", "50"] {
+            let text = format!(
+                r#"
+                default_feed = "b"
+                default_symbol = "AAA"
+                [[feeds]]
+                id = "b"
+                name = "B"
+                provider = "binance"
+                symbols = ["AAA"]
+                default_bars = "{bad}"
+            "#
+            );
+            let err =
+                parse(&text, ConfigSource::Embedded, &AddedSymbols::default()).expect_err(bad);
+            let message = err.to_string();
+            assert!(message.contains("default_bars"), "{message}");
+            assert!(message.contains("'b'"), "the feed is named: {message}");
+        }
+
+        // An unknown layout name is a parse error, like an unknown provider.
+        let text = r#"
+            default_feed = "b"
+            default_symbol = "AAA"
+            [[feeds]]
+            id = "b"
+            name = "B"
+            provider = "binance"
+            symbols = ["AAA"]
+            default_layout = "grid"
         "#;
         let err = parse(text, ConfigSource::Embedded, &AddedSymbols::default()).unwrap_err();
         assert!(matches!(err, ConfigError::Parse { .. }), "{err}");

--- a/crates/app/src/config.rs
+++ b/crates/app/src/config.rs
@@ -1401,6 +1401,14 @@ mod tests {
         assert_eq!(b3.bubble_preset.as_deref(), Some("live lane pie"));
         assert_eq!(tickmill.bubble_preset.as_deref(), Some("live lane pie"));
         assert_eq!(binance.bubble_preset, None);
+
+        // The default open is the split: timeframe context beside the flow
+        // chart (user decision 2026-08-06). The other feeds declare nothing
+        // and open on the factory flow pane.
+        assert_eq!(binance.default_layout, Some(DeclaredLayout::TimeAndFlow));
+        assert_eq!(hyperliquid.default_layout, None);
+        assert_eq!(tickmill.default_layout, None);
+        assert_eq!(b3.default_layout, None);
     }
 
     #[test]

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -136,6 +136,12 @@ fn main() -> eframe::Result {
         "starting quantick"
     );
 
+    // The bar type the chart opens on: the feed's declared `default_bars`
+    // when it names one, the factory tick spec otherwise.
+    let spec = config
+        .startup_spec_for(&feed_id)
+        .unwrap_or(BarSpec::Tick(INITIAL_TICK_SIZE));
+
     let feed = feed::spawn_live(provider, &symbol, &config);
 
     let icon = eframe::icon_data::from_png_bytes(include_bytes!("../assets/icon.png"))
@@ -165,11 +171,7 @@ fn main() -> eframe::Result {
             cc.egui_ctx.set_fonts(fonts);
             theme::apply(&cc.egui_ctx);
             Ok(Box::new(app::QuantickApp::new(
-                config,
-                feed_id,
-                symbol,
-                BarSpec::Tick(INITIAL_TICK_SIZE),
-                feed,
+                config, feed_id, symbol, spec, feed,
             )))
         }),
     )

--- a/crates/app/src/state.rs
+++ b/crates/app/src/state.rs
@@ -148,6 +148,88 @@ impl BarSpec {
             BarSpec::Imbalance(target) => format!("imbalance({target})"),
         }
     }
+
+    /// Parse a `kind:parameter` spec string, the form `default_bars` uses in
+    /// the feeds configuration: `tick:50`, `volume:5`, `dollar:500000`,
+    /// `imbalance:100`, `time:1m` (also `time:30s`, `time:1h`, `time:1500ms`
+    /// or a bare millisecond count).
+    ///
+    /// Every rule a UI control enforces holds here too — a positive
+    /// parameter, and a time interval inside
+    /// [`MIN_TIME_INTERVAL_MS`]..=[`MAX_TIME_INTERVAL_MS`] — so a config
+    /// cannot open a chart no control could have produced.
+    ///
+    /// # Errors
+    ///
+    /// Returns a human-readable message naming what is wrong, for the config
+    /// loader to surface verbatim.
+    pub fn parse(text: &str) -> Result<Self, String> {
+        let (kind, param) = text
+            .split_once(':')
+            .ok_or_else(|| format!("'{text}' is not a kind:parameter bar spec, like 'time:1m'"))?;
+        let (kind, param) = (kind.trim(), param.trim());
+        let positive_count = |what: &str| -> Result<u64, String> {
+            match param.parse::<u64>() {
+                Ok(n) if n > 0 => Ok(n),
+                _ => Err(format!(
+                    "{what} bars need a positive whole number, got '{param}'"
+                )),
+            }
+        };
+        let positive_decimal = |what: &str| -> Result<Decimal, String> {
+            match param.parse::<Decimal>() {
+                Ok(d) if d > Decimal::ZERO => Ok(d),
+                _ => Err(format!("{what} bars need a positive number, got '{param}'")),
+            }
+        };
+        match kind {
+            "tick" => Ok(BarSpec::Tick(positive_count("tick")?)),
+            "imbalance" => Ok(BarSpec::Imbalance(positive_count("imbalance")?)),
+            "volume" => Ok(BarSpec::Volume(positive_decimal("volume")?)),
+            "dollar" => Ok(BarSpec::Dollar(positive_decimal("dollar")?)),
+            "time" => {
+                let ms = parse_time_interval(param)?;
+                if !(MIN_TIME_INTERVAL_MS..=MAX_TIME_INTERVAL_MS).contains(&ms) {
+                    return Err(format!(
+                        "time interval '{param}' is outside {}..={} — the domain both \
+                         time-bar controls accept",
+                        fmt_time_interval(MIN_TIME_INTERVAL_MS),
+                        fmt_time_interval(MAX_TIME_INTERVAL_MS),
+                    ));
+                }
+                Ok(BarSpec::Time(ms))
+            }
+            _ => Err(format!(
+                "unknown bar kind '{kind}'; one of tick, volume, dollar, time, imbalance"
+            )),
+        }
+    }
+}
+
+/// Parse a time interval in the same vocabulary [`fmt_time_interval`] emits:
+/// `1h`, `5m`, `90s`, `1500ms`, or a bare millisecond count. The round trip is
+/// deliberate — whatever the status bar can say, a config can ask for.
+fn parse_time_interval(text: &str) -> Result<i64, String> {
+    let parse_scaled = |digits: &str, scale: i64| -> Result<i64, String> {
+        digits
+            .parse::<i64>()
+            .ok()
+            .and_then(|n| n.checked_mul(scale))
+            .filter(|ms| *ms > 0)
+            .ok_or_else(|| format!("'{text}' is not a time interval, like '1m' or '30s'"))
+    };
+    // `ms` before `m` and `s`: the longest suffix owns the string.
+    if let Some(digits) = text.strip_suffix("ms") {
+        parse_scaled(digits, 1)
+    } else if let Some(digits) = text.strip_suffix('h') {
+        parse_scaled(digits, 3_600_000)
+    } else if let Some(digits) = text.strip_suffix('m') {
+        parse_scaled(digits, 60_000)
+    } else if let Some(digits) = text.strip_suffix('s') {
+        parse_scaled(digits, 1_000)
+    } else {
+        parse_scaled(text, 1)
+    }
 }
 
 /// A time-bar interval for humans: `1m`, `5m`, `1h` for round units, `90s`
@@ -423,6 +505,74 @@ mod tests {
 
     fn dec(s: &str) -> Decimal {
         Decimal::from_str(s).unwrap()
+    }
+
+    /// `default_bars` speaks the same vocabulary the UI does — every kind,
+    /// every interval suffix, padding tolerated.
+    #[test]
+    fn bar_specs_parse_in_the_config_vocabulary() {
+        assert_eq!(BarSpec::parse("tick:50"), Ok(BarSpec::Tick(50)));
+        assert_eq!(BarSpec::parse("imbalance:100"), Ok(BarSpec::Imbalance(100)));
+        assert_eq!(BarSpec::parse("volume:5"), Ok(BarSpec::Volume(dec("5"))));
+        assert_eq!(
+            BarSpec::parse("volume:0.5"),
+            Ok(BarSpec::Volume(dec("0.5")))
+        );
+        assert_eq!(
+            BarSpec::parse("dollar:500000"),
+            Ok(BarSpec::Dollar(dec("500000")))
+        );
+        assert_eq!(BarSpec::parse("time:1m"), Ok(BarSpec::Time(60_000)));
+        assert_eq!(BarSpec::parse("time:90s"), Ok(BarSpec::Time(90_000)));
+        assert_eq!(BarSpec::parse("time:1h"), Ok(BarSpec::Time(3_600_000)));
+        assert_eq!(BarSpec::parse("time:1500ms"), Ok(BarSpec::Time(1_500)));
+        assert_eq!(BarSpec::parse("time:60000"), Ok(BarSpec::Time(60_000)));
+        assert_eq!(BarSpec::parse(" time : 5m "), Ok(BarSpec::Time(300_000)));
+    }
+
+    /// Whatever the status bar can say, a config can ask for: the interval
+    /// formatter and the parser are inverses over the whole domain shape.
+    #[test]
+    fn time_interval_labels_round_trip_through_the_parser() {
+        for ms in [
+            MIN_TIME_INTERVAL_MS,
+            1_500,
+            60_000,
+            300_000,
+            3_600_000,
+            MAX_TIME_INTERVAL_MS,
+        ] {
+            let label = fmt_time_interval(ms);
+            assert_eq!(
+                BarSpec::parse(&format!("time:{label}")),
+                Ok(BarSpec::Time(ms)),
+                "{label}"
+            );
+        }
+    }
+
+    /// A spec no live control could produce must not come in through the
+    /// config either — its only symptom would be a chart nobody asked for.
+    #[test]
+    fn a_spec_no_control_could_produce_does_not_parse() {
+        for bad in [
+            "",
+            "tick",
+            "tick:",
+            "tick:0",
+            "tick:-5",
+            "volume:0",
+            "dollar:nope",
+            "imbalance:1.5",
+            "time:0",
+            "time:50ms",
+            "time:25h",
+            "time:1w",
+            "grid:1",
+        ] {
+            let error = BarSpec::parse(bad).expect_err(bad);
+            assert!(!error.is_empty(), "{bad} must explain itself");
+        }
     }
 
     fn trade(agg_id: u64) -> Trade {

--- a/crates/app/src/tab.rs
+++ b/crates/app/src/tab.rs
@@ -44,14 +44,42 @@ const BOOK_DRAIN_BUDGET: usize = 2_048;
 /// pane's top edge, never a box drawn around market data).
 const FOCUS_RULE_PX: f32 = 1.0;
 
-/// How many charts a tab's canvas shows for its market (§11).
+/// How many charts a tab's canvas shows for its market (§11), and which.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum CanvasLayout {
     /// The flow pane alone — quantick's default and its identity.
     #[default]
     Single,
+    /// The time pane alone: a full-window timeframe chart, header included,
+    /// with no split. The flow pane keeps being fed off screen, exactly as
+    /// the time pane does while Single is showing.
+    Time,
     /// Time pane left, flow pane right, on a draggable divider.
     TimeAndFlow,
+}
+
+impl CanvasLayout {
+    /// Whether this layout draws the time pane at all.
+    #[must_use]
+    pub fn shows_time(self) -> bool {
+        matches!(self, CanvasLayout::Time | CanvasLayout::TimeAndFlow)
+    }
+
+    /// Whether this layout draws the flow pane at all.
+    #[must_use]
+    pub fn shows_flow(self) -> bool {
+        matches!(self, CanvasLayout::Single | CanvasLayout::TimeAndFlow)
+    }
+}
+
+impl From<crate::config::DeclaredLayout> for CanvasLayout {
+    fn from(declared: crate::config::DeclaredLayout) -> Self {
+        match declared {
+            crate::config::DeclaredLayout::Flow => CanvasLayout::Single,
+            crate::config::DeclaredLayout::Time => CanvasLayout::Time,
+            crate::config::DeclaredLayout::TimeAndFlow => CanvasLayout::TimeAndFlow,
+        }
+    }
 }
 
 /// The window chrome a tab's canvas borrows for one frame. The tab completes
@@ -207,6 +235,11 @@ pub struct Tab {
     ohlcv_capable: bool,
     /// The id the time pane takes when this tab first shows the split.
     time_pane_id: u64,
+    /// The interval the time pane opens on when it is first built. The
+    /// header's default unless the feed declared one (`default_bars` with a
+    /// time-showing `default_layout`); once the pane exists, its own header
+    /// owns the interval and this is never read again.
+    time_pane_opening_interval_ms: i64,
     /// Set when the split is asked for and the time pane does not exist yet;
     /// drained by [`Self::apply_pending_layout`] on the following frame.
     pending_time_pane: bool,
@@ -279,6 +312,7 @@ impl Tab {
             ohlcv_capable: false,
             time_pane: None,
             time_pane_id: pane_ids.1,
+            time_pane_opening_interval_ms: crate::time_header::DEFAULT_INTERVAL_MS,
             pending_time_pane: false,
             layout: CanvasLayout::Single,
             split_fraction: DEFAULT_PANE_FRACTION,
@@ -594,11 +628,13 @@ impl Tab {
     }
 
     /// The pane the chrome speaks for. Only a split canvas has a choice to
-    /// make; a Single canvas is the flow pane by definition, whatever the last
-    /// split left `focus` set to.
+    /// make: a single-pane layout *is* its one visible pane, whatever the
+    /// last split left `focus` set to. Time falls back to the flow pane for
+    /// the frame between asking for the layout and the pane being built.
     pub fn focused_side(&self) -> PaneSide {
         match (self.layout, self.time_pane.is_some()) {
             (CanvasLayout::TimeAndFlow, true) => self.focus,
+            (CanvasLayout::Time, true) => PaneSide::Time,
             _ => PaneSide::Flow,
         }
     }
@@ -656,16 +692,26 @@ impl Tab {
             .expect("the flow pane is built with a tape and never drops it")
     }
 
-    /// Show or hide the context chart (§11).
+    /// Switch which panes the canvas shows (§11).
     ///
-    /// The first Time + Flow builds the pane and seeds it from the trades the
-    /// flow pane already holds, so it opens showing the same market rather
-    /// than an empty chart waiting for the next print. Going back to Single
-    /// only stops drawing it: its indicators, drawings and bars survive, and
-    /// it keeps being fed, so re-showing it never has to catch up.
+    /// The first layout that needs the time pane builds it and seeds it from
+    /// the trades the flow pane already holds, so it opens showing the same
+    /// market rather than an empty chart waiting for the next print. Leaving
+    /// a layout only stops drawing its pane: indicators, drawings and bars
+    /// survive, and the pane keeps being fed, so re-showing it never has to
+    /// catch up.
+    ///
+    /// Focus follows what the switch reveals: the pane that just appeared is
+    /// the one the user asked to work on, so the chrome speaks for it without
+    /// a second click. A switch that reveals nothing new (Time + Flow from
+    /// Time + Flow) keeps the focus where it was.
     pub fn set_layout(&mut self, layout: CanvasLayout) {
+        let previous = self.layout;
+        if layout == previous {
+            return;
+        }
         self.layout = layout;
-        if layout == CanvasLayout::TimeAndFlow && self.time_pane.is_none() {
+        if layout.shows_time() && self.time_pane.is_none() {
             // Seeding replays every retained trade, which on a deep history
             // holds the render thread long enough to notice. Armed here and
             // done on the next frame, exactly as a bar-spec change is: the
@@ -675,9 +721,18 @@ impl Tab {
             self.pending_time_pane = true;
             self.loading.begin(LoadingTask::BarRebuild);
         }
-        if layout == CanvasLayout::Single {
-            self.focus = PaneSide::Flow;
-        }
+        self.focus = match layout {
+            CanvasLayout::Single => PaneSide::Flow,
+            CanvasLayout::Time => PaneSide::Time,
+            // The split reveals whichever pane the previous layout was not
+            // showing: the time pane coming from Single, the flow pane coming
+            // from Time.
+            CanvasLayout::TimeAndFlow => match previous {
+                CanvasLayout::Single => PaneSide::Time,
+                CanvasLayout::Time => PaneSide::Flow,
+                CanvasLayout::TimeAndFlow => self.focus,
+            },
+        };
         tracing::info!(
             target: "quantick::app",
             schema_version = 1_u8,
@@ -702,7 +757,7 @@ impl Tab {
             return;
         }
         self.pending_time_pane = false;
-        let mut pane = ChartPane::time(self.time_pane_id, crate::time_header::DEFAULT_INTERVAL_MS);
+        let mut pane = ChartPane::time(self.time_pane_id, self.time_pane_opening_interval_ms);
         pane.seed_from(
             self.flow_pane.state.trades(),
             self.flow_pane.state.backfill_trade_count(),
@@ -1041,6 +1096,40 @@ impl Tab {
         }
     }
 
+    /// Open wearing the layout the feed declares, if it declares one.
+    ///
+    /// Startup-scoped, like `default_feed`: it decides what a tab on this
+    /// feed *opens* showing, and never touches a layout the user has since
+    /// chosen — the callers are tab creation, nothing else. A feed with no
+    /// `default_layout` changes nothing, so the factory default stays the
+    /// flow pane (the decision on record in the UX audit §3).
+    pub fn apply_feed_declared_layout(&mut self, config: &AppConfig) {
+        let Some(declared) = config
+            .feed(&self.feed_id)
+            .and_then(|feed| feed.default_layout)
+        else {
+            return;
+        };
+        let layout = CanvasLayout::from(declared);
+        // A declared time-bar spec names the interval the declared layout's
+        // time pane opens on; the pane's own header takes over from there.
+        if layout.shows_time()
+            && let Some(BarSpec::Time(ms)) = config.startup_spec_for(&self.feed_id)
+        {
+            self.time_pane_opening_interval_ms = ms;
+        }
+        tracing::info!(
+            target: "quantick::app",
+            schema_version = 1_u8,
+            event_code = "FEED_DECLARED_LAYOUT",
+            feed = %self.feed_id,
+            layout = ?layout,
+            action = "open_declared_layout",
+            "feed declares an opening layout; applied"
+        );
+        self.set_layout(layout);
+    }
+
     /// Let every pane's selectors settle, then mirror the result onto the
     /// rebuild indicator: it is up while *any* pane has a rebuild pending.
     pub fn apply_spec_changes(&mut self) -> bool {
@@ -1069,8 +1158,8 @@ impl Tab {
     /// the rebuild to one per gesture.
     ///
     /// The two panes run this independently: the toolbar's BARS group governs
-    /// the flow pane and the time pane's own header governs the time pane
-    /// (§11), so a timeframe change must not rebuild the chart beside it.
+    /// the focused pane and the time pane's own header governs the time pane
+    /// (§11), so a change to one pane must not rebuild the chart beside it.
     fn apply_spec_change(&mut self, side: PaneSide) -> bool {
         let desired = self.pane(side).current_spec();
         let pane = self.pane_mut(side);
@@ -1495,20 +1584,31 @@ impl Tab {
         area: egui::Rect,
         chrome: &mut CanvasChrome<'_>,
     ) {
-        let split = self.layout == CanvasLayout::TimeAndFlow && self.time_pane.is_some();
-        // Unsplit, the flow pane is handed the whole canvas and the rest of
-        // this reduces to nothing: no divider, no header, no focus rule.
+        let show_time = self.layout.shows_time() && self.time_pane.is_some();
+        // The flow pane also stands in for a time pane still being built, so
+        // the frame between asking for the Time layout and the pane existing
+        // shows the market rather than nothing.
+        let show_flow = self.layout.shows_flow() || !show_time;
+        let split = show_time && show_flow;
+        // One visible pane is handed the whole canvas and the rest of this
+        // reduces to nothing: no divider, no focus rule — though a lone time
+        // pane keeps its header.
         let (time_area, divider, flow_area) = if split {
             let areas = split_canvas(area, self.split_fraction);
             (Some(areas.time), Some(areas.divider), areas.flow)
+        } else if show_time {
+            (Some(area), None, area)
         } else {
             (None, None, area)
         };
 
         let time_chart = time_area.map(|time_area| {
             // Focus before input, so the click that focuses a pane is also the
-            // click that pane goes on to handle.
-            self.focus_from_pointer(ui, time_area, flow_area);
+            // click that pane goes on to handle. Only a split has focus to
+            // move: a single visible pane is the focused one by definition.
+            if split {
+                self.focus_from_pointer(ui, time_area, flow_area);
+            }
             let areas = split_time_pane(time_area);
             // The time pane's own timeframe selector (§11): its BARS group,
             // beside the toolbar's, which keeps governing the flow pane.
@@ -1552,11 +1652,8 @@ impl Tab {
             // loop with one entry in it.
             let time =
                 time_chart.and_then(|chart| Some((time_pane.as_mut()?, chart, PaneSide::Time)));
-            for (pane, rect, side) in time.into_iter().chain(std::iter::once((
-                &mut *flow_pane,
-                flow_area,
-                PaneSide::Flow,
-            ))) {
+            let flow = show_flow.then_some((&mut *flow_pane, flow_area, PaneSide::Flow));
+            for (pane, rect, side) in time.into_iter().chain(flow) {
                 // Order entry follows the focused pane (§11): both charts are
                 // trading surfaces — a level is as true on the time pane as on
                 // the flow pane — and focus lands on the press that acts, so

--- a/crates/app/src/tabstrip.rs
+++ b/crates/app/src/tabstrip.rs
@@ -374,6 +374,8 @@ mod tests {
                 provider: ProviderKind::Binance,
                 symbols: vec!["BTCUSDT".to_string(), "ETHUSDT".to_string()],
                 bubble_preset: None,
+                default_layout: None,
+                default_bars: None,
             }],
             metatrader: MetaTraderSettings::default(),
             paper: Default::default(),

--- a/crates/app/src/time_header.rs
+++ b/crates/app/src/time_header.rs
@@ -1,10 +1,10 @@
 //! The time pane's inline timeframe selector
 //! (`docs/ux/ui-design-model.md` §11).
 //!
-//! Two selectors, two panes, no modes: the toolbar's BARS group governs the
-//! flow pane and this row governs the time pane. It sits in a strip carved off
-//! the top of the pane rather than floating over it, so nothing is ever
-//! painted across market data.
+//! This row governs the time pane and nothing else, wherever focus sits; the
+//! toolbar's BARS group governs the *focused* pane, which may be the same
+//! one. It sits in a strip carved off the top of the pane rather than
+//! floating over it, so nothing is ever painted across market data.
 //!
 //! The presets are the four timeframes a context chart is actually read at;
 //! the drag beside them accepts the same interval domain the BARS group does

--- a/docs/ux/ui-design-model.md
+++ b/docs/ux/ui-design-model.md
@@ -327,10 +327,12 @@ shell:
 Menus stay shallow; they exist for discoverability and shortcuts, never as
 the only path:
 
-- **File** — New Tab… (`Ctrl+T`), Close Tab (`Ctrl+W`), Layout ▸ Single /
-  Time + Flow (§11), Market Replay… (`Ctrl+R`), Close Replay, Exit.
-- **View** — dock show/hide (`Ctrl+B`), each dock tab, sub-pane
-  collapse-all, perf readings on/off, timezone.
+- **File** — New Tab… (`Ctrl+T`), Close Tab (`Ctrl+W`), Market Replay…
+  (`Ctrl+R`), Close Replay, Exit.
+- **View** — Layout ▸ Flow / Timeframe / Timeframe + Flow (§11; what the
+  canvas shows is a view concern, and the entries name the charts they
+  show), dock show/hide (`Ctrl+B`), each dock tab, sub-pane collapse-all,
+  perf readings on/off, timezone.
 - **Insert** — indicators (natives + library), drawing tools (§9).
 - **Tools** — appearance dialog, future: script library folder, alerts.
 - **Help** — replay file format…, future: Pine dialect reference,
@@ -392,17 +394,26 @@ budget is unchanged.
 
 ### Split view (per tab: zones 4–6 + 9 duplicate)
 
-`File → Layout → Time + Flow` (per-tab, remembered). The canvas splits on a
-draggable vertical divider — **time pane left, flow pane right**, 50/50
-default, 25% minimum each. The time pane is the *context* view; the flow
-pane keeps quantick's identity.
+`View → Layout` (per-tab, remembered) offers three canvases, each named for
+what it shows: **Flow** (the default), **Timeframe** (the time pane alone,
+full window, header included) and **Timeframe + Flow**. The split canvas
+divides on a draggable vertical divider — **time pane left, flow pane
+right**, 50/50 default, 25% minimum each. The time pane is the *context*
+view; the flow pane keeps quantick's identity. A feed may declare the canvas
+its tabs open on (`default_layout` / `default_bars` in `feeds.toml`,
+startup-scoped like `default_feed`); the factory default stays Flow.
 
 - **One engine, one tape.** Both panes are fed the same trades from the
   tab's feed; the time pane is a second `ChartState` with `BarSpec::Time`.
   No second bar-building path exists.
 - **Time pane header** carries an inline timeframe selector — `1m 5m 15m 1h`
   presets plus the existing custom interval drag. The toolbar's BARS group
-  keeps governing the flow pane only; two selectors, two panes, no modes.
+  governs the *focused* pane — the same pane the status bar reads and
+  indicator commands land on, so the chrome never disagrees with itself
+  about which chart a command describes.
+- **Focus follows the switch.** Changing layout focuses the pane the switch
+  reveals, so the first command after it already lands on the chart that
+  just appeared.
 - **Flow layers stay on the flow pane.** Heatmap, bubbles and the live strip
   never render on the time pane. Indicators and drawings work on both, each
   pane owning its slots and objects (anchors are bar-index + price and do


### PR DESCRIPTION
## What

The chart layout system becomes clear and complete — the P1 "Pain 2 structural" row of `docs/ux/ux-audit-2026-08.md` §6, plus the per-feed startup default from §3. A trader can now view the timeframe chart alone, the flow chart alone, or both, and make their preference the startup default.

- **Third layout `Time`**: the timeframe chart alone — full window, header included, no split. `CanvasLayout` gains the variant; all three canvases switch per tab, and a pane left off screen keeps being fed, so switching back never has to catch up.
- **Layout moves from File to View**, and each entry names what it shows: **Flow / Timeframe / Timeframe + Flow**, current one checked.
- **Focus follows the switch**: changing layout focuses the pane it reveals (Single→split focuses Timeframe; Time→split focuses Flow). The **BARS group now edits the focused pane** — the same pane the status bar reads and indicator commands land on, resolving the audit's BARS×focus mismatch.
- **Per-feed startup defaults**: `default_layout = "flow" | "time" | "time+flow"` and `default_bars = "kind:parameter"` (`time:1m`, `tick:50`, …) in `feeds.toml`. Startup-scoped like `default_feed`; validated at load with the same bounds the live controls enforce; a feed declaring nothing changes nothing — the factory default stays the flow pane (decision on record in audit §3).
- **ui-harness hook**: `QUANTICK_LAYOUT=<flow|time|time+flow>` opens the active tab on that canvas through the same code path the menu takes, winning over a declared default.

## Performance impact

| Path | Rate | Change |
| --- | --- | --- |
| `draw_canvas` / toolbar model | per frame | enum branches only; flat — 60 fps / frame_avg 16.7 ms in all validation captures, equal to the `flow` control run |
| `set_layout`, pane build | rare (menu click / tab open) | unchanged deferred-build pattern |
| config parse/validate | startup | new `default_bars` parse, clarity wins |

## Validation

- 727 app tests + full workspace green; new tests: `the_time_layout_shows_the_timeframe_chart_alone`, `switching_layouts_focuses_the_pane_the_switch_reveals`, `the_bars_selectors_govern_the_focused_pane`, `a_feed_declaring_layout_and_bars_opens_wearing_them`, `a_new_tab_takes_the_feeds_declared_defaults_over_inheritance`, `layout_names_agree_between_serde_and_parse`, plus `BarSpec::parse` round-trip/rejection and config validation tests.
- Visual QA (live Binance BTCUSDT, captures by PID with health gate): `time` full-window with 129 596 venue candles and the amber `venue` seam, honest "loading venue history…" while waiting; `time+flow` split with bubbles/live layers and motion across two captures 1.2 s apart; `flow` control identical to today's default. 60 fps in every state.
- Trader UX review: no Blocker / Should-fix. Consider (accepted): no keyboard shortcut for layout switching (pre-existing gap, audit P2); BARS target in split disclosed by the focus accent + status bar.
- Arch review: one Should-fix found and fixed in-branch (layout name vocabulary centralized in `DeclaredLayout::parse`). Blast radius: 9 files edited, 0 added — the change is by nature an edit of the existing layout system.

## Deferred

- Workspace persistence (`ui-state.toml`, audit §14 / P1 row above this one) — separate goal; until it lands, per-feed `default_layout` is how a preference survives a restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)