### PR TITLE
feat(agent): enforce the worktree and arch-review rules with hooks

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -1,0 +1,79 @@
+# Agent guardrails
+
+Two rules in CLAUDE.md were enforceable only by an agent remembering them:
+work happens in a worktree, and `arch-review` runs before the PR. An
+instruction in markdown is advice a long session can drift away from. A hook
+is a wall. These make the harness enforce both.
+
+Wired in `.claude/settings.json`, implemented in `guardrails.sh` (POSIX sh, no
+`jq`, so it runs under Git Bash on Windows and dash in CI) and covered by
+`guardrails_test.sh`.
+
+| Mode | Event | Acts on | Effect |
+| --- | --- | --- | --- |
+| `worktree-guard` | `PreToolUse` | `Edit`, `Write`, `NotebookEdit` | Denies the write when it lands in the main checkout while that checkout is on `main`. |
+| `pr-gate` | `PreToolUse` | `Bash` | Denies `gh pr create` until arch-review is recorded for the exact `HEAD` being shipped. |
+| `commit-reminder` | `PostToolUse` | `Bash` | Cannot block (the commit already landed). After a `git commit` on a branch ahead of `origin/main`, says the gate is coming. |
+
+## Recording an arch-review
+
+`pr-gate` reads `<git-dir>/arch-review-ok`, which holds the commit sha the
+review covered. After running the skill and handling its findings:
+
+```sh
+git rev-parse HEAD > "$(git rev-parse --absolute-git-dir)/arch-review-ok"
+```
+
+The file lives in the worktree's own git dir, so it is per-branch and never
+committed. Storing the sha rather than a timestamp is what makes the gate
+honest: commit again after the review and the sha no longer matches, so the
+gate denies and names both shas. A marker that only said "a review happened"
+would pass while the newest commits went unreviewed.
+
+The gate proves a review was *recorded*, not that it was *good*. Nothing can
+prove the latter from outside the review. What it does remove is the failure
+this repo actually hits: forgetting entirely, or reviewing and then pushing
+three more commits.
+
+## Why the filtering lives in the script
+
+Hook config supports an `if` field with permission-rule syntax to narrow a
+matcher (`"if": "Bash(gh pr create:*)"`). These hooks do not use it. A matcher
+that silently fails to match leaves a gate that looks armed and is not, which
+is worse than no gate, and the exact syntax was not verifiable from the docs.
+Each mode inspects the tool payload itself and exits immediately when the
+command is not its business, so the cost on unrelated calls is one `sed` and
+the behaviour is covered by tests.
+
+## Fail-open by design
+
+Anything `guardrails.sh` cannot determine exits 0 and the normal permission
+flow applies: no `file_path` in the payload, a path outside a git repo, a
+`git` invocation that errors. A guardrail that blocks the session over its own
+bugs would be worse than no guardrail, and the rules it protects are also
+written down in CLAUDE.md.
+
+## Overrides
+
+- `QUANTICK_ALLOW_MAIN_WRITES=1` in the environment before launching disables
+  `worktree-guard`, for the rare deliberate edit on the main checkout.
+- Paths under `.claude/` are always allowed: the goal file, its archives, the
+  skills and these hooks live in the main checkout by design, and blocking
+  them would break the workflow the guard exists to protect.
+
+## Tests
+
+```sh
+sh .claude/hooks/guardrails_test.sh
+```
+
+Builds throwaway git repos under a temp dir, exercises all three modes
+including the fail-open paths, and cleans up after itself. CI runs it as its
+own step. Neutering `guardrails.sh` to `exit 0` fails five of the fifteen
+cases, which is the check that they test the behaviour and not the harness.
+
+## If a hook does not fire
+
+The command hooks need `sh` on `PATH`; on Windows that comes with Git. Check
+with `sh --version`. Hook configuration is read at session start, so an edit
+to `settings.json` needs a new session before it takes effect.

--- a/.claude/hooks/guardrails.sh
+++ b/.claude/hooks/guardrails.sh
@@ -1,0 +1,172 @@
+#!/bin/sh
+# Agent guardrails for quantick. See .claude/hooks/README.md.
+#
+# Two CLAUDE.md rules were enforceable only by an agent remembering them.
+# These make the harness enforce them instead:
+#
+#   worktree-guard    PreToolUse on Edit|Write|NotebookEdit. Denies a write
+#                     that lands in the main checkout while it sits on the
+#                     main branch ("one goal, one worktree").
+#   pr-gate           PreToolUse on Bash. Denies `gh pr create` until
+#                     arch-review has been recorded for the exact commit
+#                     being shipped ("no branch ships un-reviewed").
+#   commit-reminder   PostToolUse on Bash. Cannot block (the commit already
+#                     landed); says the gate is coming and how to satisfy it.
+#
+# Every mode filters the tool payload itself rather than relying on the hook
+# config's `if` matcher: a matcher that silently fails to match would leave a
+# gate that looks armed and is not, and the filtering is covered by
+# guardrails_test.sh either way.
+#
+# Fail-open by design: anything this script cannot determine exits 0 and the
+# normal permission flow applies. A guardrail that blocks the session over its
+# own bugs is worse than no guardrail, and the rules are also written down in
+# CLAUDE.md.
+#
+# POSIX sh, no jq: it runs under Git Bash on Windows, under dash in CI.
+
+set -u
+
+# The branch that is never worked on directly, and the base every branch is
+# cut from and measured against.
+MAIN_BRANCH="main"
+# Where arch-review records what it approved. Lives in the worktree's own git
+# dir, so it is per-branch and never committed.
+REVIEW_MARKER_NAME="arch-review-ok"
+
+mode="${1:-}"
+input=$(cat)
+
+# --- shared helpers ---------------------------------------------------------
+
+# Pull one string field out of the hook's stdin JSON. Good enough for the flat
+# fields we need (`file_path`, `command`, `cwd`); not a JSON parser.
+json_string_field() {
+    printf '%s' "$input" |
+        tr -d '\n' |
+        sed -n "s/.*\"$1\"[[:space:]]*:[[:space:]]*\"\(\([^\"\\\\]\|\\\\.\)*\)\".*/\1/p" |
+        head -n 1
+}
+
+# JSON escapes a Windows path as C:\\src\\x. Undo that and speak one slash.
+normalize_path() {
+    printf '%s' "$1" | sed 's|\\\\|/|g; s|\\|/|g'
+}
+
+# Walk up to the first directory that exists: a Write targets a file that does
+# not exist yet, and may create its parents too.
+nearest_existing_dir() {
+    d=$(dirname "$1")
+    while [ ! -d "$d" ]; do
+        p=$(dirname "$d")
+        [ "$p" != "$d" ] || return 1
+        d="$p"
+    done
+    printf '%s' "$d"
+}
+
+deny() {
+    printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}\n' "$1"
+    exit 0
+}
+
+context() {
+    printf '{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":%s}}\n' "$1"
+    exit 0
+}
+
+review_marker_path() {
+    printf '%s/%s' "$(git -C "$1" rev-parse --absolute-git-dir 2>/dev/null)" "$REVIEW_MARKER_NAME"
+}
+
+# --- worktree-guard ---------------------------------------------------------
+
+worktree_guard() {
+    # An explicit opt-out for the rare deliberate edit on the main checkout: a
+    # hotfix, a repo-hygiene sweep. Set it in the shell before launching.
+    if [ "${QUANTICK_ALLOW_MAIN_WRITES:-}" = "1" ]; then
+        exit 0
+    fi
+
+    raw=$(json_string_field file_path)
+    [ -n "$raw" ] || exit 0
+    path=$(normalize_path "$raw")
+
+    # Agent working files live in the main checkout by design: the goal file,
+    # its archives, the skills, these hooks. Blocking them would break the
+    # very workflow this guard protects.
+    case "$path" in
+        */.claude/*) exit 0 ;;
+    esac
+
+    dir=$(nearest_existing_dir "$path") || exit 0
+
+    git_dir=$(git -C "$dir" rev-parse --absolute-git-dir 2>/dev/null) || exit 0
+    common_dir=$(git -C "$dir" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || exit 0
+
+    # In a linked worktree these differ (<common>/worktrees/<name> vs
+    # <common>). Equal means the write lands in the main checkout.
+    [ "$git_dir" = "$common_dir" ] || exit 0
+
+    branch=$(git -C "$dir" rev-parse --abbrev-ref HEAD 2>/dev/null) || exit 0
+    [ "$branch" = "$MAIN_BRANCH" ] || exit 0
+
+    deny "\"CLAUDE.md: one goal, one worktree. This write lands in the main checkout while it is on \`$MAIN_BRANCH\`. Create the worktree first:\n\n  git fetch origin\n  git worktree add -b <prefix>/<slug> ../quantick-worktrees/<prefix>-<slug> origin/$MAIN_BRANCH\n\nthen work inside that directory. Set QUANTICK_ALLOW_MAIN_WRITES=1 to override deliberately.\""
+}
+
+# --- pr-gate ----------------------------------------------------------------
+
+pr_gate() {
+    command=$(json_string_field command)
+    case "$command" in
+        *"gh pr create"*) ;;
+        *) exit 0 ;;
+    esac
+
+    dir=$(normalize_path "$(json_string_field cwd)")
+    [ -d "$dir" ] || exit 0
+
+    head=$(git -C "$dir" rev-parse HEAD 2>/dev/null) || exit 0
+    marker=$(review_marker_path "$dir")
+
+    record="git -C . rev-parse HEAD > \\\"\$(git rev-parse --absolute-git-dir)/$REVIEW_MARKER_NAME\\\""
+
+    if [ ! -f "$marker" ]; then
+        deny "\"CLAUDE.md: no branch ships un-reviewed. arch-review has not been recorded for this branch. Run the arch-review skill over \`git diff $MAIN_BRANCH...HEAD\`, resolve every Blocker and Should-fix (or note the deferral in the PR body), then record it:\n\n  $record\""
+    fi
+
+    reviewed=$(cat "$marker" 2>/dev/null)
+    if [ "$reviewed" != "$head" ]; then
+        deny "\"CLAUDE.md: no branch ships un-reviewed. arch-review was recorded for $reviewed but HEAD is now $head, so the newest commits are unreviewed. Re-run arch-review over \`git diff $MAIN_BRANCH...HEAD\` and record it again:\n\n  $record\""
+    fi
+
+    exit 0
+}
+
+# --- commit-reminder --------------------------------------------------------
+
+commit_reminder() {
+    command=$(json_string_field command)
+    case "$command" in
+        *"git commit"*) ;;
+        *) exit 0 ;;
+    esac
+
+    dir=$(normalize_path "$(json_string_field cwd)")
+    [ -d "$dir" ] || exit 0
+
+    branch=$(git -C "$dir" rev-parse --abbrev-ref HEAD 2>/dev/null) || exit 0
+    [ "$branch" != "$MAIN_BRANCH" ] || exit 0
+
+    ahead=$(git -C "$dir" rev-list --count "origin/$MAIN_BRANCH..HEAD" 2>/dev/null) || exit 0
+    [ "${ahead:-0}" -gt 0 ] || exit 0
+
+    context "\"Branch \`$branch\` is $ahead commit(s) ahead of origin/$MAIN_BRANCH. \`gh pr create\` is gated on arch-review having been recorded for the exact HEAD being shipped, so run it over \`git diff $MAIN_BRANCH...HEAD\` once the branch is final.\""
+}
+
+case "$mode" in
+    worktree-guard) worktree_guard ;;
+    pr-gate) pr_gate ;;
+    commit-reminder) commit_reminder ;;
+    *) exit 0 ;;
+esac

--- a/.claude/hooks/guardrails_test.sh
+++ b/.claude/hooks/guardrails_test.sh
@@ -1,0 +1,144 @@
+#!/bin/sh
+# Tests for .claude/hooks/guardrails.sh.
+#
+# The guard-rails are the only thing standing between a long agent session and
+# a commit on the wrong checkout, so they need the same bar as the rest of the
+# repo: a test that fails without the behaviour. Run from anywhere:
+#
+#   sh .claude/hooks/guardrails_test.sh
+#
+# Hermetic: builds throwaway git repos under a temp dir and removes them.
+# POSIX sh, no jq, so it runs under Git Bash on Windows and dash in CI.
+
+set -u
+
+script_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+GUARDRAILS="$script_dir/guardrails.sh"
+
+passed=0
+failed=0
+
+# --- fixture ----------------------------------------------------------------
+
+root=$(mktemp -d)
+trap 'git -C "$root/mainco" worktree remove --force "$root/wt" >/dev/null 2>&1; rm -rf "$root"' EXIT
+
+git init -b main -q "$root/mainco"
+git -C "$root/mainco" config user.email t@t
+git -C "$root/mainco" config user.name t
+mkdir -p "$root/mainco/src" "$root/mainco/.claude"
+echo one > "$root/mainco/src/a.txt"
+git -C "$root/mainco" add -A
+git -C "$root/mainco" commit -qm "first"
+# A remote-tracking ref without a remote: commit-reminder measures against it.
+git -C "$root/mainco" update-ref refs/remotes/origin/main HEAD
+
+git -C "$root/mainco" worktree add -q -b feat/x "$root/wt" >/dev/null 2>&1
+echo two > "$root/wt/src/a.txt"
+git -C "$root/wt" add -A
+git -C "$root/wt" commit -qm "second"
+
+head_sha=$(git -C "$root/wt" rev-parse HEAD)
+wt_git_dir=$(git -C "$root/wt" rev-parse --absolute-git-dir)
+
+# --- harness ----------------------------------------------------------------
+
+# run <name> <mode> <stdin-json> <expect: deny|context|silent>
+run() {
+    name=$1
+    mode=$2
+    payload=$3
+    expect=$4
+
+    out=$(printf '%s' "$payload" | sh "$GUARDRAILS" "$mode" 2>&1)
+    status=$?
+
+    actual=silent
+    case "$out" in
+        *'"permissionDecision":"deny"'*) actual=deny ;;
+        *'"additionalContext"'*) actual=context ;;
+    esac
+
+    if [ "$status" -ne 0 ]; then
+        printf 'FAIL %s: exited %s (guard-rails must always exit 0)\n' "$name" "$status"
+        failed=$((failed + 1))
+        return
+    fi
+    if [ "$actual" != "$expect" ]; then
+        printf 'FAIL %s: expected %s, got %s\n  output: %s\n' "$name" "$expect" "$actual" "$out"
+        failed=$((failed + 1))
+        return
+    fi
+    passed=$((passed + 1))
+}
+
+json_path() { printf '{"tool_name":"Write","tool_input":{"file_path":"%s"}}' "$1"; }
+json_bash() { printf '{"tool_name":"Bash","cwd":"%s","tool_input":{"command":"%s"}}' "$1" "$2"; }
+
+# --- worktree-guard ---------------------------------------------------------
+
+run "write into the main checkout on main is denied" \
+    worktree-guard "$(json_path "$root/mainco/src/a.txt")" deny
+
+run "a file that does not exist yet is still denied" \
+    worktree-guard "$(json_path "$root/mainco/src/deep/new.txt")" deny
+
+run "agent working files under .claude are allowed" \
+    worktree-guard "$(json_path "$root/mainco/.claude/GOAL.md")" silent
+
+run "write into a linked worktree is allowed" \
+    worktree-guard "$(json_path "$root/wt/src/a.txt")" silent
+
+run "a payload without file_path fails open" \
+    worktree-guard '{"tool_name":"Bash","tool_input":{"command":"ls"}}' silent
+
+run "a path outside any repo fails open" \
+    worktree-guard "$(json_path "$root/loose.txt")" silent
+
+out=$(printf '%s' "$(json_path "$root/mainco/src/a.txt")" |
+    QUANTICK_ALLOW_MAIN_WRITES=1 sh "$GUARDRAILS" worktree-guard)
+if [ -z "$out" ]; then
+    passed=$((passed + 1))
+else
+    printf 'FAIL the env override is honoured\n  output: %s\n' "$out"
+    failed=$((failed + 1))
+fi
+
+git -C "$root/mainco" checkout -q -b fix/y
+run "the main checkout on another branch is allowed" \
+    worktree-guard "$(json_path "$root/mainco/src/a.txt")" silent
+git -C "$root/mainco" checkout -q main
+
+# --- pr-gate ----------------------------------------------------------------
+
+rm -f "$wt_git_dir/arch-review-ok"
+
+run "a bash command that is not gh pr create is ignored" \
+    pr-gate "$(json_bash "$root/wt" "cargo test --workspace")" silent
+
+run "gh pr create without a recorded review is denied" \
+    pr-gate "$(json_bash "$root/wt" "gh pr create --fill")" deny
+
+echo "0000000000000000000000000000000000000000" > "$wt_git_dir/arch-review-ok"
+run "a review recorded for an older commit is denied" \
+    pr-gate "$(json_bash "$root/wt" "gh pr create --fill")" deny
+
+echo "$head_sha" > "$wt_git_dir/arch-review-ok"
+run "a review recorded for the exact HEAD is allowed" \
+    pr-gate "$(json_bash "$root/wt" "gh pr create --fill")" silent
+
+# --- commit-reminder --------------------------------------------------------
+
+run "a bash command that is not git commit is ignored" \
+    commit-reminder "$(json_bash "$root/wt" "git status")" silent
+
+run "a commit on main says nothing" \
+    commit-reminder "$(json_bash "$root/mainco" "git commit -m x")" silent
+
+run "a commit on a branch ahead of origin/main reminds" \
+    commit-reminder "$(json_bash "$root/wt" "git commit -m x")" context
+
+# --- report -----------------------------------------------------------------
+
+printf '\n%s passed, %s failed\n' "$passed" "$failed"
+[ "$failed" -eq 0 ]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -27,5 +27,41 @@
       "PowerShell(git show:*)",
       "PowerShell(git branch:*)"
     ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh \"${CLAUDE_PROJECT_DIR}/.claude/hooks/guardrails.sh\" worktree-guard",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh \"${CLAUDE_PROJECT_DIR}/.claude/hooks/guardrails.sh\" pr-gate",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh \"${CLAUDE_PROJECT_DIR}/.claude/hooks/guardrails.sh\" commit-reminder",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Agent guardrails
+        # The hooks in .claude/settings.json are what keep an agent session off
+        # the main checkout and off an un-reviewed PR. Nothing in cargo test
+        # touches them, so they get their own step. Hermetic: the suite builds
+        # its own throwaway repos and never reads this checkout.
+        run: sh .claude/hooks/guardrails_test.sh
       - name: Install desktop GUI dependencies
         # quantick-app (egui/eframe + winit) needs these to build/link on Linux.
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,3 +59,4 @@ CI (`.github/workflows/ci.yml`) enforces the same four checks on every PR and on
 
   Work happens inside that directory. After the branch is merged, clean up from the main checkout: `git worktree remove ../quantick-worktrees/<prefix>-<slug>` then `git branch -d <prefix>/<slug>`.
 - **Arch-review before PR**: before opening a PR (and before any merge), run the `arch-review` skill over `git diff main...HEAD` and resolve every Blocker and Should-fix finding. A finding deliberately deferred is noted in the PR body. No branch ships un-reviewed.
+- **The two rules above are enforced by hooks, not by memory**: a write landing in the main checkout while it sits on `main` is denied, and `gh pr create` is gated on arch-review having run for the branch. See `.claude/hooks/README.md` for what fires when, why the gate is a prompt hook, and how to override.


### PR DESCRIPTION
## What

CLAUDE.md asks every session to work in a dedicated worktree and to run `arch-review` before opening a PR. Both were enforceable only by the agent remembering them, which is exactly what a long session stops doing. Three hooks move the enforcement into the harness.

| Mode | Event | Acts on | Effect |
| --- | --- | --- | --- |
| `worktree-guard` | `PreToolUse` | `Edit`, `Write`, `NotebookEdit` | Denies a write landing in the main checkout while it sits on `main`, and prints the worktree recipe. |
| `pr-gate` | `PreToolUse` | `Bash` | Denies `gh pr create` until arch-review is recorded for the exact `HEAD` being shipped. |
| `commit-reminder` | `PostToolUse` | `Bash` | Cannot block (the commit already landed); announces the gate once the branch is ahead of `origin/main`. |

Full rationale in `.claude/hooks/README.md`.

## Design decisions worth reviewing

**The review marker holds a commit sha, not a timestamp or a boolean.** `pr-gate` reads `<git-dir>/arch-review-ok` and compares it to `HEAD`. Review, then commit three more times, and the sha no longer matches: the gate denies and names both shas. A marker that only recorded "a review happened" would wave through exactly the case this repo actually hits.

**The filtering lives in the script, not in the hook config's `if` field.** Hook config supports `"if": "Bash(gh pr create:*)"` to narrow a matcher, but the exact permission-rule syntax was not verifiable from the docs, and a matcher that silently fails to match leaves a gate that looks armed and is not. Each mode inspects the payload itself and returns immediately when the call is not its business, so an unrelated `Bash` call costs one `sed`.

**Fail-open throughout.** No `file_path` in the payload, a path outside a git repo, a `git` invocation that errors: all exit 0 and the normal permission flow applies. A guardrail that blocks a session over its own bugs is worse than no guardrail, and the rules are also written down in CLAUDE.md.

**What the gate does not prove.** It proves a review was *recorded*, not that it was *good*. Nothing outside the review can prove the latter. What it removes is forgetting entirely, and reviewing then pushing more commits.

## Blast radius

Added 3 files (`.claude/hooks/`), edited 3 (`.claude/settings.json`, `.github/workflows/ci.yml`, one line in `CLAUDE.md`). No Rust source touched, no crate dependency changed, no runtime path affected.

## Performance

Not applicable to the engine or the renderer. Agent-session cost only: `worktree-guard` runs a few `git rev-parse` calls per `Edit`/`Write`, `pr-gate` and `commit-reminder` exit after one `sed` unless the command is theirs.

## Proof

- `sh .claude/hooks/guardrails_test.sh` : **15 passed, 0 failed**. Hermetic, builds throwaway git repos under a temp dir and removes them.
- Mutation check: neutering `guardrails.sh` to `exit 0` fails **5 of the 15** cases, so they test the behaviour and not the harness.
- CI runs the suite as its own step, since `cargo test` cannot reach a shell hook.
- Four checks on this tree: `cargo fmt --all -- --check` clean, `cargo clippy --workspace --all-targets -- -D warnings` clean, `cargo build --workspace` clean, `cargo test --workspace` **exit 0, 1480 tests passed**. No Rust file changed afterwards.
- `pr-gate` was dogfooded to open this PR: it denied until the review was recorded, then allowed.

## arch-review

Run over `git diff main...HEAD`. Three findings, all fixed in this branch before the PR:

- **Blocker, test-coverage** : the guard-rails shipped with no committed test and `cargo test` cannot reach them. Fixed with `guardrails_test.sh` plus a CI step.
- **Blocker, standardisation** : the PR gate depended on an unverified `if` matcher syntax. Fixed by moving the filtering into the script, which also made it testable.
- **Should-fix, hardcoded-values** : `main` was a literal in three places. Fixed with `MAIN_BRANCH` and `REVIEW_MARKER_NAME` constants.

## Not in this PR

- **Hooks are read at session start**, so end-to-end firing inside Claude Code can only be confirmed on a fresh session after merge. The script's behaviour is proven by the suite; what stays unverified until then is that the harness spawns `sh` on this machine. First fresh session should try an `Edit` against the main checkout and expect the denial.
- **The `goal` skill still collides with the built-in `/goal`** (a built-in command since v2.1.139; this repo is on 2.1.225). Renaming it and having it emit a ready-to-paste `/goal` condition is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
