### PR TITLE
fix: own up to the short bar at the venue seam

### DIFF
--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -14482,7 +14482,7 @@ plot(close)
         assert_eq!(
             pane.partial_bucket_slot(),
             Some(2),
-            "the seam slot is named as partly covered"
+            "the tape's first bar is named as partly covered"
         );
         // The composed series is non-decreasing in open_time, which is what
         // the slot search depends on.

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -14458,8 +14458,31 @@ plot(close)
         assert_eq!(
             pane.seam_slot(),
             2,
-            "the overlapping bucket is dropped; what the app cut from prints \
-             is the better record of that window"
+            "the overlapping bucket is dropped, which keeps the slot search sound"
+        );
+        // Dropping it is right for ordering and lossy for volume: the engine
+        // bar inheriting that slot opened on its first print, part-way into
+        // the interval the venue candle covered whole. The pane owns up to it
+        // so a profile folding the slot can say so — the alternative is a
+        // total that silently omits everything traded before the app
+        // connected (36% of a minute, 94% of an hour, measured live).
+        let interval = crate::feed::OHLCV_BASE_INTERVAL_MS;
+        let first_open = pane
+            .state
+            .bars()
+            .first()
+            .or_else(|| pane.state.partial())
+            .map(|bar| bar.open_time)
+            .expect("the pane holds the fixture trades");
+        assert_ne!(
+            crate::resample::bucket_start(first_open, interval),
+            first_open,
+            "the fixture's first engine bar opens inside its bucket"
+        );
+        assert_eq!(
+            pane.partial_bucket_slot(),
+            Some(2),
+            "the seam slot is named as partly covered"
         );
         // The composed series is non-decreasing in open_time, which is what
         // the slot search depends on.

--- a/crates/app/src/drawings/fixed_range_profile.rs
+++ b/crates/app/src/drawings/fixed_range_profile.rs
@@ -359,10 +359,14 @@ fn status_line(
         status.push_str(" · incl. forming bar");
     }
     if cache.bars_partly_covered > 0 {
-        // The tape's first bar opened mid-interval and the venue candle that
-        // covered the rest was dropped at the seam. The shortfall is real and
-        // unmeasurable from here, so it is named rather than topped up.
-        status.push_str(" · seam bar partly covered");
+        // The tape's first bar opened mid-interval, so it holds less than the
+        // interval it occupies — and where a venue prefix exists, the candle
+        // that did cover the rest was dropped at the seam. The shortfall is
+        // real and unmeasurable from here, so it is named, not topped up.
+        //
+        // "first tape bar", not "seam bar": a pane with no venue history has
+        // no seam, and its first bar is short all the same.
+        status.push_str(" · first tape bar partly covered");
     }
     if cache.bars_covered + cache.bars_approximated < cache.bars_total {
         status.push_str(&format!(
@@ -1307,12 +1311,14 @@ mod tests {
         assert_eq!(right, 510.0);
     }
 
-    /// The seam bar's shortfall is named, not topped up. Without this the
-    /// range read as fully covered while missing whatever traded in that
+    /// The short first bar's shortfall is named, not topped up. Without this
+    /// the range read as fully covered while missing whatever traded in that
     /// interval before the app connected — 36% of a minute, 94% of an hour,
-    /// measured on a live BTCUSDT connect.
+    /// measured on a live BTCUSDT connect. It is worded for the tape, not for
+    /// the seam: a pane with no venue history has no seam and a short first
+    /// bar all the same.
     #[test]
-    fn status_line_speaks_a_partly_covered_seam_bar() {
+    fn status_line_speaks_a_partly_covered_first_tape_bar() {
         let profile = some_profile();
         let payload = FrvpPayload::default();
         let mut cache = cache_for(3, 3, 0);
@@ -1321,7 +1327,11 @@ mod tests {
         cache.bars_partly_covered = 1;
         cache.key.partly_covered = true;
         let status = status_line(&profile, &cache, &payload, false);
-        assert!(status.contains(" · seam bar partly covered"), "{status}");
+        assert!(
+            status.contains(" · first tape bar partly covered"),
+            "{status}"
+        );
+        assert!(!status.contains("seam"), "no seam is claimed: {status}");
         // It is a caveat about one bar, not a coverage shortfall: all three
         // bars still contributed, so the "N of M" clause stays quiet.
         assert!(!status.contains("profile from"), "{status}");

--- a/crates/app/src/drawings/fixed_range_profile.rs
+++ b/crates/app/src/drawings/fixed_range_profile.rs
@@ -99,6 +99,12 @@ pub struct FrvpCache {
     /// tape, their volume spread over their own high–low. Spoken by the
     /// status line, never blended away.
     pub bars_approximated: usize,
+    /// Bars folded that cover only *part* of the interval they occupy — in
+    /// practice the tape's first bar, whose venue candle was dropped at the
+    /// seam. 0 or 1 today. How much volume they are short by is unknowable
+    /// from here and is never invented; the status line names the bar and
+    /// lets the trader judge it.
+    pub bars_partly_covered: usize,
     /// Bars the anchors span on the chart, prefix candles included.
     pub bars_total: usize,
     /// The oldest global slot the L2 heatmap covers this frame — where the
@@ -129,6 +135,10 @@ pub struct FrvpCacheKey {
     /// Whether venue-history candles are folded in as approximated ladders
     /// — the payload's own switch, in the key so toggling it re-folds.
     pub approximate: bool,
+    /// Whether the range reaches a bar covering only part of its interval
+    /// (see [`FrvpCache::bars_partly_covered`]). In the key so dragging off that bar
+    /// clears the caveat and dragging back onto it restores it.
+    pub partly_covered: bool,
 }
 
 /// The versioned on-disk shape of a saved preset. Coordinates and cache never
@@ -347,6 +357,12 @@ fn status_line(
         // its interval as has traded so far. Without this the same range
         // reads differently a second later for no stated reason.
         status.push_str(" · incl. forming bar");
+    }
+    if cache.bars_partly_covered > 0 {
+        // The tape's first bar opened mid-interval and the venue candle that
+        // covered the rest was dropped at the seam. The shortfall is real and
+        // unmeasurable from here, so it is named rather than topped up.
+        status.push_str(" · seam bar partly covered");
     }
     if cache.bars_covered + cache.bars_approximated < cache.bars_total {
         status.push_str(&format!(
@@ -1149,11 +1165,13 @@ mod tests {
                 blocked: false,
                 side_inferred: false,
                 approximate: approximated > 0,
+                partly_covered: false,
             },
             profile: None,
             empty: None,
             bars_covered: covered,
             bars_approximated: approximated,
+            bars_partly_covered: 0,
             bars_total: total,
             heat_first_slot: None,
         }
@@ -1289,6 +1307,27 @@ mod tests {
         assert_eq!(right, 510.0);
     }
 
+    /// The seam bar's shortfall is named, not topped up. Without this the
+    /// range read as fully covered while missing whatever traded in that
+    /// interval before the app connected — 36% of a minute, 94% of an hour,
+    /// measured on a live BTCUSDT connect.
+    #[test]
+    fn status_line_speaks_a_partly_covered_seam_bar() {
+        let profile = some_profile();
+        let payload = FrvpPayload::default();
+        let mut cache = cache_for(3, 3, 0);
+        assert!(!status_line(&profile, &cache, &payload, false).contains("partly covered"));
+
+        cache.bars_partly_covered = 1;
+        cache.key.partly_covered = true;
+        let status = status_line(&profile, &cache, &payload, false);
+        assert!(status.contains(" · seam bar partly covered"), "{status}");
+        // It is a caveat about one bar, not a coverage shortfall: all three
+        // bars still contributed, so the "N of M" clause stays quiet.
+        assert!(!status.contains("profile from"), "{status}");
+        assert!(status.contains(" · 3 bars"), "{status}");
+    }
+
     /// Partial coverage keeps its own explicit `N of M`, on top of the span.
     #[test]
     fn status_line_still_speaks_partial_coverage() {
@@ -1394,11 +1433,13 @@ mod tests {
                     blocked: false,
                     side_inferred: false,
                     approximate: true,
+                    partly_covered: false,
                 },
                 profile: None,
                 empty: Some(FrvpEmpty::NoTape),
                 bars_covered: 0,
                 bars_approximated: 0,
+                bars_partly_covered: 0,
                 bars_total: 5,
                 heat_first_slot: None,
             }),

--- a/crates/app/src/frvp.rs
+++ b/crates/app/src/frvp.rs
@@ -91,6 +91,13 @@ pub struct RefreshInputs<'a> {
     /// that completes a one-anchor draft's range, so the histogram is live
     /// under the drag instead of appearing only on release.
     pub draft_hover_bar: Option<f32>,
+    /// The slot of a bar covering only part of its interval — the tape's
+    /// first bar, which opened on a print inside the interval while the venue
+    /// candle covering all of it was dropped at the seam. See
+    /// [`Pane::partial_bucket_slot`](crate::pane::Pane::partial_bucket_slot).
+    /// A range reaching it is short by whatever traded before the app
+    /// connected, and says so rather than being quietly topped up.
+    pub partial_bucket_slot: Option<usize>,
 }
 
 /// Bring every fixed-range-profile drawing's cached profile up to date.
@@ -186,6 +193,13 @@ fn refresh_one(payload: &mut FrvpPayload, min_bar: f32, max_bar: f32, inputs: &R
     let (start_slot, end_slot) = span.unwrap_or((0, 0));
     let bars_total = span.map_or(0, |(start, end)| end - start + 1);
     let include_partial = span.is_some() && partial_slot.is_some_and(|slot| slot <= end_slot);
+    // A range reaching the tape's first bar folds a bar that covers only part
+    // of its interval. In the key, so the caveat cannot outlive the range that
+    // earned it.
+    let partly_covered = span.is_some()
+        && inputs
+            .partial_bucket_slot
+            .is_some_and(|slot| start_slot <= slot && slot <= end_slot);
 
     let key = FrvpCacheKey {
         start_slot,
@@ -203,6 +217,7 @@ fn refresh_one(payload: &mut FrvpPayload, min_bar: f32, max_bar: f32, inputs: &R
         blocked: inputs.blocked,
         side_inferred: inputs.side_inferred,
         approximate: payload.approximate_history,
+        partly_covered,
     };
     if let Some(cache) = payload.cache.as_mut().filter(|cache| cache.key == key) {
         // Key hit: the fold is current. Presentation state still follows the
@@ -218,6 +233,7 @@ fn refresh_one(payload: &mut FrvpPayload, min_bar: f32, max_bar: f32, inputs: &R
             empty: Some(FrvpEmpty::Blocked),
             bars_covered: 0,
             bars_approximated: 0,
+            bars_partly_covered: 0,
             bars_total,
             heat_first_slot: inputs.heat_first_slot,
         });
@@ -274,6 +290,7 @@ fn refresh_one(payload: &mut FrvpPayload, min_bar: f32, max_bar: f32, inputs: &R
         empty,
         bars_covered,
         bars_approximated,
+        bars_partly_covered: usize::from(partly_covered),
         bars_total,
         heat_first_slot: inputs.heat_first_slot,
     });
@@ -356,6 +373,7 @@ mod tests {
             side_inferred: false,
             heat_first_slot: None,
             draft_hover_bar: None,
+            partial_bucket_slot: None,
         }
     }
 
@@ -441,6 +459,51 @@ mod tests {
             dec("6"),
             "the bar under the right edge is part of the profile"
         );
+    }
+
+    /// The tape's first bar opens on a print inside its interval, and the
+    /// venue candle that covered the rest was dropped at the seam. A range
+    /// reaching that bar is short by whatever traded before the app
+    /// connected — it says so, and nothing tops the volume back up.
+    #[test]
+    fn a_range_reaching_the_seam_bar_says_it_is_partly_covered() {
+        let state = state_with_tape();
+        let mut drawings = Drawings::default();
+        place_frvp(&mut drawings, 0.0, 2.0);
+
+        let seam = RefreshInputs {
+            partial_bucket_slot: Some(0),
+            ..inputs(&state, false)
+        };
+        refresh(&mut drawings, &seam);
+        let cache = cache_of(&drawings);
+        assert_eq!(cache.bars_partly_covered, 1, "the seam bar is in range");
+        assert!(cache.key.partly_covered);
+        // The caveat costs no volume: the short bar still folds its own tape.
+        assert_eq!(
+            cache.profile.expect("tape").0.total_volume(),
+            dec("6"),
+            "nothing is invented and nothing is dropped"
+        );
+
+        // Drag off the seam bar and the caveat goes with it.
+        drawings.move_anchor(0, 0, ChartPoint::at(1.0, 100.0));
+        refresh(&mut drawings, &seam);
+        let cache = cache_of(&drawings);
+        assert_eq!(cache.bars_partly_covered, 0);
+        assert!(!cache.key.partly_covered);
+    }
+
+    /// A pane with no seam bar to speak of stays silent — the caveat is not
+    /// stamped on every profile just because the plumbing exists.
+    #[test]
+    fn without_a_partial_bucket_no_caveat_is_claimed() {
+        let state = state_with_tape();
+        let mut drawings = Drawings::default();
+        place_frvp(&mut drawings, 0.0, 2.0);
+        refresh(&mut drawings, &inputs(&state, false));
+        assert_eq!(cache_of(&drawings).bars_partly_covered, 0);
+        assert!(!cache_of(&drawings).key.partly_covered);
     }
 
     #[test]

--- a/crates/app/src/pane.rs
+++ b/crates/app/src/pane.rs
@@ -1429,6 +1429,32 @@ impl ChartPane {
         self.history_prefix.len()
     }
 
+    /// The slot of a bar that covers only *part* of the interval it occupies,
+    /// when there is one.
+    ///
+    /// The tape's first bar opens on its first print, which lands somewhere
+    /// inside the interval rather than on its edge — and the venue candle
+    /// that did cover the whole interval was dropped at the seam
+    /// (`trim_to_seam`) precisely because the two overlap. So that slot holds
+    /// a short bar wearing a full bar's clothes: a range folding it is missing
+    /// whatever traded before the app connected, measured on a live BTCUSDT
+    /// connect at 36% of a 1-minute bucket and 94% of an hourly one.
+    ///
+    /// No volume is invented to close the gap. The profile says the bar is
+    /// partly covered and lets the trader judge it — the same contract the
+    /// approximated-from-OHLC label keeps.
+    ///
+    /// `None` for a pane that does not cut by time (a tick or volume bar owns
+    /// no interval to fall short of), and for a first bar that opens exactly
+    /// on its boundary.
+    pub fn partial_bucket_slot(&self) -> Option<usize> {
+        let interval = self.state.spec().time_interval_ms()?;
+        let first = self.state.bars().first().or_else(|| self.state.partial())?;
+        let opens_inside =
+            crate::resample::bucket_start(first.open_time, interval) != first.open_time;
+        opens_inside.then(|| self.seam_slot())
+    }
+
     /// The closed bar in `slot`, from whichever series owns it.
     pub fn closed_bar(&self, slot: usize) -> Option<&quantick_engine::Bar> {
         self.history_prefix
@@ -3505,6 +3531,8 @@ impl ChartPane {
                     && self.wants_range_profile()
             })
             .and_then(|frame| frame.first_heat_slot());
+        // Read before the drawings are borrowed mutably below.
+        let partial_bucket_slot = self.partial_bucket_slot();
         let prefix_approx = if self.wants_range_profile() && !footprint_blocked {
             crate::frvp::ApproxLadders::ensure(
                 &mut self.frvp_approx,
@@ -3526,6 +3554,7 @@ impl ChartPane {
                 side_inferred: chrome.side_inferred,
                 heat_first_slot,
                 draft_hover_bar: self.drawing_hover.map(|point| point.bar),
+                partial_bucket_slot,
             },
         );
 


### PR DESCRIPTION
> **Stacked on #153.** Base is `fix/profile-volume-parity` because this reuses the
> `status_line()` extracted there. Merge #153 first and GitHub retargets this to `main`.

## The defect

Found by an adversarial multi-agent audit of the volume profile data path.

`crates/app/src/tab.rs:146-148` drops the venue candle whose bucket contains
the tape's first print:

```rust
let seam = crate::resample::bucket_start(first.open_time, interval_ms);
folded.retain(|bar| bar.open_time < seam);
```

That is **correct for ordering** — keeping it would put a later-closing bar in
an earlier slot and break the slot search. The problem is what inherits the
slot: an engine bar that opened on its first print, part-way into an interval
the venue candle covered whole. `crates/app/src/frvp.rs` then computed
`bars_covered = ladders.len() - bars_approximated`, so
`bars_covered + bars_approximated == bars_total` and the only caveat clause
never fired. A short bar in a full bar's clothes.

## Measured

On a live BTCUSDT connect:

| Interval | Missing from the seam bucket | Share of it |
| --- | --- | --- |
| 1m | 4.16 BTC | **36%** |
| 1h | 307.70 BTC | **94%** |

A 3-hour range on a 1h pane read `vol 690` where the venue klines said **998**.
Read the same window an hour later, once the seam had scrolled out of range,
and it gave a different answer with nothing on screen to explain the change.

## The fix, and what it deliberately does not do

**The volume is not topped up.** How much the bar is short by is unknowable
from inside the app — the venue candle it would need was dropped precisely
because it overlaps — and synthesising it would break the rule that makes
every other number in this tool worth trusting.

So the shortfall is named instead:

- `Pane::partial_bucket_slot()` reports the slot of a bar that opens strictly
  inside its interval. `None` for panes that do not cut by time (a tick bar
  owns no interval to fall short of) and for a first bar that happens to open
  on its boundary.
- It rides `RefreshInputs` into the fold and lands on the cache as
  `bars_partly_covered`, with `partly_covered` in the cache key so dragging
  off the bar clears the caveat and dragging back restores it.
- The status line reads `· seam bar partly covered`.

Same deal the approximated-from-OHLC label already gives: the number, and what
is wrong with it.

## On screen

`vol 70.97 · Δ +22.95 · rows 1 · 14 bars · incl. forming bar · seam bar partly covered · 5 of 14 approximated from OHLC`

Captured live over the venue seam, 59 fps, label unclipped.

## Performance

| Path | Rate | Impact |
| --- | --- | --- |
| `Pane::partial_bucket_slot` | per frame per pane | one spec lookup, one slice head, one `div_euclid` — O(1), hoisted above the mutable borrow so it is computed once |
| `refresh_one` range test | per cache-key change (rare) | two integer comparisons |
| ingest / depth | — | untouched |

fps 59 with the seam scene up, unchanged from the base branch's measured
59.4 / 16.673 ms.

## Tests

- `a_range_reaching_the_seam_bar_says_it_is_partly_covered` — the caveat
  fires, the volume is unchanged (nothing invented, nothing dropped), and
  dragging off the bar clears it
- `without_a_partial_bucket_no_caveat_is_claimed` — not stamped on every
  profile just because the plumbing exists
- `status_line_speaks_a_partly_covered_seam_bar` — and the `N of M` clause
  stays quiet, because all bars did contribute
- `the_seam_drops_a_venue_bucket_that_overlaps_the_first_engine_bar`
  (existing) now also pins that the first engine bar opens **strictly inside**
  its bucket and that the pane reports the slot. It previously asserted only
  monotonic `open_time` — which is why this shipped.

`cargo fmt`/`clippy -D warnings`/`build`/`test --workspace` all green, 1032
app tests.

## Naming note

`bars_partly_covered` / `partly_covered`, deliberately not `partial`:
`include_partial` in the same struct already means the *forming* bar at the
live edge. Two different partials in one struct was a rename waiting to
happen.

## Alternative considered

Trim the *engine* side to the bucket boundary and keep the venue candle. It
would make the total correct rather than merely honest, but the seam bucket
would then be approximated placement instead of real tape, and dropping the
first engine bar from the composition reaches into the candle chart,
footprint indices and slot arithmetic. Worth its own change if the label
proves insufficient.

## Related issues from the same audit

#156 (value area crosses price gaps), #157 (POC plate vs POC line), #158
(refold blanks a live profile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019K36WEupqf6xomaG5zZzn9
