### PR TITLE
fix: bubble size means the same quantity at every zoom

### DIFF
--- a/crates/app/src/orderflow/config.rs
+++ b/crates/app/src/orderflow/config.rs
@@ -317,17 +317,6 @@ impl ConsumptionMark {
     }
 }
 
-impl BubbleSizeReference {
-    /// Whether the reference is measured from the recorded prints, as opposed
-    /// to [`Fixed`](Self::Fixed) — pinned by the user so a bubble means the
-    /// same quantity across sessions and symbols, which is exactly why
-    /// nothing the renderer decides is allowed to rescale it.
-    #[must_use]
-    pub fn is_automatic(self) -> bool {
-        !matches!(self, Self::Fixed)
-    }
-}
-
 /// How a bubble's fill is painted.
 ///
 /// `Flat` is the classic solid disc. `Sphere` shades each bubble like a ball

--- a/crates/app/src/orderflow/config.rs
+++ b/crates/app/src/orderflow/config.rs
@@ -251,18 +251,24 @@ impl IntensityMode {
 
 /// How the quantity that maps to a full-size bubble is chosen.
 ///
-/// `VisibleP99` keeps one outlier sweep from shrinking every other print to a
-/// dot, at the cost of making the top 1% all render at the maximum radius.
-/// `VisibleMax` restores a strict ordering (the biggest print is the only one
-/// at full size); `Fixed` pins the scale so bubble size means the same thing
-/// across sessions and symbols.
+/// The automatic modes measure the whole recorded tape, never the visible
+/// window: zoom decides what is on screen, not what a quantity means, so the
+/// scale only moves when the recording itself does — a new print beyond the
+/// old reference, or retention trimming the floor. `VisibleP99` keeps one
+/// outlier sweep from shrinking every other print to a dot, at the cost of
+/// making the top 1% all render at the maximum radius. `VisibleMax` restores
+/// a strict ordering among recorded prints (clusters a zoomed-out view merges
+/// past it saturate at full size); `Fixed` pins the scale so bubble size
+/// means the same thing across sessions and symbols. The `Visible*` names are
+/// the wire format shipped presets already use; what they measure stopped
+/// being the viewport the day zoom stopped being allowed to rescale a print.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum BubbleSizeReference {
-    /// 99th percentile of the visible clustered prints.
+    /// 99th percentile of the recorded clustered prints.
     #[default]
     VisibleP99,
-    /// The largest visible clustered print.
+    /// The largest recorded clustered print.
     VisibleMax,
     /// An explicit quantity, [`BubbleStyle::size_reference_quantity`].
     Fixed,
@@ -312,13 +318,12 @@ impl ConsumptionMark {
 }
 
 impl BubbleSizeReference {
-    /// Whether the reference is derived from what is on screen.
-    ///
-    /// The opposite is [`Fixed`](Self::Fixed), pinned so a bubble means the
-    /// same quantity all session — which is exactly why nothing the renderer
-    /// decides is allowed to rescale it.
+    /// Whether the reference is measured from the recorded prints, as opposed
+    /// to [`Fixed`](Self::Fixed) — pinned by the user so a bubble means the
+    /// same quantity across sessions and symbols, which is exactly why
+    /// nothing the renderer decides is allowed to rescale it.
     #[must_use]
-    pub fn is_visible(self) -> bool {
+    pub fn is_automatic(self) -> bool {
         !matches!(self, Self::Fixed)
     }
 }

--- a/crates/app/src/orderflow/history.rs
+++ b/crates/app/src/orderflow/history.rs
@@ -7,7 +7,8 @@ use quantick_engine::{Side, Trade};
 use quantick_orderbook::{ApplyOutcome, BookDelta, BookError, BookSide, BookSnapshot, OrderBook};
 use rust_decimal::Decimal;
 
-use super::config::HeatmapConfig;
+use super::config::{BubbleSizeReference, HeatmapConfig};
+use super::scale::SessionScale;
 
 /// Resting side represented by a liquidity run.
 pub type RestingSide = BookSide;
@@ -239,6 +240,7 @@ pub struct LiquidityHistory {
     archived: VecDeque<LiquidityRun>,
     active: BTreeMap<LevelKey, LiquidityRun>,
     aggressions: VecDeque<Aggression>,
+    scale: SessionScale,
     coverage: VecDeque<CoverageSegment>,
     gaps: VecDeque<CoverageGap>,
     pending_gap: Option<usize>,
@@ -249,8 +251,10 @@ impl LiquidityHistory {
     /// Construct empty history from sanitized settings.
     #[must_use]
     pub fn new(config: HeatmapConfig) -> Self {
+        let config = config.sanitized();
         Self {
-            config: config.sanitized(),
+            scale: SessionScale::new(config.price_grouping, config.bubble_cluster_ms),
+            config,
             book: OrderBook::new(),
             generation: None,
             last_generation: None,
@@ -283,6 +287,17 @@ impl LiquidityHistory {
                 current: self.config.price_grouping,
                 requested: next.price_grouping,
             });
+        }
+        // A new clustering window changes what "one cluster" means, so the
+        // session scale restarts from the prints still retained — the honest
+        // best effort, since evicted prints cannot be replayed. Every other
+        // setting leaves the scale alone: it is an accumulation, not a view.
+        if next.bubble_cluster_ms != self.config.bubble_cluster_ms {
+            let mut scale = SessionScale::new(next.price_grouping, next.bubble_cluster_ms);
+            for trade in &self.aggressions {
+                scale.record(trade.timestamp_ms, trade.price, trade.quantity, trade.side);
+            }
+            self.scale = scale;
         }
         self.config = next;
         if let Some(now_ms) = self.latest_book_ms {
@@ -413,6 +428,25 @@ impl LiquidityHistory {
         self.aggressions.iter()
     }
 
+    /// Quantity that maps to a full-size bubble, on the session scale.
+    ///
+    /// The automatic modes read the scale accumulated since the session (or
+    /// the last structural reset) began — see [`SessionScale`] for why the
+    /// answer deliberately ignores the viewport and retention alike. `Fixed`
+    /// reads the quantity the user pinned.
+    #[must_use]
+    pub fn bubble_size_reference(&self) -> Decimal {
+        match self.config.bubbles.size_reference {
+            BubbleSizeReference::VisibleP99 => self.scale.p99(),
+            BubbleSizeReference::VisibleMax => self.scale.max(),
+            BubbleSizeReference::Fixed => self
+                .config
+                .bubbles
+                .fixed_reference_decimal()
+                .unwrap_or_default(),
+        }
+    }
+
     /// Continuous synchronized intervals.
     pub fn coverage_segments(&self) -> impl Iterator<Item = &CoverageSegment> {
         self.coverage.iter()
@@ -517,6 +551,8 @@ impl LiquidityHistory {
 
     /// Retain one trade for the aggression overlay without touching the book.
     pub fn record_aggression(&mut self, trade: &Trade) {
+        self.scale
+            .record(trade.timestamp_ms, trade.price, trade.quantity, trade.side);
         self.aggressions.push_back(Aggression {
             agg_id: trade.agg_id,
             timestamp_ms: trade.timestamp_ms,
@@ -550,6 +586,7 @@ impl LiquidityHistory {
             dropped_aggressions: self.aggressions.len(),
         };
         self.config.price_grouping = grouping;
+        self.scale = SessionScale::new(grouping, self.config.bubble_cluster_ms);
         self.book = OrderBook::new();
         self.generation = None;
         self.latest_book_ms = None;

--- a/crates/app/src/orderflow/history.rs
+++ b/crates/app/src/orderflow/history.rs
@@ -370,11 +370,13 @@ impl LiquidityHistory {
         self.active.len()
     }
 
-    /// Approximate bytes used by the bounded event history.
+    /// Approximate bytes used by the bounded event history — plus the session
+    /// scale, which is the one accumulation retention does *not* bound.
     #[must_use]
     pub fn approximate_history_bytes(&self) -> usize {
         self.archived.len() * size_of::<LiquidityRun>()
             + self.aggressions.len() * size_of::<Aggression>()
+            + self.scale.approximate_bytes()
     }
 
     /// Finalized runs followed by active runs (`end_ms == None`).
@@ -1192,6 +1194,67 @@ mod tests {
             [2, 3]
         );
         assert_eq!(history.counters().aggressions_evicted, 1);
+    }
+
+    /// Retention bounds what the chart draws, never what a quantity means:
+    /// evicting the session's biggest print must not move the size scale, or
+    /// every bubble would quietly inflate as the big prints age out.
+    #[test]
+    fn evicting_a_print_never_moves_the_bubble_scale() {
+        let config = HeatmapConfig {
+            enabled: true,
+            price_grouping: Decimal::ONE,
+            max_aggressions: 1,
+            bubble_cluster_ms: 0,
+            ..HeatmapConfig::default()
+        };
+        let mut history = LiquidityHistory::new(config);
+        history.record_aggression(&Trade {
+            agg_id: 1,
+            timestamp_ms: 100,
+            price: dec("101"),
+            quantity: dec("50"),
+            side: Side::Buy,
+        });
+        let anchored = history.bubble_size_reference();
+        assert_eq!(anchored, dec("50"));
+
+        // The cap evicts the big print; the scale still remembers it.
+        history.record_aggression(&trade(2, 200, Side::Sell));
+        assert_eq!(history.aggressions().count(), 1);
+        assert_eq!(history.counters().aggressions_evicted, 1);
+        assert_eq!(history.bubble_size_reference(), anchored);
+    }
+
+    /// Changing the clustering window changes what "one cluster" means, so
+    /// the scale rebuilds from the retained prints — and a structural
+    /// grouping reset starts it over with the history it just cleared.
+    #[test]
+    fn cluster_window_changes_rebuild_the_bubble_scale_from_retained_prints() {
+        let config = HeatmapConfig {
+            enabled: true,
+            price_grouping: Decimal::ONE,
+            bubble_cluster_ms: 0,
+            ..HeatmapConfig::default()
+        };
+        let mut history = LiquidityHistory::new(config.clone());
+        // Two raw prints on one level, 500ms apart: separate clusters raw,
+        // one cluster of 4 once the window covers them.
+        history.record_aggression(&trade(1, 100, Side::Buy));
+        history.record_aggression(&trade(2, 600, Side::Buy));
+        assert_eq!(history.bubble_size_reference(), dec("2"));
+
+        history
+            .update_config(HeatmapConfig {
+                bubble_cluster_ms: 1_000,
+                ..config
+            })
+            .unwrap();
+        assert_eq!(history.bubble_size_reference(), dec("4"));
+
+        // A grouping reset drops the prints, and the scale with them.
+        history.reset_price_grouping(dec("2")).unwrap();
+        assert_eq!(history.bubble_size_reference(), Decimal::ZERO);
     }
 
     #[test]

--- a/crates/app/src/orderflow/history.rs
+++ b/crates/app/src/orderflow/history.rs
@@ -8,7 +8,7 @@ use quantick_orderbook::{ApplyOutcome, BookDelta, BookError, BookSide, BookSnaps
 use rust_decimal::Decimal;
 
 use super::config::{BubbleSizeReference, HeatmapConfig};
-use super::scale::SessionScale;
+use super::scale::{SessionScale, SummaryScale};
 
 /// Resting side represented by a liquidity run.
 pub type RestingSide = BookSide;
@@ -241,6 +241,7 @@ pub struct LiquidityHistory {
     active: BTreeMap<LevelKey, LiquidityRun>,
     aggressions: VecDeque<Aggression>,
     scale: SessionScale,
+    summary_scale: SummaryScale,
     coverage: VecDeque<CoverageSegment>,
     gaps: VecDeque<CoverageGap>,
     pending_gap: Option<usize>,
@@ -254,6 +255,7 @@ impl LiquidityHistory {
         let config = config.sanitized();
         Self {
             scale: SessionScale::new(config.price_grouping, config.bubble_cluster_ms),
+            summary_scale: SummaryScale::new(config.price_grouping),
             config,
             book: OrderBook::new(),
             generation: None,
@@ -377,6 +379,7 @@ impl LiquidityHistory {
         self.archived.len() * size_of::<LiquidityRun>()
             + self.aggressions.len() * size_of::<Aggression>()
             + self.scale.approximate_bytes()
+            + self.summary_scale.approximate_bytes()
     }
 
     /// Finalized runs followed by active runs (`end_ms == None`).
@@ -430,7 +433,7 @@ impl LiquidityHistory {
         self.aggressions.iter()
     }
 
-    /// Quantity that maps to a full-size bubble, on the session scale.
+    /// Quantity that maps to a full-size bubble, on the session print scale.
     ///
     /// The automatic modes read the scale accumulated since the session (or
     /// the last structural reset) began — see [`SessionScale`] for why the
@@ -441,6 +444,24 @@ impl LiquidityHistory {
         match self.config.bubbles.size_reference {
             BubbleSizeReference::VisibleP99 => self.scale.p99(),
             BubbleSizeReference::VisibleMax => self.scale.max(),
+            BubbleSizeReference::Fixed => self
+                .config
+                .bubbles
+                .fixed_reference_decimal()
+                .unwrap_or_default(),
+        }
+    }
+
+    /// Quantity that maps to a full-size summary pie, on the session scale of
+    /// per-minute level totals — see [`SummaryScale`] for why a pie is
+    /// measured against the busiest minute rather than against whatever pies
+    /// happen to be on screen. `Fixed` reads the pinned quantity, exactly as
+    /// the print scale does.
+    #[must_use]
+    pub fn bubble_summary_reference(&self) -> Decimal {
+        match self.config.bubbles.size_reference {
+            BubbleSizeReference::VisibleP99 => self.summary_scale.p99(),
+            BubbleSizeReference::VisibleMax => self.summary_scale.max(),
             BubbleSizeReference::Fixed => self
                 .config
                 .bubbles
@@ -555,6 +576,8 @@ impl LiquidityHistory {
     pub fn record_aggression(&mut self, trade: &Trade) {
         self.scale
             .record(trade.timestamp_ms, trade.price, trade.quantity, trade.side);
+        self.summary_scale
+            .record(trade.timestamp_ms, trade.price, trade.quantity);
         self.aggressions.push_back(Aggression {
             agg_id: trade.agg_id,
             timestamp_ms: trade.timestamp_ms,
@@ -589,6 +612,7 @@ impl LiquidityHistory {
         };
         self.config.price_grouping = grouping;
         self.scale = SessionScale::new(grouping, self.config.bubble_cluster_ms);
+        self.summary_scale = SummaryScale::new(grouping);
         self.book = OrderBook::new();
         self.generation = None;
         self.latest_book_ms = None;

--- a/crates/app/src/orderflow/mod.rs
+++ b/crates/app/src/orderflow/mod.rs
@@ -10,6 +10,7 @@ pub mod grouping;
 pub mod history;
 pub mod interaction;
 pub mod projection;
+pub mod scale;
 pub mod timeline;
 
 // This facade is intentionally wider than the first UI integration. Keeping
@@ -43,5 +44,7 @@ pub use projection::{
     LiquidityEventPrimitive, LiquidityEvidence, LiveMarks, PriceWindow, SettledProjection,
     project_live, project_settled,
 };
+#[allow(unused_imports)]
+pub use scale::SessionScale;
 #[allow(unused_imports)]
 pub use timeline::{BarTimeline, LiveEdge, TimelinePosition, reserved_span_ms};

--- a/crates/app/src/orderflow/projection.rs
+++ b/crates/app/src/orderflow/projection.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use rust_decimal::Decimal;
 use rust_decimal::prelude::{FromPrimitive as _, ToPrimitive as _};
 
-use super::config::{BubbleSizeReference, HeatmapConfig, IntensityMode};
+use super::config::{HeatmapConfig, IntensityMode};
 use super::grouping::{EffectiveGrouping, GroupedLiquidity, GroupingWindow, sweep_grouped_runs};
 use super::history::{AggressorSide, CoverageSegment, LiquidityHistory, RestingSide};
 pub use super::interaction::LiquidityEvidence;
@@ -735,39 +735,20 @@ pub fn project_settled(
     let dropped_liquidity_events = filter_events(&mut events, config, liquidity_reference);
 
     let settled_marks = refine_tier(settled, config, aggression_reference, timeline, summarizing);
-    // While every mark is a raw print they share the session scale above, so
-    // an area means the same thing everywhere. The summary breaks that
-    // premise: a pie carries a whole bar and a tape mark carries one print,
-    // quantities an order of magnitude apart, and one shared reference would
-    // peg every pie at the largest radius while flattening the tape into
-    // dots. Pies then get their own reference — pies stay comparable with
-    // pies, prints with prints — except under a fixed reference, where the
-    // user pinned an absolute quantity precisely so that nothing on screen may
-    // rescale it. Measured over the visible summaries of both halves — the
-    // forming bar's running pie included, which is the only reason the moving
-    // half is clustered here at all. A pie aggregates a viewport-grouped
-    // price range, so a viewport-free scale for pies is a separate design
-    // question from the print scale settled above.
-    let summary_reference = if summarizing && config.bubbles.size_reference.is_automatic() {
-        let live = cluster_tier(
-            history,
-            timeline,
-            prices,
-            &coverage,
-            effective_grouping,
-            (live_from_ms, None),
-            summarizing,
-        );
-        let live_marks = refine_tier(live, config, aggression_reference, timeline, summarizing);
-        size_reference(
-            &settled_marks
-                .slot
-                .iter()
-                .chain(live_marks.slot.iter())
-                .cloned()
-                .collect::<Vec<_>>(),
-            config,
-        )
+    // While every mark is a raw print they share the session print scale
+    // above, so an area means the same thing everywhere. The summary breaks
+    // that premise: a pie carries a whole bar and a tape mark carries one
+    // print, quantities an order of magnitude apart, and one shared reference
+    // would peg every pie at the largest radius while flattening the tape
+    // into dots. Pies then get their own scale — as session-anchored as the
+    // print scale, measured against the busiest minute a price level saw
+    // (`SummaryScale`), never against whatever pies happen to be on screen:
+    // pies dominate a summarized chart, so a viewport reference here would
+    // hand the zoom the very rescale the print scale just took away. Under a
+    // fixed reference both getters return the pinned quantity, because the
+    // user chose it precisely so that nothing on screen may rescale a mark.
+    let summary_reference = if summarizing {
+        history.bubble_summary_reference()
     } else {
         aggression_reference
     };
@@ -1261,25 +1242,6 @@ fn tier_primitives(
         .collect()
 }
 
-/// Quantity that maps to a full-size bubble for this set of clusters.
-///
-/// This is the *summary tier's* scale — pies sized against pies. The raw
-/// print scale is the session's, read from
-/// [`LiquidityHistory::bubble_size_reference`].
-fn size_reference(clusters: &[AggressionCluster], config: &HeatmapConfig) -> Decimal {
-    match config.bubbles.size_reference {
-        BubbleSizeReference::VisibleP99 => {
-            percentile_99(clusters.iter().map(|cluster| cluster.quantity))
-        }
-        BubbleSizeReference::VisibleMax => clusters
-            .iter()
-            .map(|cluster| cluster.quantity)
-            .max()
-            .unwrap_or(Decimal::ZERO),
-        BubbleSizeReference::Fixed => config.bubbles.fixed_reference_decimal().unwrap_or_default(),
-    }
-}
-
 fn aggression_primitive(
     cluster: AggressionCluster,
     x: f64,
@@ -1352,7 +1314,9 @@ pub(crate) fn normalized_area_size(quantity: Decimal, reference: Decimal) -> f32
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::orderflow::config::{BubbleStyle, DisplayGrouping, LiveLaneStyle};
+    use crate::orderflow::config::{
+        BubbleSizeReference, BubbleStyle, DisplayGrouping, LiveLaneStyle,
+    };
     use crate::orderflow::history::LiquidityHistory;
     use quantick_engine::{Bar, Side, Trade};
     use quantick_orderbook::BookSide;
@@ -2500,6 +2464,56 @@ mod tests {
         }
     }
 
+    /// The zoom rule holds for the summary tier too: a closed bar's pie maps
+    /// to the same normalized size through every price window. This is the
+    /// mark most of a chart is made of once the candle summary is on, so the
+    /// print scale being stable is not enough — a 1mm zoom that rescales
+    /// every pie rescales the chart.
+    #[test]
+    fn a_pie_keeps_its_size_when_the_window_zooms_out() {
+        let trades = [
+            (1_u64, 6_000_i64, "100", "2", Side::Buy),
+            (2, 6_500, "100", "2", Side::Sell),
+            (3, 7_000, "200", "100", Side::Sell),
+        ];
+        let closed = [bar(0, 5_000), bar(5_000, 10_000), bar(10_000, 15_000)];
+        let partial = bar(15_000, 20_000);
+        let timeline = BarTimeline::from_bars(0, &closed, Some(&partial), live(20_000, &closed));
+        // Zoomed in only the small pie is on screen; zoomed out the huge one
+        // joins it.
+        let zoomed_in = PriceWindow::new(dec("98"), dec("103")).unwrap();
+        let zoomed_out = PriceWindow::new(dec("98"), dec("203")).unwrap();
+        for reference in [
+            BubbleSizeReference::VisibleP99,
+            BubbleSizeReference::VisibleMax,
+            BubbleSizeReference::Fixed,
+        ] {
+            let config = HeatmapConfig {
+                bubble_candle_summary: true,
+                bubbles: BubbleStyle {
+                    size_reference: reference,
+                    size_reference_quantity: 100.0,
+                    ..bubbles_only().bubbles
+                },
+                ..bubbles_only()
+            };
+            let pie_size_through = |prices: PriceWindow| {
+                project(&tape(config.clone(), &trades), &timeline, prices)
+                    .aggressions
+                    .iter()
+                    .find(|mark| !mark.live && mark.quantity == dec("4"))
+                    .map(|mark| mark.size)
+                    .expect("the small bar's pie is inside both windows")
+            };
+            let narrow = pie_size_through(zoomed_in);
+            let wide = pie_size_through(zoomed_out);
+            assert!(
+                (narrow - wide).abs() < 1e-6,
+                "{reference:?}: one pie, one size — got {narrow} zoomed in, {wide} zoomed out"
+            );
+        }
+    }
+
     /// The one legitimate way zoom grows a bubble: a coarser grouping merges
     /// prints into one cluster, and the merged mark carries their summed
     /// quantity — so it may only read *bigger* than the prints it swallowed,
@@ -2721,9 +2735,11 @@ mod tests {
 
     /// A summary carries a whole bar's quantity. Sized against the reference
     /// single prints set, every one of them would peg at the largest radius
-    /// and the summaries would stop saying anything about each other.
+    /// and the summaries would stop saying anything about each other — so
+    /// pies read on their own scale, the session's busiest minute per level,
+    /// and stay ordered among themselves.
     #[test]
-    fn a_summary_is_sized_against_summaries_and_a_pinned_reference_never_moves() {
+    fn a_summary_is_sized_against_the_sessions_minutes_and_a_pinned_reference_never_moves() {
         // One busy bar and one quiet one, both closed, plus a live print.
         let mut trades: Vec<(u64, i64, &str, &str, Side)> = Vec::new();
         for index in 0..20_u64 {

--- a/crates/app/src/orderflow/projection.rs
+++ b/crates/app/src/orderflow/projection.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use rust_decimal::Decimal;
 use rust_decimal::prelude::{FromPrimitive as _, ToPrimitive as _};
 
-use super::config::{BubbleSizeReference, DisplayGrouping, HeatmapConfig, IntensityMode};
+use super::config::{BubbleSizeReference, HeatmapConfig, IntensityMode};
 use super::grouping::{EffectiveGrouping, GroupedLiquidity, GroupingWindow, sweep_grouped_runs};
 use super::history::{AggressorSide, CoverageSegment, LiquidityHistory, RestingSide};
 pub use super::interaction::LiquidityEvidence;
@@ -696,29 +696,16 @@ pub fn project_settled(
         (None, live_from_ms),
         summarizing,
     );
-    // The size scale is a statement about the recorded session, never about
-    // the screen: zoom decides what is visible, not what a quantity means, so
-    // the same print keeps the same area through every window. The automatic
-    // references therefore measure every retained print, clustered at the
-    // *configured* grouping — an adaptive display grouping tracks the visible
-    // span, which is the one input the scale must ignore, so it contributes
-    // its base width instead. A cluster the viewport merges past this
-    // reference saturates at full size: the honest reading of "more than
-    // anything the scale measures". Computed before the display filter below
-    // — hiding small prints must not silently rescale the ones left on screen
-    // — and only retention trimming the recording (or the user pinning a
-    // fixed quantity) may move it.
-    let reference_clusters = if config.bubbles.size_reference.is_automatic() {
-        cluster_aggressions(
-            history.aggressions(),
-            &coverage,
-            reference_grouping(config),
-            config.bubble_cluster_ms,
-        )
-    } else {
-        Vec::new()
-    };
-    let aggression_reference = size_reference(&reference_clusters, config);
+    // The size scale is a statement about the session, never about the
+    // screen: zoom decides what is visible, not what a quantity means, so the
+    // same print keeps the same area through every window, and a cluster the
+    // viewport merges past the scale saturates at full size — the honest
+    // reading of "more than anything the scale measures". The history
+    // accumulates it one print at a time (`SessionScale`), so reading it here
+    // costs the same whether ten prints are retained or a million — and it is
+    // independent of the display filter below, so hiding small prints never
+    // silently rescales the ones left on screen.
+    let aggression_reference = history.bubble_size_reference();
 
     // A reduction is allocated by the half that owns the prints around it, so
     // the same removed quantity is never claimed as evidence twice. Cut at the
@@ -1274,20 +1261,11 @@ fn tier_primitives(
         .collect()
 }
 
-/// Grouping the automatic size reference is measured at.
-///
-/// The configured grouping, with one exception: an adaptive display grouping
-/// resolves against the visible span, which is the one input the scale must
-/// ignore — so it contributes its base width and nothing else.
-fn reference_grouping(config: &HeatmapConfig) -> EffectiveGrouping {
-    let display = match config.display_grouping {
-        DisplayGrouping::Adaptive { .. } => DisplayGrouping::Native,
-        display => display,
-    };
-    EffectiveGrouping::resolve(display, config.price_grouping, Decimal::ZERO)
-}
-
 /// Quantity that maps to a full-size bubble for this set of clusters.
+///
+/// This is the *summary tier's* scale — pies sized against pies. The raw
+/// print scale is the session's, read from
+/// [`LiquidityHistory::bubble_size_reference`].
 fn size_reference(clusters: &[AggressionCluster], config: &HeatmapConfig) -> Decimal {
     match config.bubbles.size_reference {
         BubbleSizeReference::VisibleP99 => {

--- a/crates/app/src/orderflow/projection.rs
+++ b/crates/app/src/orderflow/projection.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use rust_decimal::Decimal;
 use rust_decimal::prelude::{FromPrimitive as _, ToPrimitive as _};
 
-use super::config::{BubbleSizeReference, HeatmapConfig, IntensityMode};
+use super::config::{BubbleSizeReference, DisplayGrouping, HeatmapConfig, IntensityMode};
 use super::grouping::{EffectiveGrouping, GroupedLiquidity, GroupingWindow, sweep_grouped_runs};
 use super::history::{AggressorSide, CoverageSegment, LiquidityHistory, RestingSide};
 pub use super::interaction::LiquidityEvidence;
@@ -696,33 +696,29 @@ pub fn project_settled(
         (None, live_from_ms),
         summarizing,
     );
-    // Clustered here too, and then thrown away: the size scale is a statement
-    // about everything on screen, so it has to see the prints still rolling or
-    // one area would mean one quantity beside the tape and another inside it.
-    let live = cluster_tier(
-        history,
-        timeline,
-        prices,
-        &coverage,
-        effective_grouping,
-        (live_from_ms, None),
-        summarizing,
-    );
-    // Computed over every visible cluster, before the display filter below:
-    // hiding small prints must not silently rescale the ones left on screen.
-    // This is the scale for a *raw* print, which is what the tape draws and
-    // what a slot draws until its bar is summarized.
-    let aggression_reference = size_reference(
-        &settled
-            .tape
-            .iter()
-            .chain(settled.slot.iter())
-            .chain(live.tape.iter())
-            .chain(live.slot.iter())
-            .cloned()
-            .collect::<Vec<_>>(),
-        config,
-    );
+    // The size scale is a statement about the recorded session, never about
+    // the screen: zoom decides what is visible, not what a quantity means, so
+    // the same print keeps the same area through every window. The automatic
+    // references therefore measure every retained print, clustered at the
+    // *configured* grouping — an adaptive display grouping tracks the visible
+    // span, which is the one input the scale must ignore, so it contributes
+    // its base width instead. A cluster the viewport merges past this
+    // reference saturates at full size: the honest reading of "more than
+    // anything the scale measures". Computed before the display filter below
+    // — hiding small prints must not silently rescale the ones left on screen
+    // — and only retention trimming the recording (or the user pinning a
+    // fixed quantity) may move it.
+    let reference_clusters = if config.bubbles.size_reference.is_automatic() {
+        cluster_aggressions(
+            history.aggressions(),
+            &coverage,
+            reference_grouping(config),
+            config.bubble_cluster_ms,
+        )
+    } else {
+        Vec::new()
+    };
+    let aggression_reference = size_reference(&reference_clusters, config);
 
     // A reduction is allocated by the half that owns the prints around it, so
     // the same removed quantity is never claimed as evidence twice. Cut at the
@@ -752,17 +748,30 @@ pub fn project_settled(
     let dropped_liquidity_events = filter_events(&mut events, config, liquidity_reference);
 
     let settled_marks = refine_tier(settled, config, aggression_reference, timeline, summarizing);
-    let live_marks = refine_tier(live, config, aggression_reference, timeline, summarizing);
-    // While every mark is a raw print they share one size scale, so an area
-    // means the same thing everywhere. The summary breaks that premise: a pie
-    // carries a whole bar and a tape mark carries one print, quantities an
-    // order of magnitude apart, and one shared reference would peg every pie at
-    // the largest radius while flattening the tape into dots. Pies then get
-    // their own reference — pies stay comparable with pies, prints with prints
-    // — except under a fixed reference, where the user pinned an absolute
-    // quantity precisely so that nothing on screen may rescale it. Measured
-    // over both halves, for the reason the print scale is.
-    let summary_reference = if summarizing && config.bubbles.size_reference.is_visible() {
+    // While every mark is a raw print they share the session scale above, so
+    // an area means the same thing everywhere. The summary breaks that
+    // premise: a pie carries a whole bar and a tape mark carries one print,
+    // quantities an order of magnitude apart, and one shared reference would
+    // peg every pie at the largest radius while flattening the tape into
+    // dots. Pies then get their own reference — pies stay comparable with
+    // pies, prints with prints — except under a fixed reference, where the
+    // user pinned an absolute quantity precisely so that nothing on screen may
+    // rescale it. Measured over the visible summaries of both halves — the
+    // forming bar's running pie included, which is the only reason the moving
+    // half is clustered here at all. A pie aggregates a viewport-grouped
+    // price range, so a viewport-free scale for pies is a separate design
+    // question from the print scale settled above.
+    let summary_reference = if summarizing && config.bubbles.size_reference.is_automatic() {
+        let live = cluster_tier(
+            history,
+            timeline,
+            prices,
+            &coverage,
+            effective_grouping,
+            (live_from_ms, None),
+            summarizing,
+        );
+        let live_marks = refine_tier(live, config, aggression_reference, timeline, summarizing);
         size_reference(
             &settled_marks
                 .slot
@@ -1263,6 +1272,19 @@ fn tier_primitives(
             ))
         })
         .collect()
+}
+
+/// Grouping the automatic size reference is measured at.
+///
+/// The configured grouping, with one exception: an adaptive display grouping
+/// resolves against the visible span, which is the one input the scale must
+/// ignore — so it contributes its base width and nothing else.
+fn reference_grouping(config: &HeatmapConfig) -> EffectiveGrouping {
+    let display = match config.display_grouping {
+        DisplayGrouping::Adaptive { .. } => DisplayGrouping::Native,
+        display => display,
+    };
+    EffectiveGrouping::resolve(display, config.price_grouping, Decimal::ZERO)
 }
 
 /// Quantity that maps to a full-size bubble for this set of clusters.
@@ -2450,6 +2472,105 @@ mod tests {
                 ..BubbleStyle::default()
             },
             ..HeatmapConfig::default()
+        }
+    }
+
+    /// Zooming changes what is on screen, never what a quantity means: the
+    /// same print maps to the same normalized size through every price window,
+    /// in every reference mode — the automatic ones included. Only a change in
+    /// the cluster's own quantity may change its bubble.
+    #[test]
+    fn a_prints_bubble_keeps_its_size_when_the_window_zooms_out() {
+        let trades = [
+            (1_u64, 6_000_i64, "100", "2", Side::Buy),
+            (2, 7_000, "200", "100", Side::Sell),
+        ];
+        let closed = [bar(0, 5_000), bar(5_000, 10_000), bar(10_000, 15_000)];
+        let partial = bar(15_000, 20_000);
+        let timeline = BarTimeline::from_bars(0, &closed, Some(&partial), live(20_000, &closed));
+        // Zoomed in only the small print is on screen; zoomed out the large
+        // one joins it and, today, silently rescales it.
+        let zoomed_in = PriceWindow::new(dec("98"), dec("103")).unwrap();
+        let zoomed_out = PriceWindow::new(dec("98"), dec("203")).unwrap();
+        for reference in [
+            BubbleSizeReference::VisibleP99,
+            BubbleSizeReference::VisibleMax,
+            BubbleSizeReference::Fixed,
+        ] {
+            let config = HeatmapConfig {
+                bubbles: BubbleStyle {
+                    size_reference: reference,
+                    size_reference_quantity: 100.0,
+                    ..bubbles_only().bubbles
+                },
+                ..bubbles_only()
+            };
+            let size_through = |prices: PriceWindow| {
+                project(&tape(config.clone(), &trades), &timeline, prices)
+                    .aggressions
+                    .iter()
+                    .find(|bubble| bubble.quantity == dec("2"))
+                    .map(|bubble| bubble.size)
+                    .expect("the small print is inside both windows")
+            };
+            let narrow = size_through(zoomed_in);
+            let wide = size_through(zoomed_out);
+            assert!(
+                (narrow - wide).abs() < 1e-6,
+                "{reference:?}: one quantity, one size — got {narrow} zoomed in, {wide} zoomed out"
+            );
+        }
+    }
+
+    /// The one legitimate way zoom grows a bubble: a coarser grouping merges
+    /// prints into one cluster, and the merged mark carries their summed
+    /// quantity — so it may only read *bigger* than the prints it swallowed,
+    /// never smaller.
+    #[test]
+    fn a_cluster_merged_by_zooming_out_reads_bigger_not_smaller() {
+        let trades = [
+            (1_u64, 6_000_i64, "100", "3", Side::Buy),
+            (2, 6_500, "101", "2", Side::Buy),
+            (3, 7_000, "150", "50", Side::Sell),
+        ];
+        let closed = [bar(0, 5_000), bar(5_000, 10_000), bar(10_000, 15_000)];
+        let partial = bar(15_000, 20_000);
+        let timeline = BarTimeline::from_bars(0, &closed, Some(&partial), live(20_000, &closed));
+        // Ten target rows: at a 10-wide window prints one price apart keep
+        // their own bucket; at a 200-wide window they share one.
+        let zoomed_in = PriceWindow::new(dec("98"), dec("108")).unwrap();
+        let zoomed_out = PriceWindow::new(dec("50"), dec("250")).unwrap();
+        for reference in [
+            BubbleSizeReference::VisibleP99,
+            BubbleSizeReference::VisibleMax,
+            BubbleSizeReference::Fixed,
+        ] {
+            let config = HeatmapConfig {
+                display_grouping: DisplayGrouping::Adaptive { target_rows: 10 },
+                bubble_cluster_ms: 1_000,
+                bubbles: BubbleStyle {
+                    size_reference: reference,
+                    size_reference_quantity: 100.0,
+                    ..bubbles_only().bubbles
+                },
+                ..bubbles_only()
+            };
+            let size_of = |prices: PriceWindow, quantity: &str| {
+                project(&tape(config.clone(), &trades), &timeline, prices)
+                    .aggressions
+                    .iter()
+                    .find(|bubble| bubble.quantity == dec(quantity))
+                    .map(|bubble| bubble.size)
+                    .unwrap_or_else(|| panic!("no bubble of quantity {quantity}"))
+            };
+            let three = size_of(zoomed_in, "3");
+            let two = size_of(zoomed_in, "2");
+            let merged = size_of(zoomed_out, "5");
+            assert!(
+                merged > three && merged > two,
+                "{reference:?}: the merged cluster carries more quantity, so it must read \
+                 bigger — got {merged} against {three} and {two}"
+            );
         }
     }
 

--- a/crates/app/src/orderflow/scale.rs
+++ b/crates/app/src/orderflow/scale.rs
@@ -34,6 +34,7 @@
 //!   everywhere: the same prints in the same order produce the same scale.
 
 use std::collections::BTreeMap;
+use std::mem::size_of;
 
 use quantick_engine::Side;
 use rust_decimal::Decimal;
@@ -141,6 +142,17 @@ impl SessionScale {
             remaining -= count;
         }
         Decimal::ZERO
+    }
+
+    /// Approximate bytes held by the accumulated distribution.
+    ///
+    /// The multiset is the one part of the scale a long session grows without
+    /// bound (one entry per *distinct* cluster quantity), so the history's
+    /// memory estimate counts it rather than letting it hide.
+    #[must_use]
+    pub fn approximate_bytes(&self) -> usize {
+        self.counts.len() * size_of::<(Decimal, u64)>()
+            + self.open.len() * size_of::<((u8, Decimal), OpenCluster)>()
     }
 }
 

--- a/crates/app/src/orderflow/scale.rs
+++ b/crates/app/src/orderflow/scale.rs
@@ -1,43 +1,61 @@
-//! The session-wide bubble size scale, maintained one print at a time.
+//! The session-wide bubble size scales, maintained one print at a time.
 //!
 //! The automatic size references (P99 / max) answer one question: *what
-//! quantity deserves a full-size bubble?* The answer must not depend on the
+//! quantity deserves a full-size mark?* The answer must not depend on the
 //! viewport — zoom decides what is on screen, never what a quantity means —
 //! and it must not cost a pass over the whole retained tape every time the
 //! settled projection rebuilds, which under a dense feed is every rebuild
-//! cadence. So the scale is accumulated here, incrementally: every print
-//! folds into it as it is recorded, and a query reads what is already known.
+//! cadence. So both scales are accumulated here, incrementally: every print
+//! folds into them as it is recorded, and a query reads what is already
+//! known.
 //!
-//! Three deliberate properties, all in the name of a bubble meaning the same
-//! thing all session:
+//! There are two, because the chart draws two kinds of mark an order of
+//! magnitude apart. [`SessionScale`] is the scale of a *print*: clusters at
+//! capture resolution, what the tape and an unsummarized slot draw.
+//! [`SummaryScale`] is the scale of a *pie*: a closed bar's whole flow at one
+//! price range, sized against the busiest minute a price level saw this
+//! session. One shared reference would peg every pie at the largest radius
+//! while flattening the tape into dots — the reason the tiers keep separate
+//! scales — but both scales obey the same law:
 //!
-//! - **Clustered at capture resolution.** Prints are clustered exactly the
-//!   way the tape clusters them at native price grouping — same side, same
-//!   base bucket, within [`HeatmapConfig::bubble_cluster_ms`](
+//! - **Viewport-free.** A print clusters at native price grouping — same
+//!   side, same base bucket, within [`HeatmapConfig::bubble_cluster_ms`](
 //!   super::config::HeatmapConfig::bubble_cluster_ms) of the cluster's first
-//!   print — so the scale speaks the same unit as the marks it sizes.
-//!   Display grouping of any kind (a coarser multiple, the adaptive mode) is
-//!   a *viewport* decision and contributes nothing: a cluster the display
-//!   merges past this scale simply saturates at the maximum radius, the
-//!   honest reading of "more than anything the scale measures". Resync
-//!   generations are ignored for the same reason — a burst of aggression
-//!   does not become two bursts because the book resynchronized under it.
+//!   print. A summary total accumulates per native bucket over a fixed
+//!   [`SUMMARY_WINDOW_MS`] of tape time, deliberately not per bar: bars are a
+//!   display choice the way display grouping is, so "the busiest minute this
+//!   level saw" keeps its meaning across a bar-spec switch exactly as it
+//!   does across a zoom. Display grouping contributes nothing to either
+//!   scale: a mark the viewport merges past its scale simply saturates at
+//!   the maximum radius, the honest reading of "more than anything the scale
+//!   measures". Resync generations are ignored for the same reason — a
+//!   burst of aggression does not become two bursts because the book
+//!   resynchronized under it.
 //! - **The scale never forgets.** Retention trims what the chart *draws*;
 //!   it does not change what a quantity *means*. A sweep at 10:00 still
 //!   anchors the scale at 15:00, so the same quantity reads the same size
-//!   all session instead of slowly inflating as big prints age out. The
-//!   scale resets only when the session itself does (a symbol switch, a
-//!   price-grouping reset) or when the clustering window changes — and a
+//!   all session instead of slowly inflating as big prints age out. A scale
+//!   resets only when the session itself does (a symbol switch, a
+//!   price-grouping reset) or when its own clustering input changes — and a
 //!   rebuild then replays only what is still retained, which is everything
 //!   the chart can still show.
 //! - **Deterministic.** Integer time math, `Decimal` quantities, `BTreeMap`
-//!   everywhere: the same prints in the same order produce the same scale.
+//!   everywhere: the same prints in the same order produce the same scales.
 
 use std::collections::BTreeMap;
 use std::mem::size_of;
 
 use quantick_engine::Side;
 use rust_decimal::Decimal;
+
+/// Tape time behind one summary-scale total, per price bucket.
+///
+/// Fixed, and deliberately not the bar duration: the full-size pie has to
+/// mean the same quantity whatever bars the chart is cut into, or switching
+/// from tick to time bars would silently rescale history. One minute is the
+/// same order of magnitude as the bars a summary is read on, so a typical
+/// pie lands mid-scale and only a violent bar saturates.
+pub const SUMMARY_WINDOW_MS: i64 = 60_000;
 
 /// One open cluster: anchored at its first print, still accepting joins.
 #[derive(Debug, Clone, Copy)]
@@ -46,7 +64,77 @@ struct OpenCluster {
     quantity: Decimal,
 }
 
-/// Accumulated distribution of session cluster quantities.
+/// One open per-bucket summary window: totals prints until the minute turns.
+#[derive(Debug, Clone, Copy)]
+struct OpenWindow {
+    window_index: i64,
+    quantity: Decimal,
+}
+
+/// Accumulated multiset of quantities with rank queries.
+///
+/// The shared core of both scales: entries only ever grow in count (the
+/// ratchet), an *open* aggregate is counted at its current sum and re-counted
+/// as it grows, and P99/max read the distribution without a sort.
+#[derive(Debug, Clone, Default)]
+struct Distribution {
+    counts: BTreeMap<Decimal, u64>,
+    total: u64,
+}
+
+impl Distribution {
+    /// Count a fresh aggregate.
+    fn insert(&mut self, quantity: Decimal) {
+        *self.counts.entry(quantity).or_insert(0) += 1;
+        self.total += 1;
+    }
+
+    /// Re-count an open aggregate that grew from `previous` to `grown`.
+    fn replace(&mut self, previous: Decimal, grown: Decimal) {
+        if let Some(count) = self.counts.get_mut(&previous) {
+            *count -= 1;
+            if *count == 0 {
+                self.counts.remove(&previous);
+            }
+        }
+        *self.counts.entry(grown).or_insert(0) += 1;
+    }
+
+    /// Largest quantity counted.
+    fn max(&self) -> Decimal {
+        self.counts
+            .last_key_value()
+            .map_or(Decimal::ZERO, |(quantity, _)| *quantity)
+    }
+
+    /// 99th-percentile quantity, by the same rank the projection's visible
+    /// percentile always used: over `n` quantities sorted ascending, the one
+    /// at rank `ceil(99·n / 100)`.
+    fn p99(&self) -> Decimal {
+        if self.total == 0 {
+            return Decimal::ZERO;
+        }
+        let rank = (99 * self.total).div_ceil(100);
+        // Walking from the top touches ~1% of the distinct quantities: the
+        // ascending rank `rank` is the descending rank `n − rank + 1`.
+        let mut remaining = self.total - rank + 1;
+        for (quantity, count) in self.counts.iter().rev() {
+            if *count >= remaining {
+                return *quantity;
+            }
+            remaining -= count;
+        }
+        Decimal::ZERO
+    }
+
+    /// Approximate bytes held — one entry per *distinct* quantity, the one
+    /// part of a scale a long session grows without bound.
+    fn approximate_bytes(&self) -> usize {
+        self.counts.len() * size_of::<(Decimal, u64)>()
+    }
+}
+
+/// Accumulated distribution of session cluster quantities — the print scale.
 ///
 /// Owned by [`LiquidityHistory`](super::history::LiquidityHistory), fed from
 /// [`record_aggression`](super::history::LiquidityHistory::record_aggression),
@@ -57,11 +145,7 @@ pub struct SessionScale {
     cluster_ms: i64,
     /// The still-growing cluster per (aggressor side, native bucket).
     open: BTreeMap<(u8, Decimal), OpenCluster>,
-    /// Multiset of every cluster quantity the session produced; an open
-    /// cluster is counted at its current sum and re-counted as it grows.
-    counts: BTreeMap<Decimal, u64>,
-    /// Total clusters counted — the `n` a percentile rank is taken over.
-    clusters: u64,
+    distribution: Distribution,
 }
 
 impl SessionScale {
@@ -75,8 +159,7 @@ impl SessionScale {
             bucket_width,
             cluster_ms: cluster_ms.max(0),
             open: BTreeMap::new(),
-            counts: BTreeMap::new(),
-            clusters: 0,
+            distribution: Distribution::default(),
         }
     }
 
@@ -85,11 +168,7 @@ impl SessionScale {
         if quantity <= Decimal::ZERO {
             return;
         }
-        let bucket = if self.bucket_width > Decimal::ZERO {
-            (price / self.bucket_width).floor() * self.bucket_width
-        } else {
-            price
-        };
+        let bucket = bucket_for(price, self.bucket_width);
         let key = (side_key(side), bucket);
         if self.cluster_ms > 0
             && let Some(open) = self.open.get_mut(&key)
@@ -98,8 +177,7 @@ impl SessionScale {
             let previous = open.quantity;
             open.quantity += quantity;
             let grown = open.quantity;
-            remove_count(&mut self.counts, previous);
-            *self.counts.entry(grown).or_insert(0) += 1;
+            self.distribution.replace(previous, grown);
             return;
         }
         // The previous cluster on this key (if any) is closed by displacement:
@@ -111,48 +189,112 @@ impl SessionScale {
                 quantity,
             },
         );
-        *self.counts.entry(quantity).or_insert(0) += 1;
-        self.clusters += 1;
+        self.distribution.insert(quantity);
     }
 
     /// Largest cluster quantity the session produced.
     #[must_use]
     pub fn max(&self) -> Decimal {
-        self.counts
-            .last_key_value()
-            .map_or(Decimal::ZERO, |(quantity, _)| *quantity)
+        self.distribution.max()
     }
 
-    /// 99th-percentile cluster quantity, by the same rank the projection's
-    /// visible percentile always used: over `n` quantities sorted ascending,
-    /// the one at rank `ceil(99·n / 100)`.
+    /// 99th-percentile cluster quantity.
     #[must_use]
     pub fn p99(&self) -> Decimal {
-        if self.clusters == 0 {
-            return Decimal::ZERO;
+        self.distribution.p99()
+    }
+
+    /// Approximate bytes held by the accumulated distribution, counted so the
+    /// history's memory estimate never hides it.
+    #[must_use]
+    pub fn approximate_bytes(&self) -> usize {
+        self.distribution.approximate_bytes()
+            + self.open.len() * size_of::<((u8, Decimal), OpenCluster)>()
+    }
+
+    #[cfg(test)]
+    fn clusters(&self) -> u64 {
+        self.distribution.total
+    }
+}
+
+/// Accumulated distribution of per-minute, per-level totals — the pie scale.
+///
+/// Both sides sum into one total, because a pie is the one mark that carries
+/// both sides of a price at once.
+#[derive(Debug, Clone)]
+pub struct SummaryScale {
+    bucket_width: Decimal,
+    /// The still-filling minute per native bucket.
+    open: BTreeMap<Decimal, OpenWindow>,
+    distribution: Distribution,
+}
+
+impl SummaryScale {
+    /// An empty scale totalling per `bucket_width` level.
+    #[must_use]
+    pub fn new(bucket_width: Decimal) -> Self {
+        Self {
+            bucket_width,
+            open: BTreeMap::new(),
+            distribution: Distribution::default(),
         }
-        let rank = (99 * self.clusters).div_ceil(100);
-        // Walking from the top touches ~1% of the distinct quantities: the
-        // ascending rank `rank` is the descending rank `n − rank + 1`.
-        let mut remaining = self.clusters - rank + 1;
-        for (quantity, count) in self.counts.iter().rev() {
-            if *count >= remaining {
-                return *quantity;
-            }
-            remaining -= count;
+    }
+
+    /// Fold one print into the scale.
+    pub fn record(&mut self, timestamp_ms: i64, price: Decimal, quantity: Decimal) {
+        if quantity <= Decimal::ZERO {
+            return;
         }
-        Decimal::ZERO
+        let bucket = bucket_for(price, self.bucket_width);
+        let window_index = timestamp_ms.div_euclid(SUMMARY_WINDOW_MS);
+        if let Some(open) = self.open.get_mut(&bucket)
+            && open.window_index == window_index
+        {
+            let previous = open.quantity;
+            open.quantity += quantity;
+            let grown = open.quantity;
+            self.distribution.replace(previous, grown);
+            return;
+        }
+        // The minute turned (or the level is new): the finished total stays
+        // counted and a fresh one opens.
+        self.open.insert(
+            bucket,
+            OpenWindow {
+                window_index,
+                quantity,
+            },
+        );
+        self.distribution.insert(quantity);
+    }
+
+    /// Largest per-minute level total the session produced.
+    #[must_use]
+    pub fn max(&self) -> Decimal {
+        self.distribution.max()
+    }
+
+    /// 99th-percentile per-minute level total.
+    #[must_use]
+    pub fn p99(&self) -> Decimal {
+        self.distribution.p99()
     }
 
     /// Approximate bytes held by the accumulated distribution.
-    ///
-    /// The multiset is the one part of the scale a long session grows without
-    /// bound (one entry per *distinct* cluster quantity), so the history's
-    /// memory estimate counts it rather than letting it hide.
     #[must_use]
     pub fn approximate_bytes(&self) -> usize {
-        self.counts.len() * size_of::<(Decimal, u64)>()
-            + self.open.len() * size_of::<((u8, Decimal), OpenCluster)>()
+        self.distribution.approximate_bytes() + self.open.len() * size_of::<(Decimal, OpenWindow)>()
+    }
+}
+
+/// The native-bucket lower edge containing `price`; non-positive widths
+/// degenerate to per-price, mirroring the grouping sweep.
+fn bucket_for(price: Decimal, bucket_width: Decimal) -> Decimal {
+    if bucket_width > Decimal::ZERO {
+        (price / bucket_width).floor() * bucket_width
+    } else {
+        price
     }
 }
 
@@ -160,15 +302,6 @@ fn side_key(side: Side) -> u8 {
     match side {
         Side::Buy => 0,
         Side::Sell => 1,
-    }
-}
-
-fn remove_count(counts: &mut BTreeMap<Decimal, u64>, quantity: Decimal) {
-    if let Some(count) = counts.get_mut(&quantity) {
-        *count -= 1;
-        if *count == 0 {
-            counts.remove(&quantity);
-        }
     }
 }
 
@@ -196,7 +329,7 @@ mod tests {
         // The opposite side never joins: a sell opens its own cluster of 1
         // instead of growing the buy cluster to 8.
         assert_eq!(scale.max(), dec("7"));
-        assert_eq!(scale.clusters, 3);
+        assert_eq!(scale.clusters(), 3);
     }
 
     #[test]
@@ -237,7 +370,7 @@ mod tests {
         // One cluster of 6 — not a 3 and a 6.
         assert_eq!(scale.max(), dec("6"));
         assert_eq!(scale.p99(), dec("6"));
-        assert_eq!(scale.clusters, 1);
+        assert_eq!(scale.clusters(), 1);
     }
 
     #[test]
@@ -247,5 +380,30 @@ mod tests {
         scale.record(0, dec("100"), dec("-1"), Side::Buy);
         assert_eq!(scale.max(), Decimal::ZERO);
         assert_eq!(scale.p99(), Decimal::ZERO);
+    }
+
+    #[test]
+    fn a_minute_totals_both_sides_of_one_level() {
+        let mut scale = SummaryScale::new(Decimal::ONE);
+        scale.record(1_000, dec("100"), dec("3"));
+        scale.record(59_000, dec("100.7"), dec("2"));
+        // Same bucket, same minute, sides irrelevant: one total of 5.
+        assert_eq!(scale.max(), dec("5"));
+        // The next minute opens a new total; the old one stays counted.
+        scale.record(61_000, dec("100"), dec("1"));
+        assert_eq!(scale.max(), dec("5"));
+        // A different level totals apart even inside the same minute.
+        scale.record(61_500, dec("105"), dec("9"));
+        assert_eq!(scale.max(), dec("9"));
+    }
+
+    #[test]
+    fn the_busiest_minute_is_a_ratchet() {
+        let mut scale = SummaryScale::new(Decimal::ONE);
+        scale.record(0, dec("100"), dec("40"));
+        // Hours later the tape is quiet; the anchor from the loud minute
+        // still stands.
+        scale.record(7_200_000, dec("100"), dec("1"));
+        assert_eq!(scale.max(), dec("40"));
     }
 }

--- a/crates/app/src/orderflow/scale.rs
+++ b/crates/app/src/orderflow/scale.rs
@@ -1,0 +1,239 @@
+//! The session-wide bubble size scale, maintained one print at a time.
+//!
+//! The automatic size references (P99 / max) answer one question: *what
+//! quantity deserves a full-size bubble?* The answer must not depend on the
+//! viewport — zoom decides what is on screen, never what a quantity means —
+//! and it must not cost a pass over the whole retained tape every time the
+//! settled projection rebuilds, which under a dense feed is every rebuild
+//! cadence. So the scale is accumulated here, incrementally: every print
+//! folds into it as it is recorded, and a query reads what is already known.
+//!
+//! Three deliberate properties, all in the name of a bubble meaning the same
+//! thing all session:
+//!
+//! - **Clustered at capture resolution.** Prints are clustered exactly the
+//!   way the tape clusters them at native price grouping — same side, same
+//!   base bucket, within [`HeatmapConfig::bubble_cluster_ms`](
+//!   super::config::HeatmapConfig::bubble_cluster_ms) of the cluster's first
+//!   print — so the scale speaks the same unit as the marks it sizes.
+//!   Display grouping of any kind (a coarser multiple, the adaptive mode) is
+//!   a *viewport* decision and contributes nothing: a cluster the display
+//!   merges past this scale simply saturates at the maximum radius, the
+//!   honest reading of "more than anything the scale measures". Resync
+//!   generations are ignored for the same reason — a burst of aggression
+//!   does not become two bursts because the book resynchronized under it.
+//! - **The scale never forgets.** Retention trims what the chart *draws*;
+//!   it does not change what a quantity *means*. A sweep at 10:00 still
+//!   anchors the scale at 15:00, so the same quantity reads the same size
+//!   all session instead of slowly inflating as big prints age out. The
+//!   scale resets only when the session itself does (a symbol switch, a
+//!   price-grouping reset) or when the clustering window changes — and a
+//!   rebuild then replays only what is still retained, which is everything
+//!   the chart can still show.
+//! - **Deterministic.** Integer time math, `Decimal` quantities, `BTreeMap`
+//!   everywhere: the same prints in the same order produce the same scale.
+
+use std::collections::BTreeMap;
+
+use quantick_engine::Side;
+use rust_decimal::Decimal;
+
+/// One open cluster: anchored at its first print, still accepting joins.
+#[derive(Debug, Clone, Copy)]
+struct OpenCluster {
+    anchor_ms: i64,
+    quantity: Decimal,
+}
+
+/// Accumulated distribution of session cluster quantities.
+///
+/// Owned by [`LiquidityHistory`](super::history::LiquidityHistory), fed from
+/// [`record_aggression`](super::history::LiquidityHistory::record_aggression),
+/// read by the projection as the bubble size reference.
+#[derive(Debug, Clone)]
+pub struct SessionScale {
+    bucket_width: Decimal,
+    cluster_ms: i64,
+    /// The still-growing cluster per (aggressor side, native bucket).
+    open: BTreeMap<(u8, Decimal), OpenCluster>,
+    /// Multiset of every cluster quantity the session produced; an open
+    /// cluster is counted at its current sum and re-counted as it grows.
+    counts: BTreeMap<Decimal, u64>,
+    /// Total clusters counted — the `n` a percentile rank is taken over.
+    clusters: u64,
+}
+
+impl SessionScale {
+    /// An empty scale clustering at `bucket_width` and `cluster_ms`.
+    ///
+    /// A non-positive `bucket_width` degenerates to per-price clustering,
+    /// mirroring how the grouping sweep treats it.
+    #[must_use]
+    pub fn new(bucket_width: Decimal, cluster_ms: i64) -> Self {
+        Self {
+            bucket_width,
+            cluster_ms: cluster_ms.max(0),
+            open: BTreeMap::new(),
+            counts: BTreeMap::new(),
+            clusters: 0,
+        }
+    }
+
+    /// Fold one print into the scale.
+    pub fn record(&mut self, timestamp_ms: i64, price: Decimal, quantity: Decimal, side: Side) {
+        if quantity <= Decimal::ZERO {
+            return;
+        }
+        let bucket = if self.bucket_width > Decimal::ZERO {
+            (price / self.bucket_width).floor() * self.bucket_width
+        } else {
+            price
+        };
+        let key = (side_key(side), bucket);
+        if self.cluster_ms > 0
+            && let Some(open) = self.open.get_mut(&key)
+            && timestamp_ms.saturating_sub(open.anchor_ms) <= self.cluster_ms
+        {
+            let previous = open.quantity;
+            open.quantity += quantity;
+            let grown = open.quantity;
+            remove_count(&mut self.counts, previous);
+            *self.counts.entry(grown).or_insert(0) += 1;
+            return;
+        }
+        // The previous cluster on this key (if any) is closed by displacement:
+        // its quantity simply stays counted.
+        self.open.insert(
+            key,
+            OpenCluster {
+                anchor_ms: timestamp_ms,
+                quantity,
+            },
+        );
+        *self.counts.entry(quantity).or_insert(0) += 1;
+        self.clusters += 1;
+    }
+
+    /// Largest cluster quantity the session produced.
+    #[must_use]
+    pub fn max(&self) -> Decimal {
+        self.counts
+            .last_key_value()
+            .map_or(Decimal::ZERO, |(quantity, _)| *quantity)
+    }
+
+    /// 99th-percentile cluster quantity, by the same rank the projection's
+    /// visible percentile always used: over `n` quantities sorted ascending,
+    /// the one at rank `ceil(99·n / 100)`.
+    #[must_use]
+    pub fn p99(&self) -> Decimal {
+        if self.clusters == 0 {
+            return Decimal::ZERO;
+        }
+        let rank = (99 * self.clusters).div_ceil(100);
+        // Walking from the top touches ~1% of the distinct quantities: the
+        // ascending rank `rank` is the descending rank `n − rank + 1`.
+        let mut remaining = self.clusters - rank + 1;
+        for (quantity, count) in self.counts.iter().rev() {
+            if *count >= remaining {
+                return *quantity;
+            }
+            remaining -= count;
+        }
+        Decimal::ZERO
+    }
+}
+
+fn side_key(side: Side) -> u8 {
+    match side {
+        Side::Buy => 0,
+        Side::Sell => 1,
+    }
+}
+
+fn remove_count(counts: &mut BTreeMap<Decimal, u64>, quantity: Decimal) {
+    if let Some(count) = counts.get_mut(&quantity) {
+        *count -= 1;
+        if *count == 0 {
+            counts.remove(&quantity);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr as _;
+
+    fn dec(value: &str) -> Decimal {
+        Decimal::from_str(value).unwrap()
+    }
+
+    #[test]
+    fn prints_on_one_level_within_the_window_are_one_cluster() {
+        let mut scale = SessionScale::new(Decimal::ONE, 1_000);
+        scale.record(0, dec("100"), dec("3"), Side::Buy);
+        scale.record(500, dec("100.4"), dec("2"), Side::Buy);
+        // Same native bucket, same side, inside the window: one cluster of 5.
+        assert_eq!(scale.max(), dec("5"));
+        assert_eq!(scale.p99(), dec("5"));
+        // Outside the window: a new cluster, and the old sum stays counted.
+        scale.record(2_000, dec("100"), dec("7"), Side::Buy);
+        assert_eq!(scale.max(), dec("7"));
+        scale.record(2_100, dec("100"), dec("1"), Side::Sell);
+        // The opposite side never joins: a sell opens its own cluster of 1
+        // instead of growing the buy cluster to 8.
+        assert_eq!(scale.max(), dec("7"));
+        assert_eq!(scale.clusters, 3);
+    }
+
+    #[test]
+    fn raw_mode_keeps_every_print_its_own_cluster() {
+        let mut scale = SessionScale::new(Decimal::ONE, 0);
+        scale.record(0, dec("100"), dec("3"), Side::Buy);
+        scale.record(1, dec("100"), dec("2"), Side::Buy);
+        assert_eq!(scale.max(), dec("3"));
+    }
+
+    #[test]
+    fn p99_matches_the_projections_rank_rule() {
+        // 100 distinct clusters, quantities 1..=100: rank ceil(9900/100) = 99.
+        let mut scale = SessionScale::new(Decimal::ONE, 0);
+        for value in 1..=100u32 {
+            scale.record(
+                i64::from(value),
+                Decimal::from(value),
+                Decimal::from(value),
+                Side::Buy,
+            );
+        }
+        assert_eq!(scale.p99(), dec("99"));
+        assert_eq!(scale.max(), dec("100"));
+        // Small sets degenerate to the maximum, exactly as the rank does.
+        let mut small = SessionScale::new(Decimal::ONE, 0);
+        for value in [dec("2"), dec("50")] {
+            small.record(0, dec("100"), value, Side::Sell);
+        }
+        assert_eq!(small.p99(), dec("50"));
+    }
+
+    #[test]
+    fn a_growing_open_cluster_is_recounted_not_double_counted() {
+        let mut scale = SessionScale::new(Decimal::ONE, 1_000);
+        scale.record(0, dec("100"), dec("3"), Side::Buy);
+        scale.record(100, dec("100"), dec("3"), Side::Buy);
+        // One cluster of 6 — not a 3 and a 6.
+        assert_eq!(scale.max(), dec("6"));
+        assert_eq!(scale.p99(), dec("6"));
+        assert_eq!(scale.clusters, 1);
+    }
+
+    #[test]
+    fn dust_never_moves_the_scale() {
+        let mut scale = SessionScale::new(Decimal::ONE, 0);
+        scale.record(0, dec("100"), Decimal::ZERO, Side::Buy);
+        scale.record(0, dec("100"), dec("-1"), Side::Buy);
+        assert_eq!(scale.max(), Decimal::ZERO);
+        assert_eq!(scale.p99(), Decimal::ZERO);
+    }
+}

--- a/crates/app/src/orderflow_view.rs
+++ b/crates/app/src/orderflow_view.rs
@@ -1148,12 +1148,12 @@ impl OrderflowView {
                             ui.selectable_value(
                                 &mut bubbles.size_reference,
                                 BubbleSizeReference::VisibleP99,
-                                "Auto · visible P99",
+                                "Auto · session P99",
                             );
                             ui.selectable_value(
                                 &mut bubbles.size_reference,
                                 BubbleSizeReference::VisibleMax,
-                                "Auto · largest visible",
+                                "Auto · largest in session",
                             );
                             ui.selectable_value(
                                 &mut bubbles.size_reference,
@@ -1163,10 +1163,11 @@ impl OrderflowView {
                         })
                         .response
                         .on_hover_text(
-                            "P99 keeps one outlier sweep from shrinking everything else, but \
-                             the top 1% all render at the maximum radius. 'Largest visible' \
-                             restores a strict order; a fixed quantity makes bubble size mean \
-                             the same thing across sessions.",
+                            "the automatic modes measure the recorded session, so zooming never \
+                             resizes a print. P99 keeps one outlier sweep from shrinking \
+                             everything else, but the top 1% all render at the maximum radius. \
+                             'Largest in session' restores a strict order; a fixed quantity \
+                             makes bubble size mean the same thing across sessions.",
                         );
                 });
                 if bubbles.size_reference == BubbleSizeReference::Fixed {
@@ -1838,8 +1839,8 @@ fn dust_label(milliseconds: i64) -> String {
 
 const fn size_reference_label(reference: BubbleSizeReference) -> &'static str {
     match reference {
-        BubbleSizeReference::VisibleP99 => "Auto · visible P99",
-        BubbleSizeReference::VisibleMax => "Auto · largest visible",
+        BubbleSizeReference::VisibleP99 => "Auto · session P99",
+        BubbleSizeReference::VisibleMax => "Auto · largest in session",
         BubbleSizeReference::Fixed => "Fixed quantity",
     }
 }


### PR DESCRIPTION
## Problem

Zooming rescaled every aggression bubble: the automatic size references (`VisibleP99` / `VisibleMax`) were computed over the clusters visible in the current window (`size_reference` in `orderflow/projection.rs`), so zooming out let bigger clusters into view, raised the reference, and shrank every bubble on screen. The same aggression read smaller for no reason a trader could see — reported live with screenshots showing one print changing size across three zoom levels.

## Fix

The size scale is now a statement about the **session**, never the screen. `SessionScale` (new module, `orderflow/scale.rs`) accumulates every recorded print into a cluster-quantity distribution as it arrives — clustered at native price grouping + `bubble_cluster_ms`, the capture resolution — and the projection reads P99/max from it. Zoom still merges clusters via display grouping, and a merged cluster now always reads **bigger** than the prints it swallowed, never smaller; anything the viewport merges past the scale saturates at max radius. The scale never shrinks: retention trims what the chart draws, not what a quantity means. It resets only with the session itself (symbol switch, price-grouping reset) or when the clustering window changes.

UI labels updated to match ("Auto · session P99" / "Auto · largest in session"); wire format (`visible_p99`) and shipped presets unchanged, so existing configs load as-is.

## Performance (paths classified by rate)

- `SessionScale::record` — **per trade**: 2–3 `BTreeMap` ops, O(log n).
- `p99()`/`max()` — per settled rebuild (≥220 ms cadence): walks ~1% of distinct quantities.
- Settled rebuild — no longer clusters the live half except when the candle summary needs its pie.
- Rebuild on `bubble_cluster_ms` change — rare: O(retained prints), documented.

Measured, 90 s dense replay (100k-print synthetic tape, 4×, ~615 trades/s), debug build, same machine:

| | main | fix (first cut, rejected) | fix (shipped) |
|---|---|---|---|
| fps avg | 59.56 | 59.51 | **59.64** |
| frame_cpu avg | 2.51 ms | 2.54 ms | **2.35 ms** |
| projection_ms | 2.5–4.4 flat | 4.8 → **29.8 growing** | 2.3–3.5 flat |

The first cut reclustered the whole retained tape per rebuild — caught by this measurement and replaced with the incremental scale before shipping.

## Tests (written first, failing on main)

- `a_prints_bubble_keeps_its_size_when_the_window_zooms_out` — same quantity, same normalized size through two price windows, all three reference modes (main: 1.0 → 0.14).
- `a_cluster_merged_by_zooming_out_reads_bigger_not_smaller` — adaptive grouping merges prints; merged bubble must outsize its parts (main: 0.32 < 1.0).
- `SessionScale` unit tests: clustering rules, P99 rank parity with the projection's percentile, open-cluster recount, dust ignored.
- History: eviction never moves the scale (ratchet); `bubble_cluster_ms` change rebuilds from retained prints; grouping reset clears it.

## visual-qa

Same deterministic recording (playhead reproducible to ±1 print across runs), fix + main control, three window sizes (1000×700 / 1600×900 / 2200×1200), two frames 1.2 s apart per cell, health-gated (fps 59–60 in every run):

- **Scale stability: PASS** — pixel-measured diameters of the same bubbles in the shared tape region: 30/32/34 px class identical across window sizes on the fix.
- **Settings tab (`QUANTICK_DOCK_TAB=bubbles`): PASS** — "Auto · session P99" renders untruncated.
- **Motion: PASS** — 8% of pixels changed between paired frames, bbox confined to the chart, no chrome movement.
- **Integrity/small window: PASS** — 1000×700 collapses the toolbar into overflow correctly, nothing clipped.
- Honest note: the main control did not *visibly* reproduce the shrink on the synthetic tape (its sweeps are uniform, so every window holds some and visible P99 ≈ session P99). The defect's proof is the unit test above and the original live screenshots.

## trader-ux-review

No Blockers, no Should-fixes. One Consider, deferred: under "largest in session" a monster sweep anchors the scale for the rest of the day (chosen semantics; the P99 default is robust to one outlier). A manual "reset scale" affordance is a possible follow-up.

## arch-review

Run over `git diff main...HEAD`. Two Should-fixes found and resolved in `34a34cc` (ratchet/rebuild tests; scale counted in the history memory estimate). Deferred, noted deliberately:

- `VisibleP99`/`VisibleMax` variant names are wire-compat legacy; documented at the enum.
- ~~Summary pies keep their visible-summary reference~~ — resolved in b35ff33 after live testing: pies now read on a session scale of per-minute level totals (`SummaryScale`), viewport-free like the print scale.
- The liquidity heatmap's `IntensityMode::VisibleP99` (cell colour, not bubble size) is still viewport-based — related but out of scope.

Blast radius: 1 file added, 5 edited (docs/rename, history wiring, projection consumption, UI labels).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ACWmTJChLJiE84d27DVQB1