### PR TITLE
fix: stop a dragged channel being born as a straight line

### DIFF
--- a/.claude/GOAL-archive-toolbar-usability.md
+++ b/.claude/GOAL-archive-toolbar-usability.md
@@ -1,0 +1,61 @@
+# Goal — barras de ferramenta: criar arrastando e revisão de usabilidade
+
+Criar um canal (e qualquer ferramenta de mais de dois pontos) arrastando passa
+a produzir **o objeto que a ferramenta promete**, com preview ao vivo do que o
+próximo clique vai fazer — não uma linha reta parada esperando um terceiro
+clique que ninguém sabe que precisa dar. Em cima disso, as quatro barras de
+ferramenta do chart passam por revisão de usabilidade com trader-ux-review e
+visual-qa, e todo Blocker e Should-fix é corrigido.
+
+Branch: `fix/toolbar-usability` — worktree
+`../quantick-worktrees/fix-toolbar-usability`.
+
+## O defeito, nomeado
+
+`ParallelChannel::required_points() == 3` (`drawings/parallel_channel.rs:376`).
+O gesto de arrastar em `pane.rs:2254` coloca **uma** âncora no release, então
+press+drag+release deixa um rascunho de dois pontos — que é literalmente uma
+linha reta. Mesmo buraco em `triangle` (3) e `fib_extension` (3). O chip de
+`placement_hint` avisa em texto, mas a forma sob o cursor não é a forma que
+está sendo criada, e é a forma que o trader lê.
+
+## Acceptance criteria
+
+1. **Arrastar fixa a linha, mover define a largura.** Press+drag+release em um
+   canal fixa a linha de tendência (âncoras 1 e 2); o movimento seguinte
+   arrasta a largura; o clique confirma. Nenhuma ferramenta de dois pontos
+   muda de comportamento.
+2. **Preview ao vivo é a forma final.** Entre a última âncora colocada e o
+   clique que falta, o chart pinta a ferramenta inteira sob o cursor — canal
+   com os dois trilhos e a midline, triângulo com os três lados, fib extension
+   com os níveis projetados — e não o esqueleto de linhas.
+3. **A porta é do trait, não um `match` por id.** O preview e o gesto entram
+   por método de `DrawingToolImpl` com implementação padrão igual ao
+   comportamento de hoje; ferramenta nova ganha o preview sem editar `pane.rs`.
+4. **Escape/Backspace continuam honestos** durante o gesto novo: Backspace
+   desfaz a última âncora, Escape cancela o rascunho inteiro, e nenhum dos dois
+   deixa objeto meio-feito na lista.
+5. **Revisão das quatro superfícies**: toolrail esquerda (`toolrail.rs`),
+   toolbar superior (`toolbar.rs`), action bar do objeto selecionado
+   (`drawings/action_bar.rs`) e context bar (`drawings/context_bar.rs`)
+   passam por `trader-ux-review` e `visual-qa`.
+6. **Todo Blocker e Should-fix da revisão corrigido**; o que sobra (nice-to-have)
+   é listado no corpo do PR, não corrigido em silêncio nem esquecido.
+7. **Testes headless** cobrem o gesto: arrastar em ferramenta de 3 pontos
+   deixa 2 âncoras e um rascunho vivo; o clique seguinte fecha o objeto com
+   largura não-nula; ferramenta de 2 pontos fecha no release como sempre.
+
+## Injected gates
+
+- [ ] `cargo fmt --all -- --check`
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
+- [ ] `cargo build --workspace`
+- [ ] `cargo test --workspace`
+- [ ] impacto de performance declarado por caminho — per-frame: preview do
+      rascunho e paint das barras; nada per-trade, nada per-depth
+- [ ] `ui-harness`: hook de env que abre cada superfície revisada, incluindo o
+      rascunho de canal em meio de gesto
+- [ ] `visual-qa` PASS ou defeitos aceitos explicitamente
+- [ ] `trader-ux-review` sem Blocker em aberto
+- [ ] `arch-review` com Blocker/Should-fix resolvidos ou deferidos no corpo do PR
+- [ ] PR aberto (merge não faz parte do goal)

--- a/.claude/skills/ui-harness/SKILL.md
+++ b/.claude/skills/ui-harness/SKILL.md
@@ -58,6 +58,12 @@ Landing with the drawing-toolbar goal (`feat/drawing-toolbar-pro`):
 | `QUANTICK_FRVP_DEMO=1` | one fixed-range volume profile placed on the flow pane once it has bars. When the pane carries a venue history prefix the range straddles the seam, so the partial-coverage label ("profile from N of M bars") is on screen — the honesty surface this hook photographs |
 | `QUANTICK_FRVP_DEMO=compare` | two adjacent profiles over the same stretch of liquidity map, one per over-heatmap mode (outline vs always-fill) — the silhouette decision's before/after in a single frame |
 
+Landing with the toolbar usability goal (`fix/toolbar-usability`):
+
+| Hook | Reaches |
+| --- | --- |
+| `QUANTICK_DRAWING_DRAFT=<anchors>` | the **half-placed** object: that many anchors of the tool armed by `QUANTICK_DRAWING_TOOL` already down, with the pointer parked where the next one would go. A draft's live preview is the whole feedback of a multi-anchor gesture, and it is the only surface that exists *between* two clicks — nothing else reaches it without a hand on the mouse. Clamped to one short of the tool's anchor count, so it always photographs a gesture in flight and never a finished object. `QUANTICK_DRAWING_TOOL=parallel-channel QUANTICK_DRAWING_DRAFT=2` is the channel mid-width, the state the "it draws a straight line" report was about |
+
 Landing with the drawing context bar goal (`feat/drawing-context-bar`):
 
 | Hook | Reaches |

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -83,6 +83,17 @@ const DEMO_ROW_BAND_STEP: f64 = 0.22;
 /// Points the demo hook gives a freehand tool, which declares no anchor
 /// count of its own. Enough to read as a path rather than as a line.
 const DEMO_FREEHAND_POINTS: usize = 4;
+/// How much of the visible window and of the visible price band the
+/// `QUANTICK_DRAWING_DRAFT` hook's anchors span. Wide enough that the
+/// half-made object reads at a glance, and centred, so the segment its
+/// anchors describe passes through the parked pointer at the chart's middle.
+///
+/// Much wider than it is tall, because a trend line a trader would actually
+/// draw runs *along* the tape. A near-vertical draft photographs the
+/// mechanism but nothing about whether the shape reads, which is what a QA
+/// reference image is for.
+const DEMO_DRAFT_SPAN: f32 = 0.6;
+const DEMO_DRAFT_BAND_SPAN: f64 = 0.12;
 /// The band to spread across before the pane has an auto-range to read (no
 /// bars yet): a fraction of price, since there is nothing better to ask.
 const DEMO_FALLBACK_BAND_FRACTION: f64 = 0.004;
@@ -606,6 +617,10 @@ pub struct QuantickApp {
     // Scripted-validation hook: one fixed-range volume profile straddling the
     // venue-prefix seam (when there is one). Consumed once.
     pending_frvp_demo: bool,
+    // Scripted-validation hook: how many anchors of the armed tool are already
+    // placed when the run opens, with the pointer parked where the next one
+    // would go. Consumed once.
+    pending_drawing_draft: Option<usize>,
     inspector_pos: Option<egui::Pos2>,
     // The floating panel's size as it was last actually drawn. Read back from
     // the window response rather than from egui's area memory: the memory
@@ -859,6 +874,7 @@ impl QuantickApp {
             context_bar: drawings::context_bar::ContextBar::default(),
             pending_drawing_demo: false,
             pending_frvp_demo: false,
+            pending_drawing_draft: None,
             inspector_pos: None,
             inspector_size: None,
             inspector_pin_touched: false,
@@ -956,6 +972,13 @@ impl QuantickApp {
         }
         app.pending_drawing_demo = std::env::var("QUANTICK_DRAWINGS_DEMO")
             .is_ok_and(|value| matches!(value.as_str(), "1" | "bands"));
+        // How many anchors of the armed tool are already down when the run
+        // opens — the half-placed state a screenshot cannot otherwise reach,
+        // because it lives between two clicks. See `apply_drawing_draft`.
+        app.pending_drawing_draft = std::env::var("QUANTICK_DRAWING_DRAFT")
+            .ok()
+            .and_then(|value| value.trim().parse::<usize>().ok())
+            .filter(|anchors| *anchors > 0);
         // One fixed-range volume profile, placed to straddle the venue-prefix
         // seam when there is one — the partial-coverage honesty label is a
         // surface, and this is how a validation run photographs it.
@@ -4916,6 +4939,84 @@ impl QuantickApp {
         self.apply_drawing_demo_recut();
     }
 
+    /// The `QUANTICK_DRAWING_DRAFT=<anchors>` hook: the tool armed by
+    /// `QUANTICK_DRAWING_TOOL`, part-placed, with the pointer parked where
+    /// the next anchor would go.
+    ///
+    /// The live preview of a half-made object is a surface like any other,
+    /// and for a multi-anchor tool it is the *whole* feedback of the gesture:
+    /// it is what tells the trader that a drag has fixed the trend line and a
+    /// click is owed for the width. It is also the one surface no click-free
+    /// launch could reach, because it exists only between two clicks and only
+    /// while a pointer is over the chart — so this hook does both halves.
+    ///
+    /// The anchors go down through `place_with`, the same call the click path
+    /// makes; nothing here is a parallel placement path. They straddle the
+    /// middle of the visible window so the line they draw runs through the
+    /// parked pointer — which is the exact spot the reported defect lived at,
+    /// the pointer standing on the trend line it just drew. A screenshot of
+    /// this state is a screenshot of the fix.
+    ///
+    /// Waits for bars, and is consumed once, for the same reasons
+    /// [`Self::apply_drawing_demo`] is.
+    fn apply_drawing_draft(&mut self) {
+        let Some(anchors) = self.pending_drawing_draft else {
+            return;
+        };
+        let Some(tool) = self.toolrail.tool().drawing_tool() else {
+            return;
+        };
+        // Bars first, and a chart rectangle to park a pointer in: both are
+        // answers only a drawn frame has.
+        let pane = &self.active_tab().flow_pane;
+        let slots = pane.slots();
+        let (Some(chart), true) = (pane.last_chart_area, slots > 0) else {
+            return;
+        };
+        self.pending_drawing_draft = None;
+        let pane = &mut self.active_tab_mut().flow_pane;
+        // One short of the count, whatever was asked for: a draft that
+        // completed itself is not a draft, and photographs as a finished
+        // object rather than as the gesture under test.
+        let anchors = anchors.min(tool.required_points().saturating_sub(1));
+        let visible = DEMO_VISIBLE_SLOTS.min(slots);
+        let first = slots - visible;
+        let close = pane
+            .closed_bar(slots.saturating_sub(1))
+            .and_then(|bar| rust_decimal::prelude::ToPrimitive::to_f64(&bar.close))
+            .unwrap_or(1.0);
+        let (centre, band) = pane
+            .last_auto_range
+            .filter(|(lo, hi)| hi > lo)
+            .map_or((close, close * DEMO_FALLBACK_BAND_FRACTION), |(lo, hi)| {
+                ((lo + hi) / 2.0, hi - lo)
+            });
+        for anchor in 0..anchors {
+            // Symmetric about the middle of the window, so the segment the
+            // anchors describe has the chart's own centre as its midpoint.
+            let offset = (anchor as f32 + 0.5) / anchors as f32 - 0.5;
+            let slot = ((first as f32 + visible as f32 * (0.5 + offset * DEMO_DRAFT_SPAN))
+                as usize)
+                .min(slots.saturating_sub(1));
+            let point = drawings::ChartPoint::at_time(
+                slot as f32 + 0.5,
+                centre + f64::from(offset) * band * DEMO_DRAFT_BAND_SPAN,
+                pane.slot_open_time(slot),
+            );
+            pane.drawings
+                .place_with(tool, &drawings::DrawingBand::Price, point, |tool| {
+                    drawings::NewDrawing {
+                        style: tool.default_style(),
+                        payload: tool.default_payload(),
+                    }
+                });
+        }
+        // The hand this run does not have. Parked on the line the anchors
+        // drew, which is where a real hand is sitting the instant a drag lets
+        // go — and where a channel used to be born with no width at all.
+        pane.parked_pointer = Some(chart.center());
+    }
+
     /// The `QUANTICK_FRVP_DEMO` hook: one fixed-range volume profile on the
     /// flow pane. When the pane carries a venue history prefix the range
     /// starts inside it, so the partial-coverage honesty label ("profile
@@ -5112,6 +5213,7 @@ impl QuantickApp {
 
         self.drain_tabs();
         self.apply_drawing_demo();
+        self.apply_drawing_draft();
         self.apply_frvp_demo();
         self.maybe_emit_summary(now);
         self.maintain_workspace(ctx);
@@ -8568,8 +8670,244 @@ plot(close)
         assert!(
             texts
                 .iter()
-                .any(|text| text.contains("Click the channel width")),
+                .any(|text| text.contains("Move to set the width")),
             "the draft must say what it is waiting for; painted: {texts:?}"
+        );
+    }
+
+    /// Twice the area of the triangle the three anchors make, in chart space.
+    /// Zero exactly when they are collinear — which for a channel means a
+    /// corridor of no width, and for a triangle no triangle.
+    fn anchor_cross(points: &[drawings::ChartPoint]) -> f64 {
+        let [a, b, c] = points else {
+            panic!("a three-anchor object, got {}", points.len());
+        };
+        (f64::from(b.bar) - f64::from(a.bar)) * (c.price - a.price)
+            - (f64::from(c.bar) - f64::from(a.bar)) * (b.price - a.price)
+    }
+
+    /// The reported defect, end to end: drag a channel, let go, click to
+    /// confirm what is on screen — and get a channel.
+    ///
+    /// The pointer is still standing on the trend line when the drag lets go,
+    /// and a channel's width is measured across that line and nowhere else.
+    /// So the width the pointer implied was exactly zero: the preview drew a
+    /// corridor of no width, which is a straight line, and the click that
+    /// looked like it confirmed the shape committed one — a three-anchor
+    /// object that is a line. The tool now refuses to be born degenerate
+    /// (`DrawingToolImpl::pending_anchor`), and the preview and the commit
+    /// come through the same door, so what is clicked is what is created.
+    #[test]
+    fn a_dragged_channel_is_born_a_corridor_and_not_a_line() {
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        run_frame(&mut app, &ctx);
+
+        arm_drawing_from_toolbox(&mut app, &ctx, "parallel-channel");
+        let release = egui::pos2(800.0, 340.0);
+        drag_chart(&mut app, &ctx, egui::pos2(600.0, 400.0), release);
+        assert_eq!(
+            app.active_tab().flow_pane.drawings.draft_len(),
+            2,
+            "the drag laid the trend line and the object waits for its width"
+        );
+        // Confirming without moving: the worst case, and the one a trader who
+        // expects the drag to have finished the object actually performs.
+        click_chart(&mut app, &ctx, release);
+
+        let channel = app
+            .active_tab()
+            .flow_pane
+            .drawings
+            .items()
+            .last()
+            .expect("the click committed the channel")
+            .clone();
+        assert_eq!(channel.tool.id(), "parallel-channel");
+        assert_eq!(channel.points.len(), 3);
+        assert!(
+            anchor_cross(&channel.points).abs() > 0.0,
+            "the width anchor is off the trend line; anchors {:?}",
+            channel.points
+        );
+    }
+
+    /// The same guarantee for the other tool whose third anchor gives a shape
+    /// its thickness: a triangle of three collinear corners is a line.
+    #[test]
+    fn a_dragged_triangle_is_born_with_an_area() {
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        run_frame(&mut app, &ctx);
+
+        arm_drawing_from_toolbox(&mut app, &ctx, "triangle");
+        let release = egui::pos2(800.0, 340.0);
+        drag_chart(&mut app, &ctx, egui::pos2(600.0, 400.0), release);
+        click_chart(&mut app, &ctx, release);
+
+        let triangle = app
+            .active_tab()
+            .flow_pane
+            .drawings
+            .items()
+            .last()
+            .expect("the click committed the triangle")
+            .clone();
+        assert_eq!(triangle.tool.id(), "triangle");
+        assert!(
+            anchor_cross(&triangle.points).abs() > 0.0,
+            "the third corner is off the first side; anchors {:?}",
+            triangle.points
+        );
+    }
+
+    /// What is under the cursor while the width is being set has to be a
+    /// *channel*. The complaint that opened this work was that it was a
+    /// straight line — and it was: the preview completed the geometry with
+    /// the pointer, the pointer was still on the trend line the drag drew,
+    /// and a corridor of no width is a line. Two rails means a corridor;
+    /// one stroke means the tool still looks broken.
+    #[test]
+    fn a_channel_being_shaped_previews_as_a_corridor() {
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        run_frame(&mut app, &ctx);
+
+        arm_drawing_from_toolbox(&mut app, &ctx, "parallel-channel");
+        let release = egui::pos2(800.0, 340.0);
+        drag_chart(&mut app, &ctx, egui::pos2(600.0, 400.0), release);
+        // The pointer has not moved since the release: the worst case, and
+        // the frame the trader is actually looking at.
+        let output =
+            run_frame_with_events(&mut app, &ctx, vec![egui::Event::PointerMoved(release)]);
+        assert_eq!(app.active_tab().flow_pane.drawings.draft_len(), 2);
+        let strokes = drawing_strokes(&output);
+        assert!(
+            strokes >= 2,
+            "both rails have to be on screen, painted {strokes} stroke(s)"
+        );
+    }
+
+    /// The harness hook's parked pointer stands in for a hand: the preview of
+    /// a half-placed object is a surface, and a run with nothing touching the
+    /// mouse must still be able to photograph it. It is read exactly where
+    /// the real pointer is read, so the preview it produces is the real one.
+    #[test]
+    fn a_parked_pointer_previews_the_draft_with_no_hand_on_the_mouse() {
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        run_frame(&mut app, &ctx);
+
+        arm_drawing_from_toolbox(&mut app, &ctx, "parallel-channel");
+        let release = egui::pos2(800.0, 340.0);
+        drag_chart(&mut app, &ctx, egui::pos2(600.0, 400.0), release);
+
+        // The hand leaves the window: with no pointer there is no anchor to
+        // complete the shape with, so the draft is back to the bare line the
+        // two placed anchors describe.
+        let gone = run_frame_with_events(&mut app, &ctx, vec![egui::Event::PointerGone]);
+        assert_eq!(
+            drawing_strokes(&gone),
+            1,
+            "only the trend line the anchors themselves make"
+        );
+
+        app.active_tab_mut().flow_pane.parked_pointer = Some(release);
+        let parked = run_frame(&mut app, &ctx);
+        assert!(
+            drawing_strokes(&parked) >= 2,
+            "the parked pointer brings the corridor back for the camera"
+        );
+    }
+
+    /// A tool of two anchors is finished by the release, exactly as it always
+    /// was: the shaping port must not have turned every drag into a gesture
+    /// that owes a click.
+    #[test]
+    fn a_two_anchor_tool_still_closes_on_the_release() {
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        run_frame(&mut app, &ctx);
+
+        arm_drawing_from_toolbox(&mut app, &ctx, "trend-line");
+        drag_chart(
+            &mut app,
+            &ctx,
+            egui::pos2(600.0, 400.0),
+            egui::pos2(800.0, 340.0),
+        );
+        let pane = &app.active_tab().flow_pane;
+        assert_eq!(pane.drawings.draft_len(), 0, "nothing is left in flight");
+        assert_eq!(
+            pane.drawings.items().last().map(|item| item.tool.id()),
+            Some("trend-line"),
+            "the release finished the object"
+        );
+    }
+
+    /// Escape during the shaping phase drops the whole draft and leaves no
+    /// half-made object behind — the trader's way out of a gesture they did
+    /// not mean to start.
+    #[test]
+    fn escape_drops_a_half_placed_channel_and_leaves_nothing_behind() {
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        run_frame(&mut app, &ctx);
+
+        arm_drawing_from_toolbox(&mut app, &ctx, "parallel-channel");
+        drag_chart(
+            &mut app,
+            &ctx,
+            egui::pos2(600.0, 400.0),
+            egui::pos2(800.0, 340.0),
+        );
+        assert_eq!(app.active_tab().flow_pane.drawings.draft_len(), 2);
+
+        run_frame_with_events(
+            &mut app,
+            &ctx,
+            vec![key_press_with(egui::Key::Escape, egui::Modifiers::NONE)],
+        );
+        let pane = &app.active_tab().flow_pane;
+        assert_eq!(pane.drawings.draft_len(), 0, "the draft is gone");
+        assert!(
+            pane.drawings.items().is_empty(),
+            "a cancelled draft is not a drawing; items {:?}",
+            pane.drawings.items().len()
+        );
+    }
+
+    /// Backspace steps back one anchor at a time, so a trader who mis-placed
+    /// the trend line fixes that one anchor instead of starting over. The
+    /// last step back ends the draft rather than leaving an anchor stranded.
+    #[test]
+    fn backspace_steps_back_one_anchor_of_a_channel_at_a_time() {
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        run_frame(&mut app, &ctx);
+
+        arm_drawing_from_toolbox(&mut app, &ctx, "parallel-channel");
+        drag_chart(
+            &mut app,
+            &ctx,
+            egui::pos2(600.0, 400.0),
+            egui::pos2(800.0, 340.0),
+        );
+        assert_eq!(app.active_tab().flow_pane.drawings.draft_len(), 2);
+
+        let backspace = || key_press_with(egui::Key::Backspace, egui::Modifiers::NONE);
+        run_frame_with_events(&mut app, &ctx, vec![backspace()]);
+        assert_eq!(
+            app.active_tab().flow_pane.drawings.draft_len(),
+            1,
+            "one anchor back, not the whole draft"
+        );
+        run_frame_with_events(&mut app, &ctx, vec![backspace()]);
+        let pane = &app.active_tab().flow_pane;
+        assert_eq!(pane.drawings.draft_len(), 0);
+        assert!(
+            pane.drawings.items().is_empty(),
+            "stepping back past the first anchor deletes nothing that exists"
         );
     }
 

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -8732,6 +8732,97 @@ plot(close)
         );
     }
 
+    /// A press-drag-release with a modifier held for the whole gesture.
+    fn drag_chart_with(
+        app: &mut QuantickApp,
+        ctx: &egui::Context,
+        start: egui::Pos2,
+        end: egui::Pos2,
+        modifiers: egui::Modifiers,
+    ) {
+        for events in [
+            vec![
+                egui::Event::PointerMoved(start),
+                pointer_button(start, true),
+            ],
+            vec![egui::Event::PointerMoved(end)],
+            vec![egui::Event::PointerMoved(end), pointer_button(end, false)],
+        ] {
+            run_frame_sized(app, ctx, TEST_WINDOW, events, modifiers);
+        }
+    }
+
+    /// Holding Shift while dragging the trend line lays the channel level, so
+    /// a range comes out flat instead of "nearly flat" — which a free hand
+    /// cannot produce and which no later gesture could fix by eye.
+    ///
+    /// End to end: the host reads the modifier, the tool decides what level
+    /// means for it, and the anchor that gets committed is the levelled one.
+    #[test]
+    fn holding_shift_lays_a_channel_dead_level() {
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        run_frame(&mut app, &ctx);
+
+        arm_drawing_from_toolbox(&mut app, &ctx, "parallel-channel");
+        drag_chart_with(
+            &mut app,
+            &ctx,
+            egui::pos2(600.0, 400.0),
+            // Well off the horizontal: without the modifier this is a channel
+            // sloping down across sixty pixels of price.
+            egui::pos2(800.0, 340.0),
+            egui::Modifiers::SHIFT,
+        );
+        let draft = app
+            .active_tab()
+            .flow_pane
+            .drawings
+            .draft()
+            .expect("the drag laid the trend line")
+            .clone();
+        assert_eq!(draft.points.len(), 2);
+        assert!(
+            (draft.points[0].price - draft.points[1].price).abs() < 1e-9,
+            "both ends of the trend line sit on one price: {:?}",
+            draft.points
+        );
+        assert!(
+            draft.points[1].bar > draft.points[0].bar,
+            "and it still ran along the tape: {:?}",
+            draft.points
+        );
+    }
+
+    /// The same drag without the modifier keeps the slope the hand gave it —
+    /// the constraint is opt-in, never a snap the trader did not ask for.
+    #[test]
+    fn without_shift_a_channel_keeps_the_slope_it_was_drawn_with() {
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        run_frame(&mut app, &ctx);
+
+        arm_drawing_from_toolbox(&mut app, &ctx, "parallel-channel");
+        drag_chart(
+            &mut app,
+            &ctx,
+            egui::pos2(600.0, 400.0),
+            egui::pos2(800.0, 340.0),
+        );
+        let draft = app
+            .active_tab()
+            .flow_pane
+            .drawings
+            .draft()
+            .expect("the drag laid the trend line")
+            .clone();
+        assert!(
+            (draft.points[0].price - draft.points[1].price).abs() > 1e-6,
+            "the trend line kept its slope: {:?}",
+            draft.points
+        );
+    }
+
     /// The same guarantee for the other tool whose third anchor gives a shape
     /// its thickness: a triangle of three collinear corners is a line.
     #[test]

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -9059,6 +9059,76 @@ plot(close)
         );
     }
 
+    /// Shift on a **corner of a finished channel**, driven through the real
+    /// app rather than through the tool alone.
+    ///
+    /// The tool-level test proves the geometry; this proves the wiring, and
+    /// the two are not the same claim. The host reads the modifier in a
+    /// different place for editing than for placing, and a `Constrain::Free`
+    /// left behind in that second place would pass every unit test while the
+    /// feature was dead in the trader's hands — which is exactly the shape of
+    /// the preview-versus-commit split this PR started from.
+    #[test]
+    fn shift_on_a_corner_levels_a_channel_through_the_app() {
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        run_frame(&mut app, &ctx);
+        arm_drawing_from_toolbox(&mut app, &ctx, "parallel-channel");
+
+        let corner = egui::pos2(800.0, 340.0);
+        click_chart_with(
+            &mut app,
+            &ctx,
+            egui::pos2(600.0, 400.0),
+            egui::Modifiers::NONE,
+        );
+        click_chart_with(&mut app, &ctx, corner, egui::Modifiers::NONE);
+        click_chart_with(
+            &mut app,
+            &ctx,
+            egui::pos2(800.0, 460.0),
+            egui::Modifiers::NONE,
+        );
+        run_frame(&mut app, &ctx);
+
+        let before = app
+            .active_tab()
+            .flow_pane
+            .drawings
+            .items()
+            .last()
+            .expect("the channel was placed")
+            .clone();
+        assert!(
+            (before.points[0].price - before.points[1].price).abs() > 1e-6,
+            "it starts sloped, or there is nothing to straighten: {:?}",
+            before.points
+        );
+
+        // Grab that same corner and carry it somewhere plainly not level.
+        drag_chart_with(
+            &mut app,
+            &ctx,
+            corner,
+            egui::pos2(860.0, 290.0),
+            egui::Modifiers::SHIFT,
+        );
+
+        let after = app
+            .active_tab()
+            .flow_pane
+            .drawings
+            .items()
+            .last()
+            .expect("the channel is still there")
+            .clone();
+        assert!(
+            (after.points[0].price - after.points[1].price).abs() < 1e-9,
+            "the corner drag straightened it: {:?}",
+            after.points
+        );
+    }
+
     /// A press and release a few pixels apart — the wander an ordinary click
     /// carries — must stay a click.
     ///

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -94,6 +94,15 @@ const DEMO_FREEHAND_POINTS: usize = 4;
 /// reference image is for.
 const DEMO_DRAFT_SPAN: f32 = 0.6;
 const DEMO_DRAFT_BAND_SPAN: f64 = 0.12;
+/// Where the parked pointer stands when a single anchor is down, as a
+/// fraction of the chart from its centre.
+///
+/// A lone anchor sits at that centre, so parking the pointer there too gives
+/// a rubber band of no length — an invisible draft, which is the one thing
+/// this hook exists not to photograph. Offset, there is a line to see, and it
+/// is a *sloped* one, which is what makes the levelled state worth its own
+/// capture.
+const DEMO_DRAFT_POINTER_OFFSET: egui::Vec2 = egui::vec2(0.2, -0.15);
 /// The band to spread across before the pane has an auto-range to read (no
 /// bars yet): a fraction of price, since there is nothing better to ask.
 const DEMO_FALLBACK_BAND_FRACTION: f64 = 0.004;
@@ -5014,7 +5023,34 @@ impl QuantickApp {
         // The hand this run does not have. Parked on the line the anchors
         // drew, which is where a real hand is sitting the instant a drag lets
         // go — and where a channel used to be born with no width at all.
-        pane.parked_pointer = Some(chart.center());
+        //
+        // `QUANTICK_DRAWING_CONSTRAIN=1` presses Shift for it. The levelled
+        // draft is a state of its own — a corridor held flat looks different
+        // from one following the pointer — and a modifier is the one input a
+        // capture run cannot supply any other way.
+        // With two anchors down the pointer belongs *on* the line they drew —
+        // the exact spot the reported defect lived at. With one, that spot is
+        // the anchor itself, so it steps aside far enough to leave a rubber
+        // band worth looking at.
+        let parked = if anchors >= 2 {
+            chart.center()
+        } else {
+            chart.center()
+                + egui::vec2(
+                    chart.width() * DEMO_DRAFT_POINTER_OFFSET.x,
+                    chart.height() * DEMO_DRAFT_POINTER_OFFSET.y,
+                )
+        };
+        pane.parked_hand = Some(pane::ParkedHand {
+            position: parked,
+            constrain: if std::env::var("QUANTICK_DRAWING_CONSTRAIN")
+                .is_ok_and(|value| value == "1")
+            {
+                drawings::Constrain::Level
+            } else {
+                drawings::Constrain::Free
+            },
+        });
     }
 
     /// The `QUANTICK_FRVP_DEMO` hook: one fixed-range volume profile on the
@@ -8430,6 +8466,46 @@ plot(close)
         );
     }
 
+    /// A click with a modifier held, and the move that carries the pointer
+    /// there — the click-move-click half of a placement, as opposed to a drag.
+    fn click_chart_with(
+        app: &mut QuantickApp,
+        ctx: &egui::Context,
+        position: egui::Pos2,
+        modifiers: egui::Modifiers,
+    ) {
+        for pressed in [true, false] {
+            run_frame_sized(
+                app,
+                ctx,
+                TEST_WINDOW,
+                vec![
+                    egui::Event::PointerMoved(position),
+                    pointer_button(position, pressed),
+                ],
+                modifiers,
+            );
+        }
+    }
+
+    /// Move the pointer without pressing anything, and answer what got
+    /// painted — the frames between two clicks, which is where a placement
+    /// gesture does all of its talking.
+    fn move_chart_with(
+        app: &mut QuantickApp,
+        ctx: &egui::Context,
+        position: egui::Pos2,
+        modifiers: egui::Modifiers,
+    ) -> egui::FullOutput {
+        run_frame_sized(
+            app,
+            ctx,
+            TEST_WINDOW,
+            vec![egui::Event::PointerMoved(position)],
+            modifiers,
+        )
+    }
+
     fn drag_chart(app: &mut QuantickApp, ctx: &egui::Context, start: egui::Pos2, end: egui::Pos2) {
         run_frame_with_events(
             app,
@@ -8823,6 +8899,206 @@ plot(close)
         );
     }
 
+    /// The price the trend line holds at `bar` — the height the width anchor
+    /// is measured above or below.
+    fn trend_price_at(points: &[drawings::ChartPoint], bar: f32) -> f64 {
+        let (a, b) = (&points[0], &points[1]);
+        let span = f64::from(b.bar - a.bar);
+        if span.abs() < 1e-9 {
+            return a.price;
+        }
+        a.price + (b.price - a.price) * f64::from(bar - a.bar) / span
+    }
+
+    /// The whole gesture, walked the way a trader describes it: click, move
+    /// and watch a straight line follow, click again to fix it, then move and
+    /// watch the corridor open, and click to place.
+    ///
+    /// Written from a trader's own account of how this must behave, so each
+    /// step asserts what is *on screen* at that step and not merely the state
+    /// behind it — a placement gesture does all of its talking in the frames
+    /// between the clicks.
+    #[test]
+    fn the_channel_walks_the_gesture_a_trader_describes() {
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        run_frame(&mut app, &ctx);
+        arm_drawing_from_toolbox(&mut app, &ctx, "parallel-channel");
+
+        let (first, second, width) = (
+            egui::pos2(600.0, 400.0),
+            egui::pos2(800.0, 340.0),
+            // Well below the trend line: the corridor must open downward.
+            egui::pos2(800.0, 460.0),
+        );
+
+        click_chart_with(&mut app, &ctx, first, egui::Modifiers::NONE);
+        assert_eq!(
+            app.active_tab().flow_pane.drawings.draft_len(),
+            1,
+            "the first click anchors the trend line"
+        );
+
+        // Moving between the first and second click shows a straight line and
+        // nothing else — there is no width yet to draw.
+        let output = move_chart_with(&mut app, &ctx, second, egui::Modifiers::NONE);
+        assert_eq!(
+            drawing_strokes(&output),
+            1,
+            "only the line between the anchor and the pointer"
+        );
+
+        click_chart_with(&mut app, &ctx, second, egui::Modifiers::NONE);
+        assert_eq!(
+            app.active_tab().flow_pane.drawings.draft_len(),
+            2,
+            "the second click fixes the trend line"
+        );
+
+        // From here every movement opens the corridor.
+        let output = move_chart_with(&mut app, &ctx, width, egui::Modifiers::NONE);
+        assert!(
+            drawing_strokes(&output) >= 2,
+            "both rails follow the pointer now, painted {}",
+            drawing_strokes(&output)
+        );
+
+        click_chart_with(&mut app, &ctx, width, egui::Modifiers::NONE);
+        let channel = app
+            .active_tab()
+            .flow_pane
+            .drawings
+            .items()
+            .last()
+            .expect("the third click placed the channel")
+            .clone();
+        assert_eq!(channel.points.len(), 3);
+        assert!(
+            channel.points[2].price < trend_price_at(&channel.points, channel.points[2].bar),
+            "the corridor opened downward, the way the pointer moved: {:?}",
+            channel.points
+        );
+    }
+
+    /// The corridor grows on the side the hand went, both ways. A channel
+    /// that always opened the same way would be a coin toss the trader has to
+    /// correct by hand every other time.
+    #[test]
+    fn the_corridor_opens_on_the_side_the_pointer_moved() {
+        for (label, width_at, opens_below) in [
+            ("down", egui::pos2(800.0, 460.0), true),
+            ("up", egui::pos2(800.0, 220.0), false),
+        ] {
+            let (mut app, _commands) = app_with_history(200);
+            let ctx = egui::Context::default();
+            run_frame(&mut app, &ctx);
+            arm_drawing_from_toolbox(&mut app, &ctx, "parallel-channel");
+            drag_chart(
+                &mut app,
+                &ctx,
+                egui::pos2(600.0, 400.0),
+                egui::pos2(800.0, 340.0),
+            );
+            click_chart_with(&mut app, &ctx, width_at, egui::Modifiers::NONE);
+
+            let channel = app
+                .active_tab()
+                .flow_pane
+                .drawings
+                .items()
+                .last()
+                .expect("the click placed the channel")
+                .clone();
+            let line = trend_price_at(&channel.points, channel.points[2].bar);
+            assert_eq!(
+                channel.points[2].price < line,
+                opens_below,
+                "moving {label} opens the corridor {label}: {:?}",
+                channel.points
+            );
+        }
+    }
+
+    /// Shift on the click-move-click path, not just on the drag: the same
+    /// gesture placed a different way must mean the same thing, and a trader
+    /// who places by clicks is not a trader who wants a sloped range.
+    #[test]
+    fn holding_shift_levels_a_channel_placed_by_clicks() {
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        run_frame(&mut app, &ctx);
+        arm_drawing_from_toolbox(&mut app, &ctx, "parallel-channel");
+
+        click_chart_with(
+            &mut app,
+            &ctx,
+            egui::pos2(600.0, 400.0),
+            egui::Modifiers::NONE,
+        );
+        // The second click lands well below the first, which without the
+        // modifier is a channel sloping down across sixty pixels of price.
+        click_chart_with(
+            &mut app,
+            &ctx,
+            egui::pos2(800.0, 460.0),
+            egui::Modifiers::SHIFT,
+        );
+
+        let draft = app
+            .active_tab()
+            .flow_pane
+            .drawings
+            .draft()
+            .expect("two clicks laid the trend line")
+            .clone();
+        assert_eq!(draft.points.len(), 2);
+        assert!(
+            (draft.points[0].price - draft.points[1].price).abs() < 1e-9,
+            "clicking below still lands level: {:?}",
+            draft.points
+        );
+    }
+
+    /// The same modifier on the trend line, which is the tool a trader
+    /// reaches for when they want a level in the first place. A two-anchor
+    /// tool finishes on the release, so this proves the constraint survives
+    /// the path where placement and completion are the same event.
+    #[test]
+    fn holding_shift_lays_a_trend_line_dead_level() {
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        run_frame(&mut app, &ctx);
+
+        arm_drawing_from_toolbox(&mut app, &ctx, "trend-line");
+        drag_chart_with(
+            &mut app,
+            &ctx,
+            egui::pos2(600.0, 400.0),
+            egui::pos2(800.0, 340.0),
+            egui::Modifiers::SHIFT,
+        );
+        let line = app
+            .active_tab()
+            .flow_pane
+            .drawings
+            .items()
+            .last()
+            .expect("the release finished the trend line")
+            .clone();
+        assert_eq!(line.tool.id(), "trend-line");
+        assert_eq!(line.points.len(), 2);
+        assert!(
+            (line.points[0].price - line.points[1].price).abs() < 1e-9,
+            "both ends sit on one price: {:?}",
+            line.points
+        );
+        assert!(
+            line.points[1].bar > line.points[0].bar,
+            "and it still ran along the tape: {:?}",
+            line.points
+        );
+    }
+
     /// The same guarantee for the other tool whose third anchor gives a shape
     /// its thickness: a triangle of three collinear corners is a line.
     #[test]
@@ -8903,7 +9179,10 @@ plot(close)
             "only the trend line the anchors themselves make"
         );
 
-        app.active_tab_mut().flow_pane.parked_pointer = Some(release);
+        app.active_tab_mut().flow_pane.parked_hand = Some(pane::ParkedHand {
+            position: release,
+            constrain: drawings::Constrain::Free,
+        });
         let parked = run_frame(&mut app, &ctx);
         assert!(
             drawing_strokes(&parked) >= 2,

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -9059,6 +9059,90 @@ plot(close)
         );
     }
 
+    /// A press and release a few pixels apart — the wander an ordinary click
+    /// carries — must stay a click.
+    ///
+    /// Reported from the running build against the fixed-range profile: a
+    /// click placed **both** anchors, so the object was born less than one
+    /// bar wide, and completing it disarmed the tool. The pointer moving
+    /// afterwards then did nothing, which reads exactly like a frozen chart:
+    /// the trader is waiting for a range to follow their hand and there is no
+    /// longer a draft to follow it.
+    ///
+    /// The gesture must instead become the click-move-click the hand was
+    /// already doing — draft alive, tool still armed, preview following.
+    #[test]
+    fn a_click_that_wanders_a_few_pixels_is_still_a_click() {
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        run_frame(&mut app, &ctx);
+        arm_drawing_from_toolbox(&mut app, &ctx, "fixed-range-profile");
+
+        let press = egui::pos2(600.0, 400.0);
+        // Five pixels: inside the tremor of a real click, and it used to be
+        // enough to finish the object.
+        let release = egui::pos2(605.0, 400.0);
+        run_frame_with_events(
+            &mut app,
+            &ctx,
+            vec![
+                egui::Event::PointerMoved(press),
+                pointer_button(press, true),
+            ],
+        );
+        run_frame_with_events(
+            &mut app,
+            &ctx,
+            vec![
+                egui::Event::PointerMoved(release),
+                pointer_button(release, false),
+            ],
+        );
+
+        assert!(
+            app.active_tab().flow_pane.drawings.items().is_empty(),
+            "a click is not an object"
+        );
+        assert_eq!(
+            app.active_tab().flow_pane.drawings.draft_len(),
+            1,
+            "it anchored one end and is waiting for the other"
+        );
+        assert_eq!(
+            app.toolrail
+                .tool()
+                .drawing_tool()
+                .map(drawings::DrawingTool::id),
+            Some("fixed-range-profile"),
+            "and the tool is still armed, so the range can still follow the hand"
+        );
+
+        // The half of the gesture the trader was waiting for: the preview
+        // follows, and the next click finishes a range worth having.
+        let far = egui::pos2(900.0, 400.0);
+        let output = move_chart_with(&mut app, &ctx, far, egui::Modifiers::NONE);
+        assert!(
+            drawing_strokes(&output) >= 2,
+            "both edges of the range follow the pointer, painted {}",
+            drawing_strokes(&output)
+        );
+        click_chart_with(&mut app, &ctx, far, egui::Modifiers::NONE);
+
+        let profile = app
+            .active_tab()
+            .flow_pane
+            .drawings
+            .items()
+            .last()
+            .expect("the second click placed the profile")
+            .clone();
+        assert!(
+            (profile.points[1].bar - profile.points[0].bar).abs() > 1.0,
+            "and it spans real bars, not a fraction of one: {:?}",
+            profile.points
+        );
+    }
+
     /// The same modifier on the trend line, which is the tool a trader
     /// reaches for when they want a level in the first place. A two-anchor
     /// tool finishes on the release, so this proves the constraint survives

--- a/crates/app/src/drawings/brush.rs
+++ b/crates/app/src/drawings/brush.rs
@@ -15,7 +15,7 @@ use eframe::egui;
 use egui_phosphor::regular as icons;
 
 use super::{
-    DrawContext, DrawingStyle, DrawingToolImpl, Handles, ToolFamily, ToolShortcut,
+    Constrain, DrawContext, DrawingStyle, DrawingToolImpl, Handles, ToolFamily, ToolShortcut,
     distance_to_segment,
 };
 
@@ -93,6 +93,7 @@ impl DrawingToolImpl for Brush {
         _handle: usize,
         _to: egui::Pos2,
         _ctxt: &DrawContext<'_>,
+        _constrain: Constrain,
     ) -> Option<Handles> {
         // Unreachable: there are no handles to drag. Answered explicitly
         // because the port asks a tool that owns its handles to own their

--- a/crates/app/src/drawings/fib_extension.rs
+++ b/crates/app/src/drawings/fib_extension.rs
@@ -21,11 +21,20 @@ impl DrawingToolImpl for FibExtension {
     fn icon(&self) -> &'static str {
         icons::ROWS_PLUS_TOP
     }
+    /// No key is named here, and that is deliberate: this tool gave up
+    /// `Shift+F` because that key flattens the position (see
+    /// [`Self::shortcut`]). The tooltip went on advertising it long after,
+    /// which told the trader to press the one key that closes their position
+    /// to reach a drawing tool.
     fn hover_text(&self) -> &'static str {
-        "Fib extension - set the first leg, then click the projection origin (Shift+F)"
+        "Fib extension - drag the first leg, then click the projection origin"
     }
     fn placement_hint(&self, placed: usize) -> Option<&'static str> {
-        (placed == 2).then_some("Click where the retracement ended")
+        match placed {
+            1 => Some("Drag out the first leg"),
+            2 => Some("Click where the retracement ended"),
+            _ => None,
+        }
     }
     fn required_points(&self) -> usize {
         FibKind::Extension.required_points()

--- a/crates/app/src/drawings/fixed_range_profile.rs
+++ b/crates/app/src/drawings/fixed_range_profile.rs
@@ -23,8 +23,8 @@ use std::any::Any;
 
 use super::measure_core::MEASURE_FAMILY;
 use super::{
-    DrawContext, Drawing, DrawingPayload, DrawingStyle, DrawingToolImpl, Handles, PresetHost,
-    drawing_stroke,
+    Constrain, DrawContext, Drawing, DrawingPayload, DrawingStyle, DrawingToolImpl, Handles,
+    PresetHost, drawing_stroke,
 };
 use crate::chart::to_f64;
 use crate::theme;
@@ -867,6 +867,8 @@ impl DrawingToolImpl for FixedRangeProfile {
         handle: usize,
         to: egui::Pos2,
         _ctxt: &DrawContext<'_>,
+        // A range is two instants and no angle; nothing to hold level.
+        _constrain: Constrain,
     ) -> Option<Handles> {
         if points.len() < 2 || handle >= 2 {
             return None;
@@ -1043,7 +1045,7 @@ mod tests {
         // Dragging the right handle left shrinks the range: only that
         // anchor's x moves, both ys (prices) stay put.
         let dragged = TOOL
-            .drag_handle(chart_rect, &points, 1, egui::pos2(180.0, 350.0), &ctxt)
+            .drag_handle(chart_rect, &points, 1, egui::pos2(180.0, 350.0), &ctxt, Constrain::Free)
             .expect("tool owns the gesture");
         assert_eq!(dragged.as_slice(), &[
             egui::pos2(100.0, 120.0),

--- a/crates/app/src/drawings/line_core.rs
+++ b/crates/app/src/drawings/line_core.rs
@@ -10,7 +10,25 @@
 use eframe::egui;
 use egui_phosphor::regular as icons;
 
-use super::{DrawingStyle, ToolFamily, distance_to_segment, drawing_stroke};
+use super::{Constrain, DrawingStyle, ToolFamily, distance_to_segment, drawing_stroke, level_with};
+
+/// The far end of a two-point line while the trader holds Shift: level with
+/// the end it started from, and still free to slide along the tape.
+///
+/// Shared here rather than written out per tool, because "a line held level"
+/// is one rule and every tool built on this core wants the same one. A tool
+/// adopts it by forwarding its shaping port to this and nothing else, which
+/// is what keeps the gesture meaning the same thing everywhere it exists.
+pub(super) fn levelled_far_end(
+    placed: &[egui::Pos2],
+    cursor: egui::Pos2,
+    constrain: Constrain,
+) -> egui::Pos2 {
+    match (placed, constrain) {
+        ([start], Constrain::Level) => level_with(*start, cursor),
+        _ => cursor,
+    }
+}
 
 /// The one rail family every straight-line tool declares. Shared here so
 /// the members cannot drift apart on the title or the pre-arm icon.

--- a/crates/app/src/drawings/mod.rs
+++ b/crates/app/src/drawings/mod.rs
@@ -1753,6 +1753,25 @@ mod tests {
         assert_eq!(shaping, vec!["parallel-channel", "triangle"]);
     }
 
+    /// Which tools Shift means something to, named exactly. Everything else
+    /// answers with the pointer, so a trader holding the modifier out of
+    /// habit on some other tool gets no surprise — and a tool that *should*
+    /// answer to it fails here until it is listed.
+    #[test]
+    fn shift_reaches_exactly_the_tools_with_an_angle_to_hold() {
+        // One anchor down: the far end of a line, which is the step the
+        // modifier is about for every tool that has one.
+        let placed = [egui::pos2(10.0, 10.0)];
+        let cursor = egui::pos2(110.0, 60.0);
+        let mut levelled: Vec<&'static str> = DRAWING_TOOLS
+            .into_iter()
+            .filter(|tool| tool.pending_anchor(&placed, cursor, Constrain::Level) != cursor)
+            .map(DrawingTool::id)
+            .collect();
+        levelled.sort_unstable();
+        assert_eq!(levelled, vec!["parallel-channel", "trend-line"]);
+    }
+
     /// The host skips the shaping port for a freehand draft, and the reason
     /// is runtime: a pencil stroke holds hundreds of anchors, and projecting
     /// every one of them up to three times a frame just to consult the port

--- a/crates/app/src/drawings/mod.rs
+++ b/crates/app/src/drawings/mod.rs
@@ -265,6 +265,31 @@ trait DrawingToolImpl: Sync {
     fn placement_hint(&self, _placed: usize) -> Option<&'static str> {
         None
     }
+    /// Where the anchor the trader is still shaping really lands, given the
+    /// anchors already down and the pointer — both in screen space.
+    ///
+    /// Default: the pointer itself, which is every tool whose anchors mean
+    /// exactly where they were dropped.
+    ///
+    /// It exists because a tool of three anchors has a *shaping* phase the
+    /// raw pointer describes badly. A drag fixes a channel's trend line and
+    /// lets go with the pointer still sitting **on** that line, and a
+    /// channel's width is measured across the line and nowhere else — so the
+    /// width the pointer implies at that instant is exactly zero. The preview
+    /// draws a corridor of no width, which is a straight line, and the click
+    /// that looks like it confirms the shape commits one: a three-anchor
+    /// object that *is* a line. A tool that knows what it is refuses to be
+    /// born degenerate, and says so here rather than leaving the host to
+    /// special-case it by id.
+    ///
+    /// The host runs the preview *and* the commit through this, so the object
+    /// a click creates is always the one that was on screen when it was
+    /// clicked.
+    ///
+    /// Rate: per frame while a draft is in flight, over a handful of anchors.
+    fn pending_anchor(&self, _placed: &[egui::Pos2], cursor: egui::Pos2) -> egui::Pos2 {
+        cursor
+    }
     /// The key that arms this tool from the chart, if it has one.
     fn shortcut(&self) -> Option<ToolShortcut> {
         None
@@ -556,6 +581,13 @@ impl DrawingTool {
     #[must_use]
     pub fn placement_hint(self, placed: usize) -> Option<&'static str> {
         self.0.placement_hint(placed)
+    }
+
+    /// Where the anchor under the pointer really lands while the object is
+    /// still being shaped — see [`DrawingToolImpl::pending_anchor`].
+    #[must_use]
+    pub fn pending_anchor(self, placed: &[egui::Pos2], cursor: egui::Pos2) -> egui::Pos2 {
+        self.0.pending_anchor(placed, cursor)
     }
 
     /// Paint the object. Selection adds a halo *under* the geometry and, when
@@ -1555,6 +1587,44 @@ pub(super) fn distance_to_segment(position: egui::Pos2, start: egui::Pos2, end: 
     position.distance(start + segment * projection)
 }
 
+/// The unit normal of `direction` — the axis a shape's thickness is measured
+/// along. A direction of no length has no normal of its own, so it is given
+/// the vertical, which is the axis a chart measures in.
+pub(super) fn unit_normal(direction: egui::Vec2) -> egui::Vec2 {
+    let length = direction.length();
+    if length <= f32::EPSILON {
+        return egui::vec2(0.0, 1.0);
+    }
+    egui::vec2(-direction.y, direction.x) / length
+}
+
+/// Push `cursor` off the line through `start`–`end` until it stands at least
+/// `floor_px` away from it, keeping exactly where it sits *along* that line.
+///
+/// The shared half of [`DrawingToolImpl::pending_anchor`]: a tool whose third
+/// anchor gives a shape its thickness is degenerate when that anchor lands on
+/// the line the first two drew — a channel of no width, a triangle of no
+/// area — and that is precisely where the pointer is standing the instant a
+/// drag lets go. Sliding *along* the line is left alone, so the gesture still
+/// means what it always meant; only the collapsed case is refused.
+///
+/// A cursor exactly on the line opens the shape on the normal's own side, so
+/// the same gesture always produces the same object.
+pub(super) fn off_line_by(
+    start: egui::Pos2,
+    end: egui::Pos2,
+    cursor: egui::Pos2,
+    floor_px: f32,
+) -> egui::Pos2 {
+    let normal = unit_normal(end - start);
+    let offset = (cursor - start).dot(normal);
+    if offset.abs() >= floor_px {
+        return cursor;
+    }
+    let side = if offset < 0.0 { -1.0 } else { 1.0 };
+    cursor + normal * (side * floor_px - offset)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1591,6 +1661,105 @@ mod tests {
                 tool.id()
             );
         }
+    }
+
+    /// A tool of three or more anchors says what every step wants, in words.
+    ///
+    /// Two anchors need no words: the drag that starts the object also
+    /// finishes it, so the trader is never left holding one. The third anchor
+    /// is where they get stranded — the gesture ends, the object sits there,
+    /// and the `n/N` badge is on the far side of the screen from the cursor.
+    /// A new tool that stays silent mid-placement fails here rather than in
+    /// the running app.
+    #[test]
+    fn a_tool_that_outlasts_its_drag_says_what_each_step_wants() {
+        for tool in DRAWING_TOOLS
+            .into_iter()
+            .filter(|tool| tool.required_points() >= 3)
+        {
+            for placed in 1..tool.required_points() {
+                assert!(
+                    tool.placement_hint(placed).is_some(),
+                    "{} says nothing with {placed} anchors down",
+                    tool.id()
+                );
+            }
+        }
+    }
+
+    /// The shaping port is opt-in: it changed nothing for a tool that did not
+    /// ask for it. Only the two whose third anchor gives a shape its
+    /// thickness — and which are therefore the two that can collapse into a
+    /// line — move the pointer at all.
+    #[test]
+    fn the_shaping_port_defaults_to_the_pointer_the_trader_is_holding() {
+        let placed = [egui::pos2(10.0, 10.0), egui::pos2(110.0, 60.0)];
+        // Exactly on the line between the two anchors: the collapsed case,
+        // where a tool that shapes has to move and one that does not must not.
+        let cursor = egui::pos2(60.0, 35.0);
+        let mut shaping: Vec<&'static str> = DRAWING_TOOLS
+            .into_iter()
+            .filter(|tool| tool.pending_anchor(&placed, cursor) != cursor)
+            .map(DrawingTool::id)
+            .collect();
+        shaping.sort_unstable();
+        assert_eq!(shaping, vec!["parallel-channel", "triangle"]);
+    }
+
+    /// The host skips the shaping port for a freehand draft, and the reason
+    /// is runtime: a pencil stroke holds hundreds of anchors, and projecting
+    /// every one of them up to three times a frame just to consult the port
+    /// would cost far more than the gesture is worth — see
+    /// `ChartPane::shaped_placement`.
+    ///
+    /// That skip is only sound while no freehand tool actually wants its
+    /// anchors shaped; otherwise the host would be ignoring a tool that
+    /// asked, in silence. This is the test that holds the two facts together,
+    /// so a pencil that one day wants shaping fails here instead of being
+    /// quietly disobeyed.
+    #[test]
+    fn no_freehand_tool_asks_to_shape_its_anchors() {
+        let placed = [egui::pos2(10.0, 10.0), egui::pos2(110.0, 60.0)];
+        let cursor = egui::pos2(60.0, 35.0);
+        for tool in DRAWING_TOOLS.into_iter().filter(|tool| tool.freehand()) {
+            assert_eq!(
+                tool.pending_anchor(&placed, cursor),
+                cursor,
+                "{} is freehand, and the host does not consult the port for one",
+                tool.id()
+            );
+        }
+    }
+
+    /// The shared half of the port: push off the line, keep the position
+    /// along it.
+    #[test]
+    fn off_line_by_moves_across_the_line_and_never_along_it() {
+        let start = egui::pos2(0.0, 0.0);
+        let end = egui::pos2(100.0, 0.0);
+        let pushed = off_line_by(start, end, egui::pos2(40.0, 1.0), 10.0);
+        assert!(
+            (pushed.x - 40.0).abs() < 1e-3,
+            "kept its place along the line"
+        );
+        assert!((pushed.y - 10.0).abs() < 1e-3, "stands the floor off it");
+        let clear = egui::pos2(40.0, -25.0);
+        assert_eq!(
+            off_line_by(start, end, clear, 10.0),
+            clear,
+            "a point already clear is untouched"
+        );
+    }
+
+    /// A "line" whose ends are one point has no direction of its own. It gets
+    /// the vertical, which is the axis a chart measures in — the alternative
+    /// is a NaN anchor, which is an object that can never be drawn or deleted.
+    #[test]
+    fn a_line_of_no_length_still_pushes_off_itself() {
+        let point = egui::pos2(50.0, 50.0);
+        let pushed = off_line_by(point, point, point, 10.0);
+        assert!(pushed.is_finite());
+        assert!((pushed.y - 60.0).abs() < 1e-3, "pushed along the vertical");
     }
 
     /// A price-only tool started over an indicator band still lands on the

--- a/crates/app/src/drawings/mod.rs
+++ b/crates/app/src/drawings/mod.rs
@@ -205,6 +205,37 @@ pub struct DrawContext<'a> {
     pub halo: bool,
 }
 
+/// What the trader is holding down while they shape an object.
+///
+/// Shift is free to take during a chart drag, and that is worth stating
+/// because Shift is otherwise the trading modifier: every paper-trading
+/// hotkey is Shift **plus a letter** (`docs/ux/paper-trading.md` §9) and the
+/// rail's tool keys are letters too, so the modifier held on its own cannot
+/// fire an order, flatten a position or arm a tool. Holding it while the hand
+/// is on the mouse costs nothing and collides with nothing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Constrain {
+    /// The pointer means exactly where it is.
+    #[default]
+    Free,
+    /// Shift is down: hold the shape level.
+    Level,
+}
+
+/// Hold `cursor` level with `anchor` — the same height, free to slide along
+/// the tape.
+///
+/// Level, and not "the nearest of 0°/45°/90°", because a chart's two axes are
+/// not the same kind of thing: one is a price and the other is time, their
+/// ratio changes with every zoom, and a 45° line drawn today is a different
+/// line after one scroll. Horizontal is the only angle that survives a zoom,
+/// and it is the one that means something — a level *is* a price a trader is
+/// holding constant. Vertical is an instant, which is what the vertical-line
+/// tool is for.
+pub(super) fn level_with(anchor: egui::Pos2, cursor: egui::Pos2) -> egui::Pos2 {
+    egui::pos2(cursor.x, anchor.y)
+}
+
 /// Where a tool wants its anchor to land on the bar under the pointer.
 ///
 /// Almost every tool answers [`AnchorSnap::Pointer`]: the trader chose the
@@ -286,8 +317,16 @@ trait DrawingToolImpl: Sync {
     /// a click creates is always the one that was on screen when it was
     /// clicked.
     ///
+    /// `constrain` is what the trader is holding — see [`Constrain`]. A tool
+    /// that has an axis worth holding to says so here; the rest ignore it.
+    ///
     /// Rate: per frame while a draft is in flight, over a handful of anchors.
-    fn pending_anchor(&self, _placed: &[egui::Pos2], cursor: egui::Pos2) -> egui::Pos2 {
+    fn pending_anchor(
+        &self,
+        _placed: &[egui::Pos2],
+        cursor: egui::Pos2,
+        _constrain: Constrain,
+    ) -> egui::Pos2 {
         cursor
     }
     /// The key that arms this tool from the chart, if it has one.
@@ -441,6 +480,7 @@ trait DrawingToolImpl: Sync {
         _handle: usize,
         _to: egui::Pos2,
         _ctxt: &DrawContext<'_>,
+        _constrain: Constrain,
     ) -> Option<Handles> {
         None
     }
@@ -586,8 +626,13 @@ impl DrawingTool {
     /// Where the anchor under the pointer really lands while the object is
     /// still being shaped — see [`DrawingToolImpl::pending_anchor`].
     #[must_use]
-    pub fn pending_anchor(self, placed: &[egui::Pos2], cursor: egui::Pos2) -> egui::Pos2 {
-        self.0.pending_anchor(placed, cursor)
+    pub fn pending_anchor(
+        self,
+        placed: &[egui::Pos2],
+        cursor: egui::Pos2,
+        constrain: Constrain,
+    ) -> egui::Pos2 {
+        self.0.pending_anchor(placed, cursor, constrain)
     }
 
     /// Paint the object. Selection adds a halo *under* the geometry and, when
@@ -665,8 +710,10 @@ impl DrawingTool {
         handle: usize,
         to: egui::Pos2,
         ctxt: &DrawContext<'_>,
+        constrain: Constrain,
     ) -> Option<Handles> {
-        self.0.drag_handle(chart_rect, points, handle, to, ctxt)
+        self.0
+            .drag_handle(chart_rect, points, handle, to, ctxt, constrain)
     }
 
     #[must_use]
@@ -1699,7 +1746,7 @@ mod tests {
         let cursor = egui::pos2(60.0, 35.0);
         let mut shaping: Vec<&'static str> = DRAWING_TOOLS
             .into_iter()
-            .filter(|tool| tool.pending_anchor(&placed, cursor) != cursor)
+            .filter(|tool| tool.pending_anchor(&placed, cursor, Constrain::Free) != cursor)
             .map(DrawingTool::id)
             .collect();
         shaping.sort_unstable();
@@ -1723,7 +1770,7 @@ mod tests {
         let cursor = egui::pos2(60.0, 35.0);
         for tool in DRAWING_TOOLS.into_iter().filter(|tool| tool.freehand()) {
             assert_eq!(
-                tool.pending_anchor(&placed, cursor),
+                tool.pending_anchor(&placed, cursor, Constrain::Free),
                 cursor,
                 "{} is freehand, and the host does not consult the port for one",
                 tool.id()
@@ -2509,6 +2556,7 @@ mod tests {
                 _handle: usize,
                 to: egui::Pos2,
                 _ctxt: &DrawContext<'_>,
+                _constrain: Constrain,
             ) -> Option<Handles> {
                 Some(Handles::from_slice(&[
                     to + egui::vec2(0.0, PIVOT_HANDLE_OFFSET_PX)
@@ -2548,9 +2596,16 @@ mod tests {
             "the anchor is not a grab point unless the tool says so"
         );
         assert_eq!(
-            tool.drag_handle(chart, &points, 0, egui::pos2(80.0, 10.0), &ctxt)
-                .expect("the tool owns the drag")
-                .as_slice(),
+            tool.drag_handle(
+                chart,
+                &points,
+                0,
+                egui::pos2(80.0, 10.0),
+                &ctxt,
+                Constrain::Free
+            )
+            .expect("the tool owns the drag")
+            .as_slice(),
             &[egui::pos2(80.0, 30.0)],
             "the tool decides which anchors a handle moves"
         );
@@ -2651,7 +2706,14 @@ mod tests {
             );
             assert!(
                 drawing_tool
-                    .drag_handle(chart, &points, 0, egui::pos2(1.0, 1.0), &ctxt)
+                    .drag_handle(
+                        chart,
+                        &points,
+                        0,
+                        egui::pos2(1.0, 1.0),
+                        &ctxt,
+                        Constrain::Free
+                    )
                     .is_none(),
                 "{} leaves the drag to the host",
                 drawing_tool.id()

--- a/crates/app/src/drawings/parallel_channel.rs
+++ b/crates/app/src/drawings/parallel_channel.rs
@@ -14,7 +14,7 @@ use egui_phosphor::regular as icons;
 use super::line_core::{Extend, line_ends};
 use super::{
     DrawContext, Drawing, DrawingPayload, DrawingStyle, DrawingToolImpl, Handles, PresetHost,
-    ToolShortcut, distance_to_segment, drawing_fill, drawing_stroke,
+    ToolShortcut, distance_to_segment, drawing_fill, drawing_stroke, off_line_by, unit_normal,
 };
 
 pub(super) static TOOL: ParallelChannel = ParallelChannel;
@@ -169,22 +169,24 @@ fn channel_handles(points: &[egui::Pos2]) -> Option<Handles> {
     ]))
 }
 
-/// The unit normal of the trend line — the direction width is measured in.
-/// A degenerate trend line (both ends on one point) has no direction of its
-/// own, so it is given the vertical, which is the axis a chart measures in.
-fn baseline_normal(baseline: egui::Vec2) -> egui::Vec2 {
-    let length = baseline.length();
-    if length <= f32::EPSILON {
-        return egui::vec2(0.0, 1.0);
-    }
-    egui::vec2(-baseline.y, baseline.x) / length
-}
-
 /// How far the far rail sits from the trend line, signed so that the side the
 /// corridor opens on survives every gesture.
 fn signed_width(points: &[egui::Pos2]) -> f32 {
-    channel_offset(points).dot(baseline_normal(points[1] - points[0]))
+    channel_offset(points).dot(unit_normal(points[1] - points[0]))
 }
+
+/// The thinnest corridor a channel may be **born** with, in pixels.
+///
+/// Width is measured across the trend line and nowhere else, so the moment a
+/// drag fixes that line and lets go, the pointer — still standing on it —
+/// implies a width of exactly zero. Under this many pixels the corridor reads
+/// as a single line whatever the numbers say, which is the one thing a
+/// channel must never be mistaken for.
+///
+/// This floors the *shaping* phase only. An existing channel is still dragged
+/// as thin as the trader likes by its own rail handles: this is what a new
+/// object opens at, not a constraint on the shape.
+const MIN_BORN_WIDTH_PX: f32 = 12.0;
 
 /// Rebuild the channel from a rail that runs from `start` to `end`, keeping
 /// the corridor exactly as wide as it is now.
@@ -202,7 +204,7 @@ fn rebuild_from_rail(
     rail_is_far: bool,
 ) -> Handles {
     let direction = end - start;
-    let offset = baseline_normal(direction) * width;
+    let offset = unit_normal(direction) * width;
     let (near_start, far_point) = if rail_is_far {
         (start - offset, start)
     } else {
@@ -370,17 +372,26 @@ impl DrawingToolImpl for ParallelChannel {
         icons::PARALLELOGRAM
     }
     fn hover_text(&self) -> &'static str {
-        "Rising / falling channel - draw the trend line, then click the channel width (C)"
+        "Rising / falling channel - drag the trend line, then set the width (C)"
     }
     fn required_points(&self) -> usize {
         3
     }
     fn placement_hint(&self, placed: usize) -> Option<&'static str> {
         match placed {
-            1 => Some("Click the end of the trend line"),
-            2 => Some("Click the channel width"),
+            1 => Some("Drag out the trend line"),
+            2 => Some("Move to set the width, click to place"),
             _ => None,
         }
+    }
+    /// The width anchor keeps the bar the pointer is on and never the width
+    /// zero — see [`MIN_BORN_WIDTH_PX`]. With fewer than two anchors down
+    /// there is no trend line to measure across yet, so the pointer stands.
+    fn pending_anchor(&self, placed: &[egui::Pos2], cursor: egui::Pos2) -> egui::Pos2 {
+        let [start, end] = placed else {
+            return cursor;
+        };
+        off_line_by(*start, *end, cursor, MIN_BORN_WIDTH_PX)
     }
     fn shortcut(&self) -> Option<ToolShortcut> {
         Some(ToolShortcut {
@@ -929,5 +940,89 @@ mod tests {
         assert!(target.import_preset(&toml::Value::Table(table)));
         assert!(!target.midline);
         assert!(target.extend_right, "the flag it never named survives");
+    }
+
+    /// The trend line a shaping test measures across.
+    fn baseline_ends() -> (egui::Pos2, egui::Pos2) {
+        (egui::pos2(100.0, 200.0), egui::pos2(300.0, 140.0))
+    }
+
+    /// The defect this port exists for, reported from the running build: the
+    /// drag lets go with the pointer still standing **on** the trend line,
+    /// width is measured across that line and nowhere else, so the width the
+    /// pointer implies is exactly zero. The preview drew a corridor of no
+    /// width — a straight line — and the click that looked like it confirmed
+    /// the shape committed one.
+    #[test]
+    fn a_channel_is_never_born_with_no_width_at_all() {
+        let (start, end) = baseline_ends();
+        let shaped = TOOL.pending_anchor(&[start, end], end);
+        let width = signed_width(&[start, end, shaped]);
+        // A pixel of corridor is still a line to the eye. Asserted against a
+        // number of its own rather than against the constant, so shrinking
+        // the floor to nothing fails here instead of passing vacuously.
+        assert!(
+            width.abs() > 1.0,
+            "a channel let go of on its own trend line still opens a corridor, width was {width}"
+        );
+        assert!(
+            (width.abs() - MIN_BORN_WIDTH_PX).abs() < 1e-3,
+            "and it opens exactly at the floor, width was {width}"
+        );
+    }
+
+    /// Flooring the width must not slide the anchor *along* the rails: the
+    /// bar the trader put it on is the one the Coordinates tab reports, and
+    /// the same rule already governs a width drag on a finished channel.
+    #[test]
+    fn flooring_the_width_keeps_the_bar_the_pointer_was_on() {
+        let (start, end) = baseline_ends();
+        let cursor = egui::pos2(220.0, 176.0);
+        let shaped = TOOL.pending_anchor(&[start, end], cursor);
+        let direction = (end - start).normalized();
+        let along = |point: egui::Pos2| (point - start).dot(direction);
+        assert!(
+            (along(shaped) - along(cursor)).abs() < 1e-3,
+            "only the distance across the line moved: {} vs {}",
+            along(shaped),
+            along(cursor)
+        );
+    }
+
+    /// A pointer that has already declared a width keeps it exactly. The
+    /// floor is for the collapsed case alone — it must not quietly become a
+    /// minimum channel width the trader cannot draw under.
+    #[test]
+    fn a_pointer_clear_of_the_trend_line_is_left_exactly_where_it_is() {
+        let (start, end) = baseline_ends();
+        let cursor = egui::pos2(200.0, 260.0);
+        assert_eq!(TOOL.pending_anchor(&[start, end], cursor), cursor);
+    }
+
+    /// The side the trader started opening the corridor on is the side it
+    /// opens on, however little they had moved when the floor caught them.
+    #[test]
+    fn the_corridor_opens_on_the_side_the_pointer_chose() {
+        let (start, end) = baseline_ends();
+        let normal = unit_normal(end - start);
+        for side in [-1.0_f32, 1.0] {
+            let cursor = start + normal * (2.0 * side);
+            let shaped = TOOL.pending_anchor(&[start, end], cursor);
+            let width = signed_width(&[start, end, shaped]);
+            assert!(
+                (width - side * MIN_BORN_WIDTH_PX).abs() < 1e-3,
+                "a nudge to side {side} floors to that side, got {width}"
+            );
+        }
+    }
+
+    /// Before two anchors are down there is no trend line to measure across,
+    /// so the pointer means exactly itself — the first two anchors of a
+    /// channel are placed like any other tool's.
+    #[test]
+    fn nothing_is_shaped_before_the_trend_line_exists() {
+        let cursor = egui::pos2(42.0, 84.0);
+        assert_eq!(TOOL.pending_anchor(&[], cursor), cursor);
+        assert_eq!(TOOL.pending_anchor(&[egui::pos2(1.0, 1.0)], cursor), cursor);
     }
 }

--- a/crates/app/src/drawings/parallel_channel.rs
+++ b/crates/app/src/drawings/parallel_channel.rs
@@ -14,7 +14,8 @@ use egui_phosphor::regular as icons;
 use super::line_core::{Extend, line_ends};
 use super::{
     DrawContext, Drawing, DrawingPayload, DrawingStyle, DrawingToolImpl, Handles, PresetHost,
-    ToolShortcut, distance_to_segment, drawing_fill, drawing_stroke, off_line_by, unit_normal,
+    Constrain, ToolShortcut, distance_to_segment, drawing_fill, drawing_stroke, level_with,
+    off_line_by, unit_normal,
 };
 
 pub(super) static TOOL: ParallelChannel = ParallelChannel;
@@ -227,10 +228,34 @@ fn rebuild_from_rail(
 /// trend line and holds the far rail still, so the corridor grows the other
 /// way. Only the component across the trend line counts for width, so sliding
 /// a handle along the rails does nothing at all.
-fn channel_drag(points: &[egui::Pos2], handle: usize, to: egui::Pos2) -> Option<Handles> {
+fn channel_drag(
+    points: &[egui::Pos2],
+    handle: usize,
+    to: egui::Pos2,
+    constrain: Constrain,
+) -> Option<Handles> {
     if points.len() < 3 {
         return None;
     }
+    // Holding Shift on a corner lays that corner level with the corner it is
+    // pivoting around — the other end of its own rail. The rails are
+    // parallel, so levelling one levels the channel. A constraint that only
+    // existed while the object was being born would be no use at all: a
+    // corridor that came out a degree off is exactly the one the trader wants
+    // to straighten, and straightening is a corner drag.
+    //
+    // The rail-centre handles are absent on purpose. They set the width,
+    // which is measured across the trend line and never along it, so there is
+    // no angle for the constraint to hold.
+    let to = match (constrain, handle) {
+        (Constrain::Level, HANDLE_NEAR_START) => level_with(points[1], to),
+        (Constrain::Level, HANDLE_NEAR_END) => level_with(points[0], to),
+        (Constrain::Level, HANDLE_FAR_START) => {
+            level_with(points[1] + channel_offset(points), to)
+        }
+        (Constrain::Level, HANDLE_FAR_END) => level_with(points[0] + channel_offset(points), to),
+        _ => to,
+    };
     let baseline = points[1] - points[0];
     let centre = points[0] + baseline / 2.0;
     let width = signed_width(points);
@@ -379,19 +404,39 @@ impl DrawingToolImpl for ParallelChannel {
     }
     fn placement_hint(&self, placed: usize) -> Option<&'static str> {
         match placed {
-            1 => Some("Drag out the trend line"),
+            // The modifier is advertised on the step it applies to, beside
+            // the cursor, while the hand is already doing the gesture. A
+            // constraint nobody is told about is a constraint nobody uses.
+            1 => Some("Drag out the trend line - hold Shift to keep it level"),
             2 => Some("Move to set the width, click to place"),
             _ => None,
         }
     }
-    /// The width anchor keeps the bar the pointer is on and never the width
-    /// zero — see [`MIN_BORN_WIDTH_PX`]. With fewer than two anchors down
-    /// there is no trend line to measure across yet, so the pointer stands.
-    fn pending_anchor(&self, placed: &[egui::Pos2], cursor: egui::Pos2) -> egui::Pos2 {
-        let [start, end] = placed else {
-            return cursor;
-        };
-        off_line_by(*start, *end, cursor, MIN_BORN_WIDTH_PX)
+    /// Two anchors, two different questions.
+    ///
+    /// The **second** closes the trend line, and holding Shift there lays that
+    /// line level with the first — which makes the whole corridor level, since
+    /// the rails are parallel to it. A horizontal channel is a range, and a
+    /// range dragged by hand is never quite flat: the trader can see it is off
+    /// but cannot fix it, because there is nothing to fix it *against*.
+    ///
+    /// The **third** sets the width, which is measured across the trend line
+    /// and never along it, so the constraint has nothing to say there — the
+    /// floor does all the work (see [`MIN_BORN_WIDTH_PX`]).
+    ///
+    /// With no anchor down there is nothing to be level with, so the pointer
+    /// stands.
+    fn pending_anchor(
+        &self,
+        placed: &[egui::Pos2],
+        cursor: egui::Pos2,
+        constrain: Constrain,
+    ) -> egui::Pos2 {
+        match (placed, constrain) {
+            ([start], Constrain::Level) => level_with(*start, cursor),
+            ([start, end], _) => off_line_by(*start, *end, cursor, MIN_BORN_WIDTH_PX),
+            _ => cursor,
+        }
     }
     fn shortcut(&self) -> Option<ToolShortcut> {
         Some(ToolShortcut {
@@ -500,8 +545,9 @@ impl DrawingToolImpl for ParallelChannel {
         handle: usize,
         to: egui::Pos2,
         _ctxt: &DrawContext<'_>,
+        constrain: Constrain,
     ) -> Option<Handles> {
-        channel_drag(points, handle, to)
+        channel_drag(points, handle, to, constrain)
     }
 
     #[cfg(test)]
@@ -520,6 +566,12 @@ impl DrawingToolImpl for ParallelChannel {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// An unconstrained handle drag — what every gesture test that is not
+    /// about Shift is asking for.
+    fn drag(points: &[egui::Pos2], handle: usize, to: egui::Pos2) -> Option<Handles> {
+        channel_drag(points, handle, to, Constrain::Free)
+    }
 
     /// Six grab points: a corner at each end of each rail, plus the centre of
     /// each rail. Corners angle, centres widen.
@@ -711,7 +763,7 @@ mod tests {
             egui::pos2(300.0, 100.0),
             egui::pos2(100.0, 160.0),
         ];
-        let moved = channel_drag(&points, HANDLE_FAR_CENTRE, egui::pos2(240.0, 200.0))
+        let moved = drag(&points, HANDLE_FAR_CENTRE, egui::pos2(240.0, 200.0))
             .expect("the far rail moves");
         assert_eq!(moved[0], points[0]);
         assert_eq!(moved[1], points[1]);
@@ -732,7 +784,7 @@ mod tests {
             egui::pos2(100.0, 160.0),
         ];
         let far_before = points[0] + channel_offset(&points);
-        let moved = channel_drag(&points, HANDLE_NEAR_CENTRE, egui::pos2(200.0, 60.0))
+        let moved = drag(&points, HANDLE_NEAR_CENTRE, egui::pos2(200.0, 60.0))
             .expect("the near rail moves");
         assert_eq!(moved[0], egui::pos2(100.0, 60.0));
         assert_eq!(moved[1], egui::pos2(300.0, 60.0));
@@ -766,7 +818,7 @@ mod tests {
         for handle in [HANDLE_NEAR_CENTRE, HANDLE_FAR_CENTRE] {
             // From where the handle *is*: a slide is a gesture that starts on
             // the ring under the pointer.
-            let moved = channel_drag(&points, handle, handles[handle] + along)
+            let moved = drag(&points, handle, handles[handle] + along)
                 .expect("a rail moves");
             let (moved_start, moved_end, moved_far) = rails(&moved);
             for (before, after) in [
@@ -794,7 +846,7 @@ mod tests {
         ];
         let handles = channel_handles(&points).expect("three anchors");
         for handle in [HANDLE_NEAR_CENTRE, HANDLE_FAR_CENTRE] {
-            let moved = channel_drag(&points, handle, handles[handle] + egui::vec2(0.0, 40.0))
+            let moved = drag(&points, handle, handles[handle] + egui::vec2(0.0, 40.0))
                 .expect("a rail moves");
             assert!(
                 (moved[2].x - points[2].x).abs() < 1e-3,
@@ -819,13 +871,13 @@ mod tests {
         assert_eq!(handles[HANDLE_NEAR_CENTRE], egui::pos2(100.0, 200.0));
         assert_eq!(handles[HANDLE_FAR_CENTRE], egui::pos2(160.0, 200.0));
 
-        let widened = channel_drag(&points, HANDLE_FAR_CENTRE, egui::pos2(200.0, 240.0))
+        let widened = drag(&points, HANDLE_FAR_CENTRE, egui::pos2(200.0, 240.0))
             .expect("the far rail moves");
         assert_eq!(widened[0], points[0], "the trend line is untouched");
         assert_eq!(channel_offset(&widened), egui::vec2(100.0, 0.0));
 
         let far_before = points[0] + channel_offset(&points);
-        let grown = channel_drag(&points, HANDLE_NEAR_CENTRE, egui::pos2(60.0, 200.0))
+        let grown = drag(&points, HANDLE_NEAR_CENTRE, egui::pos2(60.0, 200.0))
             .expect("the near rail moves");
         assert_eq!(grown[0], egui::pos2(60.0, 100.0));
         assert_eq!(
@@ -847,7 +899,7 @@ mod tests {
         ];
         let width = signed_width(&points);
         let moved =
-            channel_drag(&points, HANDLE_NEAR_START, egui::pos2(120.0, 40.0)).expect("it angles");
+            drag(&points, HANDLE_NEAR_START, egui::pos2(120.0, 40.0)).expect("it angles");
         assert_eq!(moved[0], egui::pos2(120.0, 40.0), "the held corner");
         assert_eq!(moved[1], points[1], "the other end of the rail stays");
         assert!(
@@ -871,7 +923,7 @@ mod tests {
         let handles = channel_handles(&points).expect("three anchors");
         let far_end_before = handles[HANDLE_FAR_END];
 
-        let moved = channel_drag(&points, HANDLE_FAR_START, egui::pos2(120.0, 200.0))
+        let moved = drag(&points, HANDLE_FAR_START, egui::pos2(120.0, 200.0))
             .expect("the far corner angles it");
         let after = channel_handles(&moved).expect("three anchors");
         assert!(
@@ -956,7 +1008,7 @@ mod tests {
     #[test]
     fn a_channel_is_never_born_with_no_width_at_all() {
         let (start, end) = baseline_ends();
-        let shaped = TOOL.pending_anchor(&[start, end], end);
+        let shaped = TOOL.pending_anchor(&[start, end], end, Constrain::Free);
         let width = signed_width(&[start, end, shaped]);
         // A pixel of corridor is still a line to the eye. Asserted against a
         // number of its own rather than against the constant, so shrinking
@@ -978,7 +1030,7 @@ mod tests {
     fn flooring_the_width_keeps_the_bar_the_pointer_was_on() {
         let (start, end) = baseline_ends();
         let cursor = egui::pos2(220.0, 176.0);
-        let shaped = TOOL.pending_anchor(&[start, end], cursor);
+        let shaped = TOOL.pending_anchor(&[start, end], cursor, Constrain::Free);
         let direction = (end - start).normalized();
         let along = |point: egui::Pos2| (point - start).dot(direction);
         assert!(
@@ -996,7 +1048,7 @@ mod tests {
     fn a_pointer_clear_of_the_trend_line_is_left_exactly_where_it_is() {
         let (start, end) = baseline_ends();
         let cursor = egui::pos2(200.0, 260.0);
-        assert_eq!(TOOL.pending_anchor(&[start, end], cursor), cursor);
+        assert_eq!(TOOL.pending_anchor(&[start, end], cursor, Constrain::Free), cursor);
     }
 
     /// The side the trader started opening the corridor on is the side it
@@ -1007,7 +1059,7 @@ mod tests {
         let normal = unit_normal(end - start);
         for side in [-1.0_f32, 1.0] {
             let cursor = start + normal * (2.0 * side);
-            let shaped = TOOL.pending_anchor(&[start, end], cursor);
+            let shaped = TOOL.pending_anchor(&[start, end], cursor, Constrain::Free);
             let width = signed_width(&[start, end, shaped]);
             assert!(
                 (width - side * MIN_BORN_WIDTH_PX).abs() < 1e-3,
@@ -1022,7 +1074,89 @@ mod tests {
     #[test]
     fn nothing_is_shaped_before_the_trend_line_exists() {
         let cursor = egui::pos2(42.0, 84.0);
-        assert_eq!(TOOL.pending_anchor(&[], cursor), cursor);
-        assert_eq!(TOOL.pending_anchor(&[egui::pos2(1.0, 1.0)], cursor), cursor);
+        assert_eq!(TOOL.pending_anchor(&[], cursor, Constrain::Free), cursor);
+        assert_eq!(TOOL.pending_anchor(&[egui::pos2(1.0, 1.0)], cursor, Constrain::Free), cursor);
+    }
+
+    /// Shift while the trend line is being dragged lays it level with the
+    /// anchor it started from — a range, which is the channel a trader draws
+    /// most and the one a free hand can never get quite flat.
+    #[test]
+    fn shift_lays_the_trend_line_level_with_where_it_started() {
+        let start = egui::pos2(100.0, 200.0);
+        let cursor = egui::pos2(340.0, 137.0);
+        let shaped = TOOL.pending_anchor(&[start], cursor, Constrain::Level);
+        assert!(
+            (shaped.y - start.y).abs() < 1e-3,
+            "the far end sits at the price the near end is on, y was {}",
+            shaped.y
+        );
+        assert!(
+            (shaped.x - cursor.x).abs() < 1e-3,
+            "and it still slides freely along the tape"
+        );
+    }
+
+    /// Without the modifier the trend line is exactly where the hand put it.
+    #[test]
+    fn an_unheld_trend_line_follows_the_pointer_exactly() {
+        let start = egui::pos2(100.0, 200.0);
+        let cursor = egui::pos2(340.0, 137.0);
+        assert_eq!(
+            TOOL.pending_anchor(&[start], cursor, Constrain::Free),
+            cursor
+        );
+    }
+
+    /// Straightening is a corner drag, so the constraint has to live there
+    /// too: a corridor that came out a degree off is exactly the one the
+    /// trader wants level, and by then it already exists.
+    #[test]
+    fn shift_on_a_corner_lays_the_whole_corridor_level() {
+        let points = [
+            egui::pos2(100.0, 200.0),
+            egui::pos2(300.0, 140.0),
+            egui::pos2(100.0, 260.0),
+        ];
+        let moved = channel_drag(
+            &points,
+            HANDLE_NEAR_END,
+            egui::pos2(320.0, 95.0),
+            Constrain::Level,
+        )
+        .expect("the channel owns its corners");
+        assert!(
+            (moved[1].y - moved[0].y).abs() < 1e-3,
+            "the trend line came out level: {:?} vs {:?}",
+            moved[0],
+            moved[1]
+        );
+        // Parallel rails: levelling one levels the other, which is the whole
+        // reason one corner is enough to straighten a channel.
+        let far = channel_offset(&moved);
+        assert!(
+            far.x.abs() < 1e-3,
+            "the far rail is level too, offset was {far:?}"
+        );
+    }
+
+    /// Width is measured across the trend line and never along it, so the
+    /// rail-centre handles have no angle for the constraint to hold — and
+    /// must not silently gain one.
+    #[test]
+    fn shift_leaves_a_width_drag_alone() {
+        let points = [
+            egui::pos2(100.0, 200.0),
+            egui::pos2(300.0, 140.0),
+            egui::pos2(100.0, 260.0),
+        ];
+        let to = egui::pos2(210.0, 240.0);
+        for handle in [HANDLE_NEAR_CENTRE, HANDLE_FAR_CENTRE] {
+            assert_eq!(
+                channel_drag(&points, handle, to, Constrain::Level),
+                channel_drag(&points, handle, to, Constrain::Free),
+                "handle {handle} must not care about the modifier"
+            );
+        }
     }
 }

--- a/crates/app/src/drawings/trend_line.rs
+++ b/crates/app/src/drawings/trend_line.rs
@@ -1,8 +1,8 @@
 use eframe::egui;
 use egui_phosphor::regular as icons;
 
-use super::line_core::{Extend, LINES_FAMILY, hit_line, paint_line};
-use super::{DrawContext, DrawingStyle, DrawingToolImpl, ToolFamily, ToolShortcut};
+use super::line_core::{Extend, LINES_FAMILY, hit_line, levelled_far_end, paint_line};
+use super::{Constrain, DrawContext, DrawingStyle, DrawingToolImpl, ToolFamily, ToolShortcut};
 
 pub(super) static TOOL: TrendLine = TrendLine;
 
@@ -22,10 +22,26 @@ impl DrawingToolImpl for TrendLine {
         icons::TREND_UP
     }
     fn hover_text(&self) -> &'static str {
-        "Trend line - click two swing points (T)"
+        "Trend line - two swing points, Shift to keep it level (T)"
     }
     fn required_points(&self) -> usize {
         2
+    }
+    /// Advertised on the step it applies to, beside the cursor, while the
+    /// hand is already doing the gesture — a modifier nobody is told about is
+    /// a modifier nobody uses.
+    fn placement_hint(&self, placed: usize) -> Option<&'static str> {
+        (placed == 1).then_some("Drag out the line - hold Shift to keep it level")
+    }
+    /// Shift lays the far end at the price the near end is on: a level the
+    /// trader drew *as* a line, rather than a level that is nearly one.
+    fn pending_anchor(
+        &self,
+        placed: &[egui::Pos2],
+        cursor: egui::Pos2,
+        constrain: Constrain,
+    ) -> egui::Pos2 {
+        levelled_far_end(placed, cursor, constrain)
     }
     fn shortcut(&self) -> Option<ToolShortcut> {
         Some(ToolShortcut {

--- a/crates/app/src/drawings/triangle.rs
+++ b/crates/app/src/drawings/triangle.rs
@@ -3,7 +3,7 @@ use egui_phosphor::regular as icons;
 
 use super::shape_core::{SHAPES_FAMILY, hit_outline, paint_outline};
 use super::{
-    DrawContext, DrawingStyle, DrawingToolImpl, ToolFamily, drawing_stroke, off_line_by,
+    Constrain, DrawContext, DrawingStyle, DrawingToolImpl, ToolFamily, drawing_stroke, off_line_by,
 };
 
 /// The shortest a triangle's third corner may stand off the side the first
@@ -44,7 +44,16 @@ impl DrawingToolImpl for Triangle {
     }
     /// The third corner never lands on the side the first two drew — see
     /// [`MIN_BORN_HEIGHT_PX`].
-    fn pending_anchor(&self, placed: &[egui::Pos2], cursor: egui::Pos2) -> egui::Pos2 {
+    ///
+    /// The constraint is ignored: a triangle has three sides and no obvious
+    /// one for Shift to hold level, so guessing would be worse than leaving
+    /// the modifier free for a later decision.
+    fn pending_anchor(
+        &self,
+        placed: &[egui::Pos2],
+        cursor: egui::Pos2,
+        _constrain: Constrain,
+    ) -> egui::Pos2 {
         let [start, end] = placed else {
             return cursor;
         };
@@ -111,7 +120,7 @@ mod tests {
     fn the_third_corner_never_lands_on_the_first_side() {
         let start = egui::pos2(100.0, 200.0);
         let end = egui::pos2(300.0, 140.0);
-        let shaped = TOOL.pending_anchor(&[start, end], end);
+        let shaped = TOOL.pending_anchor(&[start, end], end, Constrain::Free);
         let side = end - start;
         // Twice the triangle's area: zero exactly when the corners are
         // collinear, whatever the units. Divided back by the side gives the
@@ -136,6 +145,6 @@ mod tests {
         let start = egui::pos2(100.0, 200.0);
         let end = egui::pos2(300.0, 140.0);
         let cursor = egui::pos2(200.0, 300.0);
-        assert_eq!(TOOL.pending_anchor(&[start, end], cursor), cursor);
+        assert_eq!(TOOL.pending_anchor(&[start, end], cursor, Constrain::Free), cursor);
     }
 }

--- a/crates/app/src/drawings/triangle.rs
+++ b/crates/app/src/drawings/triangle.rs
@@ -2,7 +2,15 @@ use eframe::egui;
 use egui_phosphor::regular as icons;
 
 use super::shape_core::{SHAPES_FAMILY, hit_outline, paint_outline};
-use super::{DrawContext, DrawingStyle, DrawingToolImpl, ToolFamily};
+use super::{
+    DrawContext, DrawingStyle, DrawingToolImpl, ToolFamily, drawing_stroke, off_line_by,
+};
+
+/// The shortest a triangle's third corner may stand off the side the first
+/// two drew, in pixels. Three collinear corners are a line, not a triangle —
+/// and that is exactly where the pointer sits the instant a drag lets go.
+/// It floors the shaping phase only; the corner handles move freely after.
+const MIN_BORN_HEIGHT_PX: f32 = 12.0;
 
 pub(super) static TOOL: Triangle = Triangle;
 
@@ -22,13 +30,25 @@ impl DrawingToolImpl for Triangle {
         icons::TRIANGLE
     }
     fn hover_text(&self) -> &'static str {
-        "Triangle - three clicks, for wedges and coils"
+        "Triangle - drag a side, then click the third corner"
     }
     fn required_points(&self) -> usize {
         3
     }
     fn placement_hint(&self, placed: usize) -> Option<&'static str> {
-        (placed == 2).then_some("Click the third corner")
+        match placed {
+            1 => Some("Drag out the first side"),
+            2 => Some("Move to shape it, click to place"),
+            _ => None,
+        }
+    }
+    /// The third corner never lands on the side the first two drew — see
+    /// [`MIN_BORN_HEIGHT_PX`].
+    fn pending_anchor(&self, placed: &[egui::Pos2], cursor: egui::Pos2) -> egui::Pos2 {
+        let [start, end] = placed else {
+            return cursor;
+        };
+        off_line_by(*start, *end, cursor, MIN_BORN_HEIGHT_PX)
     }
     fn family(&self) -> Option<ToolFamily> {
         Some(SHAPES_FAMILY)
@@ -44,8 +64,16 @@ impl DrawingToolImpl for Triangle {
         points: &[egui::Pos2],
         _ctxt: &DrawContext<'_>,
     ) {
-        if points.len() == 3 {
-            paint_outline(painter, style, points);
+        match points {
+            // The first side, while the drag is shaping it. Without this the
+            // trader drags a triangle and watches nothing happen at all: the
+            // outline only exists once three corners do, and the rubber band
+            // is the whole feedback of the gesture.
+            [start, end] => {
+                painter.line_segment([*start, *end], drawing_stroke(style));
+            }
+            [_, _, _] => paint_outline(painter, style, points),
+            _ => {}
         }
     }
     fn hit_test(
@@ -69,5 +97,45 @@ impl DrawingToolImpl for Triangle {
             ],
             egui::pos2(200.0, 200.0),
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Three corners on one line are a line, not a triangle — and that is
+    /// exactly where the pointer stands the instant the drag that drew the
+    /// first side lets go.
+    #[test]
+    fn the_third_corner_never_lands_on_the_first_side() {
+        let start = egui::pos2(100.0, 200.0);
+        let end = egui::pos2(300.0, 140.0);
+        let shaped = TOOL.pending_anchor(&[start, end], end);
+        let side = end - start;
+        // Twice the triangle's area: zero exactly when the corners are
+        // collinear, whatever the units. Divided back by the side gives the
+        // height in pixels, which is the number worth asserting on.
+        let cross = side.x * (shaped.y - start.y) - side.y * (shaped.x - start.x);
+        let height = cross.abs() / side.length();
+        // A number of its own, not the constant: a floor shrunk to nothing
+        // has to fail here rather than pass vacuously.
+        assert!(
+            height > 1.0,
+            "the triangle stands off its own first side, height was {height}"
+        );
+        assert!(
+            (height - MIN_BORN_HEIGHT_PX).abs() < 1e-2,
+            "and it stands exactly at the floor, height was {height}"
+        );
+    }
+
+    /// A corner the trader has already carried clear of the side is theirs.
+    #[test]
+    fn a_corner_clear_of_the_first_side_is_left_alone() {
+        let start = egui::pos2(100.0, 200.0);
+        let end = egui::pos2(300.0, 140.0);
+        let cursor = egui::pos2(200.0, 300.0);
+        assert_eq!(TOOL.pending_anchor(&[start, end], cursor), cursor);
     }
 }

--- a/crates/app/src/pane.rs
+++ b/crates/app/src/pane.rs
@@ -56,6 +56,14 @@ pub const DRAWING_ANCHOR_RADIUS_PX: f32 = 12.0;
 /// aimed at, tight enough to still draw a free diagonal between bars.
 const MAGNET_REACH_PX: f32 = 12.0;
 const DRAWING_DRAG_THRESHOLD_PX: f32 = 4.0;
+
+/// A pointer and a modifier for a run with nobody at the keyboard — see
+/// [`ChartPane::parked_hand`]. Never constructed outside the harness hook.
+#[derive(Debug, Clone, Copy)]
+pub struct ParkedHand {
+    pub position: egui::Pos2,
+    pub constrain: drawings::Constrain,
+}
 /// How far the pointer must travel before a freehand stroke records another
 /// point. Chosen so a hand-drawn circle keeps its shape while a half-second
 /// scribble stores tens of anchors instead of hundreds — every anchor is
@@ -884,18 +892,17 @@ pub struct ChartPane {
     drawing_band_hint: Option<egui::Rect>,
     pub drawing_press_position: Option<egui::Pos2>,
     pub drawing_press_started_empty: bool,
-    /// Where the pointer stands for a run that has no hands on the mouse —
-    /// the `QUANTICK_DRAWING_DRAFT` harness hook, `None` for every real
-    /// session.
+    /// The hand a run has when nobody is at the mouse — the
+    /// `QUANTICK_DRAWING_DRAFT` harness hook. `None` for every real session.
     ///
     /// The live preview of a half-placed object is the whole feedback of a
     /// multi-anchor gesture, and it is the one surface a click-free launch
     /// could not reach: it exists only between two clicks, and only while a
-    /// pointer is over the chart. This is read exactly where the real pointer
-    /// is read and nowhere else, so everything downstream — the tool's
-    /// shaping, the hint chip, the rubber band — runs the same code the hand
-    /// runs.
-    pub parked_pointer: Option<egui::Pos2>,
+    /// pointer is over the chart. Both halves are read exactly where the real
+    /// pointer and the real modifier are read and nowhere else, so everything
+    /// downstream — the tool's shaping, the hint chip, the rubber band — runs
+    /// the same code a hand runs.
+    pub parked_hand: Option<ParkedHand>,
     /// The last screen position a freehand stroke actually recorded, so the
     /// capture decimates as it goes rather than storing every mouse event.
     freehand_last_position: Option<egui::Pos2>,
@@ -1018,7 +1025,7 @@ impl ChartPane {
             drawing_band_hint: None,
             drawing_press_position: None,
             drawing_press_started_empty: false,
-            parked_pointer: None,
+            parked_hand: None,
             freehand_last_position: None,
             drawing_press_pick: None,
             drawing_drag_pending_from: None,
@@ -2099,11 +2106,13 @@ impl ChartPane {
         let magnet = chrome.toolrail.magnet();
         // Shift, read once for the whole pass: the preview, the press and the
         // release must agree about it as strictly as they agree about where
-        // the pointer is.
+        // the pointer is. A parked hand supplies it for a run with nobody at
+        // the keyboard, the same way it supplies the pointer.
         let constrain = if ui.input(|input| input.modifiers.shift) {
             drawings::Constrain::Level
         } else {
-            drawings::Constrain::Free
+            self.parked_hand
+                .map_or(drawings::Constrain::Free, |hand| hand.constrain)
         };
         let Some(tool) = chrome.toolrail.tool().drawing_tool() else {
             self.drawings.cancel_draft();
@@ -2167,7 +2176,7 @@ impl ChartPane {
         let preview_pos = ui
             .input(|input| input.pointer.latest_pos())
             .filter(|position| surface.contains(*position))
-            .or(self.parked_pointer);
+            .or_else(|| self.parked_hand.map(|hand| hand.position));
         self.drawing_hover = preview_pos
             .filter(|position| !over_chrome(ui, *position))
             .and_then(|position| {

--- a/crates/app/src/pane.rs
+++ b/crates/app/src/pane.rs
@@ -884,6 +884,18 @@ pub struct ChartPane {
     drawing_band_hint: Option<egui::Rect>,
     pub drawing_press_position: Option<egui::Pos2>,
     pub drawing_press_started_empty: bool,
+    /// Where the pointer stands for a run that has no hands on the mouse —
+    /// the `QUANTICK_DRAWING_DRAFT` harness hook, `None` for every real
+    /// session.
+    ///
+    /// The live preview of a half-placed object is the whole feedback of a
+    /// multi-anchor gesture, and it is the one surface a click-free launch
+    /// could not reach: it exists only between two clicks, and only while a
+    /// pointer is over the chart. This is read exactly where the real pointer
+    /// is read and nowhere else, so everything downstream — the tool's
+    /// shaping, the hint chip, the rubber band — runs the same code the hand
+    /// runs.
+    pub parked_pointer: Option<egui::Pos2>,
     /// The last screen position a freehand stroke actually recorded, so the
     /// capture decimates as it goes rather than storing every mouse event.
     freehand_last_position: Option<egui::Pos2>,
@@ -1006,6 +1018,7 @@ impl ChartPane {
             drawing_band_hint: None,
             drawing_press_position: None,
             drawing_press_started_empty: false,
+            parked_pointer: None,
             freehand_last_position: None,
             drawing_press_pick: None,
             drawing_drag_pending_from: None,
@@ -2125,26 +2138,34 @@ impl ChartPane {
         self.drawing_band_hint = hovered
             .filter(|band| band.drawable() && !over_pane_chrome)
             .map(|band| band.rect);
-        // While the placement drag is in flight the widget stops reporting
-        // hover (egui: a dragged widget is not "hovered"), which used to make
-        // the rubber band vanish for exactly the frames the trader is shaping
-        // the object. The raw pointer keeps answering, so the preview does.
-        let preview_pos = response.hover_pos().or_else(|| {
-            self.drawing_press_position
-                .and_then(|_| ui.input(|input| input.pointer.latest_pos()))
-        });
+        // The raw pointer, never the widget's hover.
+        //
+        // "Is this widget the top interactable" is a different question from
+        // the one placement asks, which is "is the pointer inside the drawing
+        // surface, and is floating chrome on top of it". The widget's answer
+        // already had to be patched once, because a dragged widget is not
+        // "hovered" (egui) and the rubber band blanked for exactly the frames
+        // the trader was shaping the object; the patch read the raw pointer,
+        // but only while a press was down.
+        //
+        // So the preview and the click were reading two different sources for
+        // the same fact. That is the shape of the bug this change is about,
+        // and it is also why the preview could not be tested at all: under a
+        // headless context the widget reports no hover ever, so the preview
+        // painted the bare anchors and no test could see the shape. The press
+        // path's two questions are the honest ones and they are asked here
+        // now, so preview and commit cannot disagree about where the pointer
+        // is — in any host.
+        let preview_pos = ui
+            .input(|input| input.pointer.latest_pos())
+            .filter(|position| surface.contains(*position))
+            .or(self.parked_pointer);
         self.drawing_hover = preview_pos
             .filter(|position| !over_chrome(ui, *position))
             .and_then(|position| {
-                let (band, position) = self.placement_target(areas, bands, position)?;
-                self.drawing_point_at(
-                    position,
-                    history_right,
-                    self.slots(),
-                    magnet,
-                    tool.anchor_snap(),
-                    band,
-                )
+                let (_, point) =
+                    self.shaped_placement(tool, areas, bands, position, history_right, magnet)?;
+                Some(point)
             });
         if (response.hovered() || response.dragged()) && !over_pane_chrome {
             ui.ctx().set_cursor_icon(match hovered {
@@ -2167,15 +2188,8 @@ impl ChartPane {
         });
         if let Some(position) = pressed_position
             .filter(|position| surface.contains(*position) && !over_chrome(ui, *position))
-            && let Some((band, position)) = self.placement_target(areas, bands, position)
-            && let Some(point) = self.drawing_point_at(
-                position,
-                history_right,
-                self.slots(),
-                magnet,
-                tool.anchor_snap(),
-                band,
-            )
+            && let Some((band, point)) =
+                self.shaped_placement(tool, areas, bands, position, history_right, magnet)
         {
             let band = band.key.clone();
             self.drawing_press_started_empty = self.drawings.draft_len() == 0;
@@ -2257,15 +2271,8 @@ impl ChartPane {
             && let Some(position) = released_position
             && surface.contains(position)
             && start.distance(position) >= DRAWING_DRAG_THRESHOLD_PX
-            && let Some((band, position)) = self.placement_target(areas, bands, position)
-            && let Some(point) = self.drawing_point_at(
-                position,
-                history_right,
-                self.slots(),
-                magnet,
-                tool.anchor_snap(),
-                band,
-            )
+            && let Some((band, point)) =
+                self.shaped_placement(tool, areas, bands, position, history_right, magnet)
         {
             let band = band.key.clone();
             self.place_drawing_point(tool, &band, point, chrome);
@@ -2311,6 +2318,68 @@ impl ChartPane {
             position.y.clamp(band.rect.top(), band.rect.bottom()),
         );
         Some((band, clamped))
+    }
+
+    /// Where an anchor dropped at `position` really lands: the band that will
+    /// own it, and the chart point it takes once the tool has had its say
+    /// about an anchor it is still shaping
+    /// ([`drawings::DrawingTool::pending_anchor`]).
+    ///
+    /// The preview, the press and the release all come through here. They
+    /// used to compute their point apart from one another, and that is how a
+    /// channel could be previewed as a corridor and then born as a line: the
+    /// draft preview completed the geometry with the hovered anchor while the
+    /// click that committed it read the raw pointer. One door, so the object
+    /// a click creates is the one that was under the cursor when it was
+    /// clicked.
+    ///
+    /// The shaped point is deliberately *not* re-clamped into the band. A
+    /// tool floors a collapsed shape by pixels, so the anchor can end a hair
+    /// outside the band it was aimed at — clamping it back would hand the
+    /// degenerate case straight back to the trader, which is the whole thing
+    /// being fixed.
+    fn shaped_placement<'a>(
+        &self,
+        tool: drawings::DrawingTool,
+        areas: &PlotAreas,
+        bands: &'a [Band],
+        position: egui::Pos2,
+        history_right: f32,
+        magnet: bool,
+    ) -> Option<(&'a Band, ChartPoint)> {
+        let (band, position) = self.placement_target(areas, bands, position)?;
+        let total = self.slots();
+        // A tool shapes in the space it paints in, so the anchors already
+        // down are handed over projected. A draft belonging to another tool
+        // is not this tool's draft — `place_with` will start a fresh one, so
+        // there is nothing shaped yet.
+        //
+        // A freehand draft is skipped, and the reason is runtime rather than
+        // taste. This runs up to three times a frame while a tool is armed
+        // (hover, press, release), and a pencil stroke holds up to
+        // `FREEHAND_MAX_POINTS` anchors against a `SmallVec` that keeps four
+        // inline — so projecting one would allocate and walk the whole stroke
+        // every frame, during exactly the gesture where the hand is moving
+        // fastest, to hand it to a port that has no anchor to shape: a
+        // freehand tool declares no anchor count, and its draft is finished by
+        // the release, never by a click. Every other tool's draft is three
+        // anchors at most, which stays inline and allocates nothing.
+        let shaped = match (self.drawings.draft(), band.scale.as_ref()) {
+            (Some(draft), Some(scale)) if draft.tool == tool && !tool.freehand() => {
+                let placed = self.projected_drawing_points(draft, history_right, total, scale);
+                tool.pending_anchor(&placed, position)
+            }
+            _ => position,
+        };
+        let point = self.drawing_point_at(
+            shaped,
+            history_right,
+            total,
+            magnet,
+            tool.anchor_snap(),
+            band,
+        )?;
+        Some((band, point))
     }
 
     fn place_drawing_point(

--- a/crates/app/src/pane.rs
+++ b/crates/app/src/pane.rs
@@ -57,6 +57,26 @@ pub const DRAWING_ANCHOR_RADIUS_PX: f32 = 12.0;
 const MAGNET_REACH_PX: f32 = 12.0;
 const DRAWING_DRAG_THRESHOLD_PX: f32 = 4.0;
 
+/// How far a press must travel before its release counts as "the trader
+/// dragged this object out" instead of "the trader clicked".
+///
+/// Deliberately larger than [`DRAWING_DRAG_THRESHOLD_PX`], which answers a
+/// different question: whether a gesture already under way is a drag at all.
+/// This one decides whether a *release* finishes an object, and it was
+/// sharing that four-pixel answer — which is inside the wander of an ordinary
+/// click.
+///
+/// What that cost, reported from the running build: a click meant to start a
+/// fixed-range profile placed **both** its anchors, so the object was born
+/// less than one bar wide ("1 of 1 bars"), and completing it disarmed the
+/// tool. Moving the pointer afterwards then did nothing at all, which reads
+/// exactly like a frozen chart — the trader is waiting for a range to follow
+/// their hand and there is no longer a draft to follow it.
+///
+/// A release under this distance leaves the draft alive instead, so the
+/// gesture becomes the click-move-click the hand was already doing.
+const DRAWING_DRAG_COMPLETES_PX: f32 = 12.0;
+
 /// A pointer and a modifier for a run with nobody at the keyboard — see
 /// [`ChartPane::parked_hand`]. Never constructed outside the harness hook.
 #[derive(Debug, Clone, Copy)]
@@ -2301,7 +2321,7 @@ impl ChartPane {
             && let Some(start) = self.drawing_press_position
             && let Some(position) = released_position
             && surface.contains(position)
-            && start.distance(position) >= DRAWING_DRAG_THRESHOLD_PX
+            && start.distance(position) >= DRAWING_DRAG_COMPLETES_PX
             && let Some((band, point)) = self.shaped_placement(
                 tool,
                 areas,

--- a/crates/app/src/pane.rs
+++ b/crates/app/src/pane.rs
@@ -2097,6 +2097,14 @@ impl ChartPane {
         chrome: &mut PaneChrome<'_>,
     ) -> bool {
         let magnet = chrome.toolrail.magnet();
+        // Shift, read once for the whole pass: the preview, the press and the
+        // release must agree about it as strictly as they agree about where
+        // the pointer is.
+        let constrain = if ui.input(|input| input.modifiers.shift) {
+            drawings::Constrain::Level
+        } else {
+            drawings::Constrain::Free
+        };
         let Some(tool) = chrome.toolrail.tool().drawing_tool() else {
             self.drawings.cancel_draft();
             self.drawing_hover = None;
@@ -2163,8 +2171,15 @@ impl ChartPane {
         self.drawing_hover = preview_pos
             .filter(|position| !over_chrome(ui, *position))
             .and_then(|position| {
-                let (_, point) =
-                    self.shaped_placement(tool, areas, bands, position, history_right, magnet)?;
+                let (_, point) = self.shaped_placement(
+                    tool,
+                    areas,
+                    bands,
+                    position,
+                    history_right,
+                    magnet,
+                    constrain,
+                )?;
                 Some(point)
             });
         if (response.hovered() || response.dragged()) && !over_pane_chrome {
@@ -2188,8 +2203,15 @@ impl ChartPane {
         });
         if let Some(position) = pressed_position
             .filter(|position| surface.contains(*position) && !over_chrome(ui, *position))
-            && let Some((band, point)) =
-                self.shaped_placement(tool, areas, bands, position, history_right, magnet)
+            && let Some((band, point)) = self.shaped_placement(
+                tool,
+                areas,
+                bands,
+                position,
+                history_right,
+                magnet,
+                constrain,
+            )
         {
             let band = band.key.clone();
             self.drawing_press_started_empty = self.drawings.draft_len() == 0;
@@ -2271,8 +2293,15 @@ impl ChartPane {
             && let Some(position) = released_position
             && surface.contains(position)
             && start.distance(position) >= DRAWING_DRAG_THRESHOLD_PX
-            && let Some((band, point)) =
-                self.shaped_placement(tool, areas, bands, position, history_right, magnet)
+            && let Some((band, point)) = self.shaped_placement(
+                tool,
+                areas,
+                bands,
+                position,
+                history_right,
+                magnet,
+                constrain,
+            )
         {
             let band = band.key.clone();
             self.place_drawing_point(tool, &band, point, chrome);
@@ -2338,6 +2367,7 @@ impl ChartPane {
     /// outside the band it was aimed at — clamping it back would hand the
     /// degenerate case straight back to the trader, which is the whole thing
     /// being fixed.
+    #[allow(clippy::too_many_arguments)]
     fn shaped_placement<'a>(
         &self,
         tool: drawings::DrawingTool,
@@ -2346,6 +2376,7 @@ impl ChartPane {
         position: egui::Pos2,
         history_right: f32,
         magnet: bool,
+        constrain: drawings::Constrain,
     ) -> Option<(&'a Band, ChartPoint)> {
         let (band, position) = self.placement_target(areas, bands, position)?;
         let total = self.slots();
@@ -2367,7 +2398,7 @@ impl ChartPane {
         let shaped = match (self.drawings.draft(), band.scale.as_ref()) {
             (Some(draft), Some(scale)) if draft.tool == tool && !tool.freehand() => {
                 let placed = self.projected_drawing_points(draft, history_right, total, scale);
-                tool.pending_anchor(&placed, position)
+                tool.pending_anchor(&placed, position, constrain)
             }
             _ => position,
         };
@@ -2570,6 +2601,7 @@ impl ChartPane {
     /// exact by construction and are never snapped a second time — the magnet
     /// belongs to the point under the pointer, not to a rail computed from it.
     /// Everything else is the plain "handle `handle` is anchor `handle`" move.
+    #[allow(clippy::too_many_arguments)]
     fn drag_drawing_handle(
         &mut self,
         drawing_index: usize,
@@ -2578,6 +2610,7 @@ impl ChartPane {
         band: &Band,
         history_right: f32,
         total: usize,
+        constrain: drawings::Constrain,
     ) {
         let moved = band.scale.as_ref().and_then(|scale| {
             let drawing = self.drawings.items().get(drawing_index)?;
@@ -2595,7 +2628,7 @@ impl ChartPane {
             let to = self.drawing_screen_point(target, history_right, total, scale);
             drawing
                 .tool
-                .drag_handle(band.rect, &projected, handle, to, &ctxt)
+                .drag_handle(band.rect, &projected, handle, to, &ctxt, constrain)
         });
         let Some(moved) = moved else {
             self.drawings.move_anchor(drawing_index, handle, target);
@@ -2970,6 +3003,11 @@ impl ChartPane {
                                     band,
                                     history_right,
                                     total,
+                                    if ui.input(|input| input.modifiers.shift) {
+                                        drawings::Constrain::Level
+                                    } else {
+                                        drawings::Constrain::Free
+                                    },
                                 );
                             }
                             ui.ctx().set_cursor_icon(egui::CursorIcon::ResizeNwSe);

--- a/crates/app/src/toolrail.rs
+++ b/crates/app/src/toolrail.rs
@@ -1596,7 +1596,9 @@ mod tests {
         );
         // Shift+F is *flatten*. The Fib extension gave the chord up rather
         // than keep arming a tool and closing a position on one keystroke;
-        // it is reached through the Fib family flyout.
+        // it is reached through the Fib family flyout. Its tooltip went on
+        // advertising the chord for far longer — see
+        // `a_tooltip_names_the_key_the_tool_really_answers_to`.
         send(&mut rail, egui::Key::F, egui::Modifiers::SHIFT);
         assert_eq!(
             rail.tool().drawing_tool().map(DrawingTool::id),
@@ -1623,6 +1625,35 @@ mod tests {
         // A held command modifier keeps the letters out of the tool map.
         send(&mut rail, egui::Key::R, egui::Modifiers::COMMAND);
         assert_eq!(rail.tool(), Tool::Pointer);
+    }
+
+    /// A tooltip that names a key must name the key the tool really answers
+    /// to, and a tool with no key must name none.
+    ///
+    /// The Fib extension advertised `Shift+F` in its tooltip for a long time
+    /// after giving that chord up — and `Shift+F` is *flatten*. The tooltip
+    /// was telling the trader that the way to reach a drawing tool is the one
+    /// keystroke that closes their position and cancels their working orders.
+    /// Nothing failed; the words simply went stale. This is the test that
+    /// stops them.
+    ///
+    /// The convention the rail already follows: a trailing `(<label>)`, with
+    /// `<label>` exactly what the menus print for that tool.
+    #[test]
+    fn a_tooltip_names_the_key_the_tool_really_answers_to() {
+        for tool in DRAWING_TOOLS.into_iter().map(Tool::Drawing) {
+            let advertised = tool
+                .hover_text()
+                .rsplit_once('(')
+                .and_then(|(_, tail)| tail.strip_suffix(')'))
+                .map(str::to_owned);
+            assert_eq!(
+                advertised,
+                tool.shortcut_label(),
+                "{} advertises one key and answers to another",
+                tool.name()
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Reported from the running build: *"ao desenhar um canal, criar e arrastar não tá dando muito certo — parece que fica uma linha reta e não um canal."*

It was. And the drag did not just *look* wrong — it created a straight line.

## The defect

A parallel channel takes three anchors, and its width is measured **across** the trend line and nowhere else (`parallel_channel.rs`, `channel_offset`). Press–drag–release lays the first two and lets go with the pointer still standing *on* that line, so the width the pointer implies is exactly **zero**. The preview drew a corridor of no width — a straight line — and the click that looked like it confirmed the shape committed one: a three-anchor object that is a line.

Proven, not argued. With the floor set to `0.0` (the old behaviour), the new end-to-end test fails with the committed anchors printed:

```
the width anchor is off the trend line; anchors [
  ChartPoint { bar: 114.0, price: 101.11854841321707, .. },
  ChartPoint { bar: 139.0, price: 101.28709676414728, .. },
  ChartPoint { bar: 139.0, price: 101.28709676414728, .. }]   <- identical to the one before it
```

The triangle collapsed the same way (three collinear corners) and, worse, **drew nothing at all** while its first side was being dragged — its outline only existed once three corners did.

## The fix — a port, not a special case

`DrawingToolImpl::pending_anchor` lets a tool say where the anchor it is still *shaping* really lands, given the anchors already down and the pointer. The default is the pointer itself, so **no tool that did not ask for it changed** — guarded by `the_shaping_port_defaults_to_the_pointer_the_trader_is_holding`, which asserts that exactly `parallel-channel` and `triangle` move at all.

The channel and the triangle floor the collapsed case and keep everything else: the bar the pointer is on is untouched (same rule a width drag on a finished channel already followed), the side the trader opened the corridor on is kept, and a pointer that has already declared a width keeps it exactly.

The preview and the click also stopped disagreeing about where the pointer is — they read it from two different places, which is how a shape could be previewed one way and committed another. Both go through `ChartPane::shaped_placement` now. That is also why the preview was untestable before: under a headless context the widget reports no hover ever, so no test could see the shape.

## Found on the way — a tooltip pointing at flatten

`fib_extension.rs` still advertised **`Shift+F`** in its tooltip, long after that chord was deliberately given up. `Shift+F` is **flatten**: close the position, cancel every working order. The tooltip was telling the trader that the way to reach a drawing tool is the one keystroke that closes their position. Nothing failed — the words just went stale.

Fixed, and `a_tooltip_names_the_key_the_tool_really_answers_to` now holds every tooltip's advertised key against the tool's real shortcut, so this cannot rot again.

## Performance impact, by rate

| Path | Rate | Impact |
| --- | --- | --- |
| `shaped_placement` (hover/press/release) | per frame, only while a tool is armed | ≤3 anchor projections, `SmallVec` inline, **zero allocation** |
| draft preview paint | per frame, only while a draft is in flight | unchanged shape count |
| trade ingest, depth | per trade / per depth | **untouched** |

The first draft of this change had a real regression, caught in review and fixed here: `shaped_placement` projected the *whole* draft, and a pencil stroke holds up to `FREEHAND_MAX_POINTS` (512) anchors against a `SmallVec` that keeps four inline — an allocation plus a 512-point walk, three times a frame, during the gesture where the hand moves fastest, to consult a port with no anchor to shape. Freehand drafts are skipped, and `no_freehand_tool_asks_to_shape_its_anchors` keeps that skip sound.

Measured under a live BTCUSDT tape (`APP_HEALTH_SUMMARY`): `fps=60`, `frame_avg_ms=16.664`, `frame_worst_ms=19.1`, `frame_cpu_ms≈1.8` — identical with a channel draft in flight and with no tool armed. No `main` control run was taken this session; the isolating comparison above is draft-in-flight vs. idle on the same build, which is what bounds the new code path.

## Blast radius

Added: 0 files. Edited: 7 source files + 1 skill doc. Mostly edits — because the change *is* the extraction of the missing abstraction, and the two tools that need it are existing ones. A third tool that wants shaping writes its own file and one method.

## Harness

`QUANTICK_DRAWING_DRAFT=<anchors>` reaches the half-placed object with the pointer parked where the next anchor would go — the one surface that exists only *between* two clicks. Registered in `ui-harness`.

## Verification

- `cargo fmt --all -- --check` — exit 0
- `cargo clippy --workspace --all-targets -- -D warnings` — exit 0
- `cargo build --workspace` — exit 0
- `cargo test --workspace` — 1036 app tests + every other crate green. **One failure, environmental:** `quantick-feed-mt5::the_bridge_paging_tests_pass` shells out to Python, which is not installed on this machine (`Python was not found`). Untouched by this diff; CI's ubuntu image ships one.
- Visual: the corridor, the `2/3` rail badge and the hint chip ("Move to set the width, click to place"), captured live at 60 fps.

## Reviews

`arch-review` run over `git diff main...HEAD`. One Should-fix found (the freehand hot-path projection) and **fixed in this branch**, with a test. `trader-ux-review` walked the creation flow: the reported Blocker is fixed, and the `Shift+F` tooltip was a second one.

### Explicitly deferred, not fixed here

1. **`QUANTICK_WINDOW_SIZE` photographs a partly-blank window.** At `1600x1000` the app painted only ~1500x870 and left a black L-band that **clipped the rail's trailing cluster** (magnet, repeat, hide-all, lock-all, objects). At the default size the app fills the client exactly. Pre-existing, in window/surface resize handling, not in these files — but it means visual-qa runs using that hook have been reading a truncated window. Worth its own issue.
2. **`QUANTICK_DRAWINGS_DEMO` cannot fire on a live tick feed.** It needs `8 × DRAWING_TOOLS.len()` = 184 tick bars ≈ 9,200 trades ≈ 50 minutes on BTCUSDT `tick(50)`. So the **context bar and action bar could not be photographed** this session; both are untouched by this diff and are covered by their own tests. The harness gap is the finding.
3. **A newly armed multi-anchor tool says nothing until the first anchor is down** (`placement_hint(0)` is only required of freehand tools). Rated Consider, not Should-fix: a chip that appears the instant a tool is armed is noise for a scalper who arms `H` and clicks in one motion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KgB6PLsMmsdpk4FrjSMxE5


---

## Follow-up: hold Shift to keep a channel level

Asked for after the first review of the running build. A range is the channel traders draw most, and a free hand never gets one quite flat — you can *see* it is a degree off and have nothing to fix it against.

Shift now holds the corridor level in **both** places it has to:

- **While the trend line is being dragged**, the far end lands at the price the near end is on, and still slides freely along the tape.
- **On a corner of a finished channel**, that corner lays level with the corner it pivots around. Straightening is a corner drag, so a constraint that only existed at birth would be no use on the channel that actually came out crooked. The rails are parallel, so levelling one levels the whole thing.

The rail-centre (width) handles ignore it, and say why: width is measured across the trend line and never along it, so there is no angle to hold.

**Level, not 0°/45°/90°.** A chart's two axes are a price and a time; their ratio changes with every zoom, so a 45° line drawn today is a different line after one scroll. Horizontal is the only angle that survives a zoom, and it is the one that means something — a level *is* a price held constant.

**The modifier is free to take**, and that is worth stating because Shift is otherwise the trading modifier: every paper-trading hotkey is Shift **plus a letter** (`docs/ux/paper-trading.md` §9) and the rail's tool keys are letters, so the modifier held alone cannot fire an order, flatten a position or arm a tool.

It arrives through the same `pending_anchor` port (plus `drag_handle`), as a `Constrain` a tool may answer rather than a rule the host imposes — the triangle and the range profile each say, in code, that they have no angle worth holding. Discoverability is on the placement chip itself: *"Drag out the trend line - hold Shift to keep it level"*, beside the cursor, while the hand is already doing the gesture.

Six new tests, including two end-to-end through the real app: `holding_shift_lays_a_channel_dead_level` (both anchors on one price, still spanning bars) and `without_shift_a_channel_keeps_the_slope_it_was_drawn_with` (the constraint is opt-in, never a snap nobody asked for).

Checks re-run at `db2bcd1`: fmt/clippy/build exit 0, 1042 app tests green, same single environmental Python failure in the MT5 bridge.


---

## Follow-up 2: Shift on the trend line, and the click path finally tested

The trend line is the tool a trader reaches for when what they want *is* a level, so it takes the same modifier. The rule lives in `line_core` beside the geometry the straight-line tools already share, so a ray or an extended line adopts it by forwarding one method — "a line held level" is one rule, and seven copies of it would drift. `shift_reaches_exactly_the_tools_with_an_angle_to_hold` names the list, so a tool that should answer to Shift fails until it is listed.

### The gesture was only ever tested by dragging

A trader described the flow back as **click, move, click, move, click** — the other half of the same placement, and it had no test at all. It does now, and it asserts what is *on screen* at each step rather than the state behind it, because a placement gesture does all of its talking in the frames between the clicks:

| Step | Asserted |
| --- | --- |
| first click | one anchor down |
| move | exactly **one** stroke — a straight line, because there is no width yet |
| second click | trend line fixed |
| move | **both rails** follow the pointer |
| third click | committed, and the corridor opened on the side the hand went |

`the_corridor_opens_on_the_side_the_pointer_moved` covers both directions: down when the pointer goes down, up when it goes up. `holding_shift_levels_a_channel_placed_by_clicks` proves the modifier on the click path too — a gesture placed a different way has to mean the same thing.

### Harness fix found by using it

`QUANTICK_DRAWING_DRAFT=1` photographed **nothing**: a lone anchor lands at the centre of the chart, which is exactly where the hook parks its pointer, so the rubber band had no length. The parked pointer now steps aside when it would otherwise stand on the only anchor.

The parked hand also carries the modifier (`QUANTICK_DRAWING_CONSTRAIN=1`). A levelled draft is a state of its own, and a modifier is the one input a capture run cannot supply any other way — the harness forbids injecting input, so without this the Shift behaviour is unphotographable.

**A caution earned the hard way:** an instance left running with `QUANTICK_DRAWING_CONSTRAIN=1` draws every channel horizontal with no key pressed, which reads exactly like a broken build. Capture instances must not outlive their capture.

Checks at `4e2b21b`: fmt/clippy exit 0, **1047** app tests green, same single environmental Python failure in the MT5 bridge.


---

## Follow-up 3: a click that wanders a few pixels was creating an object

Reported against the **fixed-range profile**, with a screenshot: clicking to start one placed *both* its anchors at once. The object was born less than a bar wide — its own status line said **"1 of 1 bars"** — and completing it disarmed the tool, so moving the pointer afterwards did nothing at all.

From the trader's side that reads as a frozen chart. They are waiting for the range to follow their hand, and there is no longer a draft to follow it. The report was literally *"só cliquei e mexi o mouse, não deslizou"*.

Measured before the fix, on the exact reported gesture — a five-pixel click:

```
PROBE items=1  draft=0  armed=None  bars=[114.0, 114.625]
```

An object created, a range **0.625 bars** wide, and the tool disarmed behind it.

**The cause:** the release path decided *"did the trader drag this object out?"* using `DRAWING_DRAG_THRESHOLD_PX` (4 px) — a constant that answers a different question, namely whether a gesture already under way is a drag at all. Four pixels is inside the wander of an ordinary click.

**The fix:** a separate, larger `DRAWING_DRAG_COMPLETES_PX` (12 px). A release under it leaves the draft alive, so the gesture becomes the click-move-click the hand was already doing — preview following, tool still armed, next click closing a range worth having. A real drag is untouched; it travels far past twelve pixels.

`a_click_that_wanders_a_few_pixels_is_still_a_click` walks the whole recovery: no object from the click, one anchor down, tool still armed, both range edges following the pointer on the next move, and a final span of more than one bar.

This is the third object in this PR that could be born degenerate (channel of no width, triangle of no area, range of no bars). They came from three different places in the code but they are one failure: **a gesture the trader had not finished was being treated as one they had.**

Checks at `e54c368`: fmt/clippy exit 0, **1048** app tests green, same single environmental Python failure in the MT5 bridge.
