### PR TITLE
feat(app): a professional price-action drawing toolbox

### DIFF
--- a/.claude/skills/ui-harness/SKILL.md
+++ b/.claude/skills/ui-harness/SKILL.md
@@ -35,6 +35,17 @@ is the source of truth, this table is the index):
 | `QUANTICK_BACKFILL` / `QUANTICK_BOOK_DEPTH` | history paging / depth size |
 | `QUANTICK_TRADES_DIR` | paper-trading journal location (point at scratch) |
 
+Landing with the drawing-toolbar goal (`feat/drawing-toolbar-pro`):
+
+| Hook | Reaches |
+| --- | --- |
+| `QUANTICK_DRAWING_TOOL=<tool id>` | opens with that tool armed — any id in `DRAWING_TOOLS` (`trend-line`, `ray`, `measure`, `text`, …) |
+| `QUANTICK_DRAWING_MAGNET=1` | the magnet on (anchors snap to the bar's OHLC) |
+| `QUANTICK_DRAWINGS_DEMO=1` | one of every registered drawing placed on the flow pane once it has bars, the last one selected so the inspector is on screen too |
+| `QUANTICK_DRAWINGS_DEMO_SHARED=1` | those demo objects marked "show on all charts" — pair with a split layout to see the cross-pane projection |
+
+Once merged, move them into the table above.
+
 Landing with PR #127 (paper trading v2): `QUANTICK_DOCK_TAB`
 (`l2|bubbles|session|trading|trades`), `QUANTICK_PAPER_REPORT_AUTOSTART=1`,
 `QUANTICK_PAPER_DEMO=1` (scripted deterministic trade sequence). Once merged,

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ __pycache__/
 /quantick-drawing-presets.toml
 # Which chart layers the app was last showing (the right-click layer menu)
 /chart-layers.toml
+crates/app/indicators-state.toml

--- a/crates/app/indicators-state.toml
+++ b/crates/app/indicators-state.toml
@@ -1,2 +1,0 @@
-version = 1
-indicators = []

--- a/crates/app/indicators-state.toml
+++ b/crates/app/indicators-state.toml
@@ -1,0 +1,2 @@
+version = 1
+indicators = []

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -6209,6 +6209,70 @@ plot(close)
         }
     }
 
+    /// The reported flicker, root cause.
+    ///
+    /// The pinned inspector is a `SidePanel::right` laid out *before* the
+    /// central panel, so the frame a selection appears is the frame the
+    /// canvas narrows by the panel's width — and every drawing slides left
+    /// with it. Press on frame N (wide canvas) selects; release on frame N+1
+    /// (narrow canvas) hit-tests the same screen pixel, finds the drawing has
+    /// moved out from under it, and deselects. The panel opens and shuts in
+    /// two frames, forever, with the mouse standing still.
+    #[test]
+    fn a_pinned_inspector_cannot_wipe_the_selection_that_opened_it() {
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        run_frame(&mut app, &ctx);
+
+        arm_drawing_from_toolbox(&mut app, &ctx, "trend-line");
+        click_chart(&mut app, &ctx, egui::pos2(600.0, 400.0));
+        click_chart(&mut app, &ctx, egui::pos2(900.0, 300.0));
+        run_frame(&mut app, &ctx);
+        assert_eq!(app.active_tab().flow_pane.drawings.items().len(), 1);
+
+        // Pinned, and the user has expressed the preference — the exact
+        // state the report was in.
+        app.inspector_pinned = true;
+        app.inspector_pin_touched = true;
+        app.active_tab_mut().flow_pane.drawings.select(None);
+        run_frame(&mut app, &ctx);
+        let wide = app
+            .active_tab()
+            .flow_pane
+            .last_chart_area
+            .expect("the canvas drew")
+            .width();
+
+        // Click the middle of the line: nowhere near a handle, squarely on
+        // the stroke. Nothing about this gesture is marginal.
+        click_chart(&mut app, &ctx, egui::pos2(750.0, 350.0));
+        assert_eq!(
+            app.active_tab().flow_pane.drawings.selected(),
+            Some(0),
+            "the release must not undo the selection the press made"
+        );
+
+        let narrow = app
+            .active_tab()
+            .flow_pane
+            .last_chart_area
+            .expect("the canvas drew")
+            .width();
+        assert!(
+            narrow < wide,
+            "this proof needs the pinned panel to actually steal canvas              width: {wide} -> {narrow}"
+        );
+
+        for frame in 0..4 {
+            run_frame(&mut app, &ctx);
+            assert_eq!(
+                app.active_tab().flow_pane.drawings.selected(),
+                Some(0),
+                "the selection vanished {frame} frames after the click"
+            );
+        }
+    }
+
     /// The reported flicker, reduced to its cause.
     ///
     /// The press selects on an anchor grab (12 px); the release used to

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -240,26 +240,67 @@ fn clamp_into_chart(position: egui::Pos2, size: egui::Vec2, chart: egui::Rect) -
     )
 }
 
-/// The inspector placement rule (`docs/drawing-toolbar-ux.md` §4.2): eight
-/// candidates — beside the object, then the chart corners — each clamped
-/// into the chart *before* scoring, then least `bbox` overlap wins. Ties
-/// break toward the greater centre distance, then candidate order, so the
-/// result is deterministic and, at zero overlap, keeps the classic
-/// right / left / below / above preference.
+/// The inspector placement rule (`docs/ux/drawing-tools-2026-08.md` §D3).
+///
+/// The old rule scored least overlap with the object's *bounding box*, and a
+/// small object has a small box: "beside it with a 12 px gap" scored zero and
+/// won, dropping the panel straight onto the price action the trader drew the
+/// line to read. The read is the neighbourhood of the object, not its box.
+///
+/// So the corners come first, and the winner is the **farthest** clear one:
+///
+/// 1. the two **top** corners first, inset by the gap. Top before bottom is
+///    structural, not taste: a panel is positioned by its top-left and grows
+///    downwards, so a top corner always has the whole pane to grow into. A
+///    bottom-anchored panel that turns out taller than the placement assumed
+///    runs off the window and loses its last rows — and rows a trader cannot
+///    reach read as rows that do not exist;
+/// 2. of the two, the one that clears `bbox` and whose centre is farthest
+///    from the object wins, so the panel walks away from the drawing across
+///    the chart. An exact tie (a centred object) takes the left one, so the
+///    panel appears in the same place every time;
+/// 3. only if neither top corner is free, the bottom two on the same rule;
+/// 4. and if every corner is fouled — a large object covering the chart —
+///    the beside-the-object candidates, least overlap first.
 fn inspector_placement(chart: egui::Rect, bbox: egui::Rect, size: egui::Vec2) -> egui::Pos2 {
     let gap = INSPECTOR_OBJECT_GAP_PX;
-    let candidates = [
+    let top_corners = [
+        egui::pos2(chart.left() + gap, chart.top() + gap),
+        egui::pos2(chart.right() - gap - size.x, chart.top() + gap),
+    ];
+    let bottom_corners = [
+        egui::pos2(chart.left() + gap, chart.bottom() - gap - size.y),
+        egui::pos2(chart.right() - gap - size.x, chart.bottom() - gap - size.y),
+    ];
+    let farthest_clear = |candidates: [egui::Pos2; 2]| {
+        let mut best: Option<(egui::Pos2, f32)> = None;
+        for candidate in candidates {
+            let position = clamp_into_chart(candidate, size, chart);
+            let rect = egui::Rect::from_min_size(position, size);
+            if rect.intersect(bbox).is_positive() {
+                continue;
+            }
+            let distance = rect.center().distance(bbox.center());
+            if best.is_none_or(|(_, best)| distance > best) {
+                best = Some((position, distance));
+            }
+        }
+        best.map(|(position, _)| position)
+    };
+    if let Some(position) = farthest_clear(top_corners).or_else(|| farthest_clear(bottom_corners)) {
+        return position;
+    }
+    let corners = [top_corners, bottom_corners].concat();
+
+    // Nothing clear anywhere: crowd the object as little as possible.
+    let fallbacks = [
         egui::pos2(bbox.right() + gap, bbox.top()),
         egui::pos2(bbox.left() - gap - size.x, bbox.top()),
         egui::pos2(bbox.left(), bbox.bottom() + gap),
         egui::pos2(bbox.left(), bbox.top() - gap - size.y),
-        egui::pos2(chart.left() + gap, chart.top() + gap),
-        egui::pos2(chart.right() - gap - size.x, chart.top() + gap),
-        egui::pos2(chart.left() + gap, chart.bottom() - gap - size.y),
-        egui::pos2(chart.right() - gap - size.x, chart.bottom() - gap - size.y),
     ];
     let mut best: Option<(egui::Pos2, f32, f32)> = None;
-    for candidate in candidates {
+    for candidate in fallbacks.into_iter().chain(corners.iter().copied()) {
         let position = clamp_into_chart(candidate, size, chart);
         let rect = egui::Rect::from_min_size(position, size);
         let overlap = rect.intersect(bbox);
@@ -269,16 +310,11 @@ fn inspector_placement(chart: egui::Rect, bbox: egui::Rect, size: egui::Vec2) ->
             0.0
         };
         let distance = rect.center().distance(bbox.center());
-        // A clear (zero-overlap) candidate wins on order alone, keeping the
-        // beside-the-object preference over the corners; among genuinely
-        // overlapping candidates the farther-away one crowds least.
         let wins = match &best {
             None => true,
             Some((_, best_area, best_distance)) => {
                 overlap_area < *best_area
-                    || (overlap_area == *best_area
-                        && overlap_area > 0.0
-                        && distance > *best_distance)
+                    || (overlap_area == *best_area && distance > *best_distance)
             }
         };
         if wins {
@@ -461,7 +497,15 @@ pub struct QuantickApp {
     // chart rectangle it is placed against belongs to the focused
     // [`ChartPane`], so a split window places against the pane the selection
     // lives on, not the window.
+    // Scripted-validation hook: place one of every registered drawing on the
+    // flow pane as soon as it has bars to anchor them to. Consumed once.
+    pending_drawing_demo: bool,
     inspector_pos: Option<egui::Pos2>,
+    // The floating panel's size as it was last actually drawn. Read back from
+    // the window response rather than from egui's area memory: the memory
+    // lookup is empty on the frame the panel is being laid out, which is
+    // exactly the frame the placement and the clamp need a size.
+    inspector_size: Option<egui::Vec2>,
     // Whether the user ever toggled the pin — the auto-pin width rule stops
     // firing once they have expressed a preference.
     inspector_pin_touched: bool,
@@ -615,7 +659,9 @@ impl QuantickApp {
             inspector_pinned: false,
             inspector_moved: false,
             inspector_last_selection: None,
+            pending_drawing_demo: false,
             inspector_pos: None,
+            inspector_size: None,
             inspector_pin_touched: false,
             inspector_settle_frame: false,
             drawing_manager_open: false,
@@ -673,6 +719,21 @@ impl QuantickApp {
         if std::env::var("QUANTICK_LIVE_STRIP_AUTOSTART").is_ok_and(|value| value == "1") {
             app.active_tab_mut().flow_pane.live_strip_visible = true;
         }
+        // Drawing-toolbar hooks, so a validation run reaches every new
+        // surface without a click (`.claude/skills/ui-harness`).
+        if let Ok(id) = std::env::var("QUANTICK_DRAWING_TOOL")
+            && let Some(tool) = drawings::DRAWING_TOOLS
+                .into_iter()
+                .find(|tool| tool.id() == id.trim())
+        {
+            app.toolrail.arm(Tool::Drawing(tool));
+        }
+        if std::env::var("QUANTICK_DRAWING_MAGNET").is_ok_and(|value| value == "1") {
+            app.toolrail.set_magnet(true);
+        }
+        app.pending_drawing_demo =
+            std::env::var("QUANTICK_DRAWINGS_DEMO").is_ok_and(|value| value == "1");
+
         // Same convenience for the aggression layer (bubbles + the live
         // column's footprint). Same code path as the toolbar toggle.
         if std::env::var("QUANTICK_BUBBLES_AUTOSTART").is_ok_and(|value| value == "1") {
@@ -2764,6 +2825,37 @@ impl QuantickApp {
                         egui::RichText::new("Unlock the drawing to edit its coordinates.").small(),
                     );
                 }
+
+                // Where the object appears. It belongs on this tab and not
+                // with the style controls: sharing is a statement about the
+                // anchors, and the anchors are right here
+                // (`docs/ux/drawing-tools-2026-08.md` §D7).
+                ui.separator();
+                let shareable = drawing.shareable();
+                let mut shared = drawing.scope == drawings::DrawingScope::AllCharts;
+                let response = ui.add_enabled(
+                    shareable,
+                    egui::Checkbox::new(&mut shared, "Show on all charts"),
+                );
+                if response.changed() {
+                    drawing.scope = if shared {
+                        drawings::DrawingScope::AllCharts
+                    } else {
+                        drawings::DrawingScope::ThisChart
+                    };
+                    actions.edited = true;
+                }
+                // A disabled control with no reason reads as a bug (Duda).
+                let hint = if shareable {
+                    "The other chart of this tab shows it at the same moment in market time."
+                } else {
+                    "This drawing has an anchor past the newest bar, so there is no market time to \
+                     place it by on another chart."
+                };
+                response.on_hover_text(hint);
+                if !shareable {
+                    ui.label(egui::RichText::new(hint).small());
+                }
             }
         }
         actions
@@ -2842,24 +2934,29 @@ impl QuantickApp {
         }
     }
 
-    /// Where a freshly opened floating inspector should sit. Eight
-    /// candidates — four beside the object's bounding box, four in the
-    /// chart's corners — every one clamped into the chart pane *before*
-    /// scoring, then the least bbox overlap wins (ties: farther from the
-    /// object's centre, then candidate order). At zero overlap the order
-    /// tie-break keeps the right / left / below / above preference. The
-    /// chart pane already excludes both axes and the live lane, so the
-    /// popup can never cover them or leave the view.
+    /// Where a freshly opened floating inspector should sit: the farthest
+    /// chart corner that clears the object, bottom-left preferred, falling
+    /// back to beside-the-object only when no corner is free — see
+    /// [`inspector_placement`]. The chart pane already excludes both axes and
+    /// the live lane, so the popup can never cover them or leave the view.
     fn inspector_target_position(&self, ctx: &egui::Context, index: usize) -> Option<egui::Pos2> {
         let chart = self.focused_pane().last_chart_area?;
         let bbox = self.drawing_bbox_on_screen(chart, index)?;
-        let size = ctx
-            .memory(|memory| memory.area_rect(egui::Id::new("drawing_inspector")))
-            .map_or(
-                egui::vec2(INSPECTOR_DEFAULT_WIDTH_PX, INSPECTOR_FALLBACK_HEIGHT_PX),
-                |rect| rect.size(),
-            );
-        Some(inspector_placement(chart, bbox, size))
+        Some(inspector_placement(chart, bbox, self.inspector_size(ctx)))
+    }
+
+    /// How big the floating inspector is, best answer available: the size it
+    /// was last drawn at, then egui's area memory, then the assumed default.
+    fn inspector_size(&self, ctx: &egui::Context) -> egui::Vec2 {
+        self.inspector_size
+            .or_else(|| {
+                ctx.memory(|memory| memory.area_rect(egui::Id::new("drawing_inspector")))
+                    .map(|rect| rect.size())
+            })
+            .unwrap_or(egui::vec2(
+                INSPECTOR_DEFAULT_WIDTH_PX,
+                INSPECTOR_FALLBACK_HEIGHT_PX,
+            ))
     }
 
     /// The selected object's screen bounding box, expanded by the anchor
@@ -2986,13 +3083,7 @@ impl QuantickApp {
         if let (Some(position), Some(chart)) =
             (self.inspector_pos, self.focused_pane().last_chart_area)
         {
-            let size = ctx
-                .memory(|memory| memory.area_rect(egui::Id::new("drawing_inspector")))
-                .map_or(
-                    egui::vec2(INSPECTOR_DEFAULT_WIDTH_PX, INSPECTOR_FALLBACK_HEIGHT_PX),
-                    |rect| rect.size(),
-                );
-            let clamped = clamp_into_chart(position, size, chart);
+            let clamped = clamp_into_chart(position, self.inspector_size(ctx), chart);
             if clamped != position {
                 self.inspector_pos = Some(clamped);
             }
@@ -3021,6 +3112,9 @@ impl QuantickApp {
             actions.merge(self.drawing_inspector_body(ui, index));
             actions
         });
+        self.inspector_size = response
+            .as_ref()
+            .map(|response| response.response.rect.size());
         let actions = response
             .and_then(|response| response.inner)
             .unwrap_or_default();
@@ -3098,6 +3192,7 @@ impl QuantickApp {
                         let selected = self.focused_pane().drawings.selected() == Some(index);
                         let locked = drawing.locked;
                         let hidden = drawing.hidden;
+                        let shared = drawing.scope == drawings::DrawingScope::AllCharts;
                         let name = drawing.tool.name();
                         ui.horizontal(|ui| {
                             let mut label = egui::RichText::new(format!("{} {}", name, index + 1));
@@ -3112,6 +3207,15 @@ impl QuantickApp {
                             }
                             if hidden {
                                 ui.label(egui::RichText::new("hidden").small());
+                            }
+                            if shared {
+                                // Which marks are global is a question the
+                                // list must answer at a glance (Marina, §D7).
+                                ui.label(egui::RichText::new("all charts").small())
+                                    .on_hover_text(
+                                        "Also drawn on the other chart of this tab, at the same \
+                                         moment in market time",
+                                    );
                             }
                             ui.with_layout(
                                 egui::Layout::right_to_left(egui::Align::Center),
@@ -3276,7 +3380,58 @@ impl eframe::App for QuantickApp {
     }
 }
 
-impl QuantickApp {}
+impl QuantickApp {
+    /// The `QUANTICK_DRAWINGS_DEMO` hook: one of every registered drawing on
+    /// the flow pane, spread across the visible bars, the last one selected
+    /// so the inspector is on screen too.
+    ///
+    /// Waits for bars: anchors are placed on real slots, so every anchor
+    /// carries a real market time and the shared-drawing path is exercised
+    /// rather than faked. Consumed once, whether or not it placed anything on
+    /// this attempt — an env var is a request for this run, and it must never
+    /// keep re-placing objects the user then deletes.
+    fn apply_drawing_demo(&mut self) {
+        if !self.pending_drawing_demo {
+            return;
+        }
+        let pane = &mut self.active_tab_mut().flow_pane;
+        let slots = pane.slots();
+        // Enough bars for every tool to get its own stretch of chart.
+        if slots < 8 * drawings::DRAWING_TOOLS.len() {
+            return;
+        }
+        self.pending_drawing_demo = false;
+        let share = std::env::var("QUANTICK_DRAWINGS_DEMO_SHARED").is_ok_and(|v| v == "1");
+        let pane = &mut self.active_tab_mut().flow_pane;
+        let base = pane
+            .closed_bar(slots / 2)
+            .and_then(|bar| rust_decimal::prelude::ToPrimitive::to_f64(&bar.close))
+            .unwrap_or(1.0);
+        for (index, tool) in drawings::DRAWING_TOOLS.into_iter().enumerate() {
+            for anchor in 0..tool.required_points() {
+                let slot = index * 8 + anchor * 3;
+                let point = drawings::ChartPoint::at_time(
+                    slot as f32 + 0.5,
+                    base * (1.0 + f64::from(anchor as i32) * 0.001
+                        - f64::from(index as i32 % 3) * 0.002),
+                    pane.slot_open_time(slot),
+                );
+                let completed =
+                    pane.drawings
+                        .place_with(tool, point, drawings::DrawingTool::default_payload);
+                // Placement selects what it completed, so this reaches the
+                // object just made — no separate index bookkeeping.
+                if completed
+                    && share
+                    && let Some(drawing) = pane.drawings.selected_mut()
+                    && drawing.shareable()
+                {
+                    drawing.scope = drawings::DrawingScope::AllCharts;
+                }
+            }
+        }
+    }
+}
 
 impl QuantickApp {
     /// One frame of the application: drain, lay out the chrome, draw the
@@ -3293,6 +3448,7 @@ impl QuantickApp {
         self.last_frame = Some(now);
 
         self.drain_tabs();
+        self.apply_drawing_demo();
         self.maybe_emit_summary(now);
 
         let bg = pane::background_color(&self.style);
@@ -4625,13 +4781,10 @@ plot(close)
         app.active_tab_mut().request_older_history();
         app.active_tab_mut().request_older_history();
         assert_eq!(app.active_tab().loading.count(LoadingTask::History), 3);
-        app.active_tab_mut().flow_pane.drawings.place(
-            drawing_tool("horizontal-line"),
-            ChartPoint {
-                bar: 1.0,
-                price: 100.0,
-            },
-        );
+        app.active_tab_mut()
+            .flow_pane
+            .drawings
+            .place(drawing_tool("horizontal-line"), ChartPoint::at(1.0, 100.0));
 
         evt_tx.try_send(FeedEvent::Reset).unwrap();
         app.active_tab_mut().drain_feed();
@@ -4646,13 +4799,10 @@ plot(close)
     fn bar_spec_change_defers_one_frame_and_shows_the_rebuild() {
         let (mut app, _evt_tx, _cmd_rx, _book_tx) = test_app();
         app.active_tab_mut().flow_pane.tick_n = 100;
-        app.active_tab_mut().flow_pane.drawings.place(
-            drawing_tool("horizontal-line"),
-            ChartPoint {
-                bar: 1.0,
-                price: 100.0,
-            },
-        );
+        app.active_tab_mut()
+            .flow_pane
+            .drawings
+            .place(drawing_tool("horizontal-line"), ChartPoint::at(1.0, 100.0));
 
         app.active_tab_mut().apply_spec_changes();
         assert!(app.active_tab().loading.is_active(LoadingTask::BarRebuild));
@@ -5919,42 +6069,25 @@ plot(close)
         let ctx = egui::Context::default();
         run_frame(&mut app, &ctx);
 
-        arm_drawing_from_toolbox(&mut app, &ctx, "horizontal-line");
-        click_chart(&mut app, &ctx, egui::pos2(600.0, 250.0));
-
-        arm_drawing_from_toolbox(&mut app, &ctx, "rectangle");
-        drag_chart(
-            &mut app,
-            &ctx,
-            egui::pos2(620.0, 300.0),
-            egui::pos2(800.0, 450.0),
-        );
-
-        arm_drawing_from_toolbox(&mut app, &ctx, "parallel-channel");
-        drag_chart(
-            &mut app,
-            &ctx,
-            egui::pos2(650.0, 500.0),
-            egui::pos2(820.0, 350.0),
-        );
-        click_chart(&mut app, &ctx, egui::pos2(900.0, 280.0));
-
-        arm_drawing_from_toolbox(&mut app, &ctx, "fib-retracement");
-        drag_chart(
-            &mut app,
-            &ctx,
-            egui::pos2(700.0, 620.0),
-            egui::pos2(950.0, 300.0),
-        );
-
-        arm_drawing_from_toolbox(&mut app, &ctx, "fib-extension");
-        drag_chart(
-            &mut app,
-            &ctx,
-            egui::pos2(620.0, 650.0),
-            egui::pos2(820.0, 500.0),
-        );
-        click_chart(&mut app, &ctx, egui::pos2(1_000.0, 350.0));
+        // Registry-driven, not a hand-written list: a tool added to
+        // `DRAWING_TOOLS` without a rail path (family flyout, shortcut,
+        // placement) fails here on the day it is registered, instead of
+        // shipping unreachable.
+        for (index, tool) in drawings::DRAWING_TOOLS.into_iter().enumerate() {
+            arm_drawing_from_toolbox(&mut app, &ctx, tool.id());
+            for anchor in 0..tool.required_points() {
+                let offset = index as f32;
+                let step = anchor as f32;
+                click_chart(
+                    &mut app,
+                    &ctx,
+                    egui::pos2(
+                        560.0 + (offset % 4.0) * 50.0 + step * 70.0,
+                        250.0 + (offset % 3.0) * 70.0 + step * 50.0,
+                    ),
+                );
+            }
+        }
 
         let tools: Vec<_> = app
             .active_tab()
@@ -6039,12 +6172,22 @@ plot(close)
         click_chart(&mut app, &ctx, anchor);
         run_frame(&mut app, &ctx);
 
-        // The horizontal stroke crosses the whole pane, so a stroke pixel
-        // sits under the inspector. Press exactly there: the panel is opaque
-        // — the press is a style interaction, never a drawing drag.
+        // Automatic placement now sends the panel to a chart corner (§D3),
+        // deliberately clear of the object — so park it over the stroke by
+        // hand. What this proves is pointer routing over an opaque panel, not
+        // where the panel opens.
         let inspector = ctx
             .memory(|memory| memory.area_rect(egui::Id::new("drawing_inspector")))
             .expect("placing the selected line opens its inspector");
+        app.inspector_moved = true;
+        app.inspector_pos = Some(egui::pos2(
+            inspector.left(),
+            anchor.y - inspector.height() / 2.0,
+        ));
+        run_frame(&mut app, &ctx);
+        let inspector = ctx
+            .memory(|memory| memory.area_rect(egui::Id::new("drawing_inspector")))
+            .expect("the inspector is still open");
         let line_y = anchor.y;
         let start = egui::pos2(inspector.center().x, line_y);
         assert!(
@@ -6221,8 +6364,11 @@ plot(close)
         .map(|candidate| clamp_into_chart(candidate, size, chart))
     }
 
+    /// The session's complaint (`docs/ux/drawing-tools-2026-08.md` §F3): the
+    /// old rule put the panel 12 px beside a small object, right on top of
+    /// the price action the trader drew it to read. A corner must win.
     #[test]
-    fn placement_beside_a_centered_object_clears_it_and_prefers_the_right() {
+    fn placement_sends_the_panel_to_a_corner_not_beside_a_small_object() {
         let chart = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(1_400.0, 800.0));
         let bbox = egui::Rect::from_center_size(chart.center(), egui::vec2(40.0, 40.0));
         let size = egui::vec2(320.0, 280.0);
@@ -6230,15 +6376,70 @@ plot(close)
         let rect = egui::Rect::from_min_size(position, size);
         assert!(!rect.intersects(bbox), "a clear candidate exists and wins");
         assert!(chart.contains_rect(rect));
-        assert_eq!(
+        assert_ne!(
             position,
             egui::pos2(bbox.right() + INSPECTOR_OBJECT_GAP_PX, bbox.top()),
-            "at zero overlap the order tie-break keeps the right-of-object preference"
+            "beside-the-object is exactly the placement this rule replaced"
+        );
+        assert!(
+            placement_candidates(chart, bbox, size)[4..].contains(&position),
+            "the winner is one of the four chart corners"
         );
         assert_eq!(
             position,
             inspector_placement(chart, bbox, size),
             "identical inputs give identical placements"
+        );
+    }
+
+    /// With the object centred, all four corners are equidistant, so the
+    /// order tie-break decides — and it must always decide the same way, or
+    /// the panel appears somewhere new every time (Duda, §D3).
+    #[test]
+    fn placement_prefers_the_top_left_corner_on_a_tie() {
+        let chart = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(1_400.0, 800.0));
+        let bbox = egui::Rect::from_center_size(chart.center(), egui::vec2(40.0, 40.0));
+        let size = egui::vec2(320.0, 280.0);
+        let gap = INSPECTOR_OBJECT_GAP_PX;
+        assert_eq!(
+            inspector_placement(chart, bbox, size),
+            egui::pos2(chart.left() + gap, chart.top() + gap)
+        );
+    }
+
+    /// A panel taller than the placement assumed must not be sent to a bottom
+    /// corner, where it would grow off the window and lose its last rows. The
+    /// top-first order is what guarantees that, so it is worth a test of its
+    /// own: whatever height the panel turns out to have, the chosen spot
+    /// leaves room for it below.
+    #[test]
+    fn placement_leaves_a_tall_panel_room_to_grow_downwards() {
+        let chart = egui::Rect::from_min_size(egui::pos2(60.0, 88.0), egui::vec2(1_224.0, 744.0));
+        let bbox = egui::Rect::from_center_size(egui::pos2(700.0, 300.0), egui::vec2(40.0, 40.0));
+        // The height the placement believes in, and the height the panel
+        // turns out to want once its level editor is open.
+        let assumed = egui::vec2(360.0, 280.0);
+        let actual = 620.0;
+        let position = inspector_placement(chart, bbox, assumed);
+        assert!(
+            position.y + actual <= chart.bottom(),
+            "a panel that grows to {actual} px must still fit below {position:?}"
+        );
+    }
+
+    /// The farthest clear corner wins, so the panel walks away from the
+    /// object instead of hugging the nearest empty spot.
+    #[test]
+    fn placement_picks_the_corner_farthest_from_the_object() {
+        let chart = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(1_400.0, 800.0));
+        // Object parked in the bottom-left quadrant.
+        let bbox = egui::Rect::from_center_size(egui::pos2(260.0, 640.0), egui::vec2(40.0, 40.0));
+        let size = egui::vec2(320.0, 280.0);
+        let gap = INSPECTOR_OBJECT_GAP_PX;
+        assert_eq!(
+            inspector_placement(chart, bbox, size),
+            egui::pos2(chart.right() - gap - size.x, chart.top() + gap),
+            "the opposite corner is the farthest clear one"
         );
     }
 
@@ -6476,6 +6677,17 @@ plot(close)
         let inspector = ctx
             .memory(|memory| memory.area_rect(egui::Id::new("drawing_inspector")))
             .expect("the inspector is open");
+        // Parked over the stroke by hand: automatic placement now clears the
+        // object on purpose (§D3), and this proof needs the overlap.
+        app.inspector_moved = true;
+        app.inspector_pos = Some(egui::pos2(
+            inspector.left(),
+            300.0 - inspector.height() / 2.0,
+        ));
+        run_frame(&mut app, &ctx);
+        let inspector = ctx
+            .memory(|memory| memory.area_rect(egui::Id::new("drawing_inspector")))
+            .expect("the inspector is still open");
         // Over the inspector AND over the selected line's stroke: without
         // the chrome gate this hover would show a Move cursor.
         let hover = egui::pos2(inspector.center().x, 300.0);
@@ -6980,13 +7192,10 @@ plot(close)
         let (mut app, evt_tx, _cmd_rx, _book_tx) = test_app();
         let ctx = egui::Context::default();
         run_frame(&mut app, &ctx);
-        app.active_tab_mut().flow_pane.drawings.place(
-            drawing_tool("horizontal-line"),
-            ChartPoint {
-                bar: 1.0,
-                price: 100.0,
-            },
-        );
+        app.active_tab_mut()
+            .flow_pane
+            .drawings
+            .place(drawing_tool("horizontal-line"), ChartPoint::at(1.0, 100.0));
 
         evt_tx.try_send(FeedEvent::Reset).unwrap();
         // Through the window's own drain: the tab drops the marks, and the

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -6060,6 +6060,125 @@ plot(close)
         drawing
     }
 
+    /// Count the line segments painted in the drawing colour — how many
+    /// strokes of *this* object are on screen, across every pane.
+    fn drawing_strokes(output: &egui::FullOutput) -> usize {
+        let color = egui::epaint::ColorMode::Solid(crate::drawings::DEFAULT_DRAWING_COLOR);
+        output
+            .shapes
+            .iter()
+            .filter(|clipped| match &clipped.shape {
+                egui::Shape::LineSegment { stroke, .. } => stroke.color == color,
+                _ => false,
+            })
+            .count()
+    }
+
+    /// Marina's ask (`docs/ux/drawing-tools-2026-08.md` §D7): a level drawn on
+    /// one chart of the tab shows on the other, at the same moment in market
+    /// time — one version of the truth instead of two hand-drawn ones.
+    #[test]
+    fn a_shared_drawing_is_painted_on_the_other_pane_of_the_tab() {
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        app.active_tab_mut().set_layout(CanvasLayout::TimeAndFlow);
+        // One frame builds the time pane, the next lets both panes draw and
+        // cache the projection a foreign mark is re-expressed through.
+        run_frame(&mut app, &ctx);
+        run_frame(&mut app, &ctx);
+        assert!(
+            app.active_tab().time_pane.is_some(),
+            "the split is what this proof is about"
+        );
+
+        // Anchored on a real bar, so the anchor carries a real market time.
+        let slot = 100;
+        let anchored = {
+            let pane = &app.active_tab().flow_pane;
+            let time = pane.slot_open_time(slot).expect("a closed bar has a time");
+            let price = pane
+                .closed_bar(slot)
+                .map(|bar| rust_decimal::prelude::ToPrimitive::to_f64(&bar.close))
+                .flatten()
+                .expect("the bar has a close");
+            drawings::ChartPoint::at_time(slot as f32 + 0.5, price, Some(time))
+        };
+        let pane = &mut app.active_tab_mut().flow_pane;
+        assert!(pane.drawings.place_with(
+            drawing_tool("horizontal-line"),
+            anchored,
+            drawings::DrawingTool::default_payload,
+        ));
+
+        let own_pane_only = drawing_strokes(&run_frame(&mut app, &ctx));
+        assert!(
+            own_pane_only > 0,
+            "the object paints on the chart it was drawn on"
+        );
+
+        let drawing = app
+            .active_tab_mut()
+            .flow_pane
+            .drawings
+            .selected_mut()
+            .expect("placement selects what it completed");
+        assert!(drawing.shareable(), "an anchor on a real bar has a time");
+        drawing.scope = drawings::DrawingScope::AllCharts;
+
+        let both_panes = drawing_strokes(&run_frame(&mut app, &ctx));
+        assert!(
+            both_panes > own_pane_only,
+            "sharing must add strokes on the other pane: {own_pane_only} -> {both_panes}"
+        );
+    }
+
+    /// The reverse, so the test above cannot pass on a stroke that was always
+    /// there: switching sharing off takes the foreign copy away again.
+    #[test]
+    fn unsharing_removes_the_copy_from_the_other_pane() {
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        app.active_tab_mut().set_layout(CanvasLayout::TimeAndFlow);
+        run_frame(&mut app, &ctx);
+        run_frame(&mut app, &ctx);
+
+        let slot = 100;
+        let anchored = {
+            let pane = &app.active_tab().flow_pane;
+            let time = pane.slot_open_time(slot).expect("a closed bar has a time");
+            let price = pane
+                .closed_bar(slot)
+                .and_then(|bar| rust_decimal::prelude::ToPrimitive::to_f64(&bar.close))
+                .expect("the bar has a close");
+            drawings::ChartPoint::at_time(slot as f32 + 0.5, price, Some(time))
+        };
+        let pane = &mut app.active_tab_mut().flow_pane;
+        pane.drawings.place_with(
+            drawing_tool("horizontal-line"),
+            anchored,
+            drawings::DrawingTool::default_payload,
+        );
+        app.active_tab_mut()
+            .flow_pane
+            .drawings
+            .selected_mut()
+            .expect("selected")
+            .scope = drawings::DrawingScope::AllCharts;
+        let shared = drawing_strokes(&run_frame(&mut app, &ctx));
+
+        app.active_tab_mut()
+            .flow_pane
+            .drawings
+            .selected_mut()
+            .expect("selected")
+            .scope = drawings::DrawingScope::ThisChart;
+        let alone = drawing_strokes(&run_frame(&mut app, &ctx));
+        assert!(
+            alone < shared,
+            "unsharing must take the foreign copy away: {shared} -> {alone}"
+        );
+    }
+
     /// Full UI interaction proof: every registered drawing is placed through
     /// egui pointer events against the real chart frame. This catches the
     /// original regression where multi-point tools silently ignored drags.

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -2744,6 +2744,8 @@ impl QuantickApp {
         let tool = drawing.tool;
         let locked = drawing.locked;
         let hidden = drawing.hidden;
+        let shareable = drawing.shareable();
+        let mut shared = drawing.scope == drawings::DrawingScope::AllCharts;
         let show_confirm = self.drawing_delete_confirm && locked;
 
         // The always-visible textual actions (UX spec: never glyph-only,
@@ -2769,6 +2771,43 @@ impl QuantickApp {
                     .color(theme::TEXT_SUPPORT),
             );
         }
+        // Where the object appears. Always visible, never behind a tab.
+        //
+        // It used to live on the Coordinates tab, because sharing is a
+        // statement about the anchors — which is the implementer's mental
+        // model, not the trader's. Nobody hunting for "also show this on the
+        // other chart" opens a tab called Coordinates, and that is not even
+        // the tab the panel opens on. Reported as unfindable, and it was.
+        ui.separator();
+        let sharing = ui.add_enabled(
+            shareable,
+            egui::Checkbox::new(&mut shared, "Show on all charts"),
+        );
+        if sharing.changed()
+            && let Some(drawing) = self.focused_pane_mut().drawings.selected_mut()
+        {
+            drawing.scope = if shared {
+                drawings::DrawingScope::AllCharts
+            } else {
+                drawings::DrawingScope::ThisChart
+            };
+            actions.edited = true;
+        }
+        // A disabled control with no reason reads as a bug.
+        let sharing_hint = if shareable {
+            "The other chart of this tab draws it at the same moment in market time"
+        } else {
+            "This drawing has an anchor past the newest bar, so there is no market time to place              it by on another chart"
+        };
+        sharing.on_hover_text(sharing_hint);
+        if !shareable {
+            ui.label(
+                egui::RichText::new(sharing_hint)
+                    .small()
+                    .color(theme::TEXT_SUPPORT),
+            );
+        }
+
         if show_confirm {
             ui.separator();
             ui.label("Delete locked drawing?");
@@ -2926,37 +2965,6 @@ impl QuantickApp {
                     ui.label(
                         egui::RichText::new("Unlock the drawing to edit its coordinates.").small(),
                     );
-                }
-
-                // Where the object appears. It belongs on this tab and not
-                // with the style controls: sharing is a statement about the
-                // anchors, and the anchors are right here
-                // (`docs/ux/drawing-tools-2026-08.md` §D7).
-                ui.separator();
-                let shareable = drawing.shareable();
-                let mut shared = drawing.scope == drawings::DrawingScope::AllCharts;
-                let response = ui.add_enabled(
-                    shareable,
-                    egui::Checkbox::new(&mut shared, "Show on all charts"),
-                );
-                if response.changed() {
-                    drawing.scope = if shared {
-                        drawings::DrawingScope::AllCharts
-                    } else {
-                        drawings::DrawingScope::ThisChart
-                    };
-                    actions.edited = true;
-                }
-                // A disabled control with no reason reads as a bug (Duda).
-                let hint = if shareable {
-                    "The other chart of this tab shows it at the same moment in market time."
-                } else {
-                    "This drawing has an anchor past the newest bar, so there is no market time to \
-                     place it by on another chart."
-                };
-                response.on_hover_text(hint);
-                if !shareable {
-                    ui.label(egui::RichText::new(hint).small());
                 }
             }
         }
@@ -3204,6 +3212,19 @@ impl QuantickApp {
         } else {
             INSPECTOR_DEFAULT_WIDTH_PX
         };
+        // Bounded by the window and scrolled inside it. A tool's panel can be
+        // taller than the screen — the Fib level editor is — and an unbounded
+        // window simply gets cut at the edge with no way to reach the rest.
+        // Rows a trader cannot reach read as rows that do not exist, and the
+        // control that was out of reach here was the Fib's own "extend", the
+        // one that decides whether its targets project forward at all.
+        let max_height = (ctx.screen_rect().height()
+            - self
+                .focused_pane()
+                .last_chart_area
+                .map_or(0.0, |chart| chart.top())
+            - 2.0 * INSPECTOR_OBJECT_GAP_PX)
+            .max(INSPECTOR_FALLBACK_HEIGHT_PX);
         let mut window = egui::Window::new(before.tool.settings_title())
             .id(egui::Id::new("drawing_inspector"))
             .title_bar(false)
@@ -3211,6 +3232,7 @@ impl QuantickApp {
             .default_width(default_width)
             .min_width(INSPECTOR_MIN_WIDTH_PX)
             .max_width(INSPECTOR_MAX_WIDTH_PX)
+            .max_height(max_height)
             .movable(false)
             .interactable(true)
             .resizable(true);
@@ -3219,7 +3241,11 @@ impl QuantickApp {
         }
         let response = window.show(ctx, |ui| {
             let mut actions = self.draw_inspector_title_bar(ui, index, true);
-            actions.merge(self.drawing_inspector_body(ui, index));
+            egui::ScrollArea::vertical()
+                .auto_shrink([false, true])
+                .show(ui, |ui| {
+                    actions.merge(self.drawing_inspector_body(ui, index));
+                });
             actions
         });
         self.inspector_size = response
@@ -6296,6 +6322,32 @@ plot(close)
         }
     }
 
+    /// A Fib level is something price is *going* to meet. Drawn only between
+    /// the anchors, an extension's targets sit to the left of the leg that
+    /// projects them — backwards on its face — and they disappear behind the
+    /// tape the moment the market moves on. Reported from the running build.
+    #[test]
+    fn fib_levels_project_forward_from_the_swing_by_default() {
+        use crate::drawings::fib::{Extend, FibPayload};
+        assert_eq!(
+            Extend::default(),
+            Extend::Forward,
+            "a level nobody can see at current price is not a level"
+        );
+        for tool in ["fib-retracement", "fib-extension"] {
+            let payload = drawing_tool(tool).default_payload();
+            let fib = payload
+                .as_any()
+                .downcast_ref::<FibPayload>()
+                .expect("the fib tools carry a fib payload");
+            assert_eq!(
+                fib.extend,
+                Extend::Forward,
+                "{tool} must open projecting forward from its last point"
+            );
+        }
+    }
+
     /// A three-anchor tool that stops following the pointer reads as frozen —
     /// reported from the running build after a drag left a channel sitting
     /// there. It is waiting for a click, and it now says so beside the
@@ -8174,8 +8226,33 @@ plot(close)
         );
 
         app.inspector_tab = InspectorTab::Extra;
-        let texts = painted_text(&run_frame(&mut app, &ctx));
-        for label in ["Preset", "Standard", "band opacity", "log scale"] {
+        run_frame(&mut app, &ctx);
+        // The level editor is taller than the window. Everything in it must
+        // still be *reachable* — which is what the panel's scroll is for, and
+        // what a silent cut at the window edge used to deny.
+        let inspector = ctx
+            .memory(|memory| memory.area_rect(egui::Id::new("drawing_inspector")))
+            .expect("the inspector is open");
+        let over = inspector.center();
+        let mut texts = painted_text(&run_frame(&mut app, &ctx));
+        for _ in 0..12 {
+            if texts.iter().any(|text| text.contains("log scale")) {
+                break;
+            }
+            texts = painted_text(&run_frame_with_events(
+                &mut app,
+                &ctx,
+                vec![
+                    egui::Event::PointerMoved(over),
+                    egui::Event::MouseWheel {
+                        unit: egui::MouseWheelUnit::Point,
+                        delta: egui::vec2(0.0, -120.0),
+                        modifiers: egui::Modifiers::NONE,
+                    },
+                ],
+            ));
+        }
+        for label in ["band opacity", "log scale"] {
             assert!(
                 texts.iter().any(|text| text.contains(label)),
                 "the level editor must show {label:?}; painted: {texts:?}"

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -24,6 +24,7 @@ use crate::config::AppConfig;
 use crate::dock::{Dock, DockEnv, DockTab};
 use crate::drawings::{
     self, DeleteOutcome, MAX_DRAWING_FILL_ALPHA, MAX_DRAWING_WIDTH_PX, MIN_DRAWING_WIDTH_PX,
+    PresetHost as _,
 };
 use crate::feed::{self, FeedCommand, FeedHandle};
 use crate::indicator_legend;
@@ -151,6 +152,26 @@ enum InspectorTab {
 
 /// What the inspector body asked for this frame. The caller owns every
 /// mutation, so the pinned panel and the floating window share one rule set.
+/// Which default-style button the Style tab was pressed on, so the caller can
+/// say out loud that something was remembered — a silent save leaves the
+/// trader wondering whether it took.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SavedDefault {
+    OneTool,
+    EveryTool,
+    Forgotten,
+}
+
+impl SavedDefault {
+    const fn message(self) -> &'static str {
+        match self {
+            Self::OneTool => "Saved - new drawings of this tool open with this look.",
+            Self::EveryTool => "Saved - every new drawing opens with this look.",
+            Self::Forgotten => "Forgotten - this tool goes back to the built-in look.",
+        }
+    }
+}
+
 #[derive(Debug, Default, Clone, Copy)]
 struct InspectorActions {
     toggle_hidden: bool,
@@ -161,6 +182,8 @@ struct InspectorActions {
     force_delete: bool,
     close: bool,
     edited: bool,
+    /// Which default-style button was pressed, if any.
+    saved_default: Option<SavedDefault>,
 }
 
 impl InspectorActions {
@@ -175,6 +198,7 @@ impl InspectorActions {
         self.force_delete |= other.force_delete;
         self.close |= other.close;
         self.edited |= other.edited;
+        self.saved_default = self.saved_default.or(other.saved_default);
     }
 }
 
@@ -2829,6 +2853,52 @@ impl QuantickApp {
                         )
                         .changed();
                 }
+
+                // Stop asking for the same look every single time. Every tool
+                // has a Style tab, so every tool gets this — the named-preset
+                // editor only ever existed on the Fib tab, which left fifteen
+                // tools with no way to remember anything.
+                //
+                // New objects only: a default that repainted the marks already
+                // on the chart would be a bulk edit nobody asked for.
+                ui.separator();
+                ui.label(egui::RichText::new("Default for new drawings").small());
+                ui.horizontal(|ui| {
+                    let style = drawing.style;
+                    if ui
+                        .button("This tool")
+                        .on_hover_text(format!(
+                            "New {} objects open with this colour, width and fill",
+                            tool.name().to_lowercase()
+                        ))
+                        .clicked()
+                    {
+                        drawing_presets.set_default_style(tool.id(), Some(style));
+                        actions.saved_default = Some(SavedDefault::OneTool);
+                    }
+                    if ui
+                        .button("All tools")
+                        .on_hover_text("Every new drawing opens with this colour, width and fill")
+                        .clicked()
+                    {
+                        for other in drawings::DRAWING_TOOLS {
+                            drawing_presets.set_default_style(other.id(), Some(style));
+                        }
+                        actions.saved_default = Some(SavedDefault::EveryTool);
+                    }
+                    if drawing_presets.default_style(tool.id()).is_some()
+                        && ui
+                            .button("Forget")
+                            .on_hover_text(format!(
+                                "New {} objects go back to the built-in look",
+                                tool.name().to_lowercase()
+                            ))
+                            .clicked()
+                    {
+                        drawing_presets.set_default_style(tool.id(), None);
+                        actions.saved_default = Some(SavedDefault::Forgotten);
+                    }
+                });
             }
             InspectorTab::Coordinates => {
                 // Geometry through numbers: bar index and price per anchor,
@@ -2963,6 +3033,14 @@ impl QuantickApp {
         if actions.close {
             self.focused_pane_mut().drawings.select(None);
             self.drawing_delete_confirm = false;
+        }
+        if let Some(saved) = actions.saved_default {
+            // Nothing to undo: this changed a preference, not the chart.
+            self.drawing_toast = Some(DrawingToast {
+                message: saved.message(),
+                shown_at: now,
+                offers_undo: false,
+            });
         }
     }
 
@@ -3465,7 +3543,10 @@ impl QuantickApp {
                 );
                 let completed =
                     pane.drawings
-                        .place_with(tool, point, drawings::DrawingTool::default_payload);
+                        .place_with(tool, point, |tool| drawings::NewDrawing {
+                            style: drawings::DrawingStyle::default(),
+                            payload: tool.default_payload(),
+                        });
                 // Placement selects what it completed, so this reaches the
                 // object just made — no separate index bookkeeping.
                 if completed
@@ -6209,6 +6290,71 @@ plot(close)
         }
     }
 
+    /// The chore this removes: re-picking the same colour on every object.
+    /// Saving a default must reach the *next* drawing and leave the ones
+    /// already on the chart exactly as the trader drew them.
+    #[test]
+    fn a_saved_default_style_reaches_the_next_drawing_and_only_that() {
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        app.drawing_presets = drawings::presets::PresetStore::load_from(std::env::temp_dir().join(
+            format!("quantick-default-style-{}.toml", std::process::id()),
+        ));
+        run_frame(&mut app, &ctx);
+
+        arm_drawing_from_toolbox(&mut app, &ctx, "horizontal-line");
+        click_chart(&mut app, &ctx, egui::pos2(700.0, 300.0));
+        run_frame(&mut app, &ctx);
+
+        let mine = egui::Color32::from_rgb(0xFF, 0xA0, 0x10);
+        {
+            let drawing = app
+                .active_tab_mut()
+                .flow_pane
+                .drawings
+                .selected_mut()
+                .expect("the placed line is selected");
+            drawing.style.color = mine;
+            drawing.style.width_px = 2.5;
+        }
+        let edited = app.active_tab().flow_pane.drawings.items()[0].style;
+        app.drawing_presets
+            .set_default_style(drawings::DRAWING_TOOLS[0].id(), Some(edited));
+        // Saving for one tool is saving for one tool.
+        app.drawing_presets
+            .set_default_style("horizontal-line", Some(edited));
+
+        arm_drawing_from_toolbox(&mut app, &ctx, "horizontal-line");
+        click_chart(&mut app, &ctx, egui::pos2(700.0, 380.0));
+        run_frame(&mut app, &ctx);
+
+        let items = app.active_tab().flow_pane.drawings.items();
+        assert_eq!(items.len(), 2);
+        assert_eq!(
+            items[1].style, edited,
+            "the next object opens with the saved look"
+        );
+        assert_eq!(
+            items[0].style, edited,
+            "the first object is the one that was edited, untouched by the save"
+        );
+
+        // A tool with no saved default still opens as it always did.
+        arm_drawing_from_toolbox(&mut app, &ctx, "rectangle");
+        click_chart(&mut app, &ctx, egui::pos2(760.0, 420.0));
+        click_chart(&mut app, &ctx, egui::pos2(860.0, 480.0));
+        run_frame(&mut app, &ctx);
+        let items = app.active_tab().flow_pane.drawings.items();
+        assert_eq!(items.len(), 3);
+        assert_eq!(
+            items[2].style,
+            drawings::DrawingStyle::default(),
+            "a default is per tool, not a global repaint"
+        );
+
+        let _ = std::fs::remove_file(app.drawing_presets.path());
+    }
+
     /// Selecting is not moving. Without a drag threshold on the move gesture,
     /// a couple of pixels of hand tremor during a click re-angled a channel
     /// or shifted a level — and recorded it as an undo step, so the trader's
@@ -6458,11 +6604,15 @@ plot(close)
             drawings::ChartPoint::at_time(slot as f32 + 0.5, price, Some(time))
         };
         let pane = &mut app.active_tab_mut().flow_pane;
-        assert!(pane.drawings.place_with(
-            drawing_tool("horizontal-line"),
-            anchored,
-            drawings::DrawingTool::default_payload,
-        ));
+        assert!(
+            pane.drawings
+                .place_with(drawing_tool("horizontal-line"), anchored, |tool| {
+                    drawings::NewDrawing {
+                        style: drawings::DrawingStyle::default(),
+                        payload: tool.default_payload(),
+                    }
+                },)
+        );
 
         let own_pane_only = drawing_strokes(&run_frame(&mut app, &ctx));
         assert!(
@@ -6507,11 +6657,13 @@ plot(close)
             drawings::ChartPoint::at_time(slot as f32 + 0.5, price, Some(time))
         };
         let pane = &mut app.active_tab_mut().flow_pane;
-        pane.drawings.place_with(
-            drawing_tool("horizontal-line"),
-            anchored,
-            drawings::DrawingTool::default_payload,
-        );
+        pane.drawings
+            .place_with(drawing_tool("horizontal-line"), anchored, |tool| {
+                drawings::NewDrawing {
+                    style: drawings::DrawingStyle::default(),
+                    payload: tool.default_payload(),
+                }
+            });
         app.active_tab_mut()
             .flow_pane
             .drawings
@@ -6586,6 +6738,26 @@ plot(close)
         );
     }
 
+    /// A canvas point at price-line `y` that is provably clear of the open
+    /// inspector.
+    ///
+    /// These proofs are about the canvas gesture, not about where the
+    /// placement rule currently puts the panel — so they ask the panel where
+    /// it is instead of encoding an answer that changes whenever the Style
+    /// tab grows a row.
+    fn canvas_point_clear_of_inspector(
+        app: &mut QuantickApp,
+        ctx: &egui::Context,
+        y: f32,
+    ) -> egui::Pos2 {
+        run_frame(app, ctx);
+        let clear = ctx
+            .memory(|memory| memory.area_rect(egui::Id::new("drawing_inspector")))
+            .filter(|rect| rect.y_range().contains(y))
+            .map_or(400.0, |rect| rect.right() + 40.0);
+        egui::pos2(clear, y)
+    }
+
     #[test]
     fn a_drawing_can_be_selected_from_its_stroke_and_moved_without_panning() {
         let (mut app, _commands) = app_with_history(200);
@@ -6601,14 +6773,10 @@ plot(close)
             .flow_pane
             .viewport
             .right_edge_bar(app.active_tab().flow_pane.slots());
-        // Left of the anchor: clear of the inspector, which opens to its
-        // right — the panel is opaque to presses by contract.
-        drag_chart(
-            &mut app,
-            &ctx,
-            egui::pos2(400.0, 300.0),
-            egui::pos2(440.0, 340.0),
-        );
+        // Clear of the inspector: the panel is opaque to presses by
+        // contract, so a proof about dragging must not start under it.
+        let start = canvas_point_clear_of_inspector(&mut app, &ctx, 300.0);
+        drag_chart(&mut app, &ctx, start, start + egui::vec2(40.0, 40.0));
         let after = app.active_tab().flow_pane.drawings.items()[0].points[0];
 
         assert!(
@@ -6696,7 +6864,7 @@ plot(close)
         let inspector = ctx
             .memory(|memory| memory.area_rect(egui::Id::new("drawing_inspector")))
             .expect("the inspector is open");
-        let start = egui::pos2(400.0, 300.0);
+        let start = canvas_point_clear_of_inspector(&mut app, &ctx, 300.0);
         assert!(
             !inspector.contains(start),
             "the gesture must begin on the open canvas"
@@ -7484,8 +7652,8 @@ plot(close)
         );
 
         let before_drag = app.active_tab().flow_pane.drawings.items()[0].points[0];
-        // Left of the anchor, clear of the inspector that opened beside it.
-        let start = egui::pos2(400.0, 300.0);
+        // Clear of the inspector the selection opened.
+        let start = canvas_point_clear_of_inspector(&mut app, &ctx, 300.0);
         run_frame_with_events(
             &mut app,
             &ctx,
@@ -7494,10 +7662,13 @@ plot(close)
                 pointer_button(start, true),
             ],
         );
-        for step in [egui::pos2(410.0, 312.0), egui::pos2(425.0, 326.0)] {
+        for step in [
+            start + egui::vec2(10.0, 12.0),
+            start + egui::vec2(25.0, 26.0),
+        ] {
             run_frame_with_events(&mut app, &ctx, vec![egui::Event::PointerMoved(step)]);
         }
-        let end = egui::pos2(440.0, 340.0);
+        let end = start + egui::vec2(40.0, 40.0);
         run_frame_with_events(
             &mut app,
             &ctx,

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -6209,6 +6209,77 @@ plot(close)
         }
     }
 
+    /// Selecting is not moving. Without a drag threshold on the move gesture,
+    /// a couple of pixels of hand tremor during a click re-angled a channel
+    /// or shifted a level — and recorded it as an undo step, so the trader's
+    /// line was quietly no longer where they put it. Placement already
+    /// refused to read a twitch as a drag; moving refuses too now.
+    #[test]
+    fn a_twitch_while_clicking_does_not_move_the_drawing() {
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        run_frame(&mut app, &ctx);
+
+        arm_drawing_from_toolbox(&mut app, &ctx, "trend-line");
+        click_chart(&mut app, &ctx, egui::pos2(600.0, 400.0));
+        click_chart(&mut app, &ctx, egui::pos2(900.0, 300.0));
+        run_frame(&mut app, &ctx);
+        let placed = app.active_tab().flow_pane.drawings.items()[0]
+            .points
+            .clone();
+
+        // Press on the stroke, wobble inside the threshold, release.
+        let grab = egui::pos2(750.0, 350.0);
+        run_frame_with_events(
+            &mut app,
+            &ctx,
+            vec![egui::Event::PointerMoved(grab), pointer_button(grab, true)],
+        );
+        // Ending *away* from the press, still inside the threshold: a wobble
+        // that returned to its origin would net to zero movement and prove
+        // nothing about the threshold.
+        let wobbled = grab + egui::vec2(3.0, 0.0);
+        run_frame_with_events(&mut app, &ctx, vec![egui::Event::PointerMoved(wobbled)]);
+        run_frame_with_events(
+            &mut app,
+            &ctx,
+            vec![
+                egui::Event::PointerMoved(wobbled),
+                pointer_button(wobbled, false),
+            ],
+        );
+
+        assert_eq!(
+            app.active_tab().flow_pane.drawings.items()[0].points,
+            placed,
+            "a click that wobbled under the threshold must leave the geometry alone"
+        );
+        assert_eq!(
+            app.active_tab().flow_pane.drawings.selected(),
+            Some(0),
+            "and it is still a click, so it still selects"
+        );
+
+        // The same gesture past the threshold does move it.
+        let far = grab + egui::vec2(40.0, 0.0);
+        run_frame_with_events(
+            &mut app,
+            &ctx,
+            vec![egui::Event::PointerMoved(grab), pointer_button(grab, true)],
+        );
+        run_frame_with_events(&mut app, &ctx, vec![egui::Event::PointerMoved(far)]);
+        run_frame_with_events(
+            &mut app,
+            &ctx,
+            vec![egui::Event::PointerMoved(far), pointer_button(far, false)],
+        );
+        assert_ne!(
+            app.active_tab().flow_pane.drawings.items()[0].points,
+            placed,
+            "a real drag still moves it"
+        );
+    }
+
     /// The reported flicker, root cause.
     ///
     /// The pinned inspector is a `SidePanel::right` laid out *before* the

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -3512,6 +3512,12 @@ impl QuantickApp {
         }
         self.pending_drawing_demo = false;
         let share = std::env::var("QUANTICK_DRAWINGS_DEMO_SHARED").is_ok_and(|v| v == "1");
+        if share {
+            // A shared drawing has nothing to be shared *with* on a single
+            // pane, so the hook that asks for one opens the split too — the
+            // surface under test is the projection onto the other chart.
+            self.active_tab_mut().set_layout(CanvasLayout::TimeAndFlow);
+        }
         let pane = &mut self.active_tab_mut().flow_pane;
         // Anchored inside the window the chart actually opens on, not at slot
         // zero: a demo whose objects sit 300 bars off the left edge shows a
@@ -6288,6 +6294,86 @@ plot(close)
                 "the selection vanished {frame} frames after the click"
             );
         }
+    }
+
+    /// A three-anchor tool that stops following the pointer reads as frozen —
+    /// reported from the running build after a drag left a channel sitting
+    /// there. It is waiting for a click, and it now says so beside the
+    /// cursor, not only in a badge on the far side of the screen.
+    #[test]
+    fn a_draft_says_what_the_next_click_will_do() {
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        run_frame(&mut app, &ctx);
+
+        arm_drawing_from_toolbox(&mut app, &ctx, "parallel-channel");
+        // Drag the trend line, exactly the gesture that was reported.
+        drag_chart(
+            &mut app,
+            &ctx,
+            egui::pos2(600.0, 400.0),
+            egui::pos2(800.0, 340.0),
+        );
+        let hover = egui::pos2(820.0, 300.0);
+        let texts = painted_text(&run_frame_with_events(
+            &mut app,
+            &ctx,
+            vec![egui::Event::PointerMoved(hover)],
+        ));
+        assert_eq!(
+            app.active_tab().flow_pane.drawings.draft_len(),
+            2,
+            "the drag placed the trend line and the object waits for its width"
+        );
+        assert!(
+            texts
+                .iter()
+                .any(|text| text.contains("Click the channel width")),
+            "the draft must say what it is waiting for; painted: {texts:?}"
+        );
+    }
+
+    /// A tool with nothing specific to say still reports progress, because a
+    /// count beats an object that looks like it stopped responding.
+    #[test]
+    fn a_draft_without_a_hint_still_shows_its_progress() {
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        run_frame(&mut app, &ctx);
+
+        let fib = drawing_tool("fib-retracement");
+        assert_eq!(fib.placement_hint(1), None, "this tool has no words for it");
+        arm_drawing_from_toolbox(&mut app, &ctx, "fib-retracement");
+        click_chart(&mut app, &ctx, egui::pos2(600.0, 400.0));
+        let hover = egui::pos2(700.0, 320.0);
+        let texts = painted_text(&run_frame_with_events(
+            &mut app,
+            &ctx,
+            vec![egui::Event::PointerMoved(hover)],
+        ));
+        assert!(
+            texts.iter().any(|text| text == "1/2"),
+            "an unnamed next step still shows the count; painted: {texts:?}"
+        );
+    }
+
+    /// The control that shares a drawing across the tab's charts has to be
+    /// *findable*. It lives with the anchors, on the Coordinates tab, because
+    /// sharing is a statement about the anchors — and every tool has that tab.
+    #[test]
+    fn the_coordinates_tab_offers_sharing_across_charts() {
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        run_frame(&mut app, &ctx);
+
+        arm_drawing_from_toolbox(&mut app, &ctx, "horizontal-line");
+        click_chart(&mut app, &ctx, egui::pos2(700.0, 300.0));
+        app.inspector_tab = InspectorTab::Coordinates;
+        let texts = painted_text(&run_frame(&mut app, &ctx));
+        assert!(
+            texts.iter().any(|text| text.contains("Show on all charts")),
+            "the sharing control must be on screen, not folded away; painted: {texts:?}"
+        );
     }
 
     /// The chore this removes: re-picking the same colour on every object.

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -67,6 +67,14 @@ const LEGEND_BELOW_HUD_OFFSET_PX: f32 = 64.0;
 const fn pane_ids(tab: u64) -> (u64, u64) {
     (tab * 2, tab * 2 + 1)
 }
+/// How much of the newest chart the `QUANTICK_DRAWINGS_DEMO` hook spreads its
+/// objects across. Close to what a default viewport shows, so every object
+/// lands on screen — a demo the camera cannot see proves nothing.
+const DEMO_VISIBLE_SLOTS: usize = 90;
+/// How many demo objects wide the visible window is — the reciprocal of how
+/// far a multi-anchor object reaches. Four keeps a rectangle big enough to
+/// read while still leaving the tools distinguishable from each other.
+const DEMO_SPANS_PER_WINDOW: usize = 4;
 /// Initial position of the selected-drawing inspector.
 const DRAWING_INSPECTOR_DEFAULT_POSITION: egui::Pos2 = egui::pos2(90.0, 120.0);
 /// Length of the EMA the toolbar's hardcoded M1 entry adds (the settings UI
@@ -2794,15 +2802,22 @@ impl QuantickApp {
                 actions.edited |= ui
                     .color_edit_button_srgba(&mut drawing.style.color)
                     .changed();
-                actions.edited |= ui
-                    .add(
-                        egui::Slider::new(
-                            &mut drawing.style.width_px,
-                            MIN_DRAWING_WIDTH_PX..=MAX_DRAWING_WIDTH_PX,
+                // Capability-driven, like the fill slider below: a tool with
+                // no stroke has no line width, and the repo's rule is that an
+                // unsupported property is *absent*, not present and inert.
+                // Caught by the visual pass — the text note's Style tab was
+                // offering a slider that moved nothing.
+                if tool.supports_stroke_width() {
+                    actions.edited |= ui
+                        .add(
+                            egui::Slider::new(
+                                &mut drawing.style.width_px,
+                                MIN_DRAWING_WIDTH_PX..=MAX_DRAWING_WIDTH_PX,
+                            )
+                            .text("line width (px)"),
                         )
-                        .text("line width (px)"),
-                    )
-                    .changed();
+                        .changed();
+                }
                 if tool.supports_fill() {
                     actions.edited |= ui
                         .add(
@@ -3420,13 +3435,28 @@ impl QuantickApp {
         self.pending_drawing_demo = false;
         let share = std::env::var("QUANTICK_DRAWINGS_DEMO_SHARED").is_ok_and(|v| v == "1");
         let pane = &mut self.active_tab_mut().flow_pane;
+        // Anchored inside the window the chart actually opens on, not at slot
+        // zero: a demo whose objects sit 300 bars off the left edge shows a
+        // screenshot of an empty chart, which is exactly the evidence this
+        // hook exists to produce. `visible` is the newest stretch, and the
+        // objects are laid across it left to right in registry order.
+        let visible = DEMO_VISIBLE_SLOTS.min(slots);
+        let first = slots - visible;
+        // Two different spacings on purpose. `stride` walks the *starts*
+        // apart so the objects are distinguishable; `span` sets how far a
+        // multi-anchor object reaches, and it has to be wide or a rectangle
+        // lands two bars across and photographs as a sliver. The objects
+        // overlap, which is fine — a QA screen wants every tool legible, not
+        // a tidy row.
+        let stride = (visible / drawings::DRAWING_TOOLS.len()).max(1);
+        let span = (visible / DEMO_SPANS_PER_WINDOW).max(2);
         let base = pane
-            .closed_bar(slots / 2)
+            .closed_bar(slots.saturating_sub(1))
             .and_then(|bar| rust_decimal::prelude::ToPrimitive::to_f64(&bar.close))
             .unwrap_or(1.0);
         for (index, tool) in drawings::DRAWING_TOOLS.into_iter().enumerate() {
             for anchor in 0..tool.required_points() {
-                let slot = index * 8 + anchor * 3;
+                let slot = (first + index * stride + anchor * span).min(slots.saturating_sub(1));
                 let point = drawings::ChartPoint::at_time(
                     slot as f32 + 0.5,
                     base * (1.0 + f64::from(anchor as i32) * 0.001
@@ -6089,6 +6119,58 @@ plot(close)
                 _ => false,
             })
             .count()
+    }
+
+    /// The repo's capability rule: an unsupported property is *absent* from
+    /// the inspector, never present and inert. A text note has glyphs and no
+    /// stroke, so a "line width" slider on its Style tab would be a control
+    /// that moves nothing — which reads as a broken app, not as a no-op.
+    /// Found by the visual pass on a real screen.
+    #[test]
+    fn the_style_tab_offers_line_width_only_to_tools_that_have_a_stroke() {
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        run_frame(&mut app, &ctx);
+
+        let style_tab_labels = |app: &mut QuantickApp, ctx: &egui::Context| -> Vec<String> {
+            app.inspector_tab = InspectorTab::Style;
+            painted_text(&run_frame(app, ctx))
+        };
+
+        arm_drawing_from_toolbox(&mut app, &ctx, "horizontal-line");
+        click_chart(&mut app, &ctx, egui::pos2(700.0, 300.0));
+        let with_stroke = style_tab_labels(&mut app, &ctx);
+        assert!(
+            with_stroke.iter().any(|text| text.contains("line width")),
+            "a stroked tool keeps its width slider; painted: {with_stroke:?}"
+        );
+
+        arm_drawing_from_toolbox(&mut app, &ctx, "text");
+        click_chart(&mut app, &ctx, egui::pos2(760.0, 340.0));
+        assert_eq!(
+            app.active_tab()
+                .flow_pane
+                .drawings
+                .selected()
+                .and_then(|index| app
+                    .active_tab()
+                    .flow_pane
+                    .drawings
+                    .items()
+                    .get(index)
+                    .map(|drawing| drawing.tool.id())),
+            Some("text"),
+            "the note is the selection the inspector is describing"
+        );
+        let words_only = style_tab_labels(&mut app, &ctx);
+        assert!(
+            !words_only.iter().any(|text| text.contains("line width")),
+            "a note has no stroke to widen; painted: {words_only:?}"
+        );
+        assert!(
+            words_only.iter().any(|text| text.contains("Style")),
+            "the tab itself is still there, with the colour control"
+        );
     }
 
     /// Marina's ask (`docs/ux/drawing-tools-2026-08.md` §D7): a level drawn on

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -6173,6 +6173,127 @@ plot(close)
         );
     }
 
+    /// Reported from the running app: "clico no desenho, abre a propriedade
+    /// e fecha rapidamente — como se eu tivesse clicado fora dele". Selecting
+    /// an object must survive the release that made it and every frame after.
+    #[test]
+    fn clicking_a_drawing_keeps_it_selected_after_the_release() {
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        run_frame(&mut app, &ctx);
+
+        arm_drawing_from_toolbox(&mut app, &ctx, "horizontal-line");
+        let on_the_line = egui::pos2(700.0, 300.0);
+        click_chart(&mut app, &ctx, on_the_line);
+        run_frame(&mut app, &ctx);
+        assert_eq!(app.active_tab().flow_pane.drawings.items().len(), 1);
+
+        // Deselect the way the user would, then click the line again — this
+        // is the gesture that flickers.
+        app.active_tab_mut().flow_pane.drawings.select(None);
+        run_frame(&mut app, &ctx);
+
+        click_chart(&mut app, &ctx, egui::pos2(900.0, 300.0));
+        assert_eq!(
+            app.active_tab().flow_pane.drawings.selected(),
+            Some(0),
+            "the click that selects must not also deselect"
+        );
+        for frame in 0..4 {
+            run_frame(&mut app, &ctx);
+            assert_eq!(
+                app.active_tab().flow_pane.drawings.selected(),
+                Some(0),
+                "the selection vanished {frame} frames after the click"
+            );
+        }
+    }
+
+    /// The reported flicker, reduced to its cause.
+    ///
+    /// The press selects on an anchor grab (12 px); the release used to
+    /// body-test only (10 px). Just past the end of a trend line those two
+    /// disagree: the handle is in reach and the stroke is not. So the press
+    /// opened the panel and the release closed it, over and over, with the
+    /// mouse standing still.
+    #[test]
+    fn grabbing_a_handle_off_the_stroke_selects_and_stays_selected() {
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        run_frame(&mut app, &ctx);
+
+        arm_drawing_from_toolbox(&mut app, &ctx, "trend-line");
+        let start = egui::pos2(600.0, 400.0);
+        let end = egui::pos2(800.0, 400.0);
+        click_chart(&mut app, &ctx, start);
+        click_chart(&mut app, &ctx, end);
+        run_frame(&mut app, &ctx);
+        assert_eq!(app.active_tab().flow_pane.drawings.items().len(), 1);
+
+        app.active_tab_mut().flow_pane.drawings.select(None);
+        run_frame(&mut app, &ctx);
+
+        // 11 px past the far anchor, straight along the line: inside the
+        // anchor radius, outside the stroke radius.
+        let past_the_end = egui::pos2(end.x + 11.0, end.y);
+        click_chart(&mut app, &ctx, past_the_end);
+        assert_eq!(
+            app.active_tab().flow_pane.drawings.selected(),
+            Some(0),
+            "grabbing the handle is clicking the object"
+        );
+        for frame in 0..4 {
+            run_frame(&mut app, &ctx);
+            assert_eq!(
+                app.active_tab().flow_pane.drawings.selected(),
+                Some(0),
+                "the selection was wiped {frame} frames after the handle grab"
+            );
+        }
+    }
+
+    /// The same gesture on a crowded chart — the demo hook's seventeen
+    /// overlapping objects, which is what the report was looking at.
+    #[test]
+    fn clicking_a_drawing_on_a_crowded_chart_keeps_it_selected() {
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        run_frame(&mut app, &ctx);
+
+        for (index, tool) in drawings::DRAWING_TOOLS.into_iter().enumerate() {
+            arm_drawing_from_toolbox(&mut app, &ctx, tool.id());
+            for point in 0..tool.required_points() {
+                let offset = index as f32;
+                let step = point as f32;
+                click_chart(
+                    &mut app,
+                    &ctx,
+                    egui::pos2(
+                        560.0 + (offset % 4.0) * 50.0 + step * 70.0,
+                        250.0 + (offset % 3.0) * 70.0 + step * 50.0,
+                    ),
+                );
+            }
+        }
+        run_frame(&mut app, &ctx);
+        app.active_tab_mut().flow_pane.drawings.select(None);
+        run_frame(&mut app, &ctx);
+
+        // Press-release on a spot the objects cover.
+        let spot = egui::pos2(630.0, 320.0);
+        click_chart(&mut app, &ctx, spot);
+        let picked = app.active_tab().flow_pane.drawings.selected();
+        assert!(picked.is_some(), "the click found something to select");
+        for frame in 0..5 {
+            run_frame(&mut app, &ctx);
+            assert_eq!(
+                app.active_tab().flow_pane.drawings.selected(),
+                picked,
+                "the selection changed {frame} frames after the click"
+            );
+        }
+    }
+
     /// Marina's ask (`docs/ux/drawing-tools-2026-08.md` §D7): a level drawn on
     /// one chart of the tab shows on the other, at the same moment in market
     /// time — one version of the truth instead of two hand-drawn ones.

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -1935,6 +1935,23 @@ impl QuantickApp {
             bar_spec = self.active_tab().flow_pane.state.spec().summary(),
             canvas_layout = ?self.active_tab().layout,
             time_pane_spec = self.active_tab().time_pane.as_ref().map(|pane| pane.state.spec().summary()),
+            // Drawings are a per-frame, O(objects) paint cost, and the shared
+            // ones are additionally reprojected on every other pane of the
+            // tab. Counting them here is what lets a frame-cost reading be
+            // attributed instead of guessed — and it is the only way a
+            // headless run can prove the drawing overlay is populated at all.
+            drawings = self.active_tab().flow_pane.drawings.items().len()
+                + self
+                    .active_tab()
+                    .time_pane
+                    .as_ref()
+                    .map_or(0, |pane| pane.drawings.items().len()),
+            shared_drawings = self.active_tab().flow_pane.drawings.shared_count()
+                + self
+                    .active_tab()
+                    .time_pane
+                    .as_ref()
+                    .map_or(0, |pane| pane.drawings.shared_count()),
             book_enabled = book.enabled,
             book_status = book.status,
             book_generation = book.generation,
@@ -6098,8 +6115,7 @@ plot(close)
             let time = pane.slot_open_time(slot).expect("a closed bar has a time");
             let price = pane
                 .closed_bar(slot)
-                .map(|bar| rust_decimal::prelude::ToPrimitive::to_f64(&bar.close))
-                .flatten()
+                .and_then(|bar| rust_decimal::prelude::ToPrimitive::to_f64(&bar.close))
                 .expect("the bar has a close");
             drawings::ChartPoint::at_time(slot as f32 + 0.5, price, Some(time))
         };

--- a/crates/app/src/drawings/arrow.rs
+++ b/crates/app/src/drawings/arrow.rs
@@ -1,0 +1,70 @@
+use eframe::egui;
+use egui_phosphor::regular as icons;
+
+use super::line_core::{Extend, LINES_FAMILY, hit_line, paint_line};
+use super::{DrawContext, DrawingStyle, DrawingToolImpl, ToolFamily};
+
+pub(super) static TOOL: Arrow = Arrow;
+
+pub(super) struct Arrow;
+
+impl DrawingToolImpl for Arrow {
+    fn id(&self) -> &'static str {
+        "arrow"
+    }
+    fn name(&self) -> &'static str {
+        "Arrow"
+    }
+    fn settings_title(&self) -> &'static str {
+        "Arrow settings"
+    }
+    fn icon(&self) -> &'static str {
+        icons::FLOW_ARROW
+    }
+    fn hover_text(&self) -> &'static str {
+        "Arrow - click the tail, then the point it marks"
+    }
+    fn required_points(&self) -> usize {
+        2
+    }
+    fn family(&self) -> Option<ToolFamily> {
+        Some(LINES_FAMILY)
+    }
+    fn paint(
+        &self,
+        painter: &egui::Painter,
+        chart_rect: egui::Rect,
+        style: DrawingStyle,
+        points: &[egui::Pos2],
+        ctxt: &DrawContext<'_>,
+    ) {
+        // The halo pass is a widened copy of the stroke; painting the head
+        // twice would blunt it into a blob, so the head is geometry-only.
+        paint_line(
+            painter,
+            chart_rect,
+            style,
+            points,
+            Extend::None,
+            !ctxt.halo,
+        );
+    }
+    fn hit_test(
+        &self,
+        chart_rect: egui::Rect,
+        points: &[egui::Pos2],
+        position: egui::Pos2,
+        radius_px: f32,
+        _ctxt: &DrawContext<'_>,
+    ) -> bool {
+        hit_line(chart_rect, points, position, radius_px, Extend::None)
+    }
+
+    #[cfg(test)]
+    fn test_geometry(&self) -> (Vec<egui::Pos2>, egui::Pos2) {
+        (
+            vec![egui::pos2(100.0, 100.0), egui::pos2(300.0, 200.0)],
+            egui::pos2(200.0, 150.0),
+        )
+    }
+}

--- a/crates/app/src/drawings/date_range.rs
+++ b/crates/app/src/drawings/date_range.rs
@@ -1,0 +1,79 @@
+use eframe::egui;
+use egui_phosphor::regular as icons;
+
+use super::measure_core::{MEASURE_FAMILY, TIME_ONLY, hit_measure, paint_measure};
+use super::{DrawContext, DrawingStyle, DrawingToolImpl, ToolFamily};
+
+pub(super) static TOOL: DateRange = DateRange;
+
+pub(super) struct DateRange;
+
+impl DrawingToolImpl for DateRange {
+    fn id(&self) -> &'static str {
+        "date-range"
+    }
+    fn name(&self) -> &'static str {
+        "Date range"
+    }
+    fn settings_title(&self) -> &'static str {
+        "Date range settings"
+    }
+    fn icon(&self) -> &'static str {
+        icons::ARROWS_HORIZONTAL
+    }
+    fn hover_text(&self) -> &'static str {
+        "Date range - two bars, read in bars and elapsed time"
+    }
+    fn required_points(&self) -> usize {
+        2
+    }
+    fn family(&self) -> Option<ToolFamily> {
+        Some(MEASURE_FAMILY)
+    }
+    fn supports_fill(&self) -> bool {
+        true
+    }
+    fn paint(
+        &self,
+        painter: &egui::Painter,
+        chart_rect: egui::Rect,
+        style: DrawingStyle,
+        points: &[egui::Pos2],
+        ctxt: &DrawContext<'_>,
+    ) {
+        paint_measure(
+            painter,
+            chart_rect,
+            style,
+            points,
+            ctxt.anchors,
+            TIME_ONLY,
+            ctxt.halo,
+        );
+    }
+    fn hit_test(
+        &self,
+        chart_rect: egui::Rect,
+        points: &[egui::Pos2],
+        position: egui::Pos2,
+        radius_px: f32,
+        ctxt: &DrawContext<'_>,
+    ) -> bool {
+        hit_measure(
+            chart_rect,
+            ctxt.style,
+            points,
+            position,
+            radius_px,
+            TIME_ONLY,
+        )
+    }
+
+    #[cfg(test)]
+    fn test_geometry(&self) -> (Vec<egui::Pos2>, egui::Pos2) {
+        (
+            vec![egui::pos2(100.0, 200.0), egui::pos2(300.0, 100.0)],
+            egui::pos2(200.0, 150.0),
+        )
+    }
+}

--- a/crates/app/src/drawings/ellipse.rs
+++ b/crates/app/src/drawings/ellipse.rs
@@ -1,0 +1,74 @@
+use eframe::egui;
+use egui_phosphor::regular as icons;
+
+use super::shape_core::{SHAPES_FAMILY, ellipse_outline, hit_outline, paint_outline};
+use super::{DrawContext, DrawingStyle, DrawingToolImpl, ToolFamily};
+
+pub(super) static TOOL: Ellipse = Ellipse;
+
+pub(super) struct Ellipse;
+
+impl DrawingToolImpl for Ellipse {
+    fn id(&self) -> &'static str {
+        "ellipse"
+    }
+    fn name(&self) -> &'static str {
+        "Ellipse"
+    }
+    fn settings_title(&self) -> &'static str {
+        "Ellipse settings"
+    }
+    fn icon(&self) -> &'static str {
+        icons::CIRCLE
+    }
+    fn hover_text(&self) -> &'static str {
+        "Ellipse - click two corners of the area it fits inside"
+    }
+    fn required_points(&self) -> usize {
+        2
+    }
+    fn family(&self) -> Option<ToolFamily> {
+        Some(SHAPES_FAMILY)
+    }
+    fn supports_fill(&self) -> bool {
+        true
+    }
+    fn paint(
+        &self,
+        painter: &egui::Painter,
+        _chart_rect: egui::Rect,
+        style: DrawingStyle,
+        points: &[egui::Pos2],
+        _ctxt: &DrawContext<'_>,
+    ) {
+        if let [first, second, ..] = points {
+            paint_outline(painter, style, &ellipse_outline([*first, *second]));
+        }
+    }
+    fn hit_test(
+        &self,
+        _chart_rect: egui::Rect,
+        points: &[egui::Pos2],
+        position: egui::Pos2,
+        radius_px: f32,
+        ctxt: &DrawContext<'_>,
+    ) -> bool {
+        match points {
+            [first, second, ..] => hit_outline(
+                &ellipse_outline([*first, *second]),
+                position,
+                radius_px,
+                ctxt,
+            ),
+            _ => false,
+        }
+    }
+
+    #[cfg(test)]
+    fn test_geometry(&self) -> (Vec<egui::Pos2>, egui::Pos2) {
+        (
+            vec![egui::pos2(100.0, 100.0), egui::pos2(300.0, 200.0)],
+            egui::pos2(300.0, 150.0),
+        )
+    }
+}

--- a/crates/app/src/drawings/extended_line.rs
+++ b/crates/app/src/drawings/extended_line.rs
@@ -1,37 +1,31 @@
 use eframe::egui;
 use egui_phosphor::regular as icons;
 
-use super::line_core::{Axis, LINES_FAMILY, hit_axis, paint_axis};
-use super::{DrawContext, DrawingStyle, DrawingToolImpl, ToolFamily, ToolShortcut};
+use super::line_core::{Extend, LINES_FAMILY, hit_line, paint_line};
+use super::{DrawContext, DrawingStyle, DrawingToolImpl, ToolFamily};
 
-pub(super) static TOOL: HorizontalLine = HorizontalLine;
+pub(super) static TOOL: ExtendedLine = ExtendedLine;
 
-pub(super) struct HorizontalLine;
+pub(super) struct ExtendedLine;
 
-impl DrawingToolImpl for HorizontalLine {
+impl DrawingToolImpl for ExtendedLine {
     fn id(&self) -> &'static str {
-        "horizontal-line"
+        "extended-line"
     }
     fn name(&self) -> &'static str {
-        "Horizontal line"
+        "Extended line"
     }
     fn settings_title(&self) -> &'static str {
-        "Horizontal line settings"
+        "Extended line settings"
     }
     fn icon(&self) -> &'static str {
-        icons::MINUS
+        icons::ARROWS_OUT_LINE_HORIZONTAL
     }
     fn hover_text(&self) -> &'static str {
-        "Horizontal line - click a price (H)"
+        "Extended line - two points, running to both chart edges"
     }
     fn required_points(&self) -> usize {
-        1
-    }
-    fn shortcut(&self) -> Option<ToolShortcut> {
-        Some(ToolShortcut {
-            key: egui::Key::H,
-            shift: false,
-        })
+        2
     }
     fn family(&self) -> Option<ToolFamily> {
         Some(LINES_FAMILY)
@@ -44,7 +38,7 @@ impl DrawingToolImpl for HorizontalLine {
         points: &[egui::Pos2],
         _ctxt: &DrawContext<'_>,
     ) {
-        paint_axis(painter, chart_rect, style, points, Axis::Horizontal);
+        paint_line(painter, chart_rect, style, points, Extend::Both, false);
     }
     fn hit_test(
         &self,
@@ -54,11 +48,14 @@ impl DrawingToolImpl for HorizontalLine {
         radius_px: f32,
         _ctxt: &DrawContext<'_>,
     ) -> bool {
-        hit_axis(chart_rect, points, position, radius_px, Axis::Horizontal)
+        hit_line(chart_rect, points, position, radius_px, Extend::Both)
     }
 
     #[cfg(test)]
     fn test_geometry(&self) -> (Vec<egui::Pos2>, egui::Pos2) {
-        (vec![egui::pos2(100.0, 120.0)], egui::pos2(450.0, 123.0))
+        (
+            vec![egui::pos2(100.0, 100.0), egui::pos2(300.0, 200.0)],
+            egui::pos2(200.0, 150.0),
+        )
     }
 }

--- a/crates/app/src/drawings/fib.rs
+++ b/crates/app/src/drawings/fib.rs
@@ -112,20 +112,34 @@ impl LabelPosition {
 /// How far the level lines run horizontally.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub enum Extend {
-    #[default]
     Anchors,
+    /// The default: forward from the *last* anchor only.
+    ///
+    /// A Fib level is something price is going to meet, so it has to be drawn
+    /// where price is — to the right of the swing that defined it. Levels
+    /// that stop at the anchors vanish behind the tape the moment the market
+    /// moves on, and an extension whose targets sit to the *left* of the leg
+    /// they project is backwards on its face.
+    ///
+    /// Starting at the last anchor rather than the first also keeps the
+    /// projection off the leg it was measured from: the rays say "from here
+    /// on", which is what a target is.
+    #[default]
+    Forward,
+    /// The whole anchor span *and* the projection.
     Right,
     Both,
 }
 
 impl Extend {
-    const ALL: [Self; 3] = [Self::Anchors, Self::Right, Self::Both];
+    const ALL: [Self; 4] = [Self::Anchors, Self::Forward, Self::Right, Self::Both];
 
     #[must_use]
     fn describe(self) -> &'static str {
         match self {
             Self::Anchors => "Between anchors",
-            Self::Right => "To the right",
+            Self::Forward => "From the last point",
+            Self::Right => "Anchors + right",
             Self::Both => "Both sides",
         }
     }
@@ -493,6 +507,10 @@ fn level_span(points: &[egui::Pos2], chart_rect: egui::Rect, extend: Extend) -> 
         .fold(f32::NEG_INFINITY, f32::max);
     match extend {
         Extend::Anchors => (left, right),
+        // The newest anchor, not the last one placed: "forward" is a
+        // statement about the market's direction, and a Fib drawn
+        // right-to-left means the same thing as one drawn left-to-right.
+        Extend::Forward => (right, chart_rect.right()),
         Extend::Right => (left, chart_rect.right()),
         Extend::Both => (chart_rect.left(), chart_rect.right()),
     }
@@ -581,7 +599,18 @@ pub(super) fn paint(
         if let Some(labels) = &labels
             && let Some(text) = labels.labels.get(index)
         {
-            let (anchor, x) = match payload.label_position {
+            // A span that runs to the chart's edge has no "outside" left to
+            // put a label in — it would be painted past the clip and simply
+            // vanish, which is what projecting the levels forward would
+            // otherwise cost. Fall inside instead.
+            let position = if right >= chart_rect.right() - FIB_LABEL_OFFSET_PX
+                && payload.label_position == LabelPosition::RightOutside
+            {
+                LabelPosition::RightInside
+            } else {
+                payload.label_position
+            };
+            let (anchor, x) = match position {
                 LabelPosition::RightOutside => {
                     (egui::Align2::LEFT_BOTTOM, right + FIB_LABEL_OFFSET_PX)
                 }

--- a/crates/app/src/drawings/fib.rs
+++ b/crates/app/src/drawings/fib.rs
@@ -413,6 +413,18 @@ pub fn log_scale_allowed(a: f64, b: f64, c: f64) -> bool {
 
 /// The price of one level. `c` is ignored by retracement; for extension it
 /// is the projection origin. Log demands positive prices — `None` otherwise.
+///
+/// **Retracement runs backwards along the move, not forwards.** A "61.8 %
+/// retracement" is a statement about how much of a move price has *given
+/// back*: 0 % sits at the end of the move (`b`), 100 % at where it started
+/// (`a`), and 61.8 % is 61.8 % of the way back from the end toward the start.
+/// Drawn top-down over a fall, that puts 61.8 % high on the chart, where a
+/// trader waits for the bounce to stall — the whole reason the level is
+/// drawn. Anchoring 0 % at `a` instead, as this did, mirrors every level
+/// through the middle of the move and names them all wrong.
+///
+/// Extension is the other question — where the *next* leg may reach — so it
+/// projects forward from `c` by the size of the `a`→`b` move, unchanged.
 #[must_use]
 pub fn level_price(
     kind: FibKind,
@@ -424,17 +436,19 @@ pub fn level_price(
 ) -> Option<f64> {
     if !log_scale {
         return Some(match kind {
-            FibKind::Retracement => a + (b - a) * ratio,
+            FibKind::Retracement => b + (a - b) * ratio,
             FibKind::Extension => c + (b - a) * ratio,
         });
     }
     if !log_scale_allowed(a, b, c) {
         return None;
     }
-    let log_move = (b / a).ln();
+    let move_log = (b / a).ln();
     Some(match kind {
-        FibKind::Retracement => a * (log_move * ratio).exp(),
-        FibKind::Extension => c * (log_move * ratio).exp(),
+        // `b * (a / b)^ratio`, written with the same log the extension uses:
+        // ln(a / b) is -ln(b / a).
+        FibKind::Retracement => b * (-move_log * ratio).exp(),
+        FibKind::Extension => c * (move_log * ratio).exp(),
     })
 }
 
@@ -1047,18 +1061,24 @@ mod tests {
         (left - right).abs() < EPS
     }
 
+    /// A retracement runs *backwards* along the move: 0 % at the end of it,
+    /// 100 % at where it started. So on a fall drawn top-down, 61.8 % is high
+    /// on the chart — that is what "price gave back 61.8 % of the drop"
+    /// means, and where the trader waits for the bounce to stall. It used to
+    /// be mirrored, putting 61.8 % near the low and naming every level wrong.
     #[test]
-    fn retracement_formula_is_exact_in_up_and_down_moves() {
+    fn retracement_measures_how_much_of_the_move_was_given_back() {
         // Down move: A above B (the prototype's 71,824.50 -> 69,111.50).
         let (a, b) = (71_824.50, 69_111.50);
+        let span = a - b;
         let golden = [
-            (0.0, 71_824.50),
-            (0.236, 71_184.232),
-            (0.382, 70_788.134),
-            (0.5, 70_468.0),
-            (0.618, 70_147.866),
-            (0.786, 69_692.082),
-            (1.0, 69_111.50),
+            (0.0, b),
+            (0.236, b + span * 0.236),
+            (0.382, b + span * 0.382),
+            (0.5, b + span * 0.5),
+            (0.618, b + span * 0.618),
+            (0.786, b + span * 0.786),
+            (1.0, a),
         ];
         for (ratio, expected) in golden {
             let price = level_price(FibKind::Retracement, false, a, b, b, ratio).unwrap();
@@ -1067,9 +1087,35 @@ mod tests {
                 "ratio {ratio}: {price} vs {expected}"
             );
         }
-        // Up move mirrors exactly.
+        assert!(
+            level_price(FibKind::Retracement, false, a, b, b, 0.618).unwrap() > (a + b) / 2.0,
+            "on a fall, the 61.8 % line sits in the upper half of the move"
+        );
+
+        // Up move mirrors exactly: 61.8 % given back of a 100 -> 200 rally is
+        // 200 - 0.618 * 100.
         let price = level_price(FibKind::Retracement, false, 100.0, 200.0, 200.0, 0.618).unwrap();
-        assert!(close(price, 161.8));
+        assert!(close(price, 138.2), "{price}");
+        assert!(
+            level_price(FibKind::Retracement, false, 100.0, 200.0, 200.0, 0.618).unwrap() < 150.0,
+            "on a rally, the 61.8 % line sits in the lower half of the move"
+        );
+    }
+
+    /// The log formulas must land on the same two ends as the linear ones,
+    /// or a trader switching the scale sees the levels renamed.
+    #[test]
+    fn the_log_retracement_shares_the_linear_ones_endpoints() {
+        let (a, b) = (71_824.50, 69_111.50);
+        let zero = level_price(FibKind::Retracement, true, a, b, b, 0.0).unwrap();
+        let one = level_price(FibKind::Retracement, true, a, b, b, 1.0).unwrap();
+        assert!(close(zero, b), "0 % is the end of the move: {zero}");
+        assert!(close(one, a), "100 % is where it started: {one}");
+        let middle = level_price(FibKind::Retracement, true, a, b, b, 0.618).unwrap();
+        assert!(
+            middle > (a + b) / 2.0,
+            "and 61.8 % is still high on a fall: {middle}"
+        );
     }
 
     #[test]

--- a/crates/app/src/drawings/fib_extension.rs
+++ b/crates/app/src/drawings/fib_extension.rs
@@ -24,6 +24,9 @@ impl DrawingToolImpl for FibExtension {
     fn hover_text(&self) -> &'static str {
         "Fib extension - set the first leg, then click the projection origin (Shift+F)"
     }
+    fn placement_hint(&self, placed: usize) -> Option<&'static str> {
+        (placed == 2).then_some("Click where the retracement ended")
+    }
     fn required_points(&self) -> usize {
         FibKind::Extension.required_points()
     }

--- a/crates/app/src/drawings/fib_extension.rs
+++ b/crates/app/src/drawings/fib_extension.rs
@@ -83,7 +83,9 @@ impl DrawingToolImpl for FibExtension {
                 egui::pos2(200.0, 200.0),
                 egui::pos2(250.0, 150.0),
             ],
-            egui::pos2(175.0, 250.0),
+            // Right of the last anchor: the levels project forward from
+            // there now, so that is where the object can be grabbed.
+            egui::pos2(300.0, 250.0),
         )
     }
 }

--- a/crates/app/src/drawings/fib_retracement.rs
+++ b/crates/app/src/drawings/fib_retracement.rs
@@ -76,7 +76,8 @@ impl DrawingToolImpl for FibRetracement {
     fn test_geometry(&self) -> (Vec<egui::Pos2>, egui::Pos2) {
         (
             vec![egui::pos2(100.0, 100.0), egui::pos2(250.0, 200.0)],
-            egui::pos2(175.0, 150.0),
+            // Right of the last anchor: see `fib_extension`.
+            egui::pos2(300.0, 150.0),
         )
     }
 }

--- a/crates/app/src/drawings/horizontal_ray.rs
+++ b/crates/app/src/drawings/horizontal_ray.rs
@@ -1,0 +1,76 @@
+use eframe::egui;
+use egui_phosphor::regular as icons;
+
+use super::line_core::LINES_FAMILY;
+use super::{DrawContext, DrawingStyle, DrawingToolImpl, ToolFamily, drawing_stroke};
+
+pub(super) static TOOL: HorizontalRay = HorizontalRay;
+
+pub(super) struct HorizontalRay;
+
+/// The painted span: from the anchor bar to the right edge. A level only
+/// becomes a level once it has been touched, so a horizontal ray says
+/// "from here on" — which is exactly what a horizontal line cannot say.
+fn span(chart_rect: egui::Rect, point: egui::Pos2) -> (egui::Pos2, egui::Pos2) {
+    (
+        egui::pos2(point.x.min(chart_rect.right()), point.y),
+        egui::pos2(chart_rect.right(), point.y),
+    )
+}
+
+impl DrawingToolImpl for HorizontalRay {
+    fn id(&self) -> &'static str {
+        "horizontal-ray"
+    }
+    fn name(&self) -> &'static str {
+        "Horizontal ray"
+    }
+    fn settings_title(&self) -> &'static str {
+        "Horizontal ray settings"
+    }
+    fn icon(&self) -> &'static str {
+        icons::ARROW_LINE_RIGHT
+    }
+    fn hover_text(&self) -> &'static str {
+        "Horizontal ray - a level that starts at the bar you click"
+    }
+    fn required_points(&self) -> usize {
+        1
+    }
+    fn family(&self) -> Option<ToolFamily> {
+        Some(LINES_FAMILY)
+    }
+    fn paint(
+        &self,
+        painter: &egui::Painter,
+        chart_rect: egui::Rect,
+        style: DrawingStyle,
+        points: &[egui::Pos2],
+        _ctxt: &DrawContext<'_>,
+    ) {
+        if let Some(point) = points.first() {
+            let (from, to) = span(chart_rect, *point);
+            painter.line_segment([from, to], drawing_stroke(style));
+        }
+    }
+    fn hit_test(
+        &self,
+        chart_rect: egui::Rect,
+        points: &[egui::Pos2],
+        position: egui::Pos2,
+        radius_px: f32,
+        _ctxt: &DrawContext<'_>,
+    ) -> bool {
+        points.first().is_some_and(|point| {
+            let (from, to) = span(chart_rect, *point);
+            position.x >= from.x - radius_px
+                && position.x <= to.x
+                && (position.y - point.y).abs() <= radius_px
+        })
+    }
+
+    #[cfg(test)]
+    fn test_geometry(&self) -> (Vec<egui::Pos2>, egui::Pos2) {
+        (vec![egui::pos2(200.0, 150.0)], egui::pos2(400.0, 152.0))
+    }
+}

--- a/crates/app/src/drawings/line_core.rs
+++ b/crates/app/src/drawings/line_core.rs
@@ -1,0 +1,299 @@
+//! The geometry every straight-line tool shares.
+//!
+//! Trend line, ray, extended line, horizontal ray, vertical line and arrow
+//! are one shape with two questions attached: how far does it run past its
+//! anchors, and does it end in a head. Keeping that in one place means the
+//! seven tools in the Lines family are seven declarations, not seven
+//! copies of the same segment maths — and a fix to the hit-test fixes all
+//! of them at once.
+
+use eframe::egui;
+use egui_phosphor::regular as icons;
+
+use super::{DrawingStyle, ToolFamily, distance_to_segment, drawing_stroke};
+
+/// The one rail family every straight-line tool declares. Shared here so
+/// the members cannot drift apart on the title or the pre-arm icon.
+pub(super) const LINES_FAMILY: ToolFamily = ToolFamily {
+    id: "lines",
+    title: "Lines",
+    icon: icons::LINE_SEGMENT,
+};
+
+/// How far a line runs past the anchors that define it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum Extend {
+    /// A segment: it stops where the trader put it.
+    None,
+    /// A ray: past the second anchor to the chart edge.
+    Forward,
+    /// A ray the other way: past the first anchor to the chart edge. Not a
+    /// tool of its own — the channel's "extend left" is expressed with it.
+    Backward,
+    /// An infinite line: past both anchors to the chart edge.
+    Both,
+}
+
+/// Arrowhead length as a multiple of the stroke width, floored so a hairline
+/// still gets a head you can see.
+const ARROWHEAD_WIDTH_FACTOR: f32 = 6.0;
+const ARROWHEAD_MIN_PX: f32 = 8.0;
+/// Half-angle of the arrowhead, in radians (~24°).
+const ARROWHEAD_HALF_ANGLE: f32 = 0.42;
+
+/// The largest step from `origin` along `dir` that stays inside `rect`.
+///
+/// `dir` need not be normalised. A direction with no component on an axis
+/// simply never bounds `t` on it; a line that cannot reach any edge (a zero
+/// direction) stays at its origin rather than running to infinity.
+fn edge_step(origin: egui::Pos2, dir: egui::Vec2, rect: egui::Rect) -> f32 {
+    const EPSILON: f32 = 1e-4;
+    let mut step = f32::INFINITY;
+    if dir.x > EPSILON {
+        step = step.min((rect.right() - origin.x) / dir.x);
+    } else if dir.x < -EPSILON {
+        step = step.min((rect.left() - origin.x) / dir.x);
+    }
+    if dir.y > EPSILON {
+        step = step.min((rect.bottom() - origin.y) / dir.y);
+    } else if dir.y < -EPSILON {
+        step = step.min((rect.top() - origin.y) / dir.y);
+    }
+    if step.is_finite() { step.max(0.0) } else { 0.0 }
+}
+
+/// The two screen points a line with this extension actually runs between.
+/// `None` while the draft still has fewer than two anchors, or when both
+/// anchors landed on the same pixel (nothing to draw a direction from).
+pub(super) fn line_ends(
+    chart_rect: egui::Rect,
+    points: &[egui::Pos2],
+    extend: Extend,
+) -> Option<(egui::Pos2, egui::Pos2)> {
+    let (&start, &end) = match points {
+        [start, end, ..] => (start, end),
+        _ => return None,
+    };
+    let direction = end - start;
+    if direction.length_sq() <= f32::EPSILON {
+        return Some((start, end));
+    }
+    let head = match extend {
+        Extend::None | Extend::Backward => end,
+        Extend::Forward | Extend::Both => end + direction * edge_step(end, direction, chart_rect),
+    };
+    let tail = match extend {
+        Extend::None | Extend::Forward => start,
+        Extend::Backward | Extend::Both => {
+            start - direction * edge_step(start, -direction, chart_rect)
+        }
+    };
+    Some((tail, head))
+}
+
+/// Paint a straight line, optionally ending in an arrowhead at `points[1]`.
+///
+/// The head is skipped on the halo pass: a halo is a widened copy of the
+/// stroke, and painting the head twice would blunt it into a blob.
+pub(super) fn paint_line(
+    painter: &egui::Painter,
+    chart_rect: egui::Rect,
+    style: DrawingStyle,
+    points: &[egui::Pos2],
+    extend: Extend,
+    arrowhead: bool,
+) {
+    let Some((tail, head)) = line_ends(chart_rect, points, extend) else {
+        return;
+    };
+    let stroke = drawing_stroke(style);
+    painter.line_segment([tail, head], stroke);
+    if !arrowhead {
+        return;
+    }
+    let direction = head - tail;
+    if direction.length_sq() <= f32::EPSILON {
+        return;
+    }
+    let back =
+        -direction.normalized() * (style.width_px * ARROWHEAD_WIDTH_FACTOR).max(ARROWHEAD_MIN_PX);
+    let (sin, cos) = ARROWHEAD_HALF_ANGLE.sin_cos();
+    for wing in [
+        egui::vec2(back.x * cos - back.y * sin, back.x * sin + back.y * cos),
+        egui::vec2(back.x * cos + back.y * sin, -back.x * sin + back.y * cos),
+    ] {
+        painter.line_segment([head, head + wing], stroke);
+    }
+}
+
+/// Hit-test a straight line with this extension.
+pub(super) fn hit_line(
+    chart_rect: egui::Rect,
+    points: &[egui::Pos2],
+    position: egui::Pos2,
+    radius_px: f32,
+    extend: Extend,
+) -> bool {
+    line_ends(chart_rect, points, extend)
+        .is_some_and(|(tail, head)| distance_to_segment(position, tail, head) <= radius_px)
+}
+
+/// A single-anchor line running across the whole chart on one axis.
+/// Horizontal line and vertical line differ only in which axis they pin.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum Axis {
+    Horizontal,
+    Vertical,
+}
+
+pub(super) fn axis_ends(
+    chart_rect: egui::Rect,
+    point: egui::Pos2,
+    axis: Axis,
+) -> (egui::Pos2, egui::Pos2) {
+    match axis {
+        Axis::Horizontal => (
+            egui::pos2(chart_rect.left(), point.y),
+            egui::pos2(chart_rect.right(), point.y),
+        ),
+        Axis::Vertical => (
+            egui::pos2(point.x, chart_rect.top()),
+            egui::pos2(point.x, chart_rect.bottom()),
+        ),
+    }
+}
+
+/// Shared paint for the single-anchor axis lines.
+pub(super) fn paint_axis(
+    painter: &egui::Painter,
+    chart_rect: egui::Rect,
+    style: DrawingStyle,
+    points: &[egui::Pos2],
+    axis: Axis,
+) {
+    if let Some(point) = points.first() {
+        let (from, to) = axis_ends(chart_rect, *point, axis);
+        painter.line_segment([from, to], drawing_stroke(style));
+    }
+}
+
+/// Shared hit-test for the single-anchor axis lines. The cross-axis bound
+/// keeps a line selectable only where it is actually painted.
+pub(super) fn hit_axis(
+    chart_rect: egui::Rect,
+    points: &[egui::Pos2],
+    position: egui::Pos2,
+    radius_px: f32,
+    axis: Axis,
+) -> bool {
+    points.first().is_some_and(|point| match axis {
+        Axis::Horizontal => {
+            chart_rect.x_range().contains(position.x) && (position.y - point.y).abs() <= radius_px
+        }
+        Axis::Vertical => {
+            chart_rect.y_range().contains(position.y) && (position.x - point.x).abs() <= radius_px
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn chart() -> egui::Rect {
+        egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(800.0, 600.0))
+    }
+
+    #[test]
+    fn a_segment_stops_at_its_anchors() {
+        let points = [egui::pos2(100.0, 100.0), egui::pos2(200.0, 200.0)];
+        assert_eq!(
+            line_ends(chart(), &points, Extend::None),
+            Some((points[0], points[1]))
+        );
+    }
+
+    #[test]
+    fn a_ray_reaches_the_chart_edge_forward_only() {
+        let points = [egui::pos2(100.0, 100.0), egui::pos2(200.0, 200.0)];
+        let (tail, head) = line_ends(chart(), &points, Extend::Forward).expect("two anchors");
+        assert_eq!(tail, points[0], "a ray keeps its origin anchor");
+        // Slope 1 from (200,200): the bottom edge at y = 600 comes before the
+        // right edge at x = 800.
+        assert!(
+            (head.y - 600.0).abs() < 0.01,
+            "head stops on the bottom edge"
+        );
+        assert!((head.x - 600.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn an_extended_line_reaches_both_edges() {
+        let points = [egui::pos2(100.0, 100.0), egui::pos2(200.0, 200.0)];
+        let (tail, head) = line_ends(chart(), &points, Extend::Both).expect("two anchors");
+        assert!((tail.x - 0.0).abs() < 0.01 && (tail.y - 0.0).abs() < 0.01);
+        assert!((head.x - 600.0).abs() < 0.01 && (head.y - 600.0).abs() < 0.01);
+    }
+
+    /// A pan can drag both anchors onto the same pixel; the tool must not
+    /// divide by zero or run the line to infinity.
+    #[test]
+    fn coincident_anchors_do_not_produce_an_infinite_line() {
+        let points = [egui::pos2(100.0, 100.0), egui::pos2(100.0, 100.0)];
+        for extend in [
+            Extend::None,
+            Extend::Forward,
+            Extend::Backward,
+            Extend::Both,
+        ] {
+            assert_eq!(
+                line_ends(chart(), &points, extend),
+                Some((points[0], points[1])),
+                "{extend:?} must degenerate to the anchors themselves"
+            );
+        }
+    }
+
+    /// Extending is a *view* affordance: the anchors never move, so undo,
+    /// coordinates and the shared-anchor projection all keep working on the
+    /// two points the trader actually placed.
+    #[test]
+    fn extending_never_moves_the_anchors() {
+        let points = [egui::pos2(300.0, 400.0), egui::pos2(500.0, 100.0)];
+        for extend in [Extend::Forward, Extend::Backward, Extend::Both] {
+            let before = points;
+            let _ = line_ends(chart(), &points, extend);
+            assert_eq!(points, before);
+        }
+    }
+
+    #[test]
+    fn a_ray_is_selectable_past_its_second_anchor() {
+        let points = [egui::pos2(100.0, 100.0), egui::pos2(200.0, 200.0)];
+        let past = egui::pos2(400.0, 400.0);
+        assert!(!hit_line(chart(), &points, past, 4.0, Extend::None));
+        assert!(hit_line(chart(), &points, past, 4.0, Extend::Forward));
+    }
+
+    #[test]
+    fn a_vertical_line_is_only_selectable_inside_the_chart() {
+        let points = [egui::pos2(400.0, 300.0)];
+        assert!(hit_axis(
+            chart(),
+            &points,
+            egui::pos2(402.0, 10.0),
+            4.0,
+            Axis::Vertical
+        ));
+        assert!(
+            !hit_axis(
+                chart(),
+                &points,
+                egui::pos2(402.0, 900.0),
+                4.0,
+                Axis::Vertical
+            ),
+            "below the chart there is no line to click"
+        );
+    }
+}

--- a/crates/app/src/drawings/measure.rs
+++ b/crates/app/src/drawings/measure.rs
@@ -1,0 +1,85 @@
+use eframe::egui;
+use egui_phosphor::regular as icons;
+
+use super::measure_core::{BOTH_AXES, MEASURE_FAMILY, hit_measure, paint_measure};
+use super::{DrawContext, DrawingStyle, DrawingToolImpl, ToolFamily, ToolShortcut};
+
+pub(super) static TOOL: Measure = Measure;
+
+pub(super) struct Measure;
+
+impl DrawingToolImpl for Measure {
+    fn id(&self) -> &'static str {
+        "measure"
+    }
+    fn name(&self) -> &'static str {
+        "Ruler"
+    }
+    fn settings_title(&self) -> &'static str {
+        "Ruler settings"
+    }
+    fn icon(&self) -> &'static str {
+        icons::RULER
+    }
+    fn hover_text(&self) -> &'static str {
+        "Ruler - drag a leg to read it in points, percent, bars and time (M)"
+    }
+    fn required_points(&self) -> usize {
+        2
+    }
+    fn shortcut(&self) -> Option<ToolShortcut> {
+        Some(ToolShortcut {
+            key: egui::Key::M,
+            shift: false,
+        })
+    }
+    fn family(&self) -> Option<ToolFamily> {
+        Some(MEASURE_FAMILY)
+    }
+    fn supports_fill(&self) -> bool {
+        true
+    }
+    fn paint(
+        &self,
+        painter: &egui::Painter,
+        chart_rect: egui::Rect,
+        style: DrawingStyle,
+        points: &[egui::Pos2],
+        ctxt: &DrawContext<'_>,
+    ) {
+        paint_measure(
+            painter,
+            chart_rect,
+            style,
+            points,
+            ctxt.anchors,
+            BOTH_AXES,
+            ctxt.halo,
+        );
+    }
+    fn hit_test(
+        &self,
+        chart_rect: egui::Rect,
+        points: &[egui::Pos2],
+        position: egui::Pos2,
+        radius_px: f32,
+        ctxt: &DrawContext<'_>,
+    ) -> bool {
+        hit_measure(
+            chart_rect,
+            ctxt.style,
+            points,
+            position,
+            radius_px,
+            BOTH_AXES,
+        )
+    }
+
+    #[cfg(test)]
+    fn test_geometry(&self) -> (Vec<egui::Pos2>, egui::Pos2) {
+        (
+            vec![egui::pos2(100.0, 200.0), egui::pos2(300.0, 100.0)],
+            egui::pos2(200.0, 150.0),
+        )
+    }
+}

--- a/crates/app/src/drawings/measure_core.rs
+++ b/crates/app/src/drawings/measure_core.rs
@@ -1,0 +1,392 @@
+//! The measurement readout the Measure family shares.
+//!
+//! Ruler, price range and date range ask the same question with different
+//! axes suppressed, so "how do we phrase a move" is written once here
+//! (`docs/ux/drawing-tools-2026-08.md` §D5).
+//!
+//! What the readout deliberately does **not** show is ticks. A tick count
+//! needs the instrument's tick size, which several feeds never declare; a
+//! tick figure derived from a guessed step would be an invented number on a
+//! panel whose whole job is to be exact. Points and percent are computable
+//! from the anchors alone, and they are what is shown.
+
+use eframe::egui;
+use egui_phosphor::regular as icons;
+
+use super::{ChartPoint, DrawingStyle, ToolFamily, drawing_fill, drawing_stroke};
+use crate::theme;
+
+/// The one rail family every measurement tool declares.
+pub(super) const MEASURE_FAMILY: ToolFamily = ToolFamily {
+    id: "measure",
+    title: "Measure",
+    icon: icons::RULER,
+};
+
+/// Which axes a measurement reports. Price range suppresses time, date range
+/// suppresses price; the ruler reports both.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct Axes {
+    pub price: bool,
+    pub time: bool,
+}
+
+pub(super) const BOTH_AXES: Axes = Axes {
+    price: true,
+    time: true,
+};
+pub(super) const PRICE_ONLY: Axes = Axes {
+    price: true,
+    time: false,
+};
+pub(super) const TIME_ONLY: Axes = Axes {
+    price: false,
+    time: true,
+};
+
+const READOUT_TEXT_PX: f32 = 10.0;
+const READOUT_LINE_GAP_PX: f32 = 2.0;
+const READOUT_PAD_X_PX: f32 = 5.0;
+const READOUT_PAD_Y_PX: f32 = 3.0;
+const READOUT_RADIUS_PX: f32 = 3.0;
+/// The plate under the readout. Opaque enough to stay legible over candles,
+/// dark enough not to become a second chart object.
+const READOUT_PLATE: egui::Color32 = egui::Color32::from_rgba_premultiplied(14, 18, 26, 216);
+
+/// What the measured leg says, already worded. Empty lines never happen: an
+/// axis that is suppressed contributes no line at all.
+#[derive(Debug, Clone, PartialEq)]
+pub(super) struct Readout {
+    pub lines: Vec<String>,
+    /// `None` when the move is flat or the price axis is suppressed — the
+    /// readout is then painted in the object's own colour rather than
+    /// claiming a direction it does not have.
+    pub rising: Option<bool>,
+}
+
+/// Percent of the *starting* price, which is the convention every platform
+/// uses and the only one that makes a round trip read as zero. A start price
+/// at or below zero has no meaningful percentage, and none is shown.
+fn percent_move(from: f64, to: f64) -> Option<f64> {
+    (from > 0.0).then(|| (to - from) / from * 100.0)
+}
+
+fn format_points(delta: f64) -> String {
+    let magnitude = delta.abs();
+    if magnitude != 0.0 && magnitude < 1.0 {
+        format!("{delta:+.6}")
+    } else {
+        format!("{delta:+.2}")
+    }
+}
+
+/// Elapsed market time, coarsened to the largest unit that still carries
+/// information — a trader reads "4m 21s", never "261000 ms".
+fn format_elapsed(ms: i64) -> String {
+    let total = ms.unsigned_abs();
+    let seconds = total / 1_000;
+    let (days, hours, minutes, secs) = (
+        seconds / 86_400,
+        (seconds % 86_400) / 3_600,
+        (seconds % 3_600) / 60,
+        seconds % 60,
+    );
+    if days > 0 {
+        format!("{days}d {hours}h")
+    } else if hours > 0 {
+        format!("{hours}h {minutes}m")
+    } else if minutes > 0 {
+        format!("{minutes}m {secs}s")
+    } else if seconds > 0 {
+        format!("{seconds}s")
+    } else {
+        format!("{total}ms")
+    }
+}
+
+/// Word the move between two anchors.
+#[must_use]
+pub(super) fn readout(anchors: &[ChartPoint], axes: Axes) -> Option<Readout> {
+    let [from, to, ..] = anchors else {
+        return None;
+    };
+    let mut lines = Vec::with_capacity(2);
+    let mut rising = None;
+
+    if axes.price {
+        let delta = to.price - from.price;
+        rising = (delta != 0.0).then_some(delta > 0.0);
+        let mut price_line = format_points(delta);
+        price_line.push_str(" pts");
+        if let Some(percent) = percent_move(from.price, to.price) {
+            price_line.push_str(&format!("   {percent:+.2}%"));
+        }
+        lines.push(price_line);
+    }
+
+    if axes.time {
+        let bars = (to.bar - from.bar).abs().round() as i64;
+        let mut time_line = format!("{bars} bar{}", if bars == 1 { "" } else { "s" });
+        // Elapsed time needs both anchors to know when they were: an anchor
+        // dropped past the newest bar has no instant behind it, and the
+        // readout says nothing rather than inventing one.
+        if let (Some(start), Some(end)) = (from.time_ms, to.time_ms) {
+            time_line.push_str(&format!("   {}", format_elapsed(end - start)));
+        }
+        lines.push(time_line);
+    }
+
+    (!lines.is_empty()).then_some(Readout { lines, rising })
+}
+
+/// The colour a readout is spoken in: the direction of the move, so the sign
+/// is readable without reading the sign.
+#[must_use]
+pub(super) fn readout_color(readout: &Readout, style: DrawingStyle) -> egui::Color32 {
+    match readout.rising {
+        Some(true) => theme::BUY,
+        Some(false) => theme::SELL,
+        None => style.color,
+    }
+}
+
+/// Paint the measured area, its leg and the readout plate.
+///
+/// `points` are the two screen anchors. The plate is centred on the leg and
+/// nudged so it stays inside the chart — a readout half off-screen is worse
+/// than no readout.
+pub(super) fn paint_measure(
+    painter: &egui::Painter,
+    chart_rect: egui::Rect,
+    style: DrawingStyle,
+    points: &[egui::Pos2],
+    anchors: &[ChartPoint],
+    axes: Axes,
+    halo: bool,
+) {
+    let [from, to, ..] = points else {
+        return;
+    };
+    let area = span_rect(chart_rect, *from, *to, axes);
+    let stroke = drawing_stroke(style);
+
+    // The halo pass is stroke-only, like every other tool: no fill, no plate.
+    if !halo && style.fill_alpha > 0 {
+        painter.rect_filled(area, egui::Rounding::ZERO, drawing_fill(style));
+    }
+    painter.rect_stroke(area, egui::Rounding::ZERO, stroke);
+    painter.line_segment([*from, *to], stroke);
+    if halo {
+        return;
+    }
+
+    let Some(readout) = readout(anchors, axes) else {
+        return;
+    };
+    paint_plate(
+        painter,
+        chart_rect,
+        area.center(),
+        &readout,
+        readout_color(&readout, style),
+    );
+}
+
+/// The rectangle a measurement covers, with a suppressed axis spanning the
+/// whole chart instead of the anchors.
+fn span_rect(chart_rect: egui::Rect, from: egui::Pos2, to: egui::Pos2, axes: Axes) -> egui::Rect {
+    let x = if axes.time {
+        (from.x.min(to.x), from.x.max(to.x))
+    } else {
+        (chart_rect.left(), chart_rect.right())
+    };
+    let y = if axes.price {
+        (from.y.min(to.y), from.y.max(to.y))
+    } else {
+        (chart_rect.top(), chart_rect.bottom())
+    };
+    egui::Rect::from_min_max(egui::pos2(x.0, y.0), egui::pos2(x.1, y.1))
+}
+
+fn paint_plate(
+    painter: &egui::Painter,
+    chart_rect: egui::Rect,
+    centre: egui::Pos2,
+    readout: &Readout,
+    color: egui::Color32,
+) {
+    let font = egui::FontId::monospace(READOUT_TEXT_PX);
+    let galleys: Vec<_> = readout
+        .lines
+        .iter()
+        .map(|line| painter.layout_no_wrap(line.clone(), font.clone(), color))
+        .collect();
+    let width = galleys
+        .iter()
+        .fold(0.0_f32, |widest, galley| widest.max(galley.size().x));
+    let height: f32 = galleys.iter().map(|galley| galley.size().y).sum::<f32>()
+        + READOUT_LINE_GAP_PX * (galleys.len().saturating_sub(1)) as f32;
+    let size = egui::vec2(
+        width + 2.0 * READOUT_PAD_X_PX,
+        height + 2.0 * READOUT_PAD_Y_PX,
+    );
+
+    let mut plate = egui::Rect::from_center_size(centre, size);
+    // Nudge, never clamp to a corner: the readout must stay attached to the
+    // leg it describes.
+    plate = plate.translate(egui::vec2(
+        (chart_rect.left() - plate.left()).max(0.0) + (chart_rect.right() - plate.right()).min(0.0),
+        (chart_rect.top() - plate.top()).max(0.0) + (chart_rect.bottom() - plate.bottom()).min(0.0),
+    ));
+
+    painter.rect_filled(
+        plate,
+        egui::Rounding::same(READOUT_RADIUS_PX),
+        READOUT_PLATE,
+    );
+    let mut cursor = plate.min + egui::vec2(READOUT_PAD_X_PX, READOUT_PAD_Y_PX);
+    for galley in galleys {
+        let advance = galley.size().y + READOUT_LINE_GAP_PX;
+        painter.galley(cursor, galley, color);
+        cursor.y += advance;
+    }
+}
+
+/// Hit-test a measurement: its border and its leg, plus the interior while
+/// the fill is visible — the same rule the shapes follow.
+pub(super) fn hit_measure(
+    chart_rect: egui::Rect,
+    style: DrawingStyle,
+    points: &[egui::Pos2],
+    position: egui::Pos2,
+    radius_px: f32,
+    axes: Axes,
+) -> bool {
+    let [from, to, ..] = points else {
+        return false;
+    };
+    let area = span_rect(chart_rect, *from, *to, axes);
+    if super::distance_to_segment(position, *from, *to) <= radius_px {
+        return true;
+    }
+    if !area.expand(radius_px).contains(position) {
+        return false;
+    }
+    style.fill_alpha > 0 || !area.shrink(radius_px).contains(position)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn anchors(from: (f32, f64, i64), to: (f32, f64, i64)) -> Vec<ChartPoint> {
+        vec![
+            ChartPoint::at_time(from.0, from.1, Some(from.2)),
+            ChartPoint::at_time(to.0, to.1, Some(to.2)),
+        ]
+    }
+
+    /// The whole point of the session's request: points *and* percent, on one
+    /// line, from one gesture.
+    #[test]
+    fn the_ruler_reads_points_and_percent() {
+        let readout = readout(
+            &anchors((0.0, 100.0, 0), (17.0, 101.83, 261_000)),
+            BOTH_AXES,
+        )
+        .expect("two anchors");
+        assert_eq!(readout.lines[0], "+1.83 pts   +1.83%");
+        assert_eq!(readout.lines[1], "17 bars   4m 21s");
+        assert_eq!(readout.rising, Some(true));
+    }
+
+    #[test]
+    fn a_fall_is_signed_and_reads_as_a_fall() {
+        let readout = readout(&anchors((0.0, 200.0, 0), (4.0, 180.0, 60_000)), BOTH_AXES)
+            .expect("two anchors");
+        assert_eq!(readout.lines[0], "-20.00 pts   -10.00%");
+        assert_eq!(readout.rising, Some(false));
+    }
+
+    /// Percent is of the *start*, so a round trip nets to zero rather than to
+    /// the asymmetric figure a percent-of-end would produce.
+    #[test]
+    fn percent_is_measured_against_the_starting_price() {
+        assert_eq!(percent_move(50.0, 75.0), Some(50.0));
+        let back = percent_move(75.0, 50.0).expect("a positive start price");
+        assert!(
+            (back + 100.0 / 3.0).abs() < 1e-9,
+            "down from 75 to 50 is -33.33%, not the -50% a percent-of-end would give: {back}"
+        );
+    }
+
+    /// A non-positive start price has no meaningful percentage; the readout
+    /// drops the figure instead of printing an infinity or a nonsense number.
+    #[test]
+    fn a_non_positive_start_price_reports_no_percent() {
+        assert_eq!(percent_move(0.0, 10.0), None);
+        assert_eq!(percent_move(-5.0, 10.0), None);
+        let readout =
+            readout(&anchors((0.0, 0.0, 0), (2.0, 10.0, 1_000)), BOTH_AXES).expect("two anchors");
+        assert!(!readout.lines[0].contains('%'));
+        assert!(readout.lines[0].contains("pts"));
+    }
+
+    /// An anchor past the newest bar has no time behind it (`ChartPoint`), so
+    /// the readout reports bars and stays quiet about the clock.
+    #[test]
+    fn an_untimed_anchor_reports_bars_without_inventing_a_duration() {
+        let anchors = vec![
+            ChartPoint::at_time(0.0, 100.0, Some(0)),
+            ChartPoint::at(9.0, 110.0),
+        ];
+        let readout = readout(&anchors, BOTH_AXES).expect("two anchors");
+        assert_eq!(readout.lines[1], "9 bars");
+    }
+
+    #[test]
+    fn a_flat_move_claims_no_direction() {
+        let readout =
+            readout(&anchors((0.0, 100.0, 0), (3.0, 100.0, 5_000)), BOTH_AXES).expect("anchors");
+        assert_eq!(readout.rising, None);
+    }
+
+    #[test]
+    fn price_range_and_date_range_suppress_the_other_axis() {
+        let anchors = anchors((0.0, 100.0, 0), (17.0, 110.0, 261_000));
+        let price = readout(&anchors, PRICE_ONLY).expect("anchors");
+        assert_eq!(price.lines.len(), 1);
+        assert!(price.lines[0].contains('%'));
+        let time = readout(&anchors, TIME_ONLY).expect("anchors");
+        assert_eq!(time.lines.len(), 1);
+        assert!(time.lines[0].contains("bars"));
+    }
+
+    #[test]
+    fn elapsed_time_coarsens_to_the_unit_that_carries_information() {
+        assert_eq!(format_elapsed(450), "450ms");
+        assert_eq!(format_elapsed(9_000), "9s");
+        assert_eq!(format_elapsed(261_000), "4m 21s");
+        assert_eq!(format_elapsed(3_900_000), "1h 5m");
+        assert_eq!(format_elapsed(180_000_000), "2d 2h");
+        assert_eq!(format_elapsed(-261_000), "4m 21s", "duration is unsigned");
+    }
+
+    #[test]
+    fn one_bar_is_not_pluralised() {
+        let readout =
+            readout(&anchors((0.0, 100.0, 0), (1.0, 100.5, 1_000)), TIME_ONLY).expect("anchors");
+        assert!(readout.lines[0].starts_with("1 bar "));
+    }
+
+    #[test]
+    fn a_sub_unit_move_keeps_the_digits_that_matter() {
+        let readout =
+            readout(&anchors((0.0, 0.5, 0), (2.0, 0.500_12, 1_000)), PRICE_ONLY).expect("anchors");
+        assert!(
+            readout.lines[0].starts_with("+0.000120"),
+            "a crypto-sized move must not round to +0.00: {}",
+            readout.lines[0]
+        );
+    }
+}

--- a/crates/app/src/drawings/mod.rs
+++ b/crates/app/src/drawings/mod.rs
@@ -211,6 +211,12 @@ trait DrawingToolImpl: Sync {
     fn supports_fill(&self) -> bool {
         false
     }
+    /// Whether the tool paints a stroke the width control affects. Almost
+    /// every tool does; a text note has glyphs and no stroke at all, and a
+    /// width slider on its Style tab would move nothing.
+    fn supports_stroke_width(&self) -> bool {
+        true
+    }
     /// Fresh tool-owned state for a newly placed object.
     fn default_payload(&self) -> Box<dyn DrawingPayload> {
         Box::new(NoPayload)
@@ -272,6 +278,11 @@ impl DrawingTool {
     #[must_use]
     pub fn supports_fill(self) -> bool {
         self.0.supports_fill()
+    }
+
+    #[must_use]
+    pub fn supports_stroke_width(self) -> bool {
+        self.0.supports_stroke_width()
     }
 
     #[must_use]

--- a/crates/app/src/drawings/mod.rs
+++ b/crates/app/src/drawings/mod.rs
@@ -116,6 +116,12 @@ pub trait PresetHost {
     fn delete_custom_preset(&mut self, tool_id: &str, name: &str);
     fn default_preset(&self, tool_id: &str) -> Option<String>;
     fn set_default_preset(&mut self, tool_id: &str, name: Option<String>);
+    /// The colour / width / fill new objects of this tool open with, when the
+    /// trader has saved one. Separate from the named presets above because it
+    /// answers a different question: not "apply this look now" but "stop
+    /// asking me for this look every single time".
+    fn default_style(&self, tool_id: &str) -> Option<DrawingStyle>;
+    fn set_default_style(&mut self, tool_id: &str, style: Option<DrawingStyle>);
 }
 
 /// A host with no storage: custom presets are absent, saving reports success
@@ -146,6 +152,10 @@ impl PresetHost for NullPresetHost {
         None
     }
     fn set_default_preset(&mut self, _tool_id: &str, _name: Option<String>) {}
+    fn default_style(&self, _tool_id: &str) -> Option<DrawingStyle> {
+        None
+    }
+    fn set_default_style(&mut self, _tool_id: &str, _style: Option<DrawingStyle>) {}
 }
 
 /// Everything a tool may need beyond raw screen anchors when painting or
@@ -570,6 +580,15 @@ impl PartialEq for Drawing {
     }
 }
 
+/// The look a freshly placed object opens with: the trader's saved default
+/// for the tool when there is one, the built-in start otherwise. Both halves
+/// travel together because a saved look is one thing to a trader, not a style
+/// and a payload.
+pub struct NewDrawing {
+    pub style: DrawingStyle,
+    pub payload: Box<dyn DrawingPayload>,
+}
+
 /// What a delete request did. Locked objects demand an explicit `force`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DeleteOutcome {
@@ -725,31 +744,36 @@ impl Drawings {
         true
     }
 
-    /// [`Self::place_with`] with the tool's stock payload — the test-side
+    /// [`Self::place_with`] with the tool's stock look — the test-side
     /// shorthand; the app always goes through `place_with` to honour the
-    /// user's default preset.
+    /// trader's saved defaults.
     #[cfg(test)]
     pub fn place(&mut self, tool: DrawingTool, point: ChartPoint) -> bool {
-        self.place_with(tool, point, DrawingTool::default_payload)
+        self.place_with(tool, point, |tool| NewDrawing {
+            style: DrawingStyle::default(),
+            payload: tool.default_payload(),
+        })
     }
 
-    /// [`Self::place`] with a caller-chosen payload for a new draft — how the
-    /// app applies the user's default preset to newly created objects only.
+    /// [`Self::place`] with a caller-chosen look for a new draft — how the
+    /// app applies the trader's saved defaults to newly created objects only.
+    /// Objects that already exist are never touched by a default changing.
     pub fn place_with(
         &mut self,
         tool: DrawingTool,
         point: ChartPoint,
-        new_payload: impl FnOnce(DrawingTool) -> Box<dyn DrawingPayload>,
+        new_drawing: impl FnOnce(DrawingTool) -> NewDrawing,
     ) -> bool {
         if self.draft.as_ref().is_none_or(|draft| draft.tool != tool) {
+            let fresh = new_drawing(tool);
             self.draft = Some(Drawing {
                 tool,
                 points: Vec::with_capacity(tool.required_points()),
-                style: DrawingStyle::default(),
+                style: fresh.style,
                 locked: false,
                 hidden: false,
                 scope: DrawingScope::default(),
-                payload: new_payload(tool),
+                payload: fresh.payload,
             });
         }
         let draft = self.draft.as_mut().expect("draft was installed above");

--- a/crates/app/src/drawings/mod.rs
+++ b/crates/app/src/drawings/mod.rs
@@ -10,6 +10,12 @@ pub mod action_bar;
 pub mod fib;
 pub mod presets;
 
+// Geometry shared by a family of tools. Not tools themselves, so they are not
+// in the registry — a family core exists so its members stay declarations.
+mod line_core;
+mod measure_core;
+mod shape_core;
+
 use std::any::Any;
 use std::fmt;
 
@@ -19,8 +25,12 @@ use crate::chart::PriceScale;
 use crate::theme;
 
 pub const DEFAULT_DRAWING_COLOR: egui::Color32 = egui::Color32::from_rgb(138, 180, 248);
-pub const DEFAULT_DRAWING_WIDTH_PX: f32 = 1.5;
-pub const DEFAULT_DRAWING_FILL_ALPHA: u8 = 24;
+/// A drawing is an annotation *on* the chart, never a second series: the
+/// stock stroke is a hairline, thinner than the candle bodies it sits over
+/// (`docs/ux/drawing-tools-2026-08.md` §D2). The width slider keeps its full
+/// range — this is the default, not the ceiling.
+pub const DEFAULT_DRAWING_WIDTH_PX: f32 = 1.0;
+pub const DEFAULT_DRAWING_FILL_ALPHA: u8 = 14;
 pub const MIN_DRAWING_WIDTH_PX: f32 = 0.5;
 pub const MAX_DRAWING_WIDTH_PX: f32 = 6.0;
 pub const MAX_DRAWING_FILL_ALPHA: u8 = 160;
@@ -28,15 +38,19 @@ pub const MAX_DRAWING_FILL_ALPHA: u8 = 160;
 /// slider gesture is one command), so this bounds memory without cutting a
 /// working session short.
 const UNDO_HISTORY_LIMIT: usize = 64;
-const SELECTED_ANCHOR_RADIUS_PX: f32 = 4.0;
-const SELECTED_ANCHOR_FILL: egui::Color32 = egui::Color32::WHITE;
-const SELECTED_ANCHOR_RING_WIDTH_PX: f32 = 1.5;
+const SELECTED_ANCHOR_RADIUS_PX: f32 = 3.5;
+/// Handles read as hollow rings, not solid discs: the core is the chart's own
+/// backdrop, so the handle marks the anchor without adding a bright blob over
+/// the candles (`docs/ux/drawing-tools-2026-08.md` §D2).
+const SELECTED_ANCHOR_FILL: egui::Color32 = theme::CANVAS;
+const SELECTED_ANCHOR_RING_WIDTH_PX: f32 = 1.25;
 /// Selection never repaints the object white: it keeps the configured colour
-/// and paints this soft halo underneath instead, plus white anchor handles.
-/// Premultiplied ~16% white, matching the UX spec's `.halo` treatment.
-const SELECTION_HALO_COLOR: egui::Color32 = egui::Color32::from_rgba_premultiplied(40, 40, 40, 40);
+/// and paints this soft halo underneath instead, plus ring anchor handles.
+/// Premultiplied ~11% white — enough to find the object under the pointer,
+/// not enough to double its visual weight.
+const SELECTION_HALO_COLOR: egui::Color32 = egui::Color32::from_rgba_premultiplied(28, 28, 28, 28);
 /// How much wider than the object's own stroke the halo pass paints.
-const SELECTION_HALO_EXTRA_WIDTH_PX: f32 = 3.5;
+const SELECTION_HALO_EXTRA_WIDTH_PX: f32 = 2.5;
 pub(super) const FIB_LABEL_OFFSET_PX: f32 = 3.0;
 pub(super) const FIB_LABEL_SIZE_PX: f32 = 10.0;
 
@@ -389,19 +403,80 @@ macro_rules! register_drawing_tools {
     };
 }
 
-// The extension port: a new tool is one implementation file plus one name here.
+// The extension port: a new tool is one implementation file plus one name
+// here. Order is rail order, and consecutive entries declaring the same
+// family fold into one rail slot — so the grouping below is the grouping the
+// trader sees, and adding a tool cannot silently reorder the rail.
 register_drawing_tools!(
+    // Lines
+    trend_line,
+    ray,
+    extended_line,
     horizontal_line,
-    rectangle,
+    horizontal_ray,
+    vertical_line,
+    arrow,
+    // Channels
     parallel_channel,
+    // Shapes
+    rectangle,
+    ellipse,
+    triangle,
+    // Fib
     fib_retracement,
     fib_extension,
+    // Measure
+    measure,
+    price_range,
+    date_range,
+    // Annotation
+    text,
 );
 
+/// One anchor of a drawing.
+///
+/// `bar` is the pane's own fractional slot — the coordinate the chart draws
+/// from, and the one pan, zoom and history prepends keep meaningful.
+/// `time_ms` is the same instant said in market time, captured when the
+/// anchor was placed. Two panes of one symbol disagree completely about bar
+/// indices and agree exactly about market time, which is what lets a drawing
+/// cross from the timeframe chart to the tick chart
+/// (`docs/ux/drawing-tools-2026-08.md` §D7).
+///
+/// It is an `Option` because a pane cannot always name the time: an anchor
+/// dropped past the newest bar, or on a pane with no bars yet, has no instant
+/// behind it. A drawing whose anchors have no time simply cannot be shared —
+/// it is never guessed.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ChartPoint {
     pub bar: f32,
     pub price: f64,
+    pub time_ms: Option<i64>,
+}
+
+impl ChartPoint {
+    /// An anchor with no market time behind it. Test-only on purpose: every
+    /// production anchor comes from a pane, and a pane always knows whether
+    /// the slot under the pointer has an instant behind it. A production
+    /// caller reaching for this would be dropping that answer on the floor.
+    #[cfg(test)]
+    #[must_use]
+    pub const fn at(bar: f32, price: f64) -> Self {
+        Self {
+            bar,
+            price,
+            time_ms: None,
+        }
+    }
+
+    #[must_use]
+    pub const fn at_time(bar: f32, price: f64, time_ms: Option<i64>) -> Self {
+        Self {
+            bar,
+            price,
+            time_ms,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -421,6 +496,23 @@ impl Default for DrawingStyle {
     }
 }
 
+/// Which charts a drawing appears on
+/// (`docs/ux/drawing-tools-2026-08.md` §D7).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum DrawingScope {
+    /// The pane it was drawn on, and only that one. Today's behaviour, and
+    /// the default, so nothing that exists changes.
+    #[default]
+    ThisChart,
+    /// Every pane of the same tab — one symbol, one feed, two bar types. The
+    /// anchors are re-expressed through each pane's own market clock.
+    ///
+    /// Never across tabs: a price level drawn on BTC means nothing on a WIN
+    /// chart, and a mark that says otherwise is the data-honesty failure this
+    /// repo refuses.
+    AllCharts,
+}
+
 #[derive(Debug, Clone)]
 pub struct Drawing {
     pub tool: DrawingTool,
@@ -431,9 +523,28 @@ pub struct Drawing {
     pub locked: bool,
     /// A hidden drawing neither paints nor hit-tests, and stays recoverable.
     pub hidden: bool,
+    /// Whether the other panes of this tab show it too.
+    pub scope: DrawingScope,
     /// Tool-owned state (Fib levels, a future tool's own properties). The
     /// registry creates it; the shared envelope never learns its fields.
     pub payload: Box<dyn DrawingPayload>,
+}
+
+impl Drawing {
+    /// Whether this object *can* be shared: every anchor has to name a market
+    /// instant, because that is the only coordinate two panes agree on. An
+    /// anchor dropped past the newest bar has none, and no time is invented
+    /// to make the checkbox available.
+    #[must_use]
+    pub fn shareable(&self) -> bool {
+        !self.points.is_empty() && self.points.iter().all(|point| point.time_ms.is_some())
+    }
+
+    /// Whether the other panes of this tab paint it this frame.
+    #[must_use]
+    pub fn shared(&self) -> bool {
+        self.scope == DrawingScope::AllCharts && !self.hidden && self.shareable()
+    }
 }
 
 impl PartialEq for Drawing {
@@ -443,6 +554,7 @@ impl PartialEq for Drawing {
             && self.style == other.style
             && self.locked == other.locked
             && self.hidden == other.hidden
+            && self.scope == other.scope
             && self.payload.eq_dyn(other.payload.as_ref())
     }
 }
@@ -618,6 +730,7 @@ impl Drawings {
                 style: DrawingStyle::default(),
                 locked: false,
                 hidden: false,
+                scope: DrawingScope::default(),
                 payload: new_payload(tool),
             });
         }
@@ -906,13 +1019,7 @@ mod tests {
     #[test]
     fn horizontal_line_completes_with_one_point() {
         let mut drawings = Drawings::default();
-        assert!(drawings.place(
-            tool("horizontal-line"),
-            ChartPoint {
-                bar: 3.0,
-                price: 100.0
-            }
-        ));
+        assert!(drawings.place(tool("horizontal-line"), ChartPoint::at(3.0, 100.0)));
     }
 
     #[test]
@@ -920,48 +1027,21 @@ mod tests {
         let mut drawings = Drawings::default();
         let channel = tool("parallel-channel");
         for bar in [1.0, 2.0] {
-            assert!(!drawings.place(channel, ChartPoint { bar, price: 1.0 }));
+            assert!(!drawings.place(channel, ChartPoint::at(bar, 1.0)));
         }
-        assert!(drawings.place(
-            channel,
-            ChartPoint {
-                bar: 3.0,
-                price: 1.0
-            }
-        ));
+        assert!(drawings.place(channel, ChartPoint::at(3.0, 1.0)));
     }
 
     #[test]
     fn moving_a_selected_drawing_preserves_its_shape() {
         let mut drawings = Drawings::default();
         let rectangle = tool("rectangle");
-        drawings.place(
-            rectangle,
-            ChartPoint {
-                bar: 1.0,
-                price: 100.0,
-            },
-        );
-        drawings.place(
-            rectangle,
-            ChartPoint {
-                bar: 3.0,
-                price: 110.0,
-            },
-        );
+        drawings.place(rectangle, ChartPoint::at(1.0, 100.0));
+        drawings.place(rectangle, ChartPoint::at(3.0, 110.0));
         drawings.translate_selected(2.0, -5.0);
         assert_eq!(
             drawings.items()[0].points,
-            [
-                ChartPoint {
-                    bar: 3.0,
-                    price: 95.0
-                },
-                ChartPoint {
-                    bar: 5.0,
-                    price: 105.0
-                }
-            ]
+            [ChartPoint::at(3.0, 95.0), ChartPoint::at(5.0, 105.0)]
         );
     }
 
@@ -969,25 +1049,10 @@ mod tests {
     fn moving_one_anchor_does_not_move_the_other_points() {
         let mut drawings = Drawings::default();
         let rectangle = tool("rectangle");
-        drawings.place(
-            rectangle,
-            ChartPoint {
-                bar: 1.0,
-                price: 100.0,
-            },
-        );
-        drawings.place(
-            rectangle,
-            ChartPoint {
-                bar: 3.0,
-                price: 110.0,
-            },
-        );
+        drawings.place(rectangle, ChartPoint::at(1.0, 100.0));
+        drawings.place(rectangle, ChartPoint::at(3.0, 110.0));
         let opposite = drawings.items()[0].points[1];
-        let replacement = ChartPoint {
-            bar: 0.5,
-            price: 95.0,
-        };
+        let replacement = ChartPoint::at(0.5, 95.0);
 
         assert!(drawings.move_anchor(0, 0, replacement));
 
@@ -1001,13 +1066,7 @@ mod tests {
     fn deleting_the_selected_drawing_clears_both_object_and_selection() {
         let mut drawings = Drawings::default();
         let line = tool("horizontal-line");
-        assert!(drawings.place(
-            line,
-            ChartPoint {
-                bar: 1.0,
-                price: 100.0,
-            }
-        ));
+        assert!(drawings.place(line, ChartPoint::at(1.0, 100.0)));
         assert_eq!(drawings.selected(), Some(0));
 
         assert_eq!(drawings.delete_selected(false), DeleteOutcome::Deleted);
@@ -1019,54 +1078,26 @@ mod tests {
     #[test]
     fn a_locked_drawing_ignores_geometry_edits_until_unlocked() {
         let mut drawings = Drawings::default();
-        drawings.place(
-            tool("horizontal-line"),
-            ChartPoint {
-                bar: 2.0,
-                price: 100.0,
-            },
-        );
+        drawings.place(tool("horizontal-line"), ChartPoint::at(2.0, 100.0));
         drawings.set_selected_locked(true);
 
         drawings.translate_selected(3.0, 5.0);
-        assert!(!drawings.move_anchor(
-            0,
-            0,
-            ChartPoint {
-                bar: 9.0,
-                price: 50.0,
-            }
-        ));
+        assert!(!drawings.move_anchor(0, 0, ChartPoint::at(9.0, 50.0)));
         assert_eq!(
             drawings.items()[0].points[0],
-            ChartPoint {
-                bar: 2.0,
-                price: 100.0,
-            },
+            ChartPoint::at(2.0, 100.0),
             "locked geometry must not move"
         );
 
         drawings.set_selected_locked(false);
         drawings.translate_selected(3.0, 5.0);
-        assert_eq!(
-            drawings.items()[0].points[0],
-            ChartPoint {
-                bar: 5.0,
-                price: 105.0,
-            }
-        );
+        assert_eq!(drawings.items()[0].points[0], ChartPoint::at(5.0, 105.0));
     }
 
     #[test]
     fn deleting_a_locked_drawing_requires_explicit_force() {
         let mut drawings = Drawings::default();
-        drawings.place(
-            tool("horizontal-line"),
-            ChartPoint {
-                bar: 1.0,
-                price: 100.0,
-            },
-        );
+        drawings.place(tool("horizontal-line"), ChartPoint::at(1.0, 100.0));
         drawings.set_selected_locked(true);
 
         assert_eq!(
@@ -1090,13 +1121,7 @@ mod tests {
     fn placing_a_drawing_releases_hide_all() {
         let mut drawings = Drawings::default();
         drawings.set_all_hidden(true);
-        drawings.place(
-            tool("horizontal-line"),
-            ChartPoint {
-                bar: 1.0,
-                price: 100.0,
-            },
-        );
+        drawings.place(tool("horizontal-line"), ChartPoint::at(1.0, 100.0));
         assert!(!drawings.all_hidden(), "the new mark is visible");
         assert!(drawings.undo(), "placement is one undoable step");
         assert!(drawings.items().is_empty());
@@ -1112,21 +1137,9 @@ mod tests {
     fn delete_all_takes_everything_in_one_undoable_step() {
         let mut drawings = Drawings::default();
         assert_eq!(drawings.delete_all(), 0, "an empty store deletes nothing");
-        drawings.place(
-            tool("horizontal-line"),
-            ChartPoint {
-                bar: 1.0,
-                price: 100.0,
-            },
-        );
+        drawings.place(tool("horizontal-line"), ChartPoint::at(1.0, 100.0));
         drawings.set_selected_locked(true);
-        drawings.place(
-            tool("horizontal-line"),
-            ChartPoint {
-                bar: 2.0,
-                price: 105.0,
-            },
-        );
+        drawings.place(tool("horizontal-line"), ChartPoint::at(2.0, 105.0));
         let undo_before = drawings.undo_depth();
 
         assert_eq!(drawings.delete_all(), 2, "locked and unlocked both go");
@@ -1149,20 +1162,8 @@ mod tests {
         let mut drawings = Drawings::default();
         let rectangle = tool("rectangle");
         // Creation: two anchors, one entry.
-        drawings.place(
-            rectangle,
-            ChartPoint {
-                bar: 1.0,
-                price: 100.0,
-            },
-        );
-        drawings.place(
-            rectangle,
-            ChartPoint {
-                bar: 3.0,
-                price: 110.0,
-            },
-        );
+        drawings.place(rectangle, ChartPoint::at(1.0, 100.0));
+        drawings.place(rectangle, ChartPoint::at(3.0, 110.0));
         assert_eq!(drawings.undo_depth(), 1);
 
         // One drag over many frames: one entry.
@@ -1184,13 +1185,7 @@ mod tests {
         assert!(drawings.undo(), "undo the delete");
         assert_eq!(drawings.items().len(), 1);
         assert!(drawings.undo(), "undo the drag");
-        assert_eq!(
-            drawings.items()[0].points[0],
-            ChartPoint {
-                bar: 1.0,
-                price: 100.0,
-            }
-        );
+        assert_eq!(drawings.items()[0].points[0], ChartPoint::at(1.0, 100.0));
         assert!(drawings.undo(), "undo the creation");
         assert!(drawings.items().is_empty());
         assert!(!drawings.undo(), "history is exhausted");
@@ -1199,26 +1194,14 @@ mod tests {
     #[test]
     fn redo_replays_an_undone_edit_until_a_new_command_clears_it() {
         let mut drawings = Drawings::default();
-        drawings.place(
-            tool("horizontal-line"),
-            ChartPoint {
-                bar: 1.0,
-                price: 100.0,
-            },
-        );
+        drawings.place(tool("horizontal-line"), ChartPoint::at(1.0, 100.0));
         drawings.undo();
         assert!(drawings.items().is_empty());
         assert!(drawings.redo());
         assert_eq!(drawings.items().len(), 1);
 
         drawings.undo();
-        drawings.place(
-            tool("horizontal-line"),
-            ChartPoint {
-                bar: 4.0,
-                price: 90.0,
-            },
-        );
+        drawings.place(tool("horizontal-line"), ChartPoint::at(4.0, 90.0));
         assert!(!drawings.redo(), "a new command clears the redo stack");
     }
 
@@ -1226,7 +1209,7 @@ mod tests {
     fn hide_all_is_a_layer_over_each_drawings_own_eye() {
         let mut drawings = Drawings::default();
         for price in [100.0, 105.0] {
-            drawings.place(tool("horizontal-line"), ChartPoint { bar: 1.0, price });
+            drawings.place(tool("horizontal-line"), ChartPoint::at(1.0, price));
         }
         drawings.select(Some(0));
         drawings.set_selected_hidden(true);
@@ -1252,13 +1235,7 @@ mod tests {
     #[test]
     fn duplicate_lands_offset_unlocked_and_selected_as_one_entry() {
         let mut drawings = Drawings::default();
-        drawings.place(
-            tool("horizontal-line"),
-            ChartPoint {
-                bar: 4.0,
-                price: 100.0,
-            },
-        );
+        drawings.place(tool("horizontal-line"), ChartPoint::at(4.0, 100.0));
         drawings.set_selected_locked(true);
         let depth = drawings.undo_depth();
 
@@ -1281,7 +1258,7 @@ mod tests {
         let mut drawings = Drawings::default();
         let channel = tool("parallel-channel");
         for bar in [1.0, 2.0] {
-            drawings.place(channel, ChartPoint { bar, price: 1.0 });
+            drawings.place(channel, ChartPoint::at(bar, 1.0));
         }
         assert_eq!(drawings.draft_len(), 2);
 
@@ -1336,7 +1313,7 @@ mod tests {
     fn lock_all_is_one_reversible_undo_entry_and_never_deletes() {
         let mut drawings = Drawings::default();
         for price in [100.0, 105.0] {
-            drawings.place(tool("horizontal-line"), ChartPoint { bar: 1.0, price });
+            drawings.place(tool("horizontal-line"), ChartPoint::at(1.0, price));
         }
         let depth_before = drawings.undo_depth();
 
@@ -1353,13 +1330,7 @@ mod tests {
     #[test]
     fn undo_snapshots_shift_with_prepended_history() {
         let mut drawings = Drawings::default();
-        drawings.place(
-            tool("horizontal-line"),
-            ChartPoint {
-                bar: 2.0,
-                price: 100.0,
-            },
-        );
+        drawings.place(tool("horizontal-line"), ChartPoint::at(2.0, 100.0));
         drawings.begin_gesture();
         drawings.translate_selected(1.0, 0.0);
         drawings.commit_gesture();
@@ -1391,10 +1362,7 @@ mod tests {
         };
         let scale = PriceScale::from_range(0.0, 300.0, 0.0, 300.0);
         let payload = line.default_payload();
-        let anchors = [ChartPoint {
-            bar: 0.0,
-            price: scale.price_at(120.0),
-        }];
+        let anchors = [ChartPoint::at(0.0, scale.price_at(120.0))];
         let output = ctx.run(input, |ctx| {
             let painter = ctx.layer_painter(egui::LayerId::new(
                 egui::Order::Foreground,
@@ -1419,14 +1387,14 @@ mod tests {
         });
 
         let mut kept_color = false;
-        let mut white_handle = false;
+        let mut ring_handle = false;
         for clipped in &output.shapes {
             match &clipped.shape {
                 egui::Shape::LineSegment { stroke, .. } => {
                     kept_color |= stroke.color == egui::epaint::ColorMode::Solid(color);
                 }
                 egui::Shape::Circle(circle) => {
-                    white_handle |= circle.fill == SELECTED_ANCHOR_FILL;
+                    ring_handle |= circle.fill == SELECTED_ANCHOR_FILL;
                 }
                 _ => {}
             }
@@ -1435,19 +1403,71 @@ mod tests {
             kept_color,
             "selection must keep painting the configured colour"
         );
-        assert!(white_handle, "selection must add white anchor handles");
+        assert!(ring_handle, "selection must add ring anchor handles");
+    }
+
+    /// Nothing that exists changes: every object still opens on the chart it
+    /// was drawn on, and sharing is something the trader asks for.
+    #[test]
+    fn a_new_drawing_belongs_to_the_chart_it_was_drawn_on() {
+        let mut drawings = Drawings::default();
+        assert!(drawings.place(tool("horizontal-line"), ChartPoint::at(1.0, 100.0)));
+        assert_eq!(drawings.items()[0].scope, DrawingScope::ThisChart);
+        assert!(!drawings.items()[0].shared());
+    }
+
+    /// Market time is the only coordinate two panes agree on, so an anchor
+    /// without one cannot be re-expressed — and none is invented for it.
+    #[test]
+    fn an_anchor_without_a_market_time_cannot_be_shared() {
+        let mut untimed = Drawings::default();
+        assert!(untimed.place(tool("horizontal-line"), ChartPoint::at(1.0, 100.0)));
+        assert!(
+            !untimed.items()[0].shareable(),
+            "an anchor past the newest bar has no instant behind it"
+        );
+
+        let mut timed = Drawings::default();
+        assert!(timed.place(
+            tool("horizontal-line"),
+            ChartPoint::at_time(1.0, 100.0, Some(1_700_000_000_000))
+        ));
+        assert!(timed.items()[0].shareable());
+    }
+
+    /// A shared object that is switched off shows nowhere, including on the
+    /// other pane: one eye, one answer.
+    #[test]
+    fn hiding_a_shared_drawing_hides_it_everywhere() {
+        let mut drawings = Drawings::default();
+        assert!(drawings.place(
+            tool("horizontal-line"),
+            ChartPoint::at_time(1.0, 100.0, Some(1_700_000_000_000))
+        ));
+        drawings.selected_mut().expect("just placed").scope = DrawingScope::AllCharts;
+        assert!(drawings.items()[0].shared());
+        drawings.set_hidden_at(0, true);
+        assert!(!drawings.items()[0].shared());
+    }
+
+    /// A multi-anchor object shares only when *every* anchor can be placed:
+    /// half a channel on the other chart would be a lie about where it is.
+    #[test]
+    fn one_untimed_anchor_blocks_sharing_the_whole_object() {
+        let mut drawings = Drawings::default();
+        let rectangle = tool("rectangle");
+        assert!(!drawings.place(
+            rectangle,
+            ChartPoint::at_time(1.0, 100.0, Some(1_700_000_000_000))
+        ));
+        assert!(drawings.place(rectangle, ChartPoint::at(4.0, 110.0)));
+        assert!(!drawings.items()[0].shareable());
     }
 
     #[test]
     fn clearing_drawings_also_discards_an_unfinished_draft() {
         let mut drawings = Drawings::default();
-        assert!(!drawings.place(
-            tool("rectangle"),
-            ChartPoint {
-                bar: 1.0,
-                price: 100.0,
-            }
-        ));
+        assert!(!drawings.place(tool("rectangle"), ChartPoint::at(1.0, 100.0)));
         drawings.clear();
         assert!(drawings.items().is_empty());
         assert!(drawings.draft().is_none());
@@ -1457,20 +1477,8 @@ mod tests {
     #[test]
     fn prepending_history_shifts_completed_and_draft_bar_anchors() {
         let mut drawings = Drawings::default();
-        drawings.place(
-            tool("horizontal-line"),
-            ChartPoint {
-                bar: 2.5,
-                price: 100.0,
-            },
-        );
-        drawings.place(
-            tool("rectangle"),
-            ChartPoint {
-                bar: 4.0,
-                price: 101.0,
-            },
-        );
+        drawings.place(tool("horizontal-line"), ChartPoint::at(2.5, 100.0));
+        drawings.place(tool("rectangle"), ChartPoint::at(4.0, 101.0));
 
         drawings.shift_bars(3);
 
@@ -1487,10 +1495,7 @@ mod tests {
         points
             .iter()
             .enumerate()
-            .map(|(index, point)| ChartPoint {
-                bar: index as f32,
-                price: scale.price_at(point.y),
-            })
+            .map(|(index, point)| ChartPoint::at(index as f32, scale.price_at(point.y)))
             .collect()
     }
 
@@ -1672,13 +1677,7 @@ mod tests {
         let ray_tool = DrawingTool(&RAY);
 
         let mut drawings = Drawings::default();
-        assert!(drawings.place(
-            ray_tool,
-            ChartPoint {
-                bar: 1.0,
-                price: 100.0,
-            }
-        ));
+        assert!(drawings.place(ray_tool, ChartPoint::at(1.0, 100.0)));
         // The unique property lives in the payload and rides the undo
         // history exactly like the shared fields do.
         drawings.begin_gesture();

--- a/crates/app/src/drawings/mod.rs
+++ b/crates/app/src/drawings/mod.rs
@@ -597,6 +597,13 @@ impl Drawings {
         &self.items
     }
 
+    /// How many objects are painted on the tab's other panes as well — the
+    /// per-frame reprojection cost, in the health summary.
+    #[must_use]
+    pub fn shared_count(&self) -> usize {
+        self.items.iter().filter(|item| item.shared()).count()
+    }
+
     #[must_use]
     pub fn selected(&self) -> Option<usize> {
         self.selected

--- a/crates/app/src/drawings/mod.rs
+++ b/crates/app/src/drawings/mod.rs
@@ -208,6 +208,17 @@ trait DrawingToolImpl: Sync {
     fn icon(&self) -> &'static str;
     fn hover_text(&self) -> &'static str;
     fn required_points(&self) -> usize;
+    /// What the *next* click will do, with `placed` anchors already down.
+    ///
+    /// A multi-anchor tool that stops following the pointer looks broken:
+    /// the trader dragged, let go, and the object sat there waiting for a
+    /// click nobody told them about. The rail's `2/3` badge is true but it
+    /// is on the far side of the screen from where the eye is. A tool that
+    /// can say what it wants next says it here, and the draft prints it by
+    /// the cursor.
+    fn placement_hint(&self, _placed: usize) -> Option<&'static str> {
+        None
+    }
     /// The key that arms this tool from the chart, if it has one.
     fn shortcut(&self) -> Option<ToolShortcut> {
         None
@@ -338,6 +349,11 @@ impl DrawingTool {
     #[must_use]
     pub fn required_points(self) -> usize {
         self.0.required_points()
+    }
+
+    #[must_use]
+    pub fn placement_hint(self, placed: usize) -> Option<&'static str> {
+        self.0.placement_hint(placed)
     }
 
     /// Paint the object. Selection adds a halo *under* the geometry and, when

--- a/crates/app/src/drawings/parallel_channel.rs
+++ b/crates/app/src/drawings/parallel_channel.rs
@@ -127,6 +127,46 @@ fn channel_offset(points: &[egui::Pos2]) -> egui::Vec2 {
     to_width_anchor - baseline * (to_width_anchor.dot(baseline) / baseline_length_sq)
 }
 
+/// Everything a channel is made of.
+///
+/// **Open at both ends, on purpose.** An earlier version closed the corridor
+/// with cross-rail connectors at the anchors, and a closed parallelogram is
+/// the visual signature of a rectangle — the two tools became one mark. No
+/// professional platform caps a channel; where the trader anchored it is told
+/// by the selection handles, which is what handles are for.
+///
+/// One source of truth for the geometry, so paint and hit-test cannot come to
+/// disagree about what the object even is.
+struct Channel {
+    near: (egui::Pos2, egui::Pos2),
+    far: (egui::Pos2, egui::Pos2),
+    /// The line traders actually trade off, when it is on.
+    midline: Option<(egui::Pos2, egui::Pos2)>,
+}
+
+impl Channel {
+    fn new(chart_rect: egui::Rect, points: &[egui::Pos2], payload: ChannelPayload) -> Option<Self> {
+        if points.len() < 3 {
+            return None;
+        }
+        let offset = channel_offset(points);
+        let (start, end) = baseline(chart_rect, points, payload.extend());
+        let half = offset / 2.0;
+        Some(Self {
+            near: (start, end),
+            far: (start + offset, end + offset),
+            midline: payload.midline.then_some((start + half, end + half)),
+        })
+    }
+
+    /// Every stroke the object has, for hit-testing. The corridor's interior
+    /// is not one of them: a channel is grabbed by its lines, exactly like
+    /// the trend line it is built from.
+    fn segments(&self) -> impl Iterator<Item = (egui::Pos2, egui::Pos2)> + '_ {
+        [self.near, self.far].into_iter().chain(self.midline)
+    }
+}
+
 /// The baseline after extension. Rails are parallel, so extending this one
 /// and adding the offset extends all three by construction.
 fn baseline(
@@ -233,31 +273,30 @@ impl DrawingToolImpl for ParallelChannel {
         if points.len() != 3 {
             return;
         }
-        let payload = payload_of(ctxt);
-        let offset = channel_offset(points);
-        let (near_start, near_end) = baseline(chart_rect, points, payload.extend());
-        let (far_start, far_end) = (near_start + offset, near_end + offset);
+        let Some(channel) = Channel::new(chart_rect, points, payload_of(ctxt)) else {
+            return;
+        };
 
         if style.fill_alpha > 0 {
             painter.add(egui::Shape::convex_polygon(
-                vec![near_start, near_end, far_end, far_start],
+                vec![
+                    channel.near.0,
+                    channel.near.1,
+                    channel.far.1,
+                    channel.far.0,
+                ],
                 drawing_fill(style),
                 egui::Stroke::NONE,
             ));
         }
-        painter.line_segment([near_start, near_end], stroke);
-        painter.line_segment([far_start, far_end], stroke);
-        // The end caps stay on the anchors even when the rails run on: they
-        // mark where the trader actually placed the channel.
-        painter.line_segment([points[0], points[0] + offset], stroke);
-        painter.line_segment([points[1], points[1] + offset], stroke);
+        painter.line_segment([channel.near.0, channel.near.1], stroke);
+        painter.line_segment([channel.far.0, channel.far.1], stroke);
 
         // The halo pass is a widened copy of the stroke; a dashed line
         // widened underneath itself reads as a smear, so the midline is
         // geometry-only.
-        if payload.midline && !ctxt.halo {
-            let half = offset / 2.0;
-            dashed_segment(painter, near_start + half, near_end + half, stroke);
+        if let Some((from, to)) = channel.midline.filter(|_| !ctxt.halo) {
+            dashed_segment(painter, from, to, stroke);
         }
     }
     fn hit_test(
@@ -268,26 +307,11 @@ impl DrawingToolImpl for ParallelChannel {
         radius_px: f32,
         ctxt: &DrawContext<'_>,
     ) -> bool {
-        if points.len() != 3 {
-            return false;
-        }
-        let payload = payload_of(ctxt);
-        let offset = channel_offset(points);
-        let (near_start, near_end) = baseline(chart_rect, points, payload.extend());
-        let half = offset / 2.0;
-        let rails = [
-            (near_start, near_end),
-            (near_start + offset, near_end + offset),
-            (points[0], points[0] + offset),
-            (points[1], points[1] + offset),
-        ];
-        let midline = payload
-            .midline
-            .then_some((near_start + half, near_end + half));
-        rails
-            .into_iter()
-            .chain(midline)
-            .any(|(start, end)| distance_to_segment(position, start, end) <= radius_px)
+        Channel::new(chart_rect, points, payload_of(ctxt)).is_some_and(|channel| {
+            channel
+                .segments()
+                .any(|(start, end)| distance_to_segment(position, start, end) <= radius_px)
+        })
     }
 
     #[cfg(test)]
@@ -385,6 +409,62 @@ mod tests {
         assert_eq!(end.x, 800.0);
         assert_eq!(points[0], egui::pos2(100.0, 100.0));
         assert_eq!(points[1], egui::pos2(200.0, 100.0));
+    }
+
+    /// A channel is a corridor, not a box. Closing the ends with cross-rail
+    /// connectors made it read as a rectangle — the two tools became the same
+    /// mark on the chart. Nothing the object is made of may join one rail to
+    /// the other.
+    #[test]
+    fn a_channel_is_never_closed_at_its_ends() {
+        let chart = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(800.0, 600.0));
+        let points = [
+            egui::pos2(100.0, 100.0),
+            egui::pos2(300.0, 160.0),
+            egui::pos2(100.0, 200.0),
+        ];
+        let channel = Channel::new(chart, &points, ChannelPayload::default()).expect("three anchors");
+        let baseline_direction = (points[1] - points[0]).normalized();
+        for (start, end) in channel.segments() {
+            let direction = (end - start).normalized();
+            let along = direction.dot(baseline_direction).abs();
+            assert!(
+                (along - 1.0).abs() < 1e-3,
+                "every segment runs along the channel, never across it: {start:?} -> {end:?}"
+            );
+        }
+    }
+
+    /// Three strokes with the middle line, two without — and never a fourth.
+    #[test]
+    fn a_channel_is_two_rails_plus_the_middle_line() {
+        let chart = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(800.0, 600.0));
+        let points = [
+            egui::pos2(100.0, 100.0),
+            egui::pos2(300.0, 160.0),
+            egui::pos2(100.0, 200.0),
+        ];
+        assert_eq!(
+            Channel::new(chart, &points, ChannelPayload::default())
+                .expect("anchors")
+                .segments()
+                .count(),
+            3
+        );
+        assert_eq!(
+            Channel::new(
+                chart,
+                &points,
+                ChannelPayload {
+                    midline: false,
+                    ..ChannelPayload::default()
+                }
+            )
+            .expect("anchors")
+            .segments()
+            .count(),
+            2
+        );
     }
 
     #[test]

--- a/crates/app/src/drawings/parallel_channel.rs
+++ b/crates/app/src/drawings/parallel_channel.rs
@@ -223,6 +223,13 @@ impl DrawingToolImpl for ParallelChannel {
     fn required_points(&self) -> usize {
         3
     }
+    fn placement_hint(&self, placed: usize) -> Option<&'static str> {
+        match placed {
+            1 => Some("Click the end of the trend line"),
+            2 => Some("Click the channel width"),
+            _ => None,
+        }
+    }
     fn shortcut(&self) -> Option<ToolShortcut> {
         Some(ToolShortcut {
             key: egui::Key::C,

--- a/crates/app/src/drawings/parallel_channel.rs
+++ b/crates/app/src/drawings/parallel_channel.rs
@@ -1,12 +1,122 @@
+//! The rising / falling channel.
+//!
+//! Three anchors: the trend line, then the width. What the previous version
+//! lacked is the line traders actually trade off — the middle
+//! (`docs/ux/drawing-tools-2026-08.md` §D4) — plus the ability to project the
+//! rails past the swing that defined them, which is the whole point of
+//! drawing a channel on a live chart.
+
+use std::any::Any;
+
 use eframe::egui;
 use egui_phosphor::regular as icons;
 
-use super::{DrawContext, DrawingStyle, DrawingToolImpl, ToolShortcut, distance_to_segment, drawing_fill, drawing_stroke};
+use super::line_core::{Extend, line_ends};
+use super::{
+    DrawContext, Drawing, DrawingPayload, DrawingStyle, DrawingToolImpl, PresetHost, ToolShortcut,
+    distance_to_segment, drawing_fill, drawing_stroke,
+};
 
 pub(super) static TOOL: ParallelChannel = ParallelChannel;
 
 pub(super) struct ParallelChannel;
 
+/// Dash geometry of the middle line: present enough to trade off, dashed
+/// enough that it never reads as one of the two rails.
+const MIDLINE_DASH_PX: f32 = 5.0;
+const MIDLINE_GAP_PX: f32 = 4.0;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ChannelPayload {
+    /// The middle line. Default **on**: it is what a channel is drawn for,
+    /// and a channel without one is the odd one out, not the baseline.
+    pub midline: bool,
+    pub extend_left: bool,
+    pub extend_right: bool,
+}
+
+impl Default for ChannelPayload {
+    fn default() -> Self {
+        Self {
+            midline: true,
+            extend_left: false,
+            extend_right: false,
+        }
+    }
+}
+
+impl ChannelPayload {
+    /// The two flags as the one rule the line core already implements.
+    fn extend(self) -> Option<Extend> {
+        match (self.extend_left, self.extend_right) {
+            (false, false) => None,
+            (false, true) => Some(Extend::Forward),
+            (true, false) => Some(Extend::Backward),
+            (true, true) => Some(Extend::Both),
+        }
+    }
+}
+
+impl DrawingPayload for ChannelPayload {
+    fn clone_box(&self) -> Box<dyn DrawingPayload> {
+        Box::new(*self)
+    }
+    fn eq_dyn(&self, other: &dyn DrawingPayload) -> bool {
+        other
+            .as_any()
+            .downcast_ref::<Self>()
+            .is_some_and(|other| other == self)
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+    fn export_preset(&self) -> Option<toml::Value> {
+        let mut table = toml::value::Table::new();
+        table.insert("midline".to_owned(), toml::Value::Boolean(self.midline));
+        table.insert(
+            "extend_left".to_owned(),
+            toml::Value::Boolean(self.extend_left),
+        );
+        table.insert(
+            "extend_right".to_owned(),
+            toml::Value::Boolean(self.extend_right),
+        );
+        Some(toml::Value::Table(table))
+    }
+    /// A preset applies the flags it names and leaves the rest alone, so an
+    /// older preset written before a flag existed does not silently reset it.
+    fn import_preset(&mut self, value: &toml::Value) -> bool {
+        let Some(table) = value.as_table() else {
+            return false;
+        };
+        let flag = |key: &str| table.get(key).and_then(toml::Value::as_bool);
+        let mut applied = false;
+        for (found, target) in [
+            (flag("midline"), &mut self.midline),
+            (flag("extend_left"), &mut self.extend_left),
+            (flag("extend_right"), &mut self.extend_right),
+        ] {
+            if let Some(found) = found {
+                *target = found;
+                applied = true;
+            }
+        }
+        applied
+    }
+}
+
+fn payload_of(ctxt: &DrawContext<'_>) -> ChannelPayload {
+    ctxt.payload
+        .as_any()
+        .downcast_ref::<ChannelPayload>()
+        .copied()
+        .unwrap_or_default()
+}
+
+/// The perpendicular offset from the baseline to the opposite rail.
 fn channel_offset(points: &[egui::Pos2]) -> egui::Vec2 {
     let baseline = points[1] - points[0];
     let to_width_anchor = points[2] - points[0];
@@ -15,6 +125,43 @@ fn channel_offset(points: &[egui::Pos2]) -> egui::Vec2 {
         return to_width_anchor;
     }
     to_width_anchor - baseline * (to_width_anchor.dot(baseline) / baseline_length_sq)
+}
+
+/// The baseline after extension. Rails are parallel, so extending this one
+/// and adding the offset extends all three by construction.
+fn baseline(
+    chart_rect: egui::Rect,
+    points: &[egui::Pos2],
+    extend: Option<Extend>,
+) -> (egui::Pos2, egui::Pos2) {
+    match extend {
+        None => (points[0], points[1]),
+        Some(extend) => {
+            line_ends(chart_rect, points, extend).unwrap_or((points[0], points[1]))
+        }
+    }
+}
+
+/// Paint a dashed segment. egui's dashed helper allocates a `Vec` of shapes
+/// per call; a channel repaints every frame, so the midline walks the segment
+/// itself and emits plain line segments.
+fn dashed_segment(painter: &egui::Painter, from: egui::Pos2, to: egui::Pos2, stroke: egui::Stroke) {
+    let span = to - from;
+    let length = span.length();
+    if length <= f32::EPSILON {
+        return;
+    }
+    let step = MIDLINE_DASH_PX + MIDLINE_GAP_PX;
+    let direction = span / length;
+    let mut travelled = 0.0_f32;
+    while travelled < length {
+        let dash_end = (travelled + MIDLINE_DASH_PX).min(length);
+        painter.line_segment(
+            [from + direction * travelled, from + direction * dash_end],
+            stroke,
+        );
+        travelled += step;
+    }
 }
 
 impl DrawingToolImpl for ParallelChannel {
@@ -31,7 +178,7 @@ impl DrawingToolImpl for ParallelChannel {
         icons::PARALLELOGRAM
     }
     fn hover_text(&self) -> &'static str {
-        "Parallel channel - set the baseline, then click the channel width (C)"
+        "Rising / falling channel - draw the trend line, then click the channel width (C)"
     }
     fn required_points(&self) -> usize {
         3
@@ -45,52 +192,102 @@ impl DrawingToolImpl for ParallelChannel {
     fn supports_fill(&self) -> bool {
         true
     }
+    fn default_payload(&self) -> Box<dyn DrawingPayload> {
+        Box::new(ChannelPayload::default())
+    }
+    fn extra_tab(&self) -> Option<&'static str> {
+        Some("Channel")
+    }
+    fn draw_extra_tab(
+        &self,
+        ui: &mut egui::Ui,
+        drawing: &mut Drawing,
+        _host: &mut dyn PresetHost,
+    ) -> bool {
+        let Some(payload) = drawing.payload.as_any_mut().downcast_mut::<ChannelPayload>() else {
+            return false;
+        };
+        let mut changed = ui.checkbox(&mut payload.midline, "Middle line").changed();
+        ui.add_space(4.0);
+        changed |= ui
+            .checkbox(&mut payload.extend_left, "Extend left")
+            .changed();
+        changed |= ui
+            .checkbox(&mut payload.extend_right, "Extend right")
+            .changed();
+        changed
+    }
     fn paint(
         &self,
         painter: &egui::Painter,
-        _chart_rect: egui::Rect,
+        chart_rect: egui::Rect,
         style: DrawingStyle,
         points: &[egui::Pos2],
-        _ctxt: &DrawContext<'_>,
+        ctxt: &DrawContext<'_>,
     ) {
         let stroke = drawing_stroke(style);
-        if points.len() >= 2 {
+        if points.len() == 2 {
             painter.line_segment([points[0], points[1]], stroke);
+            return;
         }
-        if points.len() == 3 {
-            let offset = channel_offset(points);
-            if style.fill_alpha > 0 {
-                painter.add(egui::Shape::convex_polygon(
-                    vec![points[0], points[1], points[1] + offset, points[0] + offset],
-                    drawing_fill(style),
-                    egui::Stroke::NONE,
-                ));
-            }
-            painter.line_segment([points[0] + offset, points[1] + offset], stroke);
-            painter.line_segment([points[0], points[0] + offset], stroke);
-            painter.line_segment([points[1], points[1] + offset], stroke);
+        if points.len() != 3 {
+            return;
+        }
+        let payload = payload_of(ctxt);
+        let offset = channel_offset(points);
+        let (near_start, near_end) = baseline(chart_rect, points, payload.extend());
+        let (far_start, far_end) = (near_start + offset, near_end + offset);
+
+        if style.fill_alpha > 0 {
+            painter.add(egui::Shape::convex_polygon(
+                vec![near_start, near_end, far_end, far_start],
+                drawing_fill(style),
+                egui::Stroke::NONE,
+            ));
+        }
+        painter.line_segment([near_start, near_end], stroke);
+        painter.line_segment([far_start, far_end], stroke);
+        // The end caps stay on the anchors even when the rails run on: they
+        // mark where the trader actually placed the channel.
+        painter.line_segment([points[0], points[0] + offset], stroke);
+        painter.line_segment([points[1], points[1] + offset], stroke);
+
+        // The halo pass is a widened copy of the stroke; a dashed line
+        // widened underneath itself reads as a smear, so the midline is
+        // geometry-only.
+        if payload.midline && !ctxt.halo {
+            let half = offset / 2.0;
+            dashed_segment(painter, near_start + half, near_end + half, stroke);
         }
     }
     fn hit_test(
         &self,
-        _chart_rect: egui::Rect,
+        chart_rect: egui::Rect,
         points: &[egui::Pos2],
         position: egui::Pos2,
         radius_px: f32,
-        _ctxt: &DrawContext<'_>,
+        ctxt: &DrawContext<'_>,
     ) -> bool {
         if points.len() != 3 {
             return false;
         }
+        let payload = payload_of(ctxt);
         let offset = channel_offset(points);
-        [
-            (points[0], points[1]),
-            (points[0] + offset, points[1] + offset),
+        let (near_start, near_end) = baseline(chart_rect, points, payload.extend());
+        let half = offset / 2.0;
+        let rails = [
+            (near_start, near_end),
+            (near_start + offset, near_end + offset),
             (points[0], points[0] + offset),
             (points[1], points[1] + offset),
-        ]
-        .into_iter()
-        .any(|(start, end)| distance_to_segment(position, start, end) <= radius_px)
+        ];
+        let midline = payload
+            .midline
+            .then_some((near_start + half, near_end + half));
+        rails
+            .into_iter()
+            .chain(midline)
+            .any(|(start, end)| distance_to_segment(position, start, end) <= radius_px)
     }
 
     #[cfg(test)]
@@ -103,5 +300,118 @@ impl DrawingToolImpl for ParallelChannel {
             ],
             egui::pos2(150.0, 170.0),
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The session's request, and the reason it is on by default: the middle
+    /// line is what the channel is drawn for.
+    #[test]
+    fn a_fresh_channel_has_its_middle_line() {
+        let fresh = ChannelPayload::default();
+        assert!(fresh.midline);
+        assert!(!fresh.extend_left);
+        assert!(!fresh.extend_right);
+    }
+
+    #[test]
+    fn the_extension_flags_map_to_one_line_rule() {
+        assert_eq!(ChannelPayload::default().extend(), None);
+        assert_eq!(
+            ChannelPayload {
+                extend_right: true,
+                ..ChannelPayload::default()
+            }
+            .extend(),
+            Some(Extend::Forward)
+        );
+        assert_eq!(
+            ChannelPayload {
+                extend_left: true,
+                ..ChannelPayload::default()
+            }
+            .extend(),
+            Some(Extend::Backward)
+        );
+        assert_eq!(
+            ChannelPayload {
+                extend_left: true,
+                extend_right: true,
+                ..ChannelPayload::default()
+            }
+            .extend(),
+            Some(Extend::Both)
+        );
+    }
+
+    /// The midline is exactly halfway on the rails' normal — the level a
+    /// trader reads as "the middle of the channel", not an eyeballed one.
+    #[test]
+    fn the_middle_line_sits_halfway_between_the_rails() {
+        let points = [
+            egui::pos2(100.0, 100.0),
+            egui::pos2(200.0, 100.0),
+            egui::pos2(100.0, 160.0),
+        ];
+        let offset = channel_offset(&points);
+        assert_eq!(offset, egui::vec2(0.0, 60.0));
+        assert_eq!(points[0] + offset / 2.0, egui::pos2(100.0, 130.0));
+    }
+
+    /// Extending is a view affordance: the caps still mark the anchors, so
+    /// the trader can always see where the channel was actually defined.
+    #[test]
+    fn extending_moves_the_rails_but_not_the_anchors() {
+        let chart = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(800.0, 600.0));
+        let points = [
+            egui::pos2(100.0, 100.0),
+            egui::pos2(200.0, 100.0),
+            egui::pos2(100.0, 160.0),
+        ];
+        let (start, end) = baseline(
+            chart,
+            &points,
+            ChannelPayload {
+                extend_left: true,
+                extend_right: true,
+                ..ChannelPayload::default()
+            }
+            .extend(),
+        );
+        assert_eq!(start.x, 0.0);
+        assert_eq!(end.x, 800.0);
+        assert_eq!(points[0], egui::pos2(100.0, 100.0));
+        assert_eq!(points[1], egui::pos2(200.0, 100.0));
+    }
+
+    #[test]
+    fn a_preset_round_trips_every_flag() {
+        let source = ChannelPayload {
+            midline: false,
+            extend_left: true,
+            extend_right: false,
+        };
+        let exported = source.export_preset().expect("the channel exports one");
+        let mut target = ChannelPayload::default();
+        assert!(target.import_preset(&exported));
+        assert_eq!(target, source);
+    }
+
+    /// A preset written before a flag existed must not reset it: applying an
+    /// old preset changes what it names and nothing else.
+    #[test]
+    fn an_older_preset_leaves_flags_it_never_knew_about_alone() {
+        let mut table = toml::value::Table::new();
+        table.insert("midline".to_owned(), toml::Value::Boolean(false));
+        let mut target = ChannelPayload {
+            extend_right: true,
+            ..ChannelPayload::default()
+        };
+        assert!(target.import_preset(&toml::Value::Table(table)));
+        assert!(!target.midline);
+        assert!(target.extend_right, "the flag it never named survives");
     }
 }

--- a/crates/app/src/drawings/presets.rs
+++ b/crates/app/src/drawings/presets.rs
@@ -10,7 +10,7 @@ use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
-use super::PresetHost;
+use super::{DrawingStyle, PresetHost};
 
 /// Environment override for the preset file location.
 pub const PRESETS_ENV: &str = "QUANTICK_DRAWING_PRESETS";
@@ -19,7 +19,48 @@ pub const PRESETS_FILE: &str = "quantick-drawing-presets.toml";
 /// Version this build writes and the only one it reads.
 const STORE_FORMAT_VERSION: u32 = 1;
 
-/// Per-tool slot: named presets plus the optional default-for-new choice.
+/// The common style, as it goes to disk. Written out field by field rather
+/// than deriving on `egui::Color32` so the file stays something a human can
+/// read and edit — the reason it is tracked at all.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+struct StoredStyle {
+    /// `#rrggbb`, the notation every other config in this repo uses.
+    color: String,
+    width_px: f32,
+    fill_alpha: u8,
+}
+
+impl StoredStyle {
+    fn from_style(style: DrawingStyle) -> Self {
+        let [red, green, blue, _] = style.color.to_array();
+        Self {
+            color: format!("#{red:02x}{green:02x}{blue:02x}"),
+            width_px: style.width_px,
+            fill_alpha: style.fill_alpha,
+        }
+    }
+
+    /// A style the file could not express is no style at all: a hand-edited
+    /// colour that does not parse falls back to the built-in start rather
+    /// than to a silently different one.
+    fn to_style(&self) -> Option<DrawingStyle> {
+        let hex = self.color.strip_prefix('#')?;
+        if hex.len() != 6 {
+            return None;
+        }
+        let channel = |at: usize| u8::from_str_radix(&hex[at..at + 2], 16).ok();
+        Some(DrawingStyle {
+            color: super::egui::Color32::from_rgb(channel(0)?, channel(2)?, channel(4)?),
+            width_px: self
+                .width_px
+                .clamp(super::MIN_DRAWING_WIDTH_PX, super::MAX_DRAWING_WIDTH_PX),
+            fill_alpha: self.fill_alpha.min(super::MAX_DRAWING_FILL_ALPHA),
+        })
+    }
+}
+
+/// Per-tool slot: named presets, the optional default-for-new choice, and the
+/// colour/width/fill new objects of this tool open with.
 /// `BTreeMap` keeps the file diff-stable across saves.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 struct ToolPresets {
@@ -27,6 +68,12 @@ struct ToolPresets {
     presets: BTreeMap<String, toml::Value>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     default: Option<String>,
+    /// Added after the format shipped, so it is optional and absent by
+    /// default: a file written before it existed reads clean, and a build
+    /// without it ignores the key instead of refusing the file. That is why
+    /// the version does not move.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    style: Option<StoredStyle>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -164,6 +211,16 @@ impl PresetHost for PresetStore {
         slot.default = name;
         self.persist();
     }
+
+    fn default_style(&self, tool_id: &str) -> Option<DrawingStyle> {
+        self.tools.get(tool_id)?.style.as_ref()?.to_style()
+    }
+
+    fn set_default_style(&mut self, tool_id: &str, style: Option<DrawingStyle>) {
+        let slot = self.tools.entry(tool_id.to_owned()).or_default();
+        slot.style = style.map(StoredStyle::from_style);
+        self.persist();
+    }
 }
 
 #[cfg(test)]
@@ -240,6 +297,74 @@ mod tests {
         store.delete_custom_preset("fib-extension", "targets+");
         assert_eq!(store.default_preset("fib-extension"), None);
         assert!(store.custom_preset_names("fib-extension").is_empty());
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// The chore this removes: setting the colour on every single object.
+    #[test]
+    fn a_default_style_survives_a_restart() {
+        let path = scratch_path("default-style");
+        let mine = DrawingStyle {
+            color: super::super::egui::Color32::from_rgb(0xFF, 0xA0, 0x10),
+            width_px: 2.5,
+            fill_alpha: 40,
+        };
+        {
+            let mut store = PresetStore::load_from(&path);
+            assert_eq!(store.default_style("trend-line"), None);
+            store.set_default_style("trend-line", Some(mine));
+        }
+        let store = PresetStore::load_from(&path);
+        assert_eq!(store.default_style("trend-line"), Some(mine));
+        assert_eq!(
+            store.default_style("rectangle"),
+            None,
+            "the choice is per tool, not a global repaint"
+        );
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// The file is tracked so a human can read and edit it; a colour that
+    /// does not parse must fall back to the built-in start, never to a
+    /// silently different colour.
+    #[test]
+    fn a_hand_broken_colour_is_no_default_rather_than_a_wrong_one() {
+        let path = scratch_path("broken-colour");
+        std::fs::write(
+            &path,
+            "version = 1
+[tools.\"trend-line\".style]
+color = \"not-a-colour\"
+width_px = 1.0
+fill_alpha = 10
+",
+        )
+        .unwrap();
+        let store = PresetStore::load_from(&path);
+        assert_eq!(store.default_style("trend-line"), None);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// A width or opacity edited past the slider's range is clamped, not
+    /// trusted: the file is editable, and an out-of-range value must not
+    /// produce a drawing the UI cannot represent.
+    #[test]
+    fn hand_edited_values_are_clamped_to_what_the_sliders_allow() {
+        let path = scratch_path("clamp");
+        std::fs::write(
+            &path,
+            "version = 1
+[tools.\"rectangle\".style]
+color = \"#8ab4f8\"
+width_px = 99.0
+fill_alpha = 255
+",
+        )
+        .unwrap();
+        let store = PresetStore::load_from(&path);
+        let style = store.default_style("rectangle").expect("a readable style");
+        assert_eq!(style.width_px, super::super::MAX_DRAWING_WIDTH_PX);
+        assert_eq!(style.fill_alpha, super::super::MAX_DRAWING_FILL_ALPHA);
         let _ = std::fs::remove_file(&path);
     }
 

--- a/crates/app/src/drawings/price_range.rs
+++ b/crates/app/src/drawings/price_range.rs
@@ -1,0 +1,79 @@
+use eframe::egui;
+use egui_phosphor::regular as icons;
+
+use super::measure_core::{MEASURE_FAMILY, PRICE_ONLY, hit_measure, paint_measure};
+use super::{DrawContext, DrawingStyle, DrawingToolImpl, ToolFamily};
+
+pub(super) static TOOL: PriceRange = PriceRange;
+
+pub(super) struct PriceRange;
+
+impl DrawingToolImpl for PriceRange {
+    fn id(&self) -> &'static str {
+        "price-range"
+    }
+    fn name(&self) -> &'static str {
+        "Price range"
+    }
+    fn settings_title(&self) -> &'static str {
+        "Price range settings"
+    }
+    fn icon(&self) -> &'static str {
+        icons::ARROWS_VERTICAL
+    }
+    fn hover_text(&self) -> &'static str {
+        "Price range - two prices, read in points and percent"
+    }
+    fn required_points(&self) -> usize {
+        2
+    }
+    fn family(&self) -> Option<ToolFamily> {
+        Some(MEASURE_FAMILY)
+    }
+    fn supports_fill(&self) -> bool {
+        true
+    }
+    fn paint(
+        &self,
+        painter: &egui::Painter,
+        chart_rect: egui::Rect,
+        style: DrawingStyle,
+        points: &[egui::Pos2],
+        ctxt: &DrawContext<'_>,
+    ) {
+        paint_measure(
+            painter,
+            chart_rect,
+            style,
+            points,
+            ctxt.anchors,
+            PRICE_ONLY,
+            ctxt.halo,
+        );
+    }
+    fn hit_test(
+        &self,
+        chart_rect: egui::Rect,
+        points: &[egui::Pos2],
+        position: egui::Pos2,
+        radius_px: f32,
+        ctxt: &DrawContext<'_>,
+    ) -> bool {
+        hit_measure(
+            chart_rect,
+            ctxt.style,
+            points,
+            position,
+            radius_px,
+            PRICE_ONLY,
+        )
+    }
+
+    #[cfg(test)]
+    fn test_geometry(&self) -> (Vec<egui::Pos2>, egui::Pos2) {
+        (
+            vec![egui::pos2(100.0, 200.0), egui::pos2(300.0, 100.0)],
+            egui::pos2(200.0, 150.0),
+        )
+    }
+}

--- a/crates/app/src/drawings/ray.rs
+++ b/crates/app/src/drawings/ray.rs
@@ -1,36 +1,36 @@
 use eframe::egui;
 use egui_phosphor::regular as icons;
 
-use super::line_core::{Axis, LINES_FAMILY, hit_axis, paint_axis};
+use super::line_core::{Extend, LINES_FAMILY, hit_line, paint_line};
 use super::{DrawContext, DrawingStyle, DrawingToolImpl, ToolFamily, ToolShortcut};
 
-pub(super) static TOOL: HorizontalLine = HorizontalLine;
+pub(super) static TOOL: Ray = Ray;
 
-pub(super) struct HorizontalLine;
+pub(super) struct Ray;
 
-impl DrawingToolImpl for HorizontalLine {
+impl DrawingToolImpl for Ray {
     fn id(&self) -> &'static str {
-        "horizontal-line"
+        "ray"
     }
     fn name(&self) -> &'static str {
-        "Horizontal line"
+        "Ray"
     }
     fn settings_title(&self) -> &'static str {
-        "Horizontal line settings"
+        "Ray settings"
     }
     fn icon(&self) -> &'static str {
-        icons::MINUS
+        icons::ARROW_UP_RIGHT
     }
     fn hover_text(&self) -> &'static str {
-        "Horizontal line - click a price (H)"
+        "Ray - two points, then it runs on into the future (Shift+T)"
     }
     fn required_points(&self) -> usize {
-        1
+        2
     }
     fn shortcut(&self) -> Option<ToolShortcut> {
         Some(ToolShortcut {
-            key: egui::Key::H,
-            shift: false,
+            key: egui::Key::T,
+            shift: true,
         })
     }
     fn family(&self) -> Option<ToolFamily> {
@@ -44,7 +44,7 @@ impl DrawingToolImpl for HorizontalLine {
         points: &[egui::Pos2],
         _ctxt: &DrawContext<'_>,
     ) {
-        paint_axis(painter, chart_rect, style, points, Axis::Horizontal);
+        paint_line(painter, chart_rect, style, points, Extend::Forward, false);
     }
     fn hit_test(
         &self,
@@ -54,11 +54,14 @@ impl DrawingToolImpl for HorizontalLine {
         radius_px: f32,
         _ctxt: &DrawContext<'_>,
     ) -> bool {
-        hit_axis(chart_rect, points, position, radius_px, Axis::Horizontal)
+        hit_line(chart_rect, points, position, radius_px, Extend::Forward)
     }
 
     #[cfg(test)]
     fn test_geometry(&self) -> (Vec<egui::Pos2>, egui::Pos2) {
-        (vec![egui::pos2(100.0, 120.0)], egui::pos2(450.0, 123.0))
+        (
+            vec![egui::pos2(100.0, 100.0), egui::pos2(300.0, 200.0)],
+            egui::pos2(200.0, 150.0),
+        )
     }
 }

--- a/crates/app/src/drawings/rectangle.rs
+++ b/crates/app/src/drawings/rectangle.rs
@@ -1,7 +1,11 @@
 use eframe::egui;
 use egui_phosphor::regular as icons;
 
-use super::{DrawContext, DrawingStyle, DrawingToolImpl, ToolShortcut, drawing_fill, drawing_stroke};
+use super::shape_core::SHAPES_FAMILY;
+use super::{
+    DrawContext, DrawingStyle, DrawingToolImpl, ToolFamily, ToolShortcut, drawing_fill,
+    drawing_stroke,
+};
 
 pub(super) static TOOL: Rectangle = Rectangle;
 
@@ -31,6 +35,9 @@ impl DrawingToolImpl for Rectangle {
             key: egui::Key::R,
             shift: false,
         })
+    }
+    fn family(&self) -> Option<ToolFamily> {
+        Some(SHAPES_FAMILY)
     }
     fn supports_fill(&self) -> bool {
         true

--- a/crates/app/src/drawings/shape_core.rs
+++ b/crates/app/src/drawings/shape_core.rs
@@ -1,0 +1,162 @@
+//! The closed-outline geometry the Shapes family shares.
+//!
+//! Rectangle, ellipse and triangle are the same object to a trader: an
+//! outline with an optional interior, selectable by its border always and by
+//! its middle only while that interior is visible. That last rule is the one
+//! worth sharing — get it wrong in one tool and an invisible fill starts
+//! swallowing clicks the chart should have received.
+
+use eframe::egui;
+use egui_phosphor::regular as icons;
+
+use super::{
+    DrawContext, DrawingStyle, ToolFamily, distance_to_segment, drawing_fill, drawing_stroke,
+};
+
+/// The one rail family every closed shape declares.
+pub(super) const SHAPES_FAMILY: ToolFamily = ToolFamily {
+    id: "shapes",
+    title: "Shapes",
+    icon: icons::SHAPES,
+};
+
+/// Segments in an ellipse outline. Fixed, not derived from the on-screen
+/// size: the paint path must not change shape as the trader zooms, and 48
+/// segments are already sub-pixel on a full-height ellipse.
+const ELLIPSE_SEGMENTS: usize = 48;
+
+/// The ellipse inscribed in the box spanned by two corners, as a closed
+/// polygon in winding order.
+pub(super) fn ellipse_outline(corners: [egui::Pos2; 2]) -> Vec<egui::Pos2> {
+    let rect = egui::Rect::from_two_pos(corners[0], corners[1]);
+    let centre = rect.center();
+    let radius = rect.size() / 2.0;
+    (0..ELLIPSE_SEGMENTS)
+        .map(|step| {
+            let angle = std::f32::consts::TAU * step as f32 / ELLIPSE_SEGMENTS as f32;
+            egui::pos2(
+                centre.x + radius.x * angle.cos(),
+                centre.y + radius.y * angle.sin(),
+            )
+        })
+        .collect()
+}
+
+/// Paint a closed outline with the drawing's fill and stroke. The fill is a
+/// separate pass so the halo (which carries `fill_alpha: 0`) paints only the
+/// outline, exactly like every other tool.
+pub(super) fn paint_outline(painter: &egui::Painter, style: DrawingStyle, outline: &[egui::Pos2]) {
+    if outline.len() < 3 {
+        return;
+    }
+    if style.fill_alpha > 0 {
+        painter.add(egui::Shape::convex_polygon(
+            outline.to_vec(),
+            drawing_fill(style),
+            egui::Stroke::NONE,
+        ));
+    }
+    let stroke = drawing_stroke(style);
+    let mut closed: Vec<egui::Pos2> = outline.to_vec();
+    closed.push(outline[0]);
+    painter.add(egui::Shape::line(closed, stroke));
+}
+
+/// Whether `position` is inside a closed polygon — the even-odd ray cast.
+fn inside(outline: &[egui::Pos2], position: egui::Pos2) -> bool {
+    let mut inside = false;
+    let mut previous = outline[outline.len() - 1];
+    for &current in outline {
+        let crosses = (current.y > position.y) != (previous.y > position.y);
+        if crosses {
+            let span = previous.y - current.y;
+            if span.abs() > f32::EPSILON {
+                let x = current.x + (position.y - current.y) / span * (previous.x - current.x);
+                if position.x < x {
+                    inside = !inside;
+                }
+            }
+        }
+        previous = current;
+    }
+    inside
+}
+
+/// Hit-test a closed outline: the border always, the interior only while the
+/// fill is actually visible. An outline-only shape lets clicks through its
+/// middle reach the chart, which is what makes a big zone usable at all.
+pub(super) fn hit_outline(
+    outline: &[egui::Pos2],
+    position: egui::Pos2,
+    radius_px: f32,
+    ctxt: &DrawContext<'_>,
+) -> bool {
+    if outline.len() < 3 {
+        return false;
+    }
+    let on_border = outline
+        .iter()
+        .zip(outline.iter().cycle().skip(1))
+        .any(|(start, end)| distance_to_segment(position, *start, *end) <= radius_px);
+    on_border || (ctxt.style.fill_alpha > 0 && inside(outline, position))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::chart::PriceScale;
+    use crate::drawings::NoPayload;
+
+    fn with_fill<R>(fill_alpha: u8, body: impl FnOnce(&DrawContext<'_>) -> R) -> R {
+        let payload = NoPayload;
+        let scale = PriceScale::from_range(0.0, 300.0, 0.0, 300.0);
+        let style = DrawingStyle {
+            fill_alpha,
+            ..DrawingStyle::default()
+        };
+        let ctxt = DrawContext {
+            payload: &payload,
+            anchors: &[],
+            scale: &scale,
+            style,
+            selected: false,
+            halo: false,
+        };
+        body(&ctxt)
+    }
+
+    #[test]
+    fn an_ellipse_outline_is_inscribed_in_its_box() {
+        let corners = [egui::pos2(100.0, 100.0), egui::pos2(300.0, 200.0)];
+        let outline = ellipse_outline(corners);
+        let box_rect = egui::Rect::from_two_pos(corners[0], corners[1]).expand(0.01);
+        assert_eq!(outline.len(), ELLIPSE_SEGMENTS);
+        assert!(outline.iter().all(|point| box_rect.contains(*point)));
+        // It touches all four sides: an inscribed ellipse, not a smaller one.
+        let widest = outline
+            .iter()
+            .fold(f32::MIN, |widest, point| widest.max(point.x));
+        assert!((widest - 300.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn an_unfilled_shape_lets_clicks_through_its_middle() {
+        let outline = ellipse_outline([egui::pos2(100.0, 100.0), egui::pos2(300.0, 200.0)]);
+        let middle = egui::pos2(200.0, 150.0);
+        assert!(!with_fill(0, |ctxt| hit_outline(
+            &outline, middle, 4.0, ctxt
+        )));
+        assert!(with_fill(20, |ctxt| hit_outline(
+            &outline, middle, 4.0, ctxt
+        )));
+    }
+
+    #[test]
+    fn the_border_is_always_selectable() {
+        let outline = ellipse_outline([egui::pos2(100.0, 100.0), egui::pos2(300.0, 200.0)]);
+        let on_border = egui::pos2(300.0, 150.0);
+        assert!(with_fill(0, |ctxt| hit_outline(
+            &outline, on_border, 4.0, ctxt
+        )));
+    }
+}

--- a/crates/app/src/drawings/text.rs
+++ b/crates/app/src/drawings/text.rs
@@ -1,0 +1,292 @@
+//! An anchored note.
+//!
+//! The only tool whose content is words, so it is the only one that has to
+//! answer "what does an empty one look like?". It looks like a placeholder in
+//! muted type — never nothing, because an invisible object the trader cannot
+//! find to delete is worse than a visible empty one.
+
+use std::any::Any;
+
+use eframe::egui;
+use egui_phosphor::regular as icons;
+
+use super::{
+    DrawContext, Drawing, DrawingPayload, DrawingStyle, DrawingToolImpl, PresetHost, ToolShortcut,
+};
+use crate::theme;
+
+pub(super) static TOOL: Text = Text;
+
+pub(super) struct Text;
+
+/// Shown when the note has no words yet.
+const PLACEHOLDER: &str = "Note";
+const DEFAULT_TEXT_PX: f32 = 12.0;
+const MIN_TEXT_PX: f32 = 8.0;
+const MAX_TEXT_PX: f32 = 28.0;
+/// How far the note's baseline sits above its anchor, so the anchor marks the
+/// price and the words do not cover it.
+const TEXT_LIFT_PX: f32 = 4.0;
+/// Hit padding around the laid-out words, so a short note is still grabbable.
+const TEXT_HIT_PAD_PX: f32 = 3.0;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct TextPayload {
+    pub text: String,
+    pub size_px: f32,
+}
+
+impl Default for TextPayload {
+    fn default() -> Self {
+        Self {
+            text: String::new(),
+            size_px: DEFAULT_TEXT_PX,
+        }
+    }
+}
+
+impl DrawingPayload for TextPayload {
+    fn clone_box(&self) -> Box<dyn DrawingPayload> {
+        Box::new(self.clone())
+    }
+    fn eq_dyn(&self, other: &dyn DrawingPayload) -> bool {
+        other
+            .as_any()
+            .downcast_ref::<Self>()
+            .is_some_and(|other| other == self)
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+    /// A preset carries the type size, never the words: a saved "big red
+    /// heading" style applied to a new note must not also paste someone
+    /// else's sentence into it.
+    fn export_preset(&self) -> Option<toml::Value> {
+        let mut table = toml::value::Table::new();
+        table.insert(
+            "size_px".to_owned(),
+            toml::Value::Float(f64::from(self.size_px)),
+        );
+        Some(toml::Value::Table(table))
+    }
+    fn import_preset(&mut self, value: &toml::Value) -> bool {
+        let Some(size) = value.get("size_px").and_then(toml::Value::as_float) else {
+            return false;
+        };
+        self.size_px = (size as f32).clamp(MIN_TEXT_PX, MAX_TEXT_PX);
+        true
+    }
+}
+
+fn payload_of(ctxt: &DrawContext<'_>) -> TextPayload {
+    ctxt.payload
+        .as_any()
+        .downcast_ref::<TextPayload>()
+        .cloned()
+        .unwrap_or_default()
+}
+
+/// The words as painted, and the colour they are painted in — an empty note
+/// shows its placeholder muted, so it reads as "nothing typed yet" rather
+/// than as content.
+fn shown(payload: &TextPayload, style: DrawingStyle) -> (String, egui::Color32) {
+    if payload.text.trim().is_empty() {
+        (PLACEHOLDER.to_owned(), theme::TEXT_MUTED)
+    } else {
+        (payload.text.clone(), style.color)
+    }
+}
+
+impl DrawingToolImpl for Text {
+    fn id(&self) -> &'static str {
+        "text"
+    }
+    fn name(&self) -> &'static str {
+        "Text"
+    }
+    fn settings_title(&self) -> &'static str {
+        "Text settings"
+    }
+    fn icon(&self) -> &'static str {
+        icons::TEXT_T
+    }
+    fn hover_text(&self) -> &'static str {
+        "Text - click where the note goes, then type it in the inspector (A)"
+    }
+    fn required_points(&self) -> usize {
+        1
+    }
+    fn shortcut(&self) -> Option<ToolShortcut> {
+        Some(ToolShortcut {
+            key: egui::Key::A,
+            shift: false,
+        })
+    }
+    fn default_payload(&self) -> Box<dyn DrawingPayload> {
+        Box::new(TextPayload::default())
+    }
+    fn extra_tab(&self) -> Option<&'static str> {
+        Some("Text")
+    }
+    fn draw_extra_tab(
+        &self,
+        ui: &mut egui::Ui,
+        drawing: &mut Drawing,
+        _host: &mut dyn PresetHost,
+    ) -> bool {
+        let Some(payload) = drawing
+            .payload
+            .as_any_mut()
+            .downcast_mut::<TextPayload>()
+        else {
+            return false;
+        };
+        let mut changed = ui
+            .add(
+                egui::TextEdit::multiline(&mut payload.text)
+                    .desired_rows(3)
+                    .hint_text(PLACEHOLDER)
+                    .desired_width(f32::INFINITY),
+            )
+            .changed();
+        ui.add_space(4.0);
+        changed |= ui
+            .add(
+                egui::Slider::new(&mut payload.size_px, MIN_TEXT_PX..=MAX_TEXT_PX)
+                    .text("Size")
+                    .suffix(" px"),
+            )
+            .changed();
+        changed
+    }
+    fn paint(
+        &self,
+        painter: &egui::Painter,
+        _chart_rect: egui::Rect,
+        style: DrawingStyle,
+        points: &[egui::Pos2],
+        ctxt: &DrawContext<'_>,
+    ) {
+        // The halo pass widens strokes; type has none, and a second draw of
+        // the same glyphs would only smear them.
+        if ctxt.halo {
+            return;
+        }
+        let Some(anchor) = points.first() else {
+            return;
+        };
+        let payload = payload_of(ctxt);
+        let (text, color) = shown(&payload, style);
+        painter.text(
+            *anchor - egui::vec2(0.0, TEXT_LIFT_PX),
+            egui::Align2::LEFT_BOTTOM,
+            text,
+            egui::FontId::proportional(payload.size_px),
+            color,
+        );
+    }
+    fn hit_test(
+        &self,
+        _chart_rect: egui::Rect,
+        points: &[egui::Pos2],
+        position: egui::Pos2,
+        radius_px: f32,
+        ctxt: &DrawContext<'_>,
+    ) -> bool {
+        let Some(anchor) = points.first() else {
+            return false;
+        };
+        let payload = payload_of(ctxt);
+        let (text, _) = shown(&payload, ctxt.style);
+        // Measured from the type size rather than laid out: hit-testing runs
+        // per frame per object and must not build a galley to answer.
+        let lines = text.lines().count().max(1) as f32;
+        let widest = text.lines().map(str::chars).map(Iterator::count).max().unwrap_or(0) as f32;
+        let size = egui::vec2(
+            widest * payload.size_px * APPROX_GLYPH_ASPECT,
+            lines * payload.size_px * APPROX_LINE_HEIGHT,
+        );
+        let top_left = egui::pos2(anchor.x, anchor.y - TEXT_LIFT_PX - size.y);
+        egui::Rect::from_min_size(top_left, size)
+            .expand(radius_px.max(TEXT_HIT_PAD_PX))
+            .contains(position)
+    }
+
+    #[cfg(test)]
+    fn test_geometry(&self) -> (Vec<egui::Pos2>, egui::Pos2) {
+        (vec![egui::pos2(200.0, 150.0)], egui::pos2(202.0, 148.0))
+    }
+}
+
+/// Width of an average proportional glyph as a fraction of the font size, and
+/// line height as a multiple of it. Approximations on purpose — see the
+/// hit-test comment.
+const APPROX_GLYPH_ASPECT: f32 = 0.55;
+const APPROX_LINE_HEIGHT: f32 = 1.25;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn an_empty_note_still_shows_something_to_click() {
+        let (text, color) = shown(&TextPayload::default(), DrawingStyle::default());
+        assert_eq!(text, PLACEHOLDER);
+        assert_eq!(
+            color,
+            theme::TEXT_MUTED,
+            "a placeholder must not read as typed content"
+        );
+    }
+
+    #[test]
+    fn typed_words_are_painted_in_the_objects_own_colour() {
+        let payload = TextPayload {
+            text: "Daily high".to_owned(),
+            ..TextPayload::default()
+        };
+        let style = DrawingStyle::default();
+        let (text, color) = shown(&payload, style);
+        assert_eq!(text, "Daily high");
+        assert_eq!(color, style.color);
+    }
+
+    /// Whitespace is not content: a note holding only spaces would otherwise
+    /// paint as blank and become unfindable.
+    #[test]
+    fn a_whitespace_only_note_falls_back_to_the_placeholder() {
+        let payload = TextPayload {
+            text: "   \n ".to_owned(),
+            ..TextPayload::default()
+        };
+        assert_eq!(shown(&payload, DrawingStyle::default()).0, PLACEHOLDER);
+    }
+
+    #[test]
+    fn a_preset_carries_the_size_but_never_the_words() {
+        let source = TextPayload {
+            text: "do not travel".to_owned(),
+            size_px: 20.0,
+        };
+        let exported = source.export_preset().expect("text exports a preset");
+        let mut target = TextPayload {
+            text: "mine".to_owned(),
+            size_px: DEFAULT_TEXT_PX,
+        };
+        assert!(target.import_preset(&exported));
+        assert_eq!(target.size_px, 20.0);
+        assert_eq!(target.text, "mine", "the preset must not paste words");
+    }
+
+    #[test]
+    fn an_out_of_range_preset_size_is_clamped_not_trusted() {
+        let mut payload = TextPayload::default();
+        let mut table = toml::value::Table::new();
+        table.insert("size_px".to_owned(), toml::Value::Float(400.0));
+        assert!(payload.import_preset(&toml::Value::Table(table)));
+        assert_eq!(payload.size_px, MAX_TEXT_PX);
+    }
+}

--- a/crates/app/src/drawings/text.rs
+++ b/crates/app/src/drawings/text.rs
@@ -123,6 +123,11 @@ impl DrawingToolImpl for Text {
             shift: false,
         })
     }
+    /// Words have no stroke: the size lives on the Text tab, and the Style
+    /// tab must not offer a width slider that moves nothing.
+    fn supports_stroke_width(&self) -> bool {
+        false
+    }
     fn default_payload(&self) -> Box<dyn DrawingPayload> {
         Box::new(TextPayload::default())
     }

--- a/crates/app/src/drawings/text.rs
+++ b/crates/app/src/drawings/text.rs
@@ -81,22 +81,20 @@ impl DrawingPayload for TextPayload {
     }
 }
 
-fn payload_of(ctxt: &DrawContext<'_>) -> TextPayload {
-    ctxt.payload
-        .as_any()
-        .downcast_ref::<TextPayload>()
-        .cloned()
-        .unwrap_or_default()
+/// Borrowed, never cloned: paint and hit-test both run every frame, and a
+/// note's words can be a paragraph.
+fn payload_of<'a>(ctxt: &'a DrawContext<'_>) -> Option<&'a TextPayload> {
+    ctxt.payload.as_any().downcast_ref::<TextPayload>()
 }
 
 /// The words as painted, and the colour they are painted in — an empty note
 /// shows its placeholder muted, so it reads as "nothing typed yet" rather
 /// than as content.
-fn shown(payload: &TextPayload, style: DrawingStyle) -> (String, egui::Color32) {
+fn shown(payload: &TextPayload, style: DrawingStyle) -> (&str, egui::Color32) {
     if payload.text.trim().is_empty() {
-        (PLACEHOLDER.to_owned(), theme::TEXT_MUTED)
+        (PLACEHOLDER, theme::TEXT_MUTED)
     } else {
-        (payload.text.clone(), style.color)
+        (payload.text.as_str(), style.color)
     }
 }
 
@@ -178,12 +176,14 @@ impl DrawingToolImpl for Text {
         let Some(anchor) = points.first() else {
             return;
         };
-        let payload = payload_of(ctxt);
-        let (text, color) = shown(&payload, style);
+        let Some(payload) = payload_of(ctxt) else {
+            return;
+        };
+        let (text, color) = shown(payload, style);
         painter.text(
             *anchor - egui::vec2(0.0, TEXT_LIFT_PX),
             egui::Align2::LEFT_BOTTOM,
-            text,
+            text.to_owned(),
             egui::FontId::proportional(payload.size_px),
             color,
         );
@@ -199,8 +199,10 @@ impl DrawingToolImpl for Text {
         let Some(anchor) = points.first() else {
             return false;
         };
-        let payload = payload_of(ctxt);
-        let (text, _) = shown(&payload, ctxt.style);
+        let Some(payload) = payload_of(ctxt) else {
+            return false;
+        };
+        let (text, _) = shown(payload, ctxt.style);
         // Measured from the type size rather than laid out: hit-testing runs
         // per frame per object and must not build a galley to answer.
         let lines = text.lines().count().max(1) as f32;
@@ -233,7 +235,8 @@ mod tests {
 
     #[test]
     fn an_empty_note_still_shows_something_to_click() {
-        let (text, color) = shown(&TextPayload::default(), DrawingStyle::default());
+        let empty = TextPayload::default();
+        let (text, color) = shown(&empty, DrawingStyle::default());
         assert_eq!(text, PLACEHOLDER);
         assert_eq!(
             color,

--- a/crates/app/src/drawings/trend_line.rs
+++ b/crates/app/src/drawings/trend_line.rs
@@ -1,35 +1,35 @@
 use eframe::egui;
 use egui_phosphor::regular as icons;
 
-use super::line_core::{Axis, LINES_FAMILY, hit_axis, paint_axis};
+use super::line_core::{Extend, LINES_FAMILY, hit_line, paint_line};
 use super::{DrawContext, DrawingStyle, DrawingToolImpl, ToolFamily, ToolShortcut};
 
-pub(super) static TOOL: HorizontalLine = HorizontalLine;
+pub(super) static TOOL: TrendLine = TrendLine;
 
-pub(super) struct HorizontalLine;
+pub(super) struct TrendLine;
 
-impl DrawingToolImpl for HorizontalLine {
+impl DrawingToolImpl for TrendLine {
     fn id(&self) -> &'static str {
-        "horizontal-line"
+        "trend-line"
     }
     fn name(&self) -> &'static str {
-        "Horizontal line"
+        "Trend line"
     }
     fn settings_title(&self) -> &'static str {
-        "Horizontal line settings"
+        "Trend line settings"
     }
     fn icon(&self) -> &'static str {
-        icons::MINUS
+        icons::TREND_UP
     }
     fn hover_text(&self) -> &'static str {
-        "Horizontal line - click a price (H)"
+        "Trend line - click two swing points (T)"
     }
     fn required_points(&self) -> usize {
-        1
+        2
     }
     fn shortcut(&self) -> Option<ToolShortcut> {
         Some(ToolShortcut {
-            key: egui::Key::H,
+            key: egui::Key::T,
             shift: false,
         })
     }
@@ -44,7 +44,7 @@ impl DrawingToolImpl for HorizontalLine {
         points: &[egui::Pos2],
         _ctxt: &DrawContext<'_>,
     ) {
-        paint_axis(painter, chart_rect, style, points, Axis::Horizontal);
+        paint_line(painter, chart_rect, style, points, Extend::None, false);
     }
     fn hit_test(
         &self,
@@ -54,11 +54,14 @@ impl DrawingToolImpl for HorizontalLine {
         radius_px: f32,
         _ctxt: &DrawContext<'_>,
     ) -> bool {
-        hit_axis(chart_rect, points, position, radius_px, Axis::Horizontal)
+        hit_line(chart_rect, points, position, radius_px, Extend::None)
     }
 
     #[cfg(test)]
     fn test_geometry(&self) -> (Vec<egui::Pos2>, egui::Pos2) {
-        (vec![egui::pos2(100.0, 120.0)], egui::pos2(450.0, 123.0))
+        (
+            vec![egui::pos2(100.0, 100.0), egui::pos2(300.0, 200.0)],
+            egui::pos2(200.0, 150.0),
+        )
     }
 }

--- a/crates/app/src/drawings/triangle.rs
+++ b/crates/app/src/drawings/triangle.rs
@@ -1,0 +1,70 @@
+use eframe::egui;
+use egui_phosphor::regular as icons;
+
+use super::shape_core::{SHAPES_FAMILY, hit_outline, paint_outline};
+use super::{DrawContext, DrawingStyle, DrawingToolImpl, ToolFamily};
+
+pub(super) static TOOL: Triangle = Triangle;
+
+pub(super) struct Triangle;
+
+impl DrawingToolImpl for Triangle {
+    fn id(&self) -> &'static str {
+        "triangle"
+    }
+    fn name(&self) -> &'static str {
+        "Triangle"
+    }
+    fn settings_title(&self) -> &'static str {
+        "Triangle settings"
+    }
+    fn icon(&self) -> &'static str {
+        icons::TRIANGLE
+    }
+    fn hover_text(&self) -> &'static str {
+        "Triangle - three clicks, for wedges and coils"
+    }
+    fn required_points(&self) -> usize {
+        3
+    }
+    fn family(&self) -> Option<ToolFamily> {
+        Some(SHAPES_FAMILY)
+    }
+    fn supports_fill(&self) -> bool {
+        true
+    }
+    fn paint(
+        &self,
+        painter: &egui::Painter,
+        _chart_rect: egui::Rect,
+        style: DrawingStyle,
+        points: &[egui::Pos2],
+        _ctxt: &DrawContext<'_>,
+    ) {
+        if points.len() == 3 {
+            paint_outline(painter, style, points);
+        }
+    }
+    fn hit_test(
+        &self,
+        _chart_rect: egui::Rect,
+        points: &[egui::Pos2],
+        position: egui::Pos2,
+        radius_px: f32,
+        ctxt: &DrawContext<'_>,
+    ) -> bool {
+        points.len() == 3 && hit_outline(points, position, radius_px, ctxt)
+    }
+
+    #[cfg(test)]
+    fn test_geometry(&self) -> (Vec<egui::Pos2>, egui::Pos2) {
+        (
+            vec![
+                egui::pos2(100.0, 200.0),
+                egui::pos2(200.0, 100.0),
+                egui::pos2(300.0, 200.0),
+            ],
+            egui::pos2(200.0, 200.0),
+        )
+    }
+}

--- a/crates/app/src/drawings/triangle.rs
+++ b/crates/app/src/drawings/triangle.rs
@@ -27,6 +27,9 @@ impl DrawingToolImpl for Triangle {
     fn required_points(&self) -> usize {
         3
     }
+    fn placement_hint(&self, placed: usize) -> Option<&'static str> {
+        (placed == 2).then_some("Click the third corner")
+    }
     fn family(&self) -> Option<ToolFamily> {
         Some(SHAPES_FAMILY)
     }

--- a/crates/app/src/drawings/vertical_line.rs
+++ b/crates/app/src/drawings/vertical_line.rs
@@ -4,32 +4,32 @@ use egui_phosphor::regular as icons;
 use super::line_core::{Axis, LINES_FAMILY, hit_axis, paint_axis};
 use super::{DrawContext, DrawingStyle, DrawingToolImpl, ToolFamily, ToolShortcut};
 
-pub(super) static TOOL: HorizontalLine = HorizontalLine;
+pub(super) static TOOL: VerticalLine = VerticalLine;
 
-pub(super) struct HorizontalLine;
+pub(super) struct VerticalLine;
 
-impl DrawingToolImpl for HorizontalLine {
+impl DrawingToolImpl for VerticalLine {
     fn id(&self) -> &'static str {
-        "horizontal-line"
+        "vertical-line"
     }
     fn name(&self) -> &'static str {
-        "Horizontal line"
+        "Vertical line"
     }
     fn settings_title(&self) -> &'static str {
-        "Horizontal line settings"
+        "Vertical line settings"
     }
     fn icon(&self) -> &'static str {
-        icons::MINUS
+        icons::LINE_VERTICAL
     }
     fn hover_text(&self) -> &'static str {
-        "Horizontal line - click a price (H)"
+        "Vertical line - click a bar to mark the moment (V)"
     }
     fn required_points(&self) -> usize {
         1
     }
     fn shortcut(&self) -> Option<ToolShortcut> {
         Some(ToolShortcut {
-            key: egui::Key::H,
+            key: egui::Key::V,
             shift: false,
         })
     }
@@ -44,7 +44,7 @@ impl DrawingToolImpl for HorizontalLine {
         points: &[egui::Pos2],
         _ctxt: &DrawContext<'_>,
     ) {
-        paint_axis(painter, chart_rect, style, points, Axis::Horizontal);
+        paint_axis(painter, chart_rect, style, points, Axis::Vertical);
     }
     fn hit_test(
         &self,
@@ -54,11 +54,11 @@ impl DrawingToolImpl for HorizontalLine {
         radius_px: f32,
         _ctxt: &DrawContext<'_>,
     ) -> bool {
-        hit_axis(chart_rect, points, position, radius_px, Axis::Horizontal)
+        hit_axis(chart_rect, points, position, radius_px, Axis::Vertical)
     }
 
     #[cfg(test)]
     fn test_geometry(&self) -> (Vec<egui::Pos2>, egui::Pos2) {
-        (vec![egui::pos2(100.0, 120.0)], egui::pos2(450.0, 123.0))
+        (vec![egui::pos2(200.0, 150.0)], egui::pos2(202.0, 300.0))
     }
 }

--- a/crates/app/src/pane.rs
+++ b/crates/app/src/pane.rs
@@ -514,6 +514,15 @@ pub struct ChartPane {
     /// narrows by the panel's width and every drawing slides left with it.
     /// Re-hit-testing on the release would be asking a different chart.
     pub drawing_press_pick: Option<Option<usize>>,
+    /// Where a move/resize gesture pressed, while it is still under the drag
+    /// threshold. `None` once the threshold is passed — from then on the
+    /// object follows the pointer for the rest of the gesture.
+    ///
+    /// Without it, one pixel of hand tremor during a *click* re-angles a
+    /// channel or shifts a level the trader placed deliberately, and records
+    /// it as an undo step. Placement already refused to turn a twitch into a
+    /// drag (`DRAWING_DRAG_THRESHOLD_PX`); moving now refuses too.
+    pub drawing_drag_pending_from: Option<egui::Pos2>,
     pub drawing_drag: DrawingDrag,
 }
 
@@ -590,6 +599,7 @@ impl ChartPane {
             drawing_press_position: None,
             drawing_press_started_empty: false,
             drawing_press_pick: None,
+            drawing_drag_pending_from: None,
             drawing_drag: DrawingDrag::None,
         }
     }
@@ -1632,6 +1642,7 @@ impl ChartPane {
                 // actually looking at when they pressed.
                 self.drawing_press_pick =
                     Some(self.drawing_pick_at(position, areas.chart, history_right, total, &scale));
+                self.drawing_drag_pending_from = Some(position);
                 if let Some((drawing_index, point_index)) =
                     self.drawing_anchor_at(position, history_right, total, &scale)
                 {
@@ -1662,7 +1673,34 @@ impl ChartPane {
                 // click above, which already respects floating windows.
                 drawing_drag_started = self.drawing_drag.is_active();
             }
-            if primary_down && !drawing_drag_started {
+            // A held button is not yet a drag. Until the pointer has left the
+            // threshold the object does not move at all, so a click stays a
+            // click — the alternative is that selecting a channel re-angles
+            // it by two pixels of hand tremor, and the trader's level is
+            // quietly no longer where they put it.
+            //
+            // `travel` is measured from the press, not accumulated per frame,
+            // so crossing the threshold hands the gesture the *whole* movement
+            // and the object does not trail the cursor by 4 px forever.
+            let travel = match (self.drawing_drag_pending_from, pointer_position) {
+                (Some(origin), Some(position)) => {
+                    let travel = position - origin;
+                    if travel.length() < DRAWING_DRAG_THRESHOLD_PX {
+                        None
+                    } else {
+                        self.drawing_drag_pending_from = None;
+                        Some(travel)
+                    }
+                }
+                // No pending origin: the threshold was already passed earlier
+                // in this gesture, so this frame's own delta drives it.
+                (None, _) => Some(pointer_delta),
+                (Some(_), None) => None,
+            };
+            if primary_down
+                && !drawing_drag_started
+                && let Some(travel) = travel
+            {
                 match self.drawing_drag {
                     DrawingDrag::Anchor {
                         drawing_index,
@@ -1684,9 +1722,9 @@ impl ChartPane {
                     DrawingDrag::Translate => {
                         if let Some(scale) = drawing_scale {
                             let (lo, hi) = scale.range();
-                            let delta_bar = pointer_delta.x / self.viewport.candle_width();
+                            let delta_bar = travel.x / self.viewport.candle_width();
                             let delta_price =
-                                -f64::from(pointer_delta.y / areas.chart.height()) * (hi - lo);
+                                -f64::from(travel.y / areas.chart.height()) * (hi - lo);
                             self.drawings.translate_selected(delta_bar, delta_price);
                         }
                     }
@@ -1706,10 +1744,12 @@ impl ChartPane {
                 // click, which may be somewhere else entirely. The click path
                 // above already ran this frame and took it if it was a click.
                 self.drawing_press_pick = None;
+                self.drawing_drag_pending_from = None;
             }
         } else {
             self.drawing_drag = DrawingDrag::None;
             self.drawing_press_pick = None;
+            self.drawing_drag_pending_from = None;
         }
         // Where the press landed, not where the pointer is now: a pan that
         // started on the candles keeps working when it crosses the divider.

--- a/crates/app/src/pane.rs
+++ b/crates/app/src/pane.rs
@@ -1276,13 +1276,16 @@ impl ChartPane {
         // one is set; existing objects are never touched by that choice.
         let presets = chrome.presets;
         let completed = self.drawings.place_with(tool, point, |tool| {
+            let style = presets
+                .default_style(tool.id())
+                .unwrap_or_else(drawings::DrawingStyle::default);
             let mut payload = tool.default_payload();
             if let Some(name) = presets.default_preset(tool.id())
                 && let Some(value) = presets.load_custom_preset(tool.id(), &name)
             {
                 payload.import_preset(&value);
             }
-            payload
+            drawings::NewDrawing { style, payload }
         });
         if completed {
             // One-shot by default; the toolbox repeat pin keeps the tool

--- a/crates/app/src/pane.rs
+++ b/crates/app/src/pane.rs
@@ -504,6 +504,16 @@ pub struct ChartPane {
     pub drawing_hover: Option<ChartPoint>,
     pub drawing_press_position: Option<egui::Pos2>,
     pub drawing_press_started_empty: bool,
+    /// What the press resolved under the Pointer tool, held until the click
+    /// it belongs to completes. `Some(None)` is a real answer — a press on
+    /// empty canvas, the one that deselects.
+    ///
+    /// It exists because the canvas is not the same shape before and after a
+    /// selection: the pinned inspector is a side panel laid out *before* the
+    /// central panel, so the frame a selection appears is the frame the chart
+    /// narrows by the panel's width and every drawing slides left with it.
+    /// Re-hit-testing on the release would be asking a different chart.
+    pub drawing_press_pick: Option<Option<usize>>,
     pub drawing_drag: DrawingDrag,
 }
 
@@ -579,6 +589,7 @@ impl ChartPane {
             drawing_hover: None,
             drawing_press_position: None,
             drawing_press_started_empty: false,
+            drawing_press_pick: None,
             drawing_drag: DrawingDrag::None,
         }
     }
@@ -1381,6 +1392,23 @@ impl ChartPane {
             .map(|(point_index, _)| point_index)
     }
 
+    /// What a pointer at `pos` is on: a drawing's handle first, then its
+    /// body. One function, so the press and the click that follows it can
+    /// never answer differently — grabbing a handle *is* clicking the object,
+    /// and the handle radius is the wider of the two.
+    fn drawing_pick_at(
+        &self,
+        pos: egui::Pos2,
+        chart_rect: egui::Rect,
+        history_right: f32,
+        total: usize,
+        scale: &PriceScale,
+    ) -> Option<usize> {
+        self.drawing_anchor_at(pos, history_right, total, scale)
+            .map(|(drawing_index, _)| drawing_index)
+            .or_else(|| self.drawing_at(pos, chart_rect, history_right, total, scale))
+    }
+
     fn drawing_anchor_at(
         &self,
         pos: egui::Pos2,
@@ -1561,14 +1589,17 @@ impl ChartPane {
                 // Alt+click walks down the z-order through overlapping
                 // objects; a plain click selects the topmost hit.
                 //
-                // Anchors first, exactly as the press below does. The two
-                // paths *must* ask the same question: the press selects on an
-                // anchor grab within `DRAWING_ANCHOR_RADIUS_PX`, and if the
-                // release only body-tested at the tighter
-                // `DRAWING_SELECT_RADIUS_PX` it would find nothing there and
-                // wipe the selection the press had just made — the object's
-                // panel flickering open and shut under a stationary cursor.
-                // Grabbing a handle *is* clicking the object.
+                // A click selects what the *press* grabbed. The release must
+                // not re-decide, because opening the panel moves the chart
+                // under the pointer (see `drawing_press_pick`) and the object
+                // the user pressed on is no longer at that pixel — the
+                // release would wipe the selection the press just made, and
+                // the panel would flicker open and shut with the mouse
+                // standing still.
+                //
+                // Alt+click keeps re-deciding on purpose: it walks down the
+                // z-order from the current selection, so it only ever runs
+                // while a selection already exists and the layout is settled.
                 let selected = if ui.input(|input| input.modifiers.alt) {
                     self.drawing_below_selection(
                         position,
@@ -1578,11 +1609,11 @@ impl ChartPane {
                         &scale,
                     )
                 } else {
-                    self.drawing_anchor_at(position, history_right, total, &scale)
-                        .map(|(drawing_index, _)| drawing_index)
-                        .or_else(|| {
-                            self.drawing_at(position, areas.chart, history_right, total, &scale)
-                        })
+                    self.drawing_press_pick.take().unwrap_or_else(|| {
+                        // No press was recorded (it landed on chrome, or off
+                        // the drawing area): fall back to asking now.
+                        self.drawing_pick_at(position, areas.chart, history_right, total, &scale)
+                    })
                 };
                 self.drawings.select(selected);
             }
@@ -1597,6 +1628,10 @@ impl ChartPane {
                     pointer_position.filter(|position| drawing_area.contains(*position))
                 && let Some(scale) = drawing_scale
             {
+                // One question, asked once, on the geometry the user was
+                // actually looking at when they pressed.
+                self.drawing_press_pick =
+                    Some(self.drawing_pick_at(position, areas.chart, history_right, total, &scale));
                 if let Some((drawing_index, point_index)) =
                     self.drawing_anchor_at(position, history_right, total, &scale)
                 {
@@ -1666,9 +1701,15 @@ impl ChartPane {
                 // One gesture, one undo entry — recorded only if it moved.
                 self.drawings.commit_gesture();
                 self.drawing_drag = DrawingDrag::None;
+                // A press that ended in a drag rather than a click leaves its
+                // answer unconsumed; it must not survive to decide the *next*
+                // click, which may be somewhere else entirely. The click path
+                // above already ran this frame and took it if it was a click.
+                self.drawing_press_pick = None;
             }
         } else {
             self.drawing_drag = DrawingDrag::None;
+            self.drawing_press_pick = None;
         }
         // Where the press landed, not where the pointer is now: a pan that
         // started on the candles keeps working when it crosses the divider.

--- a/crates/app/src/pane.rs
+++ b/crates/app/src/pane.rs
@@ -1183,10 +1183,30 @@ impl ChartPane {
             return None;
         }
         let slot = bar.floor() as usize;
-        if slot >= self.slots() {
+        let slots = self.slots();
+        if slot < slots {
+            return self.slot_open_time(slot);
+        }
+        // Past the newest bar. Traders draw here constantly — a channel or a
+        // trend line pointing into the empty space to the right of the tape
+        // is the normal way to say "if this continues". Refusing the whole
+        // gesture a time would block sharing exactly where it is most used.
+        //
+        // On a *time* chart that space has an exact clock: the bars are one
+        // fixed interval apart, so the slot after the last one is the last
+        // one plus that interval. Nothing is inferred.
+        //
+        // On a tick or volume chart it does not: the next bar happens when
+        // enough trades happen, and no elapsed time can be named for it. That
+        // stays `None` — an invented timestamp is worse than a control that
+        // says why it is off.
+        if self.kind != BarKind::Time || self.time_interval_ms <= 0 {
             return None;
         }
-        self.slot_open_time(slot)
+        let last = slots.checked_sub(1)?;
+        let ahead = i64::try_from(slot - last).ok()?;
+        self.slot_open_time(last)?
+            .checked_add(ahead.checked_mul(self.time_interval_ms)?)
     }
 
     /// Placement consumes clicks while a drawing tool is armed, preventing a
@@ -2640,6 +2660,24 @@ impl ChartPane {
         }
     }
 
+    /// Where an instant later than this pane's newest bar falls, as a
+    /// fractional slot past the end. `None` unless the pane's bars run on a
+    /// fixed interval — see [`Self::anchor_time`] for why a tick chart has no
+    /// answer here.
+    fn future_slot_at_time(&self, time: i64) -> Option<f32> {
+        if self.kind != BarKind::Time || self.time_interval_ms <= 0 {
+            return None;
+        }
+        let last = self.slots().checked_sub(1)?;
+        let last_open = self.slot_open_time(last)?;
+        let ahead = time.checked_sub(last_open)?;
+        if ahead < self.time_interval_ms {
+            return None;
+        }
+        #[allow(clippy::cast_precision_loss)]
+        Some(last as f32 + ahead as f32 / self.time_interval_ms as f32)
+    }
+
     /// Re-express a foreign drawing's anchors in this pane's bar space.
     /// Returns the anchors and whether any of them had to be clamped to the
     /// end of this pane's series.
@@ -2662,6 +2700,15 @@ impl ChartPane {
                     0
                 }
             };
+            // A time chart can also place an instant *past* its newest bar,
+            // on the same fixed interval its bars already run on — which is
+            // where a trend line pointing into the future belongs. Without
+            // this the future end of a shared line would pile up on the right
+            // edge instead of running on.
+            if let Some(future) = self.future_slot_at_time(time) {
+                anchors.push(ChartPoint::at_time(future + 0.5, point.price, Some(time)));
+                continue;
+            }
             // The other clamp: a time past the end of this pane's series
             // lands on the newest slot because `slot_at_time` cannot go
             // further than the tape has. Only a *closed* bar can prove that,

--- a/crates/app/src/pane.rs
+++ b/crates/app/src/pane.rs
@@ -2747,6 +2747,13 @@ impl ChartPane {
             draft
                 .tool
                 .paint(&clipped, chart_rect, draft.style, &points, &ctxt, false);
+            // What the next click will do, printed where the eye already is.
+            // The rail's `n/N` badge says the same thing on the far side of
+            // the screen, which is why a trader who drags a three-anchor tool
+            // and lets go reads the waiting object as frozen.
+            if let Some(cursor) = points.last().copied() {
+                paint_placement_hint(&clipped, chart_rect, cursor, draft.tool, draft.points.len());
+            }
         }
     }
 
@@ -2886,6 +2893,59 @@ impl ChartPane {
             theme::AMBER,
         );
     }
+}
+
+/// Chip metrics for the placement hint: it rides beside the cursor without
+/// sitting under it, and it is the same 10 px plate the ruler readout uses.
+const HINT_CURSOR_OFFSET_PX: egui::Vec2 = egui::vec2(14.0, 14.0);
+const HINT_TEXT_PX: f32 = 10.0;
+const HINT_PAD_X_PX: f32 = 5.0;
+const HINT_PAD_Y_PX: f32 = 3.0;
+const HINT_RADIUS_PX: f32 = 3.0;
+const HINT_PLATE: egui::Color32 = egui::Color32::from_rgba_premultiplied(14, 18, 26, 216);
+
+/// Tell the trader what the next click does, beside the cursor.
+///
+/// A tool that knows says so in words (`placement_hint`); one that does not
+/// still reports its progress, because "2/3" beats an object that appears to
+/// have stopped responding. Nothing is drawn once the last anchor is placed —
+/// there is no next click to describe.
+fn paint_placement_hint(
+    painter: &egui::Painter,
+    chart_rect: egui::Rect,
+    cursor: egui::Pos2,
+    tool: drawings::DrawingTool,
+    placed: usize,
+) {
+    let required = tool.required_points();
+    if required < 2 || placed == 0 || placed >= required {
+        return;
+    }
+    let text = tool
+        .placement_hint(placed)
+        .map_or_else(|| format!("{placed}/{required}"), str::to_owned);
+    let galley = painter.layout_no_wrap(
+        text,
+        egui::FontId::proportional(HINT_TEXT_PX),
+        theme::TEXT_PRIMARY,
+    );
+    let size = galley.size() + egui::vec2(2.0 * HINT_PAD_X_PX, 2.0 * HINT_PAD_Y_PX);
+    // Flip to the other side of the cursor rather than let the chip leave the
+    // chart: a hint half off-screen is worse than no hint.
+    let mut min = cursor + HINT_CURSOR_OFFSET_PX;
+    if min.x + size.x > chart_rect.right() {
+        min.x = cursor.x - HINT_CURSOR_OFFSET_PX.x - size.x;
+    }
+    if min.y + size.y > chart_rect.bottom() {
+        min.y = cursor.y - HINT_CURSOR_OFFSET_PX.y - size.y;
+    }
+    let plate = egui::Rect::from_min_size(min, size);
+    painter.rect_filled(plate, egui::Rounding::same(HINT_RADIUS_PX), HINT_PLATE);
+    painter.galley(
+        plate.min + egui::vec2(HINT_PAD_X_PX, HINT_PAD_Y_PX),
+        galley,
+        theme::TEXT_PRIMARY,
+    );
 }
 
 /// The open / high / low / close of `candle` nearest to the pointer on

--- a/crates/app/src/pane.rs
+++ b/crates/app/src/pane.rs
@@ -2563,11 +2563,15 @@ impl ChartPane {
                     0
                 }
             };
-            clamped |= self.slot_open_time(slot).is_some_and(|open| {
-                // Landing on the newest bar for a time past it is the other
-                // clamp: `slot_at_time` cannot go further than the tape has.
-                slot + 1 == slots && open < time
-            });
+            // The other clamp: a time past the end of this pane's series
+            // lands on the newest slot because `slot_at_time` cannot go
+            // further than the tape has. Only a *closed* bar can prove that,
+            // by having ended before the anchor's instant — a time inside the
+            // forming bar is simply now, and fading it would be a lie in the
+            // other direction.
+            clamped |= self
+                .closed_bar(slot)
+                .is_some_and(|bar| bar.close_time < time);
             anchors.push(ChartPoint::at_time(
                 slot as f32 + 0.5,
                 point.price,

--- a/crates/app/src/pane.rs
+++ b/crates/app/src/pane.rs
@@ -1560,6 +1560,15 @@ impl ChartPane {
             {
                 // Alt+click walks down the z-order through overlapping
                 // objects; a plain click selects the topmost hit.
+                //
+                // Anchors first, exactly as the press below does. The two
+                // paths *must* ask the same question: the press selects on an
+                // anchor grab within `DRAWING_ANCHOR_RADIUS_PX`, and if the
+                // release only body-tested at the tighter
+                // `DRAWING_SELECT_RADIUS_PX` it would find nothing there and
+                // wipe the selection the press had just made — the object's
+                // panel flickering open and shut under a stationary cursor.
+                // Grabbing a handle *is* clicking the object.
                 let selected = if ui.input(|input| input.modifiers.alt) {
                     self.drawing_below_selection(
                         position,
@@ -1569,7 +1578,11 @@ impl ChartPane {
                         &scale,
                     )
                 } else {
-                    self.drawing_at(position, areas.chart, history_right, total, &scale)
+                    self.drawing_anchor_at(position, history_right, total, &scale)
+                        .map(|(drawing_index, _)| drawing_index)
+                        .or_else(|| {
+                            self.drawing_at(position, areas.chart, history_right, total, &scale)
+                        })
                 };
                 self.drawings.select(selected);
             }

--- a/crates/app/src/pane.rs
+++ b/crates/app/src/pane.rs
@@ -2523,7 +2523,9 @@ impl ChartPane {
             } else {
                 drawing.style
             };
-            let points: Vec<egui::Pos2> = anchors
+            // Stack-allocated: this is a per-frame path, and every shipped
+            // tool has at most three anchors, so the heap is never touched.
+            let points: SmallVec<[egui::Pos2; 4]> = anchors
                 .iter()
                 .map(|anchor| self.drawing_screen_point(*anchor, history_right, total, &scale))
                 .collect();

--- a/crates/app/src/pane.rs
+++ b/crates/app/src/pane.rs
@@ -1605,7 +1605,7 @@ impl ChartPane {
                             egui::CursorIcon::ResizeNwSe
                         });
                 } else if let Some(hovered) =
-                    self.drawing_at(position, areas.chart, history_right, total, &scale)
+                    self.drawing_at(position, drawing_area, history_right, total, &scale)
                 {
                     ui.ctx()
                         .set_cursor_icon(if self.drawings.items()[hovered].locked {
@@ -1636,7 +1636,7 @@ impl ChartPane {
                 let selected = if ui.input(|input| input.modifiers.alt) {
                     self.drawing_below_selection(
                         position,
-                        areas.chart,
+                        drawing_area,
                         history_right,
                         total,
                         &scale,
@@ -1645,7 +1645,7 @@ impl ChartPane {
                     self.drawing_press_pick.take().unwrap_or_else(|| {
                         // No press was recorded (it landed on chrome, or off
                         // the drawing area): fall back to asking now.
-                        self.drawing_pick_at(position, areas.chart, history_right, total, &scale)
+                        self.drawing_pick_at(position, drawing_area, history_right, total, &scale)
                     })
                 };
                 self.drawings.select(selected);
@@ -1663,8 +1663,13 @@ impl ChartPane {
             {
                 // One question, asked once, on the geometry the user was
                 // actually looking at when they pressed.
-                self.drawing_press_pick =
-                    Some(self.drawing_pick_at(position, areas.chart, history_right, total, &scale));
+                self.drawing_press_pick = Some(self.drawing_pick_at(
+                    position,
+                    drawing_area,
+                    history_right,
+                    total,
+                    &scale,
+                ));
                 self.drawing_drag_pending_from = Some(position);
                 if let Some((drawing_index, point_index)) =
                     self.drawing_anchor_at(position, history_right, total, &scale)
@@ -1680,7 +1685,7 @@ impl ChartPane {
                         }
                     };
                 } else if let Some(index) =
-                    self.drawing_at(position, areas.chart, history_right, total, &scale)
+                    self.drawing_at(position, drawing_area, history_right, total, &scale)
                 {
                     self.drawings.select(Some(index));
                     self.drawing_drag = if self.drawings.items()[index].locked {
@@ -2253,7 +2258,7 @@ impl ChartPane {
 
         // Drawings sit above market layers and remain anchored to chart space,
         // not the screen, while the viewport moves beneath them.
-        self.draw_drawings(painter, chart_rect, right, total, &scale);
+        self.draw_drawings(painter, self.drawing_area(chart_rect), right, total, &scale);
 
         // Closed-trade marks sit between the drawings and the live paper
         // lines: history under the orders that are still working. Only the
@@ -2577,6 +2582,21 @@ impl ChartPane {
     /// mark is real, its position on *this* chart is not exact.
     const SHARED_CLAMPED_OPACITY: f32 = 0.45;
 
+    /// The band drawings live in: the candles minus the live lane.
+    ///
+    /// The lane is the tape's own reserved strip at the right edge — a live
+    /// region, not a place for annotations, and a horizontal line running
+    /// across it was drawing over the flow. Placement already refused to put
+    /// an anchor there; paint, geometry and hit-test agree with it now, which
+    /// also keeps a line's painted end and its grabbable end the same pixel.
+    fn drawing_area(&self, chart: egui::Rect) -> egui::Rect {
+        let right = self
+            .last_lane_divider_x
+            .unwrap_or(chart.right())
+            .clamp(chart.left(), chart.right());
+        egui::Rect::from_min_max(chart.min, egui::pos2(right, chart.bottom()))
+    }
+
     /// This pane's own projection, rebuilt from the geometry the last
     /// [`Self::draw_chart`] cached. `None` before the pane has drawn once, or
     /// while it has no price range to project against.
@@ -2591,7 +2611,7 @@ impl ChartPane {
             self.last_chart_top + self.last_chart_height,
         );
         let history_right = self.last_lane_divider_x.unwrap_or(chart.right());
-        Some((chart, history_right, self.slots(), scale))
+        Some((self.drawing_area(chart), history_right, self.slots(), scale))
     }
 
     /// Paint the shared drawings that live on `source`, re-expressed on this
@@ -3021,6 +3041,37 @@ fn magnet_price_of(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The tape's lane is a live region, not a canvas. A drawing that ran
+    /// across it painted over the flow — and worse, the painted end and the
+    /// grabbable end were different pixels, because paint used the whole
+    /// chart while placement stopped at the divider.
+    #[test]
+    fn the_drawing_band_stops_at_the_live_lane() {
+        let chart = egui::Rect::from_min_max(egui::pos2(60.0, 80.0), egui::pos2(1_000.0, 700.0));
+        let mut pane = ChartPane::flow(1, BarSpec::Tick(50), "TESTUSDT".to_owned());
+
+        pane.last_lane_divider_x = None;
+        assert_eq!(
+            pane.drawing_area(chart),
+            chart,
+            "no lane, no carve — the whole chart is the canvas"
+        );
+
+        pane.last_lane_divider_x = Some(880.0);
+        let band = pane.drawing_area(chart);
+        assert_eq!(band.right(), 880.0, "the band ends where the lane begins");
+        assert_eq!(band.left(), chart.left());
+        assert_eq!(band.y_range(), chart.y_range());
+
+        // A divider reported outside the chart cannot make the band bigger
+        // than the chart or invert it.
+        pane.last_lane_divider_x = Some(5_000.0);
+        assert_eq!(pane.drawing_area(chart).right(), chart.right());
+        pane.last_lane_divider_x = Some(-40.0);
+        let degenerate = pane.drawing_area(chart);
+        assert!(degenerate.right() >= degenerate.left());
+    }
 
     /// A bar spanning 98 … 102, for the magnet.
     fn magnet_candle() -> quantick_engine::Bar {

--- a/crates/app/src/pane.rs
+++ b/crates/app/src/pane.rs
@@ -27,7 +27,7 @@ use crate::candle_view::draw_candle;
 use crate::chart::{self, PriceScale};
 use crate::chart_layers::{ChartLayer, LayerActions};
 use crate::config::FeedCapabilities;
-use crate::drawings::{self, ChartPoint, DrawContext, Drawings, PresetHost};
+use crate::drawings::{self, ChartPoint, DrawContext, Drawing, DrawingStyle, Drawings, PresetHost};
 use crate::indicator_render::{self, PlotX};
 use crate::indicator_worker::{IndicatorCommand, IndicatorSource, IndicatorWorker, SlotId};
 use crate::indicators::IndicatorViews;
@@ -46,6 +46,10 @@ const DRAWING_SELECT_RADIUS_PX: f32 = 10.0;
 /// Hit radius for a selected drawing's editable anchor.
 pub const DRAWING_ANCHOR_RADIUS_PX: f32 = 12.0;
 /// Minimum pointer travel that turns one press/release into drag placement.
+/// How near the pointer must be to a bar's open / high / low / close for
+/// the magnet to take the anchor. Generous enough to catch the swing you
+/// aimed at, tight enough to still draw a free diagonal between bars.
+const MAGNET_REACH_PX: f32 = 12.0;
 const DRAWING_DRAG_THRESHOLD_PX: f32 = 4.0;
 
 /// Alpha of the last-price line: legible at a glance without competing with a
@@ -1113,6 +1117,7 @@ impl ChartPane {
         pos: egui::Pos2,
         history_right: f32,
         total: usize,
+        magnet: bool,
     ) -> Option<ChartPoint> {
         let (auto_lo, auto_hi) = self.last_auto_range?;
         if total == 0 || self.last_chart_height <= 1.0 {
@@ -1127,10 +1132,40 @@ impl ChartPane {
         );
         let bar = self.viewport.right_edge_bar(total) + 0.5
             - (history_right - pos.x) / self.viewport.candle_width();
-        Some(ChartPoint {
-            bar,
-            price: scale.price_at(pos.y),
-        })
+        let price = magnet
+            .then(|| self.magnet_price(bar, pos.y, &scale))
+            .flatten()
+            .unwrap_or_else(|| scale.price_at(pos.y));
+        Some(ChartPoint::at_time(bar, price, self.anchor_time(bar)))
+    }
+
+    /// The magnet, applied to the bar the pointer is over.
+    ///
+    /// Only that bar is considered: snapping to a neighbour would move the
+    /// anchor sideways, and the trader chose the bar by pointing at it.
+    fn magnet_price(&self, bar: f32, pointer_y: f32, scale: &PriceScale) -> Option<f64> {
+        if !bar.is_finite() || bar < 0.0 {
+            return None;
+        }
+        magnet_price_of(self.closed_bar(bar.floor() as usize)?, pointer_y, scale)
+    }
+
+    /// The market time behind a fractional bar slot, for anchors that may have
+    /// to be re-expressed on another pane (§D7 of the drawing-tools design).
+    ///
+    /// Only a slot that actually holds a bar has an instant behind it: the
+    /// empty space past the newest bar is future the tape has not written, and
+    /// naming a time there would be an invention. `None` is the honest answer
+    /// there, and it is what keeps such an anchor out of a shared drawing.
+    fn anchor_time(&self, bar: f32) -> Option<i64> {
+        if !bar.is_finite() || bar < 0.0 {
+            return None;
+        }
+        let slot = bar.floor() as usize;
+        if slot >= self.slots() {
+            return None;
+        }
+        self.slot_open_time(slot)
     }
 
     /// Placement consumes clicks while a drawing tool is armed, preventing a
@@ -1142,6 +1177,7 @@ impl ChartPane {
         area: egui::Rect,
         chrome: &mut PaneChrome<'_>,
     ) -> bool {
+        let magnet = chrome.toolrail.magnet();
         let Some(tool) = chrome.toolrail.tool().drawing_tool() else {
             self.drawings.cancel_draft();
             self.drawing_hover = None;
@@ -1161,9 +1197,9 @@ impl ChartPane {
             egui::Sense::click_and_drag(),
         );
         self.hover_pos = response.hover_pos();
-        self.drawing_hover = response
-            .hover_pos()
-            .and_then(|position| self.drawing_point_at(position, history_right, self.slots()));
+        self.drawing_hover = response.hover_pos().and_then(|position| {
+            self.drawing_point_at(position, history_right, self.slots(), magnet)
+        });
         if response.hovered() || response.dragged() {
             ui.ctx().set_cursor_icon(egui::CursorIcon::Crosshair);
         }
@@ -1176,7 +1212,8 @@ impl ChartPane {
                 .flatten()
         });
         if let Some(position) = pressed_position.filter(|position| history.contains(*position))
-            && let Some(point) = self.drawing_point_at(position, history_right, self.slots())
+            && let Some(point) =
+                self.drawing_point_at(position, history_right, self.slots(), magnet)
         {
             self.drawing_press_started_empty = self.drawings.draft_len() == 0;
             self.drawing_press_position = Some(position);
@@ -1196,7 +1233,8 @@ impl ChartPane {
             && let Some(position) = released_position
             && history.contains(position)
             && start.distance(position) >= DRAWING_DRAG_THRESHOLD_PX
-            && let Some(point) = self.drawing_point_at(position, history_right, self.slots())
+            && let Some(point) =
+                self.drawing_point_at(position, history_right, self.slots(), magnet)
         {
             self.place_drawing_point(tool, point, chrome);
         }
@@ -1384,6 +1422,10 @@ impl ChartPane {
         chrome: &mut PaneChrome<'_>,
     ) {
         self.unhide_layer_for_armed_tool(chrome);
+        // The magnet applies to every anchor gesture, placement and re-drag
+        // alike: a handle that snaps only while you first draw it would make
+        // the second edit undo the precision of the first.
+        let magnet = chrome.toolrail.magnet();
         // Remembered for inspector placement and manager centring: the pane
         // where drawings live, already free of both axes and the live lane.
         self.last_plot_area = Some(area);
@@ -1584,7 +1626,7 @@ impl ChartPane {
                                 position.y.clamp(areas.chart.top(), areas.chart.bottom()),
                             );
                             if let Some(point) =
-                                self.drawing_point_at(position, history_right, total)
+                                self.drawing_point_at(position, history_right, total, magnet)
                             {
                                 self.drawings.move_anchor(drawing_index, point_index, point);
                             }
@@ -2413,6 +2455,128 @@ impl ChartPane {
         )
     }
 
+    /// Opacity a shared drawing is painted at on a pane whose series does not
+    /// reach its anchors. Faded, not hidden and not silently snapped: the
+    /// mark is real, its position on *this* chart is not exact.
+    const SHARED_CLAMPED_OPACITY: f32 = 0.45;
+
+    /// This pane's own projection, rebuilt from the geometry the last
+    /// [`Self::draw_chart`] cached. `None` before the pane has drawn once, or
+    /// while it has no price range to project against.
+    fn last_projection(&self) -> Option<(egui::Rect, f32, usize, PriceScale)> {
+        let chart = self.last_chart_area?;
+        let (auto_lo, auto_hi) = self.last_auto_range?;
+        let (lo, hi) = self.price_view.resolve((auto_lo, auto_hi));
+        let scale = PriceScale::from_range(
+            lo,
+            hi,
+            self.last_chart_top,
+            self.last_chart_top + self.last_chart_height,
+        );
+        let history_right = self.last_lane_divider_x.unwrap_or(chart.right());
+        Some((chart, history_right, self.slots(), scale))
+    }
+
+    /// Paint the shared drawings that live on `source`, re-expressed on this
+    /// pane (`docs/ux/drawing-tools-2026-08.md` §D7).
+    ///
+    /// The two panes cut the same trades into different bars, so a bar index
+    /// means nothing across them — the market timestamp each anchor captured
+    /// at placement is the only coordinate they share. Every anchor goes back
+    /// through this pane's own `slot_at_time`.
+    ///
+    /// Read-only here, on purpose: selection, dragging and the inspector
+    /// belong to the pane the object was drawn on. A mark that could be
+    /// grabbed in two places would be two versions of one object, which is
+    /// exactly the confusion sharing exists to remove.
+    ///
+    /// Per-frame cost: nothing at all until a drawing is actually shared —
+    /// the loop below runs over `source.drawings` and does nothing for the
+    /// `ThisChart` default every object opens with.
+    pub fn paint_shared_from(&self, painter: &egui::Painter, source: &Self) {
+        if !source.drawings.items().iter().any(Drawing::shared) {
+            return;
+        }
+        let Some((chart, history_right, total, scale)) = self.last_projection() else {
+            return;
+        };
+        let clipped = painter.with_clip_rect(chart);
+        for (index, drawing) in source.drawings.items().iter().enumerate() {
+            if !drawing.shared() || !source.drawings.is_visible(index) {
+                continue;
+            }
+            let Some((anchors, clamped)) = self.reproject(drawing) else {
+                continue;
+            };
+            // A clamped anchor is an honest half-truth: the object really is
+            // off the end of this pane's series, and it says so by fading
+            // rather than by pretending to sit on the edge bar.
+            let style = if clamped {
+                DrawingStyle {
+                    color: drawing
+                        .style
+                        .color
+                        .gamma_multiply(Self::SHARED_CLAMPED_OPACITY),
+                    fill_alpha: 0,
+                    ..drawing.style
+                }
+            } else {
+                drawing.style
+            };
+            let points: Vec<egui::Pos2> = anchors
+                .iter()
+                .map(|anchor| self.drawing_screen_point(*anchor, history_right, total, &scale))
+                .collect();
+            let ctxt = DrawContext {
+                payload: drawing.payload.as_ref(),
+                anchors: &anchors,
+                scale: &scale,
+                style,
+                selected: false,
+                halo: false,
+            };
+            drawing
+                .tool
+                .paint(&clipped, chart, style, &points, &ctxt, false);
+        }
+    }
+
+    /// Re-express a foreign drawing's anchors in this pane's bar space.
+    /// Returns the anchors and whether any of them had to be clamped to the
+    /// end of this pane's series.
+    fn reproject(&self, drawing: &Drawing) -> Option<(SmallVec<[ChartPoint; 4]>, bool)> {
+        let slots = self.slots();
+        if slots == 0 {
+            return None;
+        }
+        let mut anchors = SmallVec::new();
+        let mut clamped = false;
+        for point in &drawing.points {
+            let time = point.time_ms?;
+            let slot = match self.slot_at_time(time) {
+                Some(slot) => slot.min(slots - 1),
+                // Before this pane's first bar: the series does not reach
+                // back that far, so the anchor sits on the oldest bar and is
+                // marked as clamped.
+                None => {
+                    clamped = true;
+                    0
+                }
+            };
+            clamped |= self.slot_open_time(slot).is_some_and(|open| {
+                // Landing on the newest bar for a time past it is the other
+                // clamp: `slot_at_time` cannot go further than the tape has.
+                slot + 1 == slots && open < time
+            });
+            anchors.push(ChartPoint::at_time(
+                slot as f32 + 0.5,
+                point.price,
+                Some(time),
+            ));
+        }
+        Some((anchors, clamped))
+    }
+
     /// Paint the completed drawing objects. This runs once per frame and is
     /// O(number of drawings); it never touches the per-trade ingestion path.
     fn draw_drawings(
@@ -2621,9 +2785,95 @@ impl ChartPane {
     }
 }
 
+/// The open / high / low / close of `candle` nearest to the pointer on
+/// screen, when one is within reach.
+///
+/// This is the difference between a line that *looks* drawn off the swing
+/// high and one that is (`docs/ux/drawing-tools-2026-08.md` §D6). Nothing in
+/// reach returns `None` and the free price is used — a magnet that always
+/// snaps is a magnet you cannot draw a diagonal with.
+fn magnet_price_of(
+    candle: &quantick_engine::Bar,
+    pointer_y: f32,
+    scale: &PriceScale,
+) -> Option<f64> {
+    [candle.open, candle.high, candle.low, candle.close]
+        .into_iter()
+        .filter_map(|price| {
+            let price = price.to_f64()?;
+            let distance = (scale.y(price) - pointer_y).abs();
+            (distance <= MAGNET_REACH_PX).then_some((distance, price))
+        })
+        .min_by(|left, right| left.0.total_cmp(&right.0))
+        .map(|(_, price)| price)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A bar spanning 98 … 102, for the magnet.
+    fn magnet_candle() -> quantick_engine::Bar {
+        use rust_decimal::Decimal;
+        quantick_engine::Bar {
+            open_time: 0,
+            close_time: 59_999,
+            open: Decimal::from(100),
+            high: Decimal::from(102),
+            low: Decimal::from(98),
+            close: Decimal::from(101),
+            buy_volume: Decimal::ONE,
+            sell_volume: Decimal::ONE,
+            trade_count: 2,
+        }
+    }
+
+    /// Ten pixels per price unit over 90 … 110, so the bar's four levels are
+    /// far enough apart on screen for "nearest" to be unambiguous.
+    fn magnet_scale() -> PriceScale {
+        PriceScale::from_range(90.0, 110.0, 0.0, 200.0)
+    }
+
+    #[test]
+    fn the_magnet_takes_the_nearest_ohlc_within_reach() {
+        let candle = magnet_candle();
+        let scale = magnet_scale();
+        let high_y = scale.y(102.0);
+        assert_eq!(
+            magnet_price_of(&candle, high_y, &scale),
+            Some(102.0),
+            "exactly on the high"
+        );
+        assert_eq!(
+            magnet_price_of(&candle, high_y + 4.0, &scale),
+            Some(102.0),
+            "inside the reach, and still nearer the high than the close"
+        );
+    }
+
+    /// The point of the reach: away from every level the anchor stays free,
+    /// so a diagonal drawn through open space is still a diagonal.
+    #[test]
+    fn the_magnet_lets_go_outside_its_reach() {
+        let candle = magnet_candle();
+        let scale = magnet_scale();
+        assert_eq!(magnet_price_of(&candle, scale.y(105.0), &scale), None);
+    }
+
+    /// Near-ties resolve to the genuinely nearest level, never to the first
+    /// one in the list.
+    #[test]
+    fn the_magnet_picks_the_nearest_level_not_the_first() {
+        let candle = magnet_candle();
+        let scale = magnet_scale();
+        // Just under the low: 98 is nearer than the open at 100.
+        assert_eq!(magnet_price_of(&candle, scale.y(97.6), &scale), Some(98.0));
+        // Just over the close: 101 is nearer than the high at 102.
+        assert_eq!(
+            magnet_price_of(&candle, scale.y(101.2), &scale),
+            Some(101.0)
+        );
+    }
 
     /// One geometry for the jump-to-live chip's click region and its paint
     /// (audit F6): right-aligned inside the strip, inset on every side, so

--- a/crates/app/src/tab.rs
+++ b/crates/app/src/tab.rs
@@ -1568,6 +1568,13 @@ impl Tab {
             }
         }
 
+        // Drawings marked "show on all charts" cross here, after both panes
+        // have drawn and cached their projections. It happens outside the
+        // loop above because each pane paints the *other* pane's marks, and
+        // that needs both panes borrowed at once — immutably, which is also
+        // the guarantee that a foreign mark can only be looked at.
+        self.paint_shared_drawings(ui.painter());
+
         // The position HUD rides the pane that owns order entry (the focused
         // one). It draws here, after the pane loop, because its buttons need
         // the paper host mutably — inside the loop that borrow is pinned
@@ -1593,6 +1600,22 @@ impl Tab {
             ],
             egui::Stroke::new(FOCUS_RULE_PX, theme::ACCENT),
         );
+    }
+
+    /// Cross-pane drawings: each pane paints the shared marks of the other.
+    ///
+    /// Nothing happens on an unsplit tab — one pane has no other pane to
+    /// borrow marks from, and the drawing is already on the only chart there
+    /// is. Scope stops here, at the tab: the panes below hold one symbol on
+    /// one feed, which is what makes a price level mean the same thing on
+    /// both (`docs/ux/drawing-tools-2026-08.md` §D7).
+    fn paint_shared_drawings(&self, painter: &egui::Painter) {
+        let Some(time_pane) = self.time_pane.as_ref() else {
+            return;
+        };
+        let flow_pane = &self.flow_pane;
+        flow_pane.paint_shared_from(painter, time_pane);
+        time_pane.paint_shared_from(painter, flow_pane);
     }
 
     /// Clicking a pane focuses it (§11). Read from the raw pointer press

--- a/crates/app/src/toolrail.rs
+++ b/crates/app/src/toolrail.rs
@@ -272,11 +272,11 @@ fn minimal_length() -> f32 {
         + TOOLRAIL_ICON.hit
 }
 
-/// The full trailing cluster: separator, repeat, hide-all, lock-all,
+/// The full trailing cluster: separator, magnet, repeat, hide-all, lock-all,
 /// separator, Objects.
 fn trailing_length() -> f32 {
     SEPARATOR_BLOCK_PX
-        + (3.0 * TOOLRAIL_ICON.hit + 2.0 * TOOLBOX_ITEM_GAP_PX)
+        + (4.0 * TOOLRAIL_ICON.hit + 3.0 * TOOLBOX_ITEM_GAP_PX)
         + SEPARATOR_BLOCK_PX
         + TOOLRAIL_ICON.hit
 }
@@ -302,6 +302,10 @@ pub struct ToolRail {
     /// The repeat pin: `true` keeps a drawing tool armed after it completes
     /// an object; the default is one-shot back to Pointer.
     repeat: bool,
+    /// The magnet: anchors snap to the nearest OHLC of the bar under the
+    /// pointer. Off by default — a magnet nobody asked for moves marks the
+    /// trader placed deliberately.
+    magnet: bool,
     /// Last-armed member of each tool family, keyed by family id.
     last_family_member: BTreeMap<&'static str, DrawingTool>,
     /// Currently-nearest drop edge while a grip drag is live.
@@ -314,6 +318,8 @@ pub struct ToolRail {
     button_rects: [Option<(Tool, egui::Rect)>; TOOLBOX_BUTTON_COUNT],
     #[cfg(test)]
     grip_rect: Option<egui::Rect>,
+    #[cfg(test)]
+    magnet_rect: Option<egui::Rect>,
     #[cfg(test)]
     more_rect: Option<egui::Rect>,
     #[cfg(test)]
@@ -335,6 +341,7 @@ impl Default for ToolRail {
             visible: true,
             dock: ToolboxDock::Left,
             repeat: false,
+            magnet: false,
             last_family_member: BTreeMap::new(),
             drag_preview: None,
             dragging: false,
@@ -344,6 +351,8 @@ impl Default for ToolRail {
             button_rects: [None; TOOLBOX_BUTTON_COUNT],
             #[cfg(test)]
             grip_rect: None,
+            #[cfg(test)]
+            magnet_rect: None,
             #[cfg(test)]
             more_rect: None,
             #[cfg(test)]
@@ -418,6 +427,19 @@ impl ToolRail {
     #[cfg(test)]
     pub(crate) fn set_repeat(&mut self, repeat: bool) {
         self.repeat = repeat;
+    }
+
+    /// Whether placed anchors snap to the bar's open / high / low / close.
+    #[must_use]
+    pub fn magnet(&self) -> bool {
+        self.magnet
+    }
+
+    /// Arm the magnet without a click — the `QUANTICK_DRAWING_MAGNET` hook
+    /// and the tests both come through here, so neither can drift from what
+    /// the button does.
+    pub(crate) fn set_magnet(&mut self, magnet: bool) {
+        self.magnet = magnet;
     }
 
     #[cfg(test)]
@@ -524,6 +546,7 @@ impl ToolRail {
         {
             self.button_rects.fill(None);
             self.grip_rect = None;
+            self.magnet_rect = None;
             self.more_rect = None;
             self.hide_all_rect = None;
             self.lock_all_rect = None;
@@ -604,6 +627,7 @@ impl ToolRail {
             if stage != RailStage::Minimal {
                 self.draw_global_buttons(ui, drawings);
                 self.draw_repeat_button(ui);
+                self.draw_magnet_button(ui);
                 self.draw_separator(ui, vertical);
             }
         });
@@ -716,6 +740,24 @@ impl ToolRail {
         }
     }
 
+    /// The magnet: anchors land on the bar's open / high / low / close when
+    /// one is within reach of the pointer. A state, like the repeat pin, so
+    /// it reads off the rail without a menu.
+    fn draw_magnet_button(&mut self, ui: &mut egui::Ui) {
+        let response = IconButton::new(icons::MAGNET, TOOLRAIL_ICON)
+            .active(self.magnet)
+            .active_marker(self.dock.marker_edge())
+            .hover_text("Snap anchors to the bar's open / high / low / close")
+            .show(ui);
+        #[cfg(test)]
+        {
+            self.magnet_rect = Some(response.rect);
+        }
+        if response.clicked() {
+            self.magnet = !self.magnet;
+        }
+    }
+
     /// The More flyout of a collapsed rail: everything that lost its slot
     /// stays reachable by name with its shortcut, in registry order.
     fn draw_more_menu(&mut self, ui: &mut egui::Ui, drawings: &mut Drawings, stage: RailStage) {
@@ -737,6 +779,13 @@ impl ToolRail {
                     .clicked()
                 {
                     self.repeat = !self.repeat;
+                    ui.close_menu();
+                }
+                if ui
+                    .add(egui::Button::new("Snap anchors to OHLC").selected(self.magnet))
+                    .clicked()
+                {
+                    self.magnet = !self.magnet;
                     ui.close_menu();
                 }
                 let all_hidden = drawings.all_hidden();
@@ -1241,9 +1290,12 @@ mod tests {
     #[test]
     fn stage_lengths_match_the_spec_for_the_shipped_registry() {
         let slots = tool_slots().len();
-        assert_eq!(slots, 4, "fib family folds two registry entries into one");
-        assert_eq!(full_length(slots), 417.0);
-        assert_eq!(compact_length(), 345.0);
+        assert_eq!(
+            slots, 6,
+            "the registry folds into Lines, Channels, Shapes, Fib, Measure and Text"
+        );
+        assert_eq!(full_length(slots), 525.0);
+        assert_eq!(compact_length(), 381.0);
         assert_eq!(minimal_length(), 191.0);
     }
 
@@ -1587,18 +1639,51 @@ mod tests {
         );
     }
 
+    /// The magnet is a state, not a command: it reads off the rail and it
+    /// starts off, because a magnet nobody asked for moves marks the trader
+    /// placed deliberately (`docs/ux/drawing-tools-2026-08.md` §D6).
+    #[test]
+    fn the_magnet_is_a_rail_toggle_that_starts_off() {
+        let screen = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(800.0, 900.0));
+        let ctx = egui::Context::default();
+        let mut rail = ToolRail::new();
+        let mut drawings = Drawings::default();
+        assert!(!rail.magnet(), "the magnet opens off");
+
+        rail_frame_with(&mut rail, &mut drawings, &ctx, screen, Vec::new());
+        let button = rail
+            .magnet_rect
+            .expect("the magnet button rendered")
+            .center();
+        click_at(&mut rail, &mut drawings, &ctx, screen, button);
+        assert!(rail.magnet());
+        click_at(&mut rail, &mut drawings, &ctx, screen, button);
+        assert!(!rail.magnet(), "the same button turns it back off");
+    }
+
+    /// The scripted-validation hook (`QUANTICK_DRAWING_MAGNET`) sets the same
+    /// flag the button does; nothing may fork the two.
+    #[test]
+    fn the_hook_setter_moves_the_same_flag_the_button_does() {
+        let mut rail = ToolRail::new();
+        rail.set_magnet(true);
+        assert!(rail.magnet());
+        rail.set_magnet(false);
+        assert!(!rail.magnet());
+    }
+
     #[test]
     fn stages_are_pure_functions_of_extent() {
         let slots = tool_slots().len();
-        for extent in [100.0_f32, 200.0, 344.9, 345.0, 416.9, 417.0, 1000.0] {
+        for extent in [100.0_f32, 200.0, 380.9, 381.0, 524.9, 525.0, 1000.0] {
             let first = stage_for(extent, slots);
             let second = stage_for(extent, slots);
             assert_eq!(first, second);
         }
-        assert_eq!(stage_for(417.0, slots), RailStage::Full);
-        assert_eq!(stage_for(416.9, slots), RailStage::Compact);
-        assert_eq!(stage_for(345.0, slots), RailStage::Compact);
-        assert_eq!(stage_for(344.9, slots), RailStage::Minimal);
+        assert_eq!(stage_for(525.0, slots), RailStage::Full);
+        assert_eq!(stage_for(524.9, slots), RailStage::Compact);
+        assert_eq!(stage_for(381.0, slots), RailStage::Compact);
+        assert_eq!(stage_for(380.9, slots), RailStage::Minimal);
     }
 
     #[test]
@@ -1795,13 +1880,13 @@ mod tests {
         let ctx = egui::Context::default();
         let mut rail = ToolRail::new();
         let mut drawings = Drawings::default();
-        drawings.place(
-            DRAWING_TOOLS[0],
-            ChartPoint {
-                bar: 1.0,
-                price: 100.0,
-            },
-        );
+        // Registry-order-proof: place whatever the first tool needs rather
+        // than assuming it is a one-click tool.
+        let tool = DRAWING_TOOLS[0];
+        for anchor in 0..tool.required_points() {
+            drawings.place(tool, ChartPoint::at(anchor as f32, 100.0 + anchor as f64));
+        }
+        assert_eq!(drawings.items().len(), 1, "the object was placed");
         rail_frame_with(&mut rail, &mut drawings, &ctx, screen, Vec::new());
 
         let eye = rail.hide_all_rect.expect("hide-all rendered").center();

--- a/docs/ux/drawing-tools-2026-08.md
+++ b/docs/ux/drawing-tools-2026-08.md
@@ -1,0 +1,288 @@
+# Drawing tools — from five marks to a price-action toolbox
+
+August 2026. A design review of the drawing rail with a UX lead and a
+discretionary price-action trader, held against the shipped build. It
+extends `docs/drawing-toolbar-ux.md` (which redesigned the *rail chrome*)
+with the thing that review deliberately left alone: **which tools exist,
+how they look on the candles, and how a trader lives with them.**
+
+Personas are the fixed cast from `.claude/skills/trader-ux-review`: Rafa
+(order-flow scalper), Marina (swing / multi-timeframe) and Duda (newcomer).
+
+---
+
+## 1. Where we actually are
+
+The registry ships five tools:
+
+| Tool | Points | Shortcut |
+| --- | --- | --- |
+| Horizontal line | 1 | `H` |
+| Rectangle | 2 | `R` |
+| Parallel channel | 3 | `C` |
+| Fib retracement | 2 | `F` |
+| Fib extension | 3 | `Shift+F` |
+
+**There is no trend line.** For a chartist that is not a gap, it is the
+absence of the instrument. Everything else in this document follows from
+that one fact: the rail chrome was built well ahead of the toolbox it
+holds, and the toolbox never caught up.
+
+Four structural findings came out of the session.
+
+### F1 — The set is not a set
+
+A price-action trader works with three primitives and one measurement:
+a **line** (support, resistance, trend, ray into the future), a **zone**
+(a rectangle of value, a channel of trend), a **level ratio** (fib), and a
+**measurement** (how far, in points and in percent). We ship the zone and
+the ratio, half the measurement (none), and none of the line.
+
+> **Rafa:** "I mark support with a horizontal and everything else I hold in
+> my head. There is no ruler, so when I want to know if this leg is 0.4% or
+> 1.2% I open a calculator. On a fast tape I just don't check."
+
+### F2 — The marks are loud
+
+`DEFAULT_DRAWING_WIDTH_PX = 1.5` with a selection halo `3.5 px` wider and
+solid-white 4 px anchor discs. Against a candle body that is often 3–6 px
+wide, a 1.5 px annotation competes with the data. TradingView and
+MetaTrader both default to a **1 px hairline**; the drawing is a note *on*
+the chart, never a second series.
+
+> **Marina:** "My channel is thicker than the candles inside it. It reads
+> like a highlighter, not an annotation."
+
+Data honesty applies to visual weight too: user marks are opinion, market
+data is fact, and opinion should not out-shout fact.
+
+### F3 — The inspector lands on the evidence
+
+`inspector_placement` scores eight candidates by *least overlap with the
+object's bounding box*, tie-breaking toward greater centre distance. The
+intent was right; the outcome is that a small object (a horizontal line, a
+short trend line) has a small bbox, so "beside it with a 12 px gap" scores
+zero overlap and wins — and the panel lands directly on the price action
+the trader drew the line to read.
+
+> **Rafa:** "I click the line to change its colour and the window covers the
+> exact candles I was looking at. I have to drag it away every single time."
+
+The bug is the objective function. Zero overlap with the *bbox* is not the
+goal; **staying out of the way of the read** is. The read is the
+neighbourhood of the object, not its bounding box.
+
+### F4 — A drawing is trapped in one pane
+
+`ChartPoint { bar: f32, price: f64 }` anchors to a **bar index**, which is
+local to a pane's own series. The 5-minute pane and the tick pane of the
+same symbol have completely different bar indices for the same instant, so
+a mark drawn on one cannot be expressed on the other — even a horizontal
+line, whose price is trivially universal.
+
+> **Marina:** "I draw the trendline on the 5m and switch to ticks to time the
+> entry. The line isn't there. I draw it again, badly, and now I have two
+> slightly different lines and I don't know which one is the real one."
+
+That last sentence is the real cost: it is not inconvenience, it is
+**two versions of the truth**.
+
+---
+
+## 2. Decisions
+
+### D1 — The complete toolbox
+
+Registry order, folded into rail families:
+
+| Family | Tools | Shortcut |
+| --- | --- | --- |
+| Lines | Trend line | `T` |
+| | Ray | `Shift+T` |
+| | Extended line | — |
+| | Horizontal line | `H` |
+| | Horizontal ray | — |
+| | Vertical line | `V` |
+| | Arrow | — |
+| Channels | Parallel channel (rising / falling) | `C` |
+| Shapes | Rectangle | `R` |
+| | Ellipse | — |
+| | Triangle | — |
+| Fib | Fib retracement | `F` |
+| | Fib extension | `Shift+F` |
+| Measure | Ruler | `M` |
+| | Price range | — |
+| | Date range | — |
+| Text | Text note | `A` |
+
+Ray, extended line and horizontal ray *could* be extension flags on the
+trend line and the horizontal line. We ship them as named tools anyway:
+Duda cannot find a checkbox she does not know exists, and every competing
+platform names them. The flags exist too, on the channel, where they are
+genuinely a property of one object rather than a different intent.
+
+Deliberately **not** in this pass: pitchfork, regression channel, Gann,
+Elliott labels, harmonic patterns, the long/short position tool (the
+paper-trading order UI already owns entry / stop / target on the chart).
+
+### D2 — Hairline by default
+
+- Stroke `1.5 → 1.0 px`.
+- Fill alpha `24 → 14`.
+- Selection anchors: hollow rings in the object's own colour with a light
+  core, `3.5 px`, replacing solid-white discs.
+- Selection halo: narrower and dimmer — enough to find the object under the
+  pointer, not enough to double its weight.
+- Labels (fib levels, ruler readout): 10 px, muted, no box unless the label
+  sits over candles, where it gets a low-alpha plate for legibility rather
+  than a chrome-coloured box.
+
+The width slider keeps its full `0.5 … 6.0` range: this changes the
+*default*, not the ceiling. Existing drawings keep whatever width they
+were saved with.
+
+### D3 — The inspector goes to a corner
+
+New rule, replacing least-bbox-overlap:
+
+1. Candidates are the **chart corners**, inset by the standard gap, and the
+   two **top** corners are tried first.
+2. Of those, the one that clears the bbox entirely and whose centre is
+   **farthest** from the object wins; an exact tie (a centred object) takes
+   the left one.
+3. Only if neither top corner is free, the bottom two on the same rule.
+4. Only if all four are fouled — a large object covering the chart — fall
+   back to the beside-the-object candidates, least overlap first.
+5. Manual position still wins forever, unchanged. The auto-pin rule for
+   narrow charts is unchanged.
+
+Top before bottom is **structural, not taste**. A floating panel is
+positioned by its top-left corner and grows downwards, and the placement
+runs before the panel's real height is known (the Fib level editor is twice
+the height of the Style tab). A top corner always has the whole pane to
+grow into; a bottom-anchored panel that turns out taller than assumed runs
+off the window and silently loses its last rows. Rows a trader cannot reach
+read as rows that do not exist — the same failure the old rule had, one axis
+over.
+
+> **Duda:** "If it always opens in the same place I learn where to look. It
+> jumping around 'intelligently' is what makes it feel random."
+
+Consistency is a feature here, which is why the corner preference is
+ordered and deterministic rather than merely "the emptiest area".
+
+### D4 — The channel says what a trader calls it
+
+`ParallelChannelPayload { midline, extend_left, extend_right }`, edited in
+a tool-owned inspector tab (`Channel`), exactly the way the Fib level
+editor mounts its own tab — no central inspector edits.
+
+- `midline` paints a dashed line at half alpha through the middle of the
+  channel. Default **on**: it is the line traders trade off, and TradingView
+  users expect it. Existing channels get it via the payload default, which
+  is a visible change to an existing object — accepted deliberately and
+  called out in the PR body, because a channel without its midline is the
+  odd one out, not the baseline.
+- `extend_left` / `extend_right` project the three rails past their
+  anchors to the chart edge. Default off.
+- Naming: hover text becomes *"Rising / falling channel — set the trend
+  line, then click the channel width (C)"*. "Parallel channel" stays the
+  formal name in the inspector header; the hover is where Duda is standing.
+
+### D5 — The ruler reads in percent
+
+One readout, five numbers, laid out to be read in a glance:
+
+```
++412 pts   +1.83%   82 ticks
+17 bars    4m 21s
+```
+
+- **Points** — the raw price delta, in the instrument's own units.
+- **Percent** — `delta / start_price`, signed. This is the number the
+  session asked for and the one every other platform shows.
+- **Ticks** — points divided by the instrument tick size, for the WIN /
+  WDO traders who size in ticks.
+- **Bars** and **elapsed time** — how long the move took, on that pane's
+  own bar type.
+
+Sign and colour follow the direction (up / down), never a fixed accent, so
+the direction is readable without reading the sign. The readout sits at the
+midpoint of the measured leg with a low-alpha plate.
+
+Price range and date range are the same tool with one axis suppressed, and
+they share the readout renderer — one implementation of "how do we phrase a
+move", not three.
+
+The ruler is a **persistent, selectable drawing** like everything else,
+not TradingView's vanishing one-shot. Marina's persistence requirement
+beats the novelty, Rafa gets `Esc` / `Delete`, and one interaction model
+for every tool is worth more than matching one competitor's quirk.
+
+### D6 — Magnet
+
+A rail toggle. When on, a placed anchor snaps to the nearest of the
+open / high / low / close of the bar under the cursor, if that price is
+within a pixel threshold of the pointer. Off by default; the rail button
+shows its state like the repeat pin does.
+
+This is the difference between a line that *looks* drawn off the swing high
+and one that *is*. Every professional platform has it, and price-action
+trading is precisely the discipline that depends on it.
+
+### D7 — Show on all charts
+
+`DrawingScope { ThisChart, AllCharts }` on the drawing, default
+`ThisChart` — today's behaviour is the default, unchanged.
+
+The mechanism, in one sentence: **a shared anchor stores the market
+timestamp captured when it was placed, and every pane reprojects that
+timestamp through its own `slot_at_time`.**
+
+- `ChartPoint` gains the market time of the anchor, captured at placement
+  from the pane's `slot_open_time`. Price needs no translation — it is the
+  same instrument.
+- Panes already answer `slot_at_time(ms) -> Option<usize>` across the
+  history-prefix seam (`pane.rs`), so the projection is one existing call
+  per anchor, not new machinery.
+- A shared drawing lives in a tab-level store every pane of that tab
+  renders; a `ThisChart` drawing stays exactly where it lives today.
+- Toggled from the inspector's **Coordinates** tab, where the anchors
+  already are. The object manager marks shared objects so Marina can see at
+  a glance which marks are global.
+
+**Scope is the panes of one tab — one symbol, one feed.** Sharing across
+tabs would put a BTC line on a WIN chart, and a price level that means
+nothing on the instrument it is drawn over is exactly the "data honesty"
+failure this repo refuses. If cross-symbol sharing is ever wanted it needs
+its own design (percent-anchored levels, or an explicit symbol binding),
+not a wider checkbox.
+
+Honesty at the edges, since a timestamp can fall outside a pane's series:
+
+- Before the first bar or after the last: the anchor projects to the
+  clamped edge slot, and the drawing is painted at reduced alpha with the
+  clamp visible, rather than silently pretending the anchor is on-screen.
+- A pane with no bars yet paints no shared drawings — nothing to anchor to.
+
+---
+
+## 3. Acceptance, in persona terms
+
+- **Rafa** can arm a trend line with `T`, measure a leg in percent with
+  `M`, and never has an inspector land on the candles he is reading.
+- **Marina** draws once on the 5m, ticks *Show on all charts*, and the same
+  line — one version of the truth — appears on the tick pane at the same
+  instant in market time.
+- **Duda** opens the Lines family and reads seven names she recognises,
+  finds "rising / falling channel" by hovering the channel slot, and sees
+  the ruler answer in percent without knowing what a tick is.
+
+---
+
+## 4. What this does not change
+
+The rail chrome contract of `docs/drawing-toolbar-ux.md` stands: geometry,
+docking, badges, stages, the escape stack and the pointer-routing rules are
+unchanged. The registry macro stays the only docking point — every tool in
+D1 is one implementation file plus one name in the list.

--- a/docs/ux/drawing-tools-2026-08.md
+++ b/docs/ux/drawing-tools-2026-08.md
@@ -171,7 +171,28 @@ over.
 Consistency is a feature here, which is why the corner preference is
 ordered and deterministic rather than merely "the emptiest area".
 
-### D4 — The channel says what a trader calls it
+### D4 — The channel is a corridor, not a box
+
+Caught on the running build, after the first version shipped closed: the
+channel drew cross-rail connectors at its anchors, and **a closed
+parallelogram is the visual signature of a rectangle**. Two different tools
+became the same mark — a value zone and a trending corridor read alike at a
+glance, which is precisely the distinction a price-action trader is making.
+
+No professional platform caps a channel. TradingView and MetaTrader both
+draw two parallel lines and nothing else; where the trader anchored it is
+told by the selection handles, which is what handles are for. So the ends
+are open, and the object is exactly three strokes: two rails and the middle
+line.
+
+> **Rafa:** "at a glance I need to know whether that is a zone or a trend
+> with a slope. Closed, they are the same smear."
+
+The geometry now lives in one place (`Channel`) that paint and hit-test both
+read, so the shape and the thing you can click can no longer drift apart —
+the same class of defect as the press/release disagreement in §D8.
+
+### D4b — The channel says what a trader calls it
 
 `ParallelChannelPayload { midline, extend_left, extend_right }`, edited in
 a tool-owned inspector tab (`Channel`), exactly the way the Fib level
@@ -264,6 +285,34 @@ Honesty at the edges, since a timestamp can fall outside a pane's series:
   clamped edge slot, and the drawing is painted at reduced alpha with the
   clamp visible, rather than silently pretending the anchor is on-screen.
 - A pane with no bars yet paints no shared drawings — nothing to anchor to.
+
+### D8 — A click selects what the press grabbed
+
+Also caught on the running build, and the sharpest lesson of the pass.
+
+The pinned inspector is a side panel laid out *before* the central panel, so
+the frame a selection appears is the frame the canvas narrows by the panel's
+width — and with the newest bar pinned to the right edge, every drawing
+slides sideways with it. The press had hit the object on the wide canvas;
+the release re-hit-tested the same screen pixel on the narrow one, found
+empty chart, and deselected. The panel opened and shut in two frames,
+forever, with the mouse standing still.
+
+**Re-deciding on the release was the bug.** A click selects what the press
+resolved, on the geometry the user was looking at when they pressed. One
+resolver — handle first, then body — shared by both, so they cannot answer
+differently.
+
+The general rule this leaves behind: *no gesture may re-measure a world that
+the gesture itself moved.*
+
+### D9 — Selecting is not moving
+
+The move gesture had no drag threshold, so two pixels of hand tremor during
+a click re-angled a channel or shifted a level, and recorded it as an undo
+step. Placement already refused to read a twitch as a drag; moving refuses
+too now, measured from the press so that crossing the threshold hands the
+gesture its whole movement instead of trailing the cursor forever.
 
 ---
 


### PR DESCRIPTION
Seventeen drawing tools where there were five, in a hairline visual
language, with an inspector that stays off the price action, a ruler that
answers in percent, and drawings that can follow the symbol across every
chart of the tab.

Design discussion and every decision on record in
`docs/ux/drawing-tools-2026-08.md` — a session with a UX lead and a
discretionary price-action trader against the shipped build, then a second
pass driven by a trader using the branch live. **Ten of the fixes below
came out of that second pass**, and they are the ones that matter most:
they are the things a test suite cannot ask.

## What was actually wrong

The rail chrome was redesigned well ahead of the toolbox it holds, and the
toolbox never caught up. **There was no trend line at all.** No ruler. The
marks were 1.5 px with a halo over 3–6 px candle bodies. The inspector
scored "least overlap with the object's bounding box", so a small object
scored zero at 12 px away and the panel landed on the exact candles the
trader drew the line to read. And `ChartPoint` anchors a bar *index*, which
is local to a pane — so a line drawn on the 5m simply cannot exist on the
tick chart, and you end up with two slightly different lines and no way to
tell which is the real one.

## The toolbox

Each tool is one implementation file plus one name in the registry, through
the extension port that already existed. No central match anywhere.

| Family | Tools |
| --- | --- |
| Lines | trend line `T`, ray `Shift+T`, extended line, horizontal line `H`, horizontal ray, vertical line `V`, arrow |
| Channels | parallel channel `C`, with a middle line and extend left / right |
| Shapes | rectangle `R`, ellipse, triangle |
| Fib | retracement `F`, extension `Shift+F` |
| Measure | ruler `M`, price range, date range |
| Text | note `A` |

- **Hairline defaults**: stroke 1.5 → 1.0 px, fill alpha 24 → 14, hollow
  ring handles instead of white discs, a quieter selection halo. The width
  slider keeps its full 0.5–6.0 range; existing drawings keep their width.
- **Ruler**: points, **percent**, bars and elapsed time in one readout,
  coloured by direction. Price range and date range are the same tool with
  one axis suppressed, sharing the readout renderer.
- **Inspector placement**: the farthest clear *chart corner*, top corners
  first. Top before bottom is structural — a panel is positioned by its
  top-left and grows downwards, and placement runs before the real height
  is known, so a bottom anchor runs a tall tool off the window.
- **Magnet**: a rail toggle snapping anchors to the bar's OHLC within
  12 px. Off by default.
- **Saved defaults**: colour, width and fill can be saved as the default for
  one tool or for every tool, from the Style tab that every tool has. The
  preset file already persisted per tool; it just never carried the style,
  and the preset UI only ever existed on the Fib tab.
- **Show on all charts**: `DrawingScope` on the drawing, `time_ms` on the
  anchor. Bar indices are pane-local, market time is not, so every pane
  reprojects a shared anchor through its own `slot_at_time`.

## What the live pass found

Everything here was reported by a trader using the branch, and every one is
a defect a green suite was happy with.

1. **The panel flickered open and shut on every click.** The pinned
   inspector is a `SidePanel::right` laid out *before* the central panel, so
   the frame a selection appears is the frame the canvas narrows by the
   panel's width — and with the newest bar pinned to the right edge, every
   drawing slides ~320 px left with it. The press hit on the wide canvas;
   the release re-hit-tested the same screen pixel on the narrow one, found
   empty chart, and deselected. **A click now selects what the press
   grabbed**, on the geometry the user was looking at when they pressed. The
   general rule it leaves behind: *no gesture may re-measure a world that
   the gesture itself moved.*
2. **Selecting was moving.** No drag threshold on the move gesture, so two
   pixels of tremor during a click re-angled a channel and recorded it as an
   undo step. Proven by disabling the threshold: a 3 px twitch moved the
   object 0.375 of a bar.
3. **The channel was a closed box.** Cross-rail connectors at the anchors
   made it read as a rectangle — the one distinction a price-action trader
   is actually making. Open at both ends now, and the geometry lives in one
   `Channel` that paint and hit-test both read.
4. **The Fib retracement was mirrored.** 0 % sat at the first anchor, so a
   fall drawn top-down showed 61.8 % near the low. A retracement measures
   what price *gave back*: 0 % at the end of the move, 100 % where it
   started. Fixed in the linear and the log formula, with both asserted to
   share endpoints so switching the scale cannot rename the levels.
5. **Fib levels projected backwards.** The default drew them between the
   anchors, so an extension's targets sat to the *left* of the leg
   projecting them. The default is now `From the last point`: the newest
   anchor to the right edge — newest, not last placed, so a Fib drawn
   right-to-left means the same thing.
6. **"Show on all charts" was unfindable.** It sat on the Coordinates tab
   because sharing is a statement about the anchors — the implementer's
   mental model, not the trader's. It is in the always-visible block now.
7. **An anchor past the newest bar could not be shared.** Traders draw there
   constantly. On a *time* chart that space has an exact clock, so the
   anchor gets a real timestamp; on a tick chart no elapsed time can be
   named, so it stays refused with the reason on the control.
8. **A three-anchor tool looked frozen.** It was waiting for a click nobody
   announced except a `2/3` badge on the far side of the screen. Tools now
   declare what the next click does, printed beside the cursor.
9. **The floating panel could not be scrolled.** A tall tool was cut at the
   window edge — and the control out of reach was the Fib's own `extend`.
10. **Drawings ran across the live lane.** Placement already refused to
    anchor there, but paint and hit-test used the whole chart rect, so a
    line was drawn over the tape and its painted end was not its grabbable
    end. One `drawing_area` band now feeds all three.

Two smaller ones from the visual pass: the text note's Style tab offered a
line-width slider for an object with no stroke (`supports_stroke_width`
joins `supports_fill` on the port), and the demo hook packed its objects
into slivers no screenshot could read.

## Data honesty

- **No tick count in the ruler.** It needs a tick size several feeds never
  declare; a figure from a guessed step would be a made-up number on a
  panel whose whole job is to be exact.
- **An anchor with no market time cannot be shared**, and the control says
  why instead of guessing one.
- **A shared anchor this pane's series cannot reach is faded**, not snapped
  silently to the edge — and only a *closed* bar that ended before the
  anchor's instant proves that, because a time inside the forming bar is
  simply now.
- **A hand-broken colour in the preset file is no default** rather than a
  silently different one; out-of-range widths are clamped to what the
  sliders can represent.

Scope stops at the tab: one symbol, one feed. A BTC level on a WIN chart
would mean nothing.

## Performance

| Path | Rate | Impact |
| --- | --- | --- |
| Trade ingest, aggregator | per trade | untouched |
| Book / depth | per depth update | untouched |
| `draw_drawings` | per frame, O(objects) | more tools, same shape; no allocation added |
| `paint_shared_from` | per frame, O(objects) | early-returns on `!any(shared)`; then one `slot_at_time` (binary search) per anchor per pane, anchors on the stack |
| Magnet | per pointer sample while a tool is armed | one bar lookup, four comparisons |
| Rail | per frame, O(1) | two more family slots + the magnet button |

Measured on a live Binance BTCUSDT tape, same build, same box, 20 samples
each (`APP_HEALTH_SUMMARY` now reports `drawings` / `shared_drawings` so
the reading can be attributed):

| Run | drawings | `frame_cpu_ms` mean | max |
| --- | --- | --- | --- |
| control | 0 | **1.447** | 1.505 |
| demo | 17 (all shared) | **1.567** | 1.670 |

**+0.12 ms/frame for 17 objects — about 7 µs each, 0.7 % of a 60 Hz
budget.** Re-checked on a live desktop where the compositor is not the
limit: **60 fps, 16.7 ms/frame, `cpu 2.2 ms`** with all 17 on the chart.

Two allocations this branch introduced were found and removed by the
arch-review pass: a `Vec<Pos2>` per shared object per frame (now a
`SmallVec`) and a full payload clone per frame in the text tool's paint and
hit-test (now borrowed).

## Blast radius

15 files added, 8 edited (`app.rs`, `pane.rs`, `tab.rs`, `toolrail.rs`,
`drawings/mod.rs`, and three existing tools joining families). Twelve of
the thirteen new tools cost exactly one file and one registry line;
`DrawingScope` is what reaches into `pane.rs` and `tab.rs`, because
cross-pane projection is inherently a pane-and-tab concern.

Defaults preserve today's behaviour where they can: every object opens
`ThisChart`, the magnet opens off, channel extensions open off. Three
defaults *do* change what an existing object looks like, each deliberate
and each a correction rather than a preference: the channel's middle line,
the Fib projection direction, and the Fib retracement orientation.

## Tests

1305 green. Beyond one per tool:

- **The port, not just the features**: `every_toolbox_drawing_can_be_plotted_on_the_chart`
  is registry-driven, so a tool registered without a rail path fails on the
  day it is added instead of shipping unreachable. The same harness caught
  the Fib probes when the projection moved.
- The flicker, pinned to its *mechanism*: the test asserts the canvas really
  does narrow between press and release, so it cannot quietly stop testing
  anything.
- The drag threshold, verified by disabling it and watching the twitch move
  the object.
- A channel has no segment running across its rails, and is exactly three
  strokes with the middle line and two without.
- The retracement's linear and log formulas share endpoints.
- Sharing adds strokes on the other pane and unsharing takes them away.
- A saved default reaches the next drawing and only that one.
- The Fib level editor's last row is reachable — the test scrolls to it.

## arch-review

Run over `git diff main...HEAD`. Two performance findings against this
branch's own code, both fixed in `60f664e`. No blockers outstanding.

## visual-qa

PASS on a live desktop, `QUANTICK_DRAWINGS_DEMO=1` (see the hooks
registered in `.claude/skills/ui-harness`). Every family renders, the ruler
shows points and percent, the marks read *under* the candles, the inspector
opens clear of the selection. Cross-pane sharing verified with the split:
the same object reading **"3 bars 3m 15s"** on the 1m and **"22 bars 3m
15s"** on the tick chart — same market time, different bar counts, which is
the whole point.

Not confirmed by pixel, and reported as test-verified only: the channel's
dashed middle line, which I would not assert at that size.

## Open, for a following session

- **Drawing inside an indicator pane (CVD and friends).** Raised at the end
  of the live pass and deliberately not guessed at: each pane has its own
  value scale, so it needs its own anchor space and projection. It is a
  capability, not a clipping fix — drawings already stop at the candles.
- **Foreign shared marks are read-only** on the pane that borrows them.
  Selection and dragging belong to the pane the object was drawn on; a mark
  grabbable in two places would be two versions of one object.
- **The ruler persists** like every other drawing rather than vanishing the
  way TradingView's does. One interaction model for every tool.
- Pitchfork, regression channel, Gann, Elliott, harmonics, and the
  long/short position tool (the paper-trading order UI already owns entry /
  stop / target on the chart).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
