### PR TITLE
feat(drawings): a mark stays until the trader deletes it, and is worked from both charts

### DIFF
--- a/.claude/skills/ui-harness/SKILL.md
+++ b/.claude/skills/ui-harness/SKILL.md
@@ -45,7 +45,8 @@ Landing with the drawing-toolbar goal (`feat/drawing-toolbar-pro`):
 | `QUANTICK_DRAWING_TOOL=<tool id>` | opens with that tool armed — any id in `DRAWING_TOOLS` (`trend-line`, `ray`, `measure`, `text`, …) |
 | `QUANTICK_DRAWING_MAGNET=1` | the magnet on (anchors snap to the bar's OHLC) |
 | `QUANTICK_DRAWINGS_DEMO=1` | one of every registered drawing placed on the flow pane once it has bars, the last one selected so the inspector is on screen too |
-| `QUANTICK_DRAWINGS_DEMO_SHARED=1` | those demo objects marked "show on all charts" — pair with a split layout to see the cross-pane projection |
+| `QUANTICK_DRAWINGS_DEMO_SHARED=1` | those demo objects marked "show on all charts" — pair with a split layout to see the cross-pane projection (which is now also where they can be grabbed, moved and deleted) |
+| `QUANTICK_DRAWINGS_DEMO_RECUT=1` | re-cuts the bars under the demo objects after placing them, and adds one mark anchored before the loaded history — the two states a timeframe switch produces: every mark re-anchored onto the new bars, and one faded "off series" |
 
 Once merged, move them into the table above.
 

--- a/.claude/skills/ui-harness/SKILL.md
+++ b/.claude/skills/ui-harness/SKILL.md
@@ -47,6 +47,7 @@ Landing with the drawing-toolbar goal (`feat/drawing-toolbar-pro`):
 | `QUANTICK_DRAWINGS_DEMO=1` | one of every registered drawing placed on the flow pane once it has bars, the last one selected so the inspector is on screen too |
 | `QUANTICK_DRAWINGS_DEMO_SHARED=1` | those demo objects marked "show on all charts" — pair with a split layout to see the cross-pane projection (which is now also where they can be grabbed, moved and deleted) |
 | `QUANTICK_DRAWINGS_DEMO_RECUT=1` | re-cuts the bars under the demo objects after placing them, and adds one mark anchored before the loaded history — the two states a timeframe switch produces: every mark re-anchored onto the new bars, and one faded "off series" |
+| `QUANTICK_DRAWINGS_MANAGER=1` | opens the object manager, which is where the "off series" and "other market" badges are read — and the only place a mark clamped off the visible window can be found at all |
 
 Once merged, move them into the table above.
 

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -4141,6 +4141,7 @@ impl QuantickApp {
                         let hidden = drawing.hidden;
                         let shared = drawing.scope == drawings::DrawingScope::AllCharts;
                         let off_series = drawing.off_series;
+                        let foreign_market = drawing.foreign_market;
                         let name = drawing.tool.name();
                         ui.horizontal(|ui| {
                             let mut label = egui::RichText::new(format!("{} {}", name, index + 1));
@@ -4155,6 +4156,16 @@ impl QuantickApp {
                             }
                             if hidden {
                                 ui.label(egui::RichText::new("hidden").small());
+                            }
+                            if foreign_market {
+                                // The one state the chart alone cannot
+                                // explain: the mark resolves onto real bars,
+                                // at a price that belonged to another
+                                // instrument.
+                                ui.label(egui::RichText::new("other market").small())
+                                    .on_hover_text(
+                                        "Drawn while this tab showed a different instrument. The                                          moment still exists here; the price does not mean the                                          same thing",
+                                    );
                             }
                             if off_series {
                                 // The mark outlived the bars it was drawn on

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -1077,6 +1077,22 @@ impl QuantickApp {
         self.active_tab_mut().focused_pane_mut()
     }
 
+    /// The pane every drawing surface speaks for: the one holding the
+    /// selection, which is the focused pane unless a shared mark was taken
+    /// from the chart it is mirrored on (see [`Tab::drawing_side`]).
+    ///
+    /// The inspector, the keyboard, the object manager and the toast all read
+    /// through here, so an object selected on either of its two charts is
+    /// edited and deleted from either of them.
+    fn drawing_pane(&self) -> &ChartPane {
+        self.active_tab().drawing_pane()
+    }
+
+    /// See [`Self::drawing_pane`].
+    fn drawing_pane_mut(&mut self) -> &mut ChartPane {
+        self.active_tab_mut().drawing_pane_mut()
+    }
+
     /// The slot a command from the chrome addresses: the active tab, its
     /// focused pane, that slot.
     fn target_slot(&self, slot: SlotId) -> TabSlot {
@@ -2583,30 +2599,6 @@ impl QuantickApp {
         });
     }
 
-    /// Every pane's overlay at once, for a change that invalidates them all —
-    /// a feed switch or a source reset re-cuts both charts.
-    /// Bar-index anchors are meaningful only for the market/spec that created
-    /// them. Clear them on a source or aggregation rebuild rather than
-    /// silently attaching a mark to different market data — and say so.
-    ///
-    /// Scoped to one pane: the panes cut the same trades into different bars,
-    /// so re-cutting one of them leaves the other's anchors exactly as valid
-    /// as they were.
-    fn note_overlay_cleared(&mut self, had_drawings: bool) {
-        self.toolrail.arm(Tool::Pointer);
-        self.drawing_delete_confirm = false;
-        self.inspector_edit_baseline = None;
-        self.inspector_last_selection = None;
-        // The cleared history cannot resurrect anything, so this toast
-        // offers no Undo — a dead button would lie. But losing the marks is
-        // never silent.
-        self.toast = had_drawings.then(|| Toast {
-            message: "Drawings cleared - the bars were rebuilt under them.".into(),
-            shown_at: Instant::now(),
-            offers_undo: false,
-        });
-    }
-
     /// Periodically log a perf summary and warn on threshold breaches.
     fn maybe_emit_summary(&mut self, now: Instant) {
         let elapsed = now - self.last_summary;
@@ -2977,8 +2969,7 @@ impl QuantickApp {
                         if self.active_tab().replay.is_some() && ui.button("Close Replay").clicked()
                         {
                             let (tab, config) = self.active_with_config();
-                            let cleared = tab.close_replay(config);
-                            self.note_overlay_cleared(cleared);
+                            tab.close_replay(config);
                             ui.close_menu();
                         }
                         ui.separator();
@@ -3230,7 +3221,7 @@ impl QuantickApp {
     /// manager). A locked object raises the confirmation next to the trigger
     /// instead of deleting; a landed delete raises the Undo toast.
     fn request_delete_selected(&mut self, now: Instant) {
-        match self.focused_pane_mut().drawings.delete_selected(false) {
+        match self.drawing_pane_mut().drawings.delete_selected(false) {
             DeleteOutcome::Deleted => {
                 self.drawing_delete_confirm = false;
                 self.toast = Some(Toast {
@@ -3301,66 +3292,69 @@ impl QuantickApp {
                 // no pointer over it to arm or grab with.
             } else if self.drawing_delete_confirm {
                 self.drawing_delete_confirm = false;
-            } else if self.focused_pane().drawings.draft().is_some() {
-                self.focused_pane_mut().drawings.cancel_draft();
+            } else if self.drawing_pane().drawings.draft().is_some() {
+                self.drawing_pane_mut().drawings.cancel_draft();
                 self.toolrail.arm(Tool::Pointer);
-            } else if self.focused_pane().drawings.selected().is_some() {
-                self.focused_pane_mut().drawings.select(None);
+            } else if self.drawing_pane().drawings.selected().is_some() {
+                self.drawing_pane_mut().drawings.select(None);
             } else {
                 self.toolrail.arm(Tool::Pointer);
             }
         }
-        if self.focused_pane().drawings.draft().is_some() {
+        if self.drawing_pane().drawings.draft().is_some() {
             // During placement the delete keys belong to the draft workflow:
             // Backspace steps back one anchor.
             if keys.backspace {
-                self.focused_pane_mut().drawings.remove_last_draft_anchor();
+                self.drawing_pane_mut().drawings.remove_last_draft_anchor();
             }
         } else if keys.delete || keys.backspace {
             self.request_delete_selected(now);
         }
         if keys.undo {
-            self.focused_pane_mut().drawings.undo();
+            self.drawing_pane_mut().drawings.undo();
         }
         if keys.redo {
-            self.focused_pane_mut().drawings.redo();
+            self.drawing_pane_mut().drawings.redo();
         }
         if keys.lock
-            && let Some(index) = self.focused_pane().drawings.selected()
+            && let Some(index) = self.drawing_pane().drawings.selected()
         {
-            let locked = self.focused_pane().drawings.items()[index].locked;
-            self.focused_pane_mut()
+            let locked = self.drawing_pane().drawings.items()[index].locked;
+            self.drawing_pane_mut()
                 .drawings
                 .set_selected_locked(!locked);
         }
         if keys.hide
-            && let Some(index) = self.focused_pane().drawings.selected()
+            && let Some(index) = self.drawing_pane().drawings.selected()
         {
-            let hidden = self.focused_pane().drawings.items()[index].hidden;
-            self.focused_pane_mut()
+            let hidden = self.drawing_pane().drawings.items()[index].hidden;
+            self.drawing_pane_mut()
                 .drawings
                 .set_selected_hidden(!hidden);
         }
         if keys.duplicate {
-            self.focused_pane_mut()
+            self.drawing_pane_mut()
                 .drawings
                 .duplicate_selected(DUPLICATE_OFFSET_BARS);
         }
         if (keys.nudge_bars != 0.0 || keys.nudge_px != 0.0)
-            && self.focused_pane().drawings.selected().is_some()
+            && self.drawing_pane().drawings.selected().is_some()
         {
             // Arrows write the same honest chart coordinates a drag does:
             // one bar per horizontal step, one pixel's worth of price per
             // vertical step. Each press lands as one undo entry.
-            let price_per_px = self.focused_pane().last_auto_range.map_or(0.0, |auto| {
-                let (lo, hi) = self.focused_pane().price_view.resolve(auto);
-                (hi - lo) / f64::from(self.focused_pane().last_chart_height.max(1.0))
+            let price_per_px = self.drawing_pane().last_auto_range.map_or(0.0, |auto| {
+                let (lo, hi) = self.drawing_pane().price_view.resolve(auto);
+                (hi - lo) / f64::from(self.drawing_pane().last_chart_height.max(1.0))
             });
-            self.focused_pane_mut().drawings.begin_gesture();
-            self.focused_pane_mut()
+            self.drawing_pane_mut().drawings.begin_gesture();
+            self.drawing_pane_mut()
                 .drawings
                 .translate_selected(keys.nudge_bars, f64::from(keys.nudge_px) * price_per_px);
-            self.focused_pane_mut().drawings.commit_gesture();
+            // Same rule as the drag: the instants behind the anchors move
+            // with them, or the object's shared twin stays behind.
+            self.drawing_pane_mut().retime_selected();
+            self.drawing_pane_mut().drawings.commit_gesture();
         }
     }
 
@@ -3430,7 +3424,7 @@ impl QuantickApp {
             self.toast_undo_rect = undo_rect;
         }
         if undo_clicked {
-            self.focused_pane_mut().drawings.undo();
+            self.drawing_pane_mut().drawings.undo();
             self.toast = None;
         }
     }
@@ -3447,7 +3441,7 @@ impl QuantickApp {
         floating: bool,
     ) -> InspectorActions {
         let mut actions = InspectorActions::default();
-        let drawing = &self.focused_pane().drawings.items()[index];
+        let drawing = &self.drawing_pane().drawings.items()[index];
         let hidden = drawing.hidden;
         let title = drawing.tool.settings_title();
         let sense = if floating {
@@ -3553,7 +3547,7 @@ impl QuantickApp {
     /// tool's capabilities — an unsupported property is absent, not disabled.
     fn drawing_inspector_body(&mut self, ui: &mut egui::Ui, index: usize) -> InspectorActions {
         let mut actions = InspectorActions::default();
-        let drawing = &self.focused_pane().drawings.items()[index];
+        let drawing = &self.drawing_pane().drawings.items()[index];
         let tool = drawing.tool;
         let locked = drawing.locked;
         let hidden = drawing.hidden;
@@ -3597,7 +3591,7 @@ impl QuantickApp {
             egui::Checkbox::new(&mut shared, "Show on all charts"),
         );
         if sharing.changed()
-            && let Some(drawing) = self.focused_pane_mut().drawings.selected_mut()
+            && let Some(drawing) = self.drawing_pane_mut().drawings.selected_mut()
         {
             drawing.scope = if shared {
                 drawings::DrawingScope::AllCharts
@@ -3655,10 +3649,10 @@ impl QuantickApp {
         ui.separator();
 
         let tab = self.inspector_tab;
-        let price_speed = self.focused_pane().last_auto_range.map_or(1.0, |(lo, hi)| {
+        let price_speed = self.drawing_pane().last_auto_range.map_or(1.0, |(lo, hi)| {
             ((hi - lo) / PRICE_DRAG_STEPS).abs().max(1e-9)
         });
-        let side = self.active_tab().focused_side();
+        let side = self.active_tab().drawing_side();
         let Self {
             tabs,
             active_tab,
@@ -3809,14 +3803,14 @@ impl QuantickApp {
             self.commit_inspector_gesture();
         }
         if actions.toggle_hidden {
-            let hidden = self.focused_pane().drawings.items()[index].hidden;
-            self.focused_pane_mut()
+            let hidden = self.drawing_pane().drawings.items()[index].hidden;
+            self.drawing_pane_mut()
                 .drawings
                 .set_selected_hidden(!hidden);
         }
         if actions.toggle_lock {
-            let locked = self.focused_pane().drawings.items()[index].locked;
-            self.focused_pane_mut()
+            let locked = self.drawing_pane().drawings.items()[index].locked;
+            self.drawing_pane_mut()
                 .drawings
                 .set_selected_locked(!locked);
             self.drawing_delete_confirm = false;
@@ -3843,7 +3837,7 @@ impl QuantickApp {
         }
         if actions.force_delete {
             self.drawing_delete_confirm = false;
-            if self.focused_pane_mut().drawings.delete_selected(true) == DeleteOutcome::Deleted {
+            if self.drawing_pane_mut().drawings.delete_selected(true) == DeleteOutcome::Deleted {
                 self.toast = Some(Toast {
                     message: "Drawing deleted.".into(),
                     shown_at: now,
@@ -3852,7 +3846,7 @@ impl QuantickApp {
             }
         }
         if actions.close {
-            self.focused_pane_mut().drawings.select(None);
+            self.drawing_pane_mut().drawings.select(None);
             self.drawing_delete_confirm = false;
         }
         if let Some(saved) = actions.saved_default {
@@ -3871,7 +3865,7 @@ impl QuantickApp {
     /// [`inspector_placement`]. The chart pane already excludes both axes and
     /// the live lane, so the popup can never cover them or leave the view.
     fn inspector_target_position(&self, ctx: &egui::Context, index: usize) -> Option<egui::Pos2> {
-        let chart = self.focused_pane().last_chart_area?;
+        let chart = self.drawing_pane().last_chart_area?;
         let bbox = self.drawing_bbox_on_screen(chart, index)?;
         Some(inspector_placement(chart, bbox, self.inspector_size(ctx)))
     }
@@ -3894,22 +3888,22 @@ impl QuantickApp {
     /// radius — the rectangle the inspector must not cover. Projected on the
     /// focused pane, which is where the selection lives.
     fn drawing_bbox_on_screen(&self, chart: egui::Rect, index: usize) -> Option<egui::Rect> {
-        let total = self.focused_pane().slots();
-        let (auto_lo, auto_hi) = self.focused_pane().last_auto_range?;
-        let (lo, hi) = self.focused_pane().price_view.resolve((auto_lo, auto_hi));
+        let total = self.drawing_pane().slots();
+        let (auto_lo, auto_hi) = self.drawing_pane().last_auto_range?;
+        let (lo, hi) = self.drawing_pane().price_view.resolve((auto_lo, auto_hi));
         let scale = PriceScale::from_range(
             lo,
             hi,
-            self.focused_pane().last_chart_top,
-            self.focused_pane().last_chart_top + self.focused_pane().last_chart_height,
+            self.drawing_pane().last_chart_top,
+            self.drawing_pane().last_chart_top + self.drawing_pane().last_chart_height,
         );
         let history_right = self
-            .focused_pane()
+            .drawing_pane()
             .last_lane_divider_x
             .unwrap_or(chart.right());
-        let drawing = self.focused_pane().drawings.items().get(index)?;
+        let drawing = self.drawing_pane().drawings.items().get(index)?;
         let points =
-            self.focused_pane()
+            self.drawing_pane()
                 .projected_drawing_points(drawing, history_right, total, &scale);
         let first = points.first()?;
         let mut bbox = egui::Rect::from_min_max(*first, *first);
@@ -3922,7 +3916,7 @@ impl QuantickApp {
     /// Shared prologue of both inspector hosts. Returns the selection and its
     /// pre-frame copy, or cleans up when nothing is selected.
     fn inspector_selection(&mut self) -> Option<(usize, drawings::Drawing)> {
-        let Some(index) = self.focused_pane().drawings.selected() else {
+        let Some(index) = self.drawing_pane().drawings.selected() else {
             self.drawing_delete_confirm = false;
             self.commit_inspector_gesture();
             self.inspector_last_selection = None;
@@ -3936,7 +3930,7 @@ impl QuantickApp {
         {
             self.commit_inspector_gesture();
         }
-        Some((index, self.focused_pane().drawings.items()[index].clone()))
+        Some((index, self.drawing_pane().drawings.items()[index].clone()))
     }
 
     /// The pinned inspector: a dock panel at the chart's side. Declared with
@@ -3993,7 +3987,7 @@ impl QuantickApp {
         if selection_changed
             && !self.inspector_pin_touched
             && self
-                .focused_pane()
+                .drawing_pane()
                 .last_chart_area
                 .is_some_and(|chart| chart.width() < INSPECTOR_AUTO_PIN_CHART_WIDTH_PX)
         {
@@ -4012,7 +4006,7 @@ impl QuantickApp {
         // Repair, never override: a position that no longer fits the chart
         // pane is clamped back in, and `inspector_moved` survives.
         if let (Some(position), Some(chart)) =
-            (self.inspector_pos, self.focused_pane().last_chart_area)
+            (self.inspector_pos, self.drawing_pane().last_chart_area)
         {
             let clamped = clamp_into_chart(position, self.inspector_size(ctx), chart);
             if clamped != position {
@@ -4033,7 +4027,7 @@ impl QuantickApp {
         // one that decides whether its targets project forward at all.
         let max_height = (ctx.screen_rect().height()
             - self
-                .focused_pane()
+                .drawing_pane()
                 .last_chart_area
                 .map_or(0.0, |chart| chart.top())
             - 2.0 * INSPECTOR_OBJECT_GAP_PX)
@@ -4127,7 +4121,7 @@ impl QuantickApp {
             window = window.current_pos(position);
         }
         window.show(ctx, |ui| {
-            let count = self.focused_pane().drawings.items().len();
+            let count = self.drawing_pane().drawings.items().len();
             if count == 0 {
                 ui.label("No drawings yet.");
             }
@@ -4137,11 +4131,12 @@ impl QuantickApp {
                     // Walked in reverse: the manager lists top-most first, the
                     // same order hit-testing resolves overlap.
                     for index in (0..count).rev() {
-                        let drawing = &self.focused_pane().drawings.items()[index];
-                        let selected = self.focused_pane().drawings.selected() == Some(index);
+                        let drawing = &self.drawing_pane().drawings.items()[index];
+                        let selected = self.drawing_pane().drawings.selected() == Some(index);
                         let locked = drawing.locked;
                         let hidden = drawing.hidden;
                         let shared = drawing.scope == drawings::DrawingScope::AllCharts;
+                        let off_series = drawing.off_series;
                         let name = drawing.tool.name();
                         ui.horizontal(|ui| {
                             let mut label = egui::RichText::new(format!("{} {}", name, index + 1));
@@ -4156,6 +4151,19 @@ impl QuantickApp {
                             }
                             if hidden {
                                 ui.label(egui::RichText::new("hidden").small());
+                            }
+                            if off_series {
+                                // The mark outlived the bars it was drawn on
+                                // and the chart fades it (§D7b). The list is
+                                // where it can be found and removed, since a
+                                // clamped object may be nowhere near the
+                                // window the trader is looking at.
+                                ui.label(egui::RichText::new("off series").small())
+                                    .on_hover_text(
+                                        "Drawn at a moment this chart's bars do not cover. It is \
+                                         shown at the nearest edge, faded, until you move or \
+                                         delete it",
+                                    );
                             }
                             if shared {
                                 // Which marks are global is a question the
@@ -4232,7 +4240,7 @@ impl QuantickApp {
         });
         self.drawing_manager_open = open;
         if delete_all {
-            let deleted = self.focused_pane_mut().drawings.delete_all();
+            let deleted = self.drawing_pane_mut().drawings.delete_all();
             if deleted > 0 {
                 self.toast = Some(Toast {
                     message: "All drawings deleted.".into(),
@@ -4242,47 +4250,47 @@ impl QuantickApp {
             }
         }
         if let Some(index) = select_row {
-            self.focused_pane_mut().drawings.select(Some(index));
+            self.drawing_pane_mut().drawings.select(Some(index));
             // Centre the viewport on the object's bar span.
-            let slots = self.focused_pane().slots();
-            if let Some(chart) = self.focused_pane().last_chart_area {
-                let points = &self.focused_pane().drawings.items()[index].points;
+            let slots = self.drawing_pane().slots();
+            if let Some(chart) = self.drawing_pane().last_chart_area {
+                let points = &self.drawing_pane().drawings.items()[index].points;
                 if !points.is_empty() {
                     let mid =
                         points.iter().map(|point| point.bar).sum::<f32>() / points.len() as f32;
-                    self.focused_pane_mut()
+                    self.drawing_pane_mut()
                         .viewport
                         .center_on_bar(mid, chart.width(), slots);
                 }
             }
         }
         if let Some(index) = eye_row {
-            let hidden = self.focused_pane().drawings.items()[index].hidden;
-            self.focused_pane_mut()
+            let hidden = self.drawing_pane().drawings.items()[index].hidden;
+            self.drawing_pane_mut()
                 .drawings
                 .set_hidden_at(index, !hidden);
         }
         if let Some(index) = lock_row {
-            let locked = self.focused_pane().drawings.items()[index].locked;
-            self.focused_pane_mut()
+            let locked = self.drawing_pane().drawings.items()[index].locked;
+            self.drawing_pane_mut()
                 .drawings
                 .set_locked_at(index, !locked);
         }
         if let Some(index) = front_row {
-            self.focused_pane_mut().drawings.bring_to_front(index);
+            self.drawing_pane_mut().drawings.bring_to_front(index);
         }
         if let Some(index) = delete_row {
             // The exact same command path as the inspector button and the
             // keyboard: select, then request. Locked rows raise the same
             // confirmation in the inspector.
-            self.focused_pane_mut().drawings.select(Some(index));
+            self.drawing_pane_mut().drawings.select(Some(index));
             self.request_delete_selected(now);
         }
         if show_all {
-            self.focused_pane_mut().drawings.set_all_hidden(false);
+            self.drawing_pane_mut().drawings.set_all_hidden(false);
         }
         if unlock_all {
-            self.focused_pane_mut().drawings.set_all_locked(false);
+            self.drawing_pane_mut().drawings.set_all_locked(false);
         }
     }
 
@@ -4291,13 +4299,11 @@ impl QuantickApp {
         match action {
             ReplayAction::Open(request) => {
                 let (tab, config) = self.active_with_config();
-                let cleared = tab.open_replay(config, *request);
-                self.note_overlay_cleared(cleared);
+                tab.open_replay(config, *request);
             }
             ReplayAction::Close => {
                 let (tab, config) = self.active_with_config();
-                let cleared = tab.close_replay(config);
-                self.note_overlay_cleared(cleared);
+                tab.close_replay(config);
             }
             ReplayAction::Control(control) => {
                 // A dropped transport click is not worth a retry queue: the
@@ -4403,6 +4409,44 @@ impl QuantickApp {
                 }
             }
         }
+        self.apply_drawing_demo_recut();
+    }
+
+    /// The `QUANTICK_DRAWINGS_DEMO_RECUT` hook: re-cut the bars under the demo
+    /// objects, so a screenshot shows what a timeframe switch does to them.
+    ///
+    /// It is the only way to reach the two surfaces this behaviour added
+    /// without a human touching the BARS selector: marks that survived a
+    /// re-cut and are still on their own instants, and a mark the new series
+    /// cannot reach, faded and labelled off-series. One extra object is placed
+    /// an hour before the first bar to produce the second.
+    fn apply_drawing_demo_recut(&mut self) {
+        if !std::env::var("QUANTICK_DRAWINGS_DEMO_RECUT").is_ok_and(|value| value == "1") {
+            return;
+        }
+        let pane = &mut self.active_tab_mut().flow_pane;
+        // An anchor before anything the tab has loaded: honest input for the
+        // off-series path, not a flag set by hand.
+        if let Some(first) = pane.slot_open_time(0) {
+            let base = pane
+                .closed_bar(0)
+                .and_then(|bar| rust_decimal::prelude::ToPrimitive::to_f64(&bar.close))
+                .unwrap_or(1.0);
+            pane.drawings.place_with(
+                drawings::DRAWING_TOOLS[0],
+                drawings::ChartPoint::at_time(0.5, base, Some(first - 3_600_000)),
+                |tool| drawings::NewDrawing {
+                    style: drawings::DrawingStyle::default(),
+                    payload: tool.default_payload(),
+                },
+            );
+        }
+        // Half the bars, same trades — the plainest re-cut there is. Two
+        // settle frames because a spec change waits for the selector to hold
+        // still for one (`Tab::apply_spec_change`).
+        pane.tick_n = pane.tick_n.saturating_mul(2).max(2);
+        self.active_tab_mut().apply_spec_changes();
+        self.active_tab_mut().apply_spec_changes();
     }
 }
 
@@ -4542,17 +4586,14 @@ impl QuantickApp {
         // Respawn the feed if the feed/symbol selection changed (resets the
         // chart), then apply any bar-type change (no-op if unchanged).
         let (tab, config) = self.active_with_config();
-        let mut cleared = tab.maybe_switch_feed(config);
+        tab.maybe_switch_feed(config);
         // Both deferrals settle here, a frame after the click that armed
         // them, so the frame carrying the change paints its overlay first.
         let Self { tabs, config, .. } = self;
         for tab in tabs.iter_mut() {
             tab.apply_pending_layout(config);
         }
-        cleared |= self.active_tab_mut().apply_spec_changes();
-        if cleared {
-            self.note_overlay_cleared(true);
-        }
+        self.active_tab_mut().apply_spec_changes();
         self.draw_style_panel(ctx, now);
         // Waits owned by other components, mirrored level-style each frame so
         // the overlay needs no push notifications from either.
@@ -4612,8 +4653,7 @@ impl QuantickApp {
         self.active_tab_mut().paper.draw_toast(ctx, now);
         if notice_action == notice_card::NoticeAction::Retry {
             let (tab, config) = self.active_with_config();
-            let cleared = tab.restart_feed(config);
-            self.note_overlay_cleared(cleared);
+            tab.restart_feed(config);
         }
         // Live feed: keep polling the channel ~60×/s without busy-spinning.
         ctx.request_repaint_after(Duration::from_millis(16));
@@ -4627,12 +4667,11 @@ impl QuantickApp {
     /// indicator workers are fed on the same pass, so a tab brought forward is
     /// already current rather than rebuilding on the frame it appears.
     fn drain_tabs(&mut self) {
-        let mut cleared_active = false;
         let config = &self.config;
         let mut trades = 0_u64;
-        for (index, tab) in self.tabs.iter_mut().enumerate() {
+        for tab in &mut self.tabs {
             let before = tab.live_trades;
-            let cleared = tab.drain_feed();
+            tab.drain_feed();
             for pane in tab.panes_mut() {
                 pane.apply_indicator_events();
             }
@@ -4651,18 +4690,9 @@ impl QuantickApp {
             // answer can be a real one.
             tab.poll_ohlcv_capability(config);
             trades += tab.live_trades - before;
-            if cleared && index == self.active_tab {
-                cleared_active = true;
-            }
         }
         // What the window ingested, across every market it is holding.
         self.trades_since_summary += trades;
-        // Only the active tab's overlay chrome is on screen to react; a
-        // background tab that lost its marks says so when it comes forward,
-        // through the same empty overlay.
-        if cleared_active {
-            self.note_overlay_cleared(true);
-        }
     }
 
     /// Tab shortcuts (§10): `Ctrl+T` new, `Ctrl+W` close, `Ctrl+Tab` cycle.
@@ -6146,9 +6176,10 @@ plot(close)
         evt_tx.try_send(FeedEvent::Reset).unwrap();
         app.active_tab_mut().drain_feed();
         assert_eq!(app.active_tab().loading.count(LoadingTask::History), 1);
-        assert!(
-            app.active_tab().flow_pane.drawings.items().is_empty(),
-            "bar-index drawings cannot survive a source reset honestly"
+        assert_eq!(
+            app.active_tab().flow_pane.drawings.items().len(),
+            1,
+            "a rewind rebuilds the bars, not the trader's marks (§D7b)"
         );
     }
 
@@ -6171,9 +6202,10 @@ plot(close)
 
         app.active_tab_mut().apply_spec_changes();
         assert_eq!(app.active_tab().flow_pane.state.spec(), &BarSpec::Tick(100));
-        assert!(
-            app.active_tab().flow_pane.drawings.items().is_empty(),
-            "a new bar partition must not inherit old bar-index anchors"
+        assert_eq!(
+            app.active_tab().flow_pane.drawings.items().len(),
+            1,
+            "a new bar partition re-anchors the marks, it does not drop them"
         );
         assert!(!app.active_tab().loading.is_active(LoadingTask::BarRebuild));
     }
@@ -6533,6 +6565,10 @@ plot(close)
             symbol: &tab.symbol,
             paper: &mut tab.paper,
             paper_owns_input: true,
+            // One pane in hand and no tab around it: there is no other pane
+            // whose shared marks could be under the pointer.
+            shared_pick: None,
+            shared: pane::SharedInteraction::default(),
             capabilities,
             layers: layer_actions,
         };
@@ -8028,6 +8064,191 @@ plot(close)
         );
     }
 
+    /// A tab split in two, with one shared horizontal line drawn on the flow
+    /// pane, and the screen position that line occupies on the *time* pane.
+    ///
+    /// The mark is anchored on a real flow bar (so it carries a real market
+    /// instant) at the price sitting in the middle of the time pane's window
+    /// (so a drag has room to move in either direction without leaving the
+    /// chart). Its y is computed through the time pane's own price scale,
+    /// which is the whole point: the two panes agree on the price and on
+    /// nothing else.
+    fn split_with_a_shared_line(
+        ctx: &egui::Context,
+    ) -> (QuantickApp, mpsc::Receiver<FeedCommand>, egui::Pos2) {
+        let (mut app, commands) = app_with_history(200);
+        app.active_tab_mut().set_layout(CanvasLayout::TimeAndFlow);
+        // The layout is deferred a frame, so the time pane does not exist yet
+        // on the line above — hence these frames before it is configured.
+        run_frame(&mut app, ctx);
+        run_frame(&mut app, ctx);
+        // One-second bars, so this fixture's 20 seconds of tape is 20 bars on
+        // the time pane against 200 on the flow pane. That difference is what
+        // §D7 is about — the two panes agree on market time and on nothing
+        // else — and without it the time pane holds a single bar, most of its
+        // chart is empty space no instant can be named in, and every gesture
+        // below silently does nothing.
+        let pane = app
+            .active_tab_mut()
+            .time_pane
+            .as_mut()
+            .expect("two frames is enough for the deferred layout to build it");
+        pane.kind = crate::state::BarKind::Time;
+        pane.time_interval_ms = 1_000;
+        app.active_tab_mut().apply_spec_changes();
+        app.active_tab_mut().apply_spec_changes();
+        run_frame(&mut app, ctx);
+        run_frame(&mut app, ctx);
+        assert!(
+            app.active_tab()
+                .time_pane
+                .as_ref()
+                .is_some_and(|pane| pane.slots() > 5),
+            "the time pane must hold a real series, or these tests pass on a              gesture that never reached a bar"
+        );
+
+        let (chart, scale) = time_pane_projection(&app);
+        // Mid-window price, and an x near the newest bar: both panes can name
+        // an instant there, and a drag has room above and below.
+        let price = scale.price_at(chart.center().y);
+        let slot = 100;
+        let time = app
+            .active_tab()
+            .flow_pane
+            .slot_open_time(slot)
+            .expect("a closed bar has a time");
+        app.active_tab_mut().flow_pane.drawings.place_with(
+            drawing_tool("horizontal-line"),
+            drawings::ChartPoint::at_time(slot as f32 + 0.5, price, Some(time)),
+            |tool| drawings::NewDrawing {
+                style: drawings::DrawingStyle::default(),
+                payload: tool.default_payload(),
+            },
+        );
+        app.active_tab_mut()
+            .flow_pane
+            .drawings
+            .selected_mut()
+            .expect("placement selects what it completed")
+            .scope = drawings::DrawingScope::AllCharts;
+        // Nothing selected to start with, so the assertions cannot pass on the
+        // selection placement left behind.
+        app.active_tab_mut().flow_pane.drawings.select(None);
+        run_frame(&mut app, ctx);
+
+        let (chart, scale) = time_pane_projection(&app);
+        (
+            app,
+            commands,
+            egui::pos2(chart.right() - 30.0, scale.y(price)),
+        )
+    }
+
+    /// The time pane's chart rect and price scale, as it last drew them.
+    fn time_pane_projection(app: &QuantickApp) -> (egui::Rect, PriceScale) {
+        let time_pane = app
+            .active_tab()
+            .time_pane
+            .as_ref()
+            .expect("the split built a time pane");
+        let chart = time_pane.last_chart_area.expect("the time pane drew");
+        let (lo, hi) = time_pane
+            .price_view
+            .resolve(time_pane.last_auto_range.expect("the pane has a range"));
+        let scale = PriceScale::from_range(
+            lo,
+            hi,
+            time_pane.last_chart_top,
+            time_pane.last_chart_top + time_pane.last_chart_height,
+        );
+        (chart, scale)
+    }
+
+    #[test]
+    fn a_shared_mark_is_selected_and_deleted_from_the_other_chart() {
+        let ctx = egui::Context::default();
+        let (mut app, _commands, on_the_time_pane) = split_with_a_shared_line(&ctx);
+
+        click_chart(&mut app, &ctx, on_the_time_pane);
+
+        assert_eq!(
+            app.active_tab().flow_pane.drawings.selected(),
+            Some(0),
+            "pressing the mirrored copy takes the one object it mirrors"
+        );
+        assert_eq!(
+            app.active_tab().drawing_side(),
+            PaneSide::Flow,
+            "and the chrome follows the object, not the pane under the pointer"
+        );
+
+        run_frame_with_events(&mut app, &ctx, vec![key_press(egui::Key::Delete)]);
+        assert!(
+            app.active_tab().flow_pane.drawings.items().is_empty(),
+            "Delete on the chart the mark was seen on deletes the mark"
+        );
+    }
+
+    #[test]
+    fn a_shared_mark_is_dragged_from_the_other_chart() {
+        let ctx = egui::Context::default();
+        let (mut app, _commands, on_the_time_pane) = split_with_a_shared_line(&ctx);
+        let before = app.active_tab().flow_pane.drawings.items()[0].points[0];
+        let undo_before = app.active_tab().flow_pane.drawings.undo_depth();
+
+        // Straight up: a horizontal line has one anchor and price is the
+        // coordinate both panes read the same way.
+        drag_chart(
+            &mut app,
+            &ctx,
+            on_the_time_pane,
+            on_the_time_pane - egui::vec2(0.0, 60.0),
+        );
+
+        let after = app.active_tab().flow_pane.drawings.items()[0].points[0];
+        assert!(
+            after.price > before.price,
+            "dragging the mirror up moves the object up: {} -> {}",
+            before.price,
+            after.price
+        );
+        assert_eq!(
+            app.active_tab().flow_pane.drawings.undo_depth(),
+            undo_before + 1,
+            "the whole drag is one undo entry on the store that holds it"
+        );
+    }
+
+    #[test]
+    fn a_drag_on_a_mirrored_mark_does_not_also_pan_the_chart_under_it() {
+        let ctx = egui::Context::default();
+        let (mut app, _commands, on_the_time_pane) = split_with_a_shared_line(&ctx);
+        let time_pane = app
+            .active_tab()
+            .time_pane
+            .as_ref()
+            .expect("the split built a time pane");
+        let before = time_pane.viewport.right_edge_bar(time_pane.slots());
+
+        drag_chart(
+            &mut app,
+            &ctx,
+            on_the_time_pane,
+            on_the_time_pane - egui::vec2(80.0, 40.0),
+        );
+
+        let time_pane = app
+            .active_tab()
+            .time_pane
+            .as_ref()
+            .expect("the split built a time pane");
+        assert_eq!(
+            time_pane.viewport.right_edge_bar(time_pane.slots()),
+            before,
+            "the gesture belongs to the mark, so the chart behind it holds still"
+        );
+    }
+
     /// The reverse, so the test above cannot pass on a stroke that was always
     /// there: switching sharing off takes the foreign copy away again.
     #[test]
@@ -9219,33 +9440,59 @@ plot(close)
     }
 
     #[test]
-    fn a_bar_rebuild_clears_drawings_with_an_explicit_notice_and_no_dead_undo() {
+    fn a_source_reset_keeps_the_marks_and_re_anchors_them_by_market_time() {
         let (mut app, evt_tx, _cmd_rx, _book_tx) = test_app();
         let ctx = egui::Context::default();
+        app.active_tab_mut().flow_pane.tick_n = 1;
+        app.active_tab_mut().apply_spec_changes();
+        app.active_tab_mut().apply_spec_changes();
         run_frame(&mut app, &ctx);
-        app.active_tab_mut()
-            .flow_pane
-            .drawings
-            .place(drawing_tool("horizontal-line"), ChartPoint::at(1.0, 100.0));
-
-        evt_tx.try_send(FeedEvent::Reset).unwrap();
-        // Through the window's own drain: the tab drops the marks, and the
-        // window is what turns that into the toast.
+        // One bar per trade, so the anchor placed on bar 3 is the trade at
+        // that instant — and the rewind below refills with half as many bars
+        // per trade, moving where that instant lives.
+        let trades: Vec<_> = (1..=8).map(trade).collect();
+        let anchor_time = trades[3].timestamp_ms;
+        evt_tx.try_send(FeedEvent::Backfilled(trades)).unwrap();
         app.drain_tabs();
-        assert!(app.active_tab().flow_pane.drawings.items().is_empty());
-        assert!(app.toast.is_some(), "the clear must raise the notice toast");
+        app.active_tab_mut().flow_pane.drawings.place(
+            drawing_tool("horizontal-line"),
+            ChartPoint::at_time(3.5, 100.0, Some(anchor_time)),
+        );
 
-        // A fresh egui Area sizes itself on its first frame; the text is
-        // on screen from the second one.
+        // A rewind: the source throws the timeline away and refills it.
+        evt_tx.try_send(FeedEvent::Reset).unwrap();
+        app.drain_tabs();
+        assert_eq!(
+            app.active_tab().flow_pane.drawings.items().len(),
+            1,
+            "a rebuilt timeline never deletes what the trader drew"
+        );
+        evt_tx
+            .try_send(FeedEvent::Backfilled((1..=8).map(trade).collect()))
+            .unwrap();
+        app.drain_tabs();
+
+        let point = app.active_tab().flow_pane.drawings.items()[0].points[0];
+        assert_eq!(
+            point.time_ms,
+            Some(anchor_time),
+            "the instant it was placed at is what survives"
+        );
+        assert_eq!(
+            app.active_tab().flow_pane.slot_at_time(anchor_time),
+            Some(point.bar.floor() as usize),
+            "and the bar it sits on is that instant, re-asked of the new series"
+        );
+        assert!(
+            !app.active_tab().flow_pane.drawings.items()[0].off_series,
+            "the refilled series does reach the anchor, so nothing is faded"
+        );
+
         run_frame(&mut app, &ctx);
         let texts = painted_text(&run_frame(&mut app, &ctx));
         assert!(
-            texts.iter().any(|text| text.contains("Drawings cleared")),
-            "losing the marks is never silent; painted: {texts:?}"
-        );
-        assert!(
-            !texts.iter().any(|text| text == "Undo"),
-            "the clear toast must not offer an Undo it cannot honour"
+            !texts.iter().any(|text| text.contains("Drawings cleared")),
+            "there is no loss left to announce; painted: {texts:?}"
         );
     }
 

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -77,6 +77,10 @@ const DEMO_VISIBLE_SLOTS: usize = 90;
 /// far a multi-anchor object reaches. Four keeps a rectangle big enough to
 /// read while still leaving the tools distinguishable from each other.
 const DEMO_SPANS_PER_WINDOW: usize = 4;
+/// How far before the loaded history the re-cut demo anchors its off-series
+/// mark. Any distance the tab cannot possibly hold would do; an hour is
+/// unambiguous at every timeframe the chart offers.
+const DEMO_OFF_SERIES_LEAD_MS: i64 = 3_600_000;
 /// Initial position of the selected-drawing inspector.
 const DRAWING_INSPECTOR_DEFAULT_POSITION: egui::Pos2 = egui::pos2(90.0, 120.0);
 /// Length of the EMA the toolbar's hardcoded M1 entry adds (the settings UI
@@ -4434,7 +4438,7 @@ impl QuantickApp {
                 .unwrap_or(1.0);
             pane.drawings.place_with(
                 drawings::DRAWING_TOOLS[0],
-                drawings::ChartPoint::at_time(0.5, base, Some(first - 3_600_000)),
+                drawings::ChartPoint::at_time(0.5, base, Some(first - DEMO_OFF_SERIES_LEAD_MS)),
                 |tool| drawings::NewDrawing {
                     style: drawings::DrawingStyle::default(),
                     payload: tool.default_payload(),
@@ -8216,6 +8220,43 @@ plot(close)
             app.active_tab().flow_pane.drawings.undo_depth(),
             undo_before + 1,
             "the whole drag is one undo entry on the store that holds it"
+        );
+    }
+
+    /// The other direction, and the regression this pass exists to hold:
+    /// moving a shared mark on the chart it *lives* on has to carry its
+    /// instants with it, or the twin on the other chart stays where it was.
+    /// `translate_selected` moved bar indices only, which made the two views
+    /// disagree the moment either was dragged.
+    #[test]
+    fn moving_a_shared_mark_on_its_own_chart_carries_its_instants() {
+        let ctx = egui::Context::default();
+        let (mut app, _commands, _position) = split_with_a_shared_line(&ctx);
+        app.active_tab_mut().flow_pane.drawings.select(Some(0));
+        let before = app.active_tab().flow_pane.drawings.items()[0].points[0];
+
+        // Four bars to the right, through the same path a drag takes.
+        app.active_tab_mut().flow_pane.drawings.begin_gesture();
+        app.active_tab_mut()
+            .flow_pane
+            .drawings
+            .translate_selected(4.0, 0.0);
+        app.active_tab_mut().flow_pane.retime_selected();
+        app.active_tab_mut().flow_pane.drawings.commit_gesture();
+
+        let after = app.active_tab().flow_pane.drawings.items()[0].points[0];
+        assert!(after.bar > before.bar, "the mark moved on its own chart");
+        assert_ne!(
+            after.time_ms, before.time_ms,
+            "and the instant behind it moved too, or the other chart still \
+             paints it at the old moment"
+        );
+        assert_eq!(
+            app.active_tab()
+                .flow_pane
+                .slot_at_time(after.time_ms.expect("a mark on a bar has an instant")),
+            Some(after.bar.floor() as usize),
+            "the bar and the instant say the same thing"
         );
     }
 

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -873,6 +873,13 @@ impl QuantickApp {
         }
         app.pending_drawing_demo =
             std::env::var("QUANTICK_DRAWINGS_DEMO").is_ok_and(|value| value == "1");
+        // The object manager is where a mark that cannot be trusted says so —
+        // the "off series" and "other market" badges live there, and a mark
+        // clamped to an edge may be nowhere near the visible window, making
+        // the list the only place it can be found. Reachable from a launch,
+        // like every other surface, or it cannot be checked without a mouse.
+        app.drawing_manager_open =
+            std::env::var("QUANTICK_DRAWINGS_MANAGER").is_ok_and(|value| value == "1");
 
         // Same convenience for the aggression layer (bubbles + the live
         // column's footprint). Same code path as the toolbar toggle.
@@ -4447,14 +4454,24 @@ impl QuantickApp {
                 .closed_bar(0)
                 .and_then(|bar| rust_decimal::prelude::ToPrimitive::to_f64(&bar.close))
                 .unwrap_or(1.0);
-            pane.drawings.place_with(
-                drawings::DRAWING_TOOLS[0],
-                drawings::ChartPoint::at_time(0.5, base, Some(first - DEMO_OFF_SERIES_LEAD_MS)),
-                |tool| drawings::NewDrawing {
-                    style: drawings::DrawingStyle::default(),
-                    payload: tool.default_payload(),
-                },
-            );
+            // A one-anchor tool by name, not `DRAWING_TOOLS[0]` — that is the
+            // trend line, which needs two, so a single `place_with` left a
+            // half-finished draft and no object at all. The whole point here
+            // is to produce one *completed* off-series mark.
+            let single_anchor = drawings::DRAWING_TOOLS
+                .into_iter()
+                .find(|tool| tool.id() == "horizontal-line");
+            if let Some(tool) = single_anchor {
+                let placed = pane.drawings.place_with(
+                    tool,
+                    drawings::ChartPoint::at_time(0.5, base, Some(first - DEMO_OFF_SERIES_LEAD_MS)),
+                    |tool| drawings::NewDrawing {
+                        style: drawings::DrawingStyle::default(),
+                        payload: tool.default_payload(),
+                    },
+                );
+                debug_assert!(placed, "a horizontal line completes on one anchor");
+            }
         }
         // Half the bars, same trades — the plainest re-cut there is. Two
         // settle frames because a spec change waits for the selector to hold

--- a/crates/app/src/drawings/mod.rs
+++ b/crates/app/src/drawings/mod.rs
@@ -562,6 +562,16 @@ pub struct Drawing {
     pub hidden: bool,
     /// Whether the other panes of this tab show it too.
     pub scope: DrawingScope,
+    /// Set by [`Drawings::reanchor`] when this pane's series does not reach
+    /// the market instant an anchor was placed at — the mark survived a
+    /// re-cut, a rewind or a symbol switch, but it is no longer sitting on
+    /// the data it was drawn against.
+    ///
+    /// Derived state, never edited: it is what the honesty fade and the
+    /// object manager's off-series badge read, and it is deliberately absent
+    /// from [`PartialEq`] so re-anchoring can never look like a user edit to
+    /// the undo history.
+    pub off_series: bool,
     /// Tool-owned state (Fib levels, a future tool's own properties). The
     /// registry creates it; the shared envelope never learns its fields.
     pub payload: Box<dyn DrawingPayload>,
@@ -789,6 +799,7 @@ impl Drawings {
                 locked: false,
                 hidden: false,
                 scope: DrawingScope::default(),
+                off_series: false,
                 payload: fresh.payload,
             });
         }
@@ -844,18 +855,94 @@ impl Drawings {
         self.record(before);
     }
 
-    /// Honest reset: the anchors cannot survive a source or bar-spec change,
-    /// and neither can a history that would resurrect them onto different
-    /// market data.
-    pub fn clear(&mut self) {
-        self.items.clear();
-        self.draft = None;
-        self.selected = None;
-        self.all_hidden = false;
-        self.undo.clear();
-        self.redo.clear();
-        self.gesture_baseline = None;
+    /// Re-express every anchor against a series that was cut again — a
+    /// timeframe or bar-kind switch, a replay seek, a reconnect, a symbol
+    /// change.
+    ///
+    /// A bar index means nothing across two cuts of the tape; the market
+    /// instant each anchor captured at placement does, and it is the same
+    /// coordinate that already carries a drawing between the panes of a tab
+    /// (`docs/ux/drawing-tools-2026-08.md` §D7). So the object is not
+    /// discarded and not left pointing at a stale index: it is asked where
+    /// its own timestamps landed.
+    ///
+    /// `slot_of` answers where a market instant sits on the new series, or
+    /// `None` when the series does not reach it — before its first bar, or on
+    /// an instrument that never traded at that moment. Those anchors clamp to
+    /// the nearest edge and the object is flagged [`Drawing::off_series`], so
+    /// it fades and says so rather than pretending to sit on data.
+    ///
+    /// An anchor with no timestamp at all is one dropped past the newest bar,
+    /// where the tape has written nothing (see `ChartPoint::time_ms`). It has
+    /// no instant to look up, so it keeps its distance past the end of the
+    /// series instead — which is exactly where the trader put it.
+    ///
+    /// Rate: once per re-cut, never per frame or per trade, over a handful of
+    /// objects. The undo stacks travel with the live items for the same
+    /// reason [`Self::shift_bars`] moves them — undoing later must not
+    /// resurrect coordinates from a series that no longer exists.
+    pub fn reanchor(
+        &mut self,
+        old_slots: usize,
+        new_slots: usize,
+        slot_of: impl Fn(i64) -> Option<f32>,
+    ) {
+        #[allow(clippy::cast_precision_loss)]
+        let past_end = new_slots as f32 - old_slots as f32;
+        let reanchor_all = |items: &mut [Drawing]| {
+            for drawing in items {
+                let mut off_series = false;
+                for point in &mut drawing.points {
+                    let Some(time) = point.time_ms else {
+                        point.bar += past_end;
+                        continue;
+                    };
+                    match slot_of(time) {
+                        Some(slot) => point.bar = slot,
+                        None => {
+                            off_series = true;
+                            point.bar = 0.0;
+                        }
+                    }
+                }
+                drawing.off_series = off_series;
+            }
+        };
+        reanchor_all(&mut self.items);
+        if let Some(draft) = self.draft.as_mut() {
+            reanchor_all(std::slice::from_mut(draft));
+        }
+        for entry in self.undo.iter_mut().chain(self.redo.iter_mut()) {
+            reanchor_all(&mut entry.items);
+        }
+        if let Some(baseline) = &mut self.gesture_baseline {
+            reanchor_all(&mut baseline.items);
+        }
     }
+
+    /// Rewrite the market instants behind one object's anchors, after a move
+    /// that changed their bar positions.
+    ///
+    /// [`Self::translate_selected`] and the keyboard nudge shift bar indices
+    /// directly; the timestamp behind each anchor is what every *other* pane
+    /// reads, so leaving it stale would drag a mark on one chart and leave
+    /// its shared twin standing where it used to be. Only the pane knows how
+    /// to name the instant under a slot, so it hands the answers back here.
+    pub fn set_times(&mut self, index: usize, times: &[Option<i64>]) {
+        let Some(drawing) = self.items.get_mut(index) else {
+            return;
+        };
+        for (point, time) in drawing.points.iter_mut().zip(times) {
+            point.time_ms = *time;
+        }
+    }
+
+    // There is deliberately no `clear`. A re-cut of the bars used to wipe the
+    // store, on the reasoning that a bar index cannot survive one; the anchors
+    // carry market time, so they are re-expressed instead
+    // ([`Self::reanchor`]). The only way a drawing leaves is the trader
+    // removing it — [`Self::delete_selected`] or [`Self::delete_all`], both of
+    // which are undoable.
 
     pub fn shift_bars(&mut self, delta: isize) {
         if delta == 0 {
@@ -1522,14 +1609,23 @@ mod tests {
         assert!(!drawings.items()[0].shareable());
     }
 
+    /// A re-cut used to throw the whole store away, draft included. Nothing is
+    /// thrown away now, and a half-placed object is no exception: its first
+    /// anchor moves onto the new bars like any other, so the trader finishes
+    /// the shape they started rather than starting over.
     #[test]
-    fn clearing_drawings_also_discards_an_unfinished_draft() {
+    fn reanchoring_carries_an_unfinished_draft_too() {
         let mut drawings = Drawings::default();
-        assert!(!drawings.place(tool("rectangle"), ChartPoint::at(1.0, 100.0)));
-        drawings.clear();
-        assert!(drawings.items().is_empty());
-        assert!(drawings.draft().is_none());
-        assert_eq!(drawings.selected(), None);
+        assert!(!drawings.place(
+            tool("rectangle"),
+            ChartPoint::at_time(6.0, 100.0, Some(1_700_000_006_000))
+        ));
+
+        drawings.reanchor(10, 5, halved);
+
+        let draft = drawings.draft().expect("the draft survives the re-cut");
+        assert_eq!(draft.points[0].bar, 3.0);
+        assert_eq!(draft.points[0].time_ms, Some(1_700_000_006_000));
     }
 
     #[test]
@@ -1544,6 +1640,106 @@ mod tests {
         assert_eq!(
             drawings.draft().expect("rectangle draft").points[0].bar,
             7.0
+        );
+    }
+
+    /// A series re-cut so that every instant lands on half its old slot —
+    /// what doubling a timeframe does to the bars under a drawing.
+    fn halved(time: i64) -> Option<f32> {
+        Some((time - 1_700_000_000_000) as f32 / 2_000.0)
+    }
+
+    #[test]
+    fn reanchoring_puts_an_anchor_on_the_slot_its_timestamp_now_lands_on() {
+        let mut drawings = Drawings::default();
+        drawings.place(
+            tool("horizontal-line"),
+            ChartPoint::at_time(6.0, 100.0, Some(1_700_000_006_000)),
+        );
+
+        drawings.reanchor(10, 5, halved);
+
+        assert_eq!(drawings.items()[0].points[0].bar, 3.0);
+        assert_eq!(drawings.items()[0].points[0].price, 100.0);
+        assert!(!drawings.items()[0].off_series);
+    }
+
+    #[test]
+    fn reanchoring_keeps_an_undated_anchor_past_the_end_of_the_new_series() {
+        let mut drawings = Drawings::default();
+        // Two bars past the newest of a ten-bar series, where the tape has
+        // written nothing and there is no instant to look up.
+        drawings.place(tool("horizontal-line"), ChartPoint::at(12.0, 100.0));
+
+        drawings.reanchor(10, 5, halved);
+
+        // Still two bars past the newest, now that the newest is bar 5.
+        assert_eq!(drawings.items()[0].points[0].bar, 7.0);
+    }
+
+    #[test]
+    fn reanchoring_flags_an_anchor_the_new_series_cannot_reach() {
+        let mut drawings = Drawings::default();
+        drawings.place(
+            tool("horizontal-line"),
+            ChartPoint::at_time(6.0, 100.0, Some(1_700_000_006_000)),
+        );
+
+        // A symbol switch: the new instrument's series does not cover the
+        // instant this mark was drawn at.
+        drawings.reanchor(10, 5, |_| None);
+
+        assert!(drawings.items()[0].off_series, "the mark must say so");
+        assert_eq!(
+            drawings.items()[0].points[0].time_ms,
+            Some(1_700_000_006_000),
+            "the instant it was placed at is never rewritten"
+        );
+    }
+
+    #[test]
+    fn reanchoring_travels_with_the_undo_history() {
+        let mut drawings = Drawings::default();
+        drawings.place(
+            tool("horizontal-line"),
+            ChartPoint::at_time(6.0, 100.0, Some(1_700_000_006_000)),
+        );
+        drawings.begin_gesture();
+        drawings.translate_selected(4.0, 0.0);
+        drawings.commit_gesture();
+
+        drawings.reanchor(10, 5, halved);
+        drawings.undo();
+
+        // Undo must not resurrect a coordinate from the series that is gone.
+        assert_eq!(drawings.items()[0].points[0].bar, 3.0);
+    }
+
+    #[test]
+    fn setting_times_rewrites_the_instants_behind_the_anchors() {
+        let mut drawings = Drawings::default();
+        let rectangle = tool("rectangle");
+        drawings.place(
+            rectangle,
+            ChartPoint::at_time(1.0, 100.0, Some(1_700_000_001_000)),
+        );
+        drawings.place(
+            rectangle,
+            ChartPoint::at_time(3.0, 110.0, Some(1_700_000_003_000)),
+        );
+
+        drawings.translate_selected(2.0, 0.0);
+        drawings.set_times(0, &[Some(1_700_000_003_000), Some(1_700_000_005_000)]);
+
+        let times: Vec<_> = drawings.items()[0]
+            .points
+            .iter()
+            .map(|point| point.time_ms)
+            .collect();
+        assert_eq!(
+            times,
+            [Some(1_700_000_003_000), Some(1_700_000_005_000)],
+            "a moved mark carries its new instants, or its shared twin stays behind"
         );
     }
 

--- a/crates/app/src/drawings/mod.rs
+++ b/crates/app/src/drawings/mod.rs
@@ -562,6 +562,17 @@ pub struct Drawing {
     pub hidden: bool,
     /// Whether the other panes of this tab show it too.
     pub scope: DrawingScope,
+    /// Set when the tab changed the instrument under this mark.
+    ///
+    /// Time survives a symbol switch and price does not: BTC traded at the
+    /// same instants the index did, so the anchors resolve perfectly and the
+    /// level lands at a price that means nothing on the chart it is now over.
+    /// `off_series` cannot catch it — the series *does* reach those instants.
+    ///
+    /// Marks are never deleted by a state change, so this is what keeps that
+    /// honest: the object stays, and it says it belongs to another market
+    /// rather than pretending to be a level on this one.
+    pub foreign_market: bool,
     /// Set by [`Drawings::reanchor`] when this pane's series does not reach
     /// the market instant an anchor was placed at — the mark survived a
     /// re-cut, a rewind or a symbol switch, but it is no longer sitting on
@@ -799,6 +810,7 @@ impl Drawings {
                 locked: false,
                 hidden: false,
                 scope: DrawingScope::default(),
+                foreign_market: false,
                 off_series: false,
                 payload: fresh.payload,
             });
@@ -917,6 +929,34 @@ impl Drawings {
         }
         if let Some(baseline) = &mut self.gesture_baseline {
             reanchor_all(&mut baseline.items);
+        }
+    }
+
+    /// Mark every object as belonging to a market this tab no longer shows.
+    ///
+    /// Called on the one transition that changes the instrument under the
+    /// marks. Everything present at that moment was drawn on the old market;
+    /// anything placed afterwards is on the new one and starts clean.
+    ///
+    /// The undo stacks travel with the live items, for the same reason
+    /// [`Self::reanchor`] moves them: undoing back to a state from before the
+    /// switch must not restore a mark that claims to be a level on this
+    /// instrument.
+    pub fn mark_market_changed(&mut self) {
+        let mark = |items: &mut [Drawing]| {
+            for drawing in items {
+                drawing.foreign_market = true;
+            }
+        };
+        mark(&mut self.items);
+        if let Some(draft) = self.draft.as_mut() {
+            mark(std::slice::from_mut(draft));
+        }
+        for entry in self.undo.iter_mut().chain(self.redo.iter_mut()) {
+            mark(&mut entry.items);
+        }
+        if let Some(baseline) = &mut self.gesture_baseline {
+            mark(&mut baseline.items);
         }
     }
 
@@ -1740,6 +1780,56 @@ mod tests {
             times,
             [Some(1_700_000_003_000), Some(1_700_000_005_000)],
             "a moved mark carries its new instants, or its shared twin stays behind"
+        );
+    }
+
+    /// The honesty hole a symbol switch opens, and the one `off_series`
+    /// cannot close: both instruments traded at the same instants, so every
+    /// anchor resolves onto a real bar and only the *price* is meaningless.
+    /// A mark left painting at full strength there reads as a level on a
+    /// market it was never drawn on.
+    #[test]
+    fn a_market_change_marks_every_object_as_belonging_to_the_old_one() {
+        let mut drawings = Drawings::default();
+        drawings.place(
+            tool("horizontal-line"),
+            ChartPoint::at_time(6.0, 118_000.0, Some(1_700_000_006_000)),
+        );
+
+        drawings.mark_market_changed();
+
+        assert!(drawings.items()[0].foreign_market);
+        assert!(
+            !drawings.items()[0].off_series,
+            "the instants are still on this series - which is exactly why the \
+             time-based flag cannot catch this case"
+        );
+
+        // Anything drawn after the switch is on the market now showing.
+        drawings.place(
+            tool("horizontal-line"),
+            ChartPoint::at_time(7.0, 138_000.0, Some(1_700_000_007_000)),
+        );
+        assert!(!drawings.items()[1].foreign_market);
+    }
+
+    #[test]
+    fn undo_cannot_restore_a_mark_that_claims_the_new_market() {
+        let mut drawings = Drawings::default();
+        drawings.place(
+            tool("horizontal-line"),
+            ChartPoint::at_time(6.0, 118_000.0, Some(1_700_000_006_000)),
+        );
+        drawings.begin_gesture();
+        drawings.translate_selected(1.0, 0.0);
+        drawings.commit_gesture();
+
+        drawings.mark_market_changed();
+        drawings.undo();
+
+        assert!(
+            drawings.items()[0].foreign_market,
+            "stepping back through history must not undo the market change"
         );
     }
 

--- a/crates/app/src/pane.rs
+++ b/crates/app/src/pane.rs
@@ -116,6 +116,18 @@ pub enum PaneSide {
     Time,
 }
 
+impl PaneSide {
+    /// The other pane of the tab — the one that mirrors this one's shared
+    /// marks, and the one an edit made here has to be handed to.
+    #[must_use]
+    pub const fn other(self) -> Self {
+        match self {
+            Self::Flow => Self::Time,
+            Self::Time => Self::Flow,
+        }
+    }
+}
+
 /// Width of the draggable divider between the two panes, in pixels.
 pub const CANVAS_DIVIDER_PX: f32 = 4.0;
 /// Half-width of the divider's grab area, which reaches a little into both
@@ -505,6 +517,120 @@ impl DrawingDrag {
     }
 }
 
+/// What a pane resolved on *another* pane's shared marks this frame.
+///
+/// Said in market time and price, because those are the only coordinates two
+/// panes of a tab agree on — a bar index means nothing across two cuts of the
+/// same tape (`docs/ux/drawing-tools-2026-08.md` §D7). The pane that holds the
+/// object turns them back into its own bar space, so the trader edits the one
+/// object rather than a copy of it.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum SharedEdit {
+    /// Take the selection, without moving anything.
+    Select(usize),
+    /// Put one anchor at this instant and price.
+    MoveAnchor {
+        index: usize,
+        anchor: usize,
+        time_ms: i64,
+        price: f64,
+    },
+    /// Shift every anchor of the object by this much time and price.
+    Translate {
+        index: usize,
+        delta_ms: i64,
+        delta_price: f64,
+    },
+}
+
+/// A shared mark under the pointer, as the tab resolved it for one pane.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SharedPick {
+    /// Its index in the owning pane's store.
+    pub index: usize,
+    /// Which handle was grabbed, or `None` for the body.
+    pub anchor: Option<usize>,
+    /// Locked geometry refuses to move, exactly as it does on its own pane.
+    pub locked: bool,
+}
+
+/// What a pane did to another pane's marks in one frame.
+///
+/// The gesture flags bracket the edits so a whole drag lands on the owning
+/// store as one undo entry — the same coalescing a drag on the object's own
+/// chart gets, because it is the same gesture on the same object.
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub struct SharedInteraction {
+    pub edit: Option<SharedEdit>,
+    pub begin_gesture: bool,
+    pub commit_gesture: bool,
+}
+
+/// What the pointer is doing this frame, as the shared-mark handler needs it.
+struct SharedPointer {
+    /// Where it is, wherever that is. The band below decides what counts.
+    position: Option<egui::Pos2>,
+    /// The band drawings live in on this pane, this frame.
+    ///
+    /// A press must land inside it. A drag already running is *clamped* into
+    /// it instead, exactly as a drag on this pane's own marks is: the canvas
+    /// narrows by the inspector's width on the very frame a press opens it
+    /// (§D8), and a gesture that stopped whenever the pointer left the
+    /// shrunken pane would die on the frame it was born.
+    area: egui::Rect,
+    /// Whether floating chrome — the inspector, the manager, a flyout — is
+    /// under it right now.
+    ///
+    /// Read at press time only, like every other pointer path here:
+    /// continuity, not priority. A drag that started on the canvas keeps
+    /// running while the pointer crosses a panel, which matters most here of
+    /// all — the press that selects a mark is what *opens* the inspector, and
+    /// the inspector opens over the chart the mark is on.
+    over_chrome: bool,
+    pressed: bool,
+    down: bool,
+    released: bool,
+    history_right: f32,
+    total: usize,
+    magnet: bool,
+}
+
+/// A gesture a pane is running on another pane's mark.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+enum SharedDrag {
+    #[default]
+    None,
+    /// Dragging the whole object.
+    Body { index: usize },
+    /// Dragging one handle.
+    Anchor { index: usize, anchor: usize },
+    /// The mark is locked: the gesture is ours (the chart must not pan under
+    /// it) but the geometry stays exactly where the trader left it.
+    Blocked,
+}
+
+impl SharedDrag {
+    const fn is_active(self) -> bool {
+        !matches!(self, Self::None)
+    }
+}
+
+/// Which handle of a projected object `pos` grabs, if any.
+///
+/// The one handle rule, shared by a pane's own marks and the mirrored ones,
+/// so the two can never disagree about what a press landed on.
+fn anchor_hit(points: &[egui::Pos2], pos: egui::Pos2) -> Option<usize> {
+    points
+        .iter()
+        .enumerate()
+        .map(|(index, point)| (index, point.distance_sq(pos)))
+        .filter(|(_, distance_sq)| {
+            *distance_sq <= DRAWING_ANCHOR_RADIUS_PX * DRAWING_ANCHOR_RADIUS_PX
+        })
+        .min_by(|left, right| left.1.total_cmp(&right.1))
+        .map(|(index, _)| index)
+}
+
 /// What a pane borrows from the window around it for one frame.
 ///
 /// All of it is single-instance chrome: there is one toolbox, one preset
@@ -535,6 +661,16 @@ pub struct PaneChrome<'a> {
     /// pane may drive them. Running both would let the second pane inherit a
     /// drag the first started and re-clamp it into the wrong rectangle.
     pub paper_owns_input: bool,
+    /// What the pointer grabs among the *other* pane's shared marks, and
+    /// whether that mark is locked.
+    ///
+    /// Resolved by the tab before the panes are borrowed one at a time, since
+    /// answering it needs both panes at once. `None` on an unsplit tab, and
+    /// on any tab where nothing is shared.
+    pub shared_pick: Option<SharedPick>,
+    /// What this pane did to a shared mark, for the tab to apply to the pane
+    /// that owns it.
+    pub shared: SharedInteraction,
     /// What the running source can actually produce. The layer menu offers a
     /// layer this feed has no data for as disabled-with-a-reason rather than as
     /// a switch that would do nothing — the wording the toolbar already uses.
@@ -677,6 +813,21 @@ pub struct ChartPane {
     /// drag (`DRAWING_DRAG_THRESHOLD_PX`); moving now refuses too.
     pub drawing_drag_pending_from: Option<egui::Pos2>,
     pub drawing_drag: DrawingDrag,
+    /// A gesture this pane is running on a mark the other pane holds, and the
+    /// two pieces of pointer state it needs: where the press landed while the
+    /// drag threshold is still unmet, and the market instant and price the
+    /// pointer was last over — what a body drag sends its deltas against.
+    shared_drag: SharedDrag,
+    shared_drag_pending_from: Option<egui::Pos2>,
+    shared_pointer_mark: Option<(i64, f64)>,
+    /// A re-anchor owed to the drawings, holding the slot count of the series
+    /// they were last anchored to.
+    ///
+    /// A reset empties the pane, and an empty series cannot say where an
+    /// instant lands — so the answer is deferred to the first frame that has
+    /// bars again, rather than clamping every mark onto a series that is not
+    /// there yet.
+    pending_reanchor: Option<usize>,
 }
 
 impl ChartPane {
@@ -755,6 +906,10 @@ impl ChartPane {
             drawing_press_pick: None,
             drawing_drag_pending_from: None,
             drawing_drag: DrawingDrag::None,
+            shared_drag: SharedDrag::None,
+            shared_drag_pending_from: None,
+            shared_pointer_mark: None,
+            pending_reanchor: None,
         }
     }
 
@@ -1245,13 +1400,98 @@ impl ChartPane {
         added
     }
 
-    /// Throw away this pane's bars and everything anchored to them, keeping
-    /// the spec its own selectors ask for.
+    /// Where a market instant sits on this pane's series, as a fractional
+    /// slot — the answer re-anchoring and the shared mirror both run on.
+    ///
+    /// Bar centres, not edges: an anchor is being asked which *bar* it
+    /// belongs to, and the middle of that bar is where it reads as being on
+    /// it. `None` means the series does not reach the instant at all.
+    fn slot_of_time(&self, time: i64) -> Option<f32> {
+        // Past the newest bar first: on a time chart that space has an exact
+        // clock, and asking `slot_at_time` there would clamp a future anchor
+        // onto the right edge instead of letting it run on.
+        if let Some(future) = self.future_slot_at_time(time) {
+            return Some(future + 0.5);
+        }
+        // Before the first bar this pane holds. `slot_at_time` answers slot 0
+        // there, which is a clamp and not a location — taking it would put the
+        // anchor on a bar it has nothing to do with and say nothing about it.
+        // `None` is what the off-series fade and the refused drag both read.
+        if self.slot_open_time(0).is_some_and(|first| time < first) {
+            return None;
+        }
+        let slots = self.slots();
+        let slot = self.slot_at_time(time)?.min(slots.checked_sub(1)?);
+        #[allow(clippy::cast_precision_loss)]
+        Some(slot as f32 + 0.5)
+    }
+
+    /// Re-express this pane's drawings against the series it holds now,
+    /// `old_slots` being the length of the series they were anchored to.
+    ///
+    /// The one call behind every re-cut — a timeframe switch, a bar-kind
+    /// switch, a rewind, a symbol change. Marks are never dropped by a state
+    /// change: the trader placed them and the trader removes them.
+    pub fn reanchor_drawings(&mut self, old_slots: usize) {
+        let new_slots = self.slots();
+        // Taken out of `self` for the call: the store has to be handed this
+        // pane's own time→slot answer, and a closure borrowing `&self` cannot
+        // coexist with a `&mut` borrow of one of its fields.
+        let mut drawings = std::mem::take(&mut self.drawings);
+        drawings.reanchor(old_slots, new_slots, |time| self.slot_of_time(time));
+        self.drawings = drawings;
+    }
+
+    /// Re-anchor as soon as there are bars to anchor to, after a reset left
+    /// the pane empty. Cheap enough to ask every frame: it is a flag test.
+    pub fn settle_pending_reanchor(&mut self) {
+        let Some(old_slots) = self.pending_reanchor else {
+            return;
+        };
+        if self.slots() == 0 {
+            return;
+        }
+        self.pending_reanchor = None;
+        self.reanchor_drawings(old_slots);
+    }
+
+    /// Rewrite the market instants behind the selected object's anchors after
+    /// a move that changed their bar positions (drag or keyboard nudge).
+    ///
+    /// Without this the mark moves on this chart and its shared twin stays
+    /// where it was: market time is what the other panes read, so a move that
+    /// does not update it has moved only half the object.
+    pub fn retime_selected(&mut self) {
+        let Some(index) = self.drawings.selected() else {
+            return;
+        };
+        let Some(drawing) = self.drawings.items().get(index) else {
+            return;
+        };
+        // Collected first so the immutable borrow of the store ends before
+        // the write; every shipped tool has at most four anchors.
+        let times: SmallVec<[Option<i64>; 4]> = drawing
+            .points
+            .iter()
+            .map(|point| self.anchor_time(point.bar))
+            .collect();
+        self.drawings.set_times(index, &times);
+    }
+
+    /// Throw away this pane's bars, keeping the spec its own selectors ask
+    /// for and the marks the trader drew.
     ///
     /// Called when the market underneath changes — a feed switch, a source
     /// reset — because a bar index means nothing across two streams. The
-    /// drawings are cleared by the window, which owns the notice saying so.
+    /// drawings survive it: their anchors carry market time, so they are
+    /// re-expressed against the refilled series rather than discarded
+    /// ([`Self::settle_pending_reanchor`]). The re-anchor waits for bars to
+    /// exist, because an empty series can answer nothing.
     pub fn reset_series(&mut self) {
+        // A second reset before the first settled must not overwrite the
+        // baseline with the empty series it is looking at now.
+        let slots = self.slots();
+        self.pending_reanchor.get_or_insert(slots);
         // The prefix is bar-indexed against a series that no longer exists,
         // and its seam was trimmed against a first bar that is gone. A replay
         // never has one today; the invariant must not depend on that.
@@ -1367,6 +1607,141 @@ impl ChartPane {
             .flatten()
             .unwrap_or_else(|| scale.price_at(pos.y));
         Some(ChartPoint::at_time(bar, price, self.anchor_time(bar)))
+    }
+
+    /// Work a shared mark that lives on the other pane, from this one.
+    ///
+    /// Every answer leaves in market time and price — the coordinates two cuts
+    /// of one tape agree on — so the tab can hand them to the pane that holds
+    /// the object without either pane learning the other's bar space.
+    ///
+    /// The pointer rules are the ones this pane already applies to its own
+    /// marks: a handle before a body, a locked object that takes the gesture
+    /// and refuses to move, and a drag threshold so a click never re-angles a
+    /// level by two pixels of hand tremor.
+    fn interact_shared(
+        &mut self,
+        ui: &egui::Ui,
+        chrome: &mut PaneChrome<'_>,
+        pointer: SharedPointer,
+    ) {
+        let mark = |pane: &Self, position: egui::Pos2| {
+            pane.drawing_point_at(
+                position,
+                pointer.history_right,
+                pointer.total,
+                pointer.magnet,
+            )
+            .and_then(|point| Some((point.time_ms?, point.price)))
+        };
+
+        if pointer.pressed
+            && !pointer.over_chrome
+            && let Some((position, pick)) = pointer
+                .position
+                .filter(|position| pointer.area.contains(*position))
+                .zip(chrome.shared_pick)
+        {
+            // Selecting is not moving (§D9): the press takes the object
+            // whether or not the drag that may follow is allowed.
+            chrome.shared.edit = Some(SharedEdit::Select(pick.index));
+            self.shared_drag_pending_from = Some(position);
+            self.shared_pointer_mark = mark(self, position);
+            self.shared_drag = if pick.locked {
+                SharedDrag::Blocked
+            } else {
+                chrome.shared.begin_gesture = true;
+                match pick.anchor {
+                    Some(anchor) => SharedDrag::Anchor {
+                        index: pick.index,
+                        anchor,
+                    },
+                    None => SharedDrag::Body { index: pick.index },
+                }
+            };
+            return;
+        }
+
+        if !self.shared_drag.is_active() {
+            // Hover feedback, so a mirrored mark does not feel deader than the
+            // object it is: the same three cursors its own pane shows.
+            if !pointer.over_chrome
+                && pointer
+                    .position
+                    .is_some_and(|position| pointer.area.contains(position))
+                && let Some(pick) = chrome.shared_pick
+            {
+                ui.ctx().set_cursor_icon(match (pick.locked, pick.anchor) {
+                    (true, _) => egui::CursorIcon::NotAllowed,
+                    (false, Some(_)) => egui::CursorIcon::ResizeNwSe,
+                    (false, None) => egui::CursorIcon::Move,
+                });
+            }
+            return;
+        }
+
+        if pointer.released {
+            chrome.shared.commit_gesture = true;
+            self.shared_drag = SharedDrag::None;
+            self.shared_drag_pending_from = None;
+            self.shared_pointer_mark = None;
+            return;
+        }
+        if !pointer.down {
+            return;
+        }
+        // Under the threshold the object does not move at all, so a click on
+        // the mirror stays a click.
+        if let Some(origin) = self.shared_drag_pending_from {
+            let travelled = pointer
+                .position
+                .is_some_and(|position| (position - origin).length() >= DRAWING_DRAG_THRESHOLD_PX);
+            if !travelled {
+                return;
+            }
+            self.shared_drag_pending_from = None;
+        }
+        // Clamped, not filtered: the gesture is already ours, and it keeps
+        // working while the pointer travels off the pane — over the inspector
+        // that this very press opened, most of all.
+        let Some(position) = pointer.position.map(|position| {
+            egui::pos2(
+                position.x.clamp(pointer.area.left(), pointer.area.right()),
+                position.y.clamp(pointer.area.top(), pointer.area.bottom()),
+            )
+        }) else {
+            return;
+        };
+        // A pointer over the empty space past the newest bar of a tick or
+        // volume chart names no instant, and none is invented: the mark holds
+        // still for that frame rather than jumping to a guess.
+        let Some((time_ms, price)) = mark(self, position) else {
+            return;
+        };
+        match self.shared_drag {
+            SharedDrag::Anchor { index, anchor } => {
+                chrome.shared.edit = Some(SharedEdit::MoveAnchor {
+                    index,
+                    anchor,
+                    time_ms,
+                    price,
+                });
+                ui.ctx().set_cursor_icon(egui::CursorIcon::ResizeNwSe);
+            }
+            SharedDrag::Body { index } => {
+                if let Some((last_time, last_price)) = self.shared_pointer_mark {
+                    chrome.shared.edit = Some(SharedEdit::Translate {
+                        index,
+                        delta_ms: time_ms - last_time,
+                        delta_price: price - last_price,
+                    });
+                }
+                ui.ctx().set_cursor_icon(egui::CursorIcon::Move);
+            }
+            SharedDrag::Blocked => ui.ctx().set_cursor_icon(egui::CursorIcon::NotAllowed),
+            SharedDrag::None => {}
+        }
+        self.shared_pointer_mark = Some((time_ms, price));
     }
 
     /// The magnet, applied to the bar the pointer is over.
@@ -1623,15 +1998,10 @@ impl ChartPane {
             return None;
         }
         let drawing = self.drawings.items().get(drawing_index)?;
-        self.projected_drawing_points(drawing, history_right, total, scale)
-            .iter()
-            .enumerate()
-            .map(|(point_index, point)| (point_index, point.distance_sq(pos)))
-            .filter(|(_, distance_sq)| {
-                *distance_sq <= DRAWING_ANCHOR_RADIUS_PX * DRAWING_ANCHOR_RADIUS_PX
-            })
-            .min_by(|left, right| left.1.total_cmp(&right.1))
-            .map(|(point_index, _)| point_index)
+        anchor_hit(
+            &self.projected_drawing_points(drawing, history_right, total, scale),
+            pos,
+        )
     }
 
     /// What a pointer at `pos` is on: a drawing's handle first, then its
@@ -1963,6 +2333,11 @@ impl ChartPane {
                             let delta_price =
                                 -f64::from(travel.y / areas.chart.height()) * (hi - lo);
                             self.drawings.translate_selected(delta_bar, delta_price);
+                            // Market time is what every other pane reads the
+                            // object through; a move that left it behind
+                            // would drag the mark here and leave its shared
+                            // twin standing where it used to be.
+                            self.retime_selected();
                         }
                     }
                     DrawingDrag::Blocked => {
@@ -1971,7 +2346,36 @@ impl ChartPane {
                     DrawingDrag::None => {}
                 }
             }
-            drawing_drag_consumes_gesture = self.drawing_drag.is_active();
+            // Marks the *other* pane owns, worked from this one (§D7).
+            //
+            // A shared object is one object, so the trader may grab it on
+            // either chart it appears on — the alternative is a mark that can
+            // be seen here and only deleted over there, which is the split
+            // getting in the way of the work. This pane's own objects still
+            // win the press: the mirror is the second answer, never the first.
+            //
+            // Everything below is said in market time and price, and the tab
+            // hands it to the pane that holds the object. Nothing is written
+            // to a copy.
+            if !self.drawing_drag.is_active() {
+                self.interact_shared(
+                    ui,
+                    chrome,
+                    SharedPointer {
+                        position: pointer_position,
+                        area: drawing_area,
+                        over_chrome,
+                        pressed: primary_pressed,
+                        down: primary_down,
+                        released: primary_released,
+                        history_right,
+                        total,
+                        magnet,
+                    },
+                );
+            }
+            drawing_drag_consumes_gesture =
+                self.drawing_drag.is_active() || self.shared_drag.is_active();
             if primary_released {
                 // One gesture, one undo entry — recorded only if it moved.
                 self.drawings.commit_gesture();
@@ -1987,6 +2391,9 @@ impl ChartPane {
             self.drawing_drag = DrawingDrag::None;
             self.drawing_press_pick = None;
             self.drawing_drag_pending_from = None;
+            self.shared_drag = SharedDrag::None;
+            self.shared_drag_pending_from = None;
+            self.shared_pointer_mark = None;
         }
         // Where the press landed, not where the pointer is now: a pan that
         // started on the candles keeps working when it crosses the divider.
@@ -2928,10 +3335,12 @@ impl ChartPane {
         )
     }
 
-    /// Opacity a shared drawing is painted at on a pane whose series does not
-    /// reach its anchors. Faded, not hidden and not silently snapped: the
-    /// mark is real, its position on *this* chart is not exact.
-    const SHARED_CLAMPED_OPACITY: f32 = 0.45;
+    /// Opacity a drawing is painted at on a pane whose series does not reach
+    /// its anchors — a mirrored mark clamped to an edge, or one of this
+    /// pane's own that outlived the bars it was drawn on. Faded, not hidden
+    /// and not silently snapped: the mark is real, its position on *this*
+    /// chart is not exact.
+    const CLAMPED_OPACITY: f32 = 0.45;
 
     /// The band drawings live in: the candles minus the live lane.
     ///
@@ -2963,6 +3372,124 @@ impl ChartPane {
         );
         let history_right = self.last_lane_divider_x.unwrap_or(chart.right());
         Some((self.drawing_area(chart), history_right, self.slots(), scale))
+    }
+
+    /// What a pointer at `pos` grabs among `source`'s shared marks: a handle
+    /// anywhere first, then the topmost body — the same order, and the same
+    /// primitives, this pane uses on its own objects.
+    ///
+    /// Runs on the projection cached by the last frame, which is the geometry
+    /// the trader was looking at when they pressed (§D8: no gesture re-measures
+    /// a world it moved).
+    ///
+    /// Per-frame cost: nothing until a mark is actually shared, and bounded by
+    /// the handful of objects on the chart when one is.
+    pub fn shared_pick(&self, source: &Self, pos: egui::Pos2) -> Option<(usize, Option<usize>)> {
+        if !source.drawings.items().iter().any(Drawing::shared) {
+            return None;
+        }
+        let (chart, history_right, total, scale) = self.last_projection()?;
+        let mut body = None;
+        for (index, drawing) in source.drawings.items().iter().enumerate().rev() {
+            if !drawing.shared() || !source.drawings.is_visible(index) {
+                continue;
+            }
+            let Some((anchors, _)) = self.reproject(drawing) else {
+                continue;
+            };
+            let points: SmallVec<[egui::Pos2; 4]> = anchors
+                .iter()
+                .map(|anchor| self.drawing_screen_point(*anchor, history_right, total, &scale))
+                .collect();
+            if let Some(anchor) = anchor_hit(&points, pos) {
+                return Some((index, Some(anchor)));
+            }
+            if body.is_none() {
+                let ctxt = DrawContext {
+                    payload: drawing.payload.as_ref(),
+                    anchors: &anchors,
+                    scale: &scale,
+                    style: drawing.style,
+                    selected: source.drawings.selected() == Some(index),
+                    halo: false,
+                };
+                if drawing
+                    .tool
+                    .hit_test(chart, &points, pos, DRAWING_SELECT_RADIUS_PX, &ctxt)
+                {
+                    body = Some((index, None));
+                }
+            }
+        }
+        body
+    }
+
+    /// Apply an edit another pane of this tab made to one of this pane's
+    /// shared marks, back in this pane's own bar space.
+    ///
+    /// The instants arrive as they were read off the other chart and are
+    /// resolved here, which is what makes the two views one object rather than
+    /// two copies of one.
+    pub fn apply_shared_edit(&mut self, edit: SharedEdit) {
+        match edit {
+            SharedEdit::Select(index) => self.drawings.select(Some(index)),
+            SharedEdit::MoveAnchor {
+                index,
+                anchor,
+                time_ms,
+                price,
+            } => {
+                let Some(bar) = self.slot_of_time(time_ms) else {
+                    return;
+                };
+                self.drawings.move_anchor(
+                    index,
+                    anchor,
+                    ChartPoint::at_time(bar, price, Some(time_ms)),
+                );
+            }
+            SharedEdit::Translate {
+                index,
+                delta_ms,
+                delta_price,
+            } => self.translate_shared(index, delta_ms, delta_price),
+        }
+    }
+
+    /// Move a whole shared object by an amount of market time and price.
+    ///
+    /// Time, not bars: the two panes cut the tape differently, so the same
+    /// drag is a different number of bars on each — and market time is what
+    /// both of them mean by it.
+    ///
+    /// Resolved in full before anything is written. A drag that would put part
+    /// of the object where this pane's series cannot reach moves nothing at
+    /// all, rather than leaving a shape with one end on a bar and the other on
+    /// an instant that has none.
+    fn translate_shared(&mut self, index: usize, delta_ms: i64, delta_price: f64) {
+        let Some(drawing) = self.drawings.items().get(index) else {
+            return;
+        };
+        if drawing.locked {
+            return;
+        }
+        let mut moved: SmallVec<[ChartPoint; 4]> = SmallVec::new();
+        for point in &drawing.points {
+            let Some(time) = point.time_ms.and_then(|time| time.checked_add(delta_ms)) else {
+                return;
+            };
+            let Some(bar) = self.slot_of_time(time) else {
+                return;
+            };
+            moved.push(ChartPoint::at_time(
+                bar,
+                point.price + delta_price,
+                Some(time),
+            ));
+        }
+        for (anchor, point) in moved.into_iter().enumerate() {
+            self.drawings.move_anchor(index, anchor, point);
+        }
     }
 
     /// Paint the shared drawings that live on `source`, re-expressed on this
@@ -3001,10 +3528,7 @@ impl ChartPane {
             // rather than by pretending to sit on the edge bar.
             let style = if clamped {
                 DrawingStyle {
-                    color: drawing
-                        .style
-                        .color
-                        .gamma_multiply(Self::SHARED_CLAMPED_OPACITY),
+                    color: drawing.style.color.gamma_multiply(Self::CLAMPED_OPACITY),
                     fill_alpha: 0,
                     ..drawing.style
                 }
@@ -3017,17 +3541,29 @@ impl ChartPane {
                 .iter()
                 .map(|anchor| self.drawing_screen_point(*anchor, history_right, total, &scale))
                 .collect();
+            // A mark selected here shows it here. The trader can now take and
+            // move it from this pane (`Self::interact_shared`), and a
+            // selection that painted only on the other chart would leave the
+            // gesture with no visible subject.
+            let selected = source.drawings.selected() == Some(index);
             let ctxt = DrawContext {
                 payload: drawing.payload.as_ref(),
                 anchors: &anchors,
                 scale: &scale,
                 style,
-                selected: false,
+                selected,
                 halo: false,
             };
-            drawing
-                .tool
-                .paint(&clipped, chart, style, &points, &ctxt, false);
+            // Locked geometry shows no handles on either chart: they would
+            // advertise a drag that is refused.
+            drawing.tool.paint(
+                &clipped,
+                chart,
+                style,
+                &points,
+                &ctxt,
+                selected && !drawing.locked,
+            );
         }
     }
 
@@ -3115,11 +3651,26 @@ impl ChartPane {
             }
             let points = self.projected_drawing_points(drawing, history_right, total, scale);
             let selected = self.drawings.selected() == Some(index);
+            // A mark whose anchors this series cannot reach — drawn before
+            // the history now loaded, or on the instrument this tab used to
+            // show. It survived the change, because only the trader deletes a
+            // drawing, and it says what it is by fading rather than by
+            // pretending to sit on the bar it was clamped to. Same opacity the
+            // mirrored marks use for the same reason.
+            let style = if drawing.off_series {
+                DrawingStyle {
+                    color: drawing.style.color.gamma_multiply(Self::CLAMPED_OPACITY),
+                    fill_alpha: 0,
+                    ..drawing.style
+                }
+            } else {
+                drawing.style
+            };
             let ctxt = DrawContext {
                 payload: drawing.payload.as_ref(),
                 anchors: &drawing.points,
                 scale,
-                style: drawing.style,
+                style,
                 selected,
                 halo: false,
             };
@@ -3128,7 +3679,7 @@ impl ChartPane {
             drawing.tool.paint(
                 &clipped,
                 chart_rect,
-                drawing.style,
+                style,
                 &points,
                 &ctxt,
                 selected && !drawing.locked,
@@ -3422,6 +3973,162 @@ mod tests {
         pane.last_lane_divider_x = Some(-40.0);
         let degenerate = pane.drawing_area(chart);
         assert!(degenerate.right() >= degenerate.left());
+    }
+
+    /// A pane cutting one bar per trade, with `count` bars a second apart —
+    /// so a market instant and a slot are the same statement, and a test can
+    /// say which bar it means by naming the moment.
+    fn pane_of_seconds(count: u64) -> ChartPane {
+        use rust_decimal::Decimal;
+        let mut pane = ChartPane::flow(1, BarSpec::Tick(1), "TESTUSDT".to_owned());
+        let trades: Vec<_> = (0..count)
+            .map(|index| quantick_engine::Trade {
+                agg_id: index,
+                timestamp_ms: 1_700_000_000_000 + index as i64 * 1_000,
+                price: Decimal::from(100),
+                quantity: Decimal::ONE,
+                side: quantick_engine::Side::Buy,
+            })
+            .collect();
+        pane.ingest_backfill(&trades);
+        pane
+    }
+
+    /// A mark placed on the bar at `slot`, shared with the tab's other panes.
+    fn shared_mark_at(pane: &mut ChartPane, slot: usize, price: f64) {
+        let time = pane.slot_open_time(slot).expect("the slot holds a bar");
+        #[allow(clippy::cast_precision_loss)]
+        let point = ChartPoint::at_time(slot as f32 + 0.5, price, Some(time));
+        pane.drawings.place(
+            drawings::DRAWING_TOOLS
+                .into_iter()
+                .find(|tool| tool.id() == "horizontal-line")
+                .expect("the horizontal line is registered"),
+            point,
+        );
+        pane.drawings
+            .selected_mut()
+            .expect("placement selects what it completed")
+            .scope = drawings::DrawingScope::AllCharts;
+    }
+
+    #[test]
+    fn an_edit_from_the_other_pane_lands_on_this_panes_own_bars() {
+        let mut pane = pane_of_seconds(20);
+        shared_mark_at(&mut pane, 4, 100.0);
+
+        // The other chart reports where it put the handle in market time; this
+        // pane is the one that knows which of *its* bars that is.
+        let moved_to = pane.slot_open_time(11).expect("the slot holds a bar");
+        pane.apply_shared_edit(SharedEdit::MoveAnchor {
+            index: 0,
+            anchor: 0,
+            time_ms: moved_to,
+            price: 101.5,
+        });
+
+        let point = pane.drawings.items()[0].points[0];
+        assert_eq!(point.time_ms, Some(moved_to));
+        assert_eq!(point.bar.floor() as usize, 11, "resolved into this pane");
+        assert!((point.price - 101.5).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn a_body_drag_from_the_other_pane_moves_every_anchor_by_the_same_time() {
+        let mut pane = pane_of_seconds(20);
+        shared_mark_at(&mut pane, 4, 100.0);
+        let before = pane.drawings.items()[0].points[0];
+
+        pane.apply_shared_edit(SharedEdit::Translate {
+            index: 0,
+            delta_ms: 3_000,
+            delta_price: 2.0,
+        });
+
+        let after = pane.drawings.items()[0].points[0];
+        assert_eq!(
+            after.time_ms,
+            before.time_ms.map(|time| time + 3_000),
+            "the drag is said in market time"
+        );
+        assert_eq!(
+            after.bar.floor() as usize,
+            7,
+            "and three seconds is three bars on a one-trade-per-bar cut"
+        );
+        assert!((after.price - 102.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn a_locked_mark_refuses_an_edit_from_the_other_pane_too() {
+        let mut pane = pane_of_seconds(20);
+        shared_mark_at(&mut pane, 4, 100.0);
+        pane.drawings
+            .selected_mut()
+            .expect("the mark is selected")
+            .locked = true;
+        let before = pane.drawings.items()[0].points.clone();
+
+        pane.apply_shared_edit(SharedEdit::Translate {
+            index: 0,
+            delta_ms: 3_000,
+            delta_price: 2.0,
+        });
+        let moved_to = pane.slot_open_time(11).expect("the slot holds a bar");
+        pane.apply_shared_edit(SharedEdit::MoveAnchor {
+            index: 0,
+            anchor: 0,
+            time_ms: moved_to,
+            price: 101.5,
+        });
+
+        assert_eq!(
+            pane.drawings.items()[0].points,
+            before,
+            "a lock protects the geometry from both charts, not just its own"
+        );
+    }
+
+    #[test]
+    fn a_drag_this_pane_cannot_place_moves_nothing_at_all() {
+        let mut pane = pane_of_seconds(20);
+        shared_mark_at(&mut pane, 4, 100.0);
+        let before = pane.drawings.items()[0].points.clone();
+
+        // Back past the first bar this pane holds: there is no slot for it,
+        // and half a shape on a bar and half on an instant is not an option.
+        pane.apply_shared_edit(SharedEdit::Translate {
+            index: 0,
+            delta_ms: -600_000,
+            delta_price: 0.0,
+        });
+
+        assert_eq!(pane.drawings.items()[0].points, before);
+    }
+
+    #[test]
+    fn a_recut_keeps_the_mark_on_its_own_instant() {
+        let mut pane = pane_of_seconds(20);
+        shared_mark_at(&mut pane, 6, 100.0);
+        let placed_at = pane.drawings.items()[0].points[0]
+            .time_ms
+            .expect("placed on a bar");
+        let old_slots = pane.slots();
+
+        // Two trades per bar: the same tape, half the bars.
+        pane.tick_n = 2;
+        let spec = pane.current_spec();
+        pane.state.set_spec(spec);
+        pane.reanchor_drawings(old_slots);
+
+        let point = pane.drawings.items()[0].points[0];
+        assert_eq!(point.time_ms, Some(placed_at), "the instant is untouched");
+        assert_eq!(
+            pane.slot_at_time(placed_at),
+            Some(point.bar.floor() as usize),
+            "the bar is that instant, re-asked of the new cut"
+        );
+        assert!(!pane.drawings.items()[0].off_series);
     }
 
     /// A bar spanning 98 … 102, for the magnet.

--- a/crates/app/src/pane.rs
+++ b/crates/app/src/pane.rs
@@ -1401,11 +1401,20 @@ impl ChartPane {
     }
 
     /// Where a market instant sits on this pane's series, as a fractional
-    /// slot — the answer re-anchoring and the shared mirror both run on.
+    /// slot — the strict answer, behind re-anchoring and every edit arriving
+    /// from another pane.
     ///
-    /// Bar centres, not edges: an anchor is being asked which *bar* it
-    /// belongs to, and the middle of that bar is where it reads as being on
-    /// it. `None` means the series does not reach the instant at all.
+    /// Bar centres, not edges: an anchor is being asked which *bar* it belongs
+    /// to, and the middle of that bar is where it reads as being on it. `None`
+    /// means the series does not reach the instant at all.
+    ///
+    /// Deliberately not what [`Self::reproject`] uses. That one is answering a
+    /// different question — *where do I paint a mark whose instant may be off
+    /// my series?* — so it clamps to the nearest edge and reports the clamp,
+    /// which is what the fade is drawn from. This one is asked before the
+    /// store is written, where a clamp would silently move the trader's mark
+    /// onto data it has nothing to do with. Same lookup, opposite answer at
+    /// the edges, on purpose.
     fn slot_of_time(&self, time: i64) -> Option<f32> {
         // Past the newest bar first: on a time chart that space has an exact
         // clock, and asking `slot_at_time` there would clamp a future anchor

--- a/crates/app/src/pane.rs
+++ b/crates/app/src/pane.rs
@@ -3660,13 +3660,13 @@ impl ChartPane {
             }
             let points = self.projected_drawing_points(drawing, history_right, total, scale);
             let selected = self.drawings.selected() == Some(index);
-            // A mark whose anchors this series cannot reach — drawn before
-            // the history now loaded, or on the instrument this tab used to
-            // show. It survived the change, because only the trader deletes a
-            // drawing, and it says what it is by fading rather than by
-            // pretending to sit on the bar it was clamped to. Same opacity the
-            // mirrored marks use for the same reason.
-            let style = if drawing.off_series {
+            // A mark this chart's data does not back: its anchors are outside
+            // the loaded series, or it was drawn on the instrument this tab
+            // used to show. It survived the change, because only the trader
+            // deletes a drawing, and it says what it is by fading rather than
+            // by passing itself off as a level on this market. Same opacity
+            // the mirrored marks use for the same reason.
+            let style = if drawing.off_series || drawing.foreign_market {
                 DrawingStyle {
                     color: drawing.style.color.gamma_multiply(Self::CLAMPED_OPACITY),
                     fill_alpha: 0,

--- a/crates/app/src/tab.rs
+++ b/crates/app/src/tab.rs
@@ -1088,6 +1088,14 @@ impl Tab {
             pane.reset_series();
         }
         self.drop_overlay_gestures();
+        // The marks stay — only the trader deletes a drawing — but they were
+        // drawn on the instrument that just left. Time survives a symbol
+        // switch and price does not, so without this a BTC level would paint
+        // at full strength over an index chart, at a number that means
+        // nothing there (§D7b).
+        for pane in self.panes_mut() {
+            pane.drawings.mark_market_changed();
+        }
         self.history_trades = 0;
         // The old feed's unanswered loads died with its channel; the new feed
         // opens with exactly one backfill in flight.

--- a/crates/app/src/tab.rs
+++ b/crates/app/src/tab.rs
@@ -12,6 +12,7 @@
 //! views of one. The two are orthogonal, and a tab carries its own layout.
 
 use eframe::egui;
+use smallvec::SmallVec;
 use tokio::sync::{mpsc, watch};
 
 use quantick_feed_binance::depth::DepthEvent;
@@ -25,7 +26,7 @@ use crate::metrics;
 use crate::orderflow_view::OrderflowView;
 use crate::pane::{
     CANVAS_DIVIDER_HANDLE_PX, ChartPane, DEFAULT_PANE_FRACTION, DrawingDrag, PaneChrome, PaneSide,
-    clamp_pane_fraction, split_canvas, split_time_pane,
+    SharedEdit, SharedInteraction, SharedPick, clamp_pane_fraction, split_canvas, split_time_pane,
 };
 use crate::paper_trading::PaperTrading;
 use crate::state::{BarKind, BarSpec};
@@ -141,6 +142,26 @@ fn trim_to_seam(
 }
 
 /// One open market. See the module docs for what does and does not live here.
+/// One frame's answer, for both panes, to "what shared mark of the *other*
+/// pane is the pointer over?".
+///
+/// A pair rather than a per-pane field because the question can only be asked
+/// while both panes are in hand, and it is asked once for the frame.
+#[derive(Debug, Clone, Copy, Default)]
+struct SharedPicks {
+    time: Option<SharedPick>,
+    flow: Option<SharedPick>,
+}
+
+impl SharedPicks {
+    const fn for_side(self, side: PaneSide) -> Option<SharedPick> {
+        match side {
+            PaneSide::Time => self.time,
+            PaneSide::Flow => self.flow,
+        }
+    }
+}
+
 pub struct Tab {
     /// Stable for as long as the tab is open, and never reused. The indicator
     /// state file names one of these (see `QuantickApp::persisted_tab`), and
@@ -370,31 +391,23 @@ impl Tab {
         self.book_channel_closed_reported = false;
     }
 
-    /// Clear the bar-anchored overlay on `side`, reporting whether anything
-    /// was actually lost.
+    /// Drop the transient pointer state of every pane's overlay, for a change
+    /// that re-cuts the bars under it — a spec switch, a source reset.
     ///
-    /// Bar indices are only meaningful for the market and spec that made them,
-    /// so a source or aggregation rebuild has to drop the marks rather than
-    /// silently reattach them to different data. The window turns the answer
-    /// into the toast that says so and the tool reset that follows — the marks
-    /// are the tab's, the chrome around them is not.
-    fn clear_overlay(&mut self, side: PaneSide) -> bool {
-        let pane = self.pane_mut(side);
-        let had_drawings = !pane.drawings.items().is_empty();
-        pane.drawings.clear();
-        pane.drawing_hover = None;
-        pane.drawing_press_position = None;
-        pane.drawing_press_started_empty = false;
-        pane.drawing_drag = DrawingDrag::None;
-        had_drawings
-    }
-
-    /// Every pane's overlay at once, for a change that invalidates them all —
-    /// a feed switch or a source reset re-cuts both charts.
-    fn clear_overlays(&mut self) -> bool {
-        let flow = self.clear_overlay(PaneSide::Flow);
-        let time = self.time_pane.is_some() && self.clear_overlay(PaneSide::Time);
-        flow || time
+    /// The *objects* survive: their anchors carry market time, so they are
+    /// re-expressed against the new series rather than discarded (`ChartPane::
+    /// reanchor_drawings`). A drawing belongs to the trader who placed it and
+    /// leaves when they delete it, not when the chart is re-cut underneath.
+    ///
+    /// What cannot survive is a gesture in flight: a half-finished drag is
+    /// holding pixel coordinates of bars that no longer exist there.
+    fn drop_overlay_gestures(&mut self) {
+        for pane in self.panes_mut() {
+            pane.drawing_hover = None;
+            pane.drawing_press_position = None;
+            pane.drawing_press_started_empty = false;
+            pane.drawing_drag = DrawingDrag::None;
+        }
     }
 
     /// Where the timeframe chips landed, in `crate::time_header::PRESETS` order.
@@ -680,6 +693,40 @@ impl Tab {
     /// See [`Self::focused_pane`].
     pub fn focused_pane_mut(&mut self) -> &mut ChartPane {
         self.pane_mut(self.focused_side())
+    }
+
+    /// The pane holding the drawing selection — which is not always the
+    /// focused one.
+    ///
+    /// A shared mark can be taken from either chart it appears on, and it
+    /// stays in the store of the pane it was drawn on. So the inspector, the
+    /// keyboard and the object manager follow the *object*, not the pane the
+    /// pointer happens to be over: selecting a level on the time pane and
+    /// pressing Delete has to delete that level, wherever it lives.
+    ///
+    /// Exactly one pane holds a selection at a time
+    /// ([`Self::apply_shared_interactions`] drops the other's), so this asks
+    /// the focused pane first and takes the answer it finds.
+    pub fn drawing_side(&self) -> PaneSide {
+        let focused = self.focused_side();
+        if self.pane(focused).drawings.selected().is_some() || self.time_pane.is_none() {
+            return focused;
+        }
+        let other = focused.other();
+        if self.pane(other).drawings.selected().is_some() {
+            return other;
+        }
+        focused
+    }
+
+    /// The pane every drawing surface reads from — see [`Self::drawing_side`].
+    pub fn drawing_pane(&self) -> &ChartPane {
+        self.pane(self.drawing_side())
+    }
+
+    /// See [`Self::drawing_pane`].
+    pub fn drawing_pane_mut(&mut self) -> &mut ChartPane {
+        self.pane_mut(self.drawing_side())
     }
 
     /// Every pane holding this market's bars, on screen or not. One tape, and
@@ -991,15 +1038,15 @@ impl Tab {
 
     /// Respawn the feed and reset the chart when the selected feed or symbol
     /// differs from what is currently streaming. A no-op otherwise.
-    pub fn maybe_switch_feed(&mut self, config: &AppConfig) -> bool {
+    pub fn maybe_switch_feed(&mut self, config: &AppConfig) {
         // A replay owns the chart until it is closed. The selectors are not
         // drawn while it plays, so nothing can diverge here — but a stale
         // selection must not respawn a live feed underneath the recording.
         if self.replay.is_some() {
-            return false;
+            return;
         }
         if self.active == (self.feed_id.clone(), self.symbol.clone()) {
-            return false;
+            return;
         }
         let previous_feed = self.active.0.clone();
         let Some(provider) = config.provider_of(&self.feed_id) else {
@@ -1010,7 +1057,7 @@ impl Tab {
             );
             // Snap the selection back to what is actually running.
             (self.feed_id, self.symbol) = self.active.clone();
-            return false;
+            return;
         };
         // The recorder follows the feed, not the toggle: a market that can
         // stream depth is recorded from the moment it starts streaming. Kept
@@ -1040,7 +1087,7 @@ impl Tab {
         for pane in self.panes_mut() {
             pane.reset_series();
         }
-        let cleared = self.clear_overlays();
+        self.drop_overlay_gestures();
         self.history_trades = 0;
         // The old feed's unanswered loads died with its channel; the new feed
         // opens with exactly one backfill in flight.
@@ -1058,7 +1105,6 @@ impl Tab {
         self.refresh_chip_label(config);
         self.ensure_book_capture(config);
         self.apply_feed_bubble_preset_after_switch(config, &previous_feed);
-        cleared
     }
 
     /// Apply the arrived-at feed's declared preset — only when the switch
@@ -1194,10 +1240,10 @@ impl Tab {
 
     /// Let every pane's selectors settle, then mirror the result onto the
     /// rebuild indicator: it is up while *any* pane has a rebuild pending.
-    pub fn apply_spec_changes(&mut self) -> bool {
-        let mut cleared = self.apply_spec_change(PaneSide::Flow);
+    pub fn apply_spec_changes(&mut self) {
+        self.apply_spec_change(PaneSide::Flow);
         if self.time_pane.is_some() {
-            cleared |= self.apply_spec_change(PaneSide::Time);
+            self.apply_spec_change(PaneSide::Time);
         }
         let rebuilding = self.flow_pane.pending_spec.is_some()
             || self
@@ -1205,7 +1251,6 @@ impl Tab {
                 .as_ref()
                 .is_some_and(|pane| pane.pending_spec.is_some());
         self.loading.set_active(LoadingTask::BarRebuild, rebuilding);
-        cleared
     }
 
     /// Apply one pane's bar-type/parameter change, a frame after its selectors
@@ -1222,26 +1267,20 @@ impl Tab {
     /// The two panes run this independently: the toolbar's BARS group governs
     /// the focused pane and the time pane's own header governs the time pane
     /// (§11), so a change to one pane must not rebuild the chart beside it.
-    fn apply_spec_change(&mut self, side: PaneSide) -> bool {
+    fn apply_spec_change(&mut self, side: PaneSide) {
         let desired = self.pane(side).current_spec();
         let pane = self.pane_mut(side);
         if desired == *pane.state.spec() {
             // Selection and chart agree — nothing is pending any more (a feed
             // switch or reset may have rebuilt the state under a pending spec).
             pane.pending_spec = None;
-            return false;
+            return;
         }
         match pane.pending_spec.take() {
             // The frame that changed the selector: arm the indicator, paint.
-            None => {
-                pane.pending_spec = Some(desired);
-                false
-            }
+            None => pane.pending_spec = Some(desired),
             // Still moving: wait for the selector to settle for a frame.
-            Some(pending) if pending != desired => {
-                pane.pending_spec = Some(desired);
-                false
-            }
+            Some(pending) if pending != desired => pane.pending_spec = Some(desired),
             // Settled since last frame: do the rebuild.
             Some(_) => {
                 // Where the user is looking, in market time — the one thing a
@@ -1250,6 +1289,11 @@ impl Tab {
                 // may not exist in it at all: keeping it would leave the
                 // window past the end of the data, drawing nothing.
                 let anchor = pane.right_edge_time();
+                // The series the drawings are still anchored to, captured
+                // before it is replaced: their bar indices are meaningless in
+                // the new cut and have to be re-derived from the market time
+                // each anchor carries.
+                let old_slots = pane.slots();
                 pane.state.set_spec(desired);
                 // The venue prefix folds to the new interval before the view
                 // is reanchored: the market time the user was looking at has
@@ -1270,26 +1314,29 @@ impl Tab {
                 let slot = anchor.and_then(|ms| pane.slot_at_time(ms));
                 let slots = pane.slots();
                 pane.viewport.reanchor(slot, slots);
-                self.clear_overlay(side)
+                // The marks follow the view: same market time, this pane's
+                // new bar space. Nothing is lost, so there is nothing to
+                // announce.
+                pane.reanchor_drawings(old_slots);
+                self.drop_overlay_gestures();
             }
         }
     }
 
     /// Drain every feed event available this frame into the engine, tracking the
     /// observed arrival latency and live-trade counts for the metrics.
-    pub fn drain_feed(&mut self) -> bool {
-        self.drain_feed_with_clock(metrics::wall_clock_ms)
+    pub fn drain_feed(&mut self) {
+        self.drain_feed_with_clock(metrics::wall_clock_ms);
     }
 
     /// Clock-injected drain used to prove that one UI cycle is one observation.
-    pub fn drain_feed_with_clock(&mut self, mut wall_clock_ms: impl FnMut() -> i64) -> bool {
+    pub fn drain_feed_with_clock(&mut self, mut wall_clock_ms: impl FnMut() -> i64) {
         // The journal follows this tab's symbol; synced before the drain so a
         // new feed's first trades are never attributed to the old symbol.
         // Every tab drains every frame, so every journal tracks its own market
         // whether or not that tab is the one on screen.
         let Self { paper, symbol, .. } = self;
         paper.set_symbol(symbol);
-        let mut cleared = false;
         let mut live = false;
         let mut received_at_ms = None;
         loop {
@@ -1337,7 +1384,7 @@ impl Tab {
                         live = true;
                     }
                 }
-                Ok(FeedEvent::Reset) => cleared |= self.reset_market_state(),
+                Ok(FeedEvent::Reset) => self.reset_market_state(),
                 Ok(FeedEvent::OhlcvHistory {
                     interval_ms,
                     bars,
@@ -1355,7 +1402,12 @@ impl Tab {
                 pane.publish_partial();
             }
         }
-        cleared
+        // A reset left the marks waiting for bars to anchor to, and this is
+        // the drain that may have just delivered them. One flag test per pane
+        // when nothing is owed.
+        for pane in self.panes_mut() {
+            pane.settle_pending_reanchor();
+        }
     }
 
     /// Take the newest feed notice, if the feed sent any this frame.
@@ -1405,7 +1457,7 @@ impl Tab {
     /// Sent by a source that rewound — seeking a replay, for instance. The
     /// chart is rebuilt from the history that follows rather than patched,
     /// because bars that already closed cannot be reopened.
-    pub fn reset_market_state(&mut self) -> bool {
+    pub fn reset_market_state(&mut self) {
         for pane in self.panes_mut() {
             pane.reset_series();
             // Indicators follow the chart into the empty state; the refill's
@@ -1414,7 +1466,7 @@ impl Tab {
             pane.send_indicator_rebuild();
             pane.last_lane_divider_x = None;
         }
-        let cleared = self.clear_overlays();
+        self.drop_overlay_gestures();
         self.history_trades = 0;
         self.latest_trade_latency_ms = None;
         self.latest_trade_ms = None;
@@ -1427,7 +1479,6 @@ impl Tab {
         // The simulator flattens at its last mark and says so — a position
         // cannot honestly survive into a rebuilt timeline.
         self.paper.on_timeline_reset();
-        cleared
     }
 
     /// Everything this tab must settle before it is dropped.
@@ -1548,7 +1599,7 @@ impl Tab {
     /// Make a recorded session the chart's source, replacing whatever feed is
     /// running. The live selection is untouched, so closing the replay comes
     /// back to exactly the feed and symbol that were streaming before.
-    pub fn open_replay(&mut self, config: &AppConfig, request: crate::feed::ReplayRequest) -> bool {
+    pub fn open_replay(&mut self, config: &AppConfig, request: crate::feed::ReplayRequest) {
         tracing::info!(
             target: "quantick::app",
             schema_version = 1_u8,
@@ -1572,13 +1623,13 @@ impl Tab {
         // and the view must not keep drawing a book from the live feed.
         let generation = self.next_book_generation();
         self.tape_mut().set_enabled(false, generation);
-        self.reset_market_state()
+        self.reset_market_state();
     }
 
     /// Leave replay and put the live feed back.
-    pub fn close_replay(&mut self, config: &AppConfig) -> bool {
+    pub fn close_replay(&mut self, config: &AppConfig) {
         if self.replay.take().is_none() {
-            return false;
+            return;
         }
         let (feed_id, symbol) = self.active.clone();
         self.feed_id = feed_id;
@@ -1597,11 +1648,12 @@ impl Tab {
         let Some(provider) = config.provider_of(&self.feed_id) else {
             // The configuration changed under us; there is nothing to go back
             // to, so the chart stays as it is rather than dying.
-            return self.reset_market_state();
+            self.reset_market_state();
+            return;
         };
         let handle = feed::spawn_live(provider, &self.symbol, config);
         self.attach(handle);
-        self.reset_market_state()
+        self.reset_market_state();
     }
 
     /// Start the current feed over, from the card that asked the user to fix
@@ -1611,12 +1663,12 @@ impl Tab {
     /// terminal is opened or the package installed, the way back has to be one
     /// click, not a restart of quantick. A replay owns the chart while it
     /// plays and has nothing to retry.
-    pub fn restart_feed(&mut self, config: &AppConfig) -> bool {
+    pub fn restart_feed(&mut self, config: &AppConfig) {
         if self.replay.is_some() {
-            return false;
+            return;
         }
         let Some(provider) = config.provider_of(&self.feed_id) else {
-            return false;
+            return;
         };
         tracing::info!(
             target: "quantick::app",
@@ -1629,11 +1681,10 @@ impl Tab {
         );
         let handle = feed::spawn_live(provider, &self.symbol, config);
         self.attach(handle);
-        let cleared = self.reset_market_state();
+        self.reset_market_state();
         // The live market is back and it can stream depth again; start
         // recording immediately rather than waiting for the map to be opened.
         self.ensure_book_capture(config);
-        cleared
     }
     /// Lay the canvas out and run every visible pane through it (§11).
     ///
@@ -1688,6 +1739,12 @@ impl Tab {
             areas.chart
         });
 
+        // Which shared mark the pointer is over, on each pane, against the
+        // other pane's store. Answered here because answering it needs both
+        // panes at once, and the loop below holds them one at a time.
+        let picks = self.shared_picks(ui);
+
+        let mut edits: SmallVec<[(PaneSide, SharedInteraction); 2]> = SmallVec::new();
         {
             let focused = self.focused_side();
             let Self {
@@ -1705,6 +1762,8 @@ impl Tab {
                 symbol,
                 paper,
                 paper_owns_input: false,
+                shared_pick: None,
+                shared: SharedInteraction::default(),
                 capabilities: chrome.capabilities,
                 layers: chrome.layers,
             };
@@ -1722,10 +1781,19 @@ impl Tab {
                 // the first click already trades where the accent rule is.
                 // Unsplit, the flow pane is the only pane and nothing changes.
                 chrome.paper_owns_input = side == focused;
+                chrome.shared_pick = picks.for_side(side);
+                chrome.shared = SharedInteraction::default();
                 pane.handle_navigation(ui, rect, &mut chrome);
                 pane.draw_chart(ui.painter(), rect, &mut chrome);
+                // Whatever this pane did to the other's marks travels out of
+                // the loop: the store it belongs to is the pane that is not
+                // borrowed right now.
+                if chrome.shared != SharedInteraction::default() {
+                    edits.push((side, chrome.shared));
+                }
             }
         }
+        self.apply_shared_interactions(&edits);
 
         // Drawings marked "show on all charts" cross here, after both panes
         // have drawn and cached their projections. It happens outside the
@@ -1759,6 +1827,70 @@ impl Tab {
             ],
             egui::Stroke::new(FOCUS_RULE_PX, theme::ACCENT),
         );
+    }
+
+    /// What the pointer is over, on each pane, among the *other* pane's
+    /// shared marks.
+    ///
+    /// Resolved with both panes in hand and before either is borrowed for its
+    /// input pass, which is the only moment a pane can be asked about marks it
+    /// does not hold. Nothing to answer on an unsplit tab: one pane has no
+    /// other pane to mirror.
+    fn shared_picks(&self, ui: &egui::Ui) -> SharedPicks {
+        let Some(time_pane) = self.time_pane.as_ref() else {
+            return SharedPicks::default();
+        };
+        let Some(position) = ui.input(|input| input.pointer.latest_pos()) else {
+            return SharedPicks::default();
+        };
+        let pick = |pane: &ChartPane, source: &ChartPane| {
+            // Only the pane the pointer is actually over is asked. Besides
+            // halving the work, it is what stops a horizontal line — which
+            // spans a whole chart — from reporting a hit on the pane beside
+            // the one the pointer is in, at the same height.
+            if !pane
+                .last_chart_area
+                .is_some_and(|chart| chart.contains(position))
+            {
+                return None;
+            }
+            pane.shared_pick(source, position)
+                .map(|(index, anchor)| SharedPick {
+                    index,
+                    anchor,
+                    locked: source.drawings.items()[index].locked,
+                })
+        };
+        SharedPicks {
+            time: pick(time_pane, &self.flow_pane),
+            flow: pick(&self.flow_pane, time_pane),
+        }
+    }
+
+    /// Land what each pane did to the other's marks on the store that holds
+    /// them.
+    ///
+    /// The gesture brackets travel with the edits so a whole drag started on
+    /// the mirror lands as one undo entry on the owning store — the same
+    /// coalescing the object gets on its own chart, because it is the same
+    /// gesture on the same object. A selection taken on one pane is dropped on
+    /// the other, so the tab never holds two.
+    fn apply_shared_interactions(&mut self, edits: &[(PaneSide, SharedInteraction)]) {
+        for (side, interaction) in edits {
+            let owner = side.other();
+            if interaction.begin_gesture {
+                self.pane_mut(owner).drawings.begin_gesture();
+            }
+            if let Some(edit) = interaction.edit {
+                if matches!(edit, SharedEdit::Select(_)) {
+                    self.pane_mut(*side).drawings.select(None);
+                }
+                self.pane_mut(owner).apply_shared_edit(edit);
+            }
+            if interaction.commit_gesture {
+                self.pane_mut(owner).drawings.commit_gesture();
+            }
+        }
     }
 
     /// Cross-pane drawings: each pane paints the shared marks of the other.

--- a/docs/ux/drawing-tools-2026-08.md
+++ b/docs/ux/drawing-tools-2026-08.md
@@ -266,8 +266,28 @@ timestamp through its own `slot_at_time`.**
 - Panes already answer `slot_at_time(ms) -> Option<usize>` across the
   history-prefix seam (`pane.rs`), so the projection is one existing call
   per anchor, not new machinery.
-- A shared drawing lives in a tab-level store every pane of that tab
-  renders; a `ThisChart` drawing stays exactly where it lives today.
+- A shared drawing lives in the store of the pane it was drawn on and every
+  pane of the tab renders it; a `ThisChart` drawing is one no other pane
+  asks for.
+- **It is one object, and it is worked from either chart it appears on.** A
+  press on the mirror selects, drags and deletes the original: the pane the
+  gesture happened on reports what it did in market time and price, and the
+  pane that holds the object resolves that back into its own bars
+  (`ChartPane::interact_shared` → `Tab::apply_shared_interactions` →
+  `ChartPane::apply_shared_edit`). Nothing is written to a copy, and a whole
+  drag lands on the owning store as one undo entry.
+
+  This replaces the rule that first shipped, which made the mirror
+  read-only so a mark could not be grabbed in two places. The reasoning was
+  sound and the result was not: a trader who can see a level on the tick
+  chart but has to walk back to the timeframe chart to nudge it is being
+  asked to remember which chart they drew on, which is the bookkeeping
+  sharing exists to remove. Two places to grab it, one selection tab-wide —
+  so only one of them is ever holding it.
+- Because the object outlives the pane the pointer is over, the inspector,
+  the keyboard and the object manager follow the *selection* rather than the
+  focus (`Tab::drawing_side`). Selecting a level on the time pane and
+  pressing Delete deletes that level.
 - Toggled from the inspector's **Coordinates** tab, where the anchors
   already are. The object manager marks shared objects so Marina can see at
   a glance which marks are global.
@@ -285,6 +305,41 @@ Honesty at the edges, since a timestamp can fall outside a pane's series:
   clamped edge slot, and the drawing is painted at reduced alpha with the
   clamp visible, rather than silently pretending the anchor is on-screen.
 - A pane with no bars yet paints no shared drawings — nothing to anchor to.
+
+### D7b — A drawing leaves when the trader deletes it, and not before
+
+The market timestamp §D7 put on every anchor answers a second question the
+first pass got wrong: what happens to a mark when the bars underneath it are
+re-cut.
+
+The original rule was that a bar index is meaningless across two cuts of the
+tape, so a timeframe switch, a bar-kind switch, a replay seek, a reconnect
+or a symbol change dropped every mark and raised a toast saying so. That is
+honest about the coordinate and wrong about the object. A trader who marks a
+swing high on the 5-minute chart and flips to the 1-minute to time the entry
+has not asked for the level to be forgotten — the level is *why* they
+flipped.
+
+**No state change deletes a drawing.** Every re-cut re-asks the same
+question §D7 already answers: where does this anchor's instant land on the
+series I hold now (`Drawings::reanchor`)? An anchor with no instant behind it
+— one dropped past the newest bar, where the tape has written nothing —
+keeps its distance past the end instead.
+
+Honesty moves from deleting to labelling. A mark whose instant the new
+series cannot reach (drawn before the loaded history, or on the instrument
+this tab used to show) is flagged `off_series`: it paints at the same
+reduced alpha a clamped shared mark uses, and it stays selectable and
+deletable. The trader is told the mark is no longer over its data; they are
+not told what to do about it.
+
+**This holds across a symbol or feed switch too** — an explicit call, made
+in the goal that shipped this. The cross-*tab* boundary in §D7 stands for a
+different reason: nothing was ever drawn on the other tab's chart, so there
+is no object whose survival is in question.
+
+Out of scope, and a separate design: surviving a restart of the app. Nothing
+here is written to disk.
 
 ### D8 — A click selects what the press grabbed
 

--- a/docs/ux/drawing-tools-2026-08.md
+++ b/docs/ux/drawing-tools-2026-08.md
@@ -338,6 +338,18 @@ in the goal that shipped this. The cross-*tab* boundary in §D7 stands for a
 different reason: nothing was ever drawn on the other tab's chart, so there
 is no object whose survival is in question.
 
+That call needs a second label, because the first one cannot carry it.
+Market time survives a symbol switch and price does not: BTC traded at the
+same instants the index did, so every anchor resolves onto a real bar and
+`off_series` stays false — while the level itself now sits at a number that
+means nothing on the chart under it. A mark left painting at full strength
+there is inferred data reading as fact, which is the failure this repo
+refuses hardest. So the switch flags every object present as
+`foreign_market`: same fade, and an "other market" badge in the object
+manager saying the moment still exists here and the price does not mean the
+same thing. Marks drawn after the switch belong to the market now showing
+and start clean.
+
 Out of scope, and a separate design: surviving a restart of the app. Nothing
 here is written to disk.
 


### PR DESCRIPTION
A drawing now stays on the chart until the trader deletes it, and a mark
shared across the panes of a tab is one object that can be selected, moved
and deleted from either of them.

## Why

Two behaviours got in the way of ordinary work:

1. **Marks were deleted by state changes.** A timeframe or bar-kind switch,
   a replay seek, a reconnect or a symbol change dropped every drawing and
   raised a toast saying so. The reasoning was that a bar index is
   meaningless across two cuts of the tape — true about the *coordinate*,
   wrong about the *object*. A trader who marks a swing high on the 5-minute
   chart and flips to the 1-minute to time the entry has not asked for the
   level to be forgotten: the level is why they flipped.
2. **A shared mark could only be worked on the chart it was drawn on.** The
   mirror was read-only by explicit design (§D7), so that one object could
   not be grabbed in two places. The result was a level you could see on the
   tick chart and had to walk back to the timeframe chart to nudge — asking
   the trader to remember which chart they drew on, which is the bookkeeping
   sharing exists to remove.

The machinery to fix both was already there and unused: every `ChartPoint`
carries the market instant it was placed at, and every pane answers
`slot_at_time`.

## What changed

**Marks survive every re-cut.** `Drawings::reanchor` re-asks the question
§D7 already answers — where does this anchor's instant land on the series I
hold now? An anchor with no instant behind it (dropped past the newest bar,
where the tape has written nothing) keeps its distance past the end instead.
A reset waits for bars to exist before re-anchoring, because an empty series
can answer nothing.

**Honesty moved from deleting to labelling**, on both axes, because they
fail differently:

- *Time.* A mark whose instant the new series cannot reach — drawn before
  the loaded history — is flagged `off_series`.
- *Price.* A symbol switch is the case the time flag cannot catch: BTC
  traded at the same instants the index did, so every anchor resolves onto a
  real bar and only the price is meaningless. Those marks are flagged
  `foreign_market`.

Both paint at the same reduced alpha a clamped shared mark already used,
both stay selectable and deletable, and the object manager badges them "off
series" and "other market" with hover text saying which half is wrong. This
is what makes "never auto-delete" honest across a symbol switch, an explicit
product decision recorded in §D7b.

**The whole "overlay cleared" concept is gone**, not left behind as a dead
flag: `clear_overlay`/`clear_overlays`, the toast, `note_overlay_cleared`,
and the `-> bool` "did we clear?" return threaded through
`maybe_switch_feed`, `apply_spec_changes`, `drain_feed`, `open_replay`,
`close_replay` and `restart_feed`. What a re-cut still drops is a gesture in
flight (`drop_overlay_gestures`) — a half-finished drag holds pixels of bars
that no longer exist.

**A shared mark is worked from either chart.** The pane the gesture happened
on reports what it did in market time and price — the only coordinates two
cuts of one tape agree on — and the pane that holds the object resolves that
back into its own bars:

    ChartPane::interact_shared  →  Tab::apply_shared_interactions
                                →  ChartPane::apply_shared_edit

Nothing is written to a copy. A whole drag lands on the owning store as one
undo entry. Locked geometry refuses the drag from both charts. A drag this
pane cannot place moves nothing at all, rather than leaving a shape with one
end on a bar and the other on an instant that has none.

**Chrome follows the object, not the pointer.** The inspector, the keyboard
and the object manager read through `Tab::drawing_side` — the pane holding
the selection, which is not always the focused one. Without it, selecting a
level on the time pane and pressing Delete would delete nothing.

Three bugs fell out on the way, all caught by the cross-pane drag test:

- `translate_selected` and the keyboard nudge moved bar indices and left the
  market instant stale, so dragging a shared mark on its own chart left its
  twin standing where it was. Both retime their anchors now.
- `slot_at_time` answers slot 0 for an instant before the first bar. That is
  a clamp, not a location, and taking it silently put an anchor on data it
  has nothing to do with. `slot_of_time` refuses it — which is what both the
  off-series fade and the refused drag read.
- A shared drag died on the frame it was born: the press opens the
  inspector, the canvas narrows by its width (§D8), and the pointer leaves
  the pane. It is clamped into the pane now, exactly as a drag on the pane's
  own marks already was.

## Performance

| Path | Rate | Change |
| --- | --- | --- |
| `Drawings::reanchor` | rare (once per re-cut) | new; a few objects, a binary search per anchor |
| `ChartPane::settle_pending_reanchor` | per drain | one `Option` test per pane when nothing is owed |
| `ChartPane::shared_pick` | per frame | new; returns immediately unless the tab is split, something is shared, **and** the pointer is over that pane |
| `ChartPane::interact_shared` | per frame | new; returns immediately with no pick and no drag in flight |
| `ChartPane::retime_selected` | per drag frame | ≤4 anchors, only while an object is being moved |
| `draw_drawings` | per frame | one bool test and a branch per drawing |
| `paint_shared_from` | per frame | unchanged shape; now also reads the selection |

No per-trade or per-depth path is touched.

### Measured

Two runs of each build, alternated, on the same recorded tape (WINJ26
`20260316.csv` at 64x, split `time+flow` layout, 17 shared demo drawings on
screen), 75 s each:

| Build | frame_cpu_ms avg | min | max |
| --- | --- | --- | --- |
| `main` run 1 | 15.77 | 14.86 | 16.75 |
| `main` run 2 | 16.14 | 14.23 | 17.52 |
| branch run 1 | 10.63 | 9.52 | 11.92 |
| branch run 2 | 10.51 | 9.38 | 11.62 |

Identical workload on both sides — same `bar_spec="tick(50)"`, same
`time_pane_spec="time(1m)"`, same `canvas_layout=TimeAndFlow`, 8274
aggressions, ~22k trades replayed, 502 vs 505 projection builds.

**The branch is not slower.** I am *not* claiming the change made frames
cheaper: nothing in it removes per-frame work, and the delta tracks
`heatmap_projection_ms` (9.34 -> 7.03), which follows how many aggressions
the visible window happens to hold. The gate this evidence answers is "flat
or better", and it is answered.

`fps` is deliberately absent from the table: the desktop had been idle 85
minutes, the DWM had stopped compositing, and `fps`/`frame_avg_ms` measure
presentation rather than work in that state. `frame_cpu_ms` is the honest
number there — see the note in `agent-launched-app-renders-white`.

## Verification

All four green on `feat/drawings-persist`:

```
cargo fmt --all -- --check                                    ok
cargo clippy --workspace --all-targets -- -D warnings         ok, no findings
cargo build --workspace                                       ok
cargo test --workspace                                        875 passed, 0 failed
```

Rebased onto `main` @ 369a0f9 (after #135 landed). Four conflicts, all in
`app.rs` and all the same shape: #135 renamed `drawing_toast` -> `toast`
while this branch moved `focused_pane` -> `drawing_pane`. One was
conceptual rather than textual — `main` still asserted "the clear must
raise the notice toast", which is the behaviour this branch removes.

**Gates**

- `arch-review` — run over `git diff main...HEAD`. Three Should-fix found
  and fixed (a doc that misdescribed `slot_of_time` against `reproject`, an
  inline hour offset in the demo hook, and a missing app-level regression
  test for the stale-timestamp bug). Two accepted with reasons, below.
- `trader-ux-review` — one Blocker found and fixed: the foreign-market
  label. See the commit; it is the finding no other gate could have caught,
  because the others were all watching the time axis.
- `ui-harness` — `QUANTICK_DRAWINGS_DEMO_RECUT=1` added and registered; it
  reaches both new surfaces (marks re-anchored after a re-cut, and one
  faded off-series mark) from a fresh launch with no clicks.
- `visual-qa` — **PASS**, run once the machine was in use again (the first
  attempt came back blank at `idle_ms=5128703`: the compositor stops in an
  idle session, and only real input revives it). Captured at 49-60 fps on
  the WINJ26 tape:
  - *Shared mark on both panes.* The same dashed level paints in both, and
    the ruler reads "3 bars · 2m 29s" on the time pane against "14 bars ·
    2m 29s" on the flow pane — one object, different bar counts, identical
    market duration.
  - *Marks through a re-cut.* `tick(50)` → `tick(100)`: those same rulers
    become "7 bars" and "11 bars" with the durations unchanged, and
    `drawings=17 shared_drawings=17` before and after.
  - *Off-series label.* "Horizontal line 18 · off series" in the object
    manager, the one mark anchored an hour before the loaded history.
  - *Honest refusal.* A mark dropped past the newest bar shows "Show on all
    charts" disabled, with the reason written out.

  Two defects the run found are fixed in this branch (see the last commit):
  the object manager had no hook to open it, and the re-cut demo never
  actually placed its off-series mark. One is left open: the manager
  truncates long badges ("off serie", "all chart:") in a narrow window —
  pre-existing, since "all charts" already truncated, and my badge only
  inherits it. Not verified: the *fade* on the off-series mark itself, which
  clamps to slot 0 and sits outside the visible window — which is precisely
  why the manager badge exists.

## Deferred

- **A tab-level drawing store.** §D7 originally called for one, and it would
  be cleaner than routing edits between two per-pane stores. It would also
  mean making market time the *stored* coordinate and re-deriving bar indices
  everywhere, which touches all 13 drawing tools and every hit-test. The
  approach here reuses the `reproject` that already existed and keeps the
  blast radius to the drawing seam. Worth revisiting if a third pane ever
  lands.
- **Surviving a restart.** Nothing is written to disk; that needs a file
  format and versioning of its own (`feat/workspace-persistence` is the
  natural home).
- **Cross-tab sharing** stays out, for the reason §D7 already gives: nothing
  was ever drawn on the other tab's chart, so no object's survival is in
  question.
- **`SharedPicks` has a field per pane** (`time`, `flow`), so a third pane
  would force it open. Accepted: `PaneSide` is a two-variant enum repo-wide,
  and inventing generality here would be a second way to do a solved thing.
- **A horizontal shared mark now captures the pointer on the mirror pane**,
  where before it was inert — a band across the other chart where a pan does
  not start. Accepted for consistency: it is exactly the behaviour the mark
  has on the chart it lives on, and being able to grab it there is the point
  of the change. Worth watching if a trader reports it.

## Docs

`docs/ux/drawing-tools-2026-08.md` §D7 records that the read-only-mirror rule
was replaced and why; the new §D7b records the never-auto-delete rule, the
off-series labelling, and the symbol-switch decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
