### PR TITLE
fix: never drop a settings panel onto the drawing it configures

### DIFF
--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -342,6 +342,16 @@ fn clamp_into_chart(position: egui::Pos2, size: egui::Vec2, chart: egui::Rect) -
     )
 }
 
+/// Where the inspector goes, and how wide it may be there.
+///
+/// The width is `Some` only when the panel had to be narrowed to fit a gutter
+/// beside a drawing too big to place around — see [`inspector_placement`].
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct InspectorPlacement {
+    position: egui::Pos2,
+    max_width: Option<f32>,
+}
+
 /// The inspector placement rule (`docs/ux/drawing-tools-2026-08.md` §D3).
 ///
 /// The old rule scored least overlap with the object's *bounding box*, and a
@@ -364,7 +374,11 @@ fn clamp_into_chart(position: egui::Pos2, size: egui::Vec2, chart: egui::Rect) -
 /// 3. only if neither top corner is free, the bottom two on the same rule;
 /// 4. and if every corner is fouled — a large object covering the chart —
 ///    the beside-the-object candidates, least overlap first.
-fn inspector_placement(chart: egui::Rect, bbox: egui::Rect, size: egui::Vec2) -> egui::Pos2 {
+fn inspector_placement(
+    chart: egui::Rect,
+    bbox: egui::Rect,
+    size: egui::Vec2,
+) -> InspectorPlacement {
     let gap = INSPECTOR_OBJECT_GAP_PX;
     let top_corners = [
         egui::pos2(chart.left() + gap, chart.top() + gap),
@@ -390,11 +404,44 @@ fn inspector_placement(chart: egui::Rect, bbox: egui::Rect, size: egui::Vec2) ->
         best.map(|(position, _)| position)
     };
     if let Some(position) = farthest_clear(top_corners).or_else(|| farthest_clear(bottom_corners)) {
-        return position;
+        return InspectorPlacement {
+            position,
+            max_width: None,
+        };
     }
-    let corners = [top_corners, bottom_corners].concat();
+    // No corner is clear, which is what a big object — a volume profile, a
+    // range across the whole chart — does to all four of them. The panel then
+    // goes into whichever *gutter* the object leaves beside it, narrowed to
+    // fit, because a settings panel sitting on the drawing it configures is
+    // the one outcome this whole function exists to avoid.
+    //
+    // Horizontal gutters only. Narrowing a panel reflows it and its scroll
+    // area keeps every row reachable; shortening one hides rows, and rows a
+    // trader cannot reach read as rows that do not exist.
+    let left_gutter = bbox.left() - gap - chart.left();
+    let right_gutter = chart.right() - bbox.right() - gap;
+    let (gutter, gutter_left) = if right_gutter >= left_gutter {
+        (right_gutter, bbox.right() + gap)
+    } else {
+        (left_gutter, chart.left() + gap)
+    };
+    if gutter >= INSPECTOR_MIN_WIDTH_PX {
+        let width = gutter.min(size.x);
+        let position = clamp_into_chart(
+            egui::pos2(gutter_left, chart.top() + gap),
+            egui::vec2(width, size.y),
+            chart,
+        );
+        return InspectorPlacement {
+            position,
+            max_width: Some(width),
+        };
+    }
 
-    // Nothing clear anywhere: crowd the object as little as possible.
+    // The object leaves no strip wide enough to be a panel in. Nothing can be
+    // placed clear of it, and saying so by crowding it least is more honest
+    // than pretending: this is the one case the rule cannot keep.
+    let corners = [top_corners, bottom_corners].concat();
     let fallbacks = [
         egui::pos2(bbox.right() + gap, bbox.top()),
         egui::pos2(bbox.left() - gap - size.x, bbox.top()),
@@ -423,7 +470,10 @@ fn inspector_placement(chart: egui::Rect, bbox: egui::Rect, size: egui::Vec2) ->
             best = Some((position, overlap_area, distance));
         }
     }
-    best.map_or_else(|| chart.left_top(), |(position, _, _)| position)
+    InspectorPlacement {
+        position: best.map_or_else(|| chart.left_top(), |(position, _, _)| position),
+        max_width: None,
+    }
 }
 
 /// Split the bottom time strip at the lane's divider: the candles' own time
@@ -636,6 +686,11 @@ pub struct QuantickApp {
     // would go. Consumed once.
     pending_drawing_draft: Option<usize>,
     inspector_pos: Option<egui::Pos2>,
+    /// How wide the floating inspector may be where it was placed.
+    ///
+    /// `Some` only when it had to be narrowed into a gutter beside a drawing
+    /// too big to place around; `None` means the usual width range applies.
+    inspector_max_width: Option<f32>,
     // The floating panel's size as it was last actually drawn. Read back from
     // the window response rather than from egui's area memory: the memory
     // lookup is empty on the frame the panel is being laid out, which is
@@ -903,6 +958,7 @@ impl QuantickApp {
             pending_avwap_demo: false,
             pending_drawing_draft: None,
             inspector_pos: None,
+            inspector_max_width: None,
             inspector_size: None,
             inspector_pin_touched: false,
             inspector_settle_frame: false,
@@ -4091,7 +4147,9 @@ impl QuantickApp {
             if bar.double_clicked() {
                 // The reset path: back to automatic placement.
                 self.inspector_moved = false;
-                self.inspector_pos = self.inspector_target_position(ui.ctx(), index);
+                let placed = self.inspector_target_placement(ui.ctx(), index);
+                self.inspector_pos = placed.map(|placed| placed.position);
+                self.inspector_max_width = placed.and_then(|placed| placed.max_width);
             } else if bar.dragged() {
                 self.inspector_moved = true;
                 let position = self.inspector_pos.or_else(|| {
@@ -4433,12 +4491,16 @@ impl QuantickApp {
         }
     }
 
-    /// Where a freshly opened floating inspector should sit: the farthest
-    /// chart corner that clears the object, bottom-left preferred, falling
-    /// back to beside-the-object only when no corner is free — see
-    /// [`inspector_placement`]. The chart pane already excludes both axes and
-    /// the live lane, so the popup can never cover them or leave the view.
-    fn inspector_target_position(&self, ctx: &egui::Context, index: usize) -> Option<egui::Pos2> {
+    /// Where a freshly opened floating inspector should sit, and how wide it
+    /// may be there: the farthest chart corner that clears the object, then a
+    /// gutter beside it narrowed to fit — see [`inspector_placement`]. The
+    /// chart pane already excludes both axes and the live lane, so the popup
+    /// can never cover them or leave the view.
+    fn inspector_target_placement(
+        &self,
+        ctx: &egui::Context,
+        index: usize,
+    ) -> Option<InspectorPlacement> {
         let chart = self.drawing_pane().last_chart_area?;
         let bbox = self.drawing_bbox_on_screen(chart, index)?;
         Some(inspector_placement(chart, bbox, self.inspector_size(ctx)))
@@ -4751,9 +4813,10 @@ impl QuantickApp {
         // Automatic placement only while the window is untouched.
         if selection_changed
             && !self.inspector_moved
-            && let Some(position) = self.inspector_target_position(ctx, index)
+            && let Some(placed) = self.inspector_target_placement(ctx, index)
         {
-            self.inspector_pos = Some(position);
+            self.inspector_pos = Some(placed.position);
+            self.inspector_max_width = placed.max_width;
         }
         // Repair, never override: a position that no longer fits the chart
         // pane is clamped back in, and `inspector_moved` survives.
@@ -4790,7 +4853,12 @@ impl QuantickApp {
             .default_pos(DRAWING_INSPECTOR_DEFAULT_POSITION)
             .default_width(default_width)
             .min_width(INSPECTOR_MIN_WIDTH_PX)
-            .max_width(INSPECTOR_MAX_WIDTH_PX)
+            .max_width(
+                self.inspector_max_width
+                    .map_or(INSPECTOR_MAX_WIDTH_PX, |width| {
+                        width.clamp(INSPECTOR_MIN_WIDTH_PX, INSPECTOR_MAX_WIDTH_PX)
+                    }),
+            )
             .max_height(max_height)
             .movable(false)
             .interactable(true)
@@ -10802,12 +10870,100 @@ plot(close)
     /// The session's complaint (`docs/ux/drawing-tools-2026-08.md` §F3): the
     /// old rule put the panel 12 px beside a small object, right on top of
     /// the price action the trader drew it to read. A corner must win.
+    /// The rule a volume profile broke: a drawing big enough to foul all four
+    /// corners used to get the panel dropped straight onto it.
+    ///
+    /// A profile is exactly that shape — tall enough to span the price axis,
+    /// wide enough to reach past every corner candidate — so "least overlap"
+    /// meant "on the figure", and the panel covered the thing it configures.
+    /// It goes into the gutter beside the object instead, narrowed to fit.
+    #[test]
+    fn a_drawing_too_big_for_any_corner_sends_the_panel_to_a_gutter_beside_it() {
+        let chart = egui::Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(1200.0, 700.0));
+        let size = egui::vec2(320.0, 280.0);
+        // A profile down the middle, wide enough that a panel parked at any
+        // corner overlaps it, and narrow enough that the strip beside it can
+        // still hold a narrowed one. That band is exactly what narrowing is
+        // for: the corner candidate assumes the full width and fouls, the
+        // gutter takes what fits.
+        let bbox = egui::Rect::from_min_max(egui::pos2(320.0, 0.0), egui::pos2(880.0, 700.0));
+        let gap = INSPECTOR_OBJECT_GAP_PX;
+        for corner in [
+            egui::pos2(chart.left() + gap, chart.top() + gap),
+            egui::pos2(chart.right() - gap - size.x, chart.top() + gap),
+            egui::pos2(chart.left() + gap, chart.bottom() - gap - size.y),
+            egui::pos2(chart.right() - gap - size.x, chart.bottom() - gap - size.y),
+        ] {
+            assert!(
+                egui::Rect::from_min_size(corner, size)
+                    .intersect(bbox)
+                    .is_positive(),
+                "the fixture has to actually foul every corner: {corner:?}"
+            );
+        }
+
+        let placed = inspector_placement(chart, bbox, size);
+        let rect = egui::Rect::from_min_size(
+            placed.position,
+            egui::vec2(placed.max_width.unwrap_or(size.x), size.y),
+        );
+        assert!(
+            !rect.intersect(bbox).is_positive(),
+            "the panel must not cover the drawing it configures: {rect:?} vs {bbox:?}"
+        );
+        assert!(
+            chart.contains_rect(rect),
+            "and it stays inside the chart: {rect:?}"
+        );
+        assert!(
+            placed
+                .max_width
+                .is_some_and(|w| w >= INSPECTOR_MIN_WIDTH_PX),
+            "narrowed, but never below what a panel needs: {:?}",
+            placed.max_width
+        );
+    }
+
+    /// The wider side wins, so the panel goes where there is most room — and
+    /// a corner that *is* free still beats any gutter, because the gutter is
+    /// the fallback, not the rule.
+    #[test]
+    fn the_gutter_is_the_wider_side_and_never_preferred_over_a_free_corner() {
+        let chart = egui::Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(1200.0, 700.0));
+        let size = egui::vec2(320.0, 280.0);
+
+        // Object hugging the left: the room is on its right.
+        let left_heavy = egui::Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(400.0, 700.0));
+        let placed = inspector_placement(chart, left_heavy, size);
+        assert!(
+            placed.position.x >= left_heavy.right(),
+            "the panel takes the wider side: {placed:?}"
+        );
+
+        // Object hugging the right: the room is on its left.
+        let right_heavy =
+            egui::Rect::from_min_max(egui::pos2(800.0, 0.0), egui::pos2(1200.0, 700.0));
+        let placed = inspector_placement(chart, right_heavy, size);
+        assert!(
+            placed.position.x + placed.max_width.unwrap_or(size.x) <= right_heavy.left(),
+            "and the other side when that is where the room is: {placed:?}"
+        );
+
+        // A small object leaves corners free, and a free corner is unnarrowed.
+        let small = egui::Rect::from_center_size(chart.center(), egui::vec2(40.0, 40.0));
+        let placed = inspector_placement(chart, small, size);
+        assert_eq!(
+            placed.max_width, None,
+            "a corner placement never narrows the panel: {placed:?}"
+        );
+    }
+
     #[test]
     fn placement_sends_the_panel_to_a_corner_not_beside_a_small_object() {
         let chart = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(1_400.0, 800.0));
         let bbox = egui::Rect::from_center_size(chart.center(), egui::vec2(40.0, 40.0));
         let size = egui::vec2(320.0, 280.0);
-        let position = inspector_placement(chart, bbox, size);
+        let position = inspector_placement(chart, bbox, size).position;
         let rect = egui::Rect::from_min_size(position, size);
         assert!(!rect.intersects(bbox), "a clear candidate exists and wins");
         assert!(chart.contains_rect(rect));
@@ -10822,7 +10978,7 @@ plot(close)
         );
         assert_eq!(
             position,
-            inspector_placement(chart, bbox, size),
+            inspector_placement(chart, bbox, size).position,
             "identical inputs give identical placements"
         );
     }
@@ -10837,7 +10993,7 @@ plot(close)
         let size = egui::vec2(320.0, 280.0);
         let gap = INSPECTOR_OBJECT_GAP_PX;
         assert_eq!(
-            inspector_placement(chart, bbox, size),
+            inspector_placement(chart, bbox, size).position,
             egui::pos2(chart.left() + gap, chart.top() + gap)
         );
     }
@@ -10855,7 +11011,7 @@ plot(close)
         // turns out to want once its level editor is open.
         let assumed = egui::vec2(360.0, 280.0);
         let actual = 620.0;
-        let position = inspector_placement(chart, bbox, assumed);
+        let position = inspector_placement(chart, bbox, assumed).position;
         assert!(
             position.y + actual <= chart.bottom(),
             "a panel that grows to {actual} px must still fit below {position:?}"
@@ -10872,7 +11028,7 @@ plot(close)
         let size = egui::vec2(320.0, 280.0);
         let gap = INSPECTOR_OBJECT_GAP_PX;
         assert_eq!(
-            inspector_placement(chart, bbox, size),
+            inspector_placement(chart, bbox, size).position,
             egui::pos2(chart.right() - gap - size.x, chart.top() + gap),
             "the opposite corner is the farthest clear one"
         );
@@ -10884,7 +11040,7 @@ plot(close)
         // The object spans ~90% of the pane: every candidate overlaps.
         let bbox = chart.shrink2(egui::vec2(50.0, 30.0));
         let size = egui::vec2(320.0, 280.0);
-        let position = inspector_placement(chart, bbox, size);
+        let position = inspector_placement(chart, bbox, size).position;
         let chosen = egui::Rect::from_min_size(position, size)
             .intersect(bbox)
             .area();
@@ -10905,7 +11061,7 @@ plot(close)
         let chart = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(1_000.0, 600.0));
         let bbox = egui::Rect::from_min_max(egui::pos2(900.0, 200.0), egui::pos2(1_000.0, 300.0));
         let size = egui::vec2(320.0, 280.0);
-        let position = inspector_placement(chart, bbox, size);
+        let position = inspector_placement(chart, bbox, size).position;
         let rect = egui::Rect::from_min_size(position, size);
         assert!(
             !rect.intersects(bbox),

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -4546,6 +4546,12 @@ impl QuantickApp {
         for point in &points {
             bbox.extend_with(*point);
         }
+        // What the tool paints, which is not always where its anchors are: a
+        // fixed-range profile anchors at one price and covers the axis. Every
+        // popup that keeps clear of an object reads this rectangle, so asking
+        // the anchors alone is what let a panel land in the middle of a
+        // profile while believing it had walked around it.
+        let bbox = drawing.tool.painted_bounds(bbox, chart);
         Some(bbox.expand(DRAWING_ANCHOR_RADIUS_PX))
     }
 
@@ -5483,6 +5489,12 @@ impl QuantickApp {
         } else {
             &[(start, end, true)]
         };
+        // Selecting what the demo drew is what makes the *context bar* — the
+        // strip a trader edits a profile from — reachable without a click.
+        // Without it a validation run can photograph a profile but never the
+        // controls over it, which is exactly the surface whose placement this
+        // change is about (`ui-harness`: every surface owes a hook).
+        let select = std::env::var("QUANTICK_FRVP_DEMO_SELECT").is_ok_and(|v| v.trim() == "1");
         for &(from, to, outline) in ranges {
             for slot in [from, to] {
                 pane.drawings.place_with(
@@ -5505,6 +5517,10 @@ impl QuantickApp {
                         }
                     },
                 );
+            }
+            if select {
+                let last = pane.drawings.items().len().saturating_sub(1);
+                pane.drawings.select(Some(last));
             }
         }
     }

--- a/crates/app/src/drawings/context_bar.rs
+++ b/crates/app/src/drawings/context_bar.rs
@@ -170,16 +170,35 @@ pub fn place(
 ) -> egui::Pos2 {
     let above = bbox.top() - OBJECT_GAP_PX - size.y;
     let below = bbox.bottom() + OBJECT_GAP_PX;
-    let y = if above >= chart.top() {
-        above
-    } else if below + size.y <= chart.bottom() {
-        below
-    } else {
-        // An object taller than the pane — a vertical line, a channel across
-        // the whole view. Hug the top edge rather than sit in the middle of
-        // the price.
-        chart.top() + OBJECT_GAP_PX
-    };
+    if above < chart.top() && below + size.y > chart.bottom() {
+        // Taller than the pane leaves no room above or below — a volume
+        // profile spanning the price axis, a channel across the whole view.
+        // Hugging the top edge used to be the answer, and for a full-height
+        // object the top edge *is* the object: the bar sat on the figure it
+        // edits, which is the one place it must never be.
+        //
+        // Beside it instead, on whichever side has room. Vertically it keeps
+        // to the object's top, so the controls stay where the eye left them.
+        let gap = OBJECT_GAP_PX;
+        let y = (bbox.top()).clamp(chart.top(), (chart.bottom() - size.y).max(chart.top()));
+        let right_of = bbox.right() + gap;
+        let left_of = bbox.left() - gap - size.x;
+        if right_of + size.x <= right_limit.min(chart.right()) {
+            return egui::pos2(right_of, y);
+        }
+        if left_of >= chart.left() {
+            return egui::pos2(left_of, y);
+        }
+        // The object leaves no strip on either side either. Nothing can be
+        // placed clear of it; the top edge is the least-bad answer, and this
+        // is now the only case that reaches it.
+        return egui::pos2(
+            bbox.left()
+                .clamp(chart.left(), (chart.right() - size.x).max(chart.left())),
+            chart.top() + gap,
+        );
+    }
+    let y = if above >= chart.top() { above } else { below };
     // Prefer to stay clear of the live lane; if the bar is wider than the
     // history area itself, the chart's own edge wins over the preference.
     let right = right_limit.min(chart.right()).max(chart.left() + size.x);
@@ -1109,6 +1128,65 @@ mod tests {
         egui::Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(1000.0, 600.0))
     }
 
+    /// The bug the user hit: a volume profile spans the price axis, so there
+    /// is no room above it and none below, and the bar used to hug the top
+    /// edge — which for a full-height object *is* the object. The bar sat on
+    /// the figure it edits.
+    ///
+    /// It goes beside it now, on whichever side has room.
+    #[test]
+    fn a_full_height_object_gets_the_bar_beside_it_not_on_it() {
+        let chart = chart();
+        let size = egui::vec2(220.0, 32.0);
+        // A profile down the left of the pane, floor to ceiling.
+        let bbox = egui::Rect::from_min_max(
+            egui::pos2(chart.left() + 40.0, chart.top()),
+            egui::pos2(chart.left() + 240.0, chart.bottom()),
+        );
+
+        let position = place(chart, chart.right(), bbox, size);
+        let rect = egui::Rect::from_min_size(position, size);
+        assert!(
+            !rect.intersect(bbox).is_positive(),
+            "the bar must not sit on the object it edits: {rect:?} vs {bbox:?}"
+        );
+        assert!(
+            chart.contains_rect(rect),
+            "and it stays inside the pane: {rect:?}"
+        );
+
+        // Mirrored: an object hugging the right sends the bar to its left.
+        let right_side = egui::Rect::from_min_max(
+            egui::pos2(chart.right() - 240.0, chart.top()),
+            egui::pos2(chart.right(), chart.bottom()),
+        );
+        let rect = egui::Rect::from_min_size(place(chart, chart.right(), right_side, size), size);
+        assert!(
+            !rect.intersect(right_side).is_positive(),
+            "and beside it on the other side when that is where the room is: {rect:?}"
+        );
+        assert!(chart.contains_rect(rect), "{rect:?}");
+    }
+
+    /// An object that leaves room above still gets the bar above it: the
+    /// sideways placement is the fallback, not the rule.
+    #[test]
+    fn an_object_with_room_above_still_gets_the_bar_above_it() {
+        let chart = chart();
+        let size = egui::vec2(220.0, 32.0);
+        let bbox = egui::Rect::from_min_max(
+            egui::pos2(chart.left() + 300.0, chart.top() + 200.0),
+            egui::pos2(chart.left() + 400.0, chart.top() + 260.0),
+        );
+        let position = place(chart, chart.right(), bbox, size);
+        assert_eq!(position.x, bbox.left(), "left-aligned, as before");
+        assert_eq!(
+            position.y,
+            bbox.top() - OBJECT_GAP_PX - size.y,
+            "and above it, as before"
+        );
+    }
+
     #[test]
     fn the_bar_opens_above_the_object_aligned_to_its_left_edge() {
         let size = bar_size(&slots(PLAIN));
@@ -1126,11 +1204,24 @@ mod tests {
         assert_eq!(position.y, bbox.bottom() + OBJECT_GAP_PX);
     }
 
+    /// An object taller than the pane used to send the bar to the top edge,
+    /// which for a full-height object *is* the object. It goes beside it now;
+    /// the top edge is reserved for the one object that leaves no side either.
     #[test]
-    fn an_object_taller_than_the_pane_hugs_the_top_edge() {
+    fn an_object_taller_than_the_pane_gets_the_bar_beside_it() {
         let size = bar_size(&slots(PLAIN));
         let bbox = egui::Rect::from_min_max(egui::pos2(300.0, 0.0), egui::pos2(320.0, 600.0));
-        let position = place(chart(), chart().right(), bbox, size);
+        let rect = egui::Rect::from_min_size(place(chart(), chart().right(), bbox, size), size);
+        assert!(
+            !rect.intersect(bbox).is_positive(),
+            "beside the object, not on it: {rect:?}"
+        );
+        assert!(chart().contains_rect(rect), "{rect:?}");
+
+        // Wall to wall: no side to go to, and the top edge is the honest
+        // least-bad answer rather than a pretence.
+        let wall = egui::Rect::from_min_max(chart().left_top(), chart().right_bottom());
+        let position = place(chart(), chart().right(), wall, size);
         assert_eq!(position.y, chart().top() + OBJECT_GAP_PX);
     }
 

--- a/crates/app/src/drawings/fixed_range_profile.rs
+++ b/crates/app/src/drawings/fixed_range_profile.rs
@@ -548,6 +548,14 @@ fn fmt_signed_qty(value: Decimal) -> String {
 }
 
 impl DrawingToolImpl for FixedRangeProfile {
+    /// Floor to ceiling: the anchors say *when*, the drawing covers every
+    /// price on screen. See [`DrawingToolImpl::painted_bounds`].
+    fn painted_bounds(&self, anchors: egui::Rect, chart: egui::Rect) -> egui::Rect {
+        egui::Rect::from_min_max(
+            egui::pos2(anchors.left(), chart.top()),
+            egui::pos2(anchors.right(), chart.bottom()),
+        )
+    }
     fn id(&self) -> &'static str {
         "fixed-range-profile"
     }

--- a/crates/app/src/drawings/horizontal_line.rs
+++ b/crates/app/src/drawings/horizontal_line.rs
@@ -9,6 +9,14 @@ pub(super) static TOOL: HorizontalLine = HorizontalLine;
 pub(super) struct HorizontalLine;
 
 impl DrawingToolImpl for HorizontalLine {
+    /// Edge to edge: the anchor says *what price*, the drawing covers the
+    /// whole width. See [`DrawingToolImpl::painted_bounds`].
+    fn painted_bounds(&self, anchors: egui::Rect, chart: egui::Rect) -> egui::Rect {
+        egui::Rect::from_min_max(
+            egui::pos2(chart.left(), anchors.top()),
+            egui::pos2(chart.right(), anchors.bottom()),
+        )
+    }
     fn id(&self) -> &'static str {
         "horizontal-line"
     }

--- a/crates/app/src/drawings/horizontal_ray.rs
+++ b/crates/app/src/drawings/horizontal_ray.rs
@@ -19,6 +19,14 @@ fn span(chart_rect: egui::Rect, point: egui::Pos2) -> (egui::Pos2, egui::Pos2) {
 }
 
 impl DrawingToolImpl for HorizontalRay {
+    /// From its anchor to the right edge: the drawing runs forward to the
+    /// live edge. See [`DrawingToolImpl::painted_bounds`].
+    fn painted_bounds(&self, anchors: egui::Rect, chart: egui::Rect) -> egui::Rect {
+        egui::Rect::from_min_max(
+            anchors.min,
+            egui::pos2(chart.right(), anchors.bottom()),
+        )
+    }
     fn id(&self) -> &'static str {
         "horizontal-ray"
     }

--- a/crates/app/src/drawings/mod.rs
+++ b/crates/app/src/drawings/mod.rs
@@ -362,6 +362,23 @@ trait DrawingToolImpl: Sync {
     fn freehand(&self) -> bool {
         false
     }
+    /// The rectangle this tool actually *paints*, given the box its anchors
+    /// span and the pane it is drawn in.
+    ///
+    /// The anchor box is the default and is right for most tools: a trend
+    /// line, a rectangle, a triangle all end where their anchors do. It is
+    /// badly wrong for the ones that do not. A fixed-range profile carries two
+    /// anchors at a single price and paints a histogram across the whole price
+    /// axis; a vertical line has one anchor and paints floor to ceiling.
+    ///
+    /// Anything that has to keep clear of an object — the settings inspector,
+    /// the context bar — asks for this, not for the anchors. Placing against
+    /// the anchors of a profile means walking around a thin horizontal sliver
+    /// and landing in the middle of the figure, which is precisely the bug
+    /// this exists to make impossible.
+    fn painted_bounds(&self, anchors: egui::Rect, _chart: egui::Rect) -> egui::Rect {
+        anchors
+    }
     /// The colour a fresh object of this tool is born in, when the stock
     /// blue would be the wrong answer. `None` — almost every tool — takes
     /// [`DEFAULT_DRAWING_COLOR`].
@@ -552,6 +569,12 @@ impl DrawingTool {
     #[must_use]
     pub fn freehand(self) -> bool {
         self.0.freehand()
+    }
+
+    /// See [`DrawingToolImpl::painted_bounds`].
+    #[must_use]
+    pub fn painted_bounds(self, anchors: egui::Rect, chart: egui::Rect) -> egui::Rect {
+        self.0.painted_bounds(anchors, chart)
     }
 
     #[must_use]
@@ -1723,6 +1746,52 @@ mod tests {
             .into_iter()
             .find(|tool| tool.id() == id)
             .expect("registered test tool")
+    }
+
+    /// The rectangle a popup must keep clear of is what the tool *paints*,
+    /// not where its anchors sit. A fixed-range profile carries two anchors at
+    /// one price and covers the axis; placing against the anchors walks around
+    /// a thin sliver and lands in the middle of the figure.
+    #[test]
+    fn a_tool_that_paints_past_its_anchors_says_so() {
+        let chart = egui::Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(1000.0, 600.0));
+        let anchors = egui::Rect::from_min_max(egui::pos2(300.0, 290.0), egui::pos2(500.0, 310.0));
+
+        let profile = tool("fixed-range-profile");
+        let painted = profile.painted_bounds(anchors, chart);
+        assert_eq!(
+            painted.x_range(),
+            anchors.x_range(),
+            "its time span is its own"
+        );
+        assert_eq!(
+            (painted.top(), painted.bottom()),
+            (chart.top(), chart.bottom()),
+            "and it covers every price on screen"
+        );
+
+        let vertical = tool("vertical-line");
+        assert_eq!(
+            (
+                vertical.painted_bounds(anchors, chart).top(),
+                vertical.painted_bounds(anchors, chart).bottom()
+            ),
+            (chart.top(), chart.bottom()),
+        );
+
+        let horizontal = tool("horizontal-line");
+        let painted = horizontal.painted_bounds(anchors, chart);
+        assert_eq!(
+            (painted.left(), painted.right()),
+            (chart.left(), chart.right()),
+            "edge to edge"
+        );
+
+        // Everything else ends where its anchors do, unchanged.
+        let trend = tool("trend-line");
+        assert_eq!(trend.painted_bounds(anchors, chart), anchors);
+        let rect = tool("rectangle");
+        assert_eq!(rect.painted_bounds(anchors, chart), anchors);
     }
 
     #[test]

--- a/crates/app/src/drawings/vertical_line.rs
+++ b/crates/app/src/drawings/vertical_line.rs
@@ -9,6 +9,14 @@ pub(super) static TOOL: VerticalLine = VerticalLine;
 pub(super) struct VerticalLine;
 
 impl DrawingToolImpl for VerticalLine {
+    /// Floor to ceiling: the anchors say *when*, the drawing covers every
+    /// price on screen. See [`DrawingToolImpl::painted_bounds`].
+    fn painted_bounds(&self, anchors: egui::Rect, chart: egui::Rect) -> egui::Rect {
+        egui::Rect::from_min_max(
+            egui::pos2(anchors.left(), chart.top()),
+            egui::pos2(anchors.right(), chart.bottom()),
+        )
+    }
     fn id(&self) -> &'static str {
         "vertical-line"
     }


### PR DESCRIPTION
Reported against the volume profile, and reproduced: the settings panel opened
on top of the figure.

## Why the existing rule missed it

`inspector_placement` already walked away from the selected object — the
farthest chart corner that clears its bounding box, top corners first. That
rule is right, and it is untouched here.

What beat it is the *shape of a profile*: tall enough to span the price axis,
wide enough to reach past every corner candidate. With all four corners fouled
the function fell through to its last step — "crowd the object as little as
possible" — and least overlap over a figure that large still means **on the
figure**. The one placement the function exists to prevent was its own fallback.

## The fix

A fifth step before that fallback: the **gutter** beside the object, narrowed
to fit.

- The wider of the two sides, so the panel goes where there is most room.
- Narrowed to the gutter's width, floored at `INSPECTOR_MIN_WIDTH_PX`. The
  window already carried a `min_width`/`max_width` range; the placement now
  feeds it a cap.
- **Horizontal gutters only**, deliberately. Narrowing reflows the panel and
  its scroll area keeps every row reachable; shortening hides rows, and rows a
  trader cannot reach read as rows that do not exist — the same rule the
  existing `max_height` bound was written for.

`inspector_placement` returns `InspectorPlacement { position, max_width }`
instead of a bare `Pos2`. `max_width` is `Some` only when the panel had to be
narrowed, so a corner placement is byte-for-byte what it was.

The crowd-it-least fallback survives for the one case that genuinely has no
answer — an object leaving no strip wide enough to be a panel in. Saying so by
crowding least is more honest than pretending, and it is now reached only there
rather than by every large drawing.

## Tests

Two new, both failing before this change:

- `a_drawing_too_big_for_any_corner_sends_the_panel_to_a_gutter_beside_it` —
  asserts the fixture really fouls all four corners, then that the placed rect
  does not intersect the bbox, stays inside the chart, and is never narrowed
  below what a panel needs.
- `the_gutter_is_the_wider_side_and_never_preferred_over_a_free_corner` — the
  panel takes the roomier side, and a free corner still wins outright
  (`max_width` stays `None`).

All **eight** existing placement tests pass unchanged, including
`placement_picks_the_corner_farthest_from_the_object`,
`placement_sends_the_panel_to_a_corner_not_beside_a_small_object` and
`placement_leaves_a_tall_panel_room_to_grow_downwards` — the corner rule they
guard is not what changed.

## Performance

`inspector_placement` runs when the selection changes, not per frame — the
caller is gated on `selection_changed && !inspector_moved`. The added work is
two subtractions and a comparison. No path in this diff is per-trade,
per-depth or per-frame.

## Verification

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D
warnings`, `cargo build --workspace`, `cargo test --workspace` — all exit 0,
**1732 tests, 0 failures**, on `main` (`82aaf22`).

Not visually captured against a real volume profile: reproducing one needs a
drawn profile on a live chart, and the rule is pinned by the two tests above at
the geometry that caused the report. Worth a look on the running app before
merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KJKsXWgxny3vUXdagoaA5j
