### PR TITLE
feat: replace the black consumption slash with a golden-ratio crown

### DIFF
--- a/.claude/GOAL-archive-bubble-visual-language.md
+++ b/.claude/GOAL-archive-bubble-visual-language.md
@@ -59,3 +59,14 @@ Worktree: `../quantick-worktrees/feat-bubble-visual-language`
 
 Heatmap de liquidez, footprint, candles, layout. A missão é a linguagem visual
 da agressão e o preset que a publica.
+
+## Resultado
+
+Concluída. PR aberto a partir de `feat/bubble-visual-language`.
+
+Todos os critérios específicos atendidos, com um achado do próprio operador
+durante a revisão: mover `active` para um preset novo derrubou em silêncio as
+três janelas de agregação (`cluster_ms` 500→200, `candle_summary` on→off), o
+que deixou a camada correta e ilegível. Corrigido e travado por
+`the_shipped_default_aggregates_before_it_draws` — nenhum teste olhava para a
+agregação do preset publicado, que é exatamente por que a regressão foi muda.

--- a/.claude/GOAL.md
+++ b/.claude/GOAL.md
@@ -1,0 +1,61 @@
+# Mission — linguagem visual das bolhas de agressão
+
+Redesenhar como uma agressão é desenhada no chart — marca de consumo, rastro e
+bolhas pequenas — para uma leitura harmônica, calma e profissional, com as
+proporções derivadas da razão áurea, e publicar o resultado como o preset
+**padrão** do projeto open source.
+
+Branch: `feat/bubble-visual-language`
+Worktree: `../quantick-worktrees/feat-bubble-visual-language`
+
+## O que hoje incomoda (diagnóstico, não opinião)
+
+| Sintoma relatado | Causa no código |
+| --- | --- |
+| "cortados em preto" | `show_consumption_front` desenha um `line_segment` vertical atravessando a bolha inteira (`orderflow_render.rs`, `draw_bubble`), na cor `front_color`; o preset ativo `dense tape btc` a define como `[2, 2, 0]` (quase preto). O `impact_ring` usa a mesma cor. |
+| "rastros não ficaram legais / poluição" | Cada bolha que consumiu liquidez arrasta um retângulo com gradiente para a direita (`draw_aggression_bubbles`), `trail_color = [0, 0, 0]`, `trail_opacity = 0.77`. Numa fita densa isso é uma mancha preta contínua. |
+| "bolhas menores não têm preenchimento" | `hollow_small_buys = true` (default): print de **compra** com raio abaixo de `readable_min_radius` vira anel aberto com apenas `HOLLOW_FILL_ALPHA = 0.22` de fill. |
+
+## Critérios de aceite
+
+### Específicos da missão
+
+1. **A marca de consumo não corta mais a bolha.** A informação "esta agressão
+   comeu book" continua legível, mas por uma forma que respeita o disco em vez
+   de atravessá-lo. Provado por screenshot lado a lado (antes/depois) na mesma
+   fita.
+2. **O rastro deixa de ser mancha.** Ou é redesenhado para algo que decai e não
+   soma numa massa preta, ou sai do preset padrão — a decisão é justificada no
+   corpo do PR, e o "antes/depois" mostra a diferença numa fita densa.
+3. **Nenhuma bolha do preset padrão lê como anel vazio.** Bolhas pequenas têm
+   preenchimento sólido; se a distinção de lado por forma for mantida, é por
+   outro meio que não "tirar o fill".
+4. **Proporções derivadas de φ.** As razões da nova geometria (raio → marca,
+   raio → halo, opacidades em escala) saem de constantes nomeadas ancoradas em
+   φ = 1.618…, documentadas no código. Nenhum número mágico solto.
+5. **Preset padrão publicado.** `config/bubbles.toml` ganha o novo preset como
+   `default` e como `active`, e é o que o app abre numa instalação limpa. Os
+   presets existentes continuam carregando sem erro (teste cobre isso).
+6. **Nenhuma regressão de comportamento para quem já configurou.** Mudança de
+   default nunca reescreve o `bubbles.toml` de um usuário existente.
+
+### Gates padrão (injetados pela classe da missão)
+
+**Mudança de código**
+- [ ] `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo build --workspace`, `cargo test --workspace` — todos verdes, rebaseado no `main` atual
+- [ ] Impacto de performance declarado por caminho tocado (per-trade / per-depth / per-frame / raro)
+- [ ] `arch-review` rodado, todo Blocker/Should-fix resolvido ou deferido no corpo do PR
+- [ ] PR aberto (mergear não faz parte da missão)
+
+**Toca hot path (render per-frame)**
+- [ ] fps / frame_avg do `APP_HEALTH_SUMMARY` sob fita densa comparados contra um control build do `main` — números no corpo do PR
+
+**Toca superfície visível ao trader**
+- [ ] Todo estado novo alcançável por env hook do `ui-harness` (hook adicionado na mesma mudança, linha na tabela do skill)
+- [ ] `visual-qa` com todas as superfícies PASS ou defeitos explicitamente aceitos
+- [ ] `trader-ux-review` sem Blocker em aberto
+
+## Fora de escopo
+
+Heatmap de liquidez, footprint, candles, layout. A missão é a linguagem visual
+da agressão e o preset que a publica.

--- a/config/bubbles.toml
+++ b/config/bubbles.toml
@@ -32,9 +32,24 @@ active = "default"
 #     question it raised: did the level refill?
 #   * small prints are solid discs. Side is carried by the buy/sell luminance
 #     gap and by `side_offset`, not by hollowing out the mark.
+#
+# Aggregation is the fourth decision, and it is not a detail: the marks above
+# only read as calm if there are few enough of them. Three windows do that
+# work, and all three are set here rather than left to the bare code defaults,
+# which are tuned for a slow tape:
+#   * cluster_ms — compatible prints inside this window become one bubble.
+#   * dust_merge_ms — prints too small to read on their own fold into one
+#     bubble per price range. The threshold is whatever quantity lands on
+#     `readable_min_radius`, so it moves with the radius range.
+#   * candle_summary — once a bar closes, its prints become one bubble per
+#     price range, drawn as a pie of the buy and sell shares. The pie is the
+#     only mark that shows both sides of one price at once, and it is what
+#     keeps history reading as a summary instead of as a wall of specks.
 [[presets]]
 name = "default"
-cluster_ms = 200
+cluster_ms = 500
+dust_merge_ms = 1500
+candle_summary = true
 
 [presets.bubbles]
 min_radius = 2.1885

--- a/config/bubbles.toml
+++ b/config/bubbles.toml
@@ -5,146 +5,194 @@
 # this folder.
 # `active` names the preset the panel opens on. Colour overrides are optional
 # `[r, g, b]` triples; leave them out to follow the chart theme.
+#
+# The radii of every shipped preset are rungs of one golden-ratio ladder off
+# `max_radius`: `min = max/φ⁴`, `detail_min = max/φ³`, `readable_min = max/φ²`,
+# and the halo switches on at `max/φ`. Radius is area-proportional to quantity,
+# so a φ step in radius is a φ² ≈ 2.6× step in quantity — the ladder is a
+# measuring stick, not an ornament. See `PHI` in
+# `crates/app/src/orderflow/config.rs`.
+#
+# `consumption_mark` replaces the older `show_consumption_front` switch. A
+# preset written before the crown existed simply does not carry the key and
+# opens wearing the crown.
 
-active = "dense tape btc"
+active = "default"
 
+# The shipped default, and deliberately identical to `BubbleStyle::default()`
+# in code — a test asserts it, so the file a new user reads and the behaviour a
+# fresh install gets can never drift apart.
+#
+# Three decisions define it:
+#   * consumption is a crown — an open arc just outside the rim, on the side of
+#     the book the print ate, whose length carries how much of it matched. It
+#     never crosses the disc, whose area is the quantity reading.
+#   * no trail. It fired on nearly every print, so it carried almost no
+#     information, and it painted over the strip of heat map that answers the
+#     question it raised: did the level refill?
+#   * small prints are solid discs. Side is carried by the buy/sell luminance
+#     gap and by `side_offset`, not by hollowing out the mark.
 [[presets]]
 name = "default"
 cluster_ms = 200
 
 [presets.bubbles]
-min_radius = 2.0
+min_radius = 2.1885
 max_radius = 15.0
-opacity = 0.78
-outline_width = 1.0
-halo_strength = 0.12
-detail_min_radius = 4.0
+opacity = 0.9
+outline_width = 0.0
+halo_strength = 0.1
+detail_min_radius = 3.541
+readable_min_radius = 5.7295
+hollow_small_buys = false
+render_mode = "sphere"
+sphere_shading = 0.34
+sphere_highlight = 0.18
 size_reference = "visible_p99"
 size_reference_quantity = 100.0
 min_quantity = 0.0
-side_offset = 3.5
-show_consumption_front = true
-front_width = 3.0
-front_length_scale = 2.1
-show_impact_ring = true
-impact_ring_width = 2.2
-trail_length = 18.0
-trail_opacity = 0.62
+side_offset = 3.0
+consumption_mark = "crown"
+front_width = 1.6
+front_length_scale = 0.618
+show_impact_ring = false
+impact_ring_width = 1.4
+trail_length = 0.0
+trail_opacity = 0.45
 show_quantity_labels = true
 show_trade_count = true
-label_min_radius = 16.0
+label_min_radius = 13.5
 
 [[presets]]
 name = "dense tape"
 cluster_ms = 500
 
 [presets.bubbles]
-min_radius = 1.5
+min_radius = 1.6049
 max_radius = 11.0
-opacity = 0.7
+opacity = 0.9
 outline_width = 0.0
 halo_strength = 0.08
-detail_min_radius = 6.0
+detail_min_radius = 2.5967
+readable_min_radius = 4.2016
+hollow_small_buys = false
+render_mode = "sphere"
+sphere_shading = 0.34
+sphere_highlight = 0.18
 size_reference = "visible_p99"
 size_reference_quantity = 100.0
 min_quantity = 0.0
 side_offset = 4.5
-show_consumption_front = true
-front_width = 2.0
-front_length_scale = 1.6
+consumption_mark = "crown"
+front_width = 1.6
+front_length_scale = 0.618
 show_impact_ring = false
-impact_ring_width = 2.2
-trail_length = 10.0
+impact_ring_width = 1.4
+trail_length = 0.0
 trail_opacity = 0.45
 show_quantity_labels = false
 show_trade_count = false
-label_min_radius = 20.0
+label_min_radius = 9.9
 
 [[presets]]
 name = "mini index sweeps"
 cluster_ms = 200
 
 [presets.bubbles]
-min_radius = 3.0
+min_radius = 3.2098
 max_radius = 22.0
-opacity = 0.85
-outline_width = 1.2
+opacity = 0.92
+outline_width = 0.0
 halo_strength = 0.16
-detail_min_radius = 4.0
+detail_min_radius = 5.1935
+readable_min_radius = 8.4033
+hollow_small_buys = false
+render_mode = "sphere"
+sphere_shading = 0.34
+sphere_highlight = 0.18
 size_reference = "fixed"
 size_reference_quantity = 200.0
 min_quantity = 10.0
 side_offset = 5.0
-show_consumption_front = true
-front_width = 3.5
-front_length_scale = 2.4
-show_impact_ring = true
-impact_ring_width = 2.6
-trail_length = 22.0
-trail_opacity = 0.7
+consumption_mark = "crown"
+front_width = 1.6
+front_length_scale = 0.618
+show_impact_ring = false
+impact_ring_width = 1.4
+trail_length = 0.0
+trail_opacity = 0.45
 show_quantity_labels = true
 show_trade_count = true
-label_min_radius = 14.0
+label_min_radius = 19.8
 
+# The one preset that keeps the older vertical front and the trail, because
+# that is what it is for: a slow tape where the question is which levels got
+# eaten and whether they came back, and where both marks have room to be read.
 [[presets]]
 name = "consumption focus"
 cluster_ms = 200
 
 [presets.bubbles]
-min_radius = 2.0
+min_radius = 1.7508
 max_radius = 12.0
-opacity = 0.55
+opacity = 0.75
 outline_width = 0.0
 halo_strength = 0.06
-detail_min_radius = 3.0
+detail_min_radius = 2.8328
+readable_min_radius = 4.5836
+hollow_small_buys = false
+render_mode = "flat"
+sphere_shading = 0.34
+sphere_highlight = 0.18
 size_reference = "visible_max"
 size_reference_quantity = 100.0
 min_quantity = 0.0
 side_offset = 6.0
-show_consumption_front = true
-front_width = 5.0
-front_length_scale = 3.2
+consumption_mark = "front"
+front_width = 2.0
+front_length_scale = 1.2
 show_impact_ring = true
-impact_ring_width = 3.0
-trail_length = 40.0
-trail_opacity = 0.85
+impact_ring_width = 2.0
+trail_length = 22.0
+trail_opacity = 0.5
 show_quantity_labels = false
 show_trade_count = false
-label_min_radius = 16.0
+label_min_radius = 10.8
 front_color = [255, 246, 205]
 trail_color = [255, 190, 90]
 
-# Bookmap-style shaded spheres. The darkened rim on every bubble keeps
-# overlapping prints readable as separate bubbles on a dense tape, so the
-# detail floor is low: even small prints get the shading.
+# Bookmap-style shaded spheres, pushed a little harder than the default: a
+# heavier rim buys separation on a tape where prints pile up.
 [[presets]]
 name = "3d spheres"
 cluster_ms = 200
 
 [presets.bubbles]
-min_radius = 2.0
+min_radius = 2.3344
 max_radius = 16.0
-opacity = 0.85
-outline_width = 1.0
-halo_strength = 0.05
-detail_min_radius = 2.0
+opacity = 0.9
+outline_width = 0.0
+halo_strength = 0.1
+detail_min_radius = 3.7771
+readable_min_radius = 6.1115
+hollow_small_buys = false
 render_mode = "sphere"
-sphere_shading = 0.6
-sphere_highlight = 0.4
+sphere_shading = 0.4
+sphere_highlight = 0.2
 size_reference = "visible_p99"
 size_reference_quantity = 100.0
 min_quantity = 0.0
 side_offset = 3.5
-show_consumption_front = true
-front_width = 3.0
-front_length_scale = 2.1
-show_impact_ring = true
-impact_ring_width = 2.2
-trail_length = 18.0
-trail_opacity = 0.62
+consumption_mark = "crown"
+front_width = 1.6
+front_length_scale = 0.618
+show_impact_ring = false
+impact_ring_width = 1.4
+trail_length = 0.0
+trail_opacity = 0.45
 show_quantity_labels = true
 show_trade_count = true
-label_min_radius = 16.0
+label_min_radius = 14.4
 
 [[presets]]
 name = "dense tape btc"
@@ -152,31 +200,31 @@ cluster_ms = 500
 candle_summary = true
 
 [presets.bubbles]
-min_radius = 2.2
+min_radius = 2.0426
 max_radius = 14.0
-opacity = 0.75
-outline_width = 0.2
-halo_strength = 0.25
-detail_min_radius = 2.0
+opacity = 0.9
+outline_width = 0.0
+halo_strength = 0.1
+detail_min_radius = 3.3049
+readable_min_radius = 5.3475
+hollow_small_buys = false
 render_mode = "sphere"
-sphere_shading = 0.55
-sphere_highlight = 0.35
+sphere_shading = 0.34
+sphere_highlight = 0.18
 size_reference = "visible_p99"
 size_reference_quantity = 100.0
 min_quantity = 0.0
-side_offset = 1.0
-show_consumption_front = true
-front_width = 0.5
-front_length_scale = 1.1
-show_impact_ring = true
-impact_ring_width = 0.5
-trail_length = 7.0
-trail_opacity = 0.77
+side_offset = 3.0
+consumption_mark = "crown"
+front_width = 1.6
+front_length_scale = 0.618
+show_impact_ring = false
+impact_ring_width = 1.4
+trail_length = 0.0
+trail_opacity = 0.45
 show_quantity_labels = false
 show_trade_count = true
-label_min_radius = 20.0
-front_color = [2, 2, 0]
-trail_color = [0, 0, 0]
+label_min_radius = 12.6
 
 [[presets]]
 name = "live lane pie"
@@ -185,32 +233,31 @@ dust_merge_ms = 1500
 candle_summary = true
 
 [presets.bubbles]
-min_radius = 2.2
+min_radius = 2.918
 max_radius = 20.0
-opacity = 0.8
-outline_width = 0.4
-halo_strength = 0.2
-detail_min_radius = 5.0
-readable_min_radius = 8.0
+opacity = 0.9
+outline_width = 0.0
+halo_strength = 0.1
+detail_min_radius = 4.7214
+readable_min_radius = 7.6393
+hollow_small_buys = false
 render_mode = "sphere"
-sphere_shading = 0.55
-sphere_highlight = 0.35
+sphere_shading = 0.34
+sphere_highlight = 0.18
 size_reference = "visible_p99"
 size_reference_quantity = 100.0
 min_quantity = 0.0
-side_offset = 1.0
-show_consumption_front = true
-front_width = 0.5
-front_length_scale = 1.1
-show_impact_ring = true
-impact_ring_width = 0.5
-trail_length = 7.0
-trail_opacity = 0.77
+side_offset = 3.0
+consumption_mark = "crown"
+front_width = 1.6
+front_length_scale = 0.618
+show_impact_ring = false
+impact_ring_width = 1.4
+trail_length = 0.0
+trail_opacity = 0.45
 show_quantity_labels = false
 show_trade_count = true
-label_min_radius = 20.0
-front_color = [2, 2, 0]
-trail_color = [0, 0, 0]
+label_min_radius = 18.0
 
 [presets.live_lane]
 width_share = 0.5

--- a/crates/app/config/bubbles.toml
+++ b/crates/app/config/bubbles.toml
@@ -32,9 +32,24 @@ active = "default"
 #     question it raised: did the level refill?
 #   * small prints are solid discs. Side is carried by the buy/sell luminance
 #     gap and by `side_offset`, not by hollowing out the mark.
+#
+# Aggregation is the fourth decision, and it is not a detail: the marks above
+# only read as calm if there are few enough of them. Three windows do that
+# work, and all three are set here rather than left to the bare code defaults,
+# which are tuned for a slow tape:
+#   * cluster_ms — compatible prints inside this window become one bubble.
+#   * dust_merge_ms — prints too small to read on their own fold into one
+#     bubble per price range. The threshold is whatever quantity lands on
+#     `readable_min_radius`, so it moves with the radius range.
+#   * candle_summary — once a bar closes, its prints become one bubble per
+#     price range, drawn as a pie of the buy and sell shares. The pie is the
+#     only mark that shows both sides of one price at once, and it is what
+#     keeps history reading as a summary instead of as a wall of specks.
 [[presets]]
 name = "default"
-cluster_ms = 200
+cluster_ms = 500
+dust_merge_ms = 1500
+candle_summary = true
 
 [presets.bubbles]
 min_radius = 2.1885

--- a/crates/app/config/bubbles.toml
+++ b/crates/app/config/bubbles.toml
@@ -1,207 +1,231 @@
-# quantick — built-in aggression bubble presets (FALLBACK ONLY).
+# quantick — aggression bubble presets.
 #
-# Compiled into the binary so the app runs with no external file. The file the
-# panel actually reads and writes is `config/bubbles.toml` at the repository
-# root — edit that one. See config/README.md.
+# Written by the "aggression bubbles" panel (save), and safe to edit by hand:
+# this file is the versioned record of how the tape is read. See README.md in
+# this folder.
+# `active` names the preset the panel opens on. Colour overrides are optional
+# `[r, g, b]` triples; leave them out to follow the chart theme.
 #
-# Quantities are in the symbol's own units: contracts on the mini index, coins
-# on Binance. A `min_quantity` that hides noise on WIN$N hides everything on
-# BTCUSDT, so size-based presets say which market they were built for.
+# The radii of every shipped preset are rungs of one golden-ratio ladder off
+# `max_radius`: `min = max/φ⁴`, `detail_min = max/φ³`, `readable_min = max/φ²`,
+# and the halo switches on at `max/φ`. Radius is area-proportional to quantity,
+# so a φ step in radius is a φ² ≈ 2.6× step in quantity — the ladder is a
+# measuring stick, not an ornament. See `PHI` in
+# `crates/app/src/orderflow/config.rs`.
 #
-# Colour overrides are optional `[r, g, b]` triples. Leave a colour out and it
-# follows the chart theme.
-#
-# A preset only describes how bubbles LOOK. Turning the layer on stays a live
-# decision in the panel, so having this file can never start capture by itself.
+# `consumption_mark` replaces the older `show_consumption_front` switch. A
+# preset written before the crown existed simply does not carry the key and
+# opens wearing the crown.
 
-active = "dense tape btc"
+active = "default"
 
+# The shipped default, and deliberately identical to `BubbleStyle::default()`
+# in code — a test asserts it, so the file a new user reads and the behaviour a
+# fresh install gets can never drift apart.
+#
+# Three decisions define it:
+#   * consumption is a crown — an open arc just outside the rim, on the side of
+#     the book the print ate, whose length carries how much of it matched. It
+#     never crosses the disc, whose area is the quantity reading.
+#   * no trail. It fired on nearly every print, so it carried almost no
+#     information, and it painted over the strip of heat map that answers the
+#     question it raised: did the level refill?
+#   * small prints are solid discs. Side is carried by the buy/sell luminance
+#     gap and by `side_offset`, not by hollowing out the mark.
 [[presets]]
 name = "default"
 cluster_ms = 200
 
 [presets.bubbles]
-min_radius = 2.0
+min_radius = 2.1885
 max_radius = 15.0
-opacity = 0.78
-outline_width = 1.0
-halo_strength = 0.12
-detail_min_radius = 4.0
+opacity = 0.9
+outline_width = 0.0
+halo_strength = 0.1
+detail_min_radius = 3.541
+readable_min_radius = 5.7295
+hollow_small_buys = false
+render_mode = "sphere"
+sphere_shading = 0.34
+sphere_highlight = 0.18
 size_reference = "visible_p99"
 size_reference_quantity = 100.0
 min_quantity = 0.0
-side_offset = 3.5
-show_consumption_front = true
-front_width = 3.0
-front_length_scale = 2.1
-show_impact_ring = true
-impact_ring_width = 2.2
-trail_length = 18.0
-trail_opacity = 0.62
+side_offset = 3.0
+consumption_mark = "crown"
+front_width = 1.6
+front_length_scale = 0.618
+show_impact_ring = false
+impact_ring_width = 1.4
+trail_length = 0.0
+trail_opacity = 0.45
 show_quantity_labels = true
 show_trade_count = true
-label_min_radius = 16.0
+label_min_radius = 13.5
 
-# A fast tape with hundreds of prints per minute: smaller dots, harder
-# clustering, no labels. Reading direction and size beats reading numbers.
 [[presets]]
 name = "dense tape"
 cluster_ms = 500
 
 [presets.bubbles]
-min_radius = 1.5
+min_radius = 1.6049
 max_radius = 11.0
-opacity = 0.7
+opacity = 0.9
 outline_width = 0.0
 halo_strength = 0.08
-detail_min_radius = 6.0
+detail_min_radius = 2.5967
+readable_min_radius = 4.2016
+hollow_small_buys = false
+render_mode = "sphere"
+sphere_shading = 0.34
+sphere_highlight = 0.18
 size_reference = "visible_p99"
 size_reference_quantity = 100.0
 min_quantity = 0.0
 side_offset = 4.5
-show_consumption_front = true
-front_width = 2.0
-front_length_scale = 1.6
+consumption_mark = "crown"
+front_width = 1.6
+front_length_scale = 0.618
 show_impact_ring = false
-impact_ring_width = 2.2
-trail_length = 10.0
+impact_ring_width = 1.4
+trail_length = 0.0
 trail_opacity = 0.45
 show_quantity_labels = false
 show_trade_count = false
-label_min_radius = 20.0
+label_min_radius = 9.9
 
-# Only what moves the book: everything under 10 contracts is hidden and the
-# scale is pinned, so a bubble means the same size all session. Built for the
-# B3 mini index (WIN$N / WDO$N).
 [[presets]]
 name = "mini index sweeps"
 cluster_ms = 200
 
 [presets.bubbles]
-min_radius = 3.0
+min_radius = 3.2098
 max_radius = 22.0
-opacity = 0.85
-outline_width = 1.2
+opacity = 0.92
+outline_width = 0.0
 halo_strength = 0.16
-detail_min_radius = 4.0
+detail_min_radius = 5.1935
+readable_min_radius = 8.4033
+hollow_small_buys = false
+render_mode = "sphere"
+sphere_shading = 0.34
+sphere_highlight = 0.18
 size_reference = "fixed"
 size_reference_quantity = 200.0
 min_quantity = 10.0
 side_offset = 5.0
-show_consumption_front = true
-front_width = 3.5
-front_length_scale = 2.4
-show_impact_ring = true
-impact_ring_width = 2.6
-trail_length = 22.0
-trail_opacity = 0.7
+consumption_mark = "crown"
+front_width = 1.6
+front_length_scale = 0.618
+show_impact_ring = false
+impact_ring_width = 1.4
+trail_length = 0.0
+trail_opacity = 0.45
 show_quantity_labels = true
 show_trade_count = true
-label_min_radius = 14.0
+label_min_radius = 19.8
 
-# For studying who is eating whom: the bubble shrinks and the consumption mark
-# takes over — a wide, bright front and a long trail into the consumed side.
+# The one preset that keeps the older vertical front and the trail, because
+# that is what it is for: a slow tape where the question is which levels got
+# eaten and whether they came back, and where both marks have room to be read.
 [[presets]]
 name = "consumption focus"
 cluster_ms = 200
 
 [presets.bubbles]
-min_radius = 2.0
+min_radius = 1.7508
 max_radius = 12.0
-opacity = 0.55
+opacity = 0.75
 outline_width = 0.0
 halo_strength = 0.06
-detail_min_radius = 3.0
+detail_min_radius = 2.8328
+readable_min_radius = 4.5836
+hollow_small_buys = false
+render_mode = "flat"
+sphere_shading = 0.34
+sphere_highlight = 0.18
 size_reference = "visible_max"
 size_reference_quantity = 100.0
 min_quantity = 0.0
 side_offset = 6.0
-show_consumption_front = true
-front_width = 5.0
-front_length_scale = 3.2
+consumption_mark = "front"
+front_width = 2.0
+front_length_scale = 1.2
 show_impact_ring = true
-impact_ring_width = 3.0
-trail_length = 40.0
-trail_opacity = 0.85
+impact_ring_width = 2.0
+trail_length = 22.0
+trail_opacity = 0.5
 show_quantity_labels = false
 show_trade_count = false
-label_min_radius = 16.0
+label_min_radius = 10.8
 front_color = [255, 246, 205]
 trail_color = [255, 190, 90]
 
-# Bookmap-style shaded spheres. The darkened rim on every bubble keeps
-# overlapping prints readable as separate bubbles on a dense tape, so the
-# detail floor is low: even small prints get the shading.
+# Bookmap-style shaded spheres, pushed a little harder than the default: a
+# heavier rim buys separation on a tape where prints pile up.
 [[presets]]
 name = "3d spheres"
 cluster_ms = 200
 
 [presets.bubbles]
-min_radius = 2.0
+min_radius = 2.3344
 max_radius = 16.0
-opacity = 0.85
-outline_width = 1.0
-halo_strength = 0.05
-detail_min_radius = 2.0
+opacity = 0.9
+outline_width = 0.0
+halo_strength = 0.1
+detail_min_radius = 3.7771
+readable_min_radius = 6.1115
+hollow_small_buys = false
 render_mode = "sphere"
-sphere_shading = 0.6
-sphere_highlight = 0.4
+sphere_shading = 0.4
+sphere_highlight = 0.2
 size_reference = "visible_p99"
 size_reference_quantity = 100.0
 min_quantity = 0.0
 side_offset = 3.5
-show_consumption_front = true
-front_width = 3.0
-front_length_scale = 2.1
-show_impact_ring = true
-impact_ring_width = 2.2
-trail_length = 18.0
-trail_opacity = 0.62
+consumption_mark = "crown"
+front_width = 1.6
+front_length_scale = 0.618
+show_impact_ring = false
+impact_ring_width = 1.4
+trail_length = 0.0
+trail_opacity = 0.45
 show_quantity_labels = true
 show_trade_count = true
-label_min_radius = 16.0
+label_min_radius = 14.4
 
-# The project's default open: a BTC-tuned dense tape saved from the panel,
-# rendered as 3D spheres. Small quiet dots hugging the tape, thin fronts,
-# near-black consumption marks. Built for Binance BTCUSDT. Kept in sync with
-# `config/bubbles.toml`.
 [[presets]]
 name = "dense tape btc"
 cluster_ms = 500
 candle_summary = true
 
 [presets.bubbles]
-min_radius = 2.2
+min_radius = 2.0426
 max_radius = 14.0
-opacity = 0.75
-outline_width = 0.2
-halo_strength = 0.25
-detail_min_radius = 2.0
+opacity = 0.9
+outline_width = 0.0
+halo_strength = 0.1
+detail_min_radius = 3.3049
+readable_min_radius = 5.3475
+hollow_small_buys = false
 render_mode = "sphere"
-sphere_shading = 0.55
-sphere_highlight = 0.35
+sphere_shading = 0.34
+sphere_highlight = 0.18
 size_reference = "visible_p99"
 size_reference_quantity = 100.0
 min_quantity = 0.0
-side_offset = 1.0
-show_consumption_front = true
-front_width = 0.5
-front_length_scale = 1.1
-show_impact_ring = true
-impact_ring_width = 0.5
-trail_length = 7.0
-trail_opacity = 0.77
+side_offset = 3.0
+consumption_mark = "crown"
+front_width = 1.6
+front_length_scale = 0.618
+show_impact_ring = false
+impact_ring_width = 1.4
+trail_length = 0.0
+trail_opacity = 0.45
 show_quantity_labels = false
 show_trade_count = true
-label_min_radius = 20.0
-front_color = [2, 2, 0]
-trail_color = [0, 0, 0]
+label_min_radius = 12.6
 
-# The lane and the summary as one look: closed bars fold into pie bubbles whose
-# sectors are the buy/sell proportion, while the live lane keeps every print
-# separate, clustered tighter and drawn larger. Sized so a pie is only ever
-# drawn where it can be read (`detail_min_radius` well above the dot floor).
-# Built for Binance BTCUSDT; the lane settings carry over to any symbol.
 [[presets]]
 name = "live lane pie"
 cluster_ms = 500
@@ -209,32 +233,31 @@ dust_merge_ms = 1500
 candle_summary = true
 
 [presets.bubbles]
-min_radius = 2.2
+min_radius = 2.918
 max_radius = 20.0
-opacity = 0.8
-outline_width = 0.4
-halo_strength = 0.2
-detail_min_radius = 5.0
-readable_min_radius = 8.0
+opacity = 0.9
+outline_width = 0.0
+halo_strength = 0.1
+detail_min_radius = 4.7214
+readable_min_radius = 7.6393
+hollow_small_buys = false
 render_mode = "sphere"
-sphere_shading = 0.55
-sphere_highlight = 0.35
+sphere_shading = 0.34
+sphere_highlight = 0.18
 size_reference = "visible_p99"
 size_reference_quantity = 100.0
 min_quantity = 0.0
-side_offset = 1.0
-show_consumption_front = true
-front_width = 0.5
-front_length_scale = 1.1
-show_impact_ring = true
-impact_ring_width = 0.5
-trail_length = 7.0
-trail_opacity = 0.77
+side_offset = 3.0
+consumption_mark = "crown"
+front_width = 1.6
+front_length_scale = 0.618
+show_impact_ring = false
+impact_ring_width = 1.4
+trail_length = 0.0
+trail_opacity = 0.45
 show_quantity_labels = false
 show_trade_count = true
-label_min_radius = 20.0
-front_color = [2, 2, 0]
-trail_color = [0, 0, 0]
+label_min_radius = 18.0
 
 [presets.live_lane]
 width_share = 0.5

--- a/crates/app/src/bubble_presets.rs
+++ b/crates/app/src/bubble_presets.rs
@@ -326,6 +326,32 @@ mod tests {
     }
 
     #[test]
+    fn the_shipped_default_aggregates_before_it_draws() {
+        // The calm the visual language buys is spent immediately if every
+        // print still gets its own mark. These three windows are what keep the
+        // count down, and they were once lost by moving `active` to a preset
+        // that inherited the bare code defaults — the layer stayed correct and
+        // became unreadable. Pinned so that cannot happen quietly again.
+        let preset = embedded()
+            .get("default")
+            .cloned()
+            .expect("the shipped default");
+        assert!(
+            preset.cluster_ms >= 500,
+            "compatible prints inside half a second must become one bubble, not {}",
+            preset.cluster_ms
+        );
+        assert!(
+            preset.dust_merge_ms > 0,
+            "prints too small to read must fold into one bubble per price range"
+        );
+        assert!(
+            preset.candle_summary,
+            "a closed bar must summarize into pies; without it history is a wall of specks"
+        );
+    }
+
+    #[test]
     fn every_shipped_preset_keeps_its_radii_on_the_golden_ladder() {
         for preset in embedded().presets {
             let bubbles = &preset.bubbles;

--- a/crates/app/src/bubble_presets.rs
+++ b/crates/app/src/bubble_presets.rs
@@ -207,6 +207,58 @@ pub fn embedded() -> BubblePresetFile {
     parse(EMBEDDED_DEFAULT).unwrap_or_default()
 }
 
+/// Keys a presets file may still carry from before a setting was replaced,
+/// each paired with what took the job over.
+///
+/// Serde ignoring an unknown key is what lets an old file keep loading, and
+/// that is the behaviour we want — but *silently* is not the same as
+/// *honestly*. Someone who wrote `show_consumption_front` asked for a specific
+/// mark by name, and the chart now draws a different one. Saying so once at
+/// load is the difference between a documented default change and what reads
+/// from the outside like the setting broke.
+const RETIRED_KEYS: [(&str, &str); 1] = [("show_consumption_front", "consumption_mark")];
+
+/// Retired keys actually *set* by this presets text, as
+/// `(retired, replacement)`.
+///
+/// A line scan rather than a second parse: this runs once at startup, and the
+/// shape being matched — a key at the start of a line followed by `=` — is
+/// exactly what TOML assignment looks like. It deliberately does not match a
+/// mention inside a comment, because the shipped file documents the migration
+/// by name and would otherwise warn about itself on every launch.
+#[must_use]
+pub fn retired_keys(text: &str) -> Vec<(&'static str, &'static str)> {
+    let assigns = |key: &str| {
+        text.lines().any(|line| {
+            let statement = line.split('#').next().unwrap_or_default().trim();
+            statement
+                .strip_prefix(key)
+                .is_some_and(|rest| rest.trim_start().starts_with('='))
+        })
+    };
+    RETIRED_KEYS
+        .into_iter()
+        .filter(|(retired, _)| assigns(retired))
+        .collect()
+}
+
+/// Log every retired key a presets file still carries.
+fn report_retired_keys(text: &str, path: &Path) {
+    for (retired, replacement) in retired_keys(text) {
+        tracing::warn!(
+            target: "quantick::app",
+            schema_version = 1_u8,
+            event_code = "BUBBLE_PRESET_KEY_RETIRED",
+            file = %path.display(),
+            retired,
+            replacement,
+            action = "using_replacement_default",
+            "a bubble preset still sets a retired key; the setting that replaced it \
+             is at its default"
+        );
+    }
+}
+
 /// Path the panel reads from and writes to.
 #[must_use]
 pub fn presets_path() -> PathBuf {
@@ -230,7 +282,10 @@ pub fn load() -> (BubblePresetFile, PresetSource, Option<String>) {
     }
     match std::fs::read_to_string(&path) {
         Ok(text) => match parse(&text) {
-            Ok(file) => (file, source(path), None),
+            Ok(file) => {
+                report_retired_keys(&text, &path);
+                (file, source(path), None)
+            }
             Err(message) => (
                 embedded(),
                 PresetSource::Embedded,
@@ -292,7 +347,7 @@ const PRESET_FILE_HEADER: &str = "\
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::orderflow::{BubbleSizeReference, INV_PHI};
+    use crate::orderflow::{BubbleSizeReference, ConsumptionMark, INV_PHI};
 
     #[test]
     fn the_embedded_file_parses_and_carries_a_valid_active_preset() {
@@ -323,6 +378,41 @@ mod tests {
             .get("default")
             .expect("the shipped file carries a preset named 'default'");
         assert_eq!(preset.bubbles, BubbleStyle::default());
+    }
+
+    #[test]
+    fn a_retired_key_is_named_rather_than_ignored_in_silence() {
+        // The file still loads — that is the point of ignoring unknown keys —
+        // but a preset that asked for the vertical front by name now draws a
+        // crown, and nothing else in the app would ever say so.
+        let legacy = "
+            active = \"mine\"
+            [[presets]]
+            name = \"mine\"
+            [presets.bubbles]
+            show_consumption_front = true
+        ";
+        assert_eq!(
+            retired_keys(legacy),
+            vec![("show_consumption_front", "consumption_mark")]
+        );
+        let parsed = parse(legacy).expect("a legacy file still parses");
+        assert_eq!(
+            parsed.get("mine").expect("preset").bubbles.consumption_mark,
+            ConsumptionMark::Crown
+        );
+
+        // And a file written today says nothing, so the warning stays rare
+        // enough to mean something — even though the shipped file documents
+        // the migration by name in a comment, which must not count as setting
+        // it.
+        assert!(retired_keys(EMBEDDED_DEFAULT).is_empty());
+        assert!(
+            EMBEDDED_DEFAULT.contains("show_consumption_front"),
+            "the shipped file explains the migration, so this test is really \
+             asserting that a comment is not an assignment"
+        );
+        assert!(retired_keys("# show_consumption_front = true").is_empty());
     }
 
     #[test]

--- a/crates/app/src/bubble_presets.rs
+++ b/crates/app/src/bubble_presets.rs
@@ -292,7 +292,7 @@ const PRESET_FILE_HEADER: &str = "\
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::orderflow::BubbleSizeReference;
+    use crate::orderflow::{BubbleSizeReference, INV_PHI};
 
     #[test]
     fn the_embedded_file_parses_and_carries_a_valid_active_preset() {
@@ -305,6 +305,95 @@ mod tests {
         );
         for preset in &file.presets {
             assert!(preset.bubbles.max_radius >= preset.bubbles.min_radius);
+        }
+    }
+
+    #[test]
+    fn the_shipped_default_preset_is_the_code_default() {
+        // The file a new user reads and the behaviour a fresh install gets are
+        // the same thing said twice, so they are asserted to agree. Without
+        // this, changing one default in code silently leaves the published
+        // preset describing a chart the app no longer draws.
+        let shipped = embedded();
+        assert_eq!(
+            shipped.active, "default",
+            "a fresh install opens on the shipped default"
+        );
+        let preset = shipped
+            .get("default")
+            .expect("the shipped file carries a preset named 'default'");
+        assert_eq!(preset.bubbles, BubbleStyle::default());
+    }
+
+    #[test]
+    fn every_shipped_preset_keeps_its_radii_on_the_golden_ladder() {
+        for preset in embedded().presets {
+            let bubbles = &preset.bubbles;
+            let name = &preset.name;
+            assert!(
+                bubbles.min_radius < bubbles.detail_min_radius
+                    && bubbles.detail_min_radius < bubbles.readable_min_radius
+                    && bubbles.readable_min_radius < bubbles.max_radius,
+                "'{name}' has rungs out of order: {} {} {} {}",
+                bubbles.min_radius,
+                bubbles.detail_min_radius,
+                bubbles.readable_min_radius,
+                bubbles.max_radius
+            );
+            // One ladder, every preset, whatever its radius range. The
+            // readability floor hangs two steps under the top — the rung
+            // between them, `max/φ`, is where the halo switches on and is not
+            // a stored field — and each rung below is the one above it over φ.
+            for (label, expected, actual) in [
+                (
+                    "readable",
+                    bubbles.max_radius * INV_PHI * INV_PHI,
+                    bubbles.readable_min_radius,
+                ),
+                (
+                    "detail",
+                    bubbles.readable_min_radius * INV_PHI,
+                    bubbles.detail_min_radius,
+                ),
+                (
+                    "min",
+                    bubbles.detail_min_radius * INV_PHI,
+                    bubbles.min_radius,
+                ),
+            ] {
+                assert!(
+                    (actual - expected).abs() <= 0.001,
+                    "'{name}' {label} rung {actual} is not {expected}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn no_shipped_preset_smears_the_book_or_hollows_a_print() {
+        for preset in embedded().presets {
+            let bubbles = &preset.bubbles;
+            let name = &preset.name;
+            assert!(
+                !bubbles.hollow_small_buys,
+                "'{name}' still draws small buys as an open ring"
+            );
+            // One preset is allowed a trail, and it is the one named for the
+            // marks: a slow tape where the question is which levels got eaten.
+            if bubbles.trail_length > 0.0 {
+                assert_eq!(
+                    name, "consumption focus",
+                    "'{name}' ships a trail; only the consumption preset may"
+                );
+            }
+            // Nothing ships a near-black consumption colour: over this canvas
+            // that mark is invisible, and over the heat map it is a hole.
+            if let Some([r, g, b]) = bubbles.front_color {
+                assert!(
+                    u16::from(r) + u16::from(g) + u16::from(b) > 180,
+                    "'{name}' paints its consumption mark almost black: {r},{g},{b}"
+                );
+            }
         }
     }
 
@@ -441,15 +530,15 @@ mod tests {
             text.starts_with(PRESET_FILE_HEADER),
             "the explanatory header survives a save:\n{text}"
         );
+        assert!(text.contains("opacity = 0.9"), "floats stay short:\n{text}");
         assert!(
-            text.contains("opacity = 0.78"),
+            text.contains("front_length_scale = 0.618"),
             "floats stay short:\n{text}"
         );
         assert!(
-            text.contains("front_length_scale = 2.1"),
-            "floats stay short:\n{text}"
+            !text.contains("0.61803398"),
+            "no binary expansions:\n{text}"
         );
-        assert!(!text.contains("0.7799"), "no binary expansions:\n{text}");
         assert!(
             text.contains("front_color = [255, 246, 205]"),
             "colour triples stay on one line, as config/README.md documents:\n{text}"

--- a/crates/app/src/orderflow/config.rs
+++ b/crates/app/src/orderflow/config.rs
@@ -116,6 +116,17 @@ pub const DEFAULT_READABLE_MIN_RADIUS: f32 = 5.7295;
 /// radius: `1/φ`, at the precision the presets file stores. Only
 /// [`ConsumptionMark::Front`] reads it.
 pub const DEFAULT_FRONT_LENGTH_SCALE: f32 = 0.618;
+/// Smallest radius that gets a label, as a fraction of
+/// [`DEFAULT_BUBBLE_MAX_RADIUS`].
+///
+/// Not a φ rung, and deliberately not dressed up as one: the rule is "the top
+/// of the radius range", because laying out text is the most expensive thing
+/// a bubble can ask for and only the largest prints have room to hold it.
+pub const DEFAULT_LABEL_MIN_RADIUS_SHARE: f32 = 0.9;
+/// Smallest radius that gets a label, in pixels — see
+/// [`DEFAULT_LABEL_MIN_RADIUS_SHARE`].
+pub const DEFAULT_LABEL_MIN_RADIUS: f32 =
+    DEFAULT_BUBBLE_MAX_RADIUS * DEFAULT_LABEL_MIN_RADIUS_SHARE;
 /// Largest accepted readability floor.
 pub const MAX_READABLE_MIN_RADIUS: f32 = 32.0;
 /// Default edge darkening of a sphere-rendered bubble.
@@ -530,7 +541,7 @@ impl Default for BubbleStyle {
             show_trade_count: true,
             // Only the largest bubbles get a (text-layout-costly) label: the
             // top of the radius range, not a number picked beside it.
-            label_min_radius: DEFAULT_BUBBLE_MAX_RADIUS * 0.9,
+            label_min_radius: DEFAULT_LABEL_MIN_RADIUS,
             buy_color: None,
             sell_color: None,
             front_color: None,
@@ -586,12 +597,8 @@ impl BubbleStyle {
         self.impact_ring_width = finite_clamp(self.impact_ring_width, 0.5, 8.0, 1.4);
         self.trail_length = finite_clamp(self.trail_length, 0.0, 120.0, 0.0);
         self.trail_opacity = finite_clamp(self.trail_opacity, 0.0, 1.0, 0.45);
-        self.label_min_radius = finite_clamp(
-            self.label_min_radius,
-            4.0,
-            64.0,
-            DEFAULT_BUBBLE_MAX_RADIUS * 0.9,
-        );
+        self.label_min_radius =
+            finite_clamp(self.label_min_radius, 4.0, 64.0, DEFAULT_LABEL_MIN_RADIUS);
     }
 
     /// Quantity at which a print stops being dust: the exact quantity whose

--- a/crates/app/src/orderflow/config.rs
+++ b/crates/app/src/orderflow/config.rs
@@ -40,8 +40,45 @@ pub const MAX_BUBBLE_DUST_MERGE_MS: i64 = 30_000;
 pub const DEFAULT_LIQUIDITY_CORRELATION_MS: i64 = 250;
 /// Safe upper bound for depth/aggression correlation.
 pub const MAX_LIQUIDITY_CORRELATION_MS: i64 = 10_000;
+/// The golden ratio, φ.
+///
+/// The aggression layer's proportions are steps on this one ladder rather than
+/// a scatter of independently tuned numbers. Radius is *area*-proportional to
+/// quantity, so a φ step in radius is a φ² ≈ 2.6× step in quantity — "roughly
+/// two and a half times the print" is a size class a flow trader already reads
+/// in, which is what makes the ladder a measuring stick and not an ornament.
+///
+/// It is used where a *proportion* is being expressed. It is deliberately not
+/// used for pixel floors (below ~3px the display grid rules, and a 0.38px
+/// stroke is a rounding error) nor for alphas, which are perceptual and tuned
+/// against the heat ramp's actual luminance.
+pub const PHI: f32 = 1.618_034;
+/// 1/φ ≈ 0.618 — see [`PHI`]. Each rung is derived from the last rather than
+/// written out, so the ladder cannot drift apart one literal at a time.
+pub const INV_PHI: f32 = 1.0 / PHI;
+/// 1/φ² ≈ 0.382 — see [`PHI`].
+pub const INV_PHI_2: f32 = INV_PHI / PHI;
+/// 1/φ³ ≈ 0.236 — see [`PHI`].
+///
+/// The bottom rung of the ladder, `1/φ⁴`, is deliberately not a constant of
+/// its own: nothing computes with it at runtime — the smallest radius is a
+/// stored default, not a derived value — so it would be a name with no
+/// caller. It is written as `INV_PHI_3 / PHI` where it is needed.
+pub const INV_PHI_3: f32 = INV_PHI_2 / PHI;
+/// The golden angle, 360°/φ² ≈ 137.5°, in radians.
+///
+/// The sweep a fully consuming print's crown reaches. Being 1/φ² of the rim
+/// rather than all of it is what makes the crown structurally incapable of
+/// closing into a second circle around the bubble — the exact ambiguity the
+/// old closed impact ring created with the disc's own edge.
+pub const GOLDEN_ANGLE: f32 = std::f32::consts::TAU * INV_PHI_2;
 /// Default alpha applied to aggression bubbles.
-pub const DEFAULT_BUBBLE_OPACITY: f32 = 0.78;
+///
+/// High enough that a bubble occludes rather than tints: translucency over a
+/// coloured heat cell drags the fill toward the heat's own hue, and occlusion
+/// is the strongest cue for counting overlapping prints. Short of opaque, so a
+/// bubble still admits it is sitting over the book.
+pub const DEFAULT_BUBBLE_OPACITY: f32 = 0.9;
 /// Default on-screen radius, in points, of the largest aggression bubble.
 pub const DEFAULT_BUBBLE_MAX_RADIUS: f32 = 15.0;
 /// Smallest accepted maximum bubble radius.
@@ -50,16 +87,49 @@ pub const MIN_BUBBLE_MAX_RADIUS: f32 = 4.0;
 pub const MAX_BUBBLE_MAX_RADIUS: f32 = 48.0;
 /// Largest accepted radius for the smallest drawn bubble.
 pub const MAX_BUBBLE_MIN_RADIUS: f32 = 12.0;
+/// Default radius of the smallest drawn print: the bottom rung of the φ
+/// ladder, `max / φ⁴`. See [`PHI`].
+///
+/// Written as a literal, not as `DEFAULT_BUBBLE_MAX_RADIUS * INV_PHI_4`, for
+/// one mechanical reason: the presets file stores floats to
+/// [`SERIALIZED_FLOAT_PLACES`] decimals, so a default carrying more precision
+/// than that would come back different from a save-and-reload and every
+/// preset round trip would drift. The rungs are therefore the exact ladder
+/// rounded to what the file can hold — asserted by
+/// `the_default_radii_are_rungs_of_one_golden_ladder`.
+pub const DEFAULT_BUBBLE_MIN_RADIUS: f32 = 2.1885;
+/// Default radius at which a bubble can afford its dressing — shading and the
+/// separator hair. The `max / φ³` rung.
+///
+/// It lands where hue starts working: below roughly 3.5px the eye's chromatic
+/// channel is too low-pass to separate a green speck from a red one, so that
+/// is exactly the size at which shading a bubble by side begins to pay. Under
+/// it a print is one flat disc, which is also what keeps the per-frame
+/// tessellation budget flat on a fast tape.
+pub const DEFAULT_DETAIL_MIN_RADIUS: f32 = 3.541;
 /// Default radius, in pixels, below which a bubble is treated as unreadable
 /// on its own: small enough to be a routine print, large enough that side
-/// colour and the side nudge actually register at a glance.
-pub const DEFAULT_READABLE_MIN_RADIUS: f32 = 6.0;
+/// colour and the side nudge actually register at a glance. The `max / φ²`
+/// rung, and the floor the consumption crown and the pie split gate on.
+pub const DEFAULT_READABLE_MIN_RADIUS: f32 = 5.7295;
+/// Default half-length of the vertical consumption front, as a multiple of the
+/// radius: `1/φ`, at the precision the presets file stores. Only
+/// [`ConsumptionMark::Front`] reads it.
+pub const DEFAULT_FRONT_LENGTH_SCALE: f32 = 0.618;
 /// Largest accepted readability floor.
 pub const MAX_READABLE_MIN_RADIUS: f32 = 32.0;
 /// Default edge darkening of a sphere-rendered bubble.
-pub const DEFAULT_SPHERE_SHADING: f32 = 0.55;
+///
+/// Enough contrast that two piled bubbles keep a boundary, and no more:
+/// counting overlapping discs needs only a soft edge, while a hard one reads
+/// as a black outline drawn around every print on the tape.
+pub const DEFAULT_SPHERE_SHADING: f32 = 0.34;
 /// Default highlight strength of a sphere-rendered bubble.
-pub const DEFAULT_SPHERE_HIGHLIGHT: f32 = 0.35;
+///
+/// A specular cue, not a second colour. Pushed harder, the sell side's core
+/// washes out to pink — the loudest thing on the canvas and the one that makes
+/// the layer read as decoration rather than as instrumentation.
+pub const DEFAULT_SPHERE_HIGHLIGHT: f32 = 0.18;
 /// Default share of the chart width taken by the live lane. Enough room for
 /// the tape to be read as a tape, with two thirds of the chart left for the
 /// history it is read against.
@@ -187,6 +257,49 @@ pub enum BubbleSizeReference {
     Fixed,
 }
 
+/// How a print that ate resting liquidity says so.
+///
+/// The signal has to survive three things at once: a dense tape where prints
+/// overlap, a canvas that is nearly black, and a heat map underneath that is
+/// the only layer carrying liquidity. That rules out any mark that works by
+/// *subtraction* — a dark stroke is invisible over the canvas and a hole
+/// punched in the book everywhere else — and it rules out any mark that
+/// crosses the disc, whose area is the quantity reading.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConsumptionMark {
+    /// An open arc outside the rim, on the side of the book that was eaten:
+    /// buy aggression lifts the ask, so its crown sits above; sell aggression
+    /// hits the bid and wears it below.
+    ///
+    /// Arc *length* carries how much of the print matched resting liquidity —
+    /// the one channel the eye reads ordinally without a reference beside it —
+    /// from [`INV_PHI_2`] of the [`GOLDEN_ANGLE`] at a nibble to the whole
+    /// golden angle at a full sweep. Because it never closes and never crosses
+    /// the disc, it cannot be confused with the bubble's own rim, and stacked
+    /// crowns at one price row read as the nested brackets that absorption
+    /// actually is.
+    #[default]
+    Crown,
+    /// The vertical line through the bubble that shipped before the crown.
+    ///
+    /// Kept because a chart is someone's muscle memory and a preset that asked
+    /// for it should still get it — not because it reads well on a fast tape,
+    /// where it slices every disc it marks.
+    Front,
+    /// No consumption mark at all. The heat map to the right of the print
+    /// still shows whether the level refilled, which is the honest record.
+    None,
+}
+
+impl ConsumptionMark {
+    /// Whether this mark draws the vertical front.
+    #[must_use]
+    pub fn is_front(self) -> bool {
+        matches!(self, Self::Front)
+    }
+}
+
 impl BubbleSizeReference {
     /// Whether the reference is derived from what is on screen.
     ///
@@ -283,10 +396,15 @@ pub struct BubbleStyle {
     /// Whether buy prints below [`readable_min_radius`](Self::readable_min_radius)
     /// are drawn as an open ring instead of a solid dot.
     ///
-    /// Shape survives where colour does not: at that size a green speck and a
-    /// red speck are the same speck, but a ring and a disc still read as two
-    /// different things. Bubbles above the floor keep their fill, so a sphere
-    /// look is untouched.
+    /// Off by default. The intent was that shape survives where colour does
+    /// not, but the ring spends most of the disc's area to say it: at 2px a
+    /// green ring around a 22%-alpha interior carries *less* green than the
+    /// dot it replaced, so the side became harder to read, not easier — and
+    /// the two sides ended up drawn in visibly different media. Side is
+    /// carried instead by the buy/sell luminance gap, which the achromatic
+    /// channel resolves several times smaller than the chromatic one, and by
+    /// [`side_offset`](Self::side_offset). The knob stays for anyone who
+    /// preferred the ring.
     pub hollow_small_buys: bool,
     /// Whether the fill is a flat disc or a shaded sphere.
     pub render_mode: BubbleRenderMode,
@@ -316,10 +434,15 @@ pub struct BubbleStyle {
     /// restores exact price placement.
     #[serde(serialize_with = "serialize_short_f32")]
     pub side_offset: f32,
-    /// Whether a bubble that ate resting liquidity draws its vertical
-    /// consumption front.
-    pub show_consumption_front: bool,
-    /// Width of that front, in pixels.
+    /// How a bubble that ate resting liquidity says so.
+    ///
+    /// Replaces the older `show_consumption_front` switch. A preset written
+    /// before the crown existed simply does not carry this key, so it opens
+    /// wearing the crown — which is the point of changing the default, and is
+    /// covered by a test that such a preset still loads.
+    pub consumption_mark: ConsumptionMark,
+    /// Width of the vertical front, in pixels. Unused by
+    /// [`ConsumptionMark::Crown`], whose width is a proportion of the radius.
     #[serde(serialize_with = "serialize_short_f32")]
     pub front_width: f32,
     /// Half-length of the front as a multiple of the bubble radius.
@@ -364,35 +487,50 @@ pub struct BubbleStyle {
 impl Default for BubbleStyle {
     fn default() -> Self {
         Self {
-            // Area stays quantity-proportional: the minimum keeps the smallest
-            // print a subtle dot, the maximum lets a real sweep dominate.
-            min_radius: 2.0,
+            // Area stays quantity-proportional, and the four radii are rungs
+            // of one φ ladder off `max_radius` — see `PHI`.
+            min_radius: DEFAULT_BUBBLE_MIN_RADIUS,
             max_radius: DEFAULT_BUBBLE_MAX_RADIUS,
             opacity: DEFAULT_BUBBLE_OPACITY,
-            outline_width: 1.0,
-            halo_strength: 0.12,
-            detail_min_radius: 4.0,
+            // Zero, not a hairline: a sub-pixel stroke is antialiased into a
+            // grey fringe around every print, and in sphere mode the darkened
+            // rim already is the boundary. A second edge on top of it is what
+            // made each bubble wear three outlines.
+            outline_width: 0.0,
+            halo_strength: 0.1,
+            detail_min_radius: DEFAULT_DETAIL_MIN_RADIUS,
             readable_min_radius: DEFAULT_READABLE_MIN_RADIUS,
-            hollow_small_buys: true,
-            // Flat, so merely gaining the sphere option changes no pixels.
-            render_mode: BubbleRenderMode::Flat,
+            hollow_small_buys: false,
+            // Shading is what keeps piled bubbles countable where their rims
+            // coincide, which a dense tape does constantly.
+            render_mode: BubbleRenderMode::Sphere,
             sphere_shading: DEFAULT_SPHERE_SHADING,
             sphere_highlight: DEFAULT_SPHERE_HIGHLIGHT,
             size_reference: BubbleSizeReference::VisibleP99,
             size_reference_quantity: 100.0,
             min_quantity: 0.0,
-            side_offset: 3.5,
-            show_consumption_front: true,
-            front_width: 3.0,
-            front_length_scale: 2.1,
-            show_impact_ring: true,
-            impact_ring_width: 2.2,
-            trail_length: 18.0,
-            trail_opacity: 0.62,
+            // Wide enough that two prints on one price row visibly straddle
+            // it, which is the second channel carrying side at speck size.
+            side_offset: 3.0,
+            consumption_mark: ConsumptionMark::Crown,
+            front_width: 1.6,
+            front_length_scale: DEFAULT_FRONT_LENGTH_SCALE,
+            // The crown says "ate the book" without closing a second circle
+            // around the rim; a closed ring on top of it restates the same
+            // fact in the one shape that blurs the disc's own edge.
+            show_impact_ring: false,
+            impact_ring_width: 1.4,
+            // Off. The trail fired on nearly every print, so it carried almost
+            // no information, and it painted over the strip of heat map that
+            // answers the question it raised — did the level refill? The knob
+            // stays; the default stops smearing the book.
+            trail_length: 0.0,
+            trail_opacity: 0.45,
             show_quantity_labels: true,
             show_trade_count: true,
-            // Only the largest bubbles get a (text-layout-costly) label.
-            label_min_radius: 16.0,
+            // Only the largest bubbles get a (text-layout-costly) label: the
+            // top of the radius range, not a number picked beside it.
+            label_min_radius: DEFAULT_BUBBLE_MAX_RADIUS * 0.9,
             buy_color: None,
             sell_color: None,
             front_color: None,
@@ -405,7 +543,12 @@ impl Default for BubbleStyle {
 impl BubbleStyle {
     /// Clamp every numeric field to a value that is safe for geometry and math.
     pub fn sanitize(&mut self) {
-        self.min_radius = finite_clamp(self.min_radius, 0.5, MAX_BUBBLE_MIN_RADIUS, 2.0);
+        self.min_radius = finite_clamp(
+            self.min_radius,
+            0.5,
+            MAX_BUBBLE_MIN_RADIUS,
+            DEFAULT_BUBBLE_MIN_RADIUS,
+        );
         self.max_radius = finite_clamp(
             self.max_radius,
             self.min_radius,
@@ -413,9 +556,10 @@ impl BubbleStyle {
             DEFAULT_BUBBLE_MAX_RADIUS,
         );
         self.opacity = finite_clamp(self.opacity, 0.05, 1.0, DEFAULT_BUBBLE_OPACITY);
-        self.outline_width = finite_clamp(self.outline_width, 0.0, 6.0, 1.0);
-        self.halo_strength = finite_clamp(self.halo_strength, 0.0, 1.0, 0.12);
-        self.detail_min_radius = finite_clamp(self.detail_min_radius, 0.0, 32.0, 4.0);
+        self.outline_width = finite_clamp(self.outline_width, 0.0, 6.0, 0.0);
+        self.halo_strength = finite_clamp(self.halo_strength, 0.0, 1.0, 0.1);
+        self.detail_min_radius =
+            finite_clamp(self.detail_min_radius, 0.0, 32.0, DEFAULT_DETAIL_MIN_RADIUS);
         self.readable_min_radius = finite_clamp(
             self.readable_min_radius,
             0.0,
@@ -431,13 +575,23 @@ impl BubbleStyle {
         if !self.min_quantity.is_finite() || self.min_quantity < 0.0 {
             self.min_quantity = 0.0;
         }
-        self.side_offset = finite_clamp(self.side_offset, 0.0, 40.0, 3.5);
-        self.front_width = finite_clamp(self.front_width, 0.5, 12.0, 3.0);
-        self.front_length_scale = finite_clamp(self.front_length_scale, 0.2, 8.0, 2.1);
-        self.impact_ring_width = finite_clamp(self.impact_ring_width, 0.5, 8.0, 2.2);
-        self.trail_length = finite_clamp(self.trail_length, 0.0, 120.0, 18.0);
-        self.trail_opacity = finite_clamp(self.trail_opacity, 0.0, 1.0, 0.62);
-        self.label_min_radius = finite_clamp(self.label_min_radius, 4.0, 64.0, 16.0);
+        self.side_offset = finite_clamp(self.side_offset, 0.0, 40.0, 3.0);
+        self.front_width = finite_clamp(self.front_width, 0.5, 12.0, 1.6);
+        self.front_length_scale = finite_clamp(
+            self.front_length_scale,
+            0.2,
+            8.0,
+            DEFAULT_FRONT_LENGTH_SCALE,
+        );
+        self.impact_ring_width = finite_clamp(self.impact_ring_width, 0.5, 8.0, 1.4);
+        self.trail_length = finite_clamp(self.trail_length, 0.0, 120.0, 0.0);
+        self.trail_opacity = finite_clamp(self.trail_opacity, 0.0, 1.0, 0.45);
+        self.label_min_radius = finite_clamp(
+            self.label_min_radius,
+            4.0,
+            64.0,
+            DEFAULT_BUBBLE_MAX_RADIUS * 0.9,
+        );
     }
 
     /// Quantity at which a print stops being dust: the exact quantity whose
@@ -953,7 +1107,10 @@ mod tests {
             config.live_lane.scaled_radii(&config.bubbles),
             (config.bubbles.min_radius, config.bubbles.max_radius)
         );
-        assert!(config.bubbles.hollow_small_buys);
+        assert!(
+            !config.bubbles.hollow_small_buys,
+            "a small print keeps its fill; side is carried by luminance and the nudge"
+        );
         assert_eq!(config.bubbles.opacity, DEFAULT_BUBBLE_OPACITY);
         assert_eq!(config.bubbles.max_radius, DEFAULT_BUBBLE_MAX_RADIUS);
         // Every visual layer defaults to on: gaining per-layer switches must
@@ -1213,17 +1370,108 @@ mod tests {
             bubbles.side_offset > 0.0,
             "buy and sell must not stack on the same row by default"
         );
-        assert!(bubbles.show_consumption_front);
+        assert_eq!(bubbles.consumption_mark, ConsumptionMark::Crown);
         assert_eq!(bubbles.size_reference, BubbleSizeReference::VisibleP99);
         assert_eq!(bubbles.min_quantity, 0.0, "nothing is hidden by default");
         assert_eq!(bubbles.min_quantity_decimal(), None);
-        assert_eq!(
-            bubbles.render_mode,
-            BubbleRenderMode::Flat,
-            "gaining the sphere option must not change existing charts"
-        );
+        assert_eq!(bubbles.render_mode, BubbleRenderMode::Sphere);
         assert!((0.0..=1.0).contains(&bubbles.sphere_shading));
         assert!((0.0..=1.0).contains(&bubbles.sphere_highlight));
+    }
+
+    #[test]
+    fn the_default_bubble_never_hollows_a_print_or_smears_the_book() {
+        let bubbles = BubbleStyle::default();
+        assert!(
+            !bubbles.hollow_small_buys,
+            "a small print is a solid disc: hollowing it spends the disc's own area \
+             to say something the luminance gap and the side nudge already say"
+        );
+        assert_eq!(
+            bubbles.trail_length, 0.0,
+            "the trail painted over the strip of heat map that answers the question \
+             it raised — whether the level refilled"
+        );
+        assert!(
+            !bubbles.show_impact_ring,
+            "the crown already says the print ate; a closed ring on top of it \
+             restates the fact in the one shape that blurs the disc's own edge"
+        );
+    }
+
+    #[test]
+    fn the_default_radii_are_rungs_of_one_golden_ladder() {
+        let bubbles = BubbleStyle::default();
+        // The rungs really are successive powers of φ, not four numbers that
+        // merely look related.
+        for (power, inverse) in [
+            (1, INV_PHI),
+            (2, INV_PHI_2),
+            (3, INV_PHI_3),
+            (4, INV_PHI_3 / PHI),
+        ] {
+            assert!(
+                (inverse * PHI.powi(power) - 1.0).abs() < 1e-5,
+                "1/φ^{power} = {inverse} is not the reciprocal of φ^{power}"
+            );
+        }
+        // The defaults are those rungs rounded to the precision the presets
+        // file stores, so the tolerance is that rounding step and nothing
+        // looser: this is what stops a literal from quietly becoming a number
+        // nobody can derive.
+        let tolerance = 0.5 * 10_f32.powi(-SERIALIZED_FLOAT_PLACES);
+        for (label, actual, expected) in [
+            (
+                "min radius",
+                bubbles.min_radius,
+                bubbles.max_radius * INV_PHI_3 / PHI,
+            ),
+            (
+                "detail radius",
+                bubbles.detail_min_radius,
+                bubbles.max_radius * INV_PHI_3,
+            ),
+            (
+                "readable radius",
+                bubbles.readable_min_radius,
+                bubbles.max_radius * INV_PHI_2,
+            ),
+            ("front length scale", bubbles.front_length_scale, INV_PHI),
+        ] {
+            assert!(
+                (actual - expected).abs() <= tolerance,
+                "{label} {actual} is not the φ rung {expected} at file precision"
+            );
+        }
+        assert!(bubbles.min_radius < bubbles.detail_min_radius);
+        assert!(bubbles.detail_min_radius < bubbles.readable_min_radius);
+        assert!(bubbles.readable_min_radius < bubbles.max_radius);
+    }
+
+    #[test]
+    fn a_preset_written_before_the_crown_still_loads_and_gains_it() {
+        // Exactly the shape every shipped preset had before this change: the
+        // old boolean switch, and no `consumption_mark` key at all.
+        let legacy = "
+            min_radius = 2.0
+            max_radius = 15.0
+            show_consumption_front = true
+            front_width = 3.0
+            front_length_scale = 2.1
+            hollow_small_buys = true
+        ";
+        let style: BubbleStyle = toml::from_str(legacy).expect("a legacy preset still parses");
+        assert_eq!(style.max_radius, 15.0, "its own values survive");
+        assert_eq!(style.front_width, 3.0);
+        assert!(
+            style.hollow_small_buys,
+            "a preset that asked for hollow buys keeps them"
+        );
+        assert_eq!(
+            style.consumption_mark,
+            ConsumptionMark::Crown,
+            "the key it never carried takes the new default"
+        );
     }
 
     #[test]
@@ -1244,9 +1492,12 @@ mod tests {
         let parsed: BubbleStyle = toml::from_str(&text).expect("parse");
         assert_eq!(parsed, style);
 
-        // A presets file written before the mode existed keeps rendering flat.
+        // A presets file that predates the mode adopts the shipped default,
+        // which is now the shaded sphere: it is what keeps piled bubbles
+        // countable where their rims coincide.
         let old: BubbleStyle = toml::from_str("max_radius = 30.0").expect("parse old file");
-        assert_eq!(old.render_mode, BubbleRenderMode::Flat);
+        assert_eq!(old.render_mode, BubbleRenderMode::Sphere);
+        assert_eq!(old.max_radius, 30.0);
     }
 
     #[test]
@@ -1263,11 +1514,11 @@ mod tests {
             ..BubbleStyle::default()
         };
         style.sanitize();
-        assert_eq!(style.min_radius, 2.0);
+        assert_eq!(style.min_radius, DEFAULT_BUBBLE_MIN_RADIUS);
         assert!(style.max_radius >= style.min_radius);
         assert_eq!(style.opacity, 1.0);
         assert_eq!(style.front_width, 0.5);
-        assert_eq!(style.trail_length, 18.0);
+        assert_eq!(style.trail_length, 0.0);
         assert_eq!(style.side_offset, 0.0);
         assert_eq!(style.min_quantity, 0.0);
         assert_eq!(style.size_reference_quantity, 100.0);
@@ -1283,7 +1534,7 @@ mod tests {
             ..HeatmapConfig::default()
         }
         .sanitized();
-        assert_eq!(config.bubbles.opacity, 0.78);
+        assert_eq!(config.bubbles.opacity, DEFAULT_BUBBLE_OPACITY);
     }
 
     #[test]

--- a/crates/app/src/orderflow/mod.rs
+++ b/crates/app/src/orderflow/mod.rs
@@ -16,10 +16,11 @@ pub mod timeline;
 // the public DTOs here gives later renderers one stable import surface.
 #[allow(unused_imports)]
 pub use config::{
-    BubbleRenderMode, BubbleSizeReference, BubbleStyle, DisplayGrouping, HeatmapConfig,
-    HeatmapTheme, IntensityMode, LiveLaneStyle, MAX_BUBBLE_MAX_RADIUS, MAX_BUBBLE_MIN_RADIUS,
-    MAX_LIVE_LANE_RADIUS_SCALE, MAX_LIVE_LANE_SHARE, MAX_LIVE_LANE_ZOOM, MIN_BUBBLE_MAX_RADIUS,
-    MIN_LIVE_LANE_RADIUS_SCALE, MIN_LIVE_LANE_SHARE, MIN_LIVE_LANE_ZOOM,
+    BubbleRenderMode, BubbleSizeReference, BubbleStyle, ConsumptionMark, DisplayGrouping,
+    GOLDEN_ANGLE, HeatmapConfig, HeatmapTheme, INV_PHI, INV_PHI_2, INV_PHI_3, IntensityMode,
+    LiveLaneStyle, MAX_BUBBLE_MAX_RADIUS, MAX_BUBBLE_MIN_RADIUS, MAX_LIVE_LANE_RADIUS_SCALE,
+    MAX_LIVE_LANE_SHARE, MAX_LIVE_LANE_ZOOM, MIN_BUBBLE_MAX_RADIUS, MIN_LIVE_LANE_RADIUS_SCALE,
+    MIN_LIVE_LANE_SHARE, MIN_LIVE_LANE_ZOOM,
 };
 #[allow(unused_imports)]
 pub use grouping::{

--- a/crates/app/src/orderflow_render.rs
+++ b/crates/app/src/orderflow_render.rs
@@ -3506,6 +3506,26 @@ mod tests {
             )
         });
         assert!(untouched.len() < crowned.len());
+
+        // The third variant is a port, not a placeholder: asking for no mark
+        // must paint exactly what a print that ate nothing paints, so the
+        // consumption signal can be switched off without also changing the
+        // disc. Without this the arm is only reachable through the panel.
+        let silent = painted(|painter| {
+            draw_bubble(
+                painter,
+                mark,
+                &BubbleStyle {
+                    consumption_mark: ConsumptionMark::None,
+                    ..bubbles.clone()
+                },
+                &colors,
+            )
+        });
+        assert_eq!(
+            silent, untouched,
+            "ConsumptionMark::None must leave the bubble exactly as it was"
+        );
     }
 
     #[test]

--- a/crates/app/src/orderflow_render.rs
+++ b/crates/app/src/orderflow_render.rs
@@ -13,8 +13,9 @@ use rust_decimal::Decimal;
 use rust_decimal::prelude::ToPrimitive as _;
 
 use crate::orderflow::{
-    AggressionPrimitive, BEFORE_CAPTURE, BubbleRenderMode, BubbleStyle, HeatmapConfig,
-    HeatmapProjection, HeatmapTheme, LiquidityEvidence, LiveLaneStyle,
+    AggressionPrimitive, BEFORE_CAPTURE, BubbleRenderMode, BubbleStyle, ConsumptionMark,
+    GOLDEN_ANGLE, HeatmapConfig, HeatmapProjection, HeatmapTheme, INV_PHI, INV_PHI_2, INV_PHI_3,
+    LiquidityEvidence, LiveLaneStyle,
 };
 use crate::viewport::Viewport;
 
@@ -205,18 +206,36 @@ struct BubbleColors {
     front: egui::Color32,
     trail: egui::Color32,
     text: egui::Color32,
+    /// The crown's colour per side. Derived from the side colour rather than
+    /// from [`front`](Self::front), so consumption reads as the same event
+    /// hotter instead of introducing a third hue — unless the panel explicitly
+    /// overrode the consumption colour, which stays the one door to change it.
+    crown_buy: egui::Color32,
+    crown_sell: egui::Color32,
 }
 
 impl BubbleColors {
     fn resolve(palette: &Palette, bubbles: &BubbleStyle) -> Self {
         let front = bubbles.front_color.map_or(palette.consumption, opaque_rgb);
+        let buy = bubbles.buy_color.map_or(palette.buy, opaque_rgb);
+        let sell = bubbles.sell_color.map_or(palette.sell, opaque_rgb);
+        let crown_of = |side: egui::Color32| match bubbles.front_color {
+            Some(rgb) => opaque_rgb(rgb),
+            None => opaque_rgb(mix_rgb(
+                [side.r(), side.g(), side.b()],
+                [255, 255, 255],
+                CROWN_WHITE_MIX,
+            )),
+        };
         Self {
-            buy: bubbles.buy_color.map_or(palette.buy, opaque_rgb),
-            sell: bubbles.sell_color.map_or(palette.sell, opaque_rgb),
+            buy,
+            sell,
             front,
             // The trail is the front's own glow, so it follows it by default.
             trail: bubbles.trail_color.map_or(front, opaque_rgb),
             text: bubbles.label_color.map_or(palette.bubble_text, opaque_rgb),
+            crown_buy: crown_of(buy),
+            crown_sell: crown_of(sell),
         }
     }
 
@@ -224,6 +243,13 @@ impl BubbleColors {
         match side {
             Side::Buy => self.buy,
             Side::Sell => self.sell,
+        }
+    }
+
+    const fn crown_for_side(self, side: Side) -> egui::Color32 {
+        match side {
+            Side::Buy => self.crown_buy,
+            Side::Sell => self.crown_sell,
         }
     }
 }
@@ -283,19 +309,57 @@ fn hollow_ring_width(radius: f32) -> f32 {
     (radius * HOLLOW_RING_SCALE).clamp(HOLLOW_MIN_RING_PX, HOLLOW_MAX_RING_PX)
 }
 
-/// Width of the dark separator ring drawn just outside a bubble's rim. The
-/// heat ramp passes through greens the buy side almost matches, so without a
-/// dark hair between them "aggression" and "liquidity" melt into one layer
-/// wherever a bubble sits on warm heat — the ring is what keeps them two.
-const SEPARATOR_RING_PX: f32 = 1.2;
-/// Alpha of that ring: translucent black, so it darkens whatever heat is
+/// Width of the dark separator hair drawn just outside a bubble's rim, as a
+/// fraction of the radius, and the pixel range it is held to.
+///
+/// The heat ramp passes through greens the buy side almost matches, so without
+/// a dark hair between them "aggression" and "liquidity" melt into one layer
+/// wherever a bubble sits on warm heat — the hair is what keeps them two.
+///
+/// Proportional rather than fixed: at a flat 1.2px the hair was over half the
+/// radius of a routine 2px print and under a tenth of a full sweep's, so small
+/// prints wore a heavy black collar and large ones a thread. One ratio makes
+/// every bubble the same drawing at a different size.
+const SEPARATOR_RING_SCALE: f32 = 0.14;
+/// See [`SEPARATOR_RING_SCALE`].
+const SEPARATOR_MIN_RING_PX: f32 = 0.5;
+/// See [`SEPARATOR_RING_SCALE`].
+const SEPARATOR_MAX_RING_PX: f32 = 1.5;
+/// Alpha of that hair: translucent black, so it darkens whatever heat is
 /// behind it instead of assuming one canvas colour.
-const SEPARATOR_RING_ALPHA: u8 = 200;
+const SEPARATOR_RING_ALPHA: u8 = 170;
 
-/// Gap, in pixels, between a bubble's rim and the halo drawn behind it.
-const HALO_PADDING_PX: f32 = 2.5;
-/// Gap, in pixels, between a bubble's rim and its impact ring.
-const IMPACT_RING_PADDING_PX: f32 = 2.2;
+/// Separator-hair width for a bubble of this radius.
+fn separator_ring_width(radius: f32) -> f32 {
+    (radius * SEPARATOR_RING_SCALE).clamp(SEPARATOR_MIN_RING_PX, SEPARATOR_MAX_RING_PX)
+}
+
+/// Gap between a bubble's rim and the halo behind it, as a fraction of the
+/// radius, and the pixel range it is held to.
+const HALO_PADDING_SCALE: f32 = 0.2;
+/// See [`HALO_PADDING_SCALE`].
+const HALO_MIN_PADDING_PX: f32 = 2.0;
+/// See [`HALO_PADDING_SCALE`].
+const HALO_MAX_PADDING_PX: f32 = 5.0;
+
+/// Halo gap for a bubble of this radius.
+fn halo_padding(radius: f32) -> f32 {
+    (radius * HALO_PADDING_SCALE).clamp(HALO_MIN_PADDING_PX, HALO_MAX_PADDING_PX)
+}
+
+/// Gap between a bubble's rim and its impact ring, as a fraction of the
+/// radius, and the pixel range it is held to.
+const IMPACT_RING_PADDING_SCALE: f32 = 0.16;
+/// See [`IMPACT_RING_PADDING_SCALE`].
+const IMPACT_RING_MIN_PADDING_PX: f32 = 1.6;
+/// See [`IMPACT_RING_PADDING_SCALE`].
+const IMPACT_RING_MAX_PADDING_PX: f32 = 3.5;
+
+/// Impact-ring gap for a bubble of this radius.
+fn impact_ring_padding(radius: f32) -> f32 {
+    (radius * IMPACT_RING_PADDING_SCALE)
+        .clamp(IMPACT_RING_MIN_PADDING_PX, IMPACT_RING_MAX_PADDING_PX)
+}
 /// Pixels added beyond `front_length_scale × radius`, so the consumption mark
 /// on even the smallest bubble is long enough to read as a mark.
 const FRONT_END_PADDING_PX: f32 = 6.0;
@@ -337,6 +401,153 @@ const SPHERE_MAX_SEGMENTS: usize = 32;
 fn sphere_segments(radius: f32) -> usize {
     ((radius * SPHERE_SEGMENTS_PER_RADIUS_PX) as usize)
         .clamp(SPHERE_MIN_SEGMENTS, SPHERE_MAX_SEGMENTS)
+}
+
+/// Gap between the rim and the consumption crown, as a fraction of the radius,
+/// and the pixel range it is held to. `1/φ³` — the innermost step of the
+/// nested `1/φ³` gap + `1/φ²` stroke that lands the whole crown apparatus at
+/// about `r/φ²` beyond the rim on a full-size print.
+const CROWN_GAP_SCALE: f32 = INV_PHI_3;
+/// See [`CROWN_GAP_SCALE`].
+const CROWN_MIN_GAP_PX: f32 = 1.4;
+/// See [`CROWN_GAP_SCALE`].
+const CROWN_MAX_GAP_PX: f32 = 3.0;
+/// Stroke width of the crown as a fraction of the radius, and the pixel range
+/// it is held to. `1/φ²`.
+const CROWN_WIDTH_SCALE: f32 = INV_PHI_2;
+/// See [`CROWN_WIDTH_SCALE`].
+const CROWN_MIN_WIDTH_PX: f32 = 1.0;
+/// See [`CROWN_WIDTH_SCALE`].
+const CROWN_MAX_WIDTH_PX: f32 = 2.4;
+/// Arc length, in pixels, below which an arc has stopped reading as an arc.
+/// Under it the crown collapses to a pip at the pole — a print small enough to
+/// be a speck still gets to say it ate something, for about four pixels of ink.
+const CROWN_MIN_ARC_PX: f32 = 4.0;
+/// Radius of that pip, in pixels.
+const CROWN_PIP_RADIUS_PX: f32 = 1.2;
+/// How far the crown's colour is pushed from its side colour toward white.
+///
+/// `1/φ`. Consumption is the same event, hotter — deriving the crown from the
+/// side keeps a third hue off the canvas, and means N stacked crowns saturate
+/// toward their own green or red instead of toward glare or toward mud.
+const CROWN_WHITE_MIX: f32 = INV_PHI;
+/// Crown alpha before the matched share.
+const CROWN_BASE_ALPHA: f32 = 0.62;
+/// Share of the crown's alpha that tracks the matched fraction. Secondary to
+/// arc length, which is the channel actually carrying the reading.
+const CROWN_MATCH_ALPHA: f32 = 0.38;
+/// Extra width of the dark stroke laid under the crown, so the arc survives
+/// over a bright heat band without assuming one canvas colour. A hairline each
+/// side, never a mass.
+const CROWN_BACKING_PX: f32 = 1.0;
+/// See [`CROWN_BACKING_PX`].
+const CROWN_BACKING_ALPHA: u8 = 110;
+
+/// The pole a crown is centred on.
+///
+/// Buy aggression lifts the ask, so its crown sits above the print; sell
+/// aggression hits the bid and wears it below. Screen y grows downward. This
+/// is the same fact [`side_offset_y`] encodes, deliberately restated: on a
+/// dense tape the two reinforce each other rather than compete.
+const fn crown_center_angle(side: Side) -> f32 {
+    match side {
+        Side::Buy => -std::f32::consts::FRAC_PI_2,
+        Side::Sell => std::f32::consts::FRAC_PI_2,
+    }
+}
+
+/// The crown's geometry for a bubble of this radius and matched share.
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct CrownGeometry {
+    /// Radius of the arc itself — outside the rim, never on it.
+    arc_radius: f32,
+    /// Stroke width.
+    width: f32,
+    /// Angular length, in radians. Never exceeds the [`GOLDEN_ANGLE`], so the
+    /// crown cannot close into a second circle around the bubble.
+    sweep: f32,
+}
+
+impl CrownGeometry {
+    /// Length of the arc in pixels — what decides whether it can be drawn as
+    /// an arc at all.
+    fn arc_length(self) -> f32 {
+        self.arc_radius * self.sweep
+    }
+}
+
+/// Crown geometry for a print of this radius that matched this fraction of
+/// resting liquidity.
+fn crown_geometry(radius: f32, matched: f32) -> CrownGeometry {
+    let gap = (radius * CROWN_GAP_SCALE).clamp(CROWN_MIN_GAP_PX, CROWN_MAX_GAP_PX);
+    CrownGeometry {
+        arc_radius: radius + gap,
+        width: (radius * CROWN_WIDTH_SCALE).clamp(CROWN_MIN_WIDTH_PX, CROWN_MAX_WIDTH_PX),
+        // A `1/φ²` floor plus a `1/φ` span: a nibble still shows a mark, a
+        // full sweep reaches the golden angle and no further.
+        sweep: GOLDEN_ANGLE * (INV_PHI_2 + INV_PHI * finite_unit(matched)),
+    }
+}
+
+/// The crown's colour for a print that matched this fraction.
+fn crown_alpha(matched: f32) -> f32 {
+    CROWN_BASE_ALPHA + CROWN_MATCH_ALPHA * finite_unit(matched)
+}
+
+/// Draw the consumption crown: an open arc outside the rim, on the side of the
+/// book the print ate, whose length carries how much of it matched.
+///
+/// Additive rather than subtractive — the arc is the side colour pushed toward
+/// white — because the canvas is nearly black and the layer underneath is the
+/// only one carrying liquidity. A dark mark here is invisible over the canvas
+/// and a hole punched in the book everywhere else, which is what the vertical
+/// front it replaces had become.
+fn draw_crown(
+    painter: &egui::Painter,
+    center: egui::Pos2,
+    radius: f32,
+    side: Side,
+    matched: f32,
+    color: egui::Color32,
+) {
+    if !center.is_finite() || !radius.is_finite() || radius <= 0.0 {
+        return;
+    }
+    let geometry = crown_geometry(radius, matched);
+    let color = color.gamma_multiply(crown_alpha(matched));
+    let pole = crown_center_angle(side);
+    if geometry.arc_length() < CROWN_MIN_ARC_PX {
+        let direction = egui::vec2(pole.cos(), pole.sin());
+        painter.circle_filled(
+            center + direction * geometry.arc_radius,
+            CROWN_PIP_RADIUS_PX,
+            color,
+        );
+        return;
+    }
+    // The arc is a slice of a circle of this radius, so it inherits the same
+    // segment budget and spends only its own share of it.
+    let full = sphere_segments(geometry.arc_radius);
+    let segments =
+        (((full as f32) * (geometry.sweep / std::f32::consts::TAU)).ceil() as usize).max(3);
+    let start = pole - geometry.sweep / 2.0;
+    let points: Vec<egui::Pos2> = (0..=segments)
+        .map(|index| {
+            let angle = start + geometry.sweep * (index as f32 / segments as f32);
+            center + egui::vec2(angle.cos(), angle.sin()) * geometry.arc_radius
+        })
+        .collect();
+    painter.add(egui::Shape::line(
+        points.clone(),
+        egui::Stroke::new(
+            geometry.width + CROWN_BACKING_PX,
+            egui::Color32::from_black_alpha(CROWN_BACKING_ALPHA),
+        ),
+    ));
+    painter.add(egui::Shape::line(
+        points,
+        egui::Stroke::new(geometry.width, color),
+    ));
 }
 
 /// Label font size as a fraction of the bubble radius, and the range it is
@@ -386,6 +597,24 @@ fn impact_ring_alpha(matched_fraction: f32) -> f32 {
     IMPACT_RING_BASE_ALPHA
         + finite_unit(matched_fraction).max(MIN_MATCH_STRENGTH) * IMPACT_RING_MATCH_ALPHA
 }
+
+/// Half-height of the trail behind a bubble of this radius, and the pixel
+/// range it is held to.
+///
+/// `1/φ` of the radius, so the trail stays strictly *smaller* than the bubble
+/// it belongs to. It used to borrow the consumption front's half-length, which
+/// carries a fixed 6px addition — on a routine 2px print that made the trail a
+/// 17px-tall bar behind a 4px disc, and a chart whose signal is horizontal
+/// bands does not need decorative horizontal bands eight times the ink of the
+/// mark they decorate.
+fn trail_half_height(radius: f32) -> f32 {
+    (radius * INV_PHI).clamp(TRAIL_MIN_HALF_HEIGHT_PX, TRAIL_MAX_HALF_HEIGHT_PX)
+}
+
+/// See [`trail_half_height`].
+const TRAIL_MIN_HALF_HEIGHT_PX: f32 = 1.5;
+/// See [`trail_half_height`].
+const TRAIL_MAX_HALF_HEIGHT_PX: f32 = 9.0;
 
 /// The consumption trail leaking to the right of a bubble, stopped at
 /// `right_edge` so it never paints past the chart.
@@ -592,23 +821,26 @@ fn draw_bubble(
         && matches!(side, Side::Buy)
         && radius < bubbles.readable_min_radius;
     let sphere = !hollow && dressed && bubbles.render_mode == BubbleRenderMode::Sphere;
-    if !hollow && dressed && bubbles.halo_strength > 0.0 {
+    // The halo says "this one is big", so it is gated on size rather than
+    // merely scaled with it: the top rung of the φ ladder, `max / φ`. Under a
+    // gate it is a handful of prints a minute; under none it was a fog beneath
+    // every speck on the tape, which is the same ink spent to say nothing.
+    let haloed = !hollow && dressed && radius >= bubbles.max_radius * INV_PHI;
+    if haloed && bubbles.halo_strength > 0.0 {
         painter.circle_filled(
             center,
-            radius + HALO_PADDING_PX,
+            radius + halo_padding(radius),
             color.gamma_multiply(halo_alpha(size, bubbles)),
         );
     }
     // The dark hair between the mark and the heat behind it. Skipped on the
     // cheap-dot path, which stays a single circle per print.
     if dressed || hollow {
+        let hair = separator_ring_width(radius);
         painter.circle_stroke(
             center,
-            radius + SEPARATOR_RING_PX / 2.0,
-            egui::Stroke::new(
-                SEPARATOR_RING_PX,
-                egui::Color32::from_black_alpha(SEPARATOR_RING_ALPHA),
-            ),
+            radius + hair / 2.0,
+            egui::Stroke::new(hair, egui::Color32::from_black_alpha(SEPARATOR_RING_ALPHA)),
         );
     }
     if hollow {
@@ -675,20 +907,36 @@ fn draw_bubble(
     let Some(matched_fraction) = matched else {
         return;
     };
-    if bubbles.show_consumption_front {
-        let half_length = front_half_length(radius, bubbles);
-        painter.line_segment(
-            [
-                egui::pos2(center.x, center.y - half_length),
-                egui::pos2(center.x, center.y + half_length),
-            ],
-            egui::Stroke::new(bubbles.front_width, colors.front),
-        );
+    match bubbles.consumption_mark {
+        // The crown lives outside the rim, so it costs the disc nothing and
+        // the smallest prints can still afford their pip.
+        ConsumptionMark::Crown => draw_crown(
+            painter,
+            center,
+            radius,
+            side,
+            matched_fraction,
+            colors.crown_for_side(side),
+        ),
+        // The old vertical front, for a preset that asked for it by name. It
+        // outgrows its own bubble by construction, so it stays behind the
+        // dressing gate, where the bubble is at least big enough to carry it.
+        ConsumptionMark::Front if dressed => {
+            let half_length = front_half_length(radius, bubbles);
+            painter.line_segment(
+                [
+                    egui::pos2(center.x, center.y - half_length),
+                    egui::pos2(center.x, center.y + half_length),
+                ],
+                egui::Stroke::new(bubbles.front_width, colors.front),
+            );
+        }
+        ConsumptionMark::Front | ConsumptionMark::None => {}
     }
     if dressed && bubbles.show_impact_ring {
         painter.circle_stroke(
             center,
-            radius + IMPACT_RING_PADDING_PX,
+            radius + impact_ring_padding(radius),
             egui::Stroke::new(
                 bubbles.impact_ring_width,
                 colors
@@ -1419,10 +1667,10 @@ pub(crate) fn draw_aggression_bubbles(painter: &egui::Painter, context: &RenderC
                 continue;
             };
             let pane = context.layout.pane(trade.x);
-            let half_length = front_half_length(radius_of(trade), bubbles);
+            let half_height = trail_half_height(radius_of(trade));
             add_gradient_rect(
                 &mut trail_mesh,
-                trail_rect(center, half_length, bubbles.trail_length, pane.right()).intersect(pane),
+                trail_rect(center, half_height, bubbles.trail_length, pane.right()).intersect(pane),
                 colors.trail.gamma_multiply(bubbles.trail_opacity),
                 egui::Color32::TRANSPARENT,
             );
@@ -2653,6 +2901,10 @@ mod tests {
             min_radius: 2.2,
             max_radius: 14.0,
             detail_min_radius: 2.0,
+            // Opt in explicitly: the ring is off by default now, and this test
+            // is about the readability floor still arming it when the dressing
+            // radius is set below the minimum.
+            hollow_small_buys: true,
             ..BubbleStyle::default()
         };
         assert!(dense_tape_btc.detail_min_radius < dense_tape_btc.min_radius);
@@ -3159,6 +3411,138 @@ mod tests {
     }
 
     #[test]
+    fn the_crown_never_touches_the_disc_and_never_closes_a_circle() {
+        // The two properties the mark exists for. The first is why it replaced
+        // the vertical front: a bubble's area is its quantity, so nothing may
+        // be drawn over it. The second is why it is an arc and not a ring: a
+        // closed circle concentric with the disc makes the disc's own edge
+        // ambiguous, which is what the impact ring did.
+        for radius in [1.0_f32, 2.2, 3.5, 5.7, 9.3, 15.0, 22.0, 48.0] {
+            for matched in [0.0_f32, 0.1, 0.5, 0.99, 1.0] {
+                let geometry = crown_geometry(radius, matched);
+                assert!(
+                    geometry.arc_radius - geometry.width / 2.0 > radius,
+                    "at r={radius} m={matched} the crown's inner edge \
+                     {} is not clear of the rim",
+                    geometry.arc_radius - geometry.width / 2.0
+                );
+                assert!(
+                    geometry.sweep <= GOLDEN_ANGLE + 1e-5,
+                    "at r={radius} m={matched} the sweep {} exceeds the golden angle",
+                    geometry.sweep
+                );
+                assert!(
+                    geometry.sweep >= GOLDEN_ANGLE * INV_PHI_2 - 1e-5,
+                    "a print that ate anything still shows a mark"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn the_crown_grows_with_the_matched_share() {
+        // Arc length is the channel a trader reads ordinally without a
+        // reference beside it, so it has to be monotone in what it encodes.
+        let radius = 12.0;
+        let mut previous = f32::NEG_INFINITY;
+        for matched in [0.0_f32, 0.25, 0.5, 0.75, 1.0] {
+            let length = crown_geometry(radius, matched).arc_length();
+            assert!(
+                length > previous,
+                "matched={matched} must draw a longer arc than the share below it"
+            );
+            previous = length;
+        }
+        // A full sweep reaches the golden angle exactly, and a nibble 1/φ² of it.
+        assert!((crown_geometry(radius, 1.0).sweep - GOLDEN_ANGLE).abs() < 1e-5);
+        assert!((crown_geometry(radius, 0.0).sweep - GOLDEN_ANGLE * INV_PHI_2).abs() < 1e-5);
+    }
+
+    #[test]
+    fn the_crown_replaces_the_front_and_leaves_the_disc_alone() {
+        let bubbles = BubbleStyle::default();
+        assert_eq!(bubbles.consumption_mark, ConsumptionMark::Crown);
+        let colors = BubbleColors::resolve(&Palette::for_theme(HeatmapTheme::Bookmap), &bubbles);
+        let mark = BubbleMark {
+            center: egui::pos2(60.0, 60.0),
+            radius: 10.0,
+            side: Side::Buy,
+            size: 0.6,
+            matched: Some(0.7),
+            buy_share: 1.0,
+        };
+        let crowned = painted(|painter| draw_bubble(painter, mark, &bubbles, &colors));
+        let fronted = painted(|painter| {
+            draw_bubble(
+                painter,
+                mark,
+                &BubbleStyle {
+                    consumption_mark: ConsumptionMark::Front,
+                    ..bubbles.clone()
+                },
+                &colors,
+            )
+        });
+        assert_ne!(crowned, fronted, "the mark must change what is painted");
+        assert!(
+            fronted.contains("LineSegment"),
+            "the front is still the line it always was: {fronted}"
+        );
+        assert!(
+            !crowned.contains("LineSegment"),
+            "the crown draws no line through the bubble: {crowned}"
+        );
+
+        // A print that ate nothing wears no crown at all.
+        let untouched = painted(|painter| {
+            draw_bubble(
+                painter,
+                BubbleMark {
+                    matched: None,
+                    ..mark
+                },
+                &bubbles,
+                &colors,
+            )
+        });
+        assert!(untouched.len() < crowned.len());
+    }
+
+    #[test]
+    fn a_crown_follows_its_own_side_unless_the_panel_overrode_it() {
+        let palette = Palette::for_theme(HeatmapTheme::Bookmap);
+        let bubbles = BubbleStyle::default();
+        let colors = BubbleColors::resolve(&palette, &bubbles);
+        // Derived from the side colour, and brighter than it: consumption is
+        // the same event, hotter — no third hue enters the canvas.
+        for (side, base) in [(Side::Buy, colors.buy), (Side::Sell, colors.sell)] {
+            let crown = colors.crown_for_side(side);
+            assert_ne!(crown, base);
+            assert!(
+                crown.r() >= base.r() && crown.g() >= base.g() && crown.b() >= base.b(),
+                "the crown is the side colour pushed toward white, not away from it"
+            );
+        }
+        assert_ne!(
+            colors.crown_for_side(Side::Buy),
+            colors.crown_for_side(Side::Sell)
+        );
+
+        // The consumption colour override stays the one door to change it.
+        let overridden = BubbleColors::resolve(
+            &palette,
+            &BubbleStyle {
+                front_color: Some([10, 20, 30]),
+                ..bubbles
+            },
+        );
+        assert_eq!(
+            overridden.crown_for_side(Side::Buy),
+            egui::Color32::from_rgb(10, 20, 30)
+        );
+    }
+
+    #[test]
     fn sphere_mode_swaps_the_flat_fill_for_a_shaded_mesh() {
         let mark = BubbleMark {
             center: egui::pos2(120.0, 80.0),
@@ -3169,7 +3553,13 @@ mod tests {
             buy_share: 1.0,
         };
         let palette = Palette::for_theme(HeatmapTheme::Bookmap);
-        let flat_style = BubbleStyle::default();
+        // Both modes are named explicitly: the shipped default is the sphere
+        // now, and a test comparing the two must not depend on which one that
+        // happens to be.
+        let flat_style = BubbleStyle {
+            render_mode: BubbleRenderMode::Flat,
+            ..BubbleStyle::default()
+        };
         let sphere_style = BubbleStyle {
             render_mode: BubbleRenderMode::Sphere,
             ..BubbleStyle::default()
@@ -3251,11 +3641,13 @@ mod tests {
 
     #[test]
     fn hollow_small_buys_opens_the_dot_and_leaves_dressed_bubbles_alone() {
+        // The ring is off by default now; this test is about the knob still
+        // doing what it says for anyone who turns it back on.
         let hollow = BubbleStyle {
             trail_length: 0.0,
+            hollow_small_buys: true,
             ..BubbleStyle::default()
         };
-        assert!(hollow.hollow_small_buys);
         let solid = BubbleStyle {
             hollow_small_buys: false,
             ..hollow.clone()

--- a/crates/app/src/orderflow_view.rs
+++ b/crates/app/src/orderflow_view.rs
@@ -21,10 +21,10 @@ use crate::chart::PriceScale;
 use crate::live_strip;
 use crate::orderflow::projection::normalized_area_size;
 use crate::orderflow::{
-    BubbleRenderMode, BubbleSizeReference, DisplayGrouping, HeatmapConfig, HeatmapTheme,
-    IntensityMode, MAX_BUBBLE_MAX_RADIUS, MAX_BUBBLE_MIN_RADIUS, MAX_LIVE_LANE_RADIUS_SCALE,
-    MAX_LIVE_LANE_SHARE, MAX_LIVE_LANE_ZOOM, MIN_BUBBLE_MAX_RADIUS, MIN_LIVE_LANE_RADIUS_SCALE,
-    MIN_LIVE_LANE_SHARE, MIN_LIVE_LANE_ZOOM, reserved_span_ms,
+    BubbleRenderMode, BubbleSizeReference, ConsumptionMark, DisplayGrouping, HeatmapConfig,
+    HeatmapTheme, IntensityMode, MAX_BUBBLE_MAX_RADIUS, MAX_BUBBLE_MIN_RADIUS,
+    MAX_LIVE_LANE_RADIUS_SCALE, MAX_LIVE_LANE_SHARE, MAX_LIVE_LANE_ZOOM, MIN_BUBBLE_MAX_RADIUS,
+    MIN_LIVE_LANE_RADIUS_SCALE, MIN_LIVE_LANE_SHARE, MIN_LIVE_LANE_ZOOM, reserved_span_ms,
 };
 use crate::orderflow_engine::{
     BookPublished, CaptureStatus, OrderflowHealth, ProjectionRequest, VisibleOrderflow,
@@ -1239,19 +1239,41 @@ impl OrderflowView {
                     "Drawn only when a print aligned with a factual L2 reduction — the bubble \
                      ate resting liquidity.",
                 );
-                ui.checkbox(
-                    &mut bubbles.show_consumption_front,
-                    "vertical front through the bubble",
-                );
-                ui.add_enabled(
-                    bubbles.show_consumption_front,
-                    egui::Slider::new(&mut bubbles.front_width, 0.5..=10.0).text("front width px"),
-                );
-                ui.add_enabled(
-                    bubbles.show_consumption_front,
-                    egui::Slider::new(&mut bubbles.front_length_scale, 0.5..=6.0)
-                        .text("front length × radius"),
-                );
+                ui.horizontal(|ui| {
+                    ui.label("mark");
+                    egui::ComboBox::from_id_salt("bubble_consumption_mark")
+                        .selected_text(consumption_mark_label(bubbles.consumption_mark))
+                        .show_ui(ui, |ui| {
+                            for mark in [
+                                ConsumptionMark::Crown,
+                                ConsumptionMark::Front,
+                                ConsumptionMark::None,
+                            ] {
+                                ui.selectable_value(
+                                    &mut bubbles.consumption_mark,
+                                    mark,
+                                    consumption_mark_label(mark),
+                                );
+                            }
+                        })
+                        .response
+                        .on_hover_text(
+                            "the crown is an open arc just outside the rim, on the side of the \
+                             book the print ate — its length grows with how much of the print \
+                             matched, and it never crosses the disc whose area is the quantity. \
+                             The front is the older vertical line through the bubble.",
+                        );
+                });
+                if bubbles.consumption_mark.is_front() {
+                    ui.add(
+                        egui::Slider::new(&mut bubbles.front_width, 0.5..=10.0)
+                            .text("front width px"),
+                    );
+                    ui.add(
+                        egui::Slider::new(&mut bubbles.front_length_scale, 0.5..=6.0)
+                            .text("front length × radius"),
+                    );
+                }
                 ui.checkbox(&mut bubbles.show_impact_ring, "impact ring on the rim");
                 ui.add_enabled(
                     bubbles.show_impact_ring,
@@ -1829,6 +1851,14 @@ const fn render_mode_label(mode: BubbleRenderMode) -> &'static str {
     }
 }
 
+const fn consumption_mark_label(mark: ConsumptionMark) -> &'static str {
+    match mark {
+        ConsumptionMark::Crown => "Crown · arc outside the rim",
+        ConsumptionMark::Front => "Front · line through the bubble",
+        ConsumptionMark::None => "None",
+    }
+}
+
 /// One optional colour: a swatch that adopts the override the moment it is
 /// touched, and a way back to the theme.
 fn color_override(ui: &mut egui::Ui, label: &str, value: &mut Option<[u8; 3]>, fallback: [u8; 3]) {
@@ -1880,7 +1910,7 @@ mod tests {
         // Now the conditional branches: fixed size reference (extra field),
         // marks turned off, no trail, and a custom colour instead of the theme.
         view.config.bubbles.size_reference = BubbleSizeReference::Fixed;
-        view.config.bubbles.show_consumption_front = false;
+        view.config.bubbles.consumption_mark = ConsumptionMark::Front;
         view.config.bubbles.show_impact_ring = false;
         view.config.bubbles.trail_length = 0.0;
         view.config.bubbles.buy_color = Some([1, 2, 3]);


### PR DESCRIPTION
## O que muda

A camada de agressão dizia "este print comeu liquidez parada" com três marcas **subtrativas** ao mesmo tempo: uma linha quase preta desenhada *através* da bolha, um anel fechado concêntrico com o aro, e um retângulo preto com gradiente vazando à direita de cada print consumidor. Sobre um canvas quase preto a primeira é invisível; sobre o mapa de liquidez as três são buracos. O rastro disparava em quase todo print — logo carregava quase nenhuma informação — e pintava exatamente sobre a faixa de book que responde à pergunta que ele levantava: o nível recompôs?

**A coroa substitui o risco.** É um arco aberto logo fora do aro, do lado do book que foi comido, e o seu *comprimento* carrega quanto do print casou com liquidez parada — de `1/φ²` do ângulo áureo numa mordida até o ângulo áureo inteiro numa varrida. Nunca cruza o disco, cuja área é a leitura de quantidade, e nunca fecha, então não se confunde com a borda da própria bolha. É aditiva: a cor do lado empurrada `1/φ` na direção do branco, de forma que coroas empilhadas saturam para o próprio verde ou vermelho em vez de para uma massa escura.

**Prints pequenos mantêm o preenchimento.** `hollow_small_buys` gastava a área do próprio disco para carregar o lado exatamente no tamanho em que área é mais escassa: a 2 px, um anel verde em volta de um interior com 22% de alpha tem *menos* verde que o ponto que substituiu. O lado passa a ser carregado pelo gap de luminância entre compra e venda e pelo `side_offset`, que o canal acromático resolve várias vezes menor que o cromático.

**Toda proporção é um degrau de uma escada áurea** sobre `max_radius`: `min = max/φ⁴`, `detail = max/φ³`, `readable = max/φ²`, e o halo acende em `max/φ`. Raio é proporcional à *área* por quantidade, então um passo de φ no raio é um passo de φ² ≈ 2,6× em quantidade — uma classe de tamanho que um trader de fluxo já lê. As constantes de dressing em pixel fixo viraram razões do raio pelo mesmo motivo: a 1,2 px fixos, o fio separador era mais da metade do raio de um print rotineiro e um fio de cabelo numa varrida.

`consumption_mark` substitui o booleano `show_consumption_front`. Um preset escrito antes da coroa não carrega a chave e abre usando-a — e, como isso troca em silêncio uma escolha que alguém fez pelo nome, o carregamento agora emite `BUBBLE_PRESET_KEY_RETIRED` nomeando a chave aposentada e o que assumiu o lugar.

## Impacto de performance, por caminho

| Caminho | Taxa | Impacto |
| --- | --- | --- |
| `draw_bubble` / `draw_crown` | por frame (~60 Hz), limitado por `max_aggression_primitives` | **mais barato.** Sai um `circle_stroke` fechado + um `line_segment` por bolha consumidora, entra um polyline curto (mais um de backing). Custo em alocação: 2 `Vec<Pos2>` por coroa por frame — declarado como folga, não como regressão |
| malha do rastro | por frame | **removida do padrão** (`trail_length = 0`): um quad com gradiente por print consumidor deixa de ser construído |
| halo | por frame | **gated** em `max/φ`; antes acendia sob todo speck |
| tesselação de esfera | por frame | inalterada acima de `detail_min_radius`, que subiu de 2,0 para `max/φ³`, então *menos* prints pagam por ela |
| `BubbleStyle::sanitize`, carga de preset | raro | clareza livre |

Medido, mesmo símbolo (BTCUSDT/Binance), mesmos hooks, ~2 min cada, contra um build de controle do `main`:

| | fps mediano | `frame_avg` | `frame_cpu` mediano | `frame_cpu` máx |
| --- | --- | --- | --- | --- |
| `main` (controle) | 59 | 16,67 ms | 3,797 ms | 4,542 ms |
| este branch | 59 | 16,67 ms | **2,445 ms** | **3,266 ms** |

fps preso no vsync nos dois; o ganho aparece no CPU por frame.

## Provas

- `the_crown_never_touches_the_disc_and_never_closes_a_circle` — a borda interna do traço fica fora do aro e a varredura nunca passa do ângulo áureo, para toda a faixa de raio e de fração casada.
- `the_crown_grows_with_the_matched_share` — comprimento de arco monótono na fração casada, com os dois extremos exatos.
- `the_crown_replaces_the_front_and_leaves_the_disc_alone` — a coroa não desenha `LineSegment` nenhum; a `Front` desenha; `None` pinta exatamente o que um print que não comeu nada pinta.
- `a_preset_written_before_the_crown_still_loads_and_gains_it` — o preset antigo carrega, mantém os próprios valores, mantém um opt-in de anel se tinha, e ganha a coroa na chave que nunca carregou.
- `a_retired_key_is_named_rather_than_ignored_in_silence` — a chave aposentada é detectada como atribuição e não como menção em comentário (o arquivo publicado documenta a migração pelo nome).
- `the_shipped_default_preset_is_the_code_default` — o preset `default` publicado é exatamente `BubbleStyle::default()`, então o arquivo que um usuário novo lê e o comportamento que uma instalação limpa entrega não podem divergir.
- `the_shipped_default_aggregates_before_it_draws` — trava as três janelas de agregação do preset publicado.
- `every_shipped_preset_keeps_its_radii_on_the_golden_ladder` / `the_default_radii_are_rungs_of_one_golden_ladder` — cada degrau é o de cima dividido por φ, na precisão que o arquivo guarda.
- `no_shipped_preset_smears_the_book_or_hollows_a_print` — nenhum preset publicado sai com rastro (exceto o `consumption focus`, que existe para isso) nem com marca de consumo quase preta.

## Uma regressão pega pelo operador, e o que ela ensinou

Mover `active` para um preset novo derrubou em silêncio as **três janelas que decidem quantas marcas chegam à tela**, porque todas as três vivem no preset e o novo herdou os defaults nus do código: `cluster_ms` caiu de 500 para 200 e `candle_summary` de ligado para desligado. A camada continuou correta e ficou ilegível — cerca de duas vezes e meia as bolhas numa fita de BTC, e nenhuma pizza por barra, que é a única marca que mostra os dois lados de um preço ao mesmo tempo.

A calma que a linguagem visual compra é gasta na hora se todo print ainda ganha a própria marca. O padrão publicado agora define as três explicitamente, e um teste as prende. Nada olhava para a agregação do preset publicado antes — é por isso que a regressão foi muda.

## Revisões

**arch-review** — 4 achados, 2 corrigidos neste branch:

- *(hardcoded, corrigido)* o piso de raio para rótulo estava escrito como `DEFAULT_BUBBLE_MAX_RADIUS * 0.9` no `Default` **e** no fallback do `sanitize`, então o número mágico existia duas vezes e podia divergir. Virou `DEFAULT_LABEL_MIN_RADIUS_SHARE` com a regra declarada.
- *(test-coverage, corrigido)* `ConsumptionMark::None` não tinha teste — uma variante alcançável só pelo combo box não está coberta.
- *(performance, deferido)* `draw_crown` aloca dois `Vec<Pos2>` por bolha consumidora por frame. Medido como folga, não regressão (o `frame_cpu` caiu). O caminho para eliminar é batelar todas as coroas numa malha só, como o rastro fazia; `trade_paint.rs:220` já usa o mesmo padrão de traço-com-backing, então isto é consistente com o repo hoje.
- *(standardisation, deferido)* vários defaults de `BubbleStyle` são literais repetidos entre o `Default` e o `sanitize` em vez de constantes nomeadas. Padrão pré-existente do repo; esta mudança só alterou os valores.

**trader-ux-review** — sem Blocker.

- *Rafa (scalper)*: nenhum gesto novo em nenhum caminho de trade, nenhum roubo de foco — é mudança de render. A absorção num mesmo nível agora empilha como arcos aninhados no mesmo *y*, que é legível; antes empilhava como uma barra preta. Latência é UX e foi medida: `frame_cpu` menor sob fita densa. Custo real: reaprender um glifo. Mitigado — a `Front` continua disponível pelo nome.
- *Marina (swing)*: um achado, corrigido neste branch — o preset dela carregava mas a escolha era trocada sem que nada dissesse; agora o carregamento nomeia a chave aposentada.
- *Duda (iniciante)*: o combo "mark" com três opções nomeadas e um hover explicando a coroa descobre melhor que o checkbox anterior, que nomeava uma forma e não um significado. *(Consider)* a coroa não tem entrada na legenda — mas o risco de consumo e o anel de impacto que ela substitui também não tinham: a legenda chaveia *camadas*, não modificadores.

**visual-qa** — PASS nas superfícies de chart, com uma limitação declarada.

| Superfície | Estado | Evidência |
| --- | --- | --- |
| chart, fita densa, antes | referência | `02-before-dense.png` |
| chart, fita densa, depois | PASS | `03-after-dense.png` |
| coroa em close (3×), antes | referência | `05-before-zoom.png` |
| coroa em close (3×), depois | PASS — arco fora do aro, acima nas compras e abaixo nas vendas, comprimento variando com a fração casada, sem risco atravessando disco, sem smear, pequenas preenchidas | `04-after-zoom.png` |
| chart com agregação corrigida | PASS | `06-after-aggregated.png` |
| painel de bolhas (combo `mark`) | **não fotografado** | ver abaixo |

O painel não foi fotografado porque o operador estava com as mãos na máquina (`GetLastInputInfo` idle ≈ 47 ms) e a regra do `ui-harness` é não disputar o desktop. A superfície é alcançável por hook sem clique (`QUANTICK_DOCK_TAB=bubbles`) e o combo é exercitado por `the_bubble_tab_lays_out_every_control`.

## Hooks

Nenhum hook novo foi necessário e nenhuma superfície nova foi criada: `QUANTICK_BUBBLES=<toml>` já alcança qualquer marca de consumo apontando para um arquivo de preset, e `QUANTICK_DOCK_TAB=bubbles` já abre o painel onde o seletor vive.

## Fora de escopo, anotado

A análise de cor da equipe visual apontou que o verde de compra do tema (`46,224,150`) colide em matiz e croma com a parada verde da rampa Bookmap (`60,208,120`), e que é *essa* colisão que obriga o fio preto separador em volta de toda bolha. Mexer nisso é mexer na paleta do tema, que a legenda, o live strip e o footprint também consomem — raio de alcance maior do que esta missão. Fica anotado como próximo passo.

## Verificação

```
cargo fmt --all -- --check      exit 0
cargo clippy --workspace --all-targets -- -D warnings   exit 0
cargo build --workspace         exit 0
cargo test --workspace          exit 0   (1016 no app, suíte inteira verde)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KgB6PLsMmsdpk4FrjSMxE5
