### PR TITLE
feat(app): venue history joins the range profile as approximated ladders (#148 v1)

### DIFF
--- a/crates/app/src/drawings/fixed_range_profile.rs
+++ b/crates/app/src/drawings/fixed_range_profile.rs
@@ -90,6 +90,10 @@ pub struct FrvpCache {
     pub empty: Option<FrvpEmpty>,
     /// Bars whose ladders went into the fold (the partial counts once).
     pub bars_covered: usize,
+    /// Bars folded from an **approximated** ladder — venue candles with no
+    /// tape, their volume spread over their own high–low. Spoken by the
+    /// status line, never blended away.
+    pub bars_approximated: usize,
     /// Bars the anchors span on the chart, prefix candles included.
     pub bars_total: usize,
     /// The oldest global slot the L2 heatmap covers this frame — where the
@@ -117,6 +121,9 @@ pub struct FrvpCacheKey {
     /// delta whose sides were guessed must say so, like the footprint legend
     /// does.
     pub side_inferred: bool,
+    /// Whether venue-history candles are folded in as approximated ladders
+    /// — the payload's own switch, in the key so toggling it re-folds.
+    pub approximate: bool,
 }
 
 /// The versioned on-disk shape of a saved preset. Coordinates and cache never
@@ -138,6 +145,10 @@ struct FrvpPresetData {
     /// honest behaviour (outline over the map).
     #[serde(default = "default_true")]
     outline_over_heatmap: bool,
+    /// Same vintage rule again: approximating venue history is the default
+    /// because the label speaks whenever it happens.
+    #[serde(default = "default_true")]
+    approximate_history: bool,
 }
 
 fn default_true() -> bool {
@@ -165,6 +176,11 @@ pub struct FrvpPayload {
     /// the cells. Off = always fill, for whoever prefers the solid object
     /// and accepts the fight.
     pub outline_over_heatmap: bool,
+    /// Venue-history candles (no tape) join the fold as approximated
+    /// ladders — volume spread over each candle's high–low, labeled
+    /// `approximated from OHLC` in the status. Off = those bars contribute
+    /// nothing, exactly as before this option existed.
+    pub approximate_history: bool,
     /// Derived state, refreshed by `frvp::refresh`; see [`FrvpCache`].
     pub cache: Option<FrvpCache>,
 }
@@ -180,6 +196,7 @@ impl Default for FrvpPayload {
             show_labels: true,
             extend_right: false,
             outline_over_heatmap: true,
+            approximate_history: true,
             cache: None,
         }
     }
@@ -197,6 +214,7 @@ impl PartialEq for FrvpPayload {
             && self.show_labels == other.show_labels
             && self.extend_right == other.extend_right
             && self.outline_over_heatmap == other.outline_over_heatmap
+            && self.approximate_history == other.approximate_history
     }
 }
 
@@ -227,6 +245,7 @@ impl DrawingPayload for FrvpPayload {
             show_labels: self.show_labels,
             extend_right: self.extend_right,
             outline_over_heatmap: self.outline_over_heatmap,
+            approximate_history: self.approximate_history,
         })
         .ok()
     }
@@ -249,6 +268,7 @@ impl DrawingPayload for FrvpPayload {
         self.show_labels = data.show_labels;
         self.extend_right = data.extend_right;
         self.outline_over_heatmap = data.outline_over_heatmap;
+        self.approximate_history = data.approximate_history;
         // The cache key carries the value-area fraction, so the next refresh
         // recomputes; nothing to invalidate by hand.
         true
@@ -698,10 +718,20 @@ impl DrawingToolImpl for FixedRangeProfile {
                     // The developing mode: this profile follows the tape.
                     status.push_str(" · to live");
                 }
-                if cache.bars_covered < cache.bars_total {
+                if cache.bars_covered + cache.bars_approximated < cache.bars_total {
                     status.push_str(&format!(
                         " · profile from {} of {} bars",
-                        cache.bars_covered, cache.bars_total
+                        cache.bars_covered + cache.bars_approximated,
+                        cache.bars_total
+                    ));
+                }
+                if cache.bars_approximated > 0 {
+                    // Venue candles joined without tape: their placement is
+                    // approximated, and the profile says so at the point of
+                    // reading, never in a tooltip.
+                    status.push_str(&format!(
+                        " · approximated from OHLC ({} of {} bars)",
+                        cache.bars_approximated, cache.bars_total
                     ));
                 }
                 if cache.key.side_inferred {
@@ -908,6 +938,12 @@ fn draw_profile_tab(ui: &mut egui::Ui, drawing: &mut Drawing, host: &mut dyn Pre
              layers compose.",
         )
         .changed();
+    edited |= ui
+        .checkbox(&mut payload.approximate_history, "approximate from candles")
+        .on_hover_text(
+            "Venue-history candles carry no tape; with this on their volume              is spread over each candle's high–low and the status line says              'approximated from OHLC'. Off = those bars contribute nothing.",
+        )
+        .changed();
 
     ui.separator();
 
@@ -1054,6 +1090,7 @@ mod tests {
             show_labels: false,
             extend_right: true,
             outline_over_heatmap: false,
+            approximate_history: false,
             cache: Some(FrvpCache {
                 key: FrvpCacheKey {
                     start_slot: 1,
@@ -1066,10 +1103,12 @@ mod tests {
                     value_area_pct: 68,
                     blocked: false,
                     side_inferred: false,
+                    approximate: true,
                 },
                 profile: None,
                 empty: Some(FrvpEmpty::NoTape),
                 bars_covered: 0,
+                bars_approximated: 0,
                 bars_total: 5,
                 heat_first_slot: None,
             }),

--- a/crates/app/src/frvp.rs
+++ b/crates/app/src/frvp.rs
@@ -10,7 +10,7 @@
 //!
 //! Never on the per-trade path: ingestion does not know this module exists.
 
-use quantick_engine::{BarFootprint, DEFAULT_LEVEL_CAP, VolumeProfile};
+use quantick_engine::{Bar, BarFootprint, DEFAULT_LEVEL_CAP, VolumeProfile};
 use rust_decimal::Decimal;
 
 use crate::drawings::{Drawings, FrvpCache, FrvpCacheKey, FrvpEmpty, FrvpPayload};
@@ -25,10 +25,12 @@ pub const TOOL_ID: &str = "fixed-range-profile";
 /// the snapshot cadence, never per paint.
 pub struct RefreshInputs<'a> {
     pub state: &'a ChartState,
-    /// Venue history candles before the trade-built bars. They carry no tape
-    /// and therefore no ladder; a range over them is *partial coverage* and
-    /// the cache says so.
-    pub prefix_len: usize,
+    /// Venue history candles before the trade-built bars. They carry no
+    /// tape; with the payload's `approximate_history` on they join the fold
+    /// as approximated ladders (volume over their own high–low), labeled —
+    /// otherwise a range over them is *partial coverage* and the cache says
+    /// so. `prefix_bars.len()` is the prefix length.
+    pub prefix_bars: &'a [Bar],
     /// The throttled snapshot of the forming bar's ladder, if any.
     pub partial_ladder: Option<&'a BarFootprint>,
     /// Bumped whenever the snapshot above is re-taken.
@@ -102,7 +104,7 @@ fn covered_slots(min_bar: f32, max_bar: f32, last_slot: Option<usize>) -> Option
 
 fn refresh_one(payload: &mut FrvpPayload, min_bar: f32, max_bar: f32, inputs: &RefreshInputs<'_>) {
     let closed_len = inputs.state.bars().len();
-    let closed_total = inputs.prefix_len + closed_len;
+    let closed_total = inputs.prefix_bars.len() + closed_len;
     let partial_slot = inputs.partial_ladder.is_some().then_some(closed_total);
     let last_slot = partial_slot.or_else(|| closed_total.checked_sub(1));
 
@@ -134,6 +136,7 @@ fn refresh_one(payload: &mut FrvpPayload, min_bar: f32, max_bar: f32, inputs: &R
         value_area_pct: payload.value_area_pct,
         blocked: inputs.blocked,
         side_inferred: inputs.side_inferred,
+        approximate: payload.approximate_history,
     };
     if let Some(cache) = payload.cache.as_mut().filter(|cache| cache.key == key) {
         // Key hit: the fold is current. Presentation state still follows the
@@ -148,6 +151,7 @@ fn refresh_one(payload: &mut FrvpPayload, min_bar: f32, max_bar: f32, inputs: &R
             profile: None,
             empty: Some(FrvpEmpty::Blocked),
             bars_covered: 0,
+            bars_approximated: 0,
             bars_total,
             heat_first_slot: inputs.heat_first_slot,
         });
@@ -158,13 +162,28 @@ fn refresh_one(payload: &mut FrvpPayload, min_bar: f32, max_bar: f32, inputs: &R
     // construction; the difference between what the span asks for and what
     // the tape can answer is `bars_covered < bars_total`, spoken by paint.
     let ladders_all = inputs.state.bar_footprints();
-    let mut ladders: Vec<&BarFootprint> = Vec::new();
+    // Approximated ladders for the venue-prefix slots the span reaches —
+    // built on key change only (this whole path is key-guarded above), each
+    // bounded by the cap. Owned here so the merge below can borrow them
+    // beside the real ones: one fold, one profile, one code path.
+    let mut approx: Vec<BarFootprint> = Vec::new();
+    if payload.approximate_history && span.is_some() && start_slot < inputs.prefix_bars.len() {
+        let group = inputs.state.footprint_group();
+        let hi_prefix = end_slot.min(inputs.prefix_bars.len().saturating_sub(1));
+        for bar in &inputs.prefix_bars[start_slot..=hi_prefix] {
+            if let Some(ladder) = BarFootprint::approximated(bar, group, DEFAULT_LEVEL_CAP) {
+                approx.push(ladder);
+            }
+        }
+    }
+    let bars_approximated = approx.len();
+    let mut ladders: Vec<&BarFootprint> = approx.iter().collect();
     if span.is_some() {
         // State-bar coverage exists only where the span reaches past the
         // prefix and into the closed bars at all.
-        if end_slot >= inputs.prefix_len && start_slot < closed_total && closed_total > 0 {
-            let lo = start_slot.max(inputs.prefix_len) - inputs.prefix_len;
-            let hi_state = end_slot.min(closed_total - 1) - inputs.prefix_len;
+        if end_slot >= inputs.prefix_bars.len() && start_slot < closed_total && closed_total > 0 {
+            let lo = start_slot.max(inputs.prefix_bars.len()) - inputs.prefix_bars.len();
+            let hi_state = end_slot.min(closed_total - 1) - inputs.prefix_bars.len();
             if lo <= hi_state {
                 for ladder in ladders_all.iter().skip(lo).take(hi_state - lo + 1) {
                     // A bar whose ladder printed nothing contributes nothing;
@@ -178,7 +197,7 @@ fn refresh_one(payload: &mut FrvpPayload, min_bar: f32, max_bar: f32, inputs: &R
             ladders.push(partial);
         }
     }
-    let bars_covered = ladders.len();
+    let bars_covered = ladders.len() - bars_approximated;
 
     let profile = VolumeProfile::merge(ladders, DEFAULT_LEVEL_CAP).map(|profile| {
         let fraction = Decimal::from(payload.value_area_pct) / Decimal::ONE_HUNDRED;
@@ -191,6 +210,7 @@ fn refresh_one(payload: &mut FrvpPayload, min_bar: f32, max_bar: f32, inputs: &R
         profile,
         empty,
         bars_covered,
+        bars_approximated,
         bars_total,
         heat_first_slot: inputs.heat_first_slot,
     });
@@ -266,7 +286,7 @@ mod tests {
     fn inputs<'a>(state: &'a ChartState, blocked: bool) -> RefreshInputs<'a> {
         RefreshInputs {
             state,
-            prefix_len: 0,
+            prefix_bars: &[],
             partial_ladder: None,
             partial_version: 0,
             blocked,
@@ -365,38 +385,86 @@ mod tests {
         assert_eq!(cache.profile.expect("tape").0.total_volume(), dec("6"));
     }
 
+    /// Two venue candles standing in for a prefix: $2-tall bodies with a
+    /// real taker split, one unit of volume each.
+    fn prefix_bars() -> Vec<quantick_engine::Bar> {
+        (0..2)
+            .map(|i| quantick_engine::Bar {
+                open_time: 1_699_999_000_000 + i * 60_000,
+                close_time: 1_699_999_060_000 + i * 60_000,
+                open: dec("99"),
+                high: dec("100.9"),
+                low: dec("99"),
+                close: dec("100.5"),
+                buy_volume: dec("0.6"),
+                sell_volume: dec("0.4"),
+                trade_count: 10,
+            })
+            .collect()
+    }
+
+    /// A mixed range folds both worlds: the tape bars exactly, the venue
+    /// prefix as approximated ladders — counted apart, never blended away.
     #[test]
-    fn prefix_candles_count_toward_total_but_not_covered() {
+    fn prefix_candles_join_approximated_and_are_counted_apart() {
         let state = state_with_tape();
+        let prefix = prefix_bars();
         let mut drawings = Drawings::default();
         // Slots 0-1 are venue prefix, 2-4 are the three state bars.
         place_frvp(&mut drawings, 0.0, 4.9);
         let with_prefix = RefreshInputs {
-            prefix_len: 2,
+            prefix_bars: &prefix,
             ..inputs(&state, false)
         };
         refresh(&mut drawings, &with_prefix);
         let cache = cache_of(&drawings);
         assert_eq!(cache.bars_total, 5);
-        assert_eq!(cache.bars_covered, 3, "prefix candles carry no tape");
-        assert_eq!(cache.profile.expect("tape").0.total_volume(), dec("6"));
+        assert_eq!(cache.bars_covered, 3, "tape bars stay exact");
+        assert_eq!(cache.bars_approximated, 2, "venue candles join, labeled");
+        // Six units of tape plus one unit per approximated candle.
+        assert_eq!(cache.profile.expect("fold").0.total_volume(), dec("8"));
     }
 
+    /// The off-switch restores exactly the pre-approximation behaviour: a
+    /// prefix-only range is honest empty again.
     #[test]
-    fn a_range_entirely_on_the_prefix_is_no_tape() {
+    fn approximation_off_leaves_the_prefix_as_no_tape() {
         let state = state_with_tape();
+        let prefix = prefix_bars();
         let mut drawings = Drawings::default();
         place_frvp(&mut drawings, 0.0, 1.9);
+        drawings.items_mut()[0]
+            .payload
+            .as_any_mut()
+            .downcast_mut::<FrvpPayload>()
+            .unwrap()
+            .approximate_history = false;
         let with_prefix = RefreshInputs {
-            prefix_len: 2,
+            prefix_bars: &prefix,
             ..inputs(&state, false)
         };
         refresh(&mut drawings, &with_prefix);
         let cache = cache_of(&drawings);
         assert_eq!(cache.bars_total, 2);
         assert_eq!(cache.bars_covered, 0);
+        assert_eq!(cache.bars_approximated, 0);
         assert!(cache.profile.is_none());
         assert_eq!(cache.empty, Some(FrvpEmpty::NoTape));
+
+        // Toggling back on re-keys and the approximated fold appears.
+        drawings.items_mut()[0]
+            .payload
+            .as_any_mut()
+            .downcast_mut::<FrvpPayload>()
+            .unwrap()
+            .approximate_history = true;
+        refresh(&mut drawings, &with_prefix);
+        let cache = cache_of(&drawings);
+        assert_eq!(cache.bars_approximated, 2);
+        assert_eq!(
+            cache.profile.expect("approximated fold").0.total_volume(),
+            dec("2")
+        );
     }
 
     #[test]

--- a/crates/app/src/frvp.rs
+++ b/crates/app/src/frvp.rs
@@ -20,17 +20,58 @@ use crate::state::ChartState;
 /// module and the pane share to recognise a profile object.
 pub const TOOL_ID: &str = "fixed-range-profile";
 
+/// The venue prefix's approximated ladders, built **once** per
+/// `(group, prefix length)` and borrowed by every refresh after — a ladder
+/// is static data (the candle never changes), and rebuilding 25k of them on
+/// every cache-key change would put a BTreeMap construction storm inside an
+/// anchor drag. `None` per slot = that candle traded nothing.
+pub struct ApproxLadders {
+    group: Decimal,
+    ladders: Vec<Option<BarFootprint>>,
+}
+
+impl ApproxLadders {
+    /// The cached ladders for `prefix` at `group`, rebuilding only when the
+    /// prefix grew or the capture grouping refolded. O(prefix) on rebuild —
+    /// once per backfill page or group change, declared; O(1) after.
+    pub fn ensure<'a>(
+        slot: &'a mut Option<ApproxLadders>,
+        prefix: &[Bar],
+        group: Decimal,
+    ) -> &'a ApproxLadders {
+        let stale = slot
+            .as_ref()
+            .is_none_or(|cache| cache.group != group || cache.ladders.len() != prefix.len());
+        if stale {
+            *slot = Some(ApproxLadders {
+                group,
+                ladders: prefix
+                    .iter()
+                    .map(|bar| BarFootprint::approximated(bar, group, DEFAULT_LEVEL_CAP))
+                    .collect(),
+            });
+        }
+        slot.as_ref().expect("just ensured")
+    }
+
+    /// Ladders indexed by prefix slot; `None` where the candle traded nothing.
+    #[must_use]
+    pub fn ladders(&self) -> &[Option<BarFootprint>] {
+        &self.ladders
+    }
+}
+
 /// Everything one refresh reads. The partial ladder comes in as the pane's
 /// throttled snapshot (not the live one), so the forming bar re-merges at
 /// the snapshot cadence, never per paint.
 pub struct RefreshInputs<'a> {
     pub state: &'a ChartState,
-    /// Venue history candles before the trade-built bars. They carry no
-    /// tape; with the payload's `approximate_history` on they join the fold
-    /// as approximated ladders (volume over their own high–low), labeled —
-    /// otherwise a range over them is *partial coverage* and the cache says
-    /// so. `prefix_bars.len()` is the prefix length.
-    pub prefix_bars: &'a [Bar],
+    /// The venue prefix's approximated ladders (see [`ApproxLadders`]) —
+    /// one entry per prefix slot, `None` where the candle traded nothing.
+    /// With the payload's `approximate_history` on they join the fold,
+    /// labeled; otherwise a range over them is *partial coverage* and the
+    /// cache says so. Its length is the prefix length.
+    pub prefix_approx: &'a [Option<BarFootprint>],
     /// The throttled snapshot of the forming bar's ladder, if any.
     pub partial_ladder: Option<&'a BarFootprint>,
     /// Bumped whenever the snapshot above is re-taken.
@@ -104,7 +145,7 @@ fn covered_slots(min_bar: f32, max_bar: f32, last_slot: Option<usize>) -> Option
 
 fn refresh_one(payload: &mut FrvpPayload, min_bar: f32, max_bar: f32, inputs: &RefreshInputs<'_>) {
     let closed_len = inputs.state.bars().len();
-    let closed_total = inputs.prefix_bars.len() + closed_len;
+    let closed_total = inputs.prefix_approx.len() + closed_len;
     let partial_slot = inputs.partial_ladder.is_some().then_some(closed_total);
     let last_slot = partial_slot.or_else(|| closed_total.checked_sub(1));
 
@@ -162,28 +203,25 @@ fn refresh_one(payload: &mut FrvpPayload, min_bar: f32, max_bar: f32, inputs: &R
     // construction; the difference between what the span asks for and what
     // the tape can answer is `bars_covered < bars_total`, spoken by paint.
     let ladders_all = inputs.state.bar_footprints();
-    // Approximated ladders for the venue-prefix slots the span reaches —
-    // built on key change only (this whole path is key-guarded above), each
-    // bounded by the cap. Owned here so the merge below can borrow them
-    // beside the real ones: one fold, one profile, one code path.
-    let mut approx: Vec<BarFootprint> = Vec::new();
-    if payload.approximate_history && span.is_some() && start_slot < inputs.prefix_bars.len() {
-        let group = inputs.state.footprint_group();
-        let hi_prefix = end_slot.min(inputs.prefix_bars.len().saturating_sub(1));
-        for bar in &inputs.prefix_bars[start_slot..=hi_prefix] {
-            if let Some(ladder) = BarFootprint::approximated(bar, group, DEFAULT_LEVEL_CAP) {
-                approx.push(ladder);
-            }
-        }
+    // The venue-prefix slots the span reaches join through the prebuilt
+    // approximated ladders — borrowed, never rebuilt here: one fold, one
+    // profile, one code path.
+    let mut ladders: Vec<&BarFootprint> = Vec::new();
+    if payload.approximate_history && span.is_some() && start_slot < inputs.prefix_approx.len() {
+        let hi_prefix = end_slot.min(inputs.prefix_approx.len().saturating_sub(1));
+        ladders.extend(
+            inputs.prefix_approx[start_slot..=hi_prefix]
+                .iter()
+                .filter_map(Option::as_ref),
+        );
     }
-    let bars_approximated = approx.len();
-    let mut ladders: Vec<&BarFootprint> = approx.iter().collect();
+    let bars_approximated = ladders.len();
     if span.is_some() {
         // State-bar coverage exists only where the span reaches past the
         // prefix and into the closed bars at all.
-        if end_slot >= inputs.prefix_bars.len() && start_slot < closed_total && closed_total > 0 {
-            let lo = start_slot.max(inputs.prefix_bars.len()) - inputs.prefix_bars.len();
-            let hi_state = end_slot.min(closed_total - 1) - inputs.prefix_bars.len();
+        if end_slot >= inputs.prefix_approx.len() && start_slot < closed_total && closed_total > 0 {
+            let lo = start_slot.max(inputs.prefix_approx.len()) - inputs.prefix_approx.len();
+            let hi_state = end_slot.min(closed_total - 1) - inputs.prefix_approx.len();
             if lo <= hi_state {
                 for ladder in ladders_all.iter().skip(lo).take(hi_state - lo + 1) {
                     // A bar whose ladder printed nothing contributes nothing;
@@ -286,7 +324,7 @@ mod tests {
     fn inputs<'a>(state: &'a ChartState, blocked: bool) -> RefreshInputs<'a> {
         RefreshInputs {
             state,
-            prefix_bars: &[],
+            prefix_approx: &[],
             partial_ladder: None,
             partial_version: 0,
             blocked,
@@ -412,8 +450,10 @@ mod tests {
         let mut drawings = Drawings::default();
         // Slots 0-1 are venue prefix, 2-4 are the three state bars.
         place_frvp(&mut drawings, 0.0, 4.9);
+        let mut approx_slot = None;
+        let approx = ApproxLadders::ensure(&mut approx_slot, &prefix, dec("1"));
         let with_prefix = RefreshInputs {
-            prefix_bars: &prefix,
+            prefix_approx: approx.ladders(),
             ..inputs(&state, false)
         };
         refresh(&mut drawings, &with_prefix);
@@ -439,8 +479,10 @@ mod tests {
             .downcast_mut::<FrvpPayload>()
             .unwrap()
             .approximate_history = false;
+        let mut approx_slot = None;
+        let approx = ApproxLadders::ensure(&mut approx_slot, &prefix, dec("1"));
         let with_prefix = RefreshInputs {
-            prefix_bars: &prefix,
+            prefix_approx: approx.ladders(),
             ..inputs(&state, false)
         };
         refresh(&mut drawings, &with_prefix);

--- a/crates/app/src/pane.rs
+++ b/crates/app/src/pane.rs
@@ -3282,7 +3282,7 @@ impl ChartPane {
             &mut self.drawings,
             &crate::frvp::RefreshInputs {
                 state: &self.state,
-                prefix_len: prefix.len(),
+                prefix_bars: prefix,
                 partial_ladder: self.footprint_live.as_ref().map(|(_, _, ladder)| ladder),
                 partial_version: self.footprint_live_version,
                 blocked: footprint_blocked,

--- a/crates/app/src/pane.rs
+++ b/crates/app/src/pane.rs
@@ -759,6 +759,9 @@ pub struct ChartPane {
     /// changes: at a bar close the previous bar's ladder must never linger
     /// on the new bar, not even for one throttle interval.
     footprint_live: Option<(f64, usize, quantick_engine::BarFootprint)>,
+    /// The venue prefix's approximated ladders for the range profile —
+    /// built once per (group, prefix length), see `frvp::ApproxLadders`.
+    frvp_approx: Option<crate::frvp::ApproxLadders>,
     /// Bumped whenever [`Self::footprint_live`] is re-taken or cleared — the
     /// cache key the range-profile drawings use to notice the live edge
     /// moved, so they re-fold at the snapshot cadence, never per paint.
@@ -947,6 +950,7 @@ impl ChartPane {
             footprint_override: None,
             footprint_lod: crate::footprint_render::FootprintLod::default(),
             footprint_live: None,
+            frvp_approx: None,
             footprint_live_version: 0,
             // The backfill divider opens off: it is a full-height rule across
             // the candles for a boundary that matters once, when reading how
@@ -3278,11 +3282,21 @@ impl ChartPane {
                     && self.wants_range_profile()
             })
             .and_then(|frame| frame.first_heat_slot());
+        let prefix_approx = if self.wants_range_profile() && !footprint_blocked {
+            crate::frvp::ApproxLadders::ensure(
+                &mut self.frvp_approx,
+                prefix,
+                self.state.footprint_group(),
+            )
+            .ladders()
+        } else {
+            &[]
+        };
         crate::frvp::refresh(
             &mut self.drawings,
             &crate::frvp::RefreshInputs {
                 state: &self.state,
-                prefix_bars: prefix,
+                prefix_approx,
                 partial_ladder: self.footprint_live.as_ref().map(|(_, _, ladder)| ladder),
                 partial_version: self.footprint_live_version,
                 blocked: footprint_blocked,

--- a/crates/engine/src/footprint.rs
+++ b/crates/engine/src/footprint.rs
@@ -37,9 +37,14 @@
 
 use std::collections::BTreeMap;
 
-use rust_decimal::Decimal;
+use rust_decimal::{Decimal, RoundingStrategy};
 
 use crate::{Side, Trade};
+
+/// Decimal places an approximated ladder's per-row share is truncated to.
+/// Deeper than any venue's quantity step, shallow enough that a truncated
+/// share times a full ladder of rows never overdraws the bar's own total.
+const APPROX_SHARE_DECIMALS: u32 = 12;
 
 /// Default ladder size cap: beyond this many price levels in one bar the
 /// grouping doubles. Generous for every realistic bar (a dense Binance tick
@@ -123,6 +128,93 @@ impl BarFootprint {
             base_group,
             doublings: 0,
         }
+    }
+
+    /// An **approximated** ladder built from a bar's summary alone — for
+    /// bars with no tape behind them (venue history candles), where the real
+    /// per-price distribution is unknowable.
+    ///
+    /// The bar's volume is spread uniformly over the buckets its low–high
+    /// range crosses, each side separately (a venue that reports the
+    /// taker-buy split — Binance klines do — keeps its real side totals);
+    /// division remainders land in the close's bucket, so every total is
+    /// conserved *exactly*: folding approximated ladders into a
+    /// [`VolumeProfile`](crate::VolumeProfile) sums to precisely the bars'
+    /// own volumes. A range too wide for `level_cap` doubles the grouping
+    /// first and reports itself [`aggregated`](Self::is_aggregated).
+    ///
+    /// The shape is honest about *totals* and approximate about *placement*
+    /// — the consumer must label it so (data honesty); the engine cannot,
+    /// because an approximated ladder reads identically to a real one on
+    /// purpose: one fold, one profile, one code path.
+    ///
+    /// `None` when the bar traded nothing. # Panics — on a non-positive
+    /// `base_group` or a zero `level_cap`, the same configuration contract
+    /// as [`FootprintBuilder::new`].
+    #[must_use]
+    pub fn approximated(bar: &crate::Bar, base_group: Decimal, level_cap: usize) -> Option<Self> {
+        assert!(
+            base_group > Decimal::ZERO,
+            "footprint base group must be positive"
+        );
+        assert!(level_cap > 0, "footprint level cap must be positive");
+        let volume = bar.buy_volume.saturating_add(bar.sell_volume);
+        if volume <= Decimal::ZERO {
+            return None;
+        }
+        // Widen the grouping until the bar's price span fits the cap — the
+        // same bound the trade fold enforces, decided up front because the
+        // span is known before any bucket exists.
+        let mut ladder = Self::new(base_group);
+        let (lo, hi) = loop {
+            let group = ladder.group();
+            let lo = bucket_of(bar.low.min(bar.high), group);
+            let hi = bucket_of(bar.high.max(bar.low), group);
+            let span = hi.saturating_sub(lo).saturating_add(1);
+            if span >= 0 && (span as u128) <= level_cap as u128 {
+                break (lo, hi);
+            }
+            ladder.doublings += 1;
+        };
+        let close_bucket = bucket_of(bar.close, ladder.group()).clamp(lo, hi);
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let rows = (hi - lo + 1) as u64;
+        let rows_dec = Decimal::from(rows);
+        // Per-row shares rounded *down*, remainders to the close's row:
+        // totals conserve exactly, whatever the divisions truncated — a
+        // share rounded up would overdraw the total by an epsilon and break
+        // the conservation the fold is trusted for.
+        let share = |total: Decimal| {
+            total
+                .checked_div(rows_dec)
+                .unwrap_or(Decimal::ZERO)
+                .round_dp_with_strategy(APPROX_SHARE_DECIMALS, RoundingStrategy::ToZero)
+        };
+        let buy_share = share(bar.buy_volume);
+        let sell_share = share(bar.sell_volume);
+        let count_share = bar.trade_count / rows;
+        for bucket in lo..=hi {
+            ladder.levels.insert(
+                bucket,
+                FootprintLevel {
+                    buy: buy_share,
+                    sell: sell_share,
+                    trade_count: count_share,
+                },
+            );
+        }
+        let close_level = ladder
+            .levels
+            .get_mut(&close_bucket)
+            .expect("close bucket is clamped into the spread range");
+        close_level.buy = bar
+            .buy_volume
+            .saturating_sub(buy_share.saturating_mul(Decimal::from(rows - 1)));
+        close_level.sell = bar
+            .sell_volume
+            .saturating_sub(sell_share.saturating_mul(Decimal::from(rows - 1)));
+        close_level.trade_count = bar.trade_count - count_share * (rows - 1);
+        Some(ladder)
     }
 
     /// The ladder, lowest bucket first. Keys are `floor(price / group())`.
@@ -654,6 +746,89 @@ mod tests {
             side: Side::Buy,
         });
         assert_eq!(builder.close().unwrap().extreme_ratio(Extreme::Low), None);
+    }
+
+    fn venue_bar(
+        low: &str,
+        high: &str,
+        close: &str,
+        buy: &str,
+        sell: &str,
+        trades: u64,
+    ) -> crate::Bar {
+        crate::Bar {
+            open_time: 1_700_000_000_000,
+            close_time: 1_700_000_060_000,
+            open: dec(low),
+            high: dec(high),
+            low: dec(low),
+            close: dec(close),
+            buy_volume: dec(buy),
+            sell_volume: dec(sell),
+            trade_count: trades,
+        }
+    }
+
+    /// The approximated ladder conserves every total exactly: shares are
+    /// rounded down and the remainders land in the close's row, so folding
+    /// approximated bars sums to precisely the bars' own volumes — the
+    /// property the range profile trusts.
+    #[test]
+    fn an_approximated_ladder_conserves_volume_sides_and_count_exactly() {
+        // 1.0 buy over three $1 rows: 0.333… truncated, remainder to close.
+        let bar = venue_bar("100", "102.9", "100.5", "1", "0.2", 7);
+        let ladder = BarFootprint::approximated(&bar, dec("1"), DEFAULT_LEVEL_CAP).unwrap();
+
+        let buckets: Vec<i64> = ladder.levels().keys().copied().collect();
+        assert_eq!(buckets, vec![100, 101, 102]);
+        let total_buy: Decimal = ladder.levels().values().map(|l| l.buy).sum();
+        let total_sell: Decimal = ladder.levels().values().map(|l| l.sell).sum();
+        let total_count: u64 = ladder.levels().values().map(|l| l.trade_count).sum();
+        assert_eq!(total_buy, dec("1"), "buy conserved exactly");
+        assert_eq!(total_sell, dec("0.2"), "sell conserved exactly");
+        assert_eq!(total_count, 7, "trade count conserved exactly");
+        // The close's row (bucket 100) carries the remainders, so it is the
+        // heaviest — every other row holds the truncated share.
+        assert!(ladder.levels()[&100].buy > ladder.levels()[&101].buy);
+        assert_eq!(ladder.levels()[&101], ladder.levels()[&102]);
+        assert!(!ladder.is_aggregated());
+    }
+
+    #[test]
+    fn a_one_row_candle_puts_everything_in_that_row() {
+        let bar = venue_bar("100.2", "100.7", "100.4", "3", "2", 5);
+        let ladder = BarFootprint::approximated(&bar, dec("1"), DEFAULT_LEVEL_CAP).unwrap();
+        assert_eq!(ladder.levels().len(), 1);
+        assert_eq!(ladder.levels()[&100].buy, dec("3"));
+        assert_eq!(ladder.levels()[&100].sell, dec("2"));
+        assert_eq!(ladder.levels()[&100].trade_count, 5);
+    }
+
+    #[test]
+    fn a_bar_that_traded_nothing_yields_no_ladder() {
+        assert!(
+            BarFootprint::approximated(
+                &venue_bar("100", "101", "100", "0", "0", 0),
+                dec("1"),
+                DEFAULT_LEVEL_CAP
+            )
+            .is_none()
+        );
+    }
+
+    /// A span wider than the cap coarsens the grouping up front and says so
+    /// — same contract as the trade fold's cap, same honesty flag.
+    #[test]
+    fn an_oversized_span_coarsens_and_says_so() {
+        let bar = venue_bar("100", "163", "120", "8", "0", 8);
+        let ladder = BarFootprint::approximated(&bar, dec("1"), 32).unwrap();
+        assert!(ladder.is_aggregated());
+        assert_eq!(ladder.group(), dec("2"));
+        let total: Decimal = ladder.levels().values().map(|l| l.buy).sum();
+        assert_eq!(total, dec("8"));
+        // An approximated ladder folds into a profile beside real ones.
+        let profile = crate::VolumeProfile::merge([&ladder], DEFAULT_LEVEL_CAP).unwrap();
+        assert_eq!(profile.total_volume(), dec("8"));
     }
 
     /// The doubled ladder equals the ladder a builder with the doubled base


### PR DESCRIPTION
## What

Closes the v1 tier of #148. A range profile over the time chart's venue history (klines, no tape) was honest and empty — now those candles join the fold as **approximated ladders**, spoken as such.

## Mechanics

- **Engine** (`BarFootprint::approximated`, test-first): the candle's volume spread uniformly over the buckets its high–low crosses; shares rounded **down** and remainders landing in the close's bucket, so every total conserves *exactly* (proved by test). The venue's real taker-buy split (Binance klines carry it) spreads the same way — sides stay venue-reported even where placement is approximated. Spans wider than the cap coarsen first and report aggregated.
- **App**: prefix slots fold prebuilt ladders (`frvp::ApproxLadders`, cached per (group, prefix length) — arch-review caught the per-re-key rebuild storm on 25k-candle charts and it builds once now); exact and approximated bars counted apart.
- **Honesty**: status chain gains `· approximated from OHLC (K of M bars)`; `approximate from candles` toggle on the Profile tab, preset-safe, off restores exactly the previous behaviour.

## Declared deviation (arch-review)

This defaults **on**, which changes what a prefix-range profile shows (histogram instead of "no tape in range"). Deliberate and user-requested: the label speaks whenever approximation happens, and the off-switch is one checkbox.

## Declared performance

- Per trade / per frame: zero added.
- Ladder build: O(prefix) once per backfill page or group refold (~25k small ladders, one-time), then borrowed.
- Fold on key change: unchanged shape; deep-drag over a 25k-bar range is a large merge by nature — incremental prefix sums are the known follow-up, noted in #148.

## Verification

- fmt / clippy -D warnings / build / test green: engine 76 (4 new: conservation, one-row, zero-volume, oversized-span), app 955 (2 new: mixed-range counts, off-switch restores).
- Scene: existing `QUANTICK_FRVP_DEMO=1` straddles the prefix seam and photographs the mixed label.
- Stacked on #142 (→ #140). v2 (intrabar subdivision) and v3 (real aggTrades backfill) tracked in #148.

🤖 Generated with [Claude Code](https://claude.com/claude-code)