### PR TITLE
feat(app): the indicator band holds up in a small window

### DIFF
--- a/.claude/skills/ui-harness/SKILL.md
+++ b/.claude/skills/ui-harness/SKILL.md
@@ -25,6 +25,7 @@ is the source of truth, this table is the index):
 | --- | --- |
 | `QUANTICK_CONFIG=<toml>` | full feed/symbol config override (use a scratchpad toml; **never** edit the user's root `quantick.toml`) |
 | `QUANTICK_DEFAULT_FEED` / `QUANTICK_DEFAULT_SYMBOL` | startup feed/symbol |
+| `QUANTICK_WINDOW_SIZE=WxH` | the size the window opens at, floored at the app's own 900x560 minimum. Window size decides whether the indicator band has room for its panes and the time axis for its labels, so without this that whole class of defect is invisible to anything but a human dragging a corner. With it plus `QUANTICK_INDICATORS_AUTOSTART`, the collapsed-pane strip is reachable from a fresh launch. |
 | `QUANTICK_BOOK_AUTOSTART=1` | L2 heatmap layer |
 | `QUANTICK_LIVE_STRIP_AUTOSTART=1` | live strip |
 | `QUANTICK_BUBBLES_AUTOSTART=1` | aggression layer (bubbles + live-column footprint) |

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -181,17 +181,23 @@ const STYLE_LOG_DEBOUNCE: Duration = Duration::from_millis(350);
 /// `live_strip_width` of zero means the strip is off and the chart runs
 /// straight into the gutter, exactly as it did before the strip existed.
 ///
-/// `pane_count` is the number of *visible* pane indicators: the band they
-/// claim is carved here, once, rather than by each caller — a chart rect that
-/// two call sites disagree about is two price scales for the same pixels.
-pub fn plot_split(area: egui::Rect, live_strip_width: f32, pane_count: usize) -> PlotAreas {
+/// `pane_sizing` carries one entry per *visible* pane indicator, top to
+/// bottom: the band they claim is carved here, once, rather than by each
+/// caller — a chart rect that two call sites disagree about is two price
+/// scales for the same pixels. Sizing rather than a count, because how tall a
+/// pane is and whether it has room to be drawn at all is the same decision.
+pub fn plot_split(
+    area: egui::Rect,
+    live_strip_width: f32,
+    pane_sizing: &[crate::indicators::PaneSizing],
+) -> PlotAreas {
     let plot = area.shrink(16.0);
     let strip_width = live_strip_width.max(0.0);
     let gutter_x = (plot.right() - AXIS_GUTTER).max(plot.left() + 20.0);
     let split_x = (gutter_x - strip_width).max(plot.left() + 20.0);
     let split_y = (plot.bottom() - TIME_STRIP).max(plot.top() + 20.0);
     let body = egui::Rect::from_min_max(plot.min, egui::pos2(split_x, split_y));
-    let (chart, indicator_panes) = crate::indicators::split_panes(body, pane_count);
+    let (chart, indicator_panes) = crate::indicators::split_panes(body, pane_sizing);
     // The gutter is banded exactly like the body it labels: the candles' price
     // scale owns the height of the candles and not a pixel more, so a drag
     // over a pane's numbers can only ever move that pane.
@@ -200,7 +206,7 @@ pub fn plot_split(area: egui::Rect, live_strip_width: f32, pane_count: usize) ->
     };
     let pane_gutters = indicator_panes
         .iter()
-        .map(|pane| band(pane.top(), pane.bottom()))
+        .map(|pane| band(pane.rect.top(), pane.rect.bottom()))
         .collect();
     PlotAreas {
         chart,
@@ -319,7 +325,7 @@ pub struct PlotAreas {
     pub chart: egui::Rect,
     /// Stacked indicator panes below the candles, top to bottom. Empty when
     /// no pane indicator is visible.
-    pub indicator_panes: Vec<egui::Rect>,
+    pub indicator_panes: Vec<crate::indicators::PaneSlot>,
     /// The gutter band beside each pane, in the same order: where that pane's
     /// value labels are drawn and where its own zoom gesture lives.
     pub pane_gutters: Vec<egui::Rect>,
@@ -358,10 +364,15 @@ pub fn fmt_window(milliseconds: i64) -> String {
 /// Format a UTC epoch-millisecond timestamp as `HH:MM:SS` in the display
 /// timezone `tz`, for the time axis.
 pub fn fmt_time(ms: i64, tz: TzOffset) -> String {
+    fmt_time_as(ms, tz, crate::chart::TimeLabelFormat::Full)
+}
+
+/// The same instant written in a chosen [`TimeLabelFormat`] — what the time
+/// axis calls when the strip is too narrow for the full form.
+pub fn fmt_time_as(ms: i64, tz: TzOffset, format: crate::chart::TimeLabelFormat) -> String {
     let local = ms.saturating_add(tz.offset_ms());
     let secs = local.div_euclid(1000).rem_euclid(86_400);
-    let (h, m, s) = (secs / 3600, (secs % 3600) / 60, secs % 60);
-    format!("{h:02}:{m:02}:{s:02}")
+    format.write(secs / 3600, (secs % 3600) / 60, secs % 60)
 }
 
 /// The quantick chart window.
@@ -3737,11 +3748,15 @@ mod tests {
     fn the_live_strip_carves_between_chart_and_gutter_only_when_shown() {
         let area = egui::Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(1000.0, 600.0));
 
-        let off = plot_split(area, 0.0, 0);
+        let off = plot_split(area, 0.0, &[crate::indicators::PaneSizing::Auto; 0]);
         assert!(off.live_strip.is_none());
         assert_eq!(off.chart.right(), off.price_gutter.left());
 
-        let on = plot_split(area, crate::live_strip::LIVE_STRIP_WIDTH_PX, 0);
+        let on = plot_split(
+            area,
+            crate::live_strip::LIVE_STRIP_WIDTH_PX,
+            &[crate::indicators::PaneSizing::Auto; 0],
+        );
         let strip = on.live_strip.expect("strip rect");
         assert_eq!(on.chart.right(), strip.left());
         assert_eq!(strip.right(), on.price_gutter.left());
@@ -3765,10 +3780,10 @@ mod tests {
     fn the_pane_band_comes_out_of_every_callers_chart_rect() {
         let area = egui::Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(1000.0, 600.0));
 
-        let none = plot_split(area, 0.0, 0);
+        let none = plot_split(area, 0.0, &[crate::indicators::PaneSizing::Auto; 0]);
         assert!(none.indicator_panes.is_empty());
 
-        let one = plot_split(area, 0.0, 1);
+        let one = plot_split(area, 0.0, &[crate::indicators::PaneSizing::Auto; 1]);
         let pane = *one
             .indicator_panes
             .first()
@@ -3777,14 +3792,14 @@ mod tests {
             one.chart.height() < none.chart.height(),
             "the band is paid for out of the candles' pixels"
         );
-        assert_eq!(one.chart.bottom(), pane.top(), "no gap, no overlap");
-        assert_eq!(pane.bottom(), none.chart.bottom());
+        assert_eq!(one.chart.bottom(), pane.rect.top(), "no gap, no overlap");
+        assert_eq!(pane.rect.bottom(), none.chart.bottom());
         assert_eq!(one.chart.width(), none.chart.width());
         // The axes keep their column; the time strip is untouched.
         assert_eq!(one.price_gutter.x_range(), none.price_gutter.x_range());
         assert_eq!(one.time_strip, none.time_strip);
 
-        let three = plot_split(area, 0.0, 3);
+        let three = plot_split(area, 0.0, &[crate::indicators::PaneSizing::Auto; 3]);
         assert_eq!(three.indicator_panes.len(), 3);
         assert!(three.chart.height() < one.chart.height());
     }
@@ -3797,7 +3812,7 @@ mod tests {
     fn every_pane_owns_the_gutter_band_beside_it() {
         let area = egui::Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(1000.0, 600.0));
 
-        let none = plot_split(area, 0.0, 0);
+        let none = plot_split(area, 0.0, &[crate::indicators::PaneSizing::Auto; 0]);
         assert!(none.pane_gutters.is_empty());
         assert_eq!(
             none.price_gutter.bottom(),
@@ -3805,7 +3820,7 @@ mod tests {
             "with no pane the gutter is the candles', top to bottom"
         );
 
-        let two = plot_split(area, 0.0, 2);
+        let two = plot_split(area, 0.0, &[crate::indicators::PaneSizing::Auto; 2]);
         assert_eq!(two.pane_gutters.len(), two.indicator_panes.len());
         assert_eq!(
             two.price_gutter.bottom(),
@@ -3813,7 +3828,11 @@ mod tests {
             "the candles' scale stops where the candles do"
         );
         for (pane, gutter) in two.indicator_panes.iter().zip(&two.pane_gutters) {
-            assert_eq!(gutter.y_range(), pane.y_range(), "band beside its pane");
+            assert_eq!(
+                gutter.y_range(),
+                pane.rect.y_range(),
+                "band beside its pane"
+            );
             assert_eq!(gutter.x_range(), two.price_gutter.x_range(), "one column");
         }
         // No pixel answers to two scales: the bands tile the gutter exactly.
@@ -3822,7 +3841,11 @@ mod tests {
 
         // The strip pays out of the candles, not the gutter: the pane bands
         // keep the same column when the tape is shown.
-        let with_strip = plot_split(area, crate::live_strip::LIVE_STRIP_WIDTH_PX, 2);
+        let with_strip = plot_split(
+            area,
+            crate::live_strip::LIVE_STRIP_WIDTH_PX,
+            &[crate::indicators::PaneSizing::Auto; 2],
+        );
         assert_eq!(with_strip.pane_gutters, two.pane_gutters);
     }
 
@@ -3898,7 +3921,7 @@ mod tests {
         let areas = plot_split(
             pane.last_plot_area.expect("a frame has been drawn"),
             pane.live_strip_width(),
-            pane.indicators.visible_panes().count(),
+            &pane.indicators.pane_sizing(),
         );
         areas.pane_gutters[index]
     }
@@ -3910,9 +3933,9 @@ mod tests {
         let areas = plot_split(
             pane.last_plot_area.expect("a frame has been drawn"),
             pane.live_strip_width(),
-            pane.indicators.visible_panes().count(),
+            &pane.indicators.pane_sizing(),
         );
-        areas.indicator_panes[index]
+        areas.indicator_panes[index].rect
     }
 
     /// The bar the viewport has at its right edge — how far the chart is
@@ -3920,6 +3943,139 @@ mod tests {
     fn right_edge(app: &QuantickApp) -> f32 {
         let pane = &app.active_tab().flow_pane;
         pane.viewport.right_edge_bar(pane.slots())
+    }
+
+    /// The pane band as the last drawn frame carved it.
+    fn pane_slots(app: &QuantickApp) -> Vec<crate::indicators::PaneSlot> {
+        let pane = &app.active_tab().flow_pane;
+        plot_split(
+            pane.last_plot_area.expect("a frame has been drawn"),
+            pane.live_strip_width(),
+            &pane.indicators.pane_sizing(),
+        )
+        .indicator_panes
+    }
+
+    /// An app showing every pane it allows, drawn once at `size`.
+    fn app_with_full_pane_band(
+        ctx: &egui::Context,
+        size: egui::Vec2,
+    ) -> (QuantickApp, mpsc::Receiver<FeedCommand>) {
+        let (mut app, cmd_rx) = app_with_history(200);
+        for index in 0..crate::indicators::MAX_PANES {
+            add_pane_indicator(
+                &mut app,
+                &format!("pane{index}"),
+                (0..200).map(f64::from).collect(),
+            );
+        }
+        run_frame_at(&mut app, ctx, size);
+        (app, cmd_rx)
+    }
+
+    /// The whole point of collapsing: a strip is not a dead band. One click on
+    /// it brings the curve back, and it must survive the frame after — the
+    /// automatic rule is what collapsed the pane, so handing the pane back to
+    /// it would undo the click immediately.
+    /// Three panes in the smallest window the app allows: the state the user
+    /// reported as unusable. Something must collapse — that is the point — and
+    /// nothing that stays open may be below the readable floor.
+    #[test]
+    fn the_smallest_window_collapses_rather_than_squeezing_every_pane() {
+        let ctx = egui::Context::default();
+        let (app, _cmd_rx) = app_with_full_pane_band(&ctx, MIN_WINDOW);
+
+        let panes = pane_slots(&app);
+        assert_eq!(panes.len(), crate::indicators::MAX_PANES);
+        assert!(
+            panes.iter().any(|pane| pane.collapsed),
+            "the smallest window cannot hold three readable panes: {panes:?}"
+        );
+        for pane in &panes {
+            assert!(
+                pane.collapsed || pane.rect.height() >= crate::indicators::MIN_PANE_HEIGHT_PX,
+                "an expanded pane below the readable floor: {pane:?}"
+            );
+        }
+    }
+
+    /// The same band in a roomy window: nothing collapses, so the floor never
+    /// costs a user with a big screen anything.
+    #[test]
+    fn a_roomy_window_draws_every_pane() {
+        let ctx = egui::Context::default();
+        let (app, _cmd_rx) = app_with_full_pane_band(&ctx, TEST_WINDOW);
+        assert!(
+            pane_slots(&app).iter().all(|pane| !pane.collapsed),
+            "a tall window has room for all of them: {:?}",
+            pane_slots(&app)
+        );
+    }
+
+    /// The whole point of collapsing: a strip is not a dead band. One click on
+    /// it brings the curve back, and it must survive the frame after — the
+    /// automatic rule is what collapsed the pane, so handing the pane back to
+    /// it would undo the click immediately.
+    #[test]
+    fn clicking_a_collapsed_strip_opens_it_and_it_stays_open() {
+        let ctx = egui::Context::default();
+        let (mut app, _cmd_rx) = app_with_full_pane_band(&ctx, MIN_WINDOW);
+
+        let collapsed = pane_slots(&app)
+            .iter()
+            .position(|pane| pane.collapsed)
+            .expect("the smallest window collapses at least one pane");
+
+        let strip = pane_slots(&app)[collapsed].rect;
+        click_sized(&mut app, &ctx, MIN_WINDOW, strip.center());
+        run_frame_at(&mut app, &ctx, MIN_WINDOW);
+        assert!(
+            !pane_slots(&app)[collapsed].collapsed,
+            "one click opens the strip"
+        );
+
+        run_frame_at(&mut app, &ctx, MIN_WINDOW);
+        assert!(
+            !pane_slots(&app)[collapsed].collapsed,
+            "and it is still open a frame later, not re-collapsed by the layout"
+        );
+    }
+
+    /// The other half of the disclosure. A control that only opens is half a
+    /// control: a trader who wants the candles back must be able to put a pane
+    /// away without deleting the indicator, and the value must survive it.
+    #[test]
+    fn the_disclosure_closes_a_pane_as_well_as_opening_it() {
+        let ctx = egui::Context::default();
+        let (mut app, _cmd_rx) = app_with_full_pane_band(&ctx, TEST_WINDOW);
+        assert!(
+            pane_slots(&app).iter().all(|pane| !pane.collapsed),
+            "the roomy window starts with every pane open"
+        );
+
+        let corner = crate::indicator_render::pane_disclosure_rect(pane_slots(&app)[0].rect, false);
+        click_sized(&mut app, &ctx, TEST_WINDOW, corner.center());
+        run_frame_at(&mut app, &ctx, TEST_WINDOW);
+        assert!(
+            pane_slots(&app)[0].collapsed,
+            "clicking the open disclosure puts the pane away"
+        );
+        assert!(
+            !pane_slots(&app)[1].collapsed,
+            "and only that pane: the click was over one corner"
+        );
+
+        // Room is not what is keeping it shut, so it stays shut.
+        run_frame_at(&mut app, &ctx, TEST_WINDOW);
+        assert!(pane_slots(&app)[0].collapsed, "a hand-closed pane stays shut");
+
+        let strip = pane_slots(&app)[0].rect;
+        click_sized(&mut app, &ctx, TEST_WINDOW, strip.center());
+        run_frame_at(&mut app, &ctx, TEST_WINDOW);
+        assert!(
+            !pane_slots(&app)[0].collapsed,
+            "and the same control brings it back"
+        );
     }
 
     /// A pane body is a piece of the chart, so the chart's own gestures have
@@ -4097,7 +4253,7 @@ mod tests {
             plot_split(
                 pane.last_plot_area.expect("a frame has been drawn"),
                 pane.live_strip_width(),
-                1,
+                &pane.indicators.pane_sizing(),
             )
             .price_gutter
         };
@@ -5939,22 +6095,44 @@ plot(close)
         run_frame_with_modifiers(app, ctx, events, egui::Modifiers::NONE)
     }
 
+    /// The window every frame-driving test gets unless it asks for another:
+    /// roomy, so a test about something else is never accidentally a test
+    /// about a cramped layout.
+    const TEST_WINDOW: egui::Vec2 = egui::vec2(1400.0, 900.0);
+    /// The smallest window the app itself allows (`main.rs`
+    /// `with_min_inner_size`). The layout has to hold here, and this is where
+    /// the pane band is under real pressure.
+    const MIN_WINDOW: egui::Vec2 = egui::vec2(900.0, 560.0);
+
     fn run_frame_with_modifiers(
         app: &mut QuantickApp,
         ctx: &egui::Context,
         events: Vec<egui::Event>,
         modifiers: egui::Modifiers,
     ) -> egui::FullOutput {
+        run_frame_sized(app, ctx, TEST_WINDOW, events, modifiers)
+    }
+
+    /// A frame at a chosen window size — how a test reaches the layout a
+    /// smaller window produces without resizing anything global.
+    fn run_frame_sized(
+        app: &mut QuantickApp,
+        ctx: &egui::Context,
+        size: egui::Vec2,
+        events: Vec<egui::Event>,
+        modifiers: egui::Modifiers,
+    ) -> egui::FullOutput {
         let input = egui::RawInput {
-            screen_rect: Some(egui::Rect::from_min_size(
-                egui::pos2(0.0, 0.0),
-                egui::vec2(1400.0, 900.0),
-            )),
+            screen_rect: Some(egui::Rect::from_min_size(egui::pos2(0.0, 0.0), size)),
             events,
             modifiers,
             ..Default::default()
         };
         ctx.run(input, |ctx| app.draw_frame(ctx, Instant::now()))
+    }
+
+    fn run_frame_at(app: &mut QuantickApp, ctx: &egui::Context, size: egui::Vec2) {
+        run_frame_sized(app, ctx, size, Vec::new(), egui::Modifiers::NONE);
     }
 
     fn pointer_button(position: egui::Pos2, pressed: bool) -> egui::Event {
@@ -6501,12 +6679,7 @@ plot(close)
         size: egui::Vec2,
         events: Vec<egui::Event>,
     ) -> egui::FullOutput {
-        let input = egui::RawInput {
-            screen_rect: Some(egui::Rect::from_min_size(egui::Pos2::ZERO, size)),
-            events,
-            ..Default::default()
-        };
-        ctx.run(input, |ctx| app.draw_frame(ctx, Instant::now()))
+        run_frame_sized(app, ctx, size, events, egui::Modifiers::NONE)
     }
 
     fn click_sized(

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -4041,6 +4041,90 @@ mod tests {
         );
     }
 
+    /// Drag a pane's top edge and that pane resizes — the grammar the canvas
+    /// split and the live lane already use, on the one band in the app that
+    /// did not have it. Dragging up grows the pane into the chart.
+    #[test]
+    fn dragging_a_panes_top_edge_resizes_that_pane() {
+        let ctx = egui::Context::default();
+        let (mut app, _cmd_rx) = app_with_full_pane_band(&ctx, TEST_WINDOW);
+
+        let before = pane_slots(&app)[0].rect.height();
+        let edge = pane_slots(&app)[0].rect.center_top();
+        drag_sized(
+            &mut app,
+            &ctx,
+            TEST_WINDOW,
+            edge,
+            edge - egui::vec2(0.0, 40.0),
+        );
+        run_frame_at(&mut app, &ctx, TEST_WINDOW);
+
+        let after = pane_slots(&app)[0].rect.height();
+        assert!(
+            after > before,
+            "dragging the edge up grows the pane: {before} -> {after}"
+        );
+    }
+
+    /// The floor holds during a drag too: a divider stops rather than
+    /// producing a pane too short to read. Anything else would hand the user a
+    /// way to recreate exactly the state this branch exists to prevent.
+    #[test]
+    fn a_divider_cannot_be_dragged_past_the_readable_floor() {
+        let ctx = egui::Context::default();
+        let (mut app, _cmd_rx) = app_with_full_pane_band(&ctx, TEST_WINDOW);
+
+        let edge = pane_slots(&app)[0].rect.center_top();
+        drag_sized(
+            &mut app,
+            &ctx,
+            TEST_WINDOW,
+            edge,
+            edge + egui::vec2(0.0, 400.0),
+        );
+        run_frame_at(&mut app, &ctx, TEST_WINDOW);
+
+        let pane = pane_slots(&app)[0];
+        assert!(
+            pane.collapsed || pane.rect.height() >= crate::indicators::MIN_PANE_HEIGHT_PX,
+            "a drag cannot squeeze a pane below the floor: {pane:?}"
+        );
+    }
+
+    /// Double click on a divider gives the pane back to the automatic layout —
+    /// the escape every other axis in the app offers on the same gesture.
+    #[test]
+    fn double_clicking_a_divider_returns_the_pane_to_automatic() {
+        let ctx = egui::Context::default();
+        let (mut app, _cmd_rx) = app_with_full_pane_band(&ctx, TEST_WINDOW);
+
+        let automatic = pane_slots(&app)[0].rect.height();
+        let edge = pane_slots(&app)[0].rect.center_top();
+        drag_sized(
+            &mut app,
+            &ctx,
+            TEST_WINDOW,
+            edge,
+            edge - egui::vec2(0.0, 60.0),
+        );
+        run_frame_at(&mut app, &ctx, TEST_WINDOW);
+        assert!(
+            (pane_slots(&app)[0].rect.height() - automatic).abs() > 1.0,
+            "the drag took manual control"
+        );
+
+        let edge = pane_slots(&app)[0].rect.center_top();
+        click_sized(&mut app, &ctx, TEST_WINDOW, edge);
+        click_sized(&mut app, &ctx, TEST_WINDOW, edge);
+        run_frame_at(&mut app, &ctx, TEST_WINDOW);
+        assert!(
+            (pane_slots(&app)[0].rect.height() - automatic).abs() < 1.0,
+            "and a double click hands it back: {} vs {automatic}",
+            pane_slots(&app)[0].rect.height()
+        );
+    }
+
     /// The other half of the disclosure. A control that only opens is half a
     /// control: a trader who wants the candles back must be able to put a pane
     /// away without deleting the indicator, and the value must survive it.
@@ -6132,6 +6216,40 @@ plot(close)
             ..Default::default()
         };
         ctx.run(input, |ctx| app.draw_frame(ctx, Instant::now()))
+    }
+
+    /// A press-drag-release in a window of `size`.
+    fn drag_sized(
+        app: &mut QuantickApp,
+        ctx: &egui::Context,
+        size: egui::Vec2,
+        start: egui::Pos2,
+        end: egui::Pos2,
+    ) {
+        run_frame_sized(
+            app,
+            ctx,
+            size,
+            vec![
+                egui::Event::PointerMoved(start),
+                pointer_button(start, true),
+            ],
+            egui::Modifiers::NONE,
+        );
+        run_frame_sized(
+            app,
+            ctx,
+            size,
+            vec![egui::Event::PointerMoved(end)],
+            egui::Modifiers::NONE,
+        );
+        run_frame_sized(
+            app,
+            ctx,
+            size,
+            vec![egui::Event::PointerMoved(end), pointer_button(end, false)],
+            egui::Modifiers::NONE,
+        );
     }
 
     fn run_frame_at(app: &mut QuantickApp, ctx: &egui::Context, size: egui::Vec2) {

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -3921,7 +3921,9 @@ mod tests {
         let areas = plot_split(
             pane.last_plot_area.expect("a frame has been drawn"),
             pane.live_strip_width(),
-            &pane.indicators.pane_sizing(),
+            pane.indicators.pane_sizing(
+                &mut [crate::indicators::PaneSizing::Auto; crate::indicators::MAX_PANES],
+            ),
         );
         areas.pane_gutters[index]
     }
@@ -3933,7 +3935,9 @@ mod tests {
         let areas = plot_split(
             pane.last_plot_area.expect("a frame has been drawn"),
             pane.live_strip_width(),
-            &pane.indicators.pane_sizing(),
+            pane.indicators.pane_sizing(
+                &mut [crate::indicators::PaneSizing::Auto; crate::indicators::MAX_PANES],
+            ),
         );
         areas.indicator_panes[index].rect
     }
@@ -3951,7 +3955,9 @@ mod tests {
         plot_split(
             pane.last_plot_area.expect("a frame has been drawn"),
             pane.live_strip_width(),
-            &pane.indicators.pane_sizing(),
+            pane.indicators.pane_sizing(
+                &mut [crate::indicators::PaneSizing::Auto; crate::indicators::MAX_PANES],
+            ),
         )
         .indicator_panes
     }
@@ -4340,7 +4346,9 @@ mod tests {
             plot_split(
                 pane.last_plot_area.expect("a frame has been drawn"),
                 pane.live_strip_width(),
-                &pane.indicators.pane_sizing(),
+                pane.indicators.pane_sizing(
+                    &mut [crate::indicators::PaneSizing::Auto; crate::indicators::MAX_PANES],
+                ),
             )
             .price_gutter
         };

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -4067,7 +4067,10 @@ mod tests {
 
         // Room is not what is keeping it shut, so it stays shut.
         run_frame_at(&mut app, &ctx, TEST_WINDOW);
-        assert!(pane_slots(&app)[0].collapsed, "a hand-closed pane stays shut");
+        assert!(
+            pane_slots(&app)[0].collapsed,
+            "a hand-closed pane stays shut"
+        );
 
         let strip = pane_slots(&app)[0].rect;
         click_sized(&mut app, &ctx, TEST_WINDOW, strip.center());

--- a/crates/app/src/chart.rs
+++ b/crates/app/src/chart.rs
@@ -340,6 +340,134 @@ const AXIS_LABEL_MIN_GAP_PX: f32 = 18.0;
 /// Same spellings as the aggression bubbles' own `format_quantity`: one chart,
 /// one way to write a thousand.
 const AXIS_UNITS: [(f64, &str); 3] = [(1e9, "B"), (1e6, "M"), (1e3, "K")];
+/// Least horizontal room between two time labels, in pixels.
+///
+/// The horizontal twin of [`AXIS_LABEL_MIN_GAP_PX`]. Smaller than it because a
+/// time label is read as one word and its neighbours are far apart in bars;
+/// the price column is read as a column and needs more air.
+const TIME_LABEL_MIN_GAP_PX: f32 = 12.0;
+/// Comfortable distance between two time labels, in pixels.
+///
+/// The ask, as [`AXIS_LABEL_SPACING_PX`] is for price: a label roughly this
+/// far apart reads as a scale rather than as a ribbon of numbers. It is a
+/// floor on the spacing, never a cap — the collision rule can only push
+/// labels further apart.
+const TIME_LABEL_SPACING_PX: f32 = 110.0;
+/// Fewest time labels a strip is worth writing at a given format. Below two
+/// there is no scale to read, only an instant floating in a band — and that is
+/// the signal to write the same axis in a shorter format instead.
+const TIME_MIN_LABELS: usize = 2;
+/// Time label font size, in pixels.
+pub const TIME_LABEL_FONT_PX: f32 = 10.0;
+
+/// How a time label is written, longest first.
+///
+/// Dropping seconds is the time axis' version of the price axis' `1.2M`: the
+/// same instant, written coarser, so the axis stays a scale on a strip too
+/// narrow for the full form. It is never the *labels* that are dropped to make
+/// room — thinning already guarantees they cannot collide; this is what keeps
+/// a narrow strip from being reduced to one lonely timestamp.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TimeLabelFormat {
+    /// `HH:MM:SS` — the full instant.
+    Full,
+    /// `HH:MM` — seconds dropped.
+    Short,
+}
+
+impl TimeLabelFormat {
+    /// Longest first: the axis takes the first one that fits.
+    pub const ALL: [Self; 2] = [Self::Full, Self::Short];
+
+    /// A representative string of this format's exact width. Monospace, so
+    /// every instant written this way measures the same — one measurement per
+    /// frame answers for every label on the strip.
+    #[must_use]
+    pub fn sample(self) -> &'static str {
+        match self {
+            Self::Full => "00:00:00",
+            Self::Short => "00:00",
+        }
+    }
+
+    /// Write `hours`, `minutes` and `seconds` in this format.
+    #[must_use]
+    pub fn write(self, hours: i64, minutes: i64, seconds: i64) -> String {
+        match self {
+            Self::Full => format!("{hours:02}:{minutes:02}:{seconds:02}"),
+            Self::Short => format!("{hours:02}:{minutes:02}"),
+        }
+    }
+}
+
+/// Bar slots to advance between two time labels so that neighbours can never
+/// touch, given how wide one candle and one label are on screen.
+///
+/// This is the time axis' [`thin_to_fit`]: the old rule asked for a fixed six
+/// labels however narrow the strip had become, and six `HH:MM:SS` need some
+/// 300 px of text — which the history strip stops having once the live lane
+/// takes its share of the chart. Counting labels cannot answer a question
+/// about pixels.
+///
+/// Returns at least 1: a stride of zero would be an infinite loop, and one
+/// label per bar is what a chart zoomed right in genuinely wants.
+#[must_use]
+pub fn time_label_stride(candle_width_px: f32, label_width_px: f32) -> usize {
+    if !candle_width_px.is_finite() || candle_width_px <= 0.0 {
+        return 1;
+    }
+    let label = if label_width_px.is_finite() {
+        label_width_px.max(0.0)
+    } else {
+        0.0
+    };
+    // Whichever is further apart: comfortable, or far enough not to collide.
+    let needed = (label + TIME_LABEL_MIN_GAP_PX).max(TIME_LABEL_SPACING_PX);
+    let stride = (needed / candle_width_px).ceil();
+    if stride.is_finite() && stride >= 1.0 {
+        // A strip narrower than one label asks for a stride wider than any
+        // chart has bars; saturating keeps that a very large number rather
+        // than an undefined cast.
+        stride as usize
+    } else {
+        1
+    }
+}
+
+/// Whether a label of this width, centred at `x`, fits wholly inside
+/// `[left, right]`.
+///
+/// Centre-only containment let the label at the strip's live end draw its
+/// right half over the price gutter. A label half in the gutter is not a
+/// smaller label, it is a smudge.
+#[must_use]
+pub fn label_fits(x: f32, label_width_px: f32, left: f32, right: f32) -> bool {
+    let half = label_width_px / 2.0;
+    x - half >= left && x + half <= right
+}
+
+/// The widest [`TimeLabelFormat`] that still writes [`TIME_MIN_LABELS`] labels
+/// across a strip this wide, given each format's measured width.
+///
+/// `measured` answers with the pixel width of a format's
+/// [`sample`](TimeLabelFormat::sample). Falls back to the shortest form when
+/// even that does not fit — something has to be written, and the coarser
+/// instant is still true.
+#[must_use]
+pub fn time_label_format(
+    strip_width_px: f32,
+    measured: impl Fn(TimeLabelFormat) -> f32,
+) -> TimeLabelFormat {
+    TimeLabelFormat::ALL
+        .into_iter()
+        .find(|format| {
+            let width = measured(*format);
+            let per_label = width + TIME_LABEL_MIN_GAP_PX;
+            per_label > 0.0 && strip_width_px >= per_label * TIME_MIN_LABELS as f32
+        })
+        .unwrap_or(TimeLabelFormat::Short)
+}
+
 /// Gap between the axis rule and a tick label, in pixels. Shared by the price
 /// gutter and every pane's, so the numbers form one column down the chart.
 pub const AXIS_LABEL_GAP_PX: f32 = 6.0;
@@ -912,5 +1040,90 @@ mod tests {
         assert!(geometry.body.bottom.is_finite());
         assert!(geometry.body.left <= geometry.body.right);
         assert!(geometry.body.top <= geometry.body.bottom);
+    }
+
+    /// The defect this rule exists for: the old axis asked for a fixed six
+    /// labels however narrow the strip was. Six `HH:MM:SS` need some 300 px of
+    /// text, and the history strip stops having that once the live lane takes
+    /// its share — so they overlapped. The stride now comes out of pixels, and
+    /// a narrower chart simply gets fewer labels.
+    #[test]
+    fn a_narrow_chart_gets_fewer_labels_rather_than_overlapping_ones() {
+        let label = 50.0; // an `HH:MM:SS` in monospace 10 px
+
+        // Wide candles: one label every few bars.
+        let wide = time_label_stride(40.0, label);
+        // Narrow candles: the same pixel distance costs many more bars.
+        let narrow = time_label_stride(4.0, label);
+        assert!(
+            narrow > wide,
+            "thinner candles must space labels further apart in bars:              {wide} vs {narrow}"
+        );
+
+        // Whatever the candle width, neighbouring labels clear their own width.
+        for candle in [0.5_f32, 1.0, 4.0, 13.0, 40.0, 120.0] {
+            let gap = time_label_stride(candle, label) as f32 * candle;
+            assert!(
+                gap >= label + TIME_LABEL_MIN_GAP_PX,
+                "candle {candle}: labels {gap} px apart cannot hold a {label} px label"
+            );
+        }
+    }
+
+    /// A stride of zero would be an infinite loop in the strip's own draw
+    /// loop, and a degenerate candle width is exactly what a chart with no
+    /// bars reports.
+    #[test]
+    fn the_stride_is_never_zero_however_degenerate_the_geometry() {
+        for candle in [0.0_f32, -1.0, f32::NAN, f32::INFINITY] {
+            assert!(time_label_stride(candle, 50.0) >= 1, "candle {candle}");
+        }
+        assert!(time_label_stride(10.0, f32::NAN) >= 1);
+        assert!(time_label_stride(10.0, -5.0) >= 1);
+    }
+
+    /// Comfort is a floor on the spacing, never a cap: a chart zoomed so far in
+    /// that one bar is wider than a label still must not write one label per
+    /// bar, or the strip becomes a ribbon of numbers.
+    #[test]
+    fn very_wide_candles_still_leave_room_between_labels() {
+        assert!(
+            time_label_stride(60.0, 50.0) as f32 * 60.0 >= TIME_LABEL_SPACING_PX,
+            "labels stay at least a comfortable distance apart"
+        );
+    }
+
+    /// Seconds are dropped before labels are: a strip too narrow for two full
+    /// timestamps writes the same instants coarser rather than showing one
+    /// lonely label.
+    #[test]
+    fn a_strip_too_narrow_for_the_full_format_drops_the_seconds() {
+        let measured = |format: TimeLabelFormat| match format {
+            TimeLabelFormat::Full => 50.0,
+            TimeLabelFormat::Short => 31.0,
+        };
+        assert_eq!(time_label_format(400.0, measured), TimeLabelFormat::Full);
+        // 2 x (50 + 12) = 124: below that the full form stops fitting twice.
+        assert_eq!(time_label_format(123.0, measured), TimeLabelFormat::Short);
+        // Narrower than even the short form fits twice: it is still what gets
+        // written, because a coarser instant is true and a blank axis is not.
+        assert_eq!(time_label_format(10.0, measured), TimeLabelFormat::Short);
+    }
+
+    /// A label is placed by its centre but occupies its width. Containing only
+    /// the centre let the label at the live end draw its right half over the
+    /// price gutter.
+    #[test]
+    fn a_label_must_fit_whole_not_just_its_centre() {
+        assert!(label_fits(100.0, 50.0, 0.0, 200.0), "well inside");
+        assert!(
+            !label_fits(190.0, 50.0, 0.0, 200.0),
+            "right half in the gutter"
+        );
+        assert!(
+            !label_fits(10.0, 50.0, 0.0, 200.0),
+            "left half off the strip"
+        );
+        assert!(label_fits(25.0, 50.0, 0.0, 200.0), "exactly flush is fine");
     }
 }

--- a/crates/app/src/indicator_render.rs
+++ b/crates/app/src/indicator_render.rs
@@ -11,6 +11,7 @@
 
 use eframe::egui;
 use eframe::egui::{Color32, Pos2, Rect, Shape, Stroke, pos2};
+use egui_phosphor::regular as icons;
 use quantick_indicators::{PlotStyle, Rgba8};
 
 use crate::chart::PriceScale;
@@ -65,9 +66,13 @@ const PANE_MARKER_INSET_PX: f32 = MARKER_GAP_PX * 2.0;
 /// there, and a number crossing either reads as a smudge rather than a value.
 const AXIS_LABEL_EDGE_MARGIN_PX: f32 = 7.0;
 /// Marks a collapsed pane: a closed disclosure, pointing the way it opens.
-const COLLAPSED_CHEVRON: char = '▸';
+///
+/// From the bundled Phosphor font, like every other glyph in the chrome. The
+/// Unicode geometric triangles (`▸`, `▾`) are *not* in it and drew as
+/// tofu boxes — a visual capture caught it, which is exactly what one is for.
+const COLLAPSED_CHEVRON: &str = icons::CARET_RIGHT;
 /// Marks an expanded pane: an open disclosure, pointing the way it closes.
-const EXPANDED_CHEVRON: char = '▾';
+const EXPANDED_CHEVRON: &str = icons::CARET_DOWN;
 /// Side of the square at a pane's top-left corner that toggles it open or
 /// shut. Bigger than the glyph it holds, because a control you have to aim at
 /// is a control a trader does not use mid-tape.

--- a/crates/app/src/indicator_render.rs
+++ b/crates/app/src/indicator_render.rs
@@ -64,6 +64,34 @@ const PANE_MARKER_INSET_PX: f32 = MARKER_GAP_PX * 2.0;
 /// the pane's own edge: the frame hairline and the pane's title/headline live
 /// there, and a number crossing either reads as a smudge rather than a value.
 const AXIS_LABEL_EDGE_MARGIN_PX: f32 = 7.0;
+/// Marks a collapsed pane: a closed disclosure, pointing the way it opens.
+const COLLAPSED_CHEVRON: char = '▸';
+/// Marks an expanded pane: an open disclosure, pointing the way it closes.
+const EXPANDED_CHEVRON: char = '▾';
+/// Side of the square at a pane's top-left corner that toggles it open or
+/// shut. Bigger than the glyph it holds, because a control you have to aim at
+/// is a control a trader does not use mid-tape.
+const PANE_DISCLOSURE_PX: f32 = 18.0;
+
+/// The square at a pane's top-left that opens or closes it.
+///
+/// Shared by the paint and the input pass so the glyph and the thing you can
+/// click are the same square — a hit box computed twice is a hit box that
+/// drifts. For a collapsed pane the whole strip is the target instead: a
+/// one-row band has no room to aim inside, and it has nothing else to click.
+#[must_use]
+pub(crate) fn pane_disclosure_rect(band: Rect, collapsed: bool) -> Rect {
+    if collapsed {
+        return band;
+    }
+    Rect::from_min_size(
+        band.left_top(),
+        egui::vec2(
+            PANE_DISCLOSURE_PX.min(band.width()),
+            PANE_DISCLOSURE_PX.min(band.height()),
+        ),
+    )
+}
 
 fn color32(c: Rgba8) -> Color32 {
     Color32::from_rgba_unmultiplied(c.r, c.g, c.b, c.a)
@@ -185,6 +213,10 @@ pub(crate) struct PaneFrame<'a> {
     /// chart with no tape, and the pane then ends at `rect` exactly as it
     /// always has.
     pub lane: Option<LaneFrame<'a>>,
+    /// `true` when the band is too short to draw this pane legibly. The name
+    /// and the live value are still written; only the curve is dropped, and
+    /// the strip says how to get it back.
+    pub collapsed: bool,
     /// The gutter band beside `rect`, where this pane's value labels go. It
     /// is the same band the pane's zoom gesture is registered over, which is
     /// what makes the numbers the thing you grab.
@@ -255,6 +287,11 @@ pub(crate) fn draw_pane(
         Stroke::new(PANE_RULE_WIDTH_PX, frame.grid),
     );
 
+    if frame.collapsed {
+        draw_collapsed_pane(painter, band, view);
+        return;
+    }
+
     let Some((lo, hi)) = range else {
         painter.text(
             band.center(),
@@ -314,7 +351,7 @@ pub(crate) fn draw_pane(
     painter.text(
         pane.left_top() + PANE_LABEL_INSET_PX,
         egui::Align2::LEFT_TOP,
-        view.label(),
+        format!("{EXPANDED_CHEVRON} {}", view.label()),
         egui::FontId::proportional(PANE_LABEL_FONT_PX),
         theme::TEXT_MUTED,
     );
@@ -322,6 +359,34 @@ pub(crate) fn draw_pane(
         painter.text(
             band.right_top() + egui::vec2(-PANE_LABEL_INSET_PX.x, PANE_LABEL_INSET_PX.y),
             egui::Align2::RIGHT_TOP,
+            format_value(last),
+            egui::FontId::monospace(PANE_LABEL_FONT_PX),
+            theme::TEXT_MUTED,
+        );
+    }
+}
+
+/// A pane with no room for its curve: its name on the left, its live value on
+/// the right, and a chevron saying the curve is one click away.
+///
+/// The value is what the user added the indicator *for*, so it survives the
+/// collapse — a strip that hid the number too would be an indicator switched
+/// off without being asked. The chevron points right, the direction a closed
+/// disclosure points.
+fn draw_collapsed_pane(painter: &egui::Painter, band: Rect, view: &IndicatorView) {
+    let font = egui::FontId::proportional(PANE_LABEL_FONT_PX);
+    let y = band.center().y;
+    painter.text(
+        pos2(band.left() + PANE_LABEL_INSET_PX.x, y),
+        egui::Align2::LEFT_CENTER,
+        format!("{COLLAPSED_CHEVRON} {}", view.label()),
+        font,
+        theme::TEXT_MUTED,
+    );
+    if let Some(last) = last_value(view) {
+        painter.text(
+            pos2(band.right() - PANE_LABEL_INSET_PX.x, y),
+            egui::Align2::RIGHT_CENTER,
             format_value(last),
             egui::FontId::monospace(PANE_LABEL_FONT_PX),
             theme::TEXT_MUTED,
@@ -1046,6 +1111,7 @@ mod tests {
             error: None,
             hidden: false,
             scale: crate::price_view::PriceView::new(),
+            sizing: crate::indicators::PaneSizing::Auto,
             last_auto: None,
         }
     }

--- a/crates/app/src/indicators/mod.rs
+++ b/crates/app/src/indicators/mod.rs
@@ -273,8 +273,22 @@ impl IndicatorViews {
     /// What the layout needs to carve the pane band: one sizing per visible
     /// pane, top to bottom. Handed over as a whole rather than pane by pane,
     /// because how tall each one gets is one decision about all of them.
-    pub(crate) fn pane_sizing(&self) -> Vec<PaneSizing> {
-        self.visible_panes().map(|view| view.sizing).collect()
+    ///
+    /// Written into a caller-owned array rather than returned as a `Vec`:
+    /// [`plot_split`](crate::app::plot_split) runs more than once per frame,
+    /// and there is no reason for a chart to reach the allocator sixty times a
+    /// second for at most [`MAX_PANES`] copies of an eight-byte enum. Returns
+    /// the slice actually written.
+    pub(crate) fn pane_sizing<'a>(
+        &self,
+        buffer: &'a mut [PaneSizing; MAX_PANES],
+    ) -> &'a [PaneSizing] {
+        let mut count = 0;
+        for view in self.visible_panes() {
+            buffer[count] = view.sizing;
+            count += 1;
+        }
+        &buffer[..count]
     }
 
     /// The same panes, in the same order, mutable: the renderer records the

--- a/crates/app/src/indicators/mod.rs
+++ b/crates/app/src/indicators/mod.rs
@@ -65,6 +65,13 @@ pub(crate) struct IndicatorView {
     /// with it, so a later pane can never inherit a range someone set for a
     /// different series.
     pub scale: PriceView,
+    /// How tall this pane asks to be: the layout's call until the user drags
+    /// its divider or collapses it by hand.
+    ///
+    /// Render-side state like `hidden` and `scale`, and on the view for the
+    /// same reason: a removed indicator takes its height with it, so a later
+    /// pane can never inherit a size someone set for a different series.
+    pub sizing: PaneSizing,
     /// The auto-fitted `(lo, hi)` the last frame drew this pane with.
     ///
     /// The gesture that zooms the pane runs before the frame that draws it,
@@ -157,6 +164,7 @@ impl IndicatorViews {
                         input_values: inputs,
                         stale,
                         scale: PriceView::new(),
+                        sizing: PaneSizing::Auto,
                         last_auto: None,
                     });
                 }
@@ -262,6 +270,13 @@ impl IndicatorViews {
             .take(MAX_PANES)
     }
 
+    /// What the layout needs to carve the pane band: one sizing per visible
+    /// pane, top to bottom. Handed over as a whole rather than pane by pane,
+    /// because how tall each one gets is one decision about all of them.
+    pub(crate) fn pane_sizing(&self) -> Vec<PaneSizing> {
+        self.visible_panes().map(|view| view.sizing).collect()
+    }
+
     /// The same panes, in the same order, mutable: the renderer records the
     /// range it fitted and the axis gesture moves the scale, both on the view
     /// the pane rect belongs to.
@@ -284,24 +299,137 @@ fn is_visible_pane(view: &IndicatorView) -> bool {
     !view.descriptor.overlay && !view.hidden && view.error.is_none()
 }
 
-/// Carve the pane band off the bottom of the chart rect: each pane takes
-/// [`PANE_HEIGHT_FRAC`] of the *original* height, the chart keeps the rest.
+/// Shortest a pane may be drawn and still be read.
+///
+/// Added up rather than guessed, from what a pane actually has to fit:
+///
+/// | Piece | Pixels |
+/// | --- | --- |
+/// | Title + live value row (`PANE_LABEL_FONT_PX` + its inset, top and bottom) | 28 |
+/// | Two axis labels: `AXIS_LABEL_MIN_GAP_PX` between, `AXIS_LABEL_EDGE_MARGIN_PX` clear of each edge | 32 |
+/// | Curve amplitude worth reading a shape from | 40 |
+///
+/// A hundred pixels. Below it the labels start dropping out and the trace has
+/// nowhere to move, so the pane is chrome with a squiggle in it — and the
+/// honest move is to stop drawing the curve and say so
+/// ([`PaneSlot::collapsed`]) rather than to draw something unreadable.
+///
+/// The number matters: at the smallest window the app allows, three panes come
+/// to about 81 px each, so a floor set below that would never bite and this
+/// whole rule would be dead code.
+pub(crate) const MIN_PANE_HEIGHT_PX: f32 = 100.0;
+/// Height of a collapsed pane: one row, enough for its name and its live
+/// value. Never zero — a pane that vanished would be an indicator the user
+/// added and the chart silently dropped.
+pub(crate) const COLLAPSED_PANE_HEIGHT_PX: f32 = 20.0;
+/// Shortest the candles may be squeezed to by the pane band. The candles are
+/// what the panes are *about*; a band that leaves them a sliver has inverted
+/// the chart.
+pub(crate) const MIN_CHART_HEIGHT_PX: f32 = 120.0;
+
+/// What decides one pane's height.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) enum PaneSizing {
+    /// The layout decides: a share of the band, floored, collapsing when the
+    /// band cannot hold it.
+    Auto,
+    /// The user dragged this pane's divider to a height in pixels. Still
+    /// floored — a drag cannot produce a pane too short to read either.
+    Manual(f32),
+    /// The user collapsed it by hand. Stays collapsed however much room
+    /// appears, until they expand it again.
+    Collapsed,
+}
+
+impl PaneSizing {
+    /// Height this sizing asks for in a band `band_height_px` tall, before the
+    /// layout decides whether there is room for it.
+    fn desired(self, band_height_px: f32) -> f32 {
+        match self {
+            Self::Auto => (band_height_px * PANE_HEIGHT_FRAC).max(MIN_PANE_HEIGHT_PX),
+            Self::Manual(px) => px.max(MIN_PANE_HEIGHT_PX),
+            Self::Collapsed => COLLAPSED_PANE_HEIGHT_PX,
+        }
+    }
+}
+
+/// One pane's band, and whether it is showing its curve or only its name.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct PaneSlot {
+    pub rect: egui::Rect,
+    /// `true`: too little room to draw this pane legibly, so it is a labelled
+    /// strip instead. Collapsing hides the *curve*; the name and the live
+    /// value are still written, because those are what the user added the
+    /// indicator for.
+    pub collapsed: bool,
+}
+
+/// Carve the pane band off the bottom of the chart rect.
+///
+/// Two rules the old fraction-only split had neither of:
+///
+/// - **Nothing is drawn below the height at which it can be read.** A pane
+///   that cannot have [`MIN_PANE_HEIGHT_PX`] becomes a collapsed strip rather
+///   than a squeezed one. Three slivers are worth less than one readable pane
+///   and two labelled strips.
+/// - **The candles keep [`MIN_CHART_HEIGHT_PX`].** Panes are read against the
+///   bars; a band that eats the bars has inverted the chart.
+///
+/// Room is granted top-down, so the first pane — the one the user added first,
+/// and the one the eye lands on — is the last to lose its curve. Every pane
+/// always gets at least a strip: an indicator that is on must never be
+/// silently absent.
+///
 /// Pure, so the split is unit-testable without a display.
-pub(crate) fn split_panes(chart: egui::Rect, pane_count: usize) -> (egui::Rect, Vec<egui::Rect>) {
-    let count = pane_count.min(MAX_PANES);
+pub(crate) fn split_panes(chart: egui::Rect, sizing: &[PaneSizing]) -> (egui::Rect, Vec<PaneSlot>) {
+    let count = sizing.len().min(MAX_PANES);
     if count == 0 {
         return (chart, Vec::new());
     }
-    let pane_height = chart.height() * PANE_HEIGHT_FRAC;
-    let chart_bottom = chart.bottom() - pane_height * count as f32;
+    let band_height = chart.height().max(0.0);
+    // Strips are mandatory chrome; only the expansion above a strip has to be
+    // negotiated for.
+    let mandatory = COLLAPSED_PANE_HEIGHT_PX * count as f32;
+    let mut budget = (band_height - MIN_CHART_HEIGHT_PX - mandatory).max(0.0);
+
+    // Explicit choices are served first, in two passes over the same order:
+    // a pane the user dragged or expanded by hand must get its height even
+    // when the automatic ones above it would have spent the budget. Without
+    // this, clicking a collapsed strip open is a click that does nothing.
+    let mut heights = vec![COLLAPSED_PANE_HEIGHT_PX; count];
+    for explicit in [true, false] {
+        for (index, sizing) in sizing[..count].iter().enumerate() {
+            if matches!(sizing, PaneSizing::Manual(_)) != explicit {
+                continue;
+            }
+            if matches!(sizing, PaneSizing::Collapsed) {
+                continue;
+            }
+            let desired = sizing.desired(band_height);
+            let extra = desired - COLLAPSED_PANE_HEIGHT_PX;
+            if extra <= budget {
+                budget -= extra;
+                heights[index] = desired;
+            }
+        }
+    }
+
+    let total: f32 = heights.iter().sum();
+    let chart_bottom = (chart.bottom() - total).max(chart.top());
     let shrunk = egui::Rect::from_min_max(chart.min, egui::pos2(chart.right(), chart_bottom));
-    let panes = (0..count)
-        .map(|i| {
-            let top = chart_bottom + pane_height * i as f32;
-            egui::Rect::from_min_max(
+    let mut top = chart_bottom;
+    let panes = heights
+        .into_iter()
+        .map(|height| {
+            let rect = egui::Rect::from_min_max(
                 egui::pos2(chart.left(), top),
-                egui::pos2(chart.right(), top + pane_height),
-            )
+                egui::pos2(chart.right(), top + height),
+            );
+            top += height;
+            PaneSlot {
+                rect,
+                collapsed: height <= COLLAPSED_PANE_HEIGHT_PX,
+            }
         })
         .collect();
     (shrunk, panes)
@@ -466,21 +594,113 @@ mod tests {
         assert!(fresh.last_auto.is_none(), "and has not been drawn yet");
     }
 
+    fn band(height: f32) -> egui::Rect {
+        egui::Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(400.0, height))
+    }
+
+    fn auto(n: usize) -> Vec<PaneSizing> {
+        vec![PaneSizing::Auto; n]
+    }
+
     #[test]
     fn pane_split_is_stacked_and_bounded() {
-        let chart = egui::Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(100.0, 100.0));
-        let (shrunk, panes) = split_panes(chart, 2);
-        assert_eq!(shrunk.height(), 60.0, "two panes take 2 x 20%");
+        let chart = band(1000.0);
+        let (shrunk, panes) = split_panes(chart, &auto(2));
+        assert_eq!(shrunk.height(), 600.0, "two panes take 2 x 20%");
         assert_eq!(panes.len(), 2);
-        assert_eq!(panes[0].top(), 60.0);
-        assert_eq!(panes[1].top(), 80.0);
-        assert_eq!(panes[1].bottom(), 100.0);
+        assert_eq!(panes[0].rect.top(), 600.0);
+        assert_eq!(panes[1].rect.top(), 800.0);
+        assert_eq!(panes[1].rect.bottom(), 1000.0);
+        assert!(panes.iter().all(|pane| !pane.collapsed), "there is room");
 
-        let (unchanged, none) = split_panes(chart, 0);
+        let (unchanged, none) = split_panes(chart, &auto(0));
         assert_eq!(unchanged, chart);
         assert!(none.is_empty());
 
-        let (_, capped) = split_panes(chart, 9);
+        let (_, capped) = split_panes(chart, &auto(9));
         assert_eq!(capped.len(), MAX_PANES);
+    }
+
+    /// The headline of this change: a band too short for three readable panes
+    /// gives room to the ones it can and collapses the rest, instead of
+    /// handing all three a sliver. Room goes top-down, so the pane the user
+    /// added first is the last to lose its curve.
+    #[test]
+    fn a_short_band_collapses_the_panes_it_cannot_draw_legibly() {
+        let (chart, panes) = split_panes(band(300.0), &auto(3));
+
+        assert_eq!(panes.len(), 3, "every pane is still present");
+        assert!(!panes[0].collapsed, "the first keeps its curve");
+        assert!(
+            panes[1].collapsed && panes[2].collapsed,
+            "300 px cannot hold two readable panes and the candles' own floor"
+        );
+        for pane in &panes {
+            assert!(
+                pane.rect.height() >= COLLAPSED_PANE_HEIGHT_PX,
+                "no pane is ever thinner than its own name"
+            );
+            assert!(
+                pane.collapsed || pane.rect.height() >= MIN_PANE_HEIGHT_PX,
+                "an expanded pane always clears the readable floor: {pane:?}"
+            );
+        }
+        assert!(
+            chart.height() >= MIN_CHART_HEIGHT_PX,
+            "and the candles keep their floor: {}",
+            chart.height()
+        );
+    }
+
+    /// The floor holds all the way down. At the smallest window the app
+    /// allows, three panes are three labelled strips and the candles are still
+    /// candles — the state the old split turned into three unreadable bands.
+    #[test]
+    fn the_floors_hold_at_every_band_height() {
+        for height in [0.0_f32, 60.0, 120.0, 200.0, 300.0, 560.0, 1000.0] {
+            let (chart, panes) = split_panes(band(height), &auto(MAX_PANES));
+            let total: f32 = panes.iter().map(|pane| pane.rect.height()).sum();
+            assert!(
+                (chart.height() + total - height.max(0.0)).abs() < 0.01 || chart.height() == 0.0,
+                "height {height}: the band and the chart must tile the space"
+            );
+            for pane in &panes {
+                assert!(
+                    pane.collapsed || pane.rect.height() >= MIN_PANE_HEIGHT_PX,
+                    "height {height}: an expanded pane below the floor: {pane:?}"
+                );
+            }
+            assert!(
+                panes
+                    .windows(2)
+                    .all(|pair| { (pair[0].rect.bottom() - pair[1].rect.top()).abs() < 0.01 }),
+                "height {height}: panes must not overlap or leave a seam"
+            );
+        }
+    }
+
+    /// A pane the user collapsed by hand stays collapsed however much room
+    /// appears — the automatic rule decides what *cannot* be shown, never what
+    /// the user decided not to show.
+    #[test]
+    fn a_hand_collapsed_pane_stays_collapsed_in_a_tall_band() {
+        let (_, panes) = split_panes(band(1000.0), &[PaneSizing::Collapsed, PaneSizing::Auto]);
+        assert!(panes[0].collapsed, "the user's choice survives the room");
+        assert!(!panes[1].collapsed);
+    }
+
+    /// A dragged height is honoured, and still cannot go below the floor: the
+    /// divider stops rather than producing a pane nobody can read.
+    #[test]
+    fn a_dragged_height_is_honoured_but_never_below_the_floor() {
+        let (_, tall) = split_panes(band(1000.0), &[PaneSizing::Manual(300.0)]);
+        assert!((tall[0].rect.height() - 300.0).abs() < 0.01);
+
+        let (_, squeezed) = split_panes(band(1000.0), &[PaneSizing::Manual(5.0)]);
+        assert!(
+            (squeezed[0].rect.height() - MIN_PANE_HEIGHT_PX).abs() < 0.01,
+            "the drag stops at the floor: {:?}",
+            squeezed[0]
+        );
     }
 }

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -143,11 +143,8 @@ fn main() -> eframe::Result {
 
     let options = eframe::NativeOptions {
         viewport: egui::ViewportBuilder::default()
-            .with_inner_size([1100.0, 650.0])
-            // Below this the drawing rail would fall past its Minimal stage
-            // (191 px of long axis, docs/drawing-toolbar-ux.md §2.8) and
-            // clip chrome instead of collapsing it.
-            .with_min_inner_size([900.0, 560.0])
+            .with_inner_size(window_size())
+            .with_min_inner_size(MIN_WINDOW_PX)
             .with_title("quantick")
             .with_icon(icon),
         ..Default::default()
@@ -173,4 +170,87 @@ fn main() -> eframe::Result {
             )))
         }),
     )
+}
+
+/// Size the window opens at: [`DEFAULT_WINDOW_PX`] unless
+/// `QUANTICK_WINDOW_SIZE=WxH` says otherwise.
+///
+/// The hook exists because window size is not decoration here — it is what
+/// decides whether the indicator band has room for its panes and whether the
+/// time axis has room for its labels. Without a way to ask for a small window,
+/// that entire class of defect is invisible to any validation that is not a
+/// human dragging a corner.
+///
+/// Clamped to the same minimum the window itself enforces, so the hook can
+/// reach the smallest real layout and no smaller. A value that does not parse
+/// is ignored with a warning rather than failing the launch: a malformed
+/// env var must not stand between the user and their chart.
+/// Size the window opens at when nothing asks for another.
+const DEFAULT_WINDOW_PX: [f32; 2] = [1100.0, 650.0];
+/// Smallest the window may be. Below this the drawing rail would fall past its
+/// Minimal stage (191 px of long axis, docs/drawing-toolbar-ux.md §2.8) and
+/// clip chrome instead of collapsing it.
+const MIN_WINDOW_PX: [f32; 2] = [900.0, 560.0];
+
+fn window_size() -> [f32; 2] {
+    let Ok(raw) = std::env::var("QUANTICK_WINDOW_SIZE") else {
+        return DEFAULT_WINDOW_PX;
+    };
+    match parse_window_size(&raw) {
+        Some(size) => {
+            tracing::info!(
+                target: "quantick::app",
+                schema_version = 1_u8,
+                event_code = "APP_WINDOW_SIZE_OVERRIDE",
+                width = size[0],
+                height = size[1],
+                "opening at the requested window size"
+            );
+            size
+        }
+        None => {
+            tracing::warn!(
+                target: "quantick::app",
+                schema_version = 1_u8,
+                event_code = "APP_WINDOW_SIZE_REJECTED",
+                value = %raw,
+                action = "using_default",
+                "QUANTICK_WINDOW_SIZE is not WIDTHxHEIGHT"
+            );
+            DEFAULT_WINDOW_PX
+        }
+    }
+}
+
+/// `WIDTHxHEIGHT` in pixels, clamped to the window's own minimum. `None` when
+/// the text is not two positive numbers.
+fn parse_window_size(raw: &str) -> Option<[f32; 2]> {
+    let (width, height) = raw.split_once(['x', 'X'])?;
+    let width: f32 = width.trim().parse().ok()?;
+    let height: f32 = height.trim().parse().ok()?;
+    (width.is_finite() && height.is_finite() && width > 0.0 && height > 0.0)
+        .then_some([width.max(MIN_WINDOW_PX[0]), height.max(MIN_WINDOW_PX[1])])
+}
+
+#[cfg(test)]
+mod window_size_tests {
+    use super::*;
+
+    #[test]
+    fn a_requested_size_is_honoured_and_floored_at_the_windows_own_minimum() {
+        assert_eq!(parse_window_size("1280x720"), Some([1280.0, 720.0]));
+        assert_eq!(parse_window_size(" 1280 X 720 "), Some([1280.0, 720.0]));
+        assert_eq!(
+            parse_window_size("200x100"),
+            Some(MIN_WINDOW_PX),
+            "the hook reaches the smallest real layout and no smaller"
+        );
+    }
+
+    #[test]
+    fn a_malformed_size_is_rejected_rather_than_guessed_at() {
+        for raw in ["", "1280", "1280x", "x720", "wide x tall", "0x0", "-5x10"] {
+            assert_eq!(parse_window_size(raw), None, "{raw:?}");
+        }
+    }
 }

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -174,6 +174,13 @@ fn main() -> eframe::Result {
     )
 }
 
+/// Size the window opens at when nothing asks for another.
+const DEFAULT_WINDOW_PX: [f32; 2] = [1100.0, 650.0];
+/// Smallest the window may be. Below this the drawing rail would fall past its
+/// Minimal stage (191 px of long axis, docs/drawing-toolbar-ux.md §2.8) and
+/// clip chrome instead of collapsing it.
+const MIN_WINDOW_PX: [f32; 2] = [900.0, 560.0];
+
 /// Size the window opens at: [`DEFAULT_WINDOW_PX`] unless
 /// `QUANTICK_WINDOW_SIZE=WxH` says otherwise.
 ///
@@ -187,13 +194,6 @@ fn main() -> eframe::Result {
 /// reach the smallest real layout and no smaller. A value that does not parse
 /// is ignored with a warning rather than failing the launch: a malformed
 /// env var must not stand between the user and their chart.
-/// Size the window opens at when nothing asks for another.
-const DEFAULT_WINDOW_PX: [f32; 2] = [1100.0, 650.0];
-/// Smallest the window may be. Below this the drawing rail would fall past its
-/// Minimal stage (191 px of long axis, docs/drawing-toolbar-ux.md §2.8) and
-/// clip chrome instead of collapsing it.
-const MIN_WINDOW_PX: [f32; 2] = [900.0, 560.0];
-
 fn window_size() -> [f32; 2] {
     let Ok(raw) = std::env::var("QUANTICK_WINDOW_SIZE") else {
         return DEFAULT_WINDOW_PX;

--- a/crates/app/src/pane.rs
+++ b/crates/app/src/pane.rs
@@ -1085,10 +1085,11 @@ impl ChartPane {
     /// This pane's regions inside `area`, carved once so the input handler and
     /// the renderer can never disagree about a boundary.
     fn plot_areas(&self, area: egui::Rect) -> PlotAreas {
+        let mut sizing = [PaneSizing::Auto; crate::indicators::MAX_PANES];
         plot_split(
             area,
             self.live_strip_width(),
-            &self.indicators.pane_sizing(),
+            self.indicators.pane_sizing(&mut sizing),
         )
     }
 

--- a/crates/app/src/pane.rs
+++ b/crates/app/src/pane.rs
@@ -209,6 +209,15 @@ fn lane_rungs(lane_width_px: f32) -> usize {
     rungs.clamp(1, MAX_LANE_RUNGS)
 }
 
+/// Half-height of the grab band over a pane's top edge, in pixels.
+///
+/// The rule itself stays a hairline — a thick bar between a chart and its
+/// indicator reads as a wall in the data. The handle around it is what makes
+/// it catchable, and the resize cursor is the only thing that announces it:
+/// the same bargain the live lane's divider and the canvas split already
+/// strike.
+const PANE_DIVIDER_HANDLE_PX: f32 = 4.0;
+
 /// Pixels of drag on a vertical axis that change its span by a factor of `e`.
 ///
 /// One number for the price gutter and for every indicator pane's gutter: the
@@ -219,6 +228,49 @@ const AXIS_ZOOM_DRAG_PX: f32 = 150.0;
 /// reports far more units than a pointer travels in a frame, so each unit has
 /// to count for less — a larger divisor, not a smaller one.
 const AXIS_ZOOM_SCROLL_PX: f32 = 200.0;
+
+/// The divider along a pane's top edge, as a resize handle.
+///
+/// The band it opens is the pane *below* it, which is what a top edge means:
+/// drag it up and that pane grows into the chart, drag it down and it gives
+/// the room back. Double click hands the pane to the automatic layout again —
+/// the same escape the price axis and every pane's own scale offer.
+///
+/// Returns the sizing the pane should now have, or `None` when the divider was
+/// not touched this frame.
+fn pane_divider_gesture(
+    ui: &egui::Ui,
+    id: egui::Id,
+    slot: &crate::indicators::PaneSlot,
+    plot: egui::Rect,
+) -> Option<PaneSizing> {
+    let edge = slot.rect.top();
+    let handle = ui.interact(
+        egui::Rect::from_min_max(
+            egui::pos2(plot.left(), edge - PANE_DIVIDER_HANDLE_PX),
+            egui::pos2(plot.right(), edge + PANE_DIVIDER_HANDLE_PX),
+        ),
+        id,
+        egui::Sense::click_and_drag(),
+    );
+    if handle.hovered() || handle.dragged() {
+        ui.ctx().set_cursor_icon(egui::CursorIcon::ResizeVertical);
+    }
+    if handle.double_clicked() {
+        return Some(PaneSizing::Auto);
+    }
+    if handle.dragged() {
+        let delta = handle.drag_delta().y;
+        if delta != 0.0 {
+            // Dragging the top edge upwards makes the band below it taller.
+            // The floor is not applied here: `PaneSizing::desired` owns it, so
+            // a drag and the automatic layout cannot disagree about how short
+            // a pane may be.
+            return Some(PaneSizing::Manual(slot.rect.height() - delta));
+        }
+    }
+    None
+}
 
 /// The gesture that pans a pane's own scale: press inside the pane and drag it
 /// up or down, exactly as a press on the candles drags price.
@@ -1955,6 +2007,26 @@ impl ChartPane {
         if pane_time_gesture.scroll_y.abs() > 0.0 {
             self.viewport
                 .zoom(2.0_f32.powf(pane_time_gesture.scroll_y / SCROLL_ZOOM_PX));
+        }
+
+        // The dividers last of all: registered after every pane body so the
+        // grab band takes the drag that would otherwise pan the pane behind
+        // it, exactly as the canvas split's divider is registered after both
+        // its panes and the lane's after the candles.
+        let plot = areas.chart;
+        for (view, slot) in self
+            .indicators
+            .visible_panes_mut()
+            .zip(&areas.indicator_panes)
+        {
+            if let Some(sizing) = pane_divider_gesture(
+                ui,
+                egui::Id::new(("pane_divider", pane_id, view.slot)),
+                slot,
+                plot,
+            ) {
+                view.sizing = sizing;
+            }
         }
     }
 

--- a/crates/app/src/pane.rs
+++ b/crates/app/src/pane.rs
@@ -21,7 +21,7 @@ use rust_decimal::prelude::{FromPrimitive as _, ToPrimitive as _};
 use smallvec::SmallVec;
 
 use crate::app::{
-    PlotAreas, fmt_time, fmt_window, gesture_hits_lane, plot_split, split_time_strip,
+    PlotAreas, fmt_time_as, fmt_window, gesture_hits_lane, plot_split, split_time_strip,
 };
 use crate::candle_view::draw_candle;
 use crate::chart::{self, PriceScale};
@@ -32,7 +32,7 @@ use crate::indicator_render::{self, PlotX};
 use crate::indicator_worker::{
     IndicatorCommand, IndicatorSource, IndicatorWorker, MAX_LANE_RUNGS, SlotId,
 };
-use crate::indicators::IndicatorViews;
+use crate::indicators::{IndicatorViews, MIN_PANE_HEIGHT_PX, PaneSizing};
 use crate::orderflow_view::{OrderflowView, VisibleBarTimeline};
 use crate::paper_trading::{ChartInput, PaperTrading};
 use crate::price_view::PriceView;
@@ -1036,7 +1036,7 @@ impl ChartPane {
         plot_split(
             area,
             self.live_strip_width(),
-            self.indicators.visible_panes().count(),
+            &self.indicators.pane_sizing(),
         )
     }
 
@@ -1905,18 +1905,45 @@ impl ChartPane {
                 &mut view.scale,
                 view.last_auto,
             );
-            // The body moves the scale the gutter scales. Registered after it
-            // so the two never fight over the same pixel: the gutter is a band
-            // beside the pane, and egui gives an overlap to the later claim.
-            let gesture = pane_pan_gesture(
-                ui,
-                egui::Id::new(("pane_pan", pane_id, view.slot)),
-                *body,
-                &mut view.scale,
-                view.last_auto,
+            if !body.collapsed {
+                // The body moves the scale the gutter scales. Registered after
+                // the gutter so the two never fight over the same pixel: the
+                // gutter is a band beside the pane, and egui gives an overlap
+                // to the later claim.
+                let gesture = pane_pan_gesture(
+                    ui,
+                    egui::Id::new(("pane_pan", pane_id, view.slot)),
+                    body.rect,
+                    &mut view.scale,
+                    view.last_auto,
+                );
+                pane_time_gesture.pan_x += gesture.pan_x;
+                pane_time_gesture.scroll_y += gesture.scroll_y;
+            }
+            // The disclosure, in both directions: a control that only opens is
+            // half a control, so the square that brings a pane back is what
+            // puts it away. Registered *last* for the same reason the body is
+            // registered after the gutter — the later claim wins the overlap,
+            // and this corner has to beat the pan that covers the whole band.
+            let disclosure = ui.interact(
+                indicator_render::pane_disclosure_rect(body.rect, body.collapsed),
+                egui::Id::new(("pane_disclosure", pane_id, view.slot)),
+                egui::Sense::click(),
             );
-            pane_time_gesture.pan_x += gesture.pan_x;
-            pane_time_gesture.scroll_y += gesture.scroll_y;
+            if disclosure.hovered() {
+                ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);
+            }
+            if disclosure.clicked() {
+                view.sizing = if body.collapsed {
+                    // Manual, not Auto: the automatic rule is what collapsed
+                    // it, so handing it back would undo the click on the very
+                    // next frame. An explicit height is served before the
+                    // automatic ones and therefore always fits.
+                    PaneSizing::Manual(MIN_PANE_HEIGHT_PX)
+                } else {
+                    PaneSizing::Collapsed
+                };
+            }
         }
         // Time, once, whichever pane the pointer was over: the panes share the
         // candles' x axis, so a sideways drag or a scroll there has to move the
@@ -2233,13 +2260,13 @@ impl ChartPane {
             view.last_auto = auto;
             let frame = indicator_render::PaneFrame {
                 rect: egui::Rect::from_min_max(
-                    egui::pos2(history_rect.left(), pane.top()),
-                    egui::pos2(history_rect.right(), pane.bottom()),
+                    egui::pos2(history_rect.left(), pane.rect.top()),
+                    egui::pos2(history_rect.right(), pane.rect.bottom()),
                 ),
                 lane: lane_window.map(|(divider, start_ms, end_ms)| indicator_render::LaneFrame {
                     rect: egui::Rect::from_min_max(
-                        egui::pos2(divider, pane.top()),
-                        egui::pos2(chart_rect.right(), pane.bottom()),
+                        egui::pos2(divider, pane.rect.top()),
+                        egui::pos2(chart_rect.right(), pane.rect.bottom()),
                     ),
                     start_ms,
                     end_ms,
@@ -2248,6 +2275,7 @@ impl ChartPane {
                 gutter: *gutter,
                 background: canvas_background,
                 grid,
+                collapsed: pane.collapsed,
             };
             indicator_render::draw_pane(
                 painter,
@@ -2449,30 +2477,50 @@ impl ChartPane {
             ],
             egui::Stroke::new(1.0_f32, grid_color(chrome.style)),
         );
-        let font = egui::FontId::monospace(10.0);
+        let font = egui::FontId::monospace(crate::chart::TIME_LABEL_FONT_PX);
         let y = strip.center().y;
-        // Up to ~6 evenly-spaced labels across the visible closed bars.
         let visible = end.saturating_sub(start);
         if visible == 0 {
             return;
         }
         let (history_strip, _) = split_time_strip(strip, self.last_lane_divider_x);
-        let step = (visible / 6).max(1);
+
+        // Measured, not counted. One layout per format per frame — monospace,
+        // so a format's sample answers for every label written in it — and the
+        // stride comes out of pixels rather than out of a fixed label count
+        // that a narrower strip could not honour.
+        let width_of = |format: crate::chart::TimeLabelFormat| {
+            painter
+                .layout_no_wrap(format.sample().to_owned(), font.clone(), theme::TEXT_MUTED)
+                .size()
+                .x
+        };
+        let format = crate::chart::time_label_format(history_strip.width(), width_of);
+        let label_width = width_of(format);
+        let stride = crate::chart::time_label_stride(self.viewport.candle_width(), label_width);
+
         let mut index = start;
         while index < end {
             if let Some(bar) = self.closed_bar(index) {
                 let x = self.viewport.x_center(index, history_strip.right(), total);
-                if history_strip.x_range().contains(x) {
+                // The whole label, not just its centre: a label centred a few
+                // pixels from the end drew its other half over the gutter.
+                if crate::chart::label_fits(
+                    x,
+                    label_width,
+                    history_strip.left(),
+                    history_strip.right(),
+                ) {
                     painter.text(
                         egui::pos2(x, y),
                         egui::Align2::CENTER_CENTER,
-                        fmt_time(bar.open_time, chrome.tz),
+                        fmt_time_as(bar.open_time, chrome.tz, format),
                         font.clone(),
                         theme::TEXT_MUTED,
                     );
                 }
             }
-            index += step;
+            index = index.saturating_add(stride);
         }
     }
 


### PR DESCRIPTION
> Stacked on #130 (`feat/pane-live-lane`). Both change `plot_split`,
> `split_panes` and `draw_pane`, so cutting this from `main` would conflict in
> exactly those functions. Review #130 first; this diff is `feat/pane-live-lane...HEAD`.

The band below the chart was written for a big window and had no answer for a
small one. Reported as "quando eu coloco janela menor, os dados do eixo X de
tempo comprime e fica feião" — and the axis was only the visible half of it.

## The three defects

**The time axis counted its labels instead of measuring them.**
`draw_time_strip` asked for a fixed ~6 (`step = (visible / 6).max(1)`) however
narrow the strip had become. Six `HH:MM:SS` want some 300 px of text, and the
history strip stops having that as soon as the live lane takes its share of a
smaller window. Counting labels cannot answer a question about pixels — and the
price axis one column over had solved this years of code ago with
`AXIS_LABEL_MIN_GAP_PX`.

**Panes were a bare fraction with no floor.** `PANE_HEIGHT_FRAC` per pane, up
to three, so a short window handed out three slivers and took 60% of the chart
to do it.

**Panes were the only band in the app that could not be resized.** The canvas
split has a draggable divider and so does the live lane. Same product, three
answers to "can I adjust this?".

## What changes

- **Labels are spaced by measured pixels**, from the candle width and the
  label's own width. Seconds are dropped before labels are: a strip too narrow
  for two full timestamps writes `HH:MM` rather than showing one lonely
  instant. A label must now fit *whole* inside the strip — containing only its
  centre let the one at the live end draw its right half over the gutter.
- **Nothing is drawn below `MIN_PANE_HEIGHT_PX`**, and a pane with no room
  becomes a labelled strip carrying its name and its live value. Collapsing
  hides the curve, never the number. The candles keep their own floor: panes
  are read *against* the bars.
- **A disclosure at each pane's corner** opens and closes it by hand, and an
  explicit choice is served before the automatic ones — otherwise clicking a
  strip open would be undone by the layout on the very next frame.
- **A pane's top edge is a resize handle**, with the resize cursor as the only
  affordance, which is the bargain the other two dividers already strike.
  Double click hands the pane back to the automatic layout. The floor is
  enforced by the layout rather than by the drag, so a divider cannot recreate
  the squeezed band this PR exists to prevent.
- **`QUANTICK_WINDOW_SIZE=WxH`**, registered in the `ui-harness` table.

## The number that mattered

`MIN_PANE_HEIGHT_PX` is added up, not guessed: a title row (28 px) + two axis
labels with their gaps and edge margins (32 px) + curve amplitude worth reading
a shape from (40 px) = **100 px**. The first value tried was 72 px, and a test
at the app's own minimum window showed three panes landing at ~81 px each —
above it. The floor would never have triggered at any window the app allows and
the whole rule would have been dead code. Deriving the number is what caught
that.

## Verification

- `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`,
  `cargo build --workspace`, `cargo test --workspace` — all green.
- Tests drive the app at `MIN_WINDOW` (900x560, the app's own minimum) rather
  than the roomy default. At the default nothing collapses, and a test that
  cannot see the defect cannot guard the fix — the first version of the
  collapse test passed vacuously for exactly that reason.

### Performance

Declared per touched path: the layout split and the label measurement are
**per frame** and stay O(panes ≤ 3) and O(labels); the divider drag is **per
frame**, O(1); no per-trade or per-depth path is touched. The one genuinely new
per-frame cost is text measurement, and it is at most three `layout_no_wrap`
calls of monospace samples, which egui serves from its galley cache. A per-frame
`Vec` allocation was *removed* on the way through (0dda7e9).

Measured: `APP_HEALTH_SUMMARY` `frame_cpu_ms`, same hooks, 40 health windows
each, alternating parent / branch four times on a live BTCUSDT tape.

| Run | parent | branch |
| --- | --- | --- |
| 1 | 2.24 ms (650 cells) | 2.59 ms (1036) |
| 2 | 2.55 ms (1337) | 3.52 ms (1142) |
| 3 | 2.94 ms (952) | 2.92 ms (1359) |
| 4 | 2.68 ms (1023) | 2.52 ms (700) |
| **mean** | **2.60 ms** (sd 0.25) | **2.89 ms** (sd 0.40) |

**The result is inconclusive, and that is the honest word for it.** The branch's
mean is 0.29 ms higher, which is 0.79 pooled standard deviations at n=4 — well
inside the run-to-run spread, and the branch happened to average 7% more
heatmap cells. Two branch runs at nearly identical load (1036 and 1142 cells)
differ by 0.93 ms between themselves, so within-arm variance swamps the
between-arm gap on this machine.

What can be said without a measurement: nothing added here scales with data
volume. If a reviewer wants a verdict rather than a range, the measurement to
run is a bench over a fixed frame rather than a live tape.

### Reviews, and what they changed

`arch-review` over this diff found a per-frame allocation: `pane_sizing`
returned a `Vec` and `plot_split` runs more than once per frame. Fixed in
0dda7e9 rather than deferred — it writes into a caller-owned array now.

**Visual QA found what no test could.** The disclosure chevron used the Unicode
geometric triangles, which are not in the bundled Phosphor font: every pane
header rendered as a tofu box. Fixed in f714878. This is the argument for
taking the screenshot even when the suite is green.

Also worth recording: the environment problem that blocked visual QA on #130
was **not** a limitation of this machine. It was the compositor going quiet on
an idle desktop. With the desktop active the capture runs at 59-60 fps and is
real — which also means #130's lane curve has now been seen working for the
first time, in the pane band of these captures.

### Known defects seen but not fixed here

At 900x560 the floating indicator legend and the aggression legend overlap the
candles, and the status bar's segments collide (`17/50 ticks10072 trades`).
Both are pre-existing and outside this branch's scope; they deserve their own
pass.

### Tests

| Behaviour | Test |
| --- | --- |
| A narrow chart gets fewer labels, never overlapping ones | `chart::a_narrow_chart_gets_fewer_labels_rather_than_overlapping_ones` |
| The stride survives degenerate geometry | `chart::the_stride_is_never_zero_however_degenerate_the_geometry` |
| Comfort is a floor on spacing, not a cap | `chart::very_wide_candles_still_leave_room_between_labels` |
| Seconds are dropped before labels are | `chart::a_strip_too_narrow_for_the_full_format_drops_the_seconds` |
| A label must fit whole, not just its centre | `chart::a_label_must_fit_whole_not_just_its_centre` |
| A short band collapses what it cannot draw legibly | `indicators::a_short_band_collapses_the_panes_it_cannot_draw_legibly` |
| The floors hold at every band height | `indicators::the_floors_hold_at_every_band_height` |
| A hand-collapsed pane stays collapsed in a tall band | `indicators::a_hand_collapsed_pane_stays_collapsed_in_a_tall_band` |
| A dragged height is honoured but never below the floor | `indicators::a_dragged_height_is_honoured_but_never_below_the_floor` |
| The smallest window collapses rather than squeezing | `app::the_smallest_window_collapses_rather_than_squeezing_every_pane` |
| A roomy window still draws every pane | `app::a_roomy_window_draws_every_pane` |
| Clicking a strip opens it, and it stays open | `app::clicking_a_collapsed_strip_opens_it_and_it_stays_open` |
| The disclosure closes as well as opens | `app::the_disclosure_closes_a_pane_as_well_as_opening_it` |
| Dragging a top edge resizes that pane | `app::dragging_a_panes_top_edge_resizes_that_pane` |
| A divider cannot be dragged past the floor | `app::a_divider_cannot_be_dragged_past_the_readable_floor` |
| Double click returns a pane to automatic | `app::double_clicking_a_divider_returns_the_pane_to_automatic` |
| The window hook is honoured and floored | `main::a_requested_size_is_honoured_and_floored_at_the_windows_own_minimum` |
| A malformed size is rejected, not guessed at | `main::a_malformed_size_is_rejected_rather_than_guessed_at` |
