### PR TITLE
feat(app): indicator panes draw across the live lane, and answer the chart's gestures

### DIFF
--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -3903,6 +3903,146 @@ mod tests {
         areas.pane_gutters[index]
     }
 
+    /// The plot band of pane `index` — where its curve is drawn, as opposed to
+    /// the gutter where its numbers are.
+    fn pane_body(app: &QuantickApp, index: usize) -> egui::Rect {
+        let pane = &app.active_tab().flow_pane;
+        let areas = plot_split(
+            pane.last_plot_area.expect("a frame has been drawn"),
+            pane.live_strip_width(),
+            pane.indicators.visible_panes().count(),
+        );
+        areas.indicator_panes[index]
+    }
+
+    /// The bar the viewport has at its right edge — how far the chart is
+    /// panned along time.
+    fn right_edge(app: &QuantickApp) -> f32 {
+        let pane = &app.active_tab().flow_pane;
+        pane.viewport.right_edge_bar(pane.slots())
+    }
+
+    /// A pane body is a piece of the chart, so the chart's own gestures have
+    /// to work on it: drag to move, and the pane's own axis for the vertical
+    /// half. Before this the body answered nothing at all — the only way to
+    /// move a pane's curve out of its own way was to travel to the gutter on
+    /// the far side of the tape and drag it there.
+    #[test]
+    fn dragging_a_pane_body_pans_that_pane_and_the_shared_time_axis() {
+        let (mut app, _cmd_rx) = app_with_history(200);
+        let ctx = egui::Context::default();
+        let flow = add_pane_indicator(&mut app, "cvd", (0..200).map(f64::from).collect());
+        let other = add_pane_indicator(&mut app, "delta", (0..200).map(f64::from).collect());
+        run_frame(&mut app, &ctx); // the frame that fits each pane and records it
+
+        let body = pane_body(&app, 0);
+        let (lo, hi) = pane_range(&app, flow);
+        let edge_before = right_edge(&app);
+
+        drag_chart(
+            &mut app,
+            &ctx,
+            body.center(),
+            body.center() + egui::vec2(40.0, 30.0),
+        );
+
+        let (panned_lo, panned_hi) = pane_range(&app, flow);
+        assert!(
+            ((panned_hi - panned_lo) - (hi - lo)).abs() < 1e-6,
+            "a pan moves the window without resizing it: {lo}..{hi} -> {panned_lo}..{panned_hi}"
+        );
+        assert!(
+            panned_lo > lo,
+            "the candles' direction: pull the content down and the window climbs ({lo} -> {panned_lo})"
+        );
+        // Not the neighbour's resolved range: panning time changes what is
+        // visible, so every pane still on auto legitimately refits. What must
+        // not happen is the neighbour being taken off auto by a drag that was
+        // never over it.
+        assert!(
+            pane_is_auto(&app, other),
+            "one pane, one scale: the neighbour still fits its own values"
+        );
+        assert!(
+            !pane_is_auto(&app, flow),
+            "and the dragged one took control"
+        );
+        assert!(
+            app.active_tab().flow_pane.price_view.is_auto(),
+            "and the candles' own price scale is not a pane's to move"
+        );
+        assert!(
+            (right_edge(&app) - edge_before).abs() > f32::EPSILON,
+            "time is shared: the sideways half of the drag moved the chart"
+        );
+    }
+
+    /// Time is moved once per drag, not once per pane. Three stacked panes
+    /// answering the same sideways drag would pan the chart three times, and
+    /// the bars would run away from the pointer.
+    #[test]
+    fn a_pane_drag_pans_time_once_however_many_panes_are_stacked() {
+        let ctx = egui::Context::default();
+
+        let mut travelled = Vec::new();
+        for panes in [1_usize, 3] {
+            let (mut app, _cmd_rx) = app_with_history(200);
+            for index in 0..panes {
+                add_pane_indicator(
+                    &mut app,
+                    &format!("pane{index}"),
+                    (0..200).map(f64::from).collect(),
+                );
+            }
+            run_frame(&mut app, &ctx);
+
+            let body = pane_body(&app, 0);
+            let before = right_edge(&app);
+            drag_chart(
+                &mut app,
+                &ctx,
+                body.center(),
+                body.center() + egui::vec2(40.0, 0.0),
+            );
+            travelled.push(right_edge(&app) - before);
+        }
+
+        assert!(
+            (travelled[0] - travelled[1]).abs() < 1e-4,
+            "one pane and three must pan time by the same amount: {travelled:?}"
+        );
+        assert!(travelled[0].abs() > f32::EPSILON, "and it did pan");
+    }
+
+    /// Double click inside a pane hands its scale back to auto-fit — the same
+    /// escape its gutter offers, so a trader who panned a pane by mistake gets
+    /// out of it wherever the pointer happens to be.
+    #[test]
+    fn double_clicking_a_pane_body_returns_it_to_auto_fit() {
+        let (mut app, _cmd_rx) = app_with_history(200);
+        let ctx = egui::Context::default();
+        let flow = add_pane_indicator(&mut app, "cvd", (0..200).map(f64::from).collect());
+        run_frame(&mut app, &ctx);
+
+        let body = pane_body(&app, 0);
+        drag_chart(
+            &mut app,
+            &ctx,
+            body.center(),
+            body.center() + egui::vec2(0.0, 30.0),
+        );
+        assert!(!pane_is_auto(&app, flow), "the drag took manual control");
+
+        click_chart(&mut app, &ctx, body.center());
+        click_chart(&mut app, &ctx, body.center());
+        run_frame(&mut app, &ctx);
+
+        assert!(
+            pane_is_auto(&app, flow),
+            "and a double click gives it back to the values"
+        );
+    }
+
     /// The headline of this feature: a pane's numbers are its own axis. A drag
     /// there stretches that pane and nothing else — before the gutter was
     /// banded, the same pixels moved the *candles'* price scale, and the pane

--- a/crates/app/src/indicator_render.rs
+++ b/crates/app/src/indicator_render.rs
@@ -137,14 +137,54 @@ pub(crate) fn draw_overlays<'a>(
     }
 }
 
+/// The slice of the live lane a pane draws on, and the window of tape time it
+/// stands for.
+///
+/// The lane is a band of *time*, mapped linearly from `start_ms` at its left
+/// edge to `end_ms` (the live edge) at its right — the tape's own mapping, so
+/// a pane's curve lands under the prints it was computed from. The candles'
+/// bar-slot x-mapping says nothing here, which is why this travels separately
+/// from [`PlotX`].
+pub(crate) struct LaneFrame<'a> {
+    /// The band right of the divider, at this pane's height.
+    pub rect: Rect,
+    /// Tape instant at the band's left edge.
+    pub start_ms: i64,
+    /// Tape instant at the band's right edge: the live edge.
+    pub end_ms: i64,
+    /// `(close time, committed row)` for every bar that closed inside the
+    /// window, oldest first — the same for every pane, so the chart computes
+    /// it once.
+    ///
+    /// These are the lane's *committed* resolution. A closed bar cannot be
+    /// re-entered, so what it did print by print is not recoverable and is not
+    /// invented: its value holds flat across the band and steps at its close,
+    /// which is exactly what "the indicator committed this at that instant"
+    /// looks like.
+    pub steps: &'a [(i64, usize)],
+}
+
+impl LaneFrame<'_> {
+    /// Screen x of a tape instant, clamped to the band.
+    fn x(&self, ms: i64) -> f32 {
+        let span = (self.end_ms - self.start_ms).max(1) as f64;
+        let fraction = ((ms - self.start_ms) as f64 / span).clamp(0.0, 1.0) as f32;
+        self.rect.left() + fraction * self.rect.width()
+    }
+}
+
 /// Where one pane paints, and in what colours.
 ///
 /// A pane spans two rects that the chart's own layout keeps apart — the plot
 /// area and the slice of the right-hand gutter beside it — so they travel
 /// together rather than as two more positional arguments no caller can read.
-pub(crate) struct PaneFrame {
+pub(crate) struct PaneFrame<'a> {
     /// The pane's plot area: the candles' x-range, the live lane excluded.
     pub rect: Rect,
+    /// The lane band beside `rect`, when the chart draws one. `None` is a
+    /// chart with no tape, and the pane then ends at `rect` exactly as it
+    /// always has.
+    pub lane: Option<LaneFrame<'a>>,
     /// The gutter band beside `rect`, where this pane's value labels go. It
     /// is the same band the pane's zoom gesture is registered over, which is
     /// what makes the numbers the thing you grab.
@@ -179,7 +219,7 @@ pub(crate) fn pane_auto_range(
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn draw_pane(
     painter: &egui::Painter,
-    frame: &PaneFrame,
+    frame: &PaneFrame<'_>,
     view: &IndicatorView,
     x: &PlotX<'_>,
     range: Option<(f64, f64)>,
@@ -188,9 +228,17 @@ pub(crate) fn draw_pane(
     partial_slot: Option<usize>,
 ) {
     let pane = frame.rect;
-    painter.rect_filled(pane, egui::Rounding::ZERO, frame.background);
+    // The pane is the plot area *and* the lane band beside it: one strip of
+    // canvas from the chart's left edge to its gutter. Anything less leaves a
+    // band of bare canvas between a pane's curve and the numbers that describe
+    // it, which is what this whole frame exists to close.
+    let band = frame
+        .lane
+        .as_ref()
+        .map_or(pane, |lane| pane.union(lane.rect));
+    painter.rect_filled(band, egui::Rounding::ZERO, frame.background);
     painter.line_segment(
-        [pane.left_top(), pane.right_top()],
+        [band.left_top(), band.right_top()],
         Stroke::new(
             PANE_RULE_WIDTH_PX,
             theme::TEXT_MUTED.gamma_multiply(PANE_FRAME_ALPHA),
@@ -209,7 +257,7 @@ pub(crate) fn draw_pane(
 
     let Some((lo, hi)) = range else {
         painter.text(
-            pane.center(),
+            band.center(),
             egui::Align2::CENTER_CENTER,
             format!("{} — warming up", view.label()),
             egui::FontId::proportional(PANE_LABEL_FONT_PX),
@@ -219,15 +267,15 @@ pub(crate) fn draw_pane(
     };
     let scale = PriceScale::from_range(lo, hi, pane.top(), pane.bottom());
 
-    let clipped = painter.with_clip_rect(pane);
+    let clipped = painter.with_clip_rect(band);
     // The axis first, so its grid sits behind the plots rather than over them
     // — the price axis' own paint order.
-    draw_pane_axis(painter, &clipped, frame, &scale);
+    draw_pane_axis(painter, &clipped, frame, &scale, band);
     // A zero line anchors flow panes (cvd, delta) visually.
     if lo < 0.0 && hi > 0.0 {
         let y = scale.y(0.0);
         clipped.line_segment(
-            [pos2(pane.left(), y), pos2(pane.right(), y)],
+            [pos2(band.left(), y), pos2(band.right(), y)],
             Stroke::new(
                 PANE_RULE_WIDTH_PX,
                 theme::TEXT_MUTED.gamma_multiply(ZERO_LINE_ALPHA),
@@ -251,6 +299,9 @@ pub(crate) fn draw_pane(
         partial_slot,
         &pane_extents,
     );
+    if let Some(lane) = &frame.lane {
+        draw_lane_plots(&clipped, view, lane, &|v| scale.y(v));
+    }
     draw_objects(
         &clipped,
         view.render_objects(),
@@ -269,12 +320,87 @@ pub(crate) fn draw_pane(
     );
     if let Some(last) = last_value(view) {
         painter.text(
-            pane.right_top() + egui::vec2(-PANE_LABEL_INSET_PX.x, PANE_LABEL_INSET_PX.y),
+            band.right_top() + egui::vec2(-PANE_LABEL_INSET_PX.x, PANE_LABEL_INSET_PX.y),
             egui::Align2::RIGHT_TOP,
             format_value(last),
             egui::FontId::monospace(PANE_LABEL_FONT_PX),
             theme::TEXT_MUTED,
         );
+    }
+}
+
+/// A pane's line-shaped plots across the live lane: the committed steps of
+/// the bars that closed inside the window, then the forming bar rung by rung.
+///
+/// Only line-shaped plots are drawn here. A histogram or a marker is a
+/// statement about *a bar* — one column, one bar, at the bar's own width —
+/// and the lane is a time axis with no bar widths in it; drawing them here
+/// would have to invent a width the tape cannot justify. Those plots keep to
+/// the history pane, where their slot is real.
+fn draw_lane_plots(
+    painter: &egui::Painter,
+    view: &IndicatorView,
+    lane: &LaneFrame<'_>,
+    y_of: &impl Fn(f64) -> f32,
+) {
+    for (index, spec) in view.descriptor.plots.iter().enumerate() {
+        if spec.marker.is_some()
+            || !matches!(
+                spec.style,
+                PlotStyle::Line | PlotStyle::StepLine | PlotStyle::Area
+            )
+        {
+            continue;
+        }
+        let Some(column) = view.columns.get(index) else {
+            continue;
+        };
+        let stroke = Stroke::new(spec.width, color32(spec.base_color));
+        let mut segment: Vec<Pos2> = Vec::new();
+        // The value a closed bar committed holds until the next close: the
+        // horizontal-then-vertical corner is the shape of "this was the value
+        // for that whole stretch", and a straight line between two closes
+        // would draw an intra-bar path nobody recorded.
+        let mut held: Option<f32> = None;
+        for &(close_ms, row) in lane.steps {
+            let Some(value) = column.get(row).copied().filter(|v| !v.is_nan()) else {
+                flush_segment(painter, &mut segment, stroke);
+                held = None;
+                continue;
+            };
+            let point = pos2(lane.x(close_ms), y_of(value));
+            if let Some(previous) = held {
+                segment.push(pos2(point.x, previous));
+            }
+            segment.push(point);
+            held = Some(point.y);
+        }
+        // The rungs: real evaluations of real prefixes, so they join point to
+        // point like any other line.
+        let mut first_rung = true;
+        for sample in &view.lane {
+            let Some(value) = sample.values.get(index).copied().filter(|v| !v.is_nan()) else {
+                flush_segment(painter, &mut segment, stroke);
+                held = None;
+                first_rung = false;
+                continue;
+            };
+            let point = pos2(lane.x(sample.close_time), y_of(value));
+            // The last committed value holds right up to the forming bar's
+            // first print — the bar had not opened yet, and the indicator had
+            // not moved.
+            if first_rung && let Some(previous) = held.take() {
+                segment.push(pos2(point.x, previous));
+            }
+            segment.push(point);
+            first_rung = false;
+        }
+        // Nothing forming: the last committed value is still the value, and it
+        // holds out to the live edge.
+        if let Some(previous) = held {
+            segment.push(pos2(lane.rect.right(), previous));
+        }
+        flush_segment(painter, &mut segment, stroke);
     }
 }
 
@@ -286,8 +412,9 @@ pub(crate) fn draw_pane(
 fn draw_pane_axis(
     painter: &egui::Painter,
     clipped: &egui::Painter,
-    frame: &PaneFrame,
+    frame: &PaneFrame<'_>,
     scale: &PriceScale,
+    band: Rect,
 ) {
     let pane = frame.rect;
     let (lo, hi) = scale.range();
@@ -295,7 +422,7 @@ fn draw_pane_axis(
     for (tick, label) in crate::chart::axis_labels(lo, hi, pane.height()) {
         let y = scale.y(tick);
         clipped.line_segment(
-            [pos2(pane.left(), y), pos2(pane.right(), y)],
+            [pos2(band.left(), y), pos2(band.right(), y)],
             Stroke::new(PANE_RULE_WIDTH_PX, frame.grid),
         );
         // A label centred on the pane's own edge would be sliced in half by
@@ -912,6 +1039,7 @@ mod tests {
             },
             columns,
             preview: preview.map(PreviewFrame::new),
+            lane: Vec::new(),
             objects: quantick_indicators::ObjectSnapshot::default(),
             input_values: Vec::new(),
             stale: None,
@@ -1017,5 +1145,138 @@ mod tests {
         assert_eq!(format_value(1234.5678), "1234.6");
         assert_eq!(format_value(0.12345), "0.1235");
         assert_eq!(format_value(-9999.99), "-10000.0");
+    }
+
+    fn painted(draw: impl Fn(&egui::Painter)) -> String {
+        let ctx = egui::Context::default();
+        let output = ctx.run(egui::RawInput::default(), |ctx| {
+            draw(&ctx.layer_painter(egui::LayerId::background()));
+        });
+        format!("{:?}", output.shapes)
+    }
+
+    fn lane_of(steps: &[(i64, usize)]) -> LaneFrame<'_> {
+        LaneFrame {
+            rect: Rect::from_min_max(pos2(100.0, 0.0), pos2(200.0, 50.0)),
+            start_ms: 1_000,
+            end_ms: 2_000,
+            steps,
+        }
+    }
+
+    /// The lane is a linear map of tape time onto its band — the tape's own
+    /// mapping, which is the whole reason a pane's curve can be trusted to
+    /// sit under the prints it was computed from. Instants outside the window
+    /// clamp to the edges rather than escaping the band.
+    #[test]
+    fn a_lane_maps_tape_time_linearly_and_clamps_outside_its_window() {
+        let lane = lane_of(&[]);
+        assert!((lane.x(1_000) - 100.0).abs() < 1e-3, "the window's start");
+        assert!((lane.x(2_000) - 200.0).abs() < 1e-3, "the live edge");
+        assert!((lane.x(1_500) - 150.0).abs() < 1e-3, "halfway is halfway");
+        assert!((lane.x(0) - 100.0).abs() < 1e-3, "older than the window");
+        assert!((lane.x(9_999) - 200.0).abs() < 1e-3, "past the live edge");
+    }
+
+    /// A degenerate window (start == end, which a stalled feed can produce)
+    /// must not divide by zero or paint at NaN.
+    #[test]
+    fn a_zero_width_window_still_maps_to_a_finite_x() {
+        let lane = LaneFrame {
+            rect: Rect::from_min_max(pos2(100.0, 0.0), pos2(200.0, 50.0)),
+            start_ms: 5_000,
+            end_ms: 5_000,
+            steps: &[],
+        };
+        assert!(lane.x(5_000).is_finite());
+        assert!(lane.x(1).is_finite());
+    }
+
+    /// The rungs are drawn as a line across the band: with a lane, a pane
+    /// paints more than it does without one, and the extra ink lands inside
+    /// the lane's own rect.
+    #[test]
+    fn the_rungs_are_drawn_across_the_lane_band() {
+        let mut with_lane = view(vec![vec![1.0, 2.0]], Some(vec![3.0]));
+        with_lane.lane = vec![
+            crate::indicator_worker::LaneSample {
+                close_time: 1_200,
+                values: vec![2.2],
+            },
+            crate::indicator_worker::LaneSample {
+                close_time: 1_600,
+                values: vec![2.8],
+            },
+            crate::indicator_worker::LaneSample {
+                close_time: 2_000,
+                values: vec![3.0],
+            },
+        ];
+
+        let shapes = painted(|painter| {
+            draw_lane_plots(painter, &with_lane, &lane_of(&[]), &|v| 50.0 - v as f32);
+        });
+        assert!(
+            shapes.contains("Path"),
+            "the rungs are a polyline: {shapes}"
+        );
+        // 1_200, 1_600 and 2_000 ms across a 1_000 ms window on a 100 px band.
+        assert!(
+            shapes.contains("120.0") && shapes.contains("160.0") && shapes.contains("200.0"),
+            "each rung lands at its own instant on the tape: {shapes}"
+        );
+
+        let bare = view(vec![vec![1.0, 2.0]], Some(vec![3.0]));
+        let nothing = painted(|painter| {
+            draw_lane_plots(painter, &bare, &lane_of(&[]), &|v| 50.0 - v as f32);
+        });
+        assert!(!nothing.contains("Path"), "no rungs, no curve: {nothing}");
+    }
+
+    /// A committed value holds until the next close and then steps. Drawing a
+    /// slanted line between two closes would claim an intra-bar path nobody
+    /// recorded — so the corner has to be there, and the test is that the
+    /// polyline visits the corner's x twice.
+    #[test]
+    fn committed_values_step_across_the_lane_instead_of_interpolating() {
+        let pane = view(vec![vec![10.0, 20.0]], None);
+        let shapes = painted(|painter| {
+            draw_lane_plots(painter, &pane, &lane_of(&[(1_200, 0), (1_600, 1)]), &|v| {
+                100.0 - v as f32
+            });
+        });
+        // Rows 0 and 1 sit at y 90 and 80; the hold means y 90 appears at the
+        // second close's x before the step down to 80.
+        assert!(
+            shapes.contains("90.0") && shapes.contains("80.0"),
+            "{shapes}"
+        );
+        assert_eq!(
+            shapes.matches("90.0").count(),
+            2,
+            "the earlier value is held to the next close: {shapes}"
+        );
+    }
+
+    /// Histograms and markers keep to the history pane: a column is a
+    /// statement about one bar at that bar's width, and the lane has no bar
+    /// widths in it to honour.
+    #[test]
+    fn bar_shaped_plots_stay_out_of_the_lane() {
+        let mut pane = view(vec![vec![1.0, 2.0]], None);
+        pane.descriptor.plots[0].style = PlotStyle::Histogram;
+        pane.lane = vec![crate::indicator_worker::LaneSample {
+            close_time: 1_500,
+            values: vec![2.5],
+        }];
+        let shapes = painted(|painter| {
+            draw_lane_plots(painter, &pane, &lane_of(&[(1_200, 0)]), &|v| {
+                50.0 - v as f32
+            });
+        });
+        assert_eq!(
+            shapes, "[]",
+            "nothing drawn for a bar-shaped plot: {shapes}"
+        );
     }
 }

--- a/crates/app/src/indicator_worker.rs
+++ b/crates/app/src/indicator_worker.rs
@@ -16,12 +16,62 @@
 use std::collections::BTreeMap;
 use std::sync::mpsc::{Receiver, Sender, channel};
 
-use quantick_engine::Bar;
+use quantick_engine::{Bar, Trade};
 use quantick_indicators::{
     EvalError, Indicator, IndicatorDescriptor, IndicatorHost, InputValue, InstanceId,
     ObjectSnapshot, PreviewFrame, SourceId,
     native::{Cvd, Ema},
 };
+
+/// Most rungs a lane ladder is ever walked with.
+///
+/// The ceiling is a cost statement, not a resolution one: a rung is a full
+/// evaluation of every hosted indicator, so the count is what bounds a
+/// publish. Sixty-four rungs across a lane a few hundred pixels wide is finer
+/// than the band can show, and the renderer asks for fewer than this whenever
+/// the lane is narrower.
+pub(crate) const MAX_LANE_RUNGS: usize = 64;
+
+/// One rung of the lane ladder as the UI receives it: the instant on the
+/// tape, and what one slot's plots showed there.
+///
+/// The forming bar only — see [`IndicatorHost::walk_partial_prefixes`] for
+/// why the ladder cannot reach back past its open.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct LaneSample {
+    /// Exchange timestamp of the last print in this rung's prefix.
+    pub close_time: i64,
+    /// One value per declared plot, in descriptor order; NaN = nothing to
+    /// draw, exactly as in a committed row.
+    pub values: Vec<f64>,
+}
+
+/// Fold `run` into forming-bar prefixes, at most `rungs` of them.
+///
+/// The trades are the forming bar's own, in occurrence order, so folding all
+/// of them reproduces the bar the chart is drawing — which is why the last
+/// print always gets a rung: the lane's right edge is the live edge, and
+/// stopping a sample short of it would draw the tape as if the newest prints
+/// had not happened.
+fn lane_prefixes(run: &[Trade], rungs: usize) -> Vec<Bar> {
+    if run.is_empty() || rungs == 0 {
+        return Vec::new();
+    }
+    let step = run.len().div_ceil(rungs.min(run.len())).max(1);
+    let mut prefixes = Vec::with_capacity(run.len().div_ceil(step) + 1);
+    let mut forming: Option<Bar> = None;
+    for (index, trade) in run.iter().enumerate() {
+        match &mut forming {
+            None => forming = Some(Bar::opened_by(trade)),
+            Some(bar) => bar.extend(trade),
+        }
+        let last = index + 1 == run.len();
+        if last || (index + 1) % step == 0 {
+            prefixes.push(forming.clone().expect("a trade opened the bar"));
+        }
+    }
+    prefixes
+}
 
 /// UI-side handle for one indicator slot. The UI allocates these (so it can
 /// track an indicator it just requested without waiting for the worker); the
@@ -107,7 +157,16 @@ pub(crate) enum IndicatorCommand {
     /// One live bar closed.
     BarClosed(Bar),
     /// The forming bar changed (or vanished). Latest-wins within a batch.
-    PartialUpdated(Option<Bar>),
+    PartialUpdated {
+        partial: Option<Bar>,
+        /// The forming bar's own trades, in occurrence order — the run the
+        /// lane ladder is folded from. Empty when nothing is forming.
+        run: Vec<Trade>,
+        /// How many rungs the chart's live lane can show. `0` means there is
+        /// no lane on screen and no ladder is walked at all: a chart without
+        /// a tape must not pay for one.
+        rungs: usize,
+    },
     /// Spec switch / prepended history / source reset: replay from scratch.
     Rebuild(Vec<Bar>, Option<Bar>),
     /// Instantiate `source` behind `slot` and catch it up over history.
@@ -163,6 +222,13 @@ pub(crate) enum IndicatorEvent {
     Preview {
         slot: SlotId,
         frame: Option<PreviewFrame>,
+    },
+    /// The forming bar sampled across the live lane's window for one slot,
+    /// oldest rung first. Empty when there is no lane or nothing is forming —
+    /// which is how a vanished lane clears the curve it was drawing.
+    Lane {
+        slot: SlotId,
+        samples: Vec<LaneSample>,
     },
     /// The slot's indicator failed and is disabled until rebuilt/replaced.
     Error { slot: SlotId, error: EvalError },
@@ -236,7 +302,7 @@ impl IndicatorWorker {
     /// is bounded by feed cadence).
     pub(crate) fn send(&self, command: IndicatorCommand) {
         #[cfg(test)]
-        if matches!(command, IndicatorCommand::PartialUpdated(_)) {
+        if matches!(command, IndicatorCommand::PartialUpdated { .. }) {
             self.partial_updates.set(self.partial_updates.get() + 1);
         }
         if self.commands.send(command).is_err() {
@@ -293,6 +359,11 @@ fn run(rx: &Receiver<IndicatorCommand>, events: &Sender<IndicatorEvent>) {
         let mut flushes: Vec<Sender<()>> = Vec::new();
         // Latest-wins; `Some(None)` means "partial vanished" must be applied.
         let mut partial_update: Option<Option<Bar>> = None;
+        // The run and rung budget that came with the newest partial of the
+        // batch. Coalesced with it rather than separately: a ladder folded
+        // from one batch's trades and previewed against another's forming bar
+        // would draw a curve that never happened.
+        let mut lane_request: Option<(Vec<Trade>, usize)> = None;
         // After a rebuild every slot's full columns go out; appends would be
         // redundant (the snapshot is taken after the whole batch).
         let mut rebuilt = false;
@@ -304,14 +375,24 @@ fn run(rx: &Receiver<IndicatorCommand>, events: &Sender<IndicatorEvent>) {
                     rebuilt = true;
                 }
                 IndicatorCommand::BarClosed(bar) => host.push_closed_bar(&bar),
-                IndicatorCommand::PartialUpdated(partial) => partial_update = Some(partial),
+                IndicatorCommand::PartialUpdated {
+                    partial,
+                    run,
+                    rungs,
+                } => {
+                    partial_update = Some(partial);
+                    lane_request = Some((run, rungs));
+                }
                 IndicatorCommand::Rebuild(bars, partial) => {
                     host.rebuild(&bars, partial.as_ref());
                     rebuilt = true;
                     // The rebuild already previewed this partial; a stale
                     // earlier PartialUpdated in the same batch must not
-                    // override it backwards.
+                    // override it backwards. Its ladder goes with it — the
+                    // run it was folded from belongs to the pre-rebuild
+                    // series.
                     partial_update = None;
+                    lane_request = None;
                 }
                 IndicatorCommand::Add { slot, source } => match source.build() {
                     Ok(indicator) => {
@@ -463,11 +544,60 @@ fn run(rx: &Receiver<IndicatorCommand>, events: &Sender<IndicatorEvent>) {
             host.set_partial(partial.as_ref());
         }
 
-        publish_deltas(&host, &mut slots, events, rebuilt);
+        // The ladder is walked here, on the worker's own cadence, for the same
+        // reason previews are: the cost is per drained batch, never per print
+        // and never per frame, so a 50x replay cannot melt it.
+        let lane = lane_request
+            .map(|(run, rungs)| walk_lane(&mut host, &slots, &run, rungs))
+            .unwrap_or_default();
+
+        publish_deltas(&host, &mut slots, events, rebuilt, &lane);
         for ack in flushes {
             let _ = ack.send(());
         }
     }
+}
+
+/// Sample every slot's plots across the forming bar's run, oldest rung first.
+///
+/// Returns an empty map when there is no lane, no run, or nothing forming —
+/// the three ways a chart says "no curve on the tape", all of which must
+/// clear whatever the lane was drawing rather than leave it frozen.
+fn walk_lane(
+    host: &mut IndicatorHost,
+    slots: &BTreeMap<SlotId, SlotMirror>,
+    run: &[Trade],
+    rungs: usize,
+) -> BTreeMap<SlotId, Vec<LaneSample>> {
+    let mut lane: BTreeMap<SlotId, Vec<LaneSample>> = BTreeMap::new();
+    let prefixes = lane_prefixes(run, rungs.min(MAX_LANE_RUNGS));
+    if prefixes.is_empty() {
+        return lane;
+    }
+    for (&slot, mirror) in slots {
+        if mirror.host_id.is_some() {
+            lane.insert(slot, Vec::with_capacity(prefixes.len()));
+        }
+    }
+    host.walk_partial_prefixes(&prefixes, |prefix, previews| {
+        for (&slot, mirror) in slots {
+            let Some(host_id) = mirror.host_id else {
+                continue;
+            };
+            // A slot in its error state previews nothing, and nothing is
+            // exactly what the lane should show for it.
+            let Some(frame) = previews.get(host_id) else {
+                continue;
+            };
+            if let Some(samples) = lane.get_mut(&slot) {
+                samples.push(LaneSample {
+                    close_time: prefix.close_time,
+                    values: frame.values.clone(),
+                });
+            }
+        }
+    });
+    lane
 }
 
 /// Emit exactly the difference between what the UI has and what the host now
@@ -478,6 +608,7 @@ fn publish_deltas(
     slots: &mut BTreeMap<SlotId, SlotMirror>,
     events: &Sender<IndicatorEvent>,
     rebuilt: bool,
+    lane: &BTreeMap<SlotId, Vec<LaneSample>>,
 ) {
     for (&slot, mirror) in slots.iter_mut() {
         let Some(host_id) = mirror.host_id else {
@@ -534,6 +665,14 @@ fn publish_deltas(
         let _ = events.send(IndicatorEvent::Preview {
             slot,
             frame: host.preview(host_id).cloned(),
+        });
+
+        // Sent on the same cadence as the preview, empty vector included: the
+        // lane's curve is as transient as the forming bar it describes, and a
+        // slot that has stopped producing rungs must stop drawing them.
+        let _ = events.send(IndicatorEvent::Lane {
+            slot,
+            samples: lane.get(&slot).cloned().unwrap_or_default(),
         });
 
         if let Some(revision) = host.objects_revision(host_id)
@@ -600,7 +739,11 @@ mod tests {
         for bar in &bars[split..] {
             worker.send(IndicatorCommand::BarClosed(bar.clone()));
         }
-        worker.send(IndicatorCommand::PartialUpdated(partial.clone()));
+        worker.send(IndicatorCommand::PartialUpdated {
+            partial: partial.clone(),
+            run: Vec::new(),
+            rungs: 0,
+        });
         worker.flush();
         for event in worker.drain_events() {
             views.apply(event);
@@ -694,6 +837,160 @@ mod tests {
         assert_eq!(views.all().len(), 1);
         assert_eq!(views.all()[0].slot, survivor);
         assert_eq!(views.all()[0].rows(), 3, "the survivor saw the new bar");
+    }
+
+    /// The rung budget is a ceiling on cost, and the newest print is never the
+    /// one dropped to meet it: the lane's right edge is the live edge.
+    #[test]
+    fn a_ladder_respects_its_budget_and_always_reaches_the_newest_print() {
+        let run: Vec<Trade> = (1..=50).map(trade).collect();
+
+        for rungs in [1_usize, 3, 7, 64] {
+            let prefixes = lane_prefixes(&run, rungs);
+            assert!(
+                prefixes.len() <= rungs.max(1) + 1,
+                "{rungs} rungs asked for, {} produced",
+                prefixes.len()
+            );
+            let last = prefixes.last().expect("a non-empty run has rungs");
+            assert_eq!(
+                last.trade_count,
+                run.len() as u64,
+                "the last rung is the whole run"
+            );
+            assert_eq!(last.close_time, run[run.len() - 1].timestamp_ms);
+        }
+    }
+
+    /// A rung is a prefix of the run, folded exactly as a builder folds. The
+    /// last one must therefore *be* the forming bar the chart is drawing —
+    /// otherwise the lane's right edge and the candle beside it disagree.
+    #[test]
+    fn the_last_rung_is_the_forming_bar_itself() {
+        let (_, partial) = bars_and_partial(11, 4);
+        let partial = partial.expect("the fixture leaves a bar forming");
+        let run: Vec<Trade> = (1..=11)
+            .map(trade)
+            .filter(|t| t.timestamp_ms >= partial.open_time)
+            .collect();
+
+        let prefixes = lane_prefixes(&run, 8);
+        assert_eq!(prefixes.last(), Some(&partial));
+    }
+
+    /// No lane (`rungs == 0`) and no run are both "walk nothing": a chart
+    /// without a tape must not pay for a ladder it cannot draw.
+    #[test]
+    fn no_lane_and_no_run_both_produce_no_rungs() {
+        let run: Vec<Trade> = (1..=5).map(trade).collect();
+        assert!(lane_prefixes(&run, 0).is_empty());
+        assert!(lane_prefixes(&[], 16).is_empty());
+    }
+
+    /// End to end through the worker: a partial published with its run comes
+    /// back as lane samples whose last rung equals the slot's own preview.
+    /// The curve's live end and the pane's headline number are the same fact,
+    /// and this is what keeps them from drifting apart.
+    #[test]
+    fn the_lane_samples_end_where_the_preview_does() {
+        let (bars, partial) = bars_and_partial(11, 4);
+        let partial = partial.expect("the fixture leaves a bar forming");
+        let run: Vec<Trade> = (1..=11)
+            .map(trade)
+            .filter(|t| t.timestamp_ms >= partial.open_time)
+            .collect();
+
+        let worker = IndicatorWorker::spawn();
+        let mut views = IndicatorViews::new();
+        let slot = views.allocate_slot();
+        worker.send(IndicatorCommand::Add {
+            slot,
+            source: IndicatorSource::NativeCvd,
+        });
+        worker.send(IndicatorCommand::Backfilled(bars.clone()));
+        worker.send(IndicatorCommand::PartialUpdated {
+            partial: Some(partial),
+            run: run.clone(),
+            rungs: 8,
+        });
+        worker.flush();
+        for event in worker.drain_events() {
+            views.apply(event);
+        }
+
+        let view = &views.all()[0];
+        assert!(
+            !view.lane.is_empty(),
+            "a run with a lane budget produces rungs"
+        );
+        assert_eq!(
+            view.lane.last().map(|sample| sample.close_time),
+            run.last().map(|t| t.timestamp_ms),
+            "the newest rung sits at the newest print"
+        );
+        assert_eq!(
+            view.lane
+                .last()
+                .map(|sample| format!("{:?}", sample.values)),
+            view.preview
+                .as_ref()
+                .map(|frame| format!("{:?}", frame.values)),
+            "the lane's live end is the preview"
+        );
+        assert!(
+            view.lane
+                .windows(2)
+                .all(|pair| pair[0].close_time <= pair[1].close_time),
+            "rungs are in occurrence order"
+        );
+    }
+
+    /// A publish with no lane budget clears whatever the lane was drawing.
+    /// Toggling the tape off must not leave a frozen curve behind.
+    #[test]
+    fn dropping_the_lane_clears_the_samples_already_published() {
+        let (bars, partial) = bars_and_partial(11, 4);
+        let partial = partial.expect("the fixture leaves a bar forming");
+        let run: Vec<Trade> = (1..=11)
+            .map(trade)
+            .filter(|t| t.timestamp_ms >= partial.open_time)
+            .collect();
+
+        let worker = IndicatorWorker::spawn();
+        let mut views = IndicatorViews::new();
+        let slot = views.allocate_slot();
+        worker.send(IndicatorCommand::Add {
+            slot,
+            source: IndicatorSource::NativeCvd,
+        });
+        worker.send(IndicatorCommand::Backfilled(bars.clone()));
+        worker.send(IndicatorCommand::PartialUpdated {
+            partial: Some(partial.clone()),
+            run,
+            rungs: 8,
+        });
+        worker.flush();
+        for event in worker.drain_events() {
+            views.apply(event);
+        }
+        assert!(!views.all()[0].lane.is_empty(), "the fixture drew a lane");
+
+        worker.send(IndicatorCommand::PartialUpdated {
+            partial: Some(partial),
+            run: Vec::new(),
+            rungs: 0,
+        });
+        worker.flush();
+        for event in worker.drain_events() {
+            views.apply(event);
+        }
+
+        let view = &views.all()[0];
+        assert!(view.lane.is_empty(), "no lane, no curve");
+        assert!(
+            view.preview.is_some(),
+            "and the forming bar still previews — the walk restored it"
+        );
     }
 }
 

--- a/crates/app/src/indicator_worker.rs
+++ b/crates/app/src/indicator_worker.rs
@@ -547,11 +547,11 @@ fn run(rx: &Receiver<IndicatorCommand>, events: &Sender<IndicatorEvent>) {
         // The ladder is walked here, on the worker's own cadence, for the same
         // reason previews are: the cost is per drained batch, never per print
         // and never per frame, so a 50x replay cannot melt it.
-        let lane = lane_request
+        let mut lane = lane_request
             .map(|(run, rungs)| walk_lane(&mut host, &slots, &run, rungs))
             .unwrap_or_default();
 
-        publish_deltas(&host, &mut slots, events, rebuilt, &lane);
+        publish_deltas(&host, &mut slots, events, rebuilt, &mut lane);
         for ack in flushes {
             let _ = ack.send(());
         }
@@ -608,7 +608,7 @@ fn publish_deltas(
     slots: &mut BTreeMap<SlotId, SlotMirror>,
     events: &Sender<IndicatorEvent>,
     rebuilt: bool,
-    lane: &BTreeMap<SlotId, Vec<LaneSample>>,
+    lane: &mut BTreeMap<SlotId, Vec<LaneSample>>,
 ) {
     for (&slot, mirror) in slots.iter_mut() {
         let Some(host_id) = mirror.host_id else {
@@ -670,9 +670,11 @@ fn publish_deltas(
         // Sent on the same cadence as the preview, empty vector included: the
         // lane's curve is as transient as the forming bar it describes, and a
         // slot that has stopped producing rungs must stop drawing them.
+        // Taken, not cloned: each slot is visited once, and the rungs are
+        // already a fresh allocation from this batch's walk.
         let _ = events.send(IndicatorEvent::Lane {
             slot,
-            samples: lane.get(&slot).cloned().unwrap_or_default(),
+            samples: lane.remove(&slot).unwrap_or_default(),
         });
 
         if let Some(revision) = host.objects_revision(host_id)

--- a/crates/app/src/indicators/mod.rs
+++ b/crates/app/src/indicators/mod.rs
@@ -15,7 +15,7 @@ use quantick_indicators::{
     EvalError, IndicatorDescriptor, InputValue, ObjectSnapshot, PreviewFrame,
 };
 
-use crate::indicator_worker::{IndicatorEvent, SlotId};
+use crate::indicator_worker::{IndicatorEvent, LaneSample, SlotId};
 use crate::price_view::PriceView;
 
 /// Fraction of the chart's height each indicator pane takes (plan §4.3:
@@ -36,6 +36,12 @@ pub(crate) struct IndicatorView {
     pub columns: Vec<Vec<f64>>,
     /// Latest forming-bar frame, if a bar is forming.
     pub preview: Option<PreviewFrame>,
+    /// The forming bar sampled across the live lane's window, oldest rung
+    /// first — what this indicator showed at each instant on the tape.
+    ///
+    /// Transient like `preview`, and for the same reason: it describes a bar
+    /// that has not closed. Empty whenever the chart has no lane.
+    pub lane: Vec<LaneSample>,
     /// Error state (indicator disabled worker-side until rebuilt).
     pub error: Option<EvalError>,
     /// Eye toggle: hidden is render-side only — no recompute, state keeps
@@ -131,6 +137,7 @@ impl IndicatorViews {
                     view.columns = columns;
                     view.input_values = inputs;
                     view.preview = None;
+                    view.lane.clear();
                     view.error = None;
                     // Mirrored from the worker, not cleared: `hidden` and
                     // `errored` both survive a rebuild, and this used to be
@@ -143,6 +150,7 @@ impl IndicatorViews {
                         descriptor,
                         columns,
                         preview: None,
+                        lane: Vec::new(),
                         error: None,
                         hidden: false,
                         objects: ObjectSnapshot::default(),
@@ -162,6 +170,9 @@ impl IndicatorViews {
                     // drawing it one slot further right would be a lie. The
                     // next Preview event replaces it within the same batch.
                     view.preview = None;
+                    // Same for the rungs: they are prefixes of a bar that is
+                    // no longer forming.
+                    view.lane.clear();
                 }
             }
             IndicatorEvent::Preview { slot, frame } => {
@@ -169,10 +180,16 @@ impl IndicatorViews {
                     view.preview = frame;
                 }
             }
+            IndicatorEvent::Lane { slot, samples } => {
+                if let Some(view) = self.view_mut(slot) {
+                    view.lane = samples;
+                }
+            }
             IndicatorEvent::Error { slot, error } => {
                 if let Some(view) = self.view_mut(slot) {
                     view.error = Some(error);
                     view.preview = None;
+                    view.lane.clear();
                 }
             }
             IndicatorEvent::Objects { slot, objects } => {

--- a/crates/app/src/orderflow_view.rs
+++ b/crates/app/src/orderflow_view.rs
@@ -79,6 +79,18 @@ impl<'a> VisibleBarTimeline<'a> {
     }
 }
 
+/// The live lane's band and the instant it runs to, read together.
+///
+/// A pane draws inside this band in tape time, so it needs both numbers from
+/// the same frame's published book — see [`OrderflowView::live_lane`].
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct LiveLane {
+    /// Width of the band, in pixels, taken off the chart's right edge.
+    pub width_px: f32,
+    /// Exchange timestamp at the band's right edge: the live edge.
+    pub end_ms: i64,
+}
+
 /// Stateful UI/controller facade for the optional heatmap.
 pub struct OrderflowView {
     symbol: String,
@@ -263,18 +275,28 @@ impl OrderflowView {
         self.published.live_end_ms
     }
 
-    /// Width in pixels of the live lane's pane, taken off the right edge of a
-    /// chart this wide.
+    /// The live lane as the chart needs it: how wide its band is, and the
+    /// instant its right edge stands for.
     ///
-    /// A pane, not a slot: the candles own everything left of it and the lane
-    /// owns this band whatever they do. Panning or zooming them changes how
-    /// many bars fit beside the tape and never the tape itself, which is what
-    /// keeps the most recent prints on screen through every chart movement.
-    /// `None` when there is no live edge to run to.
+    /// A pane, not a slot: the candles own everything left of the band and the
+    /// lane owns it whatever they do. Panning or zooming them changes how many
+    /// bars fit beside the tape and never the tape itself, which is what keeps
+    /// the newest prints on screen through every chart movement.
+    ///
+    /// One call because it is one look at the published book. Reading the two
+    /// separately sends the render thread back through the worker's mutex for
+    /// a number the first read already had — a lock per frame for nothing, on
+    /// the one thread that must never wait.
+    ///
+    /// `None` when there is no live edge to run to, which is the same thing as
+    /// "this chart has no lane".
     #[must_use]
-    pub fn live_lane_width_px(&mut self, chart_width: f32) -> Option<f32> {
-        self.live_end_ms()?;
-        Some(self.config.live_lane.resolved_width_px(chart_width))
+    pub fn live_lane(&mut self, chart_width: f32) -> Option<LiveLane> {
+        let end_ms = self.live_end_ms()?;
+        Some(LiveLane {
+            width_px: self.config.live_lane.resolved_width_px(chart_width),
+            end_ms,
+        })
     }
 
     /// Widen or narrow the lane by a pixel drag on its divider. Dragging left

--- a/crates/app/src/pane.rs
+++ b/crates/app/src/pane.rs
@@ -237,29 +237,53 @@ fn pane_pan_gesture(
     body: egui::Rect,
     view: &mut PriceView,
     auto: Option<(f64, f64)>,
-) -> egui::Response {
+) -> PaneGesture {
     let response = ui.interact(body, id, egui::Sense::click_and_drag());
     if response.double_clicked() {
         view.reset();
-    }
-    let Some(auto) = auto else {
-        return response;
-    };
-    if response.dragged() {
-        let height = body.height();
-        let delta = response.drag_delta().y;
-        if delta != 0.0 && height > 1.0 {
-            let (lo, hi) = view.resolve(auto);
-            let per_px = (hi - lo) / f64::from(height);
-            view.pan(f64::from(delta) * per_px, auto);
-        }
     }
     if response.dragged() {
         ui.ctx().set_cursor_icon(egui::CursorIcon::Grabbing);
     } else if response.hovered() {
         ui.ctx().set_cursor_icon(egui::CursorIcon::Grab);
     }
-    response
+
+    // The pane's own axis moves here; time is the candles' to move, and the
+    // caller applies it once for however many panes are stacked — panning
+    // three panes' worth of x would move the chart three times per drag.
+    let mut gesture = PaneGesture::default();
+    if response.dragged() {
+        gesture.pan_x = response.drag_delta().x;
+        if let Some(auto) = auto {
+            let height = body.height();
+            let delta = response.drag_delta().y;
+            if delta != 0.0 && height > 1.0 {
+                let (lo, hi) = view.resolve(auto);
+                let per_px = (hi - lo) / f64::from(height);
+                view.pan(f64::from(delta) * per_px, auto);
+            }
+        }
+    }
+    if response.hovered() {
+        gesture.scroll_y = ui.input(|input| input.raw_scroll_delta.y);
+    }
+    gesture
+}
+
+/// What a drag or scroll over a pane body owes the *chart* — the pane's own
+/// axis has already been moved by the time this is returned.
+///
+/// A pane is a band of the same time axis the candles draw, so the gestures
+/// that mean "time" there mean time here too: drag sideways to pan it, scroll
+/// to zoom it. Collected rather than applied on the spot because the viewport
+/// belongs to the pane's owner, and because every stacked pane would otherwise
+/// apply its own copy of the same drag.
+#[derive(Default)]
+struct PaneGesture {
+    /// Horizontal drag, in pixels.
+    pan_x: f32,
+    /// Wheel travel while hovering, in egui's scroll units.
+    scroll_y: f32,
 }
 
 /// The gesture that scales a vertical axis, wherever its numbers live: drag up
@@ -307,6 +331,13 @@ fn axis_zoom_gesture(
         }
     }
 }
+
+/// Wheel travel that doubles or halves what a time axis shows.
+///
+/// One number for the candles, the lane and every pane body, so a scroll means
+/// the same amount of zoom wherever the pointer happens to be resting. It was
+/// already one number — written out four times.
+const SCROLL_ZOOM_PX: f32 = 300.0;
 
 /// Pixels of drag on the lane's own time strip that double or halve its window.
 ///
@@ -1184,11 +1215,17 @@ impl ChartPane {
     /// worker then walks no ladder at all.
     fn partial_command(&self) -> IndicatorCommand {
         let partial = self.state.partial().cloned();
-        let run = partial.as_ref().map_or_else(Vec::new, |bar| {
-            let trades = self.state.trades();
-            let count = usize::try_from(bar.trade_count).unwrap_or(usize::MAX);
-            trades[trades.len().saturating_sub(count)..].to_vec()
-        });
+        // No lane, no run. The clone is proportional to the forming bar's
+        // trade count, and a chart with nowhere to draw the result would pay
+        // it on every drain for nothing.
+        let run = partial
+            .as_ref()
+            .filter(|_| self.lane_rungs > 0)
+            .map_or_else(Vec::new, |bar| {
+                let trades = self.state.trades();
+                let count = usize::try_from(bar.trade_count).unwrap_or(usize::MAX);
+                trades[trades.len().saturating_sub(count)..].to_vec()
+            });
         IndicatorCommand::PartialUpdated {
             partial,
             run,
@@ -1740,9 +1777,9 @@ impl ChartPane {
                 if let Some(orderflow) = self.orderflow.as_mut()
                     && chart.hover_pos().is_some_and(in_lane)
                 {
-                    orderflow.zoom_live_lane(2.0_f32.powf(scroll / 300.0));
+                    orderflow.zoom_live_lane(2.0_f32.powf(scroll / SCROLL_ZOOM_PX));
                 } else {
-                    self.viewport.zoom(2.0_f32.powf(scroll / 300.0));
+                    self.viewport.zoom(2.0_f32.powf(scroll / SCROLL_ZOOM_PX));
                 }
             }
         }
@@ -1796,7 +1833,7 @@ impl ChartPane {
         if time.hovered() {
             let scroll = ui.input(|i| i.raw_scroll_delta.y);
             if scroll.abs() > 0.0 {
-                self.viewport.zoom(2.0_f32.powf(scroll / 300.0));
+                self.viewport.zoom(2.0_f32.powf(scroll / SCROLL_ZOOM_PX));
             }
         }
         // Jump-to-live (audit F6): panned into history, the way back is one
@@ -1834,7 +1871,7 @@ impl ChartPane {
             if lane_time.hovered() {
                 let scroll = ui.input(|i| i.raw_scroll_delta.y);
                 if scroll.abs() > 0.0 {
-                    orderflow.zoom_live_lane(2.0_f32.powf(scroll / 300.0));
+                    orderflow.zoom_live_lane(2.0_f32.powf(scroll / SCROLL_ZOOM_PX));
                 }
             }
         }
@@ -1854,6 +1891,7 @@ impl ChartPane {
         // split's two charts can hold the same slot number and a slot-only id
         // would make one pane's axis answer for the other's.
         let pane_id = self.id;
+        let mut pane_time_gesture = PaneGesture::default();
         for ((view, gutter), body) in self
             .indicators
             .visible_panes_mut()
@@ -1870,13 +1908,26 @@ impl ChartPane {
             // The body moves the scale the gutter scales. Registered after it
             // so the two never fight over the same pixel: the gutter is a band
             // beside the pane, and egui gives an overlap to the later claim.
-            pane_pan_gesture(
+            let gesture = pane_pan_gesture(
                 ui,
                 egui::Id::new(("pane_pan", pane_id, view.slot)),
                 *body,
                 &mut view.scale,
                 view.last_auto,
             );
+            pane_time_gesture.pan_x += gesture.pan_x;
+            pane_time_gesture.scroll_y += gesture.scroll_y;
+        }
+        // Time, once, whichever pane the pointer was over: the panes share the
+        // candles' x axis, so a sideways drag or a scroll there has to move the
+        // same viewport the candles do — otherwise the same gesture would mean
+        // one thing over the bars and nothing one pane below them.
+        if total > 0 && pane_time_gesture.pan_x != 0.0 {
+            self.viewport.pan_pixels(pane_time_gesture.pan_x, total);
+        }
+        if pane_time_gesture.scroll_y.abs() > 0.0 {
+            self.viewport
+                .zoom(2.0_f32.powf(pane_time_gesture.scroll_y / SCROLL_ZOOM_PX));
         }
     }
 
@@ -1935,11 +1986,15 @@ impl ChartPane {
         // every chart movement out of it: panning, zooming and dragging move
         // the candles beside the tape and never the tape itself, so the most
         // recent prints are on screen whatever the rest of the chart is doing.
-        let lane_width_px = self
+        // Band and live edge in one look at the published book: the panes need
+        // the instant the band's right edge stands for, and reading it again
+        // further down would put a second worker-mutex wait on the render
+        // thread for a number already in hand.
+        let live_lane = self
             .orderflow
             .as_mut()
-            .and_then(|orderflow| orderflow.live_lane_width_px(chart_rect.width()))
-            .unwrap_or(0.0);
+            .and_then(|orderflow| orderflow.live_lane(chart_rect.width()));
+        let lane_width_px = live_lane.map_or(0.0, |lane| lane.width_px);
         // Everything left of the divider is the candles' pane. They pan and
         // zoom inside it exactly as they did when it was the whole chart.
         self.last_lane_divider_x =
@@ -2146,25 +2201,27 @@ impl ChartPane {
         // curve lands under the prints it was computed from.
         let lane_window = self
             .last_lane_divider_x
-            .and_then(|divider| Some((divider, self.orderflow.as_mut()?)))
-            .and_then(|(divider, orderflow)| {
-                let end_ms = orderflow.live_end_ms()?;
+            .zip(live_lane)
+            .and_then(|(divider, lane)| {
+                let orderflow = self.orderflow.as_ref()?;
                 let window = orderflow.live_lane_window_ms(visible_state).max(1);
-                Some((divider, end_ms.saturating_sub(window), end_ms))
+                Some((divider, lane.end_ms.saturating_sub(window), lane.end_ms))
             });
         let lane_steps: Vec<(i64, usize)> =
             lane_window.map_or_else(Vec::new, |(_, start_ms, _)| {
                 let first = prefix.len();
-                closed
+                // Walked back from the newest close and reversed in place: the
+                // window holds a handful of bars, and building it front to back
+                // would mean scanning every closed bar the chart has ever seen.
+                let mut steps: Vec<(i64, usize)> = closed
                     .iter()
                     .enumerate()
                     .rev()
                     .take_while(|(_, bar)| bar.close_time >= start_ms)
                     .map(|(index, bar)| (bar.close_time, first + index))
-                    .collect::<Vec<_>>()
-                    .into_iter()
-                    .rev()
-                    .collect()
+                    .collect();
+                steps.reverse();
+                steps
             });
         for ((view, pane), gutter) in self
             .indicators

--- a/crates/app/src/pane.rs
+++ b/crates/app/src/pane.rs
@@ -29,7 +29,9 @@ use crate::chart_layers::{ChartLayer, LayerActions};
 use crate::config::FeedCapabilities;
 use crate::drawings::{self, ChartPoint, DrawContext, Drawings, PresetHost};
 use crate::indicator_render::{self, PlotX};
-use crate::indicator_worker::{IndicatorCommand, IndicatorSource, IndicatorWorker, SlotId};
+use crate::indicator_worker::{
+    IndicatorCommand, IndicatorSource, IndicatorWorker, MAX_LANE_RUNGS, SlotId,
+};
 use crate::indicators::IndicatorViews;
 use crate::orderflow_view::{OrderflowView, VisibleBarTimeline};
 use crate::paper_trading::{ChartInput, PaperTrading};
@@ -187,6 +189,26 @@ pub fn split_time_pane(area: egui::Rect) -> TimePaneAreas {
 /// so.
 const LANE_HANDLE_HALF_WIDTH_PX: f32 = 5.0;
 
+/// Pixels of lane the ladder spends one rung on.
+///
+/// A rung is a full evaluation of every hosted indicator, so this is the knob
+/// that trades cost against smoothness. Six pixels draws a curve that reads as
+/// continuous at the sizes the lane is ever given, and keeps a wide lane well
+/// under [`MAX_LANE_RUNGS`].
+const LANE_RUNG_PX: f32 = 6.0;
+
+/// How many rungs a lane this wide is worth sampling at.
+///
+/// Zero for a chart with no lane — the signal that no ladder is walked at all.
+fn lane_rungs(lane_width_px: f32) -> usize {
+    if !lane_width_px.is_finite() || lane_width_px <= 0.0 {
+        return 0;
+    }
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    let rungs = (lane_width_px / LANE_RUNG_PX) as usize;
+    rungs.clamp(1, MAX_LANE_RUNGS)
+}
+
 /// Pixels of drag on a vertical axis that change its span by a factor of `e`.
 ///
 /// One number for the price gutter and for every indicator pane's gutter: the
@@ -197,6 +219,48 @@ const AXIS_ZOOM_DRAG_PX: f32 = 150.0;
 /// reports far more units than a pointer travels in a frame, so each unit has
 /// to count for less — a larger divisor, not a smaller one.
 const AXIS_ZOOM_SCROLL_PX: f32 = 200.0;
+
+/// The gesture that pans a pane's own scale: press inside the pane and drag it
+/// up or down, exactly as a press on the candles drags price.
+///
+/// Separate from [`axis_zoom_gesture`] because they are different verbs on the
+/// same axis — the gutter *scales* it, the body *moves* it — and the candles
+/// already split them that way. A pane whose body did nothing left the axis
+/// reachable only from the gutter at the far side of the chart, which is a
+/// long way to travel to move a curve out of its own way.
+///
+/// `auto` is the range the last frame fitted; without one there is nothing to
+/// take manual control *from*, and only the reset stays available.
+fn pane_pan_gesture(
+    ui: &egui::Ui,
+    id: egui::Id,
+    body: egui::Rect,
+    view: &mut PriceView,
+    auto: Option<(f64, f64)>,
+) -> egui::Response {
+    let response = ui.interact(body, id, egui::Sense::click_and_drag());
+    if response.double_clicked() {
+        view.reset();
+    }
+    let Some(auto) = auto else {
+        return response;
+    };
+    if response.dragged() {
+        let height = body.height();
+        let delta = response.drag_delta().y;
+        if delta != 0.0 && height > 1.0 {
+            let (lo, hi) = view.resolve(auto);
+            let per_px = (hi - lo) / f64::from(height);
+            view.pan(f64::from(delta) * per_px, auto);
+        }
+    }
+    if response.dragged() {
+        ui.ctx().set_cursor_icon(egui::CursorIcon::Grabbing);
+    } else if response.hovered() {
+        ui.ctx().set_cursor_icon(egui::CursorIcon::Grab);
+    }
+    response
+}
 
 /// The gesture that scales a vertical axis, wherever its numbers live: drag up
 /// to compress the span, down to expand, scroll to zoom, double-click to hand
@@ -448,6 +512,12 @@ pub struct ChartPane {
     // Where the history pane ended last frame — the lane's divider, and the
     // handle that resizes it. The input pass runs before the draw computes it.
     pub last_lane_divider_x: Option<f32>,
+    // How many rungs the lane was wide enough for at the last draw, and so
+    // how finely the next publish samples the forming bar across it. `0` when
+    // there is no lane: the worker then walks no ladder and the panes draw
+    // nothing on the tape, which is the whole cost of this feature on a chart
+    // that has no tape to draw on.
+    lane_rungs: usize,
     // Manual price-axis pan/zoom (auto-fit until the user drags vertically).
     pub price_view: PriceView,
     // Last frame's auto-fit price range and chart height, for pixel↔price maths
@@ -561,6 +631,7 @@ impl ChartPane {
             imbalance_target,
             viewport: Viewport::new(),
             last_lane_divider_x: None,
+            lane_rungs: 0,
             price_view: PriceView::new(),
             last_auto_range: None,
             last_chart_height: 1.0,
@@ -1017,9 +1088,8 @@ impl ChartPane {
         self.state.ingest_backfill(trades);
         self.indicator_worker
             .send(IndicatorCommand::Backfilled(self.closed_bars()));
-        self.indicator_worker.send(IndicatorCommand::PartialUpdated(
-            self.state.partial().cloned(),
-        ));
+        let partial = self.partial_command();
+        self.indicator_worker.send(partial);
     }
 
     /// Prepend older trades and shift everything anchored to a bar index by the
@@ -1100,9 +1170,30 @@ impl ChartPane {
     /// Sent once per drain that took in live trades — see
     /// [`Self::ingest_live_trade`] for why it is not sent per trade.
     pub fn publish_partial(&mut self) {
-        self.indicator_worker.send(IndicatorCommand::PartialUpdated(
-            self.state.partial().cloned(),
-        ));
+        let command = self.partial_command();
+        self.indicator_worker.send(command);
+    }
+
+    /// The forming bar, the run of trades behind it, and how many rungs the
+    /// lane can show — everything the worker needs to preview the bar and to
+    /// sample it across the tape.
+    ///
+    /// The run is a slice of trades the pane already owns, cloned once per
+    /// drain rather than per print. The rung budget comes from the lane's
+    /// width at the last draw: a chart with no lane asks for none, and the
+    /// worker then walks no ladder at all.
+    fn partial_command(&self) -> IndicatorCommand {
+        let partial = self.state.partial().cloned();
+        let run = partial.as_ref().map_or_else(Vec::new, |bar| {
+            let trades = self.state.trades();
+            let count = usize::try_from(bar.trade_count).unwrap_or(usize::MAX);
+            trades[trades.len().saturating_sub(count)..].to_vec()
+        });
+        IndicatorCommand::PartialUpdated {
+            partial,
+            run,
+            rungs: self.lane_rungs,
+        }
     }
 
     /// Convert a chart pixel into an overlay anchor. The x coordinate is a
@@ -1763,11 +1854,26 @@ impl ChartPane {
         // split's two charts can hold the same slot number and a slot-only id
         // would make one pane's axis answer for the other's.
         let pane_id = self.id;
-        for (view, gutter) in self.indicators.visible_panes_mut().zip(&areas.pane_gutters) {
+        for ((view, gutter), body) in self
+            .indicators
+            .visible_panes_mut()
+            .zip(&areas.pane_gutters)
+            .zip(&areas.indicator_panes)
+        {
             axis_zoom_gesture(
                 ui,
                 egui::Id::new(("pane_price_nav", pane_id, view.slot)),
                 *gutter,
+                &mut view.scale,
+                view.last_auto,
+            );
+            // The body moves the scale the gutter scales. Registered after it
+            // so the two never fight over the same pixel: the gutter is a band
+            // beside the pane, and egui gives an overlap to the later claim.
+            pane_pan_gesture(
+                ui,
+                egui::Id::new(("pane_pan", pane_id, view.slot)),
+                *body,
                 &mut view.scale,
                 view.last_auto,
             );
@@ -1838,6 +1944,10 @@ impl ChartPane {
         // zoom inside it exactly as they did when it was the whole chart.
         self.last_lane_divider_x =
             crate::orderflow_render::lane_divider_x(chart_rect, lane_width_px);
+        self.lane_rungs = lane_rungs(
+            self.last_lane_divider_x
+                .map_or(0.0, |divider| chart_rect.right() - divider),
+        );
         let history_rect = egui::Rect::from_min_max(
             chart_rect.min,
             egui::pos2(
@@ -2030,6 +2140,32 @@ impl ChartPane {
         // pane records the range it auto-fitted to, so the gesture over its
         // axis zooms the very range this frame drew.
         let grid = grid_color(chrome.style);
+        // The lane's window of tape time, and the closes inside it. Both are
+        // the same for every pane, so they are resolved once here rather than
+        // per pane — and both come from the tape's own numbers, so a pane's
+        // curve lands under the prints it was computed from.
+        let lane_window = self
+            .last_lane_divider_x
+            .and_then(|divider| Some((divider, self.orderflow.as_mut()?)))
+            .and_then(|(divider, orderflow)| {
+                let end_ms = orderflow.live_end_ms()?;
+                let window = orderflow.live_lane_window_ms(visible_state).max(1);
+                Some((divider, end_ms.saturating_sub(window), end_ms))
+            });
+        let lane_steps: Vec<(i64, usize)> =
+            lane_window.map_or_else(Vec::new, |(_, start_ms, _)| {
+                let first = prefix.len();
+                closed
+                    .iter()
+                    .enumerate()
+                    .rev()
+                    .take_while(|(_, bar)| bar.close_time >= start_ms)
+                    .map(|(index, bar)| (bar.close_time, first + index))
+                    .collect::<Vec<_>>()
+                    .into_iter()
+                    .rev()
+                    .collect()
+            });
         for ((view, pane), gutter) in self
             .indicators
             .visible_panes_mut()
@@ -2043,6 +2179,15 @@ impl ChartPane {
                     egui::pos2(history_rect.left(), pane.top()),
                     egui::pos2(history_rect.right(), pane.bottom()),
                 ),
+                lane: lane_window.map(|(divider, start_ms, end_ms)| indicator_render::LaneFrame {
+                    rect: egui::Rect::from_min_max(
+                        egui::pos2(divider, pane.top()),
+                        egui::pos2(chart_rect.right(), pane.bottom()),
+                    ),
+                    start_ms,
+                    end_ms,
+                    steps: &lane_steps,
+                }),
                 gutter: *gutter,
                 background: canvas_background,
                 grid,
@@ -2709,5 +2854,27 @@ mod tests {
         );
         assert_eq!(areas.chart.bottom(), area.bottom());
         assert_eq!(areas.header.width(), area.width());
+    }
+
+    /// The rung budget is the lane's width in pixels, not a constant: a lane
+    /// narrow enough to be a sliver is not worth sixty evaluations, and a
+    /// chart with no lane at all is worth none.
+    #[test]
+    fn the_rung_budget_follows_the_lane_and_is_zero_without_one() {
+        assert_eq!(lane_rungs(0.0), 0, "no lane, no ladder");
+        assert_eq!(lane_rungs(-5.0), 0);
+        assert_eq!(lane_rungs(f32::NAN), 0);
+
+        assert_eq!(lane_rungs(60.0), 10);
+        assert_eq!(
+            lane_rungs(1.0),
+            1,
+            "a sliver of a lane still gets its live edge"
+        );
+        assert_eq!(
+            lane_rungs(100_000.0),
+            MAX_LANE_RUNGS,
+            "the ceiling is a cost statement and holds at any width"
+        );
     }
 }

--- a/crates/engine/src/bar.rs
+++ b/crates/engine/src/bar.rs
@@ -2,6 +2,8 @@
 
 use rust_decimal::Decimal;
 
+use crate::{Side, Trade};
+
 /// A completed — or in-progress — alternative bar.
 ///
 /// A bar summarises the run of trades that fell into one sampling bucket,
@@ -43,6 +45,47 @@ pub struct Bar {
 }
 
 impl Bar {
+    /// Open a fresh one-trade bar on `trade`.
+    ///
+    /// This and [`extend`](Bar::extend) are how *every* builder accumulates —
+    /// the bucketing rule decides when a bar closes, never how it summarises.
+    /// They are public because the summary of a run of trades is a fact about
+    /// the trades, not a private detail of one builder: a consumer that needs
+    /// the bar a prefix of the tape would have formed (the chart's live lane
+    /// asking an indicator what it would have shown mid-bar) must reach the
+    /// same numbers the builder does, and a second implementation of this
+    /// fold is a second answer waiting to drift.
+    #[must_use]
+    pub fn opened_by(trade: &Trade) -> Self {
+        let (buy_volume, sell_volume) = split_volume(trade);
+        Self {
+            open_time: trade.timestamp_ms,
+            close_time: trade.timestamp_ms,
+            open: trade.price,
+            high: trade.price,
+            low: trade.price,
+            close: trade.price,
+            buy_volume,
+            sell_volume,
+            trade_count: 1,
+        }
+    }
+
+    /// Fold `trade` into this in-progress bar. See [`opened_by`](Bar::opened_by).
+    pub fn extend(&mut self, trade: &Trade) {
+        self.high = self.high.max(trade.price);
+        self.low = self.low.min(trade.price);
+        self.close = trade.price;
+        self.close_time = trade.timestamp_ms;
+        // Saturating for the same reason as a builder's accumulator: untrusted
+        // feed quantities must not panic if a running side total overflows.
+        match trade.side {
+            Side::Buy => self.buy_volume = self.buy_volume.saturating_add(trade.quantity),
+            Side::Sell => self.sell_volume = self.sell_volume.saturating_add(trade.quantity),
+        }
+        self.trade_count += 1;
+    }
+
     /// Total traded quantity: `buy_volume + sell_volume`.
     ///
     /// Saturates rather than panicking on the (physically impossible) overflow,
@@ -62,9 +105,18 @@ impl Bar {
     }
 }
 
+/// A trade contributes its quantity to exactly one side.
+fn split_volume(trade: &Trade) -> (Decimal, Decimal) {
+    match trade.side {
+        Side::Buy => (trade.quantity, Decimal::ZERO),
+        Side::Sell => (Decimal::ZERO, trade.quantity),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::BarBuilder as _;
     use core::str::FromStr;
 
     fn dec(s: &str) -> Decimal {
@@ -86,5 +138,63 @@ mod tests {
         };
         assert_eq!(bar.volume(), dec("1.9"));
         assert_eq!(bar.delta(), dec("1.1"));
+    }
+
+    fn trade(agg_id: u64, price: &str, quantity: &str, side: Side) -> Trade {
+        Trade {
+            agg_id,
+            timestamp_ms: 1_700_000_000_000 + agg_id as i64 * 10,
+            price: dec(price),
+            quantity: dec(quantity),
+            side,
+        }
+    }
+
+    /// The public fold and the builders' own accumulation are the same fold.
+    ///
+    /// This is the guard behind [`Bar::opened_by`]'s promise: a consumer that
+    /// summarises a prefix of the tape itself must land on the numbers the
+    /// builder would have produced, bar type and all. Every builder folds
+    /// through these two methods, so the assertion is that no builder grew a
+    /// private variant of them.
+    #[test]
+    fn folding_trades_by_hand_reaches_the_builders_own_partial() {
+        let trades = [
+            trade(0, "36000.0", "1.0", Side::Buy),
+            trade(1, "36010.5", "0.25", Side::Sell),
+            trade(2, "35990.25", "2.5", Side::Buy),
+            trade(3, "36005.0", "0.75", Side::Sell),
+        ];
+
+        // A threshold high enough that nothing closes: the builder's partial
+        // is the whole run.
+        let mut builder = crate::TickBarBuilder::new(100);
+        for t in &trades {
+            assert!(
+                builder.push(t).is_none(),
+                "the fixture must not close a bar"
+            );
+        }
+
+        let mut folded: Option<Bar> = None;
+        for t in &trades {
+            match &mut folded {
+                None => folded = Some(Bar::opened_by(t)),
+                Some(bar) => bar.extend(t),
+            }
+        }
+
+        assert_eq!(folded.as_ref(), builder.partial());
+    }
+
+    /// Side totals saturate rather than panicking: the quantities come from an
+    /// untrusted feed, and the same rule the builders' accumulators follow.
+    #[test]
+    fn extending_saturates_instead_of_overflowing_a_side() {
+        let mut bar = Bar::opened_by(&trade(0, "1.0", "1.0", Side::Buy));
+        bar.buy_volume = Decimal::MAX;
+        bar.extend(&trade(1, "1.0", "1.0", Side::Buy));
+        assert_eq!(bar.buy_volume, Decimal::MAX);
+        assert_eq!(bar.trade_count, 2);
     }
 }

--- a/crates/engine/src/imbalance.rs
+++ b/crates/engine/src/imbalance.rs
@@ -51,7 +51,6 @@
 
 use rust_decimal::Decimal;
 
-use crate::threshold::{extend_bar, open_bar};
 use crate::{Bar, BarBuilder, Side, Trade};
 
 /// EWMA weight for the expected-trades-per-bar update, applied once per
@@ -163,8 +162,8 @@ impl ImbalanceBarBuilder {
 impl BarBuilder for ImbalanceBarBuilder {
     fn push(&mut self, trade: &Trade) -> Option<Bar> {
         match &mut self.current {
-            None => self.current = Some(open_bar(trade)),
-            Some(bar) => extend_bar(bar, trade),
+            None => self.current = Some(Bar::opened_by(trade)),
+            Some(bar) => bar.extend(trade),
         }
         self.count += 1;
         let b = match trade.side {

--- a/crates/engine/src/threshold.rs
+++ b/crates/engine/src/threshold.rs
@@ -27,7 +27,7 @@
 
 use rust_decimal::Decimal;
 
-use crate::{Bar, BarBuilder, BarProgress, Side, Trade};
+use crate::{Bar, BarBuilder, BarProgress, Trade};
 
 /// How much one trade contributes toward closing a bar.
 ///
@@ -86,8 +86,8 @@ impl<M: Measure> ThresholdBarBuilder<M> {
 impl<M: Measure> BarBuilder for ThresholdBarBuilder<M> {
     fn push(&mut self, trade: &Trade) -> Option<Bar> {
         match &mut self.current {
-            None => self.current = Some(open_bar(trade)),
-            Some(bar) => extend_bar(bar, trade),
+            None => self.current = Some(Bar::opened_by(trade)),
+            Some(bar) => bar.extend(trade),
         }
         // Saturating: the measure comes from untrusted feed data and must never
         // panic the builder on overflow. A saturated accumulator is `>= threshold`
@@ -118,48 +118,10 @@ impl<M: Measure> BarBuilder for ThresholdBarBuilder<M> {
     }
 }
 
-/// Start a fresh one-trade bar from `trade`.
-pub(crate) fn open_bar(trade: &Trade) -> Bar {
-    let (buy_volume, sell_volume) = split_volume(trade);
-    Bar {
-        open_time: trade.timestamp_ms,
-        close_time: trade.timestamp_ms,
-        open: trade.price,
-        high: trade.price,
-        low: trade.price,
-        close: trade.price,
-        buy_volume,
-        sell_volume,
-        trade_count: 1,
-    }
-}
-
-/// Fold `trade` into the in-progress `bar`.
-pub(crate) fn extend_bar(bar: &mut Bar, trade: &Trade) {
-    bar.high = bar.high.max(trade.price);
-    bar.low = bar.low.min(trade.price);
-    bar.close = trade.price;
-    bar.close_time = trade.timestamp_ms;
-    // Saturating for the same reason as the accumulator: untrusted feed
-    // quantities must not panic the builder if a running side total overflows.
-    match trade.side {
-        Side::Buy => bar.buy_volume = bar.buy_volume.saturating_add(trade.quantity),
-        Side::Sell => bar.sell_volume = bar.sell_volume.saturating_add(trade.quantity),
-    }
-    bar.trade_count += 1;
-}
-
-/// A trade contributes its quantity to exactly one side.
-fn split_volume(trade: &Trade) -> (Decimal, Decimal) {
-    match trade.side {
-        Side::Buy => (trade.quantity, Decimal::ZERO),
-        Side::Sell => (Decimal::ZERO, trade.quantity),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::Side;
     use std::str::FromStr as _;
 
     /// Test measure: accumulate traded quantity (a stand-in for volume bars,

--- a/crates/engine/src/time.rs
+++ b/crates/engine/src/time.rs
@@ -23,7 +23,6 @@
 //! time (a bar's `open_time` bucket may be several intervals after the previous
 //! bar's), and that gap is the honest record that no trades happened in between.
 
-use crate::threshold::{extend_bar, open_bar};
 use rust_decimal::Decimal;
 
 use crate::{Bar, BarBuilder, BarProgress, Trade};
@@ -80,20 +79,20 @@ impl BarBuilder for TimeBarBuilder {
         match &mut self.current {
             // First trade: open the first bar; nothing closes yet.
             None => {
-                self.current = Some(open_bar(trade));
+                self.current = Some(Bar::opened_by(trade));
                 self.bucket_start = bucket;
                 None
             }
             // Same interval: fold the trade into the forming bar.
             Some(bar) if bucket == self.bucket_start => {
-                extend_bar(bar, trade);
+                bar.extend(trade);
                 None
             }
             // A later interval: close the current bar and open a fresh one for
             // this trade. Any intervening empty intervals are simply skipped.
             Some(_) => {
                 let closed = self.current.take();
-                self.current = Some(open_bar(trade));
+                self.current = Some(Bar::opened_by(trade));
                 self.bucket_start = bucket;
                 closed
             }

--- a/crates/indicators/benches/eval.rs
+++ b/crates/indicators/benches/eval.rs
@@ -119,10 +119,43 @@ fn bench_host(bars: &[Bar]) {
     );
 }
 
+/// The live lane's ladder: one walk is what a chart pays per drained worker
+/// batch to draw its panes across the tape, and it is a multiple of the
+/// preview above — `rungs` previews per indicator, not one.
+///
+/// Reported per *walk* rather than per rung, because a walk is the unit the
+/// chart actually pays. At 64 rungs (the renderer's ceiling, reached only by
+/// a very wide lane) it is 64x the preview cost, and the cadence consuming it
+/// is the worker's own coalesced drain, never the feed's print rate.
+fn bench_lane_ladder(bars: &[Bar]) {
+    let mut host = IndicatorHost::new();
+    host.add(Box::new(Ema::new(21, SourceId::Close)));
+    host.add(Box::new(Cvd::new()));
+    host.rebuild(bars, None);
+
+    let partial = bars.last().expect("bars are non-empty").clone();
+    for rungs in [8_usize, 64] {
+        let prefixes: Vec<Bar> = (0..rungs).map(|_| partial.clone()).collect();
+        let walks = 2_000;
+        let start = Instant::now();
+        for _ in 0..walks {
+            host.walk_partial_prefixes(black_box(&prefixes), |_, previews| {
+                black_box(previews.iter().count());
+            });
+        }
+        report(
+            &format!("lane walk x{rungs} (EMA+CVD)"),
+            walks,
+            start.elapsed(),
+        );
+    }
+}
+
 fn main() {
     let n = 100_000;
     println!("indicator eval benchmark: {n} deterministic bars\n");
     let bars = make_bars(n);
     bench_kernels(n);
     bench_host(&bars);
+    bench_lane_ladder(&bars);
 }

--- a/crates/indicators/src/host.rs
+++ b/crates/indicators/src/host.rs
@@ -41,6 +41,33 @@ struct Instance {
     preview: Option<PreviewFrame>,
 }
 
+/// What every hosted indicator previewed for one rung of a ladder walk.
+///
+/// Borrowed rather than collected: a rung is read and turned into whatever
+/// the caller is building (a lane sample, a row of a table) before the next
+/// prefix overwrites it, so a walk of sixty rungs allocates nothing here.
+pub struct PreviewsAt<'a> {
+    instances: &'a [Instance],
+}
+
+impl PreviewsAt<'_> {
+    /// The frame one instance previewed for this rung. `None` when the
+    /// instance is in its error state — a failed indicator has nothing to say
+    /// about this instant, and saying nothing is the honest answer.
+    #[must_use]
+    pub fn get(&self, id: InstanceId) -> Option<&PreviewFrame> {
+        self.instances
+            .iter()
+            .find(|i| i.id == id)
+            .and_then(|i| i.preview.as_ref())
+    }
+
+    /// Every instance's frame for this rung, in insertion (render) order.
+    pub fn iter(&self) -> impl Iterator<Item = (InstanceId, Option<&PreviewFrame>)> + '_ {
+        self.instances.iter().map(|i| (i.id, i.preview.as_ref()))
+    }
+}
+
 /// See the module docs.
 #[derive(Default)]
 pub struct IndicatorHost {
@@ -129,6 +156,76 @@ impl IndicatorHost {
         };
         let bar = IndicatorBar::from(bar);
         self.partial = Some(bar);
+        let bar_index = self.bars.len();
+        let staged_cvd = self.cvd.last().copied().unwrap_or(0.0) + bar.delta();
+        self.cvd.push(staged_cvd);
+        let cvd = &self.cvd;
+        for instance in &mut self.instances {
+            Self::preview_instance(instance, &bar, bar_index, cvd);
+        }
+        self.cvd.pop();
+    }
+
+    /// Walk a ladder of forming-bar prefixes, handing each rung's previews to
+    /// `visit`, and leave the host exactly as it was found.
+    ///
+    /// A preview stages the forming bar's cvd, runs, and pops it again — it
+    /// touches no committed state — so the same forming bar can be previewed
+    /// as many times as a caller likes. Handed the bar as it stood after the
+    /// 1st, 10th, 20th … print of the run, that turns into an honest answer
+    /// to "what was this indicator showing mid-bar?": every rung is a real
+    /// evaluation of a real prefix of the tape, never an interpolation
+    /// between two committed points.
+    ///
+    /// **The ladder reaches back only to the forming bar's open.** A closed
+    /// bar cannot be re-entered — committing is one-way, by design — so an
+    /// instant older than the current bar's open has no rung here, and a
+    /// caller that needs the value there reads the committed column instead.
+    /// That is the boundary of what the host can honestly answer.
+    ///
+    /// The prefixes are the caller's to choose ([`Bar::opened_by`] +
+    /// [`Bar::extend`] over the run's trades produces them); they are expected
+    /// in occurrence order, and nothing here requires them to be evenly
+    /// spaced.
+    pub fn walk_partial_prefixes(
+        &mut self,
+        prefixes: &[Bar],
+        mut visit: impl FnMut(&Bar, PreviewsAt<'_>),
+    ) {
+        if prefixes.is_empty() || self.instances.is_empty() {
+            return;
+        }
+        // Every rung overwrites the retained forming bar, so the real one is
+        // put aside first: without this the host would come out of the walk
+        // believing the last rung *is* the bar that is forming, and every
+        // later preview would run against a prefix of the tape instead of all
+        // of it.
+        let retained = self.partial;
+        for prefix in prefixes {
+            self.set_partial(Some(prefix));
+            visit(
+                prefix,
+                PreviewsAt {
+                    instances: &self.instances,
+                },
+            );
+        }
+        // The walk left every instance previewing the last rung. Put the real
+        // forming bar back: whoever reads `preview()` after this must see the
+        // bar as it actually stands, not wherever the ladder stopped.
+        self.partial = retained;
+        self.restore_retained_previews();
+    }
+
+    /// Re-run the retained forming bar's previews across every instance (or
+    /// clear them when no bar is forming) — the tail of a ladder walk.
+    fn restore_retained_previews(&mut self) {
+        let Some(bar) = self.partial else {
+            for instance in &mut self.instances {
+                instance.preview = None;
+            }
+            return;
+        };
         let bar_index = self.bars.len();
         let staged_cvd = self.cvd.last().copied().unwrap_or(0.0) + bar.delta();
         self.cvd.push(staged_cvd);

--- a/crates/indicators/src/lib.rs
+++ b/crates/indicators/src/lib.rs
@@ -54,7 +54,7 @@ mod objects;
 mod output;
 
 pub use bar::IndicatorBar;
-pub use host::{IndicatorHost, InstanceId};
+pub use host::{IndicatorHost, InstanceId, PreviewsAt};
 pub use indicator::{Ctx, EvalError, Indicator, IndicatorDescriptor};
 pub use input::{InputSpec, InputValue, SourceId};
 pub use objects::{

--- a/crates/indicators/tests/host.rs
+++ b/crates/indicators/tests/host.rs
@@ -423,3 +423,143 @@ fn a_catch_up_failure_lands_in_the_newcomers_error_state() {
         2
     );
 }
+
+/// The ladder's core promise: every rung is a real evaluation of a real
+/// prefix, so a rung's values equal what a plain `set_partial` of that same
+/// prefix produces. If the walk ever interpolated, or leaked one rung's state
+/// into the next, this diverges.
+#[test]
+fn every_rung_equals_a_standalone_preview_of_the_same_prefix() {
+    let (bars, _) = bars_and_partial(5);
+    let trades = fixture::parse_trades(TRADES).expect("fixture parses");
+
+    // Prefixes of one run of trades, folded the way every builder folds.
+    let mut prefixes = Vec::new();
+    let mut forming: Option<Bar> = None;
+    for trade in trades.iter().take(6) {
+        match &mut forming {
+            None => forming = Some(Bar::opened_by(trade)),
+            Some(bar) => bar.extend(trade),
+        }
+        prefixes.push(forming.clone().expect("a bar is forming"));
+    }
+
+    let mut walked = IndicatorHost::new();
+    let walked_id = walked.add(Box::new(Cvd::new()));
+    for bar in &bars {
+        walked.push_closed_bar(bar);
+    }
+    let mut rungs = Vec::new();
+    walked.walk_partial_prefixes(&prefixes, |prefix, previews| {
+        rungs.push((
+            prefix.close_time,
+            previews
+                .get(walked_id)
+                .map(|frame| format!("{:?}", frame.values)),
+        ));
+    });
+
+    let mut one_at_a_time = IndicatorHost::new();
+    let solo_id = one_at_a_time.add(Box::new(Cvd::new()));
+    for bar in &bars {
+        one_at_a_time.push_closed_bar(bar);
+    }
+    let expected: Vec<_> = prefixes
+        .iter()
+        .map(|prefix| {
+            one_at_a_time.set_partial(Some(prefix));
+            (
+                prefix.close_time,
+                one_at_a_time
+                    .preview(solo_id)
+                    .map(|frame| format!("{:?}", frame.values)),
+            )
+        })
+        .collect();
+
+    assert_eq!(rungs, expected);
+    assert_eq!(rungs.len(), prefixes.len(), "one rung per prefix");
+}
+
+/// A walk is a read, not a write: it may not advance committed state, and it
+/// must hand the retained forming bar back to whoever reads `preview()` next.
+/// Otherwise the chart's headline value would be stuck wherever the ladder
+/// happened to stop.
+#[test]
+fn a_walk_leaves_committed_state_and_the_live_preview_untouched() {
+    let (bars, partial) = bars_and_partial(5);
+    let partial = partial.expect("the fixture leaves a bar forming");
+
+    let mut host = IndicatorHost::new();
+    let id = host.add(Box::new(Cvd::new()));
+    for bar in &bars {
+        host.push_closed_bar(bar);
+    }
+    host.set_partial(Some(&partial));
+
+    let committed = plot0(&host, id);
+    let live = host
+        .preview(id)
+        .map(|frame| format!("{:?}", frame.values))
+        .expect("the forming bar previews");
+
+    // A ladder that ends somewhere else entirely.
+    let mut halfway = partial.clone();
+    halfway.close_time -= 1;
+    halfway.buy_volume += rust_decimal::Decimal::from(1000);
+    host.walk_partial_prefixes(&[halfway], |_, _| {});
+
+    assert!(
+        same_column(&plot0(&host, id), &committed),
+        "a walk commits nothing"
+    );
+    assert_eq!(
+        host.preview(id).map(|frame| format!("{:?}", frame.values)),
+        Some(live),
+        "the retained forming bar is previewing again after the walk"
+    );
+    assert_eq!(host.bar_count(), bars.len());
+}
+
+/// With no bar forming, a walk still restores the truth: no preview at all.
+/// A leftover rung here would draw a forming value onto a chart that has none.
+#[test]
+fn a_walk_without_a_forming_bar_clears_the_previews_it_staged() {
+    let (bars, partial) = bars_and_partial(5);
+    let partial = partial.expect("the fixture leaves a bar forming");
+
+    let mut host = IndicatorHost::new();
+    let id = host.add(Box::new(Cvd::new()));
+    for bar in &bars {
+        host.push_closed_bar(bar);
+    }
+    host.set_partial(None);
+
+    host.walk_partial_prefixes(&[partial], |_, _| {});
+
+    assert!(
+        host.preview(id).is_none(),
+        "nothing is forming, so nothing previews"
+    );
+}
+
+/// An empty ladder is a no-op, and a walk over a host with no indicators
+/// visits nothing — the chart asks for a ladder every publish, including the
+/// publishes where there is nothing to ask about.
+#[test]
+fn an_empty_ladder_visits_nothing() {
+    let (bars, partial) = bars_and_partial(5);
+    let mut host = IndicatorHost::new();
+    host.add(Box::new(Cvd::new()));
+    for bar in &bars {
+        host.push_closed_bar(bar);
+    }
+
+    let mut visits = 0;
+    host.walk_partial_prefixes(&[], |_, _| visits += 1);
+    assert_eq!(visits, 0);
+
+    let mut empty = IndicatorHost::new();
+    empty.walk_partial_prefixes(&[partial.expect("forming")], |_, _| visits += 1);
+    assert_eq!(visits, 0, "no indicators, nothing to preview");
+}

--- a/crates/indicators/tests/host.rs
+++ b/crates/indicators/tests/host.rs
@@ -563,3 +563,37 @@ fn an_empty_ladder_visits_nothing() {
     empty.walk_partial_prefixes(&[partial.expect("forming")], |_, _| visits += 1);
     assert_eq!(visits, 0, "no indicators, nothing to preview");
 }
+
+/// The ladder is a port, not a CVD feature: a second implementation exercises
+/// it, and one instance failing must not cost its neighbour its rungs. A
+/// failing indicator contributes nothing to the lane — the honest answer —
+/// while the healthy one is sampled as if nothing happened.
+#[test]
+fn a_failing_instance_drops_out_of_the_ladder_without_taking_its_neighbour() {
+    let (bars, partial) = bars_and_partial(5);
+    let partial = partial.expect("the fixture leaves a bar forming");
+
+    let mut host = IndicatorHost::new();
+    let healthy = host.add(Box::new(Cvd::new()));
+    let broken = host.add(Box::new(FailingAt::failing_preview()));
+    for bar in &bars {
+        host.push_closed_bar(bar);
+    }
+
+    let mut healthy_rungs = 0;
+    let mut broken_rungs = 0;
+    host.walk_partial_prefixes(&[partial.clone(), partial], |_, previews| {
+        if previews.get(healthy).is_some() {
+            healthy_rungs += 1;
+        }
+        if previews.get(broken).is_some() {
+            broken_rungs += 1;
+        }
+        assert_eq!(previews.iter().count(), 2, "both instances are visited");
+    });
+
+    assert_eq!(healthy_rungs, 2, "the healthy instance is sampled");
+    assert_eq!(broken_rungs, 0, "the failing one says nothing");
+    assert!(host.error(broken).is_some(), "and its failure is recorded");
+    assert!(host.error(healthy).is_none(), "the neighbour is untouched");
+}


### PR DESCRIPTION
An indicator pane stopped at the live lane's divider while its value labels sat
in the gutter on the far side of the tape's band. The curve and the numbers
describing it were a lane-width apart with bare canvas in between, and the only
way to move that curve was to travel to the gutter and drag it there.

## What changes

**The pane is one strip, from the chart's left edge to its gutter.** Inside the
lane it draws in *tape time* rather than bar slots — the tape's own linear
mapping, so a pane's curve lands under the prints it was computed from.

**The lane segment is evaluated, not extrapolated.** `IndicatorHost::walk_partial_prefixes`
previews a ladder of forming-bar prefixes and restores the retained bar
afterwards: every rung is a real evaluation of a real prefix of the run, and
the walk commits nothing. The prefixes are folded with `Bar::opened_by` /
`Bar::extend` — the fold every builder already used privately, now engine API,
with a test asserting the public fold and the builders' own partial agree.

**What cannot be sampled is not invented.** A commit is one-way, so a bar that
already closed cannot be re-entered. Bars that closed inside the lane window
hold flat and step at their close — the committed resolution — and only the
forming bar gets rung-by-rung detail. The step shape *is* the label.

**Cost is bounded by the lane, not by the feed.** The rung budget is the lane's
own width (one rung per 6 px, capped at 64). A chart with no lane asks for no
rungs, sends no run of trades, and walks no ladder. The walk itself runs on the
indicator worker's existing coalesced cadence: per drained batch, never per
print and never per frame.

**Pane bodies answer the chart's gestures.** Press and drag pans the pane's own
scale vertically and the shared time axis horizontally, scroll zooms time, and
double click hands the scale back to auto-fit — the same verbs the candles use,
so the gesture language is one language. Time is applied once per drag however
many panes are stacked.

## Performance

Declared per touched path:

| Path | Rate | Cost |
| --- | --- | --- |
| Ladder walk | per drained worker batch | `rungs` previews per indicator |
| Lane polyline | per frame | one polyline per line-shaped plot, ≤ rungs + steps points |
| Lane window / steps | per frame | one published-book read, one bounded Vec |
| Pane body gesture | per frame | O(1) per pane |
| Per-trade / per-depth | — | untouched |

Measured, not asserted:

- `cargo bench -p quantick-indicators` (new `lane walk` case): a 64-rung walk
  over EMA + CVD costs **60.2 µs**, an 8-rung walk **7.6 µs** — linear in rungs,
  against a single preview at 938 ns.
- `APP_HEALTH_SUMMARY` A/B on a live BTCUSDT tape: same hooks (book + bubbles
  + live strip + the `cvd` script in a pane), 45 health windows each,
  alternating `main`, branch, `main`, branch so drift in the tape does not all
  land on one side. `frame_cpu_ms` median per run:

  | Run | frame_cpu median | heatmap_cells | trades/s |
  | --- | --- | --- | --- |
  | `main` r1 | 2.38 ms | 688 | 5.0 |
  | branch r1 | 2.39 ms | 499 | 3.6 |
  | `main` r2 | 2.26 ms | 475 | 3.4 |
  | branch r2 | 2.74 ms | 729 | 6.7 |

  The runs are not load-matched — the market decided how busy each one was, and
  frame cost tracks `heatmap_cells` closely. Fitting each build's two points
  against cell count and reading both at 600 cells gives **2.33 ms (`main`) vs
  2.54 ms (branch): about +0.2 ms of frame CPU**, on a ~16.7 ms budget, for a
  curve, a wider background fill and gridlines that were not drawn before.

  **This is not flat, and it is the honest number.** An earlier measurement of
  this branch showed +0.66 ms; most of that was a second published-book read
  per frame (a worker mutex on the render thread), fixed in b62eb57. What is
  left is the cost of the new ink.

  Both builds render the chart area **white** when launched this way in this
  environment, at fps 19 with `frame_cpu` around 2.4 ms — the surface does not
  present for a process started detached here. `main` behaves identically, so
  it is an environment state rather than a regression; `frame_cpu_ms` is real
  CPU work per frame either way, which is why the comparison above uses it and
  not fps.

## Deferrals

- **Histogram and marker plots are not drawn in the lane.** A column is a
  statement about one bar at that bar's width, and a time axis has no bar
  widths to honour. A delta-histogram pane therefore still shows an empty
  band. Line, step-line and area plots are drawn.
- **The committed and sampled halves of the lane curve share one stroke.** The
  stair vs. curve shape distinguishes them; a dimmer stroke for the coarser
  half was considered and not done.
- **Visual QA did not run.** The app's chart area captures white in this
  environment for both this branch and a `main` control build (see
  Performance), so no screenshot of the feature exists. The geometry, the
  stepping, the rung placement, the budget and all three pane gestures are
  covered by tests instead — but nobody has looked at it yet. Worth a human
  glance before merge.

## Verification

- `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`,
  `cargo build --workspace`, `cargo test --workspace` — all green.
- `arch-review` run over the diff. Three findings it raised were fixed in the
  branch rather than deferred: the forming bar's trades were cloned on every
  drain even with no lane to draw them in; the lane samples were cloned a
  second time on their way out of the worker; and reading the lane's live edge
  took a second worker-mutex lock per frame on the render thread.
- `trader-ux-review`: one Should-fix it raised was fixed rather than deferred —
  a pane body that had become an interactive surface answered a drag on y only
  and ignored scroll entirely, while the candles' body pans both axes and zooms
  time. The gesture set is now the same everywhere.

### Tests

| Behaviour | Test |
| --- | --- |
| The public fold reaches the builders' own partial | `engine::bar::folding_trades_by_hand_reaches_the_builders_own_partial` |
| A rung equals a standalone preview of the same prefix | `indicators/host::every_rung_equals_a_standalone_preview_of_the_same_prefix` |
| A walk commits nothing and restores the live preview | `indicators/host::a_walk_leaves_committed_state_and_the_live_preview_untouched` |
| The ladder is a port: a failing instance drops out, its neighbour does not | `indicators/host::a_failing_instance_drops_out_of_the_ladder_without_taking_its_neighbour` |
| The newest print always gets a rung, whatever the budget | `app::indicator_worker::a_ladder_respects_its_budget_and_always_reaches_the_newest_print` |
| The lane's live end is the preview | `app::indicator_worker::the_lane_samples_end_where_the_preview_does` |
| Dropping the lane clears the curve | `app::indicator_worker::dropping_the_lane_clears_the_samples_already_published` |
| Tape time maps linearly and clamps | `app::indicator_render::a_lane_maps_tape_time_linearly_and_clamps_outside_its_window` |
| Committed values step instead of interpolating | `app::indicator_render::committed_values_step_across_the_lane_instead_of_interpolating` |
| Bar-shaped plots stay out of the lane | `app::indicator_render::bar_shaped_plots_stay_out_of_the_lane` |
| No lane, no budget | `app::pane::the_rung_budget_follows_the_lane_and_is_zero_without_one` |
| A body drag pans the pane and the shared time axis | `app::dragging_a_pane_body_pans_that_pane_and_the_shared_time_axis` |
| Time pans once however many panes are stacked | `app::a_pane_drag_pans_time_once_however_many_panes_are_stacked` |
| Double click returns a pane to auto-fit | `app::double_clicking_a_pane_body_returns_it_to_auto_fit` |
