### PR TITLE
docs(mission): compress the /goal handover line into the built-in 4,000-char limit

### DIFF
--- a/.claude/skills/mission/SKILL.md
+++ b/.claude/skills/mission/SKILL.md
@@ -75,7 +75,14 @@ before it. Step 7 hands over the line to paste.
 
    Rules the built-in imposes on that line:
 
-   - **4,000 characters maximum.**
+   - **4,000 characters maximum.** If the criteria from step 2 do not fit,
+     compress rather than drop: state each criterion as a terse observable
+     outcome ("clippy/fmt/build/test exit 0", "PR URL printed", "GOAL.md
+     archived"), strip all rationale and repo context, and collapse per-surface
+     detail into one line ("all visual-qa surfaces PASS"). Only if it still
+     overflows, keep the gates (checks, arch-review, PR, archive) and summarize
+     the mission-specific criteria into the fewest observable outcomes that
+     still prove them. Count the characters before printing the line.
    - The evaluator **does not run commands or read files**. It only judges what
      has appeared in the conversation, so every criterion must be something
      this session's own output demonstrates — "`cargo test --workspace` exits


### PR DESCRIPTION
## What

Step 7 of the `mission` skill hands the user a ready-to-paste `/goal` line. It already stated the built-in's 4,000-character cap, but not what to do when the merged criteria overflow it. This PR teaches it to compress before dropping:

- each criterion becomes a terse observable outcome ("clippy/fmt/build/test exit 0", "PR URL printed", "GOAL.md archived");
- rationale and repo context are stripped, per-surface detail collapses into one line;
- only if it still overflows, the fixed gates (four checks, arch-review, PR, archive) stay untouchable and the mission-specific criteria are summarized into the fewest outcomes that still prove them;
- count characters before printing the line.

The example outcomes now include "GOAL.md archived", which closes a real gap: the built-in `/goal` evaluator only judges the transcript, so the post-PR archive step was previously not part of the completion condition and nothing kept the session alive until it happened.

## Verification

- `cargo fmt --all -- --check` — pass
- `cargo clippy --workspace --all-targets -- -D warnings` — pass
- `cargo build --workspace` — pass
- `cargo test --workspace` — pass, 0 failures

## Review

Docs/skill-only change (one `.md` file, +8/−1): arch-review waived per the mission skill's own docs-only rule; the pr-gate marker was recorded for this HEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)