### PR TITLE
feat: pin drawing tools from their flyout star, honest channel/fib icons

### DIFF
--- a/.claude/skills/ui-harness/SKILL.md
+++ b/.claude/skills/ui-harness/SKILL.md
@@ -50,6 +50,8 @@ Landing with the drawing-toolbar goal (`feat/drawing-toolbar-pro`):
 | --- | --- |
 | `QUANTICK_DRAWING_TOOL=<tool id>` | opens with that tool armed — any id in `DRAWING_TOOLS` (`trend-line`, `ray`, `measure`, `text`, …) |
 | `QUANTICK_DRAWING_MAGNET=1` | the magnet on (anchors snap to the bar's OHLC) |
+| `QUANTICK_TOOL_FAVORITES=<tool ids>` | comma-separated tool ids pinned as rail favorites — the starred section at the tool end of the rail, one button per id in the given order (`parallel-channel,fib-retracement`). Same restore path as the workspace file |
+| `QUANTICK_TOOLBOX_FLYOUT=<family id>` | that family's flyout open on the first frame (`lines`, `fib`, `marks`, `brush`, `shapes`, `measure`) — the rows with their favorite stars, the surface where pinning and unpinning happen |
 | `QUANTICK_DRAWINGS_DEMO=1` | one of every registered drawing placed on the flow pane once it has bars, the last one selected so the inspector is on screen too |
 | `QUANTICK_DRAWINGS_DEMO=bands` | the same set, plus a level on each indicator pane's own value and a diagonal across it — the band projection under test. Pair with `QUANTICK_INDICATORS_AUTOSTART=1` |
 | `QUANTICK_DRAWINGS_DEMO_SHARED=1` | those demo objects marked "show on all charts" — pair with a split layout to see the cross-pane projection (which is now also where they can be grabbed, moved and deleted) |

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -3763,7 +3763,6 @@ impl QuantickApp {
                         ui.menu_button("Drawing toolbar", |ui| {
                             for (dock, label) in [
                                 (ToolboxDock::Left, "Left"),
-                                (ToolboxDock::Right, "Right"),
                                 (ToolboxDock::Top, "Top"),
                                 (ToolboxDock::Bottom, "Bottom"),
                             ] {
@@ -5054,7 +5053,6 @@ impl QuantickApp {
             ToolboxDock::Left | ToolboxDock::Top => {
                 egui::pos2(chart.left() + gap, chart.top() + gap)
             }
-            ToolboxDock::Right => egui::pos2(chart.right() - gap - size.x, chart.top() + gap),
             ToolboxDock::Bottom => egui::pos2(chart.left() + gap, chart.bottom() - gap - size.y),
         };
         Some(clamp_into_chart(position, size, chart))
@@ -13928,7 +13926,7 @@ plot(close)
         app.active_tab_mut().focus = PaneSide::Flow;
         app.tz = TzOffset::new(-180);
         app.dock.open_tab(DockTab::Trading);
-        app.toolrail.set_dock(ToolboxDock::Right);
+        app.toolrail.set_dock(ToolboxDock::Bottom);
         app.show_perf = false;
 
         let workspace = app.capture_workspace();
@@ -13950,7 +13948,7 @@ plot(close)
         let chrome = workspace.chrome.expect("the chrome is part of a workspace");
         assert_eq!(chrome.timezone_minutes, -180);
         assert_eq!(chrome.dock_tab, Some(ui_state::SavedDockTab::Trading));
-        assert_eq!(chrome.rail_dock, ui_state::SavedRailDock::Right);
+        assert_eq!(chrome.rail_dock, ui_state::SavedRailDock::Bottom);
         assert!(!chrome.perf_readings);
     }
 

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -1068,6 +1068,21 @@ impl QuantickApp {
         if std::env::var("QUANTICK_DRAWING_MAGNET").is_ok_and(|value| value == "1") {
             app.toolrail.set_magnet(true);
         }
+        // Pinned favorites by tool id, comma-separated — the same restore
+        // path the workspace file takes, so the hook cannot drift from it.
+        if let Ok(ids) = std::env::var("QUANTICK_TOOL_FAVORITES") {
+            let ids: Vec<String> = ids
+                .split(',')
+                .map(|id| id.trim().to_owned())
+                .filter(|id| !id.is_empty())
+                .collect();
+            app.toolrail.set_favorites(&ids);
+        }
+        // Open a family flyout on the first frame — the star column lives
+        // there, and a screenshot cannot click a caret.
+        if let Ok(family_id) = std::env::var("QUANTICK_TOOLBOX_FLYOUT") {
+            app.toolrail.request_flyout(family_id.trim().to_owned());
+        }
         app.pending_drawing_demo = std::env::var("QUANTICK_DRAWINGS_DEMO")
             .is_ok_and(|value| matches!(value.as_str(), "1" | "bands"));
         // How many anchors of the armed tool are already down when the run
@@ -2880,6 +2895,12 @@ impl QuantickApp {
             rail_visible: self.toolrail.visible(),
             rail_dock: self.toolrail.dock().into(),
             perf_readings: self.show_perf,
+            favorite_tools: self
+                .toolrail
+                .favorites()
+                .iter()
+                .map(|tool| tool.id().to_owned())
+                .collect(),
         };
         (tabs, chrome)
     }
@@ -2910,6 +2931,7 @@ impl QuantickApp {
                 .restore(chrome.dock_visible, chrome.dock_tab.map(Into::into));
             self.toolrail.set_dock(chrome.rail_dock.into());
             self.toolrail.set_visible(chrome.rail_visible);
+            self.toolrail.set_favorites(&chrome.favorite_tools);
             self.show_perf = chrome.perf_readings;
         }
         if workspace.is_empty() {
@@ -3199,6 +3221,7 @@ impl QuantickApp {
                 .restore(chrome.dock_visible, chrome.dock_tab.map(Into::into));
             self.toolrail.set_dock(chrome.rail_dock.into());
             self.toolrail.set_visible(chrome.rail_visible);
+            self.toolrail.set_favorites(&chrome.favorite_tools);
             self.show_perf = chrome.perf_readings;
         }
         self.active_tab = entry.active_tab.min(self.tabs.len().saturating_sub(1));
@@ -13978,6 +14001,7 @@ plot(close)
                 rail_visible: false,
                 rail_dock: ui_state::SavedRailDock::Bottom,
                 perf_readings: false,
+                favorite_tools: Vec::new(),
             }),
         ));
         run_frame(&mut app, &ctx);

--- a/crates/app/src/drawings/brush.rs
+++ b/crates/app/src/drawings/brush.rs
@@ -29,6 +29,7 @@ pub(super) const BRUSH_FAMILY: ToolFamily = ToolFamily {
     id: "brush",
     title: "Freehand",
     icon: icons::SCRIBBLE,
+    icon_strokes: &[],
 };
 
 impl DrawingToolImpl for Brush {

--- a/crates/app/src/drawings/fib.rs
+++ b/crates/app/src/drawings/fib.rs
@@ -16,8 +16,28 @@ use smallvec::SmallVec;
 
 use super::{
     DrawContext, Drawing, DrawingPayload, DrawingStyle, FIB_LABEL_OFFSET_PX, FIB_LABEL_SIZE_PX,
-    PresetHost, ToolFamily, distance_to_segment, drawing_stroke,
+    IconStrokes, PresetHost, ToolFamily, distance_to_segment, drawing_stroke,
 };
+
+/// The retracement icon the way TradingView draws it: the two-anchor trend
+/// diagonal with the horizontal levels it spans. The `ROWS` glyph it
+/// replaces read as a generic list, not as levels hung on a move.
+pub(super) const FIB_RETRACEMENT_ICON: IconStrokes = &[
+    &[(0.10, 0.18), (0.90, 0.18)],
+    &[(0.10, 0.52), (0.90, 0.52)],
+    &[(0.10, 0.86), (0.90, 0.86)],
+    &[(0.16, 0.86), (0.84, 0.18)],
+];
+
+/// The extension icon: the retracement ladder plus the projected level past
+/// the move — shorter, because it hangs beyond the anchor leg.
+pub(super) const FIB_EXTENSION_ICON: IconStrokes = &[
+    &[(0.34, 0.12), (0.90, 0.12)],
+    &[(0.10, 0.42), (0.90, 0.42)],
+    &[(0.10, 0.68), (0.90, 0.68)],
+    &[(0.10, 0.90), (0.90, 0.90)],
+    &[(0.16, 0.90), (0.84, 0.42)],
+];
 
 /// The one rail family both Fib tools declare, shared here so the two
 /// members can never drift onto different family ids.
@@ -25,6 +45,7 @@ pub(super) const FIB_FAMILY: ToolFamily = ToolFamily {
     id: "fib",
     title: "Fibonacci",
     icon: egui_phosphor::regular::ROWS,
+    icon_strokes: FIB_RETRACEMENT_ICON,
 };
 
 /// Ratios closer than this are the same level; a duplicate is rejected.

--- a/crates/app/src/drawings/fib_extension.rs
+++ b/crates/app/src/drawings/fib_extension.rs
@@ -21,6 +21,9 @@ impl DrawingToolImpl for FibExtension {
     fn icon(&self) -> &'static str {
         icons::ROWS_PLUS_TOP
     }
+    fn icon_strokes(&self) -> super::IconStrokes {
+        fib::FIB_EXTENSION_ICON
+    }
     /// No key is named here, and that is deliberate: this tool gave up
     /// `Shift+F` because that key flattens the position (see
     /// [`Self::shortcut`]). The tooltip went on advertising it long after,

--- a/crates/app/src/drawings/fib_retracement.rs
+++ b/crates/app/src/drawings/fib_retracement.rs
@@ -21,6 +21,9 @@ impl DrawingToolImpl for FibRetracement {
     fn icon(&self) -> &'static str {
         icons::ROWS
     }
+    fn icon_strokes(&self) -> super::IconStrokes {
+        fib::FIB_RETRACEMENT_ICON
+    }
     fn hover_text(&self) -> &'static str {
         "Fib retracement - click two points or drag (F)"
     }

--- a/crates/app/src/drawings/line_core.rs
+++ b/crates/app/src/drawings/line_core.rs
@@ -36,6 +36,7 @@ pub(super) const LINES_FAMILY: ToolFamily = ToolFamily {
     id: "lines",
     title: "Lines",
     icon: icons::LINE_SEGMENT,
+    icon_strokes: &[],
 };
 
 /// How far a line runs past the anchors that define it.

--- a/crates/app/src/drawings/mark_core.rs
+++ b/crates/app/src/drawings/mark_core.rs
@@ -28,6 +28,7 @@ pub(super) const MARKS_FAMILY: ToolFamily = ToolFamily {
     id: "marks",
     title: "Marks",
     icon: egui_phosphor::regular::ARROW_FAT_UP,
+    icon_strokes: &[],
 };
 
 /// Gap between the candle's extreme and the tip of the mark, in pixels, so

--- a/crates/app/src/drawings/measure_core.rs
+++ b/crates/app/src/drawings/measure_core.rs
@@ -21,6 +21,7 @@ pub(super) const MEASURE_FAMILY: ToolFamily = ToolFamily {
     id: "measure",
     title: "Measure",
     icon: icons::RULER,
+    icon_strokes: &[],
 };
 
 /// Which axes a measurement reports. Price range suppresses time, date range

--- a/crates/app/src/drawings/mod.rs
+++ b/crates/app/src/drawings/mod.rs
@@ -1830,6 +1830,37 @@ mod tests {
         assert_eq!(rect.painted_bounds(anchors, chart), anchors);
     }
 
+    /// The vector-icon port's contract: every declared polyline has at
+    /// least two points and stays inside the unit square, so the paint
+    /// helper never has to clamp. The tools that replaced a lying glyph
+    /// must actually declare strokes — an accidental `&[]` would silently
+    /// bring the lozenge back.
+    #[test]
+    fn icon_strokes_have_two_points_each_and_stay_in_the_unit_square() {
+        for tool in DRAWING_TOOLS {
+            for polyline in tool.icon_strokes() {
+                assert!(
+                    polyline.len() >= 2,
+                    "{}: an icon stroke needs at least two points",
+                    tool.id()
+                );
+                for (x, y) in *polyline {
+                    assert!(
+                        (0.0..=1.0).contains(x) && (0.0..=1.0).contains(y),
+                        "{}: icon point ({x}, {y}) leaves the unit square",
+                        tool.id()
+                    );
+                }
+            }
+        }
+        for id in ["parallel-channel", "fib-retracement", "fib-extension"] {
+            assert!(
+                !tool(id).icon_strokes().is_empty(),
+                "{id} replaced its glyph and must keep vector strokes"
+            );
+        }
+    }
+
     #[test]
     fn every_registered_tool_has_metadata_and_a_valid_point_count() {
         let mut ids = Vec::with_capacity(DRAWING_TOOLS.len());

--- a/crates/app/src/drawings/mod.rs
+++ b/crates/app/src/drawings/mod.rs
@@ -275,15 +275,26 @@ pub struct ToolShortcut {
 
 /// A family of related tools sharing one rail slot. Declared by each member,
 /// never listed centrally — the rail folds consecutive registry entries with
-/// equal `id` into a single split button.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// equal `id` into a single split button. `PartialEq` only: the stroke
+/// coordinates are `f32`, and nothing orders or hashes families.
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ToolFamily {
     pub id: &'static str,
     /// Header of the family flyout.
     pub title: &'static str,
     /// Slot icon before any member has been armed.
     pub icon: &'static str,
+    /// Vector icon for the slot, painted instead of `icon` when non-empty —
+    /// same contract as [`DrawingTool::icon_strokes`].
+    pub icon_strokes: IconStrokes,
 }
+
+/// A vector icon: polylines in the unit square (x right, y down), scaled to
+/// the glyph box at paint time. `&[]` means "use the font glyph". A tool
+/// declares one when no Phosphor glyph draws its meaning — a slanted
+/// channel, Fibonacci levels — so the icon is registry data, not a special
+/// case in the chrome.
+pub type IconStrokes = &'static [&'static [(f32, f32)]];
 
 /// The implementation port every drawing plugs into. Selection visuals (halo
 /// and anchor handles) are common chrome painted by the wrapper, so a tool
@@ -296,6 +307,11 @@ trait DrawingToolImpl: Sync {
     fn name(&self) -> &'static str;
     fn settings_title(&self) -> &'static str;
     fn icon(&self) -> &'static str;
+    /// Vector strokes painted in place of [`Self::icon`] when non-empty —
+    /// see [`IconStrokes`].
+    fn icon_strokes(&self) -> IconStrokes {
+        &[]
+    }
     fn hover_text(&self) -> &'static str;
     fn required_points(&self) -> usize;
     /// What the *next* click will do, with `placed` anchors already down.
@@ -545,6 +561,20 @@ impl DrawingTool {
     #[must_use]
     pub fn id(self) -> &'static str {
         self.0.id()
+    }
+
+    /// Look up a registered tool by its stable id — how the saved favorites
+    /// list and the env hooks name tools. `None` for an id no registered
+    /// tool carries (a stale file survives a removed tool).
+    #[must_use]
+    pub fn by_id(id: &str) -> Option<Self> {
+        DRAWING_TOOLS.into_iter().find(|tool| tool.id() == id)
+    }
+
+    /// Vector icon strokes, `&[]` when the tool paints a font glyph.
+    #[must_use]
+    pub fn icon_strokes(self) -> IconStrokes {
+        self.0.icon_strokes()
     }
 
     #[must_use]

--- a/crates/app/src/drawings/parallel_channel.rs
+++ b/crates/app/src/drawings/parallel_channel.rs
@@ -396,6 +396,15 @@ impl DrawingToolImpl for ParallelChannel {
     fn icon(&self) -> &'static str {
         icons::PARALLELOGRAM
     }
+    /// Two slanted parallels — the channel's own geometry. The
+    /// `PARALLELOGRAM` glyph closed the shape into a lozenge, which reads
+    /// as a filled shape tool, not a pair of rails around a trend.
+    fn icon_strokes(&self) -> super::IconStrokes {
+        &[
+            &[(0.08, 0.70), (0.76, 0.12)],
+            &[(0.24, 0.88), (0.92, 0.30)],
+        ]
+    }
     fn hover_text(&self) -> &'static str {
         "Rising / falling channel - drag the trend line, then set the width (C)"
     }

--- a/crates/app/src/drawings/shape_core.rs
+++ b/crates/app/src/drawings/shape_core.rs
@@ -18,6 +18,7 @@ pub(super) const SHAPES_FAMILY: ToolFamily = ToolFamily {
     id: "shapes",
     title: "Shapes",
     icon: icons::SHAPES,
+    icon_strokes: &[],
 };
 
 /// Segments in an ellipse outline. Fixed, not derived from the on-screen

--- a/crates/app/src/toolrail.rs
+++ b/crates/app/src/toolrail.rs
@@ -47,15 +47,17 @@ const FLYOUT_GLYPH_PX: f32 = 18.0;
 const FLYOUT_NAME_TEXT_PX: f32 = 12.0;
 const FLYOUT_SHORTCUT_TEXT_PX: f32 = 11.0;
 const FLYOUT_HEADER_TEXT_PX: f32 = 11.0;
-/// The favorite star riding the top-right of a flyout row's tool icon:
-/// glyph size, its centre offset from the icon centre, and the square click
-/// zone around it — bigger than the glyph, a 9 px star is no hit target.
-/// Offset 8 with a 12 px hit keeps the zone clear of the glyph's own centre
-/// (x = 12): a click on the icon must arm, never silently star — the star
-/// only wins clicks that land on the star.
+/// The favorite star holds the row's right edge (trader feedback: beside
+/// the name, not on the icon), with the shortcut label stepped one slot
+/// left so the two never collide. The hit zone is bigger than the glyph —
+/// a 9 px star is no hit target — and stays clear of the icon and name, so
+/// an arming click can never silently star.
 const FLYOUT_STAR_PX: f32 = 9.0;
-const FLYOUT_STAR_OFFSET_PX: f32 = 8.0;
-const FLYOUT_STAR_HIT_PX: f32 = 12.0;
+const FLYOUT_STAR_RIGHT_INSET_PX: f32 = 10.0;
+const FLYOUT_STAR_HIT_PX: f32 = 14.0;
+/// Width the star column reserves at the row's right end; the shortcut
+/// label right-aligns just left of it.
+const FLYOUT_STAR_SLOT_PX: f32 = 20.0;
 /// The corner star badge marking a pinned button in the rail's favorites
 /// section.
 const FAVORITE_BADGE_PX: f32 = 8.0;
@@ -1278,12 +1280,9 @@ impl ToolRail {
             egui::vec2(width, TOOLBOX_FLYOUT_ROW_HEIGHT_PX),
             egui::Sense::click(),
         );
-        // The star rides the icon's top-right corner. Its hit zone outranks
-        // the row: a click there curates favorites, everywhere else arms.
-        let star_center = egui::pos2(
-            rect.left() + FLYOUT_GLYPH_CENTER_X_PX + FLYOUT_STAR_OFFSET_PX,
-            rect.center().y - FLYOUT_STAR_OFFSET_PX,
-        );
+        // The star holds the row's right edge. Its hit zone outranks the
+        // row: a click there curates favorites, everywhere else arms.
+        let star_center = egui::pos2(rect.right() - FLYOUT_STAR_RIGHT_INSET_PX, rect.center().y);
         let star_zone =
             egui::Rect::from_center_size(star_center, egui::Vec2::splat(FLYOUT_STAR_HIT_PX));
         let favorite = self.is_favorite(member);
@@ -1356,7 +1355,10 @@ impl ToolRail {
             );
             if let Some(shortcut) = Tool::Drawing(member).shortcut_label() {
                 ui.painter().text(
-                    egui::pos2(rect.right() - FLYOUT_SHORTCUT_INSET_PX, rect.center().y),
+                    egui::pos2(
+                        rect.right() - FLYOUT_STAR_SLOT_PX - FLYOUT_SHORTCUT_INSET_PX,
+                        rect.center().y,
+                    ),
                     egui::Align2::RIGHT_CENTER,
                     shortcut,
                     egui::FontId::proportional(FLYOUT_SHORTCUT_TEXT_PX),

--- a/crates/app/src/toolrail.rs
+++ b/crates/app/src/toolrail.rs
@@ -10,9 +10,9 @@ use std::collections::BTreeMap;
 use eframe::egui;
 use egui_phosphor::regular as icons;
 
-use crate::drawings::{DRAWING_TOOLS, DrawingTool, Drawings, ToolFamily};
+use crate::drawings::{DRAWING_TOOLS, DrawingTool, Drawings, IconStrokes, ToolFamily};
 use crate::theme;
-use crate::widgets::{IconButton, MarkerEdge, TOOLRAIL_ICON};
+use crate::widgets::{IconButton, MarkerEdge, TOOLRAIL_ICON, paint_icon_strokes};
 
 /// Rail cross axis, all four docks: `44 = 6 + 32 + 6`.
 const TOOLBOX_THICKNESS_PX: f32 = 44.0;
@@ -47,6 +47,16 @@ const FLYOUT_GLYPH_PX: f32 = 18.0;
 const FLYOUT_NAME_TEXT_PX: f32 = 12.0;
 const FLYOUT_SHORTCUT_TEXT_PX: f32 = 11.0;
 const FLYOUT_HEADER_TEXT_PX: f32 = 11.0;
+/// The favorite star riding the top-right of a flyout row's tool icon:
+/// glyph size, its centre offset from the icon centre, and the square click
+/// zone around it — bigger than the glyph, a 9 px star is no hit target.
+const FLYOUT_STAR_PX: f32 = 9.0;
+const FLYOUT_STAR_OFFSET_PX: f32 = 7.0;
+const FLYOUT_STAR_HIT_PX: f32 = 14.0;
+/// The corner star badge marking a pinned button in the rail's favorites
+/// section.
+const FAVORITE_BADGE_PX: f32 = 8.0;
+const FAVORITE_BADGE_INSET_PX: f32 = 3.0;
 /// Side of the caret triangle on a family slot.
 const CARET_SIDE_PX: f32 = 5.0;
 /// Inset of the caret from the button's trailing-bottom corner.
@@ -89,6 +99,14 @@ impl Tool {
             Self::Pointer => icons::CURSOR,
             Self::Crosshair => icons::CROSSHAIR,
             Self::Drawing(tool) => tool.icon(),
+        }
+    }
+
+    #[must_use]
+    fn icon_strokes(self) -> IconStrokes {
+        match self {
+            Self::Pointer | Self::Crosshair => &[],
+            Self::Drawing(tool) => tool.icon_strokes(),
         }
     }
 
@@ -240,14 +258,22 @@ fn tool_slots() -> &'static [RailSlot] {
     })
 }
 
-/// Long-axis length of the full rail (§2.8 of the spec).
-fn full_length(tool_slot_count: usize) -> f32 {
+/// Long-axis length of the full rail (§2.8 of the spec). The favorites
+/// section — a separator plus one slot per starred tool — only exists when
+/// something is starred, so an empty list costs no length.
+fn full_length(tool_slot_count: usize, favorite_count: usize) -> f32 {
     let n = tool_slot_count as f32;
+    let favorites = if favorite_count == 0 {
+        0.0
+    } else {
+        SEPARATOR_BLOCK_PX + favorite_count as f32 * (TOOLRAIL_ICON.hit + TOOLBOX_ITEM_GAP_PX)
+    };
     2.0 * TOOLBOX_MARGIN_PX
         + GRIP_BLOCK_PX
         + (2.0 * TOOLRAIL_ICON.hit + TOOLBOX_ITEM_GAP_PX)
         + SEPARATOR_BLOCK_PX
         + (n * TOOLRAIL_ICON.hit + (n - 1.0) * TOOLBOX_ITEM_GAP_PX)
+        + favorites
         + TOOLBOX_MIN_CLUSTER_GAP_PX
         + trailing_length()
 }
@@ -287,8 +313,8 @@ fn trailing_length() -> f32 {
 }
 
 /// Resolve the stage for an available long-axis extent (margins included).
-fn stage_for(available: f32, tool_slot_count: usize) -> RailStage {
-    if available >= full_length(tool_slot_count) {
+fn stage_for(available: f32, tool_slot_count: usize, favorite_count: usize) -> RailStage {
+    if available >= full_length(tool_slot_count, favorite_count) {
         RailStage::Full
     } else if available >= compact_length() {
         RailStage::Compact
@@ -313,12 +339,19 @@ pub struct ToolRail {
     magnet: bool,
     /// Last-armed member of each tool family, keyed by family id.
     last_family_member: BTreeMap<&'static str, DrawingTool>,
+    /// Starred tools, in the order the trader starred them — the pinned
+    /// section at the rail's tool end. Star order, not registry order, so a
+    /// favorite keeps the position the trader learned.
+    favorites: Vec<DrawingTool>,
     /// Currently-nearest drop edge while a grip drag is live.
     drag_preview: Option<ToolboxDock>,
     dragging: bool,
     drag_cancelled: bool,
     /// Open family flyout: the family id and the slot rect it anchors to.
     flyout: Option<(&'static str, egui::Rect)>,
+    /// A family flyout a validation hook asked for before the first frame —
+    /// honoured by the family slot once it knows its rect, then cleared.
+    hook_flyout: Option<String>,
     #[cfg(test)]
     button_rects: [Option<(Tool, egui::Rect)>; TOOLBOX_BUTTON_COUNT],
     #[cfg(test)]
@@ -337,6 +370,10 @@ pub struct ToolRail {
     rail_rect: Option<egui::Rect>,
     #[cfg(test)]
     flyout_rects: Vec<(DrawingTool, egui::Rect)>,
+    #[cfg(test)]
+    flyout_star_rects: Vec<(DrawingTool, egui::Rect)>,
+    #[cfg(test)]
+    favorite_rects: Vec<(DrawingTool, egui::Rect)>,
 }
 
 impl Default for ToolRail {
@@ -348,10 +385,12 @@ impl Default for ToolRail {
             repeat: false,
             magnet: false,
             last_family_member: BTreeMap::new(),
+            favorites: Vec::new(),
             drag_preview: None,
             dragging: false,
             drag_cancelled: false,
             flyout: None,
+            hook_flyout: None,
             #[cfg(test)]
             button_rects: [None; TOOLBOX_BUTTON_COUNT],
             #[cfg(test)]
@@ -370,6 +409,10 @@ impl Default for ToolRail {
             rail_rect: None,
             #[cfg(test)]
             flyout_rects: Vec::new(),
+            #[cfg(test)]
+            flyout_star_rects: Vec::new(),
+            #[cfg(test)]
+            favorite_rects: Vec::new(),
         }
     }
 }
@@ -432,6 +475,42 @@ impl ToolRail {
         self.tool = tool;
     }
 
+    /// The starred tools, in the order they were starred.
+    #[must_use]
+    pub fn favorites(&self) -> &[DrawingTool] {
+        &self.favorites
+    }
+
+    #[must_use]
+    pub fn is_favorite(&self, tool: DrawingTool) -> bool {
+        self.favorites.contains(&tool)
+    }
+
+    /// Star or unstar a tool. Starring appends — the pinned section grows at
+    /// its far end, and the tools already pinned never move.
+    pub fn toggle_favorite(&mut self, tool: DrawingTool) {
+        if let Some(index) = self.favorites.iter().position(|entry| *entry == tool) {
+            self.favorites.remove(index);
+        } else {
+            self.favorites.push(tool);
+        }
+    }
+
+    /// Restore the starred list from saved tool ids — the workspace file
+    /// path. An id no registered tool carries is dropped, a duplicate keeps
+    /// its first position, and saved order is kept: it is the order the
+    /// trader starred in.
+    pub fn set_favorites(&mut self, ids: &[String]) {
+        self.favorites.clear();
+        for id in ids {
+            if let Some(tool) = DrawingTool::by_id(id)
+                && !self.favorites.contains(&tool)
+            {
+                self.favorites.push(tool);
+            }
+        }
+    }
+
     /// Whether the repeat pin keeps the tool armed after an object completes.
     #[must_use]
     pub fn repeat(&self) -> bool {
@@ -454,6 +533,14 @@ impl ToolRail {
     /// the button does.
     pub(crate) fn set_magnet(&mut self, magnet: bool) {
         self.magnet = magnet;
+    }
+
+    /// Ask for a family flyout without a click — the
+    /// `QUANTICK_TOOLBOX_FLYOUT` hook. The slot honours it on its next draw,
+    /// when the anchor rect exists; an unknown family id is simply never
+    /// matched and stays pending, which draws nothing.
+    pub(crate) fn request_flyout(&mut self, family_id: String) {
+        self.hook_flyout = Some(family_id);
     }
 
     #[cfg(test)]
@@ -562,6 +649,8 @@ impl ToolRail {
             self.objects_rect = None;
             self.rail_rect = Some(ui.max_rect().expand(TOOLBOX_MARGIN_PX));
             self.flyout_rects.clear();
+            self.flyout_star_rects.clear();
+            self.favorite_rects.clear();
         }
 
         let vertical = self.dock.is_vertical();
@@ -571,7 +660,7 @@ impl ToolRail {
             ui.available_width()
         } + 2.0 * TOOLBOX_MARGIN_PX;
         let slots = tool_slots();
-        let stage = stage_for(available, slots.len());
+        let stage = stage_for(available, slots.len(), self.favorites.len());
 
         // Chart-facing hairline: the only stroke the rail paints — a
         // four-sided stroke would draw a seam against the window edge.
@@ -616,6 +705,7 @@ impl ToolRail {
                             }
                         }
                     }
+                    self.draw_favorites_section(ui, vertical, drawings);
                 }
                 RailStage::Compact | RailStage::Minimal => {
                     if let Some(armed) = self.tool.drawing_tool() {
@@ -920,6 +1010,7 @@ impl ToolRail {
 
     fn draw_button(&mut self, ui: &mut egui::Ui, tool: Tool, drawings: &Drawings) {
         let response = IconButton::new(tool.icon(), TOOLRAIL_ICON)
+            .strokes(tool.icon_strokes())
             .active(self.tool == tool)
             .active_marker(self.dock.marker_edge())
             .hover_text(tool.hover_text())
@@ -959,6 +1050,49 @@ impl ToolRail {
         true
     }
 
+    /// The pinned section at the tool end of the rail: a separator, then one
+    /// button per starred tool in star order. One click arms; unstarring
+    /// lives only on the star in the tool's own flyout row, so a pinned
+    /// button can never be destroyed by the click meant to use it.
+    fn draw_favorites_section(&mut self, ui: &mut egui::Ui, vertical: bool, drawings: &Drawings) {
+        if self.favorites.is_empty() {
+            return;
+        }
+        self.draw_separator(ui, vertical);
+        // Indexed so the loop never clones the list on the per-frame path;
+        // `DrawingTool` is `Copy` and arming cannot reorder favorites.
+        for index in 0..self.favorites.len() {
+            let tool = self.favorites[index];
+            let armed = self.tool == Tool::Drawing(tool);
+            let response = IconButton::new(tool.icon(), TOOLRAIL_ICON)
+                .strokes(tool.icon_strokes())
+                .active(armed)
+                .active_marker(self.dock.marker_edge())
+                .hover_text(tool.hover_text())
+                .show(ui);
+            self.paint_draft_badge(ui, &response, Tool::Drawing(tool), drawings);
+            if ui.is_rect_visible(response.rect) {
+                // The corner star names the section: this button is a pin,
+                // not a second registry slot.
+                ui.painter().text(
+                    egui::pos2(
+                        response.rect.right() - FAVORITE_BADGE_INSET_PX,
+                        response.rect.top() + FAVORITE_BADGE_INSET_PX,
+                    ),
+                    egui::Align2::RIGHT_TOP,
+                    icons::STAR,
+                    egui::FontId::proportional(FAVORITE_BADGE_PX),
+                    theme::ACCENT,
+                );
+            }
+            #[cfg(test)]
+            self.favorite_rects.push((tool, response.rect));
+            if response.clicked() {
+                self.arm(Tool::Drawing(tool));
+            }
+        }
+    }
+
     /// A family's shown member: the last-armed one, or `None` before any
     /// member has been used.
     fn family_member(&self, family: ToolFamily, members: &[DrawingTool]) -> Option<DrawingTool> {
@@ -983,8 +1117,10 @@ impl ToolRail {
             .drawing_tool()
             .is_some_and(|tool| members.contains(&tool));
         let icon = shown.map_or(family.icon, DrawingTool::icon);
+        let strokes = shown.map_or(family.icon_strokes, DrawingTool::icon_strokes);
         let hover = shown.map_or(family.title, DrawingTool::hover_text);
         let response = IconButton::new(icon, TOOLRAIL_ICON)
+            .strokes(strokes)
             .active(armed)
             .active_marker(self.dock.marker_edge())
             .hover_text(hover)
@@ -1029,6 +1165,11 @@ impl ToolRail {
         if let Some(slot) = self.button_rects.iter_mut().find(|slot| slot.is_none()) {
             let recorded = shown.unwrap_or(members[0]);
             *slot = Some((Tool::Drawing(recorded), response.rect));
+        }
+
+        if self.hook_flyout.as_deref() == Some(family.id) {
+            self.hook_flyout = None;
+            self.flyout = Some((family.id, response.rect));
         }
 
         let caret_clicked = response.clicked()
@@ -1095,9 +1236,17 @@ impl ToolRail {
                                 .size(FLYOUT_HEADER_TEXT_PX),
                         );
                         for member in members {
-                            if self.draw_flyout_row(ui, *member) {
-                                self.arm(Tool::Drawing(*member));
-                                self.flyout = None;
+                            match self.draw_flyout_row(ui, *member) {
+                                Some(FlyoutClick::Arm) => {
+                                    self.arm(Tool::Drawing(*member));
+                                    self.flyout = None;
+                                }
+                                // Starring neither arms nor closes: the
+                                // trader is curating the rail, not drawing.
+                                Some(FlyoutClick::ToggleFavorite) => {
+                                    self.toggle_favorite(*member);
+                                }
+                                None => {}
                             }
                         }
                     });
@@ -1117,16 +1266,28 @@ impl ToolRail {
         }
     }
 
-    /// One flyout row: glyph, name, right-aligned shortcut. Returns whether
-    /// the row was clicked.
-    fn draw_flyout_row(&mut self, ui: &mut egui::Ui, member: DrawingTool) -> bool {
+    /// One flyout row: glyph with its favorite star, name, right-aligned
+    /// shortcut. Returns what the click asked for, `None` when nothing was
+    /// clicked.
+    fn draw_flyout_row(&mut self, ui: &mut egui::Ui, member: DrawingTool) -> Option<FlyoutClick> {
         let width = ui.available_width();
         let (rect, response) = ui.allocate_exact_size(
             egui::vec2(width, TOOLBOX_FLYOUT_ROW_HEIGHT_PX),
             egui::Sense::click(),
         );
+        // The star rides the icon's top-right corner. Its hit zone outranks
+        // the row: a click there curates favorites, everywhere else arms.
+        let star_center = egui::pos2(
+            rect.left() + FLYOUT_GLYPH_CENTER_X_PX + FLYOUT_STAR_OFFSET_PX,
+            rect.center().y - FLYOUT_STAR_OFFSET_PX,
+        );
+        let star_zone =
+            egui::Rect::from_center_size(star_center, egui::Vec2::splat(FLYOUT_STAR_HIT_PX));
+        let favorite = self.is_favorite(member);
         #[cfg(test)]
         self.flyout_rects.push((member, rect));
+        #[cfg(test)]
+        self.flyout_star_rects.push((member, star_zone));
         if ui.is_rect_visible(rect) {
             let armed = self.tool == Tool::Drawing(member);
             if armed {
@@ -1147,13 +1308,42 @@ impl ToolRail {
             } else {
                 theme::TEXT_MUTED
             };
-            ui.painter().text(
-                egui::pos2(rect.left() + FLYOUT_GLYPH_CENTER_X_PX, rect.center().y),
-                egui::Align2::CENTER_CENTER,
-                member.icon(),
-                egui::FontId::proportional(FLYOUT_GLYPH_PX),
-                glyph_color,
-            );
+            let glyph_center = egui::pos2(rect.left() + FLYOUT_GLYPH_CENTER_X_PX, rect.center().y);
+            if member.icon_strokes().is_empty() {
+                ui.painter().text(
+                    glyph_center,
+                    egui::Align2::CENTER_CENTER,
+                    member.icon(),
+                    egui::FontId::proportional(FLYOUT_GLYPH_PX),
+                    glyph_color,
+                );
+            } else {
+                paint_icon_strokes(
+                    ui.painter(),
+                    egui::Rect::from_center_size(
+                        glyph_center,
+                        egui::Vec2::splat(FLYOUT_GLYPH_PX - 4.0),
+                    ),
+                    member.icon_strokes(),
+                    glyph_color,
+                );
+            }
+            // Accent when starred; otherwise the star only whispers on row
+            // hover, so an unstarred flyout stays as quiet as before.
+            if favorite || response.hovered() {
+                let star_color = if favorite {
+                    theme::ACCENT
+                } else {
+                    theme::TEXT_FAINT
+                };
+                ui.painter().text(
+                    star_center,
+                    egui::Align2::CENTER_CENTER,
+                    icons::STAR,
+                    egui::FontId::proportional(FLYOUT_STAR_PX),
+                    star_color,
+                );
+            }
             ui.painter().text(
                 egui::pos2(rect.left() + FLYOUT_NAME_X_PX, rect.center().y),
                 egui::Align2::LEFT_CENTER,
@@ -1171,8 +1361,25 @@ impl ToolRail {
                 );
             }
         }
-        response.clicked()
+        if response.clicked() {
+            let on_star = response
+                .interact_pointer_pos()
+                .is_some_and(|position| star_zone.contains(position));
+            if on_star {
+                return Some(FlyoutClick::ToggleFavorite);
+            }
+            return Some(FlyoutClick::Arm);
+        }
+        None
     }
+}
+
+/// What a click on a flyout row asked for.
+enum FlyoutClick {
+    /// Arm the row's tool and close the flyout.
+    Arm,
+    /// Star or unstar the row's tool; the flyout stays open.
+    ToggleFavorite,
 }
 
 /// The rail's frame: chrome fill, margins, and no stroke — the chart-facing
@@ -1290,7 +1497,7 @@ mod tests {
             slots, 9,
             "Lines, Channels, Marks, Freehand, Shapes, Fib, Measure, Anchored VWAP and Text"
         );
-        assert_eq!(full_length(slots), 633.0);
+        assert_eq!(full_length(slots, 0), 633.0);
         assert_eq!(compact_length(), 381.0);
         assert_eq!(minimal_length(), 191.0);
     }
@@ -1727,6 +1934,147 @@ mod tests {
         assert!(!rail.magnet(), "the same button turns it back off");
     }
 
+    /// The first family slot and its members — every favorites test walks
+    /// in through a real family flyout, the way the trader does.
+    fn first_family() -> &'static [DrawingTool] {
+        tool_slots()
+            .iter()
+            .find_map(|slot| match slot {
+                RailSlot::Family { members, .. } => Some(members.as_slice()),
+                RailSlot::Single(_) => None,
+            })
+            .expect("the registry folds at least one family")
+    }
+
+    /// Open the family's flyout through the slot's caret zone and give the
+    /// next frame a chance to record the row and star rects.
+    fn open_flyout(
+        rail: &mut ToolRail,
+        drawings: &mut Drawings,
+        ctx: &egui::Context,
+        screen: egui::Rect,
+        members: &[DrawingTool],
+    ) {
+        rail_frame_with(rail, drawings, ctx, screen, Vec::new());
+        let slot = rail
+            .button_rect(Tool::Drawing(members[0]))
+            .expect("the family slot rendered");
+        click_at(rail, drawings, ctx, screen, slot.max - egui::vec2(3.0, 3.0));
+        rail_frame_with(rail, drawings, ctx, screen, Vec::new());
+        assert!(rail.flyout.is_some(), "the caret click opened the flyout");
+    }
+
+    /// Clicking the tiny star pins the tool: nothing arms, the flyout stays
+    /// open — the trader is curating the rail, not drawing.
+    #[test]
+    fn starring_from_the_flyout_pins_without_arming_or_closing() {
+        let screen = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(800.0, 900.0));
+        let ctx = egui::Context::default();
+        let mut rail = ToolRail::new();
+        let mut drawings = Drawings::default();
+        let members = first_family();
+        open_flyout(&mut rail, &mut drawings, &ctx, screen, members);
+
+        let star = rail
+            .flyout_star_rects
+            .iter()
+            .find_map(|(tool, rect)| (*tool == members[1]).then_some(*rect))
+            .expect("every flyout row carries a star");
+        click_at(&mut rail, &mut drawings, &ctx, screen, star.center());
+
+        assert!(rail.is_favorite(members[1]), "the star click pinned");
+        assert_eq!(rail.tool(), Tool::Pointer, "starring armed nothing");
+        assert!(
+            rail.flyout.is_some(),
+            "the flyout stayed open to keep curating"
+        );
+    }
+
+    /// The pinned button arms in one click and never unstars — removal lives
+    /// only on the flyout star, so using a favorite cannot destroy it.
+    #[test]
+    fn the_pinned_button_arms_and_never_unstars() {
+        let screen = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(800.0, 900.0));
+        let ctx = egui::Context::default();
+        let mut rail = ToolRail::new();
+        let mut drawings = Drawings::default();
+        let members = first_family();
+        rail.toggle_favorite(members[1]);
+
+        rail_frame_with(&mut rail, &mut drawings, &ctx, screen, Vec::new());
+        let pinned = rail
+            .favorite_rects
+            .iter()
+            .find_map(|(tool, rect)| (*tool == members[1]).then_some(*rect))
+            .expect("the favorites section rendered the pin");
+        click_at(&mut rail, &mut drawings, &ctx, screen, pinned.center());
+
+        assert_eq!(rail.tool(), Tool::Drawing(members[1]), "one click armed");
+        assert!(
+            rail.is_favorite(members[1]),
+            "arming a favorite must never unstar it"
+        );
+    }
+
+    /// Star order is the order the trader starred in: unstarring removes in
+    /// place, re-starring appends at the end — pinned muscle memory holds.
+    #[test]
+    fn star_order_is_stable_under_unstar_and_restar() {
+        let mut rail = ToolRail::new();
+        let tools: Vec<DrawingTool> = DRAWING_TOOLS.into_iter().take(3).collect();
+        for tool in &tools {
+            rail.toggle_favorite(*tool);
+        }
+        rail.toggle_favorite(tools[1]);
+        assert_eq!(rail.favorites(), &[tools[0], tools[2]]);
+        rail.toggle_favorite(tools[1]);
+        assert_eq!(rail.favorites(), &[tools[0], tools[2], tools[1]]);
+    }
+
+    /// The saved-ids path: order kept, unknown ids dropped, duplicates kept
+    /// once — a stale or hand-edited file cannot corrupt the rail.
+    #[test]
+    fn set_favorites_round_trips_ids_and_survives_junk() {
+        let mut rail = ToolRail::new();
+        let tools: Vec<DrawingTool> = DRAWING_TOOLS.into_iter().take(2).collect();
+        let ids = vec![
+            tools[1].id().to_owned(),
+            "no-such-tool".to_owned(),
+            tools[0].id().to_owned(),
+            tools[1].id().to_owned(),
+        ];
+        rail.set_favorites(&ids);
+        assert_eq!(rail.favorites(), &[tools[1], tools[0]]);
+
+        let saved: Vec<String> = rail
+            .favorites()
+            .iter()
+            .map(|tool| tool.id().to_owned())
+            .collect();
+        let mut restored = ToolRail::new();
+        restored.set_favorites(&saved);
+        assert_eq!(
+            restored.favorites(),
+            rail.favorites(),
+            "round-trip is exact"
+        );
+    }
+
+    /// The favorites section costs rail length only when it exists, and the
+    /// stage math knows about it — pins cannot silently overflow the rail.
+    #[test]
+    fn favorites_lengthen_the_full_stage_only_when_present() {
+        let slots = tool_slots().len();
+        assert!(full_length(slots, 2) > full_length(slots, 0));
+        let extent = full_length(slots, 0);
+        assert_eq!(stage_for(extent, slots, 0), RailStage::Full);
+        assert_eq!(
+            stage_for(extent, slots, 2),
+            RailStage::Compact,
+            "two pins no longer fit the bare-full extent"
+        );
+    }
+
     /// The scripted-validation hook (`QUANTICK_DRAWING_MAGNET`) sets the same
     /// flag the button does; nothing may fork the two.
     #[test]
@@ -1742,16 +2090,16 @@ mod tests {
     fn stages_are_pure_functions_of_extent() {
         let slots = tool_slots().len();
         for extent in [100.0_f32, 200.0, 380.9, 381.0, 632.9, 633.0, 1000.0] {
-            let first = stage_for(extent, slots);
-            let second = stage_for(extent, slots);
+            let first = stage_for(extent, slots, 0);
+            let second = stage_for(extent, slots, 0);
             assert_eq!(first, second);
         }
         // The full stage grows one slot per registry addition; the anchored
         // VWAP took it from 597 to 633.
-        assert_eq!(stage_for(633.0, slots), RailStage::Full);
-        assert_eq!(stage_for(632.9, slots), RailStage::Compact);
-        assert_eq!(stage_for(381.0, slots), RailStage::Compact);
-        assert_eq!(stage_for(380.9, slots), RailStage::Minimal);
+        assert_eq!(stage_for(633.0, slots, 0), RailStage::Full);
+        assert_eq!(stage_for(632.9, slots, 0), RailStage::Compact);
+        assert_eq!(stage_for(381.0, slots, 0), RailStage::Compact);
+        assert_eq!(stage_for(380.9, slots, 0), RailStage::Minimal);
     }
 
     #[test]

--- a/crates/app/src/toolrail.rs
+++ b/crates/app/src/toolrail.rs
@@ -50,9 +50,12 @@ const FLYOUT_HEADER_TEXT_PX: f32 = 11.0;
 /// The favorite star riding the top-right of a flyout row's tool icon:
 /// glyph size, its centre offset from the icon centre, and the square click
 /// zone around it — bigger than the glyph, a 9 px star is no hit target.
+/// Offset 8 with a 12 px hit keeps the zone clear of the glyph's own centre
+/// (x = 12): a click on the icon must arm, never silently star — the star
+/// only wins clicks that land on the star.
 const FLYOUT_STAR_PX: f32 = 9.0;
-const FLYOUT_STAR_OFFSET_PX: f32 = 7.0;
-const FLYOUT_STAR_HIT_PX: f32 = 14.0;
+const FLYOUT_STAR_OFFSET_PX: f32 = 8.0;
+const FLYOUT_STAR_HIT_PX: f32 = 12.0;
 /// The corner star badge marking a pinned button in the rail's favorites
 /// section.
 const FAVORITE_BADGE_PX: f32 = 8.0;
@@ -1987,6 +1990,34 @@ mod tests {
         assert!(
             rail.flyout.is_some(),
             "the flyout stayed open to keep curating"
+        );
+    }
+
+    /// A click on the row's own icon arms the tool — the star's hit zone
+    /// must never swallow the natural arming gesture (trader review).
+    #[test]
+    fn a_click_on_the_flyout_icon_arms_and_never_stars() {
+        let screen = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(800.0, 900.0));
+        let ctx = egui::Context::default();
+        let mut rail = ToolRail::new();
+        let mut drawings = Drawings::default();
+        let members = first_family();
+        open_flyout(&mut rail, &mut drawings, &ctx, screen, members);
+
+        let row = rail
+            .flyout_row_rect(members[1])
+            .expect("the flyout lists the member");
+        let glyph_center = egui::pos2(row.left() + FLYOUT_GLYPH_CENTER_X_PX, row.center().y);
+        click_at(&mut rail, &mut drawings, &ctx, screen, glyph_center);
+
+        assert_eq!(
+            rail.tool(),
+            Tool::Drawing(members[1]),
+            "the icon click armed the tool"
+        );
+        assert!(
+            !rail.is_favorite(members[1]),
+            "an arming click must never silently star"
         );
     }
 

--- a/crates/app/src/toolrail.rs
+++ b/crates/app/src/toolrail.rs
@@ -128,12 +128,17 @@ impl Tool {
     }
 }
 
-/// One of the four window edges the toolbar can dock against.
+/// One of the three window edges the toolbar can dock against.
+///
+/// The right edge is deliberately absent. That border belongs to the price
+/// axis and to whatever the trader is reading as the tape prints; a rail
+/// parked there covers the one column of the chart that is always moving,
+/// and it is reachable by accident — a grip drag that drifts right used to
+/// land it in the way. Three edges, and the busy one stays clear.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum ToolboxDock {
     #[default]
     Left,
-    Right,
     Top,
     Bottom,
 }
@@ -141,12 +146,14 @@ pub enum ToolboxDock {
 impl ToolboxDock {
     #[must_use]
     pub const fn is_vertical(self) -> bool {
-        matches!(self, Self::Left | Self::Right)
+        matches!(self, Self::Left)
     }
 
     /// The nearest edge by *normalised* distance — raw pixels would bias
     /// every drop toward top/bottom on a wide window. Ties resolve
-    /// Left > Right > Top > Bottom, so the result is deterministic.
+    /// Left > Top > Bottom, so the result is deterministic. A drop on the
+    /// right half simply lands on whichever of the three offered edges is
+    /// closest; there is no right dock to fall into.
     #[must_use]
     fn nearest(pointer: egui::Pos2, screen: egui::Rect) -> Self {
         let pointer = pointer.clamp(screen.min, screen.max);
@@ -154,7 +161,6 @@ impl ToolboxDock {
         let height = screen.height().max(f32::EPSILON);
         let candidates = [
             (Self::Left, (pointer.x - screen.left()) / width),
-            (Self::Right, (screen.right() - pointer.x) / width),
             (Self::Top, (pointer.y - screen.top()) / height),
             (Self::Bottom, (screen.bottom() - pointer.y) / height),
         ];
@@ -173,7 +179,6 @@ impl ToolboxDock {
     const fn marker_edge(self) -> MarkerEdge {
         match self {
             Self::Left => MarkerEdge::Left,
-            Self::Right => MarkerEdge::Right,
             Self::Top => MarkerEdge::Top,
             Self::Bottom => MarkerEdge::Bottom,
         }
@@ -523,11 +528,6 @@ impl ToolRail {
                 .resizable(false)
                 .frame(rail_frame())
                 .show(ctx, |ui| self.draw_contents(ui, drawings, manager_open)),
-            ToolboxDock::Right => egui::SidePanel::right("drawing_toolbox_right")
-                .exact_width(TOOLBOX_THICKNESS_PX)
-                .resizable(false)
-                .frame(rail_frame())
-                .show(ctx, |ui| self.draw_contents(ui, drawings, manager_open)),
             ToolboxDock::Top => egui::TopBottomPanel::top("drawing_toolbox_top")
                 .exact_height(TOOLBOX_THICKNESS_PX)
                 .resizable(false)
@@ -578,7 +578,6 @@ impl ToolRail {
         let rail_rect = ui.max_rect().expand(TOOLBOX_MARGIN_PX);
         let edge = match self.dock {
             ToolboxDock::Left => [rail_rect.right_top(), rail_rect.right_bottom()],
-            ToolboxDock::Right => [rail_rect.left_top(), rail_rect.left_bottom()],
             ToolboxDock::Top => [rail_rect.left_bottom(), rail_rect.right_bottom()],
             ToolboxDock::Bottom => [rail_rect.left_top(), rail_rect.right_top()],
         };
@@ -1069,10 +1068,6 @@ impl ToolRail {
             TOOLBOX_FLYOUT_ROW_HEIGHT_PX * (members.len() + 1) as f32 + 2.0 * TOOLBOX_ITEM_GAP_PX;
         let position = match self.dock {
             ToolboxDock::Left => egui::pos2(anchor.right() + TOOLBOX_MARGIN_PX, anchor.top()),
-            ToolboxDock::Right => egui::pos2(
-                anchor.left() - TOOLBOX_MARGIN_PX - TOOLBOX_FLYOUT_WIDTH_PX,
-                anchor.top(),
-            ),
             ToolboxDock::Top => egui::pos2(anchor.left(), anchor.bottom() + TOOLBOX_MARGIN_PX),
             ToolboxDock::Bottom => {
                 egui::pos2(anchor.left(), anchor.top() - TOOLBOX_MARGIN_PX - height)
@@ -1198,10 +1193,6 @@ fn paint_drop_preview(ctx: &egui::Context, target: ToolboxDock) {
             screen.min,
             egui::pos2(screen.left() + thickness, screen.bottom()),
         ),
-        ToolboxDock::Right => egui::Rect::from_min_max(
-            egui::pos2(screen.right() - thickness, screen.top()),
-            screen.max,
-        ),
         ToolboxDock::Top => egui::Rect::from_min_max(
             screen.min,
             egui::pos2(screen.right(), screen.top() + thickness),
@@ -1216,10 +1207,6 @@ fn paint_drop_preview(ctx: &egui::Context, target: ToolboxDock) {
         ToolboxDock::Left => egui::Rect::from_min_max(
             egui::pos2(band.right() - edge, band.top()),
             band.right_bottom(),
-        ),
-        ToolboxDock::Right => egui::Rect::from_min_max(
-            band.left_top(),
-            egui::pos2(band.left() + edge, band.bottom()),
         ),
         ToolboxDock::Top => egui::Rect::from_min_max(
             egui::pos2(band.left(), band.bottom() - edge),
@@ -1368,10 +1355,6 @@ mod tests {
             ToolboxDock::Left
         );
         assert_eq!(
-            ToolboxDock::nearest(egui::pos2(790.0, 300.0), screen),
-            ToolboxDock::Right
-        );
-        assert_eq!(
             ToolboxDock::nearest(egui::pos2(400.0, 10.0), screen),
             ToolboxDock::Top
         );
@@ -1379,6 +1362,30 @@ mod tests {
             ToolboxDock::nearest(egui::pos2(400.0, 590.0), screen),
             ToolboxDock::Bottom
         );
+    }
+
+    /// The right border is not on offer. A drop anywhere in the right half —
+    /// including the far edge, where the old rail would have docked — lands
+    /// on one of the three edges that exist, and never on the price side of
+    /// the window.
+    #[test]
+    fn nothing_dropped_on_the_right_edge_docks_there() {
+        let screen = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(800.0, 600.0));
+        for point in [
+            egui::pos2(799.0, 300.0),
+            egui::pos2(790.0, 100.0),
+            egui::pos2(760.0, 500.0),
+            egui::pos2(799.0, 599.0),
+        ] {
+            let dock = ToolboxDock::nearest(point, screen);
+            assert!(
+                matches!(
+                    dock,
+                    ToolboxDock::Left | ToolboxDock::Top | ToolboxDock::Bottom
+                ),
+                "a drop at {point:?} resolved to {dock:?}"
+            );
+        }
     }
 
     #[test]
@@ -1418,7 +1425,6 @@ mod tests {
         draw_rail_frame(&mut rail, &ctx, screen, Vec::new());
 
         for (target, expected) in [
-            (egui::pos2(790.0, 300.0), ToolboxDock::Right),
             (egui::pos2(400.0, 10.0), ToolboxDock::Top),
             (egui::pos2(400.0, 590.0), ToolboxDock::Bottom),
             (egui::pos2(10.0, 300.0), ToolboxDock::Left),
@@ -1821,12 +1827,7 @@ mod tests {
     fn orientation_changes_positions_never_inventory() {
         let screen = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(900.0, 900.0));
         let mut inventories: Vec<Vec<&'static str>> = Vec::new();
-        for dock in [
-            ToolboxDock::Left,
-            ToolboxDock::Right,
-            ToolboxDock::Top,
-            ToolboxDock::Bottom,
-        ] {
+        for dock in [ToolboxDock::Left, ToolboxDock::Top, ToolboxDock::Bottom] {
             let ctx = egui::Context::default();
             let mut rail = ToolRail::new();
             rail.set_dock(dock);
@@ -1850,12 +1851,7 @@ mod tests {
     #[test]
     fn the_grip_leads_and_objects_trails_in_every_dock() {
         let screen = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(900.0, 900.0));
-        for dock in [
-            ToolboxDock::Left,
-            ToolboxDock::Right,
-            ToolboxDock::Top,
-            ToolboxDock::Bottom,
-        ] {
+        for dock in [ToolboxDock::Left, ToolboxDock::Top, ToolboxDock::Bottom] {
             let ctx = egui::Context::default();
             let mut rail = ToolRail::new();
             rail.set_dock(dock);
@@ -1892,45 +1888,56 @@ mod tests {
         }
     }
 
+    /// Lay out a central panel with the rail in a given state and report the
+    /// rect the chart is left with. `visible: false` gives the baseline: what
+    /// the canvas looks like when no rail is competing for it.
+    fn central_rect_with_rail(screen: egui::Rect, dock: ToolboxDock, visible: bool) -> egui::Rect {
+        let ctx = egui::Context::default();
+        let mut rail = ToolRail {
+            tool: Tool::Pointer,
+            visible,
+            dock,
+            ..ToolRail::default()
+        };
+        let mut central = egui::Rect::NOTHING;
+        let input = egui::RawInput {
+            screen_rect: Some(screen),
+            ..Default::default()
+        };
+        let mut drawings = Drawings::default();
+        let mut manager_open = false;
+        let _ = ctx.run(input, |ctx| {
+            rail.draw(ctx, &mut drawings, &mut manager_open);
+            egui::CentralPanel::default().show(ctx, |ui| {
+                central = ui.max_rect();
+            });
+        });
+        central
+    }
+
     #[test]
     fn every_dock_position_reserves_space_outside_the_central_chart() {
         let screen = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(800.0, 600.0));
-        for dock in [
-            ToolboxDock::Left,
-            ToolboxDock::Right,
-            ToolboxDock::Top,
-            ToolboxDock::Bottom,
-        ] {
-            let ctx = egui::Context::default();
-            let mut rail = ToolRail {
-                tool: Tool::Pointer,
-                visible: true,
-                dock,
-                ..ToolRail::default()
-            };
-            let mut central = egui::Rect::NOTHING;
-            let input = egui::RawInput {
-                screen_rect: Some(screen),
-                ..Default::default()
-            };
-            let mut drawings = Drawings::default();
-            let mut manager_open = false;
-            let _ = ctx.run(input, |ctx| {
-                rail.draw(ctx, &mut drawings, &mut manager_open);
-                egui::CentralPanel::default().show(ctx, |ui| {
-                    central = ui.max_rect();
-                });
-            });
+        // The canvas with no rail at all: the right edge to beat.
+        let bare = central_rect_with_rail(screen, ToolboxDock::Left, false);
+        for dock in [ToolboxDock::Left, ToolboxDock::Top, ToolboxDock::Bottom] {
+            let central = central_rect_with_rail(screen, dock, true);
             match dock {
                 ToolboxDock::Left => assert!(central.left() >= TOOLBOX_THICKNESS_PX),
-                ToolboxDock::Right => {
-                    assert!(central.right() <= screen.right() - TOOLBOX_THICKNESS_PX);
-                }
                 ToolboxDock::Top => assert!(central.top() >= TOOLBOX_THICKNESS_PX),
                 ToolboxDock::Bottom => {
                     assert!(central.bottom() <= screen.bottom() - TOOLBOX_THICKNESS_PX);
                 }
             }
+            // Whichever edge it took, it never took the right one: that
+            // border is the price axis and the live column.
+            assert!(
+                (central.right() - bare.right()).abs() < f32::EPSILON,
+                "the rail docked {dock:?} still narrowed the chart from the \
+                 right: {} vs {}",
+                central.right(),
+                bare.right()
+            );
         }
     }
 

--- a/crates/app/src/ui_state.rs
+++ b/crates/app/src/ui_state.rs
@@ -203,6 +203,11 @@ pub struct SavedChrome {
     pub rail_dock: SavedRailDock,
     /// Whether the status bar showed fps/frame time.
     pub perf_readings: bool,
+    /// Starred drawing tools pinned to the rail, by tool id, in the order
+    /// the trader starred them. Default empty — a file from before the
+    /// feature simply has no pinned section.
+    #[serde(default)]
+    pub favorite_tools: Vec<String>,
 }
 
 /// The workspace as a whole: what the app opens on.
@@ -650,6 +655,7 @@ mod tests {
                 rail_visible: true,
                 rail_dock: SavedRailDock::Left,
                 perf_readings: true,
+                favorite_tools: vec!["parallel-channel".to_owned()],
             }),
             saved: Vec::new(),
         }

--- a/crates/app/src/ui_state.rs
+++ b/crates/app/src/ui_state.rs
@@ -87,6 +87,13 @@ impl From<SavedFocus> for crate::pane::PaneSide {
 }
 
 /// Where the drawing rail was docked, in the file's vocabulary.
+///
+/// `Right` survives here as a *reading* vocabulary only: the rail no longer
+/// offers the right edge (see [`crate::toolrail::ToolboxDock`]), but a
+/// `ui-state.toml` written before that still says `right`, and refusing to
+/// parse it would throw away the whole file — every other remembered panel
+/// with it. It loads as `Left` and is written back as `left`, so the
+/// migration happens once and is visible in the file afterwards.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SavedRailDock {
@@ -100,7 +107,6 @@ impl From<crate::toolrail::ToolboxDock> for SavedRailDock {
     fn from(dock: crate::toolrail::ToolboxDock) -> Self {
         match dock {
             crate::toolrail::ToolboxDock::Left => Self::Left,
-            crate::toolrail::ToolboxDock::Right => Self::Right,
             crate::toolrail::ToolboxDock::Top => Self::Top,
             crate::toolrail::ToolboxDock::Bottom => Self::Bottom,
         }
@@ -110,8 +116,7 @@ impl From<crate::toolrail::ToolboxDock> for SavedRailDock {
 impl From<SavedRailDock> for crate::toolrail::ToolboxDock {
     fn from(dock: SavedRailDock) -> Self {
         match dock {
-            SavedRailDock::Left => Self::Left,
-            SavedRailDock::Right => Self::Right,
+            SavedRailDock::Left | SavedRailDock::Right => Self::Left,
             SavedRailDock::Top => Self::Top,
             SavedRailDock::Bottom => Self::Bottom,
         }

--- a/crates/app/src/widgets.rs
+++ b/crates/app/src/widgets.rs
@@ -143,6 +143,7 @@ pub fn icon_paint(
 /// A chrome icon button: one Phosphor glyph, four states, fixed hit target.
 pub struct IconButton<'a> {
     glyph: &'a str,
+    strokes: crate::drawings::IconStrokes,
     size: IconSize,
     active: bool,
     enabled: bool,
@@ -158,6 +159,7 @@ impl<'a> IconButton<'a> {
     pub fn new(glyph: &'a str, size: IconSize) -> Self {
         Self {
             glyph,
+            strokes: &[],
             size,
             active: false,
             enabled: true,
@@ -166,6 +168,15 @@ impl<'a> IconButton<'a> {
             disabled_text: "",
             marker_edge: None,
         }
+    }
+
+    /// Paint these vector strokes instead of the glyph when non-empty —
+    /// registry data from [`crate::drawings::IconStrokes`], so the button
+    /// stays one code path for every tool.
+    #[must_use]
+    pub fn strokes(mut self, strokes: crate::drawings::IconStrokes) -> Self {
+        self.strokes = strokes;
+        self
     }
 
     /// Paint a 2 px accent bar on this outer edge while the button is active
@@ -234,13 +245,19 @@ impl<'a> IconButton<'a> {
             if let Some(fill) = paint.fill {
                 painter.rect_filled(rect, egui::Rounding::same(CORNER_RADIUS), fill);
             }
-            painter.text(
-                rect.center(),
-                egui::Align2::CENTER_CENTER,
-                self.glyph,
-                egui::FontId::proportional(self.size.glyph),
-                paint.glyph,
-            );
+            if self.strokes.is_empty() {
+                painter.text(
+                    rect.center(),
+                    egui::Align2::CENTER_CENTER,
+                    self.glyph,
+                    egui::FontId::proportional(self.size.glyph),
+                    paint.glyph,
+                );
+            } else {
+                let box_rect =
+                    egui::Rect::from_center_size(rect.center(), egui::Vec2::splat(self.size.glyph));
+                paint_icon_strokes(painter, box_rect, self.strokes, paint.glyph);
+            }
             if self.active
                 && let Some(edge) = self.marker_edge
             {
@@ -264,6 +281,34 @@ impl<'a> IconButton<'a> {
         } else {
             response.on_hover_text(hover)
         }
+    }
+}
+
+/// Stroke width of a vector icon, chosen to sit near the visual weight of a
+/// Phosphor regular glyph at the rail's glyph size.
+const ICON_STROKE_WIDTH_PX: f32 = 1.4;
+
+/// Paint a vector icon: each polyline's unit-square points scaled into
+/// `rect`. A handful of line segments — cheaper than tesselating a text
+/// glyph, so safe on the per-frame rail.
+pub fn paint_icon_strokes(
+    painter: &egui::Painter,
+    rect: egui::Rect,
+    strokes: crate::drawings::IconStrokes,
+    color: egui::Color32,
+) {
+    let stroke = egui::Stroke::new(ICON_STROKE_WIDTH_PX, color);
+    for polyline in strokes {
+        let points: Vec<egui::Pos2> = polyline
+            .iter()
+            .map(|(x, y)| {
+                egui::pos2(
+                    rect.left() + x * rect.width(),
+                    rect.top() + y * rect.height(),
+                )
+            })
+            .collect();
+        painter.add(egui::Shape::line(points, stroke));
     }
 }
 

--- a/crates/app/src/widgets.rs
+++ b/crates/app/src/widgets.rs
@@ -44,10 +44,14 @@ pub const FOCUS_RING_WIDTH_PX: f32 = 1.5;
 
 /// Which outer edge of the button the active marker hugs — the edge facing
 /// the window border the owning rail is docked against.
+///
+/// Three edges, not four, because no rail docks against the right border:
+/// that side of the window belongs to the price axis and the live column
+/// (see [`crate::toolrail::ToolboxDock`]). A `Right` arm here would be a
+/// marker nothing can ever ask for.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MarkerEdge {
     Left,
-    Right,
     Top,
     Bottom,
 }
@@ -63,10 +67,6 @@ impl MarkerEdge {
             Self::Left => egui::Rect::from_min_max(
                 egui::pos2(rect.left(), rect.top() + inset),
                 egui::pos2(rect.left() + width, rect.bottom() - inset),
-            ),
-            Self::Right => egui::Rect::from_min_max(
-                egui::pos2(rect.right() - width, rect.top() + inset),
-                egui::pos2(rect.right(), rect.bottom() - inset),
             ),
             Self::Top => egui::Rect::from_min_max(
                 egui::pos2(rect.left() + inset, rect.top()),
@@ -344,8 +344,6 @@ mod tests {
         let top = MarkerEdge::Top.bar(rect);
         assert_eq!(top.top(), rect.top());
         assert_eq!(top.height(), ACTIVE_MARKER_WIDTH_PX);
-        let right = MarkerEdge::Right.bar(rect);
-        assert_eq!(right.right(), rect.right());
         let bottom = MarkerEdge::Bottom.bar(rect);
         assert_eq!(bottom.bottom(), rect.bottom());
     }


### PR DESCRIPTION
## O que muda

- **Favoritos no trilho de desenho**: cada linha de flyout de família tem uma estrela alinhada à direita da linha (feedback do trader: ao lado da descrição, não sobre o ícone); clicá-la pina a ferramenta numa seção própria na parte de baixo do cluster de ferramentas — um clique arma, sem reabrir o grupo. Desfavoritar existe **só** na estrela original do flyout, então usar um pin nunca o destrói. Ordem = ordem em que o trader favoritou; persiste em `ui-state.toml` (`favorite_tools`, ids).
- **Ícones honestos**: porta `IconStrokes` no registro (polilinhas no quadrado unitário, default vazio). O canal paralelo deixa o losango `PARALLELOGRAM` e desenha duas paralelas inclinadas; os dois Fib deixam `ROWS` e desenham níveis pendurados na diagonal das âncoras, estilo TradingView. Trilho, flyout e pins pintam da mesma fonte.
- **Resgate (escopo estreitado no rebase)**: do commit perdido do worktree, o que sobreviveu ao `main` novo é a remoção do dock direito do trilho (`ToolboxDock::Right` some do drag/seletor; `ui-state.toml` antigo com `right` migra para `left`). A metade "settings sempre popup flutuante" foi **deferida**: os PRs #174/#177 retrabalharam o inspector nesse meio-tempo e remover o modo pinado agora merece branch própria contra o código novo.
- **Shift na linha de tendência** já estava em `main` (`levelled_far_end`/`Constrain::Level`); evidência: `app::tests::holding_shift_lays_a_trend_line_dead_level ... ok`.

## Harness

`QUANTICK_TOOL_FAVORITES=<ids>` pina por id; `QUANTICK_TOOLBOX_FLYOUT=<family>` abre o flyout no primeiro frame. Registrados na tabela do `ui-harness`.

## Performance (declarada)

Caminhos tocados são **per-frame** (trilho, flyout, ícones): meia dúzia de polilinhas de 2–5 pontos no lugar de glifos de fonte; `set_favorites`/`by_id` são raros (restore/hook). Nada per-trade, nada per-depth. Evidência sob feed vivo Binance: status bar da captura mostra **60 fps · 16.7 ms · cpu 1.2 ms** com favoritos pinados e flyout aberto.

## Reviews

- **arch-review**: 2 achados corrigidos (zona da estrela podia engolir o clique de armar → zona à direita, longe de ícone e nome, + teste-guarda; porta `icon_strokes` sem teste de contrato → teste de quadrado unitário + strokes obrigatórios nos 3 glifos substituídos); 1 declarado aceito (alocação per-frame minúscula e idiomática nos ícones vetoriais).
- **trader-ux-review**: sem Blocker. Considers anotados: pins somem no estágio Compact junto com os slots (mesma regra, ferramenta segue no More); hover do pin não ensina onde desfavoritar.
- **visual-qa**: PASS — flyout com estrela accent à direita da linha favoritada (e nenhuma na não-favoritada), atalho deslocado sem colisão, seção de pins com badge de estrela na base do trilho, ícones novos legíveis em trilho + flyout.

## Raio de impacto

Adicionado: nada (feature docka em arquivos existentes por dados de registro). Editado: `toolrail.rs` (dono da feature), `widgets.rs` (porta de pintura), `drawings/mod.rs` + 8 arquivos de ferramenta/família (dados de registro), `ui_state.rs`/`app.rs` (persistência + hooks), `ui-harness/SKILL.md` (registro dos hooks).

## Testes

`cargo fmt --check` / `clippy -D warnings` / `build` / `test --workspace` verdes após rebase no main pós-#174/#176/#177 (1170 testes no app). 9 testes novos cobrem: estrela pina sem armar/fechar, clique no ícone arma sem pinar, pin arma e nunca desfavorita, ordem estável, round-trip com ids inválidos, comprimento/estágio do trilho com pins, contrato dos icon strokes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)