### PR TITLE
feat: paper-trading overhaul - durable history, honest report, replay separation, cmd trading

### DIFF
--- a/.claude/skills/ui-harness/SKILL.md
+++ b/.claude/skills/ui-harness/SKILL.md
@@ -42,7 +42,11 @@ is the source of truth, this table is the index):
 | `QUANTICK_UI_STATE=<toml>` | the saved workspace — the tab strip, each tab's layout/split/focus/bar specs, the dock, the rail, the timezone, the window size. **Always point this at a scratchpad file.** Without it a validation run reads the user's real `ui-state.toml` and, on exit, overwrites it: the run both inherits yesterday's cockpit and destroys it. Point it at a path that does not exist to force the configured default; write one by hand to open on an exact arrangement. |
 | `QUANTICK_WORKSPACE_SAVE=1` | takes `Workspace → Save workspace` at startup, through the menu entry's own path — the save really happens, so the status-line confirmation is on screen to capture. Pair with `QUANTICK_UI_STATE` pointed at a scratchpad. |
 | `QUANTICK_BACKFILL` / `QUANTICK_BOOK_DEPTH` | history paging / depth size |
-| `QUANTICK_TRADES_DIR` | paper-trading journal location (point at scratch) |
+| `QUANTICK_TRADES_DIR` | paper-trading journal location (point at scratch — and note the absent-default is now the user's documents folder, `Documents/Quantick/paper-trades`, so an unhooked run touches real history) |
+| `QUANTICK_PAPER_STATE=<toml>` | the paper sidecar: the picked journal folder and the cmd-trading settings. **Point at a scratchpad file** — an unhooked run reads and rewrites the trader's real `paper-state.toml`, and startup consolidation may clear their stored folder pick. |
+| `QUANTICK_DOCK_TAB=<l2\|bubbles\|session\|trading\|trades>` | the dock open on that tab — `trading` is the ticket (with the CMD TRADING block), `trades` the ledger |
+| `QUANTICK_PAPER_REPORT_AUTOSTART=1` | the Simulated performance window (Source/Period filter rows, typed period, import button) |
+| `QUANTICK_PAPER_DEMO=1` | scripted deterministic trade sequence — real journaled trades for every paper surface; pair with `QUANTICK_TRADES_DIR` at scratch |
 
 Landing with the drawing-toolbar goal (`feat/drawing-toolbar-pro`):
 
@@ -105,10 +109,13 @@ freehand path for the pencil, which declares no anchor count of its own.
 
 Once merged, move them into the table above.
 
-Landing with PR #127 (paper trading v2): `QUANTICK_DOCK_TAB`
-(`l2|bubbles|session|trading|trades`), `QUANTICK_PAPER_REPORT_AUTOSTART=1`,
-`QUANTICK_PAPER_DEMO=1` (scripted deterministic trade sequence). Once merged,
-move them into the table above.
+Landing with the paper-trading overhaul (`feat/paper-trading-overhaul`):
+
+| Hook | Reaches |
+| --- | --- |
+| `QUANTICK_CMD_PREVIEW=<buy\|sell>` | the cmd-trading preview painted with nobody at the keyboard: the dashed y-locked line, its clickable side/kind/qty label and the gutter price chip, parked mid-chart for that side. The held modifier is the one input a capture run cannot supply (the ParkedHand rule). Needs prints on the tape for a mark — pair with a live feed or `QUANTICK_PAPER_DEMO=1`. |
+
+Once merged, move it into the table above.
 
 For a screen that represents the user's real setup, enable the trio:
 `QUANTICK_BOOK_AUTOSTART` + `QUANTICK_BUBBLES_AUTOSTART` +

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -650,6 +650,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "dispatch"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2248,6 +2269,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "orbclient"
 version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2466,6 +2493,7 @@ checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
 name = "quantick-app"
 version = "0.1.0"
 dependencies = [
+ "dirs",
  "eframe",
  "egui-phosphor",
  "quantick-engine",
@@ -2789,6 +2817,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5102a6aaa05aa011a238e178e6bca86d2cb56fc9f586d37cb80f5bca6e07759"
 dependencies = [
  "bitflags 2.13.1",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 2.0.19",
 ]
 
 [[package]]

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -16,6 +16,10 @@ quantick-orderbook = { path = "../orderbook" }
 quantick-replay = { path = "../replay" }
 quantick-sim = { path = "../sim" }
 rust_decimal = "1"
+# The user's documents folder (Known Folders on Windows, XDG on Linux) —
+# the paper-trading journal's durable default home. Path lookup only; no
+# path is ever invented when the platform reports none.
+dirs = "6"
 # Native folder picker for Market Replay. Runs off the UI thread, so the OS
 # dialog never blocks a frame.
 rfd = { version = "0.15", default-features = false, features = ["xdg-portal", "tokio"] }

--- a/crates/app/config/feeds.toml
+++ b/crates/app/config/feeds.toml
@@ -178,7 +178,10 @@ US30 = 9103
 # QUANTICK_TRADES_DIR environment variable overrides the setting for one run,
 # and the folder picker in the Trading tab (remembered in paper-state.toml)
 # wins over this base. The section is optional; absent, trades save under
-# `paper-trades`.
+# the user's documents folder (`Documents/Quantick/paper-trades`), the one
+# home that does not move with the working directory — and on first launch
+# quantick copies (never moves) any history it can still reach from the
+# cwd-relative era into that home.
 #
 # [paper]
 # trades_dir = "paper-trades"

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -938,16 +938,15 @@ impl QuantickApp {
         feed: FeedHandle,
         workspace: ui_state::Workspace,
     ) -> Self {
-        let (trades_dir, consolidated) = {
-            let state_path = crate::paper_state::default_path();
-            let stored = crate::paper_state::load(&state_path);
-            crate::paper_home::startup_home(
-                config.paper.trades_dir.as_deref(),
-                stored.as_deref(),
-                &state_path,
-            )
-        };
-        let tab = Tab::new(
+        let state_path = crate::paper_state::default_path();
+        let paper_state = crate::paper_state::load(&state_path);
+        let cmd_trading = crate::paper_trading::CmdTradingSettings::from_state(&paper_state);
+        let (trades_dir, consolidated) = crate::paper_home::startup_home(
+            config.paper.trades_dir.as_deref(),
+            paper_state.trades_dir.as_deref(),
+            &state_path,
+        );
+        let mut tab = Tab::new(
             FIRST_TAB_ID,
             pane_ids(FIRST_TAB_ID),
             feed_id.into(),
@@ -956,6 +955,7 @@ impl QuantickApp {
             feed,
             trades_dir.clone(),
         );
+        tab.paper.set_cmd_trading(cmd_trading);
         // Resolved once: under test the settings path is a fresh scratch
         // file per call, and the load must read the same file the saves
         // will write.
@@ -1432,14 +1432,29 @@ impl QuantickApp {
         };
         self.trades_dir_picker = None;
         let Some(dir) = choice else { return };
-        crate::paper_state::save(
-            &crate::paper_state::default_path(),
-            &dir.display().to_string(),
-        );
+        let path = crate::paper_state::default_path();
+        let mut state = crate::paper_state::load(&path);
+        state.trades_dir = Some(dir.display().to_string());
+        crate::paper_state::save(&path, &state);
         self.trades_dir = dir;
         for tab in &mut self.tabs {
             tab.paper.set_trades_dir(self.trades_dir.clone());
         }
+    }
+
+    /// Persist the active tab's cmd-trading settings and fan them out —
+    /// one gesture, one meaning, every tab (the trades-dir rule).
+    fn persist_cmd_trading(&mut self) {
+        let settings = self.active_tab().paper.cmd_trading();
+        for tab in &mut self.tabs {
+            tab.paper.set_cmd_trading(settings);
+        }
+        let path = crate::paper_state::default_path();
+        let mut state = crate::paper_state::load(&path);
+        state.cmd_trading_enabled = Some(settings.enabled);
+        state.cmd_buy_modifier = Some(settings.buy.as_str().to_owned());
+        state.cmd_sell_modifier = Some(settings.sell.as_str().to_owned());
+        crate::paper_state::save(&path, &state);
     }
 
     /// The active tab beside the config it reads.
@@ -1564,15 +1579,12 @@ impl QuantickApp {
                 .unwrap_or_else(|| self.active_tab().flow_pane.state.spec().clone())
         });
         let trades_dir = self.trades_dir.clone();
-        self.tabs.push(Tab::new(
-            id,
-            pane_ids(id),
-            feed_id,
-            symbol,
-            spec,
-            feed,
-            trades_dir,
-        ));
+        // Cmd trading is app-wide (the trades-dir rule): a new tab starts
+        // with the settings every other tab already carries.
+        let cmd_trading = self.active_tab().paper.cmd_trading();
+        let mut tab = Tab::new(id, pane_ids(id), feed_id, symbol, spec, feed, trades_dir);
+        tab.paper.set_cmd_trading(cmd_trading);
+        self.tabs.push(tab);
         self.active_tab = self.tabs.len() - 1;
         let config = self.config.clone();
         self.active_tab_mut().refresh_chip_label(&config);
@@ -6141,6 +6153,9 @@ impl QuantickApp {
         }
         if dock_response.pick_trades_dir {
             self.open_trades_dir_picker();
+        }
+        if dock_response.cmd_trading_changed {
+            self.persist_cmd_trading();
         }
         self.poll_trades_dir_picker();
         // The pinned inspector is chrome: declared before the central canvas

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -6222,7 +6222,8 @@ impl QuantickApp {
         self.draw_toast(ctx, now);
         // Both are window chrome reading the active tab, like the notice card
         // and the transport strip: they speak for one market at a time.
-        self.active_tab_mut().paper.draw_report_window(ctx);
+        let tz = self.tz;
+        self.active_tab_mut().paper.draw_report_window(ctx, tz);
         self.active_tab_mut().paper.draw_toast(ctx, now);
         if notice_action == notice_card::NoticeAction::Retry {
             let (tab, config) = self.active_with_config();

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -16551,6 +16551,77 @@ plot(close)
         );
     }
 
+    /// A position carried into a replay switch belongs to the session
+    /// that is ending: its forced flatten must journal under that
+    /// session's source, not the one the switch is about to install.
+    #[test]
+    fn a_replay_switch_flattens_under_the_session_that_owned_the_position() {
+        let ctx = egui::Context::default();
+        let (mut app, _events, _commands) = history_app(&ctx);
+        let dir = std::env::temp_dir().join(format!(
+            "quantick-switch-source-test-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        let print = |agg_id: u64, price: i64| quantick_engine::Trade {
+            agg_id,
+            timestamp_ms: i64::try_from(agg_id).expect("small ids") * 1000,
+            price: rust_decimal::Decimal::from(price),
+            quantity: rust_decimal::Decimal::ONE,
+            side: quantick_engine::Side::Buy,
+        };
+        {
+            let paper = &mut app.active_tab_mut().paper;
+            paper.redirect_history_dir(dir.clone());
+            paper.set_symbol("SWITCHSRC");
+            paper.seed(&print(0, 100));
+            paper.market(quantick_engine::Side::Buy);
+            paper.on_trade(&print(1, 100));
+            assert!(
+                paper.position_summary().is_some(),
+                "a live position is open going into the switch"
+            );
+        }
+        let text = "# quantick,csv,1\n# symbol=WINJ26\n# timezone=-03:00\n\
+                    Date,Time,Price,Volume,Side\n\
+                    2026-03-16,10:01:08.000,182035,12,B\n";
+        let session = quantick_replay::Session::from_text(
+            std::path::Path::new("WINJ26_2026-03-16.csv"),
+            text,
+            quantick_replay::ParseOptions::default(),
+        )
+        .expect("fixture session parses");
+        with_config(&mut app, |tab, config| {
+            tab.open_replay(
+                config,
+                crate::feed::ReplayRequest {
+                    session: std::sync::Arc::new(session),
+                    options: crate::feed::ReplayOptions {
+                        autoplay: false,
+                        ..Default::default()
+                    },
+                },
+            )
+        });
+        let folder = dir.join("SWITCHSRC");
+        let files: Vec<_> = std::fs::read_dir(&folder)
+            .expect("the forced flatten journaled")
+            .flatten()
+            .collect();
+        assert_eq!(files.len(), 1, "one session file for the flattened trade");
+        let parsed = quantick_sim::history::parse(
+            &std::fs::read_to_string(files[0].path()).expect("readable"),
+        )
+        .expect("valid history");
+        assert_eq!(
+            parsed.source,
+            Some(quantick_sim::history::SessionSource::Live),
+            "the live session's trade files as live, not under the replay"
+        );
+        assert_eq!(parsed.trades.len(), 1);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
     /// (h) A recording is a fixed span of prints with no venue behind it.
     #[test]
     fn a_replaying_tab_never_asks_for_venue_history() {

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -38,7 +38,6 @@ use crate::loading::{self, LoadingTask};
 use crate::metrics::{self, FrameStats};
 use crate::notice_card;
 use crate::pane::{self, ChartPane, DRAWING_ANCHOR_RADIUS_PX, PaneSide};
-use crate::paper_trading::PaperTrading;
 use crate::replay_view::{ReplayAction, ReplayView};
 use crate::state::BarSpec;
 use crate::statusbar;
@@ -939,9 +938,14 @@ impl QuantickApp {
         feed: FeedHandle,
         workspace: ui_state::Workspace,
     ) -> Self {
-        let trades_dir = {
-            let stored = crate::paper_state::load(&crate::paper_state::default_path());
-            PaperTrading::resolve_trades_dir(&config.paper.trades_dir, stored.as_deref())
+        let (trades_dir, consolidated) = {
+            let state_path = crate::paper_state::default_path();
+            let stored = crate::paper_state::load(&state_path);
+            crate::paper_home::startup_home(
+                config.paper.trades_dir.as_deref(),
+                stored.as_deref(),
+                &state_path,
+            )
         };
         let tab = Tab::new(
             FIRST_TAB_ID,
@@ -1381,6 +1385,15 @@ impl QuantickApp {
         // must not be written back as though the user had asked for it every
         // launch from now on. Same rule the indicator state follows.
         app.saved_layer_mask = app.layer_mask();
+        if let Some(summary) = consolidated
+            && summary.imported() > 0
+        {
+            // A silent rescue would look like the app moved files on its
+            // own; the toast says what happened and that copies were made.
+            app.tabs[0]
+                .paper
+                .show_toast(crate::paper_home::import_toast(&summary));
+        }
         app
     }
 

--- a/crates/app/src/config.rs
+++ b/crates/app/src/config.rs
@@ -501,34 +501,31 @@ impl FeedConfig {
 }
 
 /// Paper-trading options (`[paper]` in the TOML).
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, Deserialize)]
 #[serde(default)]
 pub struct PaperSettings {
     /// Where the simulator saves closed trades — the per-symbol journals,
-    /// and the exports beside them. Relative paths resolve against
-    /// quantick's working directory; the `QUANTICK_TRADES_DIR` environment
-    /// variable still overrides it for one run (an env var is an explicit
-    /// request, like every autostart hook). The same folder is the
-    /// integration port for other producers: anything that writes the
+    /// and the exports beside them. Absent, the journal lives in the
+    /// user's documents folder (`Documents/Quantick/paper-trades`), the
+    /// one home that does not move with the working directory; set, it
+    /// pins the journal somewhere else, relative paths resolving against
+    /// quantick's working directory. The `QUANTICK_TRADES_DIR` environment
+    /// variable still overrides either for one run (an env var is an
+    /// explicit request, like every autostart hook). The same folder is
+    /// the integration port for other producers: anything that writes the
     /// `quantick-trades` format here — a bot runner, another tool — shows
     /// up in the Trades ledger, the report and the export.
-    pub trades_dir: String,
-}
-
-impl Default for PaperSettings {
-    fn default() -> Self {
-        Self {
-            trades_dir: "paper-trades".to_string(),
-        }
-    }
+    pub trades_dir: Option<String>,
 }
 
 impl PaperSettings {
     fn validate(&self) -> Result<(), String> {
-        if self.trades_dir.trim().is_empty() {
+        if let Some(dir) = &self.trades_dir
+            && dir.trim().is_empty()
+        {
             return Err(
-                "paper.trades_dir must not be empty - drop the key to use the default \
-                 `paper-trades`"
+                "paper.trades_dir must not be empty - drop the key to use the \
+                 documents-folder default"
                     .to_string(),
             );
         }

--- a/crates/app/src/dock.rs
+++ b/crates/app/src/dock.rs
@@ -130,6 +130,9 @@ pub struct DockResponse {
     /// The Trading tab asked for the trades-folder picker — app-wide, so
     /// the app owns the dialog and the fan-out to every tab.
     pub pick_trades_dir: bool,
+    /// The Trading tab changed the cmd-trading settings — app-wide like
+    /// the trades dir: the app persists and fans them out.
+    pub cmd_trading_changed: bool,
 }
 
 /// The dock's chrome state. Hidden, collapsed to the strip, or open on one
@@ -314,12 +317,14 @@ impl Dock {
                             // with no way to reach them.
                             egui::ScrollArea::vertical()
                                 .auto_shrink([false, true])
-                                .show(ui, |ui| {
-                                    if let Some(TradingTabAction::PickTradesDir) =
-                                        env.paper.draw_trading_tab(ui)
-                                    {
+                                .show(ui, |ui| match env.paper.draw_trading_tab(ui) {
+                                    Some(TradingTabAction::PickTradesDir) => {
                                         response.pick_trades_dir = true;
                                     }
+                                    Some(TradingTabAction::CmdTradingChanged) => {
+                                        response.cmd_trading_changed = true;
+                                    }
+                                    None => {}
                                 });
                         }
                         // The ledger manages its own scroll (a virtualised

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -44,6 +44,7 @@ mod orderflow_render;
 mod orderflow_view;
 mod orderflow_worker;
 mod pane;
+mod paper_home;
 mod paper_hud;
 mod paper_state;
 mod paper_trading;

--- a/crates/app/src/pane.rs
+++ b/crates/app/src/pane.rs
@@ -2967,16 +2967,24 @@ impl ChartPane {
         // can only be handed out once. Without this gate a click meant to
         // drop an anchor would *also* reach an order's ✕ and cancel it —
         // the early return this replaced used to hide that.
-        let paper_gesture = chrome.paper_owns_input
-            && !tool_armed
-            && chrome.paper.handle_chart_input(&ChartInput {
+        let paper_gesture = if chrome.paper_owns_input && !tool_armed {
+            chrome.paper.handle_chart_input(&ChartInput {
                 chart: drawing_area,
                 scale: drawing_scale.as_ref(),
                 pointer: pointer_position,
                 primary_pressed: primary_pressed && !over_chrome,
                 primary_down,
                 primary_released,
-            });
+                modifiers: ui.input(|input| input.modifiers),
+            })
+        } else {
+            if chrome.paper_owns_input {
+                // A drawing tool owns the hand this frame; a stale cmd
+                // preview must not keep painting under it.
+                chrome.paper.clear_cmd_preview();
+            }
+            false
+        };
         // The paper lines announce their grabbability (audit paper M3/M4):
         // drawings get hover cursors below, and a draggable stop must not
         // feel deader than an annotation — nor may the entry line's blocked

--- a/crates/app/src/paper_home.rs
+++ b/crates/app/src/paper_home.rs
@@ -1,0 +1,480 @@
+//! Where the paper-trading journal lives by default, and the consolidation
+//! that rescues history from the cwd-relative era.
+//!
+//! Before this module every quantick path was cwd-relative — launching the
+//! app from a different folder silently switched the journal, and even the
+//! sidecar remembering the user's picked folder. Trades were never deleted,
+//! but they were scattered; that is the "my old trades are gone" report.
+//! The durable home is the user's documents folder
+//! (`Documents/Quantick/paper-trades`), the one path that does not care
+//! where the app was launched from.
+//!
+//! Resolution keeps its spirit — an explicit ask always wins:
+//! `QUANTICK_TRADES_DIR` (one run) > the folder picked in-app
+//! (`paper-state.toml`) > `[paper] trades_dir` in the config > the
+//! documents home. Only when nothing pins the journal elsewhere does
+//! startup also *consolidate*: copy — never move, never delete — what the
+//! reachable legacy locations still hold into the home, then clear the
+//! stored pick so there is one home from now on. The copy skips
+//! byte-identical files, so running it every startup is safe and needs no
+//! "already done" flag (which would itself be cwd-relative).
+
+use std::ffi::OsStr;
+use std::path::{Path, PathBuf};
+
+use quantick_sim::history;
+
+/// Overrides the history folder for one run — the autostart family's
+/// explicit ask; nothing is consolidated or cleared under it.
+pub(crate) const TRADES_DIR_ENV: &str = "QUANTICK_TRADES_DIR";
+/// The cwd-relative folder of the legacy era: still the final fallback
+/// when the platform reports no documents folder, and always a
+/// consolidation source when it exists.
+pub(crate) const LEGACY_TRADES_DIR: &str = "paper-trades";
+/// The shelf inside the documents folder — one recognizable place for
+/// everything quantick may keep there.
+const DOCUMENTS_SHELF: &str = "Quantick";
+/// How many `.imported-N` names a clash may try before giving up — far
+/// beyond any real journal, a backstop against a pathological folder.
+const MAX_IMPORT_RENAMES: usize = 99;
+
+/// The user's documents folder, when the platform knows one.
+pub(crate) fn documents_dir() -> Option<PathBuf> {
+    dirs::document_dir()
+}
+
+/// The default journal home given a documents folder — and the legacy
+/// cwd-relative folder when the platform reports none (headless CI, bare
+/// setups): the old behaviour is honest there, inventing a home the user
+/// cannot find is not.
+pub(crate) fn default_trades_dir(documents: Option<PathBuf>) -> PathBuf {
+    documents.map_or_else(
+        || PathBuf::from(LEGACY_TRADES_DIR),
+        |documents| documents.join(DOCUMENTS_SHELF).join(LEGACY_TRADES_DIR),
+    )
+}
+
+/// The journal folder before the environment has its say: the user's own
+/// in-app pick when one is stored, else the configured base, else the
+/// documents home.
+fn chosen(configured: Option<&str>, stored: Option<&str>, documents: Option<PathBuf>) -> PathBuf {
+    stored
+        .map(PathBuf::from)
+        .or_else(|| configured.map(PathBuf::from))
+        .unwrap_or_else(|| default_trades_dir(documents))
+}
+
+/// The journal folder for this run, without consolidation — the resolution
+/// order from the module doc, for hosts that only need an answer.
+pub(crate) fn resolve(configured: Option<&str>, stored: Option<&str>) -> PathBuf {
+    std::env::var_os(TRADES_DIR_ENV).map_or_else(
+        || chosen(configured, stored, documents_dir()),
+        PathBuf::from,
+    )
+}
+
+/// Resolve the journal home for this run and, when nothing explicit (env
+/// or config) pins it elsewhere, consolidate the reachable legacy
+/// locations into it: the stored in-app pick (cleared afterwards, so the
+/// home stays singular) and the cwd-relative legacy folder.
+pub(crate) fn startup_home(
+    configured: Option<&str>,
+    stored: Option<&str>,
+    state_path: &Path,
+) -> (PathBuf, Option<ImportSummary>) {
+    if let Some(env) = std::env::var_os(TRADES_DIR_ENV) {
+        // An explicit per-run ask — a QA or autostart run must never
+        // touch, or even scan, the real home.
+        return (PathBuf::from(env), None);
+    }
+    if configured.is_some() {
+        // An explicit `[paper] trades_dir` keeps the legacy chain whole:
+        // whoever wrote the key chose a home on purpose.
+        return (chosen(configured, stored, documents_dir()), None);
+    }
+    let dest = default_trades_dir(documents_dir());
+    let mut sources = Vec::new();
+    if let Some(stored) = stored {
+        sources.push(PathBuf::from(stored));
+    }
+    sources.push(PathBuf::from(LEGACY_TRADES_DIR));
+    let summary = consolidate_into(&dest, &sources);
+    if stored.is_some() {
+        crate::paper_state::clear(state_path);
+    }
+    (dest, Some(summary))
+}
+
+/// What one consolidation pass did. Copies only — the sources keep every
+/// file, which is what makes running the pass again safe.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub(crate) struct ImportSummary {
+    /// Files newly copied into the home.
+    pub copied: usize,
+    /// Files already in the home, byte-identical — skipped.
+    pub identical: usize,
+    /// Files whose name was taken by different content — copied under an
+    /// `.imported-N` suffix so neither version is lost.
+    pub renamed: usize,
+    /// Root-level files with no readable symbol header — left in place
+    /// and logged, never guessed at.
+    pub ignored: usize,
+    /// Copies that failed with an I/O error (logged, file left in place).
+    pub failed: usize,
+}
+
+impl ImportSummary {
+    /// How many files landed in the home this pass.
+    pub(crate) fn imported(&self) -> usize {
+        self.copied + self.renamed
+    }
+}
+
+/// The toast's account of a consolidation pass — counts only, and it says
+/// "copies" out loud so the move is trustworthy.
+pub(crate) fn import_toast(summary: &ImportSummary) -> String {
+    if summary.imported() == 0 && summary.failed == 0 {
+        return "SIM: nothing new to import - every file is already in the journal.".to_owned();
+    }
+    let mut text = format!(
+        "SIM: imported {} trade file(s) into the journal (copies - originals untouched)",
+        summary.imported(),
+    );
+    if summary.identical > 0 {
+        text.push_str(&format!(", {} already present", summary.identical));
+    }
+    if summary.ignored > 0 {
+        text.push_str(&format!(", {} without a symbol skipped", summary.ignored));
+    }
+    if summary.failed > 0 {
+        text.push_str(&format!(", {} failed - see the log", summary.failed));
+    }
+    text
+}
+
+/// Copy every trade-history file under each of `sources` into `dest`,
+/// preserving the `<SYMBOL>/<session>.csv` layout. A loose file at a
+/// source's root travels by its `# symbol=` header; one with no readable
+/// symbol stays put (a symbol is never guessed). A source that is, holds,
+/// or lives inside `dest` is left alone.
+pub(crate) fn consolidate_into(dest: &Path, sources: &[PathBuf]) -> ImportSummary {
+    let mut summary = ImportSummary::default();
+    for source in sources {
+        if source.as_path() == dest || dest.starts_with(source) || source.starts_with(dest) {
+            continue;
+        }
+        let Ok(entries) = std::fs::read_dir(source) else {
+            continue;
+        };
+        let mut paths: Vec<PathBuf> = entries.flatten().map(|entry| entry.path()).collect();
+        paths.sort();
+        for path in paths {
+            if path.is_dir() {
+                if path == dest || dest.starts_with(&path) {
+                    continue;
+                }
+                copy_symbol_folder(&path, dest, &mut summary);
+            } else if is_history_file(&path) {
+                copy_loose_file(&path, dest, &mut summary);
+            }
+        }
+    }
+    if summary != ImportSummary::default() {
+        tracing::info!(
+            target: "quantick::app",
+            schema_version = 1_u8,
+            event_code = "PAPER_HISTORY_CONSOLIDATED",
+            dest = %dest.display(),
+            copied = summary.copied,
+            identical = summary.identical,
+            renamed = summary.renamed,
+            ignored = summary.ignored,
+            failed = summary.failed,
+            "paper-trading history consolidated into the journal home"
+        );
+    }
+    summary
+}
+
+fn is_history_file(path: &Path) -> bool {
+    path.extension()
+        .is_some_and(|extension| extension == history::FILE_EXTENSION)
+}
+
+/// One `<SYMBOL>/` folder: every history file inside goes to the same
+/// folder name under the home.
+fn copy_symbol_folder(folder: &Path, dest: &Path, summary: &mut ImportSummary) {
+    let Some(name) = folder.file_name() else {
+        return;
+    };
+    let Ok(entries) = std::fs::read_dir(folder) else {
+        return;
+    };
+    let mut paths: Vec<PathBuf> = entries
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| path.is_file() && is_history_file(path))
+        .collect();
+    paths.sort();
+    for path in paths {
+        copy_one(&path, &dest.join(name), summary);
+    }
+}
+
+/// A loose root-level file: its symbol comes from the `# symbol=` header,
+/// or it stays behind.
+fn copy_loose_file(path: &Path, dest: &Path, summary: &mut ImportSummary) {
+    let symbol = std::fs::read_to_string(path)
+        .ok()
+        .and_then(|text| history::parse(&text).ok())
+        .and_then(|parsed| parsed.symbol);
+    match symbol {
+        Some(symbol) => {
+            let folder = dest.join(crate::paper_trading::sanitize_symbol(&symbol));
+            copy_one(path, &folder, summary);
+        }
+        None => {
+            summary.ignored += 1;
+            tracing::warn!(
+                target: "quantick::app",
+                schema_version = 1_u8,
+                event_code = "PAPER_HISTORY_IMPORT_SKIPPED",
+                path = %path.display(),
+                action = "file_left_in_place",
+                "history file carries no readable symbol - not guessing a folder for it"
+            );
+        }
+    }
+}
+
+fn copy_one(file: &Path, folder: &Path, summary: &mut ImportSummary) {
+    match try_copy_one(file, folder) {
+        Ok(Outcome::Copied) => summary.copied += 1,
+        Ok(Outcome::Identical) => summary.identical += 1,
+        Ok(Outcome::Renamed) => summary.renamed += 1,
+        Err(error) => {
+            summary.failed += 1;
+            tracing::warn!(
+                target: "quantick::app",
+                schema_version = 1_u8,
+                event_code = "PAPER_HISTORY_IMPORT_FAILED",
+                path = %file.display(),
+                %error,
+                action = "file_left_in_place",
+                "could not copy a history file into the journal home"
+            );
+        }
+    }
+}
+
+enum Outcome {
+    Copied,
+    Identical,
+    Renamed,
+}
+
+/// Copy `file` into `folder`: keep the name when free, skip when the same
+/// bytes are already there (under any candidate name — that is what makes
+/// a re-run change nothing), suffix `.imported-N` when the name is taken
+/// by different content.
+fn try_copy_one(file: &Path, folder: &Path) -> std::io::Result<Outcome> {
+    let Some(name) = file.file_name() else {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "history file has no name",
+        ));
+    };
+    let source_bytes = std::fs::read(file)?;
+    let mut target = folder.join(name);
+    let mut suffix = 0usize;
+    loop {
+        if !target.exists() {
+            std::fs::create_dir_all(folder)?;
+            std::fs::write(&target, &source_bytes)?;
+            return Ok(if suffix == 0 {
+                Outcome::Copied
+            } else {
+                Outcome::Renamed
+            });
+        }
+        if std::fs::read(&target)? == source_bytes {
+            return Ok(Outcome::Identical);
+        }
+        suffix += 1;
+        if suffix > MAX_IMPORT_RENAMES {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::AlreadyExists,
+                "too many name clashes for one history file",
+            ));
+        }
+        target = folder.join(import_name(name, suffix));
+    }
+}
+
+/// `20260101-000000.csv` → `20260101-000000.imported-1.csv`: the session
+/// stamp stays the sort key, the suffix says where the file came from, and
+/// the kept extension keeps the ledger reading it.
+fn import_name(name: &OsStr, suffix: usize) -> PathBuf {
+    let name = Path::new(name);
+    let stem = name
+        .file_stem()
+        .map(|stem| stem.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    let extension = name
+        .extension()
+        .map(|extension| extension.to_string_lossy().into_owned())
+        .unwrap_or_else(|| history::FILE_EXTENSION.to_owned());
+    PathBuf::from(format!("{stem}.imported-{suffix}.{extension}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scratch() -> PathBuf {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static NEXT: AtomicU64 = AtomicU64::new(0);
+        let dir = std::env::temp_dir().join(format!(
+            "quantick-paper-home-test-{}-{}",
+            std::process::id(),
+            NEXT.fetch_add(1, Ordering::Relaxed)
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        dir
+    }
+
+    fn write(path: &Path, text: &str) {
+        std::fs::create_dir_all(path.parent().expect("test paths have parents")).unwrap();
+        std::fs::write(path, text).unwrap();
+    }
+
+    #[test]
+    fn the_documents_home_hangs_off_the_documents_folder() {
+        assert_eq!(
+            default_trades_dir(Some(PathBuf::from("/docs"))),
+            Path::new("/docs").join("Quantick").join("paper-trades"),
+        );
+        assert_eq!(
+            default_trades_dir(None),
+            PathBuf::from("paper-trades"),
+            "no documents folder keeps the legacy cwd-relative behaviour"
+        );
+    }
+
+    #[test]
+    fn explicit_choices_outrank_the_documents_home() {
+        let documents = Some(PathBuf::from("/docs"));
+        assert_eq!(
+            chosen(Some("cfg"), Some("picked"), documents.clone()),
+            PathBuf::from("picked"),
+            "the in-app pick wins over the config"
+        );
+        assert_eq!(
+            chosen(Some("cfg"), None, documents.clone()),
+            PathBuf::from("cfg"),
+            "the config wins over the default"
+        );
+        assert_eq!(
+            chosen(None, None, documents),
+            Path::new("/docs").join("Quantick").join("paper-trades"),
+        );
+    }
+
+    #[test]
+    fn consolidation_copies_the_symbol_layout_and_reruns_change_nothing() {
+        let root = scratch();
+        let source = root.join("source");
+        let dest = root.join("dest");
+        write(&source.join("BTCUSDT").join("s1.csv"), "session one\n");
+        write(&source.join("BTCUSDT").join("notes.txt"), "not history\n");
+
+        let first = consolidate_into(&dest, std::slice::from_ref(&source));
+        assert_eq!(first.copied, 1);
+        assert_eq!(first.imported(), 1);
+        assert_eq!(
+            std::fs::read_to_string(dest.join("BTCUSDT").join("s1.csv")).unwrap(),
+            "session one\n"
+        );
+        assert!(
+            source.join("BTCUSDT").join("s1.csv").exists(),
+            "the source keeps its file - consolidation copies"
+        );
+        assert!(
+            !dest.join("BTCUSDT").join("notes.txt").exists(),
+            "only history files travel"
+        );
+
+        let second = consolidate_into(&dest, &[source]);
+        assert_eq!(second.identical, 1, "a re-run finds the copy and skips");
+        assert_eq!(second.imported(), 0);
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn a_name_clash_with_different_content_keeps_both_and_stays_idempotent() {
+        let root = scratch();
+        let source = root.join("source");
+        let dest = root.join("dest");
+        write(&source.join("WINQ26").join("s1.csv"), "from the laptop\n");
+        write(&dest.join("WINQ26").join("s1.csv"), "already here\n");
+
+        let first = consolidate_into(&dest, std::slice::from_ref(&source));
+        assert_eq!(first.renamed, 1, "different content under one name");
+        assert_eq!(
+            std::fs::read_to_string(dest.join("WINQ26").join("s1.imported-1.csv")).unwrap(),
+            "from the laptop\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(dest.join("WINQ26").join("s1.csv")).unwrap(),
+            "already here\n",
+            "the resident file is never overwritten"
+        );
+
+        let second = consolidate_into(&dest, &[source]);
+        assert_eq!(
+            second.identical, 1,
+            "the renamed copy satisfies the next run"
+        );
+        assert_eq!(second.renamed, 0);
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn loose_files_travel_by_their_header_or_stay_behind() {
+        let root = scratch();
+        let source = root.join("source");
+        let dest = root.join("dest");
+        write(&source.join("loose.csv"), &history::write_header("WDO$"));
+        write(&source.join("junk.csv"), "not a history file at all\n");
+
+        let summary = consolidate_into(&dest, std::slice::from_ref(&source));
+        assert_eq!(summary.copied, 1, "the header names the folder");
+        assert!(dest.join("WDO$").join("loose.csv").exists());
+        assert_eq!(summary.ignored, 1, "no symbol, no guess");
+        assert!(
+            source.join("junk.csv").exists() && !dest.join("junk.csv").exists(),
+            "the unreadable file stays exactly where it was"
+        );
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn a_source_that_is_or_holds_the_home_is_left_alone() {
+        let root = scratch();
+        let dest = root.join("dest");
+        write(&dest.join("BTCUSDT").join("s1.csv"), "resident\n");
+
+        let itself = consolidate_into(&dest, std::slice::from_ref(&dest));
+        assert_eq!(itself, ImportSummary::default(), "never import the home");
+
+        // The home nested inside a source: the parent scan must not pull
+        // the home's own files through the loose-file path.
+        let parent = consolidate_into(&dest, std::slice::from_ref(&root));
+        assert_eq!(
+            parent,
+            ImportSummary::default(),
+            "a folder holding the home contributes nothing of the home"
+        );
+        let _ = std::fs::remove_dir_all(&root);
+    }
+}

--- a/crates/app/src/paper_home.rs
+++ b/crates/app/src/paper_home.rs
@@ -444,7 +444,10 @@ mod tests {
         let root = scratch();
         let source = root.join("source");
         let dest = root.join("dest");
-        write(&source.join("loose.csv"), &history::write_header("WDO$"));
+        write(
+            &source.join("loose.csv"),
+            &history::write_header("WDO$", history::SessionSource::Live),
+        );
         write(&source.join("junk.csv"), "not a history file at all\n");
 
         let summary = consolidate_into(&dest, std::slice::from_ref(&source));

--- a/crates/app/src/paper_home.rs
+++ b/crates/app/src/paper_home.rs
@@ -12,12 +12,14 @@
 //! Resolution keeps its spirit — an explicit ask always wins:
 //! `QUANTICK_TRADES_DIR` (one run) > the folder picked in-app
 //! (`paper-state.toml`) > `[paper] trades_dir` in the config > the
-//! documents home. Only when nothing pins the journal elsewhere does
-//! startup also *consolidate*: copy — never move, never delete — what the
-//! reachable legacy locations still hold into the home, then clear the
-//! stored pick so there is one home from now on. The copy skips
-//! byte-identical files, so running it every startup is safe and needs no
-//! "already done" flag (which would itself be cwd-relative).
+//! documents home. Exactly once — recorded by a `.consolidated` marker in
+//! the home itself, so the one-time-ness holds from every launch
+//! directory — startup also *consolidates*: copy — never move, never
+//! delete — what the reachable legacy locations still hold into the home,
+//! retiring the pre-rescue pick. From then on a pick made in-app is a
+//! standing choice again and survives every restart. The copy skips
+//! byte-identical files, so the ongoing sweep of the cwd-relative legacy
+//! folder stays safe to repeat.
 
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
@@ -34,6 +36,10 @@ pub(crate) const LEGACY_TRADES_DIR: &str = "paper-trades";
 /// The shelf inside the documents folder — one recognizable place for
 /// everything quantick may keep there.
 const DOCUMENTS_SHELF: &str = "Quantick";
+/// The file that marks the home as already consolidated. It lives in the
+/// home itself so the one-time rescue stays one-time from every launch
+/// directory — a flag in the cwd-relative sidecar would not.
+const CONSOLIDATED_MARKER: &str = ".consolidated";
 /// How many `.imported-N` names a clash may try before giving up — far
 /// beyond any real journal, a backstop against a pathological folder.
 const MAX_IMPORT_RENAMES: usize = 99;
@@ -73,36 +79,110 @@ pub(crate) fn resolve(configured: Option<&str>, stored: Option<&str>) -> PathBuf
     )
 }
 
-/// Resolve the journal home for this run and, when nothing explicit (env
-/// or config) pins it elsewhere, consolidate the reachable legacy
-/// locations into it: the stored in-app pick (cleared afterwards, so the
-/// home stays singular) and the cwd-relative legacy folder.
+/// Resolve the journal home for this run and, exactly once, consolidate
+/// the reachable legacy locations into it. The one-time-ness lives as a
+/// marker file in the home itself (cwd-independent, unlike this sidecar);
+/// after the rescue has run, a stored in-app pick is a live choice again
+/// and wins, exactly as the picker's tooltip promises.
 pub(crate) fn startup_home(
     configured: Option<&str>,
     stored: Option<&str>,
     state_path: &Path,
 ) -> (PathBuf, Option<ImportSummary>) {
+    if cfg!(test) {
+        // Tests must never scan, consolidate into, or journal under a
+        // real documents folder — the same scratch discipline
+        // `PaperTrading::new` applies. Per process, like the old
+        // cwd-relative default the app tests already shared.
+        return (
+            std::env::temp_dir().join(format!("quantick-paper-home-{}", std::process::id())),
+            None,
+        );
+    }
     if let Some(env) = std::env::var_os(TRADES_DIR_ENV) {
         // An explicit per-run ask — a QA or autostart run must never
         // touch, or even scan, the real home.
         return (PathBuf::from(env), None);
     }
+    resolve_startup_home(
+        configured,
+        stored,
+        state_path,
+        documents_dir(),
+        Path::new(LEGACY_TRADES_DIR),
+    )
+}
+
+/// [`startup_home`] with its environment injected, so the whole decision
+/// tree is testable against scratch folders.
+fn resolve_startup_home(
+    configured: Option<&str>,
+    stored: Option<&str>,
+    state_path: &Path,
+    documents: Option<PathBuf>,
+    legacy_dir: &Path,
+) -> (PathBuf, Option<ImportSummary>) {
     if configured.is_some() {
         // An explicit `[paper] trades_dir` keeps the legacy chain whole:
         // whoever wrote the key chose a home on purpose.
-        return (chosen(configured, stored, documents_dir()), None);
+        return (chosen(configured, stored, documents), None);
     }
-    let dest = default_trades_dir(documents_dir());
+    let dest = default_trades_dir(documents);
+    let marker = dest.join(CONSOLIDATED_MARKER);
+    if marker.exists() {
+        // The rescue already ran. A pick made since is the user's own
+        // standing choice — it must survive every restart.
+        if let Some(stored) = stored {
+            return (PathBuf::from(stored), None);
+        }
+        // Still sweep the cwd-relative legacy folder: it is the one
+        // source a home-side marker cannot see, and the pass is
+        // copies-only and idempotent.
+        let summary = consolidate_into(&dest, std::slice::from_ref(&legacy_dir.to_path_buf()));
+        return (dest, Some(summary));
+    }
     let mut sources = Vec::new();
     if let Some(stored) = stored {
         sources.push(PathBuf::from(stored));
     }
-    sources.push(PathBuf::from(LEGACY_TRADES_DIR));
+    sources.push(legacy_dir.to_path_buf());
     let summary = consolidate_into(&dest, &sources);
-    if stored.is_some() {
-        crate::paper_state::clear_trades_dir(state_path);
+    if summary.failed == 0 && summary.source_unreadable == 0 {
+        // Only a clean pass may retire the pick and declare the rescue
+        // done: clearing after a failed or unreadable copy would orphan
+        // the very files the rescue exists to keep reachable.
+        if stored.is_some() {
+            crate::paper_state::clear_trades_dir(state_path);
+        }
+        write_consolidated_marker(&marker);
     }
     (dest, Some(summary))
+}
+
+/// Stamp the home as consolidated. A failed write only means the rescue
+/// re-runs next launch — idempotent, so that is safe.
+fn write_consolidated_marker(marker: &Path) {
+    let written = marker
+        .parent()
+        .map_or(Ok(()), std::fs::create_dir_all)
+        .and_then(|()| {
+            std::fs::write(
+                marker,
+                "quantick wrote this after consolidating legacy paper-trading history \
+                 into this folder; deleting it re-runs that one-time import.\n",
+            )
+        });
+    if let Err(error) = written {
+        tracing::warn!(
+            target: "quantick::app",
+            schema_version = 1_u8,
+            event_code = "PAPER_HISTORY_MARKER_FAILED",
+            path = %marker.display(),
+            %error,
+            action = "rescue_reruns_next_launch",
+            "could not stamp the journal home as consolidated"
+        );
+    }
 }
 
 /// What one consolidation pass did. Copies only — the sources keep every
@@ -116,11 +196,14 @@ pub(crate) struct ImportSummary {
     /// Files whose name was taken by different content — copied under an
     /// `.imported-N` suffix so neither version is lost.
     pub renamed: usize,
-    /// Root-level files with no readable symbol header — left in place
-    /// and logged, never guessed at.
+    /// Files that are not readable quantick-trades history — left in
+    /// place and logged, never guessed at.
     pub ignored: usize,
     /// Copies that failed with an I/O error (logged, file left in place).
     pub failed: usize,
+    /// Sources that exist but could not be listed — a pass that could not
+    /// see everything must not be treated as complete.
+    pub source_unreadable: usize,
 }
 
 impl ImportSummary {
@@ -144,10 +227,19 @@ pub(crate) fn import_toast(summary: &ImportSummary) -> String {
         text.push_str(&format!(", {} already present", summary.identical));
     }
     if summary.ignored > 0 {
-        text.push_str(&format!(", {} without a symbol skipped", summary.ignored));
+        text.push_str(&format!(
+            ", {} not trade history - skipped",
+            summary.ignored
+        ));
     }
     if summary.failed > 0 {
         text.push_str(&format!(", {} failed - see the log", summary.failed));
+    }
+    if summary.source_unreadable > 0 {
+        text.push_str(&format!(
+            ", {} folder(s) unreadable - see the log",
+            summary.source_unreadable,
+        ));
     }
     text
 }
@@ -163,7 +255,22 @@ pub(crate) fn consolidate_into(dest: &Path, sources: &[PathBuf]) -> ImportSummar
         if source.as_path() == dest || dest.starts_with(source) || source.starts_with(dest) {
             continue;
         }
+        if !source.exists() {
+            // A source that is simply not there holds nothing to rescue.
+            continue;
+        }
         let Ok(entries) = std::fs::read_dir(source) else {
+            // Existing but unlistable is different from empty: the pass
+            // did not see everything and must not claim it did.
+            summary.source_unreadable += 1;
+            tracing::warn!(
+                target: "quantick::app",
+                schema_version = 1_u8,
+                event_code = "PAPER_HISTORY_SOURCE_UNREADABLE",
+                path = %source.display(),
+                action = "source_skipped",
+                "could not list a consolidation source"
+            );
             continue;
         };
         let mut paths: Vec<PathBuf> = entries.flatten().map(|entry| entry.path()).collect();
@@ -190,6 +297,7 @@ pub(crate) fn consolidate_into(dest: &Path, sources: &[PathBuf]) -> ImportSummar
             renamed = summary.renamed,
             ignored = summary.ignored,
             failed = summary.failed,
+            source_unreadable = summary.source_unreadable,
             "paper-trading history consolidated into the journal home"
         );
     }
@@ -201,8 +309,11 @@ fn is_history_file(path: &Path) -> bool {
         .is_some_and(|extension| extension == history::FILE_EXTENSION)
 }
 
-/// One `<SYMBOL>/` folder: every history file inside goes to the same
-/// folder name under the home.
+/// One `<SYMBOL>/` folder: every readable history file inside goes to the
+/// same folder name under the home. Same parse gate as the loose-file
+/// path — a foreign `.csv` (a price export, another tool's data) must not
+/// be planted in the journal and then counted "unreadable" every session
+/// after.
 fn copy_symbol_folder(folder: &Path, dest: &Path, summary: &mut ImportSummary) {
     let Some(name) = folder.file_name() else {
         return;
@@ -217,6 +328,20 @@ fn copy_symbol_folder(folder: &Path, dest: &Path, summary: &mut ImportSummary) {
         .collect();
     paths.sort();
     for path in paths {
+        let is_history =
+            std::fs::read_to_string(&path).is_ok_and(|text| history::parse(&text).is_ok());
+        if !is_history {
+            summary.ignored += 1;
+            tracing::warn!(
+                target: "quantick::app",
+                schema_version = 1_u8,
+                event_code = "PAPER_HISTORY_IMPORT_SKIPPED",
+                path = %path.display(),
+                action = "file_left_in_place",
+                "csv is not quantick-trades history - not planting it in the journal"
+            );
+            continue;
+        }
         copy_one(&path, &dest.join(name), summary);
     }
 }
@@ -290,7 +415,15 @@ fn try_copy_one(file: &Path, folder: &Path) -> std::io::Result<Outcome> {
     loop {
         if !target.exists() {
             std::fs::create_dir_all(folder)?;
-            std::fs::write(&target, &source_bytes)?;
+            // Temp-and-rename, the paper-state discipline: a crash
+            // mid-copy must not leave a torn journal that parses as a
+            // shorter session and double-counts after the next pass.
+            let temp = target.with_extension("csv.tmp");
+            std::fs::write(&temp, &source_bytes)
+                .and_then(|()| std::fs::rename(&temp, &target))
+                .inspect_err(|_| {
+                    let _ = std::fs::remove_file(&temp);
+                })?;
             return Ok(if suffix == 0 {
                 Outcome::Copied
             } else {
@@ -348,6 +481,12 @@ mod tests {
         std::fs::write(path, text).unwrap();
     }
 
+    /// A minimal valid quantick-trades file — the parse gate lets only
+    /// real history into the home, so fixtures must be real history.
+    fn history_text(symbol: &str) -> String {
+        history::write_header(symbol, history::SessionSource::Live)
+    }
+
     #[test]
     fn the_documents_home_hangs_off_the_documents_folder() {
         assert_eq!(
@@ -385,7 +524,10 @@ mod tests {
         let root = scratch();
         let source = root.join("source");
         let dest = root.join("dest");
-        write(&source.join("BTCUSDT").join("s1.csv"), "session one\n");
+        write(
+            &source.join("BTCUSDT").join("s1.csv"),
+            &history_text("BTCUSDT"),
+        );
         write(&source.join("BTCUSDT").join("notes.txt"), "not history\n");
 
         let first = consolidate_into(&dest, std::slice::from_ref(&source));
@@ -393,7 +535,7 @@ mod tests {
         assert_eq!(first.imported(), 1);
         assert_eq!(
             std::fs::read_to_string(dest.join("BTCUSDT").join("s1.csv")).unwrap(),
-            "session one\n"
+            history_text("BTCUSDT")
         );
         assert!(
             source.join("BTCUSDT").join("s1.csv").exists(),
@@ -415,18 +557,20 @@ mod tests {
         let root = scratch();
         let source = root.join("source");
         let dest = root.join("dest");
-        write(&source.join("WINQ26").join("s1.csv"), "from the laptop\n");
-        write(&dest.join("WINQ26").join("s1.csv"), "already here\n");
+        let laptop = history_text("WINQ26");
+        let resident = history_text("WINQ26F");
+        write(&source.join("WINQ26").join("s1.csv"), &laptop);
+        write(&dest.join("WINQ26").join("s1.csv"), &resident);
 
         let first = consolidate_into(&dest, std::slice::from_ref(&source));
         assert_eq!(first.renamed, 1, "different content under one name");
         assert_eq!(
             std::fs::read_to_string(dest.join("WINQ26").join("s1.imported-1.csv")).unwrap(),
-            "from the laptop\n"
+            laptop
         );
         assert_eq!(
             std::fs::read_to_string(dest.join("WINQ26").join("s1.csv")).unwrap(),
-            "already here\n",
+            resident,
             "the resident file is never overwritten"
         );
 
@@ -457,6 +601,131 @@ mod tests {
         assert!(
             source.join("junk.csv").exists() && !dest.join("junk.csv").exists(),
             "the unreadable file stays exactly where it was"
+        );
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn foreign_csvs_inside_symbol_folders_stay_behind() {
+        let root = scratch();
+        let source = root.join("source");
+        let dest = root.join("dest");
+        write(
+            &source.join("EXPORTS").join("prices.csv"),
+            "date,open,close\n",
+        );
+        write(
+            &source.join("EXPORTS").join("real.csv"),
+            &history_text("EXPORTS"),
+        );
+
+        let summary = consolidate_into(&dest, std::slice::from_ref(&source));
+        assert_eq!(summary.copied, 1, "only the real history travels");
+        assert_eq!(
+            summary.ignored, 1,
+            "the foreign csv is reported, not planted"
+        );
+        assert!(dest.join("EXPORTS").join("real.csv").exists());
+        assert!(
+            !dest.join("EXPORTS").join("prices.csv").exists(),
+            "a price export must not live in the journal"
+        );
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn the_rescue_runs_once_and_then_the_pick_wins_again() {
+        let root = scratch();
+        let documents = root.join("docs");
+        let picked = root.join("picked");
+        let legacy = root.join("legacy-cwd");
+        let state_path = root.join("paper-state.toml");
+        write(
+            &picked.join("BTCUSDT").join("s1.csv"),
+            &history_text("BTCUSDT"),
+        );
+        crate::paper_state::save(
+            &state_path,
+            &crate::paper_state::PaperState {
+                trades_dir: Some(picked.display().to_string()),
+                ..Default::default()
+            },
+        );
+
+        // First launch: the rescue copies the pick into the home, retires
+        // the pick, and stamps the home.
+        let (home, summary) = resolve_startup_home(
+            None,
+            Some(&picked.display().to_string()),
+            &state_path,
+            Some(documents.clone()),
+            &legacy,
+        );
+        let dest = documents.join("Quantick").join("paper-trades");
+        assert_eq!(home, dest);
+        assert_eq!(summary.expect("first launch consolidates").copied, 1);
+        assert!(dest.join(".consolidated").exists(), "the home is stamped");
+        assert_eq!(
+            crate::paper_state::load(&state_path).trades_dir,
+            None,
+            "the migrated pick is retired"
+        );
+
+        // The user picks a folder again: from now on it must win every
+        // launch — the rescue never re-runs against it.
+        let repicked = root.join("repicked");
+        std::fs::create_dir_all(&repicked).unwrap();
+        let (home, summary) = resolve_startup_home(
+            None,
+            Some(&repicked.display().to_string()),
+            &state_path,
+            Some(documents.clone()),
+            &legacy,
+        );
+        assert_eq!(home, repicked, "a post-rescue pick is a standing choice");
+        assert!(summary.is_none(), "and nothing is consolidated behind it");
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn an_unreadable_or_failing_pass_keeps_the_pick_and_the_rescue_pending() {
+        let root = scratch();
+        let documents = root.join("docs");
+        // The "picked folder" is a FILE: exists, cannot be listed.
+        let picked = root.join("picked-but-broken");
+        write(&picked, "not a directory");
+        let legacy = root.join("legacy-cwd");
+        let state_path = root.join("paper-state.toml");
+        crate::paper_state::save(
+            &state_path,
+            &crate::paper_state::PaperState {
+                trades_dir: Some(picked.display().to_string()),
+                ..Default::default()
+            },
+        );
+
+        let (home, summary) = resolve_startup_home(
+            None,
+            Some(&picked.display().to_string()),
+            &state_path,
+            Some(documents.clone()),
+            &legacy,
+        );
+        let dest = documents.join("Quantick").join("paper-trades");
+        assert_eq!(home, dest, "the run still gets a working home");
+        assert_eq!(
+            summary.expect("a pass ran").source_unreadable,
+            1,
+            "the unlistable source is counted, not ignored"
+        );
+        assert!(
+            !dest.join(".consolidated").exists(),
+            "an incomplete pass must not claim the rescue is done"
+        );
+        assert_eq!(
+            crate::paper_state::load(&state_path).trades_dir,
+            Some(picked.display().to_string()),
+            "and the pick pointing at the user's trades is kept"
         );
         let _ = std::fs::remove_dir_all(&root);
     }

--- a/crates/app/src/paper_home.rs
+++ b/crates/app/src/paper_home.rs
@@ -100,7 +100,7 @@ pub(crate) fn startup_home(
     sources.push(PathBuf::from(LEGACY_TRADES_DIR));
     let summary = consolidate_into(&dest, &sources);
     if stored.is_some() {
-        crate::paper_state::clear(state_path);
+        crate::paper_state::clear_trades_dir(state_path);
     }
     (dest, Some(summary))
 }

--- a/crates/app/src/paper_state.rs
+++ b/crates/app/src/paper_state.rs
@@ -1,16 +1,17 @@
-//! Where the paper-trading journal lives, when the user picked it in-app.
+//! The paper-trading sidecar: in-app choices that must survive a restart.
 //!
-//! One value, one home: the shipped base stays `[paper] trades_dir` in the
-//! config, the `QUANTICK_TRADES_DIR` environment variable stays the
-//! explicit per-run override, and this sidecar records the choice made
-//! with the panel's folder picker — the added-symbols pattern: an in-app
-//! edit must survive a restart without the app rewriting the user's
-//! hand-commented `quantick.toml` (a TOML writer would strip its comments,
-//! which is exactly what the config rules forbid).
+//! One value set, one home: the shipped base stays in the config
+//! (`[paper] trades_dir`), environment variables stay the explicit
+//! per-run overrides, and this sidecar records what the user changed
+//! *in-app* — the added-symbols pattern: an in-app edit must survive a
+//! restart without the app rewriting the user's hand-commented
+//! `quantick.toml` (a TOML writer would strip its comments, which is
+//! exactly what the config rules forbid). Today that is the journal
+//! folder picked with the panel's button and the cmd-trading settings.
 //!
 //! Same store discipline as the chart layers: a versioned TOML next to the
 //! config (override with `QUANTICK_PAPER_STATE`), read once at startup,
-//! written when the choice changes, temp-file-and-rename so a crash
+//! written when a choice changes, temp-file-and-rename so a crash
 //! mid-write cannot leave half a file behind. Anything unreadable is
 //! ignored entirely.
 
@@ -23,14 +24,34 @@ const STATE_ENV: &str = "QUANTICK_PAPER_STATE";
 /// Default file, next to the working directory's config.
 const STATE_FILE: &str = "paper-state.toml";
 /// Bumped on breaking layout changes; unknown versions are ignored.
+/// Adding an optional field is not breaking — absent keys stay `None`.
 const FORMAT_VERSION: u32 = 1;
+
+/// Everything the sidecar remembers. Every field is optional: `None`
+/// always means "never touched in-app", so defaults stay the resolver's
+/// business, not this file's.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct PaperState {
+    /// The folder the user picked for the trade journal, when they did.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trades_dir: Option<String>,
+    /// Cmd trading on/off; `None` has never been toggled (default on).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cmd_trading_enabled: Option<bool>,
+    /// Modifier token (`shift`/`ctrl`/`alt`) for the buy gesture; an
+    /// unknown token falls back to the default at read time.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cmd_buy_modifier: Option<String>,
+    /// See [`Self::cmd_buy_modifier`]; the sell side.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cmd_sell_modifier: Option<String>,
+}
 
 #[derive(Debug, Serialize, Deserialize)]
 struct PaperStateFile {
     version: u32,
-    /// The folder the user picked for the trade journal, when they did.
-    #[serde(default)]
-    trades_dir: Option<String>,
+    #[serde(flatten)]
+    state: PaperState,
 }
 
 /// The paper-state file the app opens with and writes back to. Under test
@@ -56,14 +77,19 @@ fn scratch_path() -> PathBuf {
     ))
 }
 
-/// The stored folder choice; `None` when the file is missing, unreadable,
-/// from an unknown version, or holds no choice.
+/// The stored state; default (all `None`) when the file is missing,
+/// unreadable or from an unknown version. A blank `trades_dir` is no
+/// choice.
 #[must_use]
-pub(crate) fn load(path: &Path) -> Option<String> {
-    let text = std::fs::read_to_string(path).ok()?;
+pub(crate) fn load(path: &Path) -> PaperState {
+    let Ok(text) = std::fs::read_to_string(path) else {
+        return PaperState::default();
+    };
     match toml::from_str::<PaperStateFile>(&text) {
         Ok(file) if file.version == FORMAT_VERSION => {
-            file.trades_dir.filter(|dir| !dir.trim().is_empty())
+            let mut state = file.state;
+            state.trades_dir = state.trades_dir.filter(|dir| !dir.trim().is_empty());
+            state
         }
         Ok(file) => {
             tracing::warn!(
@@ -72,10 +98,10 @@ pub(crate) fn load(path: &Path) -> Option<String> {
                 event_code = "PAPER_STATE_VERSION",
                 path = %path.display(),
                 version = file.version,
-                action = "keeping_configured_trades_dir",
+                action = "keeping_defaults",
                 "paper state file is from an unknown version"
             );
-            None
+            PaperState::default()
         }
         Err(error) => {
             tracing::warn!(
@@ -84,40 +110,21 @@ pub(crate) fn load(path: &Path) -> Option<String> {
                 event_code = "PAPER_STATE_UNREADABLE",
                 path = %path.display(),
                 %error,
-                action = "keeping_configured_trades_dir",
+                action = "keeping_defaults",
                 "paper state file is unreadable"
             );
-            None
+            PaperState::default()
         }
     }
 }
 
-/// Remember the picked folder.
-pub(crate) fn save(path: &Path, trades_dir: &str) {
-    write_file(
-        path,
-        &PaperStateFile {
-            version: FORMAT_VERSION,
-            trades_dir: Some(trades_dir.to_owned()),
-        },
-    );
-}
-
-/// Forget the picked folder — the consolidation's closing step: once the
-/// legacy pick's files are copied into the documents home, the resolver's
-/// own default *is* the home. An explicit "no choice" is written rather
-/// than deleting the file, so the store never looks like it was lost.
-pub(crate) fn clear(path: &Path) {
-    write_file(
-        path,
-        &PaperStateFile {
-            version: FORMAT_VERSION,
-            trades_dir: None,
-        },
-    );
-}
-
-fn write_file(path: &Path, file: &PaperStateFile) {
+/// Write the whole state back. Callers read-modify-write, so one changed
+/// choice never erases another.
+pub(crate) fn save(path: &Path, state: &PaperState) {
+    let file = PaperStateFile {
+        version: FORMAT_VERSION,
+        state: state.clone(),
+    };
     let Ok(text) = toml::to_string_pretty(&file) else {
         tracing::warn!(
             target: "quantick::app",
@@ -143,26 +150,67 @@ fn write_file(path: &Path, file: &PaperStateFile) {
     }
 }
 
+/// Forget the picked folder, keeping every other choice — the
+/// consolidation's closing step: once the legacy pick's files are copied
+/// into the documents home, the resolver's own default *is* the home.
+pub(crate) fn clear_trades_dir(path: &Path) {
+    let mut state = load(path);
+    state.trades_dir = None;
+    save(path, &state);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn the_choice_round_trips_through_disk() {
+    fn the_choices_round_trip_through_disk() {
         let path = scratch_path();
-        assert_eq!(load(&path), None, "a missing file holds no choice");
-        save(&path, "D:/trading/journals");
-        assert_eq!(load(&path), Some("D:/trading/journals".to_owned()));
+        assert_eq!(
+            load(&path),
+            PaperState::default(),
+            "missing file, no choices"
+        );
+        let state = PaperState {
+            trades_dir: Some("D:/trading/journals".to_owned()),
+            cmd_trading_enabled: Some(false),
+            cmd_buy_modifier: Some("alt".to_owned()),
+            cmd_sell_modifier: Some("ctrl".to_owned()),
+        };
+        save(&path, &state);
+        assert_eq!(load(&path), state);
         std::fs::remove_file(&path).ok();
     }
 
     #[test]
-    fn clearing_forgets_the_choice_without_losing_the_file() {
+    fn clearing_the_folder_keeps_the_other_choices() {
         let path = scratch_path();
-        save(&path, "D:/trading/journals");
-        clear(&path);
-        assert_eq!(load(&path), None, "a cleared choice is no choice");
-        assert!(path.exists(), "clearing writes an explicit no-choice");
+        save(
+            &path,
+            &PaperState {
+                trades_dir: Some("D:/trading/journals".to_owned()),
+                cmd_trading_enabled: Some(false),
+                ..PaperState::default()
+            },
+        );
+        clear_trades_dir(&path);
+        let state = load(&path);
+        assert_eq!(state.trades_dir, None, "the pick is forgotten");
+        assert_eq!(
+            state.cmd_trading_enabled,
+            Some(false),
+            "an unrelated choice survives"
+        );
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn a_legacy_file_with_only_the_folder_still_loads() {
+        let path = scratch_path();
+        std::fs::write(&path, "version = 1\ntrades_dir = \"D:/journals\"\n").unwrap();
+        let state = load(&path);
+        assert_eq!(state.trades_dir.as_deref(), Some("D:/journals"));
+        assert_eq!(state.cmd_trading_enabled, None, "absent keys stay None");
         std::fs::remove_file(&path).ok();
     }
 
@@ -170,11 +218,11 @@ mod tests {
     fn unknown_versions_and_garbage_degrade_to_no_choice() {
         let path = scratch_path();
         std::fs::write(&path, "version = 99\ntrades_dir = \"x\"\n").unwrap();
-        assert_eq!(load(&path), None, "unknown version changes nothing");
+        assert_eq!(load(&path), PaperState::default(), "unknown version");
         std::fs::write(&path, "not even toml [").unwrap();
-        assert_eq!(load(&path), None, "garbage changes nothing");
+        assert_eq!(load(&path), PaperState::default(), "garbage");
         std::fs::write(&path, "version = 1\ntrades_dir = \"  \"\n").unwrap();
-        assert_eq!(load(&path), None, "a blank choice is no choice");
+        assert_eq!(load(&path).trades_dir, None, "a blank choice is no choice");
         std::fs::remove_file(&path).ok();
     }
 }

--- a/crates/app/src/paper_state.rs
+++ b/crates/app/src/paper_state.rs
@@ -94,10 +94,30 @@ pub(crate) fn load(path: &Path) -> Option<String> {
 
 /// Remember the picked folder.
 pub(crate) fn save(path: &Path, trades_dir: &str) {
-    let file = PaperStateFile {
-        version: FORMAT_VERSION,
-        trades_dir: Some(trades_dir.to_owned()),
-    };
+    write_file(
+        path,
+        &PaperStateFile {
+            version: FORMAT_VERSION,
+            trades_dir: Some(trades_dir.to_owned()),
+        },
+    );
+}
+
+/// Forget the picked folder — the consolidation's closing step: once the
+/// legacy pick's files are copied into the documents home, the resolver's
+/// own default *is* the home. An explicit "no choice" is written rather
+/// than deleting the file, so the store never looks like it was lost.
+pub(crate) fn clear(path: &Path) {
+    write_file(
+        path,
+        &PaperStateFile {
+            version: FORMAT_VERSION,
+            trades_dir: None,
+        },
+    );
+}
+
+fn write_file(path: &Path, file: &PaperStateFile) {
     let Ok(text) = toml::to_string_pretty(&file) else {
         tracing::warn!(
             target: "quantick::app",
@@ -133,6 +153,16 @@ mod tests {
         assert_eq!(load(&path), None, "a missing file holds no choice");
         save(&path, "D:/trading/journals");
         assert_eq!(load(&path), Some("D:/trading/journals".to_owned()));
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn clearing_forgets_the_choice_without_losing_the_file() {
+        let path = scratch_path();
+        save(&path, "D:/trading/journals");
+        clear(&path);
+        assert_eq!(load(&path), None, "a cleared choice is no choice");
+        assert!(path.exists(), "clearing writes an explicit no-choice");
         std::fs::remove_file(&path).ok();
     }
 

--- a/crates/app/src/paper_trading.rs
+++ b/crates/app/src/paper_trading.rs
@@ -441,7 +441,13 @@ impl SourceFilter {
     /// Whether a row with this recorded source belongs to the filter.
     fn admits(self, source: Option<history::SessionSource>) -> bool {
         match self {
-            Self::Real => source != Some(history::SessionSource::Replay),
+            // Exhaustive on purpose: a future source variant must not fall
+            // into the real track record by default — adding one forces
+            // this match to say where it belongs.
+            Self::Real => match source {
+                None | Some(history::SessionSource::Live) => true,
+                Some(history::SessionSource::Replay) => false,
+            },
             Self::Replay => source == Some(history::SessionSource::Replay),
             Self::All => true,
         }

--- a/crates/app/src/paper_trading.rs
+++ b/crates/app/src/paper_trading.rs
@@ -28,9 +28,6 @@ use crate::chart::PriceScale;
 use crate::theme;
 use crate::timezone::TzOffset;
 
-/// Overrides the history folder (cwd-relative otherwise, like every
-/// quantick path).
-const TRADES_DIR_ENV: &str = "QUANTICK_TRADES_DIR";
 /// `=1` runs a fixed sequence of ordinary sim commands driven by print
 /// count, so a screenshot or demo run shows every trading surface without
 /// a click — the autostart family's member for paper trading. The trades
@@ -38,8 +35,6 @@ const TRADES_DIR_ENV: &str = "QUANTICK_TRADES_DIR";
 /// `QUANTICK_TRADES_DIR` somewhere scratch to keep a demo out of your
 /// journal.
 const PAPER_DEMO_ENV: &str = "QUANTICK_PAPER_DEMO";
-/// Default history folder, relative to the working directory.
-const TRADES_DIR: &str = "paper-trades";
 /// How long a paper toast stays on screen.
 const TOAST_MS: u64 = 4_000;
 /// Grab distance for order lines — the drawings' select radius, so the two
@@ -382,6 +377,10 @@ pub struct PaperTrading {
     hovered_order: Option<OrderId>,
     /// The in-flight export, if any; resolved by `draw_toast`'s poll.
     export_rx: Option<std::sync::mpsc::Receiver<Result<(PathBuf, usize), String>>>,
+    /// The in-flight history-folder import, if any; resolved by
+    /// `draw_toast`'s poll. Imports copy — the picked folder keeps its
+    /// files.
+    import_rx: Option<std::sync::mpsc::Receiver<Option<PathBuf>>>,
     toast: Option<Toast>,
     report_open: bool,
     /// Report symbol filter: `None` is every symbol, `Some` one folder.
@@ -420,18 +419,23 @@ impl PaperTrading {
     /// through [`Self::with_trades_dir`] with the configured folder.
     #[must_use]
     pub fn new() -> Self {
-        Self::with_trades_dir(Self::resolve_trades_dir(TRADES_DIR, None))
+        if cfg!(test) {
+            // Tests must never journal into a real documents folder — the
+            // same scratch discipline `paper_state::default_path` applies.
+            return Self::with_trades_dir(test_scratch_dir());
+        }
+        Self::with_trades_dir(Self::resolve_trades_dir(None, None))
     }
 
     /// The journal folder for this run: the environment override wins (an
     /// env var is an explicit request for one run, like every autostart
     /// hook), then `stored` — the folder the user last picked with the
-    /// panel's button — then `configured`, the `[paper] trades_dir` key,
-    /// defaulting to `paper-trades`.
+    /// panel's button — then `configured`, the `[paper] trades_dir` key
+    /// when the config carries one, and finally the documents home
+    /// ([`crate::paper_home::default_trades_dir`]).
     #[must_use]
-    pub fn resolve_trades_dir(configured: &str, stored: Option<&str>) -> PathBuf {
-        std::env::var_os(TRADES_DIR_ENV)
-            .map_or_else(|| chosen_trades_dir(configured, stored), PathBuf::from)
+    pub fn resolve_trades_dir(configured: Option<&str>, stored: Option<&str>) -> PathBuf {
+        crate::paper_home::resolve(configured, stored)
     }
 
     /// A host journaling to `dir`, already resolved from config and
@@ -453,6 +457,7 @@ impl PaperTrading {
             drag_price: None,
             hovered_order: None,
             export_rx: None,
+            import_rx: None,
             toast: None,
             report_open: false,
             report_symbol: None,
@@ -2589,6 +2594,15 @@ impl PaperTrading {
                 {
                     reload = true;
                 }
+                if ui
+                    .small_button(icons::DOWNLOAD_SIMPLE)
+                    .on_hover_text(
+                        "import trades from another folder - copies, the folder keeps its files",
+                    )
+                    .clicked()
+                {
+                    self.start_import();
+                }
             });
         });
         if let Some(view) = &self.report_view {
@@ -2616,6 +2630,7 @@ impl PaperTrading {
     pub fn draw_toast(&mut self, ctx: &egui::Context, now: Instant) {
         self.hovered_order = None;
         self.poll_export();
+        self.poll_import();
         let Some(toast) = &self.toast else {
             return;
         };
@@ -2638,11 +2653,59 @@ impl PaperTrading {
             });
     }
 
-    fn show_toast(&mut self, message: String) {
+    pub(crate) fn show_toast(&mut self, message: String) {
         self.toast = Some(Toast {
             message,
             shown_at: Instant::now(),
         });
+    }
+
+    // ------------------------------------------------------------------
+    // Import
+    // ------------------------------------------------------------------
+
+    /// Ask for a folder whose trades should be copied into the journal
+    /// home, off the UI thread — the manual way in for legacy folders the
+    /// startup consolidation cannot reach (an old working directory, a
+    /// backup). One dialog at a time.
+    fn start_import(&mut self) {
+        if self.import_rx.is_some() {
+            self.show_toast("SIM: an import is already running.".to_owned());
+            return;
+        }
+        let (sender, receiver) = std::sync::mpsc::channel();
+        let start = self.dir.clone();
+        std::thread::Builder::new()
+            .name("quantick-trades-import-picker".into())
+            .spawn(move || {
+                let mut dialog =
+                    rfd::FileDialog::new().set_title("Import trades from a folder (copies)");
+                if start.is_dir() {
+                    dialog = dialog.set_directory(&start);
+                }
+                let _ = sender.send(dialog.pick_folder());
+            })
+            .expect("spawn trades-import picker thread");
+        self.import_rx = Some(receiver);
+    }
+
+    /// Land the picked folder: copy its history into the journal home and
+    /// re-read, so the report answers with the merged truth.
+    fn poll_import(&mut self) {
+        let Some(receiver) = &self.import_rx else {
+            return;
+        };
+        let Ok(choice) = receiver.try_recv() else {
+            return;
+        };
+        self.import_rx = None;
+        let Some(source) = choice else { return };
+        let summary = crate::paper_home::consolidate_into(&self.dir, &[source]);
+        self.show_toast(crate::paper_home::import_toast(&summary));
+        self.history_cache = None;
+        if self.report_open {
+            self.reload_report();
+        }
     }
 
     // ------------------------------------------------------------------
@@ -4272,7 +4335,7 @@ pub(crate) fn fmt_signed_points(value: Decimal) -> String {
 /// Keep the characters real venue symbols use (`WDO$`, `WIN@N`… stay
 /// recognizable); anything else becomes `_` so a symbol can never traverse
 /// paths.
-fn sanitize_symbol(symbol: &str) -> String {
+pub(crate) fn sanitize_symbol(symbol: &str) -> String {
     let cleaned: String = symbol
         .chars()
         .map(|character| {
@@ -4432,12 +4495,16 @@ fn elide_path(path: &Path) -> String {
     })
 }
 
-/// The trades folder before the environment has its say: the user's own
-/// in-app pick when one is stored, else the configured base.
-fn chosen_trades_dir(configured: &str, stored: Option<&str>) -> PathBuf {
-    stored
-        .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from(configured))
+/// A journal folder of its own per host under test — tests must never
+/// touch a real documents folder, nor see one another's files.
+fn test_scratch_dir() -> PathBuf {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static NEXT: AtomicU64 = AtomicU64::new(0);
+    std::env::temp_dir().join(format!(
+        "quantick-paper-host-{}-{}",
+        std::process::id(),
+        NEXT.fetch_add(1, Ordering::Relaxed)
+    ))
 }
 
 /// The symbol folders under the history dir, for the report's combo box.
@@ -4538,6 +4605,60 @@ mod tests {
     }
 
     #[test]
+    fn a_second_session_adds_a_file_and_never_touches_the_first() {
+        let dir = std::env::temp_dir().join(format!(
+            "quantick-paper-accumulate-test-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        // Session one: a round trip closing at t=2s.
+        let mut first = PaperTrading::new();
+        first.dir.clone_from(&dir);
+        first.set_symbol("ACCUM");
+        first.seed(&print(0, 100));
+        first.market(Side::Buy);
+        first.on_trade(&print(1, 100));
+        let events = first.sim.apply(Command::ClosePosition);
+        first.handle_events(events);
+        first.on_trade(&print(2, 103));
+        let folder = dir.join("ACCUM");
+        let first_file = std::fs::read_dir(&folder)
+            .expect("the symbol folder exists")
+            .flatten()
+            .next()
+            .expect("one session file")
+            .path();
+        let first_bytes = std::fs::read(&first_file).expect("readable");
+
+        // Session two: a fresh host — a restart — closing hours later.
+        let mut second = PaperTrading::new();
+        second.dir.clone_from(&dir);
+        second.set_symbol("ACCUM");
+        second.seed(&print(10_000, 200));
+        second.market(Side::Sell);
+        second.on_trade(&print(10_001, 200));
+        let events = second.sim.apply(Command::ClosePosition);
+        second.handle_events(events);
+        second.on_trade(&print(10_002, 190));
+
+        let files: Vec<_> = std::fs::read_dir(&folder)
+            .expect("the symbol folder exists")
+            .flatten()
+            .collect();
+        assert_eq!(files.len(), 2, "each session opens its own file");
+        assert_eq!(
+            std::fs::read(&first_file).expect("still readable"),
+            first_bytes,
+            "the earlier session's file is byte-for-byte untouched"
+        );
+        let history = load_history(&dir, Some("ACCUM"), None);
+        assert_eq!(history.files, 2);
+        assert_eq!(history.rows.len(), 2, "both sessions' trades load");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
     fn a_timeline_reset_journals_the_flatten_and_clears_the_form_state() {
         let dir =
             std::env::temp_dir().join(format!("quantick-paper-reset-test-{}", std::process::id()));
@@ -4569,19 +4690,8 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
-    #[test]
-    fn the_stored_pick_beats_the_configured_base() {
-        assert_eq!(
-            chosen_trades_dir("paper-trades", None),
-            PathBuf::from("paper-trades"),
-            "no pick falls back to the configured base"
-        );
-        assert_eq!(
-            chosen_trades_dir("paper-trades", Some("D:/journals")),
-            PathBuf::from("D:/journals"),
-            "the in-app pick wins over the configured base"
-        );
-    }
+    // The stored-pick-vs-configured-base precedence now lives in
+    // `paper_home::chosen`, tested there beside the documents default.
 
     /// The panel's folder picker retargets everything downstream: the next
     /// close opens a new session file under the new home, and the ledger

--- a/crates/app/src/paper_trading.rs
+++ b/crates/app/src/paper_trading.rs
@@ -623,6 +623,15 @@ pub struct PaperTrading {
     dir: PathBuf,
     /// Current session file, named after the first closed trade.
     journal_path: Option<PathBuf>,
+    /// Every file this host has journaled to. The ledger excludes them
+    /// all — their trades are still in the simulator, which keeps closed
+    /// trades across every retarget; excluding only the current file
+    /// double-counted after a symbol or source switch.
+    session_journal_paths: Vec<PathBuf>,
+    /// The session source each of the simulator's closed trades closed
+    /// under, index-aligned with `sim.closed_trades()` — the export must
+    /// not stamp a pre-switch trade with the current source.
+    session_trade_sources: Vec<history::SessionSource>,
     /// A failed journal write warns once, not once per trade.
     journal_warned: bool,
     /// Where this session's trades come from — the tab's feed sets it,
@@ -727,6 +736,8 @@ impl PaperTrading {
             symbol: String::new(),
             dir,
             journal_path: None,
+            session_journal_paths: Vec::new(),
+            session_trade_sources: Vec::new(),
             journal_warned: false,
             session_source: history::SessionSource::Live,
             cmd_trading: CmdTradingSettings::default(),
@@ -801,6 +812,12 @@ impl PaperTrading {
         self.history_cache = None;
         self.report = None;
         self.report_view = None;
+        if self.report_open {
+            // An open report must answer for the new folder now — cleared
+            // caches alone left it claiming "no saved trades" until a
+            // manual refresh.
+            self.reload_report();
+        }
         self.show_toast(format!("SIM: trades now save to {}", elide_path(&self.dir)));
     }
 
@@ -923,19 +940,25 @@ impl PaperTrading {
         let had_position = self.sim.position().is_some();
         let had_orders = !self.sim.orders().is_empty() || !self.sim.queued().is_empty();
         let events = self.sim.reset();
+        let mut all_saved = true;
         for event in &events {
             if let SimEvent::Closed(trade) = event {
-                self.journal(&trade.clone());
+                all_saved &= self.journal(&trade.clone());
             }
         }
+        // A reset ends the tape session, so it ends the file session too:
+        // the next close opens a fresh file (same venue stamp lands as
+        // `.rerun-N`). Without this, replaying the same recording again
+        // without leaving replay appended run 2 into run 1's file.
+        self.journal_path = None;
         self.armed = None;
         self.drag = PaperDrag::None;
         self.drag_price = None;
-        if had_position {
+        if had_position && all_saved {
             self.show_toast(
                 "SIM position flattened - the timeline was rebuilt under it.".to_owned(),
             );
-        } else if had_orders {
+        } else if had_orders && all_saved {
             self.show_toast(
                 "SIM orders cancelled - the timeline was rebuilt under them.".to_owned(),
             );
@@ -1346,7 +1369,19 @@ impl PaperTrading {
             return;
         }
         let color = side_color(preview.side);
-        let (start, end, label) = cmd_preview_layout(ctx.chart_rect, preview.y);
+        // Lay out against the band the input hit-tests (its right edge is
+        // the lane divider when the live tape lane is up), never the full
+        // chart rect — a label painted right of the divider would be a
+        // click target the press could not find (the overlay-controls
+        // rule).
+        let band = egui::Rect::from_min_max(
+            ctx.chart_rect.min,
+            egui::pos2(
+                ctx.tag_right.min(ctx.chart_rect.right()),
+                ctx.chart_rect.max.y,
+            ),
+        );
+        let (start, end, label) = cmd_preview_layout(band, preview.y);
         let width = if preview.hover {
             LINE_HOVER_WIDTH_PX
         } else {
@@ -2668,11 +2703,7 @@ impl PaperTrading {
             ReportScope::Symbol => Some(self.symbol.as_str()),
             ReportScope::All => None,
         };
-        self.history_cache = Some(load_history(
-            &self.dir,
-            symbol,
-            self.journal_path.as_deref(),
-        ));
+        self.history_cache = Some(load_history(&self.dir, symbol, &self.session_journal_paths));
     }
 
     /// The Trades dock tab: the ledger of closed simulated trades — the
@@ -2929,7 +2960,7 @@ impl PaperTrading {
     }
 
     fn reload_report(&mut self) {
-        self.report = Some(load_history(&self.dir, self.report_symbol.as_deref(), None));
+        self.report = Some(load_history(&self.dir, self.report_symbol.as_deref(), &[]));
         self.report_view = None;
         self.report_symbols = list_symbol_folders(&self.dir);
     }
@@ -3031,14 +3062,24 @@ impl PaperTrading {
                             .as_deref()
                             .unwrap_or("any symbol")
                             .to_owned();
-                        ui.label(
-                            egui::RichText::new(format!(
+                        let hidden_by_source = self
+                            .report_view
+                            .as_ref()
+                            .map_or(0, |view| view.hidden_by_source);
+                        let text = if hidden_by_source > 0 {
+                            // The trades exist; the one control that would
+                            // reveal them must be named, not implied.
+                            format!(
+                                "{scope} has {hidden_by_source} trade(s) behind the Source \
+                                 filter. Try Source \"Both\".",
+                            )
+                        } else {
+                            format!(
                                 "{scope} has no trades in {}. Try \"All\", or another symbol.",
                                 self.report_period.phrase(),
-                            ))
-                            .color(theme::TEXT_SUPPORT)
-                            .small(),
-                        );
+                            )
+                        };
+                        ui.label(egui::RichText::new(text).color(theme::TEXT_SUPPORT).small());
                         let default_symbol = (!self.symbol.is_empty()).then(|| self.symbol.clone());
                         if (self.report_period != ReportPeriod::All
                             || self.report_symbol != default_symbol)
@@ -3049,6 +3090,7 @@ impl PaperTrading {
                         {
                             self.report_symbol = default_symbol;
                             self.report_period = ReportPeriod::All;
+                            self.report_source = SourceFilter::Real;
                             reload = true;
                         }
                     }
@@ -3212,7 +3254,7 @@ impl PaperTrading {
                     let mut text = format!(
                         "{} up to {} (newest saved trade, not the wall clock)",
                         view.period.phrase(),
-                        fmt_utc_date(anchor),
+                        fmt_offset_date(anchor, view.tz),
                     );
                     if view.hidden_before > 0 {
                         // "Where did my old trades go" gets a literal
@@ -3230,6 +3272,11 @@ impl PaperTrading {
                     }
                     text
                 }
+                None if view.hidden_by_source > 0 => format!(
+                    "no saved trades in this scope - {} trade(s) sit behind the Source \
+                     filter (try Both)",
+                    view.hidden_by_source,
+                ),
                 None => "no saved trades in this scope".to_owned(),
             };
             ui.label(egui::RichText::new(text).color(theme::TEXT_SUPPORT).small());
@@ -3345,11 +3392,24 @@ impl PaperTrading {
         if let Some(cache) = &self.history_cache {
             rows.extend(cache.rows.iter().cloned());
         }
-        rows.extend(self.sim.closed_trades().iter().map(|trade| HistoryRow {
-            symbol: self.symbol.clone(),
-            source: Some(self.session_source),
-            trade: trade.clone(),
-        }));
+        rows.extend(
+            self.sim
+                .closed_trades()
+                .iter()
+                .enumerate()
+                .map(|(index, trade)| HistoryRow {
+                    symbol: self.symbol.clone(),
+                    // The source the trade actually closed under — the
+                    // session may have flipped live/replay since.
+                    source: Some(
+                        self.session_trade_sources
+                            .get(index)
+                            .copied()
+                            .unwrap_or(self.session_source),
+                    ),
+                    trade: trade.clone(),
+                }),
+        );
         rows.sort_by_key(|row| (row.trade.closed_ms, row.trade.opened_ms));
         if rows.is_empty() {
             self.show_toast("SIM: nothing to export yet - close a trade first.".to_owned());
@@ -3435,7 +3495,7 @@ impl PaperTrading {
                     }
                 }
                 SimEvent::Closed(trade) => {
-                    self.journal(&trade);
+                    let saved = self.journal(&trade);
                     if self.report_open {
                         // The report reads from disk and the close just
                         // wrote to disk; re-read now or the window shows
@@ -3443,13 +3503,17 @@ impl PaperTrading {
                         // trade is missing" report.
                         self.reload_report();
                     }
-                    self.show_toast(format!(
-                        "SIM closed: {} {} → {} pts ({})",
-                        position_word(trade.side),
-                        fmt_decimal(trade.quantity),
-                        fmt_signed_points(trade.pnl_points),
-                        trade.exit_reason.as_str().replace('_', " "),
-                    ));
+                    // The toast slot holds one message: a healthy "closed"
+                    // must not paint over the could-not-save warning.
+                    if saved {
+                        self.show_toast(format!(
+                            "SIM closed: {} {} → {} pts ({})",
+                            position_word(trade.side),
+                            fmt_decimal(trade.quantity),
+                            fmt_signed_points(trade.pnl_points),
+                            trade.exit_reason.as_str().replace('_', " "),
+                        ));
+                    }
                 }
                 _ => {}
             }
@@ -3457,16 +3521,23 @@ impl PaperTrading {
     }
 
     /// Append one closed trade to the session's history file, creating the
-    /// file (with its header) on the first close. A failed write warns once
-    /// and never crashes a trading session.
-    fn journal(&mut self, trade: &ClosedTrade) {
+    /// file (with its header) on the first close. Also records the source
+    /// the trade closed under, for the export. Returns whether the write
+    /// landed — a failed write warns once and never crashes a trading
+    /// session, but its caller must not paint a healthy toast over the
+    /// warning.
+    fn journal(&mut self, trade: &ClosedTrade) -> bool {
+        self.session_trade_sources.push(self.session_source);
         if self.symbol.is_empty() {
-            return;
+            return false;
         }
         let folder = self.dir.join(sanitize_symbol(&self.symbol));
         let path = self
             .journal_path
             .get_or_insert_with(|| free_session_path(&folder, &utc_compact(trade.closed_ms)));
+        if self.session_journal_paths.last() != Some(path) {
+            self.session_journal_paths.push(path.clone());
+        }
         let mut text = String::new();
         if !path.exists() {
             text.push_str(&history::write_header(&self.symbol, self.session_source));
@@ -3480,7 +3551,7 @@ impl PaperTrading {
                 .open(&*path)
                 .and_then(|mut file| file.write_all(text.as_bytes()))
         });
-        if let Err(error) = written
+        if let Err(error) = &written
             && !self.journal_warned
         {
             self.journal_warned = true;
@@ -3497,6 +3568,7 @@ impl PaperTrading {
                 "SIM: could not save the trade history - see the log for the path.".to_owned(),
             );
         }
+        written.is_ok()
     }
 
     fn parse_quantity(&mut self) -> Option<Decimal> {
@@ -4172,10 +4244,10 @@ fn draw_exit_reason_grid(ui: &mut egui::Ui, report: &PerformanceReport) {
 }
 
 /// Read every history file under `dir` (one symbol's folder, or all of
-/// them), remembering each row's symbol and skipping `exclude` (the live
-/// session's own file — its trades are already in the simulator). Missing
-/// folders are simply empty, not an error.
-fn load_history(dir: &Path, symbol: Option<&str>, exclude: Option<&Path>) -> LoadedHistory {
+/// them), remembering each row's symbol and skipping every path in
+/// `exclude` (the live session's own files — their trades are already in
+/// the simulator). Missing folders are simply empty, not an error.
+fn load_history(dir: &Path, symbol: Option<&str>, exclude: &[PathBuf]) -> LoadedHistory {
     let mut folders = Vec::new();
     match symbol {
         Some(symbol) => folders.push(dir.join(sanitize_symbol(symbol))),
@@ -4213,7 +4285,7 @@ fn load_history(dir: &Path, symbol: Option<&str>, exclude: Option<&Path>) -> Loa
             .collect();
         paths.sort();
         for path in paths {
-            if exclude.is_some_and(|exclude| exclude == path) {
+            if exclude.contains(&path) {
                 continue;
             }
             files += 1;
@@ -5004,8 +5076,17 @@ fn utc_compact(timestamp_ms: i64) -> String {
 }
 
 /// `YYYY-MM-DD` in UTC — the report's anchor date.
+#[cfg(test)]
 fn fmt_utc_date(timestamp_ms: i64) -> String {
     let (year, month, day, ..) = civil_utc(timestamp_ms);
+    format!("{year:04}-{month:02}-{day:02}")
+}
+
+/// `YYYY-MM-DD` in the display timezone — the anchor date on the same
+/// calendar every other trade surface shows; a UTC date here named a day
+/// no displayed trade carried for anyone west of Greenwich after 21:00.
+fn fmt_offset_date(timestamp_ms: i64, tz: TzOffset) -> String {
+    let (year, month, day, ..) = civil_utc(timestamp_ms.saturating_add(tz.offset_ms()));
     format!("{year:04}-{month:02}-{day:02}")
 }
 
@@ -5281,7 +5362,7 @@ mod tests {
         assert_eq!(parsed.trades[0].pnl_points, Decimal::from(5));
         assert_eq!(parsed.trades[1].pnl_points, Decimal::from(2));
 
-        let history = load_history(&dir, Some("TESTUSDT"), None);
+        let history = load_history(&dir, Some("TESTUSDT"), &[]);
         assert_eq!(history.rows.len(), 2);
         assert_eq!(report_from_history(&history).net_points, Decimal::from(7));
         assert_eq!(history.files, 1);
@@ -5337,7 +5418,7 @@ mod tests {
             first_bytes,
             "the earlier session's file is byte-for-byte untouched"
         );
-        let history = load_history(&dir, Some("ACCUM"), None);
+        let history = load_history(&dir, Some("ACCUM"), &[]);
         assert_eq!(history.files, 2);
         assert_eq!(history.rows.len(), 2, "both sessions' trades load");
 
@@ -5366,7 +5447,7 @@ mod tests {
             "an armed click dies with the timeline"
         );
         assert!(paper.toast.is_some(), "the flatten is never silent");
-        let history = load_history(&dir, Some("RESETX"), None);
+        let history = load_history(&dir, Some("RESETX"), &[]);
         assert_eq!(history.rows.len(), 1);
         assert_eq!(
             report_from_history(&history).trades,
@@ -5515,7 +5596,7 @@ mod tests {
             "the second run opened its own file instead of appending duplicates"
         );
         assert!(names[1].contains(".rerun-1."), "{names:?}");
-        let history = load_history(&dir, Some("RERUN"), None);
+        let history = load_history(&dir, Some("RERUN"), &[]);
         assert_eq!(history.rows.len(), 2);
         assert!(
             history
@@ -5525,6 +5606,78 @@ mod tests {
             "both files carry the replay source"
         );
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn the_ledger_never_lists_this_sessions_trades_twice_after_a_retarget() {
+        // Hunt-confirmed: close live, flip to replay (what a same-symbol
+        // replay open does), reload the ledger — the live session's file
+        // must stay excluded, or every trade counts twice in the totals
+        // and the export.
+        let mut paper = PaperTrading::new();
+        paper.set_symbol("DUPX");
+        paper.seed(&print(0, 100));
+        paper.market(Side::Buy);
+        paper.on_trade(&print(1, 100));
+        let events = paper.sim.apply(Command::ClosePosition);
+        paper.handle_events(events);
+        paper.on_trade(&print(2, 105));
+        assert_eq!(paper.sim.closed_trades().len(), 1);
+
+        paper.set_session_source(history::SessionSource::Replay);
+        paper.on_timeline_reset();
+        paper.reload_ledger();
+        let cache = paper.history_cache.as_ref().expect("loaded");
+        assert_eq!(
+            cache.rows.len(),
+            0,
+            "the session's own files stay excluded across the retarget"
+        );
+    }
+
+    #[test]
+    fn an_in_session_rerun_opens_its_own_file() {
+        // Seek-to-start / reopen-same-recording is a timeline reset with
+        // the source unchanged: run 2 must not append into run 1's file.
+        let mut paper = PaperTrading::new();
+        paper.set_symbol("RESEEK");
+        paper.set_session_source(history::SessionSource::Replay);
+        for _ in 0..2 {
+            paper.seed(&print(0, 100));
+            paper.market(Side::Buy);
+            paper.on_trade(&print(1, 100));
+            let events = paper.sim.apply(Command::ClosePosition);
+            paper.handle_events(events);
+            paper.on_trade(&print(2, 103));
+            paper.on_timeline_reset();
+        }
+        let folder = paper.dir.join("RESEEK");
+        let mut names: Vec<String> = std::fs::read_dir(&folder)
+            .expect("the symbol folder exists")
+            .flatten()
+            .filter_map(|entry| entry.file_name().to_str().map(str::to_owned))
+            .collect();
+        names.sort();
+        assert_eq!(names.len(), 2, "each run has its own file: {names:?}");
+        assert!(names[1].contains(".rerun-1."), "{names:?}");
+    }
+
+    #[test]
+    fn export_rows_remember_the_source_each_trade_closed_under() {
+        let mut paper = PaperTrading::new();
+        paper.set_symbol("SRCX");
+        paper.seed(&print(0, 100));
+        paper.market(Side::Buy);
+        paper.on_trade(&print(1, 100));
+        let events = paper.sim.apply(Command::ClosePosition);
+        paper.handle_events(events);
+        paper.on_trade(&print(2, 105));
+        paper.set_session_source(history::SessionSource::Replay);
+        assert_eq!(
+            paper.session_trade_sources,
+            vec![history::SessionSource::Live],
+            "a trade keeps the source it closed under, not the current one"
+        );
     }
 
     #[test]
@@ -5803,11 +5956,11 @@ mod tests {
             vec!["AAAUSDT".to_owned(), "BBBUSDT".to_owned()],
             "the combo lists every traded asset"
         );
-        let all = load_history(&dir, None, None);
+        let all = load_history(&dir, None, &[]);
         assert_eq!(all.rows.len(), 2, "All symbols reads both journals");
         let symbols: Vec<&str> = all.rows.iter().map(|row| row.symbol.as_str()).collect();
         assert_eq!(symbols, vec!["AAAUSDT", "BBBUSDT"]);
-        let one = load_history(&dir, Some("BBBUSDT"), None);
+        let one = load_history(&dir, Some("BBBUSDT"), &[]);
         assert_eq!(one.rows.len(), 1, "a symbol scope reads only its folder");
         assert_eq!(one.rows[0].symbol, "BBBUSDT");
 

--- a/crates/app/src/paper_trading.rs
+++ b/crates/app/src/paper_trading.rs
@@ -129,6 +129,26 @@ const CUSTOM_PERIOD_FIELD_PX: f32 = 44.0;
 /// How many `.rerun-N` session names one venue-time stamp may try — far
 /// beyond any real journal, a backstop against a pathological folder.
 const MAX_SESSION_RERUNS: usize = 999;
+/// `=buy`/`=sell` forces the cmd-trading preview for a capture run — the
+/// held modifier is the one input a run with nobody at the keyboard
+/// cannot supply (the ParkedHand rule).
+const CMD_PREVIEW_ENV: &str = "QUANTICK_CMD_PREVIEW";
+/// Cmd-trading preview line, as a fraction of the chart width…
+const CMD_LINE_FRACTION: f32 = 0.2;
+/// …no shorter than this (a narrow pane must still show a line)…
+const CMD_LINE_MIN_PX: f32 = 120.0;
+/// …and no longer than this (a wide chart must not paint a bar across
+/// half the plot). Whether fraction or fixed reads better is a
+/// trader-ux-review question; the clamp serves both answers.
+const CMD_LINE_MAX_PX: f32 = 320.0;
+/// The preview label's fixed width: paint and press share this exact
+/// rect, so the two can never disagree (the overlay-controls rule).
+const CMD_LABEL_WIDTH_PX: f32 = 116.0;
+/// Gap between the label and the left end of its line.
+const CMD_LABEL_GAP_PX: f32 = 6.0;
+/// The label's fill while the pointer is elsewhere; hover paints it full,
+/// so the brightening itself says "clickable".
+const CMD_LABEL_RESTING_ALPHA: f32 = 0.72;
 /// The grids' readable floor inside a squeezed window.
 const REPORT_GRID_MIN_H_PX: f32 = 80.0;
 /// Width of the equity curve's y-tick gutter.
@@ -432,6 +452,9 @@ pub enum TradingTabAction {
     /// app-wide (every tab journals there) and remembered, so the app
     /// owns the dialog and the fan-out.
     PickTradesDir,
+    /// Cmd-trading settings changed — app-wide like the trades dir: the
+    /// app persists them and fans them out to every tab.
+    CmdTradingChanged,
 }
 
 /// What the Trades ledger asked of its host.
@@ -472,6 +495,120 @@ pub struct ChartInput<'a> {
     pub primary_pressed: bool,
     pub primary_down: bool,
     pub primary_released: bool,
+    /// The frame's held modifiers — what the cmd-trading gesture reads.
+    pub modifiers: egui::Modifiers,
+}
+
+/// A modifier key the cmd-trading gesture can bind to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CmdModifier {
+    Shift,
+    Ctrl,
+    Alt,
+}
+
+impl CmdModifier {
+    /// Every binding the selectors offer.
+    pub const ALL: [Self; 3] = [Self::Shift, Self::Ctrl, Self::Alt];
+
+    /// Stable token for the state file.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Shift => "shift",
+            Self::Ctrl => "ctrl",
+            Self::Alt => "alt",
+        }
+    }
+
+    /// The inverse of [`Self::as_str`]; unknown tokens are refused.
+    #[must_use]
+    pub fn parse(token: &str) -> Option<Self> {
+        match token {
+            "shift" => Some(Self::Shift),
+            "ctrl" => Some(Self::Ctrl),
+            "alt" => Some(Self::Alt),
+            _ => None,
+        }
+    }
+
+    /// Display label for the selector.
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Shift => "Shift",
+            Self::Ctrl => "Ctrl",
+            Self::Alt => "Alt",
+        }
+    }
+
+    /// Whether the key is held. `Ctrl` reads the platform command key, so
+    /// the binding keeps meaning "the control-ish key" on every OS.
+    fn is_down(self, modifiers: egui::Modifiers) -> bool {
+        match self {
+            Self::Shift => modifiers.shift,
+            Self::Ctrl => modifiers.command,
+            Self::Alt => modifiers.alt,
+        }
+    }
+}
+
+/// Cmd trading: hold a key over the chart and a dashed line shows exactly
+/// where the order will rest; click its label to place. Safer than the
+/// right-click menu because the price is visible before anything commits.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CmdTradingSettings {
+    pub enabled: bool,
+    pub buy: CmdModifier,
+    pub sell: CmdModifier,
+}
+
+impl Default for CmdTradingSettings {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            buy: CmdModifier::Shift,
+            sell: CmdModifier::Ctrl,
+        }
+    }
+}
+
+impl CmdTradingSettings {
+    /// The settings the sidecar remembers, with the defaults wherever it
+    /// never spoke — or spoke a token this build does not know.
+    #[must_use]
+    pub(crate) fn from_state(state: &crate::paper_state::PaperState) -> Self {
+        let defaults = Self::default();
+        Self {
+            enabled: state.cmd_trading_enabled.unwrap_or(defaults.enabled),
+            buy: state
+                .cmd_buy_modifier
+                .as_deref()
+                .and_then(CmdModifier::parse)
+                .unwrap_or(defaults.buy),
+            sell: state
+                .cmd_sell_modifier
+                .as_deref()
+                .and_then(CmdModifier::parse)
+                .unwrap_or(defaults.sell),
+        }
+    }
+}
+
+/// The frame's cmd-trading preview: computed by `handle_chart_input`,
+/// painted by `draw_layer`, clicked through the same geometry.
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct CmdPreview {
+    side: Side,
+    kind: EntryKind,
+    /// Snapped price, for the label and the gutter chip.
+    price: Decimal,
+    /// Raw pointer price — what a click hands to `place_resting`, which
+    /// snaps for itself (the armed-click path's contract).
+    raw_price: f64,
+    y: f32,
+    /// Pointer on the label — highlight, hand cursor, click places.
+    hover: bool,
 }
 
 /// The app-side paper-trading host: simulator, order-entry form state,
@@ -488,6 +625,15 @@ pub struct PaperTrading {
     /// Where this session's trades come from — the tab's feed sets it,
     /// the journal header records it.
     session_source: history::SessionSource,
+    /// Cmd trading: the toggle and its two key bindings (app-wide; the
+    /// app persists and fans out changes).
+    cmd_trading: CmdTradingSettings,
+    /// This frame's cmd preview — input computes, paint reads, one
+    /// geometry both sides.
+    cmd_preview: Option<CmdPreview>,
+    /// Harness override: paint the preview for this side with nobody at
+    /// the keyboard (`QUANTICK_CMD_PREVIEW`).
+    cmd_preview_force: Option<Side>,
     // Order-entry form.
     qty_text: String,
     order_type: EntryKind,
@@ -580,6 +726,24 @@ impl PaperTrading {
             journal_path: None,
             journal_warned: false,
             session_source: history::SessionSource::Live,
+            cmd_trading: CmdTradingSettings::default(),
+            cmd_preview: None,
+            cmd_preview_force: std::env::var(CMD_PREVIEW_ENV).ok().and_then(|value| {
+                match value.as_str() {
+                    "buy" => Some(Side::Buy),
+                    "sell" => Some(Side::Sell),
+                    other => {
+                        tracing::warn!(
+                            target: "quantick::app",
+                            schema_version = 1_u8,
+                            event_code = "CMD_PREVIEW_AUTOSTART_UNKNOWN",
+                            value = %other,
+                            "QUANTICK_CMD_PREVIEW wants `buy` or `sell`"
+                        );
+                        None
+                    }
+                }
+            }),
             qty_text: "1".to_owned(),
             order_type: EntryKind::Market,
             stop_offset_text: String::new(),
@@ -644,6 +808,27 @@ impl PaperTrading {
     pub(crate) fn apply_sim_command_for_tests(&mut self, command: Command) {
         let events = self.sim.apply(command);
         self.handle_events(events);
+    }
+
+    /// The cmd-trading settings, for the app to persist.
+    #[must_use]
+    pub fn cmd_trading(&self) -> CmdTradingSettings {
+        self.cmd_trading
+    }
+
+    /// Install cmd-trading settings — the app's fan-out on boot and on a
+    /// change made in any tab (one gesture, one meaning, everywhere).
+    pub fn set_cmd_trading(&mut self, settings: CmdTradingSettings) {
+        self.cmd_trading = settings;
+        if !settings.enabled {
+            self.cmd_preview = None;
+        }
+    }
+
+    /// Drop the frame's preview — the pane calls this when a drawing tool
+    /// owns the hand, so a stale line never keeps painting.
+    pub fn clear_cmd_preview(&mut self) {
+        self.cmd_preview = None;
     }
 
     /// Follow the tab's feed: a session is wholly live or wholly a
@@ -1134,6 +1319,72 @@ impl PaperTrading {
                 theme::ACCENT,
             );
         }
+
+        // On top of every order line: the cmd preview is the thing being
+        // aimed right now.
+        self.draw_cmd_preview(&ctx);
+    }
+
+    /// The cmd-trading preview: a short dashed line at the pointer's
+    /// price, hugging the right edge, with the clickable label off its
+    /// left end and the exact price on the gutter — the trader reads
+    /// where the order will rest *before* anything commits, which is the
+    /// safety the right-click menu cannot offer.
+    fn draw_cmd_preview(&self, ctx: &PaintCtx<'_>) {
+        let Some(preview) = self.cmd_preview else {
+            return;
+        };
+        // Only the pane that owns paper input paints the aim — except in
+        // a harness run, whose panes never own a pointer at all.
+        if ctx.pointer.is_none() && self.cmd_preview_force.is_none() {
+            return;
+        }
+        if !ctx.in_range(preview.y) {
+            return;
+        }
+        let color = side_color(preview.side);
+        let (start, end, label) = cmd_preview_layout(ctx.chart_rect, preview.y);
+        let width = if preview.hover {
+            LINE_HOVER_WIDTH_PX
+        } else {
+            LINE_WIDTH_PX
+        };
+        ctx.painter.extend(egui::Shape::dashed_line(
+            &[start, end],
+            egui::Stroke::new(width, color),
+            ORDER_DASH_PX,
+            ORDER_GAP_PX,
+        ));
+        ctx.gutter_chip(preview.y, color, &fmt_decimal(preview.price));
+        // The label: fixed geometry (paint and press share it), hover
+        // brightens the fill — the click target must say it is one.
+        let fill = if preview.hover {
+            color
+        } else {
+            color.gamma_multiply(CMD_LABEL_RESTING_ALPHA)
+        };
+        ctx.painter
+            .rect_filled(label, egui::Rounding::same(3.0), fill);
+        let quantity = self
+            .quantity_preview()
+            .map_or_else(|| "?".to_owned(), fmt_decimal);
+        let text = format!(
+            "{} {} {}",
+            side_word_upper(preview.side),
+            kind_word(preview.kind),
+            quantity,
+        );
+        let galley =
+            ctx.painter
+                .layout_no_wrap(text, egui::FontId::monospace(11.0), theme::CHIP_INK);
+        ctx.painter.galley(
+            egui::pos2(
+                label.center().x - galley.size().x / 2.0,
+                label.center().y - galley.size().y / 2.0,
+            ),
+            galley,
+            theme::CHIP_INK,
+        );
     }
 
     /// One protective leg: its resting line and tag, the drag that reprices
@@ -1223,6 +1474,10 @@ impl PaperTrading {
     }
 
     pub fn handle_chart_input(&mut self, input: &ChartInput<'_>) -> bool {
+        // The cmd preview is a per-frame fact: recomputed here, painted by
+        // `draw_layer`, and cleared the instant the key lifts.
+        self.cmd_preview = self.compute_cmd_preview(input);
+
         // An overlay control (a tag's ✕, a bracket handle) takes the press
         // before *everything*: before the armed click — arming an order must
         // never eat the ✕ under the pointer — and before the line grab,
@@ -1253,6 +1508,18 @@ impl PaperTrading {
                     self.drag_price = Some(scale.price_at(pointer.y));
                 }
             }
+            return true;
+        }
+
+        // The preview's label takes the press after the ✕s (they are
+        // rarer and smaller) and before everything else: clicking it *is*
+        // the gesture.
+        if input.primary_pressed
+            && self.drag == PaperDrag::None
+            && let Some(preview) = self.cmd_preview
+            && preview.hover
+        {
+            self.place_resting(preview.side, preview.kind, preview.raw_price);
             return true;
         }
 
@@ -1411,6 +1678,56 @@ impl PaperTrading {
         None
     }
 
+    /// The preview the pointer and the held key describe this frame;
+    /// `None` hides the overlay. Both keys down at once is ambiguous and
+    /// shows nothing — so a shared binding degrades to "off", never to a
+    /// wrong side.
+    fn compute_cmd_preview(&self, input: &ChartInput<'_>) -> Option<CmdPreview> {
+        if !self.cmd_trading.enabled {
+            return None;
+        }
+        let scale = input.scale?;
+        let (pointer, side) = match self.cmd_preview_force {
+            // The harness has no hand; park the pointer mid-chart.
+            Some(side) => (input.pointer.unwrap_or(input.chart.center()), side),
+            None => {
+                let pointer = input.pointer?;
+                let buy = self.cmd_trading.buy.is_down(input.modifiers);
+                let sell = self.cmd_trading.sell.is_down(input.modifiers);
+                let side = match (buy, sell) {
+                    (true, false) => Side::Buy,
+                    (false, true) => Side::Sell,
+                    _ => return None,
+                };
+                (pointer, side)
+            }
+        };
+        if !input.chart.contains(pointer) {
+            return None;
+        }
+        let mark = self.sim.mark_price()?;
+        let raw_price = scale.price_at(pointer.y);
+        let price = self.snap(raw_price);
+        // The context menu's own validity table: above the mark a buy
+        // stops in, below it a buy waits at a limit; a sell mirrors. On
+        // the mark exactly nothing can rest.
+        let kind = match (price > mark, price < mark, side) {
+            (true, _, Side::Buy) | (_, true, Side::Sell) => EntryKind::Stop,
+            (true, _, Side::Sell) | (_, true, Side::Buy) => EntryKind::Limit,
+            _ => return None,
+        };
+        let (_, _, label) = cmd_preview_layout(input.chart, pointer.y);
+        let hover = input.pointer.is_some_and(|pointer| label.contains(pointer));
+        Some(CmdPreview {
+            side,
+            kind,
+            price,
+            raw_price,
+            y: pointer.y,
+            hover,
+        })
+    }
+
     /// Turn a pending entry-line press into the leg the pull chose, once it
     /// travelled far enough to mean it.
     fn decide_pending_leg(&mut self, pointer_y: f32, scale: &PriceScale) {
@@ -1456,6 +1773,11 @@ impl PaperTrading {
         scale: &PriceScale,
     ) -> Option<egui::CursorIcon> {
         if self.control_at(pointer, chart, scale).is_some() {
+            return Some(egui::CursorIcon::PointingHand);
+        }
+        // The cmd preview's label announces its click like every painted
+        // control.
+        if self.cmd_preview.is_some_and(|preview| preview.hover) {
             return Some(egui::CursorIcon::PointingHand);
         }
         match self.line_at(pointer, scale)? {
@@ -1646,11 +1968,17 @@ impl PaperTrading {
 
         self.draw_position_card(ui);
         ui.separator();
-        self.draw_order_entry(ui);
+        let cmd_changed = self.draw_order_entry(ui);
         ui.separator();
         self.draw_pending_orders(ui);
         ui.separator();
-        self.draw_session_summary(ui)
+        let action = self.draw_session_summary(ui);
+        if action.is_none() && cmd_changed {
+            // Same-frame collision with another action is a picker click;
+            // the settings change persists on its next touch.
+            return Some(TradingTabAction::CmdTradingChanged);
+        }
+        action
     }
 
     /// A quiet action button — the HUD's control grammar, sized to share a
@@ -1925,7 +2253,7 @@ impl PaperTrading {
         }
     }
 
-    fn draw_order_entry(&mut self, ui: &mut egui::Ui) {
+    fn draw_order_entry(&mut self, ui: &mut egui::Ui) -> bool {
         ui.label(caption("ORDER"));
         // Qty: free decimal text (empty must keep meaning "fix me"), with
         // steppers beside it; Shift steps by ten.
@@ -2063,6 +2391,69 @@ impl PaperTrading {
             .color(theme::TEXT_SUPPORT)
             .small(),
         );
+        self.draw_cmd_trading_settings(ui)
+    }
+
+    /// The cmd-trading block of the ticket: the enable pill and the two
+    /// key bindings. Returns whether anything changed, so the host can
+    /// persist and fan out.
+    fn draw_cmd_trading_settings(&mut self, ui: &mut egui::Ui) -> bool {
+        let mut changed = false;
+        ui.add_space(4.0);
+        ui.label(caption("CMD TRADING"));
+        ui.horizontal(|ui| {
+            if pill_toggle(
+                ui,
+                "Enabled",
+                self.cmd_trading.enabled,
+                "hold a key over the chart: a dashed line shows exactly where the order \
+                 will rest - click its label to place it",
+            )
+            .clicked()
+            {
+                self.cmd_trading.enabled = !self.cmd_trading.enabled;
+                changed = true;
+            }
+            for (word, slot) in [("Buy", true), ("Sell", false)] {
+                ui.label(egui::RichText::new(word).color(theme::TEXT_MUTED).small());
+                let current = if slot {
+                    self.cmd_trading.buy
+                } else {
+                    self.cmd_trading.sell
+                };
+                egui::ComboBox::from_id_salt(("cmd_trading_modifier", word))
+                    .width(64.0)
+                    .selected_text(current.label())
+                    .show_ui(ui, |ui| {
+                        for modifier in CmdModifier::ALL {
+                            if ui
+                                .selectable_label(current == modifier, modifier.label())
+                                .clicked()
+                                && current != modifier
+                            {
+                                if slot {
+                                    self.cmd_trading.buy = modifier;
+                                } else {
+                                    self.cmd_trading.sell = modifier;
+                                }
+                                changed = true;
+                            }
+                        }
+                    });
+            }
+        });
+        if self.cmd_trading.enabled && self.cmd_trading.buy == self.cmd_trading.sell {
+            // A shared key is ambiguous, so the gesture shows nothing —
+            // said here rather than discovered over the chart.
+            ui.label(
+                egui::RichText::new(
+                    "buy and sell share a key - the gesture stays hidden until they differ",
+                )
+                .color(theme::AMBER)
+                .small(),
+            );
+        }
+        changed
     }
 
     /// Step the quantity field by `delta`, never below a positive value;
@@ -4700,6 +5091,26 @@ fn elide_path(path: &Path) -> String {
     })
 }
 
+/// The cmd preview's geometry from the chart frame and the pointer's y:
+/// the dashed line hugging the right edge and the clickable label off its
+/// left end. One function for paint and press alike, so a painted label
+/// and its hit-test can never disagree (the overlay-controls rule).
+fn cmd_preview_layout(chart: egui::Rect, y: f32) -> (egui::Pos2, egui::Pos2, egui::Rect) {
+    let length = (chart.width() * CMD_LINE_FRACTION).clamp(CMD_LINE_MIN_PX, CMD_LINE_MAX_PX);
+    let end = egui::pos2(chart.right(), y);
+    let start = egui::pos2((chart.right() - length).max(chart.left()), y);
+    let center_y = clamp_tag_center(y, chart.top(), chart.bottom());
+    let half = TAG_HEIGHT_PX / 2.0;
+    let label = egui::Rect::from_min_max(
+        egui::pos2(
+            start.x - CMD_LABEL_GAP_PX - CMD_LABEL_WIDTH_PX,
+            center_y - half,
+        ),
+        egui::pos2(start.x - CMD_LABEL_GAP_PX, center_y + half),
+    );
+    (start, end, label)
+}
+
 /// The session file for `stamp` under `folder`: the plain name when free,
 /// else `stamp.rerun-N` — file names derive from venue time, so replaying
 /// the same recording twice reproduces the same stamp, and the second run
@@ -5456,6 +5867,27 @@ mod tests {
             primary_pressed: pressed,
             primary_down: down,
             primary_released: released,
+            modifiers: egui::Modifiers::default(),
+        }
+    }
+
+    /// A `frame` with held modifiers and a free pointer — the cmd-trading
+    /// gesture's shape of input.
+    fn cmd_frame<'a>(
+        chart: egui::Rect,
+        scale: &'a PriceScale,
+        pointer: egui::Pos2,
+        modifiers: egui::Modifiers,
+        pressed: bool,
+    ) -> ChartInput<'a> {
+        ChartInput {
+            chart,
+            scale: Some(scale),
+            pointer: Some(pointer),
+            primary_pressed: pressed,
+            primary_down: pressed,
+            primary_released: false,
+            modifiers,
         }
     }
 
@@ -5550,6 +5982,149 @@ mod tests {
             paper.hover_cursor(egui::pos2(400.0, 40.0), chart, &scale),
             None,
             "empty tape belongs to the chart"
+        );
+    }
+
+    #[test]
+    fn the_cmd_gesture_previews_and_a_label_click_places_the_order() {
+        let shift = egui::Modifiers {
+            shift: true,
+            ..Default::default()
+        };
+        let ctrl = egui::Modifiers {
+            command: true,
+            ..Default::default()
+        };
+        let both = egui::Modifiers {
+            shift: true,
+            command: true,
+            ..Default::default()
+        };
+        let mut paper = PaperTrading::new();
+        paper.seed(&print(0, 100));
+        let (chart, scale) = chart_and_scale(80.0, 120.0);
+
+        // Hold buy above the mark: a stop. Below: a limit.
+        paper.handle_chart_input(&cmd_frame(
+            chart,
+            &scale,
+            egui::pos2(400.0, 100.0),
+            shift,
+            false,
+        ));
+        let preview = paper.cmd_preview.expect("preview above the mark");
+        assert_eq!((preview.side, preview.kind), (Side::Buy, EntryKind::Stop));
+        assert_eq!(preview.price, Decimal::from(110));
+        assert!(!preview.hover, "mid-chart is not the label");
+        paper.handle_chart_input(&cmd_frame(
+            chart,
+            &scale,
+            egui::pos2(400.0, 300.0),
+            shift,
+            false,
+        ));
+        let preview = paper.cmd_preview.expect("preview below the mark");
+        assert_eq!((preview.side, preview.kind), (Side::Buy, EntryKind::Limit));
+
+        // The sell key mirrors the table.
+        paper.handle_chart_input(&cmd_frame(
+            chart,
+            &scale,
+            egui::pos2(400.0, 100.0),
+            ctrl,
+            false,
+        ));
+        let preview = paper.cmd_preview.expect("sell above the mark");
+        assert_eq!((preview.side, preview.kind), (Side::Sell, EntryKind::Limit));
+
+        // Both keys is ambiguous, no key is no gesture.
+        paper.handle_chart_input(&cmd_frame(
+            chart,
+            &scale,
+            egui::pos2(400.0, 100.0),
+            both,
+            false,
+        ));
+        assert!(paper.cmd_preview.is_none(), "ambiguity shows nothing");
+        paper.handle_chart_input(&frame(chart, &scale, 100.0, false, false, false));
+        assert!(paper.cmd_preview.is_none(), "no key, no line");
+
+        // Clicking the label places exactly what the preview said, through
+        // the same path as the right-click menu.
+        let (_, _, label) = cmd_preview_layout(chart, 300.0);
+        let on_label = egui::pos2(label.center().x, 300.0);
+        paper.handle_chart_input(&cmd_frame(chart, &scale, on_label, shift, false));
+        assert!(
+            paper.cmd_preview.expect("hovering").hover,
+            "the label knows the pointer is on it"
+        );
+        assert!(
+            paper.handle_chart_input(&cmd_frame(chart, &scale, on_label, shift, true)),
+            "the click is the gesture's"
+        );
+        let orders = paper.working_orders();
+        assert_eq!(orders.len(), 1, "the click rested the order");
+        assert_eq!(orders[0].side, Side::Buy);
+        assert_eq!(orders[0].price, Some(Decimal::from(90)));
+
+        // Disabled means invisible.
+        paper.set_cmd_trading(CmdTradingSettings {
+            enabled: false,
+            ..Default::default()
+        });
+        paper.handle_chart_input(&cmd_frame(
+            chart,
+            &scale,
+            egui::pos2(400.0, 100.0),
+            shift,
+            false,
+        ));
+        assert!(paper.cmd_preview.is_none(), "the toggle hides the gesture");
+    }
+
+    #[test]
+    fn the_cmd_layout_hugs_the_right_edge_with_the_label_off_the_line() {
+        let chart = egui::Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(800.0, 400.0));
+        let (start, end, label) = cmd_preview_layout(chart, 250.0);
+        assert_eq!(end.x, 800.0, "the line ends at the right edge");
+        assert_eq!(start.x, 640.0, "20% of an 800px chart");
+        assert!(label.right() < start.x, "the label sits clear of the line");
+        assert_eq!(label.center().y, 250.0);
+        let narrow = egui::Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(300.0, 400.0));
+        let (start, end, _) = cmd_preview_layout(narrow, 250.0);
+        assert_eq!(
+            end.x - start.x,
+            CMD_LINE_MIN_PX,
+            "a narrow pane keeps a line"
+        );
+        let wide = egui::Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(4000.0, 400.0));
+        let (start, end, _) = cmd_preview_layout(wide, 250.0);
+        assert_eq!(
+            end.x - start.x,
+            CMD_LINE_MAX_PX,
+            "a huge chart is not painted across"
+        );
+    }
+
+    #[test]
+    fn cmd_modifier_tokens_round_trip_and_state_defaults_fill_gaps() {
+        for modifier in CmdModifier::ALL {
+            assert_eq!(CmdModifier::parse(modifier.as_str()), Some(modifier));
+        }
+        assert_eq!(CmdModifier::parse("hyper"), None);
+        let state = crate::paper_state::PaperState {
+            cmd_trading_enabled: Some(false),
+            cmd_buy_modifier: Some("alt".to_owned()),
+            cmd_sell_modifier: Some("hyper".to_owned()),
+            ..Default::default()
+        };
+        let settings = CmdTradingSettings::from_state(&state);
+        assert!(!settings.enabled);
+        assert_eq!(settings.buy, CmdModifier::Alt);
+        assert_eq!(
+            settings.sell,
+            CmdModifier::Ctrl,
+            "an unknown token falls back to the default"
         );
     }
 
@@ -5672,6 +6247,7 @@ mod tests {
             primary_pressed: true,
             primary_down: true,
             primary_released: false,
+            modifiers: egui::Modifiers::default(),
         };
         assert!(paper.handle_chart_input(&press), "the ✕ owns the press");
         assert!(
@@ -5705,6 +6281,7 @@ mod tests {
             primary_pressed: true,
             primary_down: true,
             primary_released: false,
+            modifiers: egui::Modifiers::default(),
         };
         assert!(
             paper.handle_chart_input(&press),

--- a/crates/app/src/paper_trading.rs
+++ b/crates/app/src/paper_trading.rs
@@ -124,6 +124,8 @@ const REPORT_MIN_WIDTH_PX: f32 = 440.0;
 const REPORT_MIN_HEIGHT_PX: f32 = 360.0;
 /// Height the report keeps for its honesty footer under the grids.
 const REPORT_FOOTER_RESERVE_PX: f32 = 64.0;
+/// Width of the typed-period field beside the pills — room for "999h".
+const CUSTOM_PERIOD_FIELD_PX: f32 = 44.0;
 /// The grids' readable floor inside a squeezed window.
 const REPORT_GRID_MIN_H_PX: f32 = 80.0;
 /// Width of the equity curve's y-tick gutter.
@@ -233,11 +235,14 @@ enum ReportPeriod {
     Month,
     Quarter,
     All,
+    /// A typed span (`2d`, `12h`…) in milliseconds back from the anchor —
+    /// the text box beside the pills.
+    Custom(i64),
 }
 
 impl ReportPeriod {
-    /// Every period, in pill order.
-    const ALL: [Self; 5] = [
+    /// Every fixed period, in pill order; `Custom` rides the text box.
+    const PILLS: [Self; 5] = [
         Self::Today,
         Self::Week,
         Self::Month,
@@ -252,40 +257,96 @@ impl ReportPeriod {
             Self::Month => "30d",
             Self::Quarter => "90d",
             Self::All => "All",
+            Self::Custom(_) => "custom",
         }
     }
 
     /// The anchor-relative phrase the support line reads.
-    fn phrase(self) -> &'static str {
+    fn phrase(self) -> String {
         match self {
-            Self::Today => "the newest trade's day",
-            Self::Week => "the last 7 days",
-            Self::Month => "the last 30 days",
-            Self::Quarter => "the last 90 days",
-            Self::All => "everything saved",
+            Self::Today => "the newest trade's day".to_owned(),
+            Self::Week => "the last 7 days".to_owned(),
+            Self::Month => "the last 30 days".to_owned(),
+            Self::Quarter => "the last 90 days".to_owned(),
+            Self::All => "everything saved".to_owned(),
+            Self::Custom(period_ms) => format!("the last {}", fmt_period_ms(period_ms)),
         }
     }
 
     /// Oldest closing time still inside the period, measured back from
-    /// `anchor_ms`; `None` keeps everything.
-    fn cutoff_ms(self, anchor_ms: i64) -> Option<i64> {
+    /// `anchor_ms`; `None` keeps everything. "Today" is the anchor's civil
+    /// day in the chart's display timezone — the ledger renders local
+    /// times, so the day must break where the user sees midnight, not
+    /// where UTC does.
+    fn cutoff_ms(self, anchor_ms: i64, tz: TzOffset) -> Option<i64> {
         const DAY_MS: i64 = 86_400_000;
         match self {
-            Self::Today => Some(anchor_ms.div_euclid(DAY_MS) * DAY_MS),
+            Self::Today => {
+                let local = anchor_ms.saturating_add(tz.offset_ms());
+                let local_day_start = local.div_euclid(DAY_MS) * DAY_MS;
+                Some(local_day_start.saturating_sub(tz.offset_ms()))
+            }
             Self::Week => Some(anchor_ms.saturating_sub(7 * DAY_MS)),
             Self::Month => Some(anchor_ms.saturating_sub(30 * DAY_MS)),
             Self::Quarter => Some(anchor_ms.saturating_sub(90 * DAY_MS)),
             Self::All => None,
+            Self::Custom(period_ms) => Some(anchor_ms.saturating_sub(period_ms)),
         }
     }
+}
+
+/// Parse a typed period: a positive whole number and a unit — `m`
+/// (minutes), `h`, `d`, `w` — any case, blanks tolerated. `None` is a
+/// refusal the caller must say out loud: a silently-empty report is
+/// exactly the confusion the typed field exists to end.
+fn parse_period(text: &str) -> Option<i64> {
+    let text = text.trim();
+    let unit = text.chars().last()?;
+    let count = text.get(..text.len() - unit.len_utf8())?.trim_end();
+    let count: i64 = count.parse().ok()?;
+    if count <= 0 {
+        return None;
+    }
+    let unit_ms: i64 = match unit.to_ascii_lowercase() {
+        'm' => 60_000,
+        'h' => 3_600_000,
+        'd' => 86_400_000,
+        'w' => 7 * 86_400_000,
+        _ => return None,
+    };
+    count.checked_mul(unit_ms)
+}
+
+/// `45m`, `36h`, `2d`, `1w` — the canonical spelling of a custom period,
+/// largest whole unit first.
+fn fmt_period_ms(period_ms: i64) -> String {
+    const MINUTE_MS: i64 = 60_000;
+    const HOUR_MS: i64 = 3_600_000;
+    const DAY_MS: i64 = 86_400_000;
+    const WEEK_MS: i64 = 7 * DAY_MS;
+    let (value, unit) = if period_ms % WEEK_MS == 0 {
+        (period_ms / WEEK_MS, 'w')
+    } else if period_ms % DAY_MS == 0 {
+        (period_ms / DAY_MS, 'd')
+    } else if period_ms % HOUR_MS == 0 {
+        (period_ms / HOUR_MS, 'h')
+    } else {
+        (period_ms / MINUTE_MS, 'm')
+    };
+    format!("{value}{unit}")
 }
 
 /// The report as filtered for display: the period's trades in closing
 /// order, their aggregation, and the anchor the period was measured from.
 struct ReportView {
     period: ReportPeriod,
+    /// The display timezone the view was cut with — "Today" moves with it.
+    tz: TzOffset,
     /// Newest closing time in scope — what the period counts back from.
     anchor_ms: Option<i64>,
+    /// Saved trades older than the window — the honest answer to "where
+    /// did my old trades go": they exist, the period just stops short.
+    hidden_before: usize,
     trades: Vec<ClosedTrade>,
     report: PerformanceReport,
 }
@@ -386,6 +447,9 @@ pub struct PaperTrading {
     /// Report symbol filter: `None` is every symbol, `Some` one folder.
     report_symbol: Option<String>,
     report_period: ReportPeriod,
+    /// What the typed-period field holds; applied on Enter, kept verbatim
+    /// so a refused entry stays visible for fixing.
+    report_custom_text: String,
     /// Symbol folders on disk, for the report's combo box.
     report_symbols: Vec<String>,
     /// The report's history in scope, loaded fresh from disk.
@@ -462,6 +526,7 @@ impl PaperTrading {
             report_open: false,
             report_symbol: None,
             report_period: ReportPeriod::All,
+            report_custom_text: String::new(),
             report_symbols: Vec::new(),
             report: None,
             report_view: None,
@@ -2381,13 +2446,14 @@ impl PaperTrading {
         self.report_symbols = list_symbol_folders(&self.dir);
     }
 
-    /// Rebuild the filtered view when the period (or the loaded history)
-    /// changed. The anchor is the newest trade in scope, never a clock.
-    fn ensure_report_view(&mut self) {
+    /// Rebuild the filtered view when the period, timezone or the loaded
+    /// history changed. The anchor is the newest trade in scope, never a
+    /// clock.
+    fn ensure_report_view(&mut self, tz: TzOffset) {
         let fresh = self
             .report_view
             .as_ref()
-            .is_some_and(|view| view.period == self.report_period);
+            .is_some_and(|view| view.period == self.report_period && view.tz == tz);
         if fresh {
             return;
         }
@@ -2396,7 +2462,7 @@ impl PaperTrading {
             return;
         };
         let anchor_ms = history.rows.last().map(|(_, trade)| trade.closed_ms);
-        let cutoff = anchor_ms.and_then(|anchor| self.report_period.cutoff_ms(anchor));
+        let cutoff = anchor_ms.and_then(|anchor| self.report_period.cutoff_ms(anchor, tz));
         let trades: Vec<ClosedTrade> = history
             .rows
             .iter()
@@ -2404,10 +2470,13 @@ impl PaperTrading {
             .filter(|trade| cutoff.is_none_or(|cutoff| trade.closed_ms >= cutoff))
             .cloned()
             .collect();
+        let hidden_before = history.rows.len().saturating_sub(trades.len());
         let report = PerformanceReport::from_trades(&trades);
         self.report_view = Some(ReportView {
             period: self.report_period,
+            tz,
             anchor_ms,
+            hidden_before,
             trades,
             report,
         });
@@ -2416,11 +2485,11 @@ impl PaperTrading {
     /// The performance report, computed from what is actually on disk.
     /// Non-modal by the app's contract — dimming the chart while a
     /// simulated position is open would be dangerous.
-    pub fn draw_report_window(&mut self, ctx: &egui::Context) {
+    pub fn draw_report_window(&mut self, ctx: &egui::Context, tz: TzOffset) {
         if !self.report_open {
             return;
         }
-        self.ensure_report_view();
+        self.ensure_report_view(tz);
         let mut open = true;
         let mut reload = false;
         egui::Window::new("Simulated performance")
@@ -2571,7 +2640,7 @@ impl PaperTrading {
                     .color(theme::TEXT_MUTED)
                     .small(),
             );
-            for period in ReportPeriod::ALL {
+            for period in ReportPeriod::PILLS {
                 let on = self.report_period == period;
                 if pill_toggle(
                     ui,
@@ -2584,6 +2653,25 @@ impl PaperTrading {
                 {
                     self.report_period = period;
                     self.report_view = None;
+                }
+            }
+            let response = ui
+                .add(
+                    egui::TextEdit::singleline(&mut self.report_custom_text)
+                        .desired_width(CUSTOM_PERIOD_FIELD_PX)
+                        .hint_text("2d"),
+                )
+                .on_hover_text("type a period - 45m, 12h, 2d or 1w - and press Enter");
+            if response.lost_focus() && ui.input(|input| input.key_pressed(egui::Key::Enter)) {
+                match parse_period(&self.report_custom_text) {
+                    Some(period_ms) => {
+                        self.report_period = ReportPeriod::Custom(period_ms);
+                        self.report_view = None;
+                    }
+                    None => self.show_toast(format!(
+                        "SIM: could not read `{}` as a period - use 45m, 12h, 2d or 1w",
+                        self.report_custom_text.trim(),
+                    )),
                 }
             }
             ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
@@ -2607,11 +2695,22 @@ impl PaperTrading {
         });
         if let Some(view) = &self.report_view {
             let text = match view.anchor_ms {
-                Some(anchor) => format!(
-                    "{} up to {} (newest saved trade, not the wall clock)",
-                    view.period.phrase(),
-                    fmt_utc_date(anchor),
-                ),
+                Some(anchor) => {
+                    let mut text = format!(
+                        "{} up to {} (newest saved trade, not the wall clock)",
+                        view.period.phrase(),
+                        fmt_utc_date(anchor),
+                    );
+                    if view.hidden_before > 0 {
+                        // "Where did my old trades go" gets a literal
+                        // answer: they are saved, before this window.
+                        text.push_str(&format!(
+                            " - {} older saved trade(s) before this window",
+                            view.hidden_before,
+                        ));
+                    }
+                    text
+                }
                 None => "no saved trades in this scope".to_owned(),
             };
             ui.label(egui::RichText::new(text).color(theme::TEXT_SUPPORT).small());
@@ -2819,6 +2918,13 @@ impl PaperTrading {
                 }
                 SimEvent::Closed(trade) => {
                     self.journal(&trade);
+                    if self.report_open {
+                        // The report reads from disk and the close just
+                        // wrote to disk; re-read now or the window shows
+                        // yesterday until the manual refresh — the "my
+                        // trade is missing" report.
+                        self.reload_report();
+                    }
                     self.show_toast(format!(
                         "SIM closed: {} {} → {} pts ({})",
                         position_word(trade.side),
@@ -4535,6 +4641,23 @@ mod tests {
         }
     }
 
+    fn trade_at(closed_ms: i64, pnl: i64) -> ClosedTrade {
+        ClosedTrade {
+            side: Side::Buy,
+            quantity: Decimal::ONE,
+            entry_price: Decimal::from(100),
+            exit_price: Decimal::from(100 + pnl),
+            opened_ms: closed_ms - 1000,
+            closed_ms,
+            pnl_points: Decimal::from(pnl),
+            exit_reason: quantick_sim::ExitReason::Manual,
+            entry_agg_id: None,
+            exit_agg_id: None,
+            mae_points: None,
+            mfe_points: None,
+        }
+    }
+
     #[test]
     fn utc_compact_matches_known_timestamps() {
         // 2026-03-16 13:01:08 UTC.
@@ -4851,18 +4974,58 @@ mod tests {
 
     #[test]
     fn report_periods_anchor_to_the_given_trade_never_a_clock() {
+        let utc = TzOffset::new(0);
         // 2026-03-16 13:01:08 UTC.
         let anchor = 1_773_666_068_000_i64;
-        assert_eq!(ReportPeriod::All.cutoff_ms(anchor), None);
+        assert_eq!(ReportPeriod::All.cutoff_ms(anchor, utc), None);
         assert_eq!(
-            ReportPeriod::Today.cutoff_ms(anchor),
+            ReportPeriod::Today.cutoff_ms(anchor, utc),
             Some(1_773_619_200_000),
             "the anchor's own UTC midnight"
         );
         assert_eq!(
-            ReportPeriod::Week.cutoff_ms(anchor),
+            ReportPeriod::Week.cutoff_ms(anchor, utc),
             Some(anchor - 7 * 86_400_000)
         );
+        assert_eq!(
+            ReportPeriod::Custom(2 * 86_400_000).cutoff_ms(anchor, utc),
+            Some(anchor - 2 * 86_400_000),
+            "a typed 2d reaches back exactly two days"
+        );
+    }
+
+    #[test]
+    fn today_breaks_at_the_displayed_midnight_not_utc() {
+        let day = 86_400_000_i64;
+        // 03 Jan 01:00 UTC is 02 Jan 22:00 in UTC-03:00.
+        let anchor = 2 * day + 3_600_000;
+        let sao_paulo = TzOffset::new(-180);
+        assert_eq!(
+            ReportPeriod::Today.cutoff_ms(anchor, sao_paulo),
+            Some(day + 10_800_000),
+            "midnight of the anchor's displayed day, expressed in UTC"
+        );
+        assert_eq!(
+            ReportPeriod::Today.cutoff_ms(anchor, TzOffset::new(0)),
+            Some(2 * day),
+            "UTC viewers keep the UTC midnight"
+        );
+    }
+
+    #[test]
+    fn typed_periods_parse_strictly_and_format_back() {
+        assert_eq!(parse_period("2d"), Some(2 * 86_400_000));
+        assert_eq!(parse_period(" 3D "), Some(3 * 86_400_000));
+        assert_eq!(parse_period("12h"), Some(12 * 3_600_000));
+        assert_eq!(parse_period("45m"), Some(45 * 60_000));
+        assert_eq!(parse_period("1w"), Some(7 * 86_400_000));
+        for refused in ["", "d", "2", "2x", "0d", "-2d", "2.5d", "d2"] {
+            assert_eq!(parse_period(refused), None, "{refused:?} must be refused");
+        }
+        assert_eq!(fmt_period_ms(2 * 86_400_000), "2d");
+        assert_eq!(fmt_period_ms(36 * 3_600_000), "36h");
+        assert_eq!(fmt_period_ms(45 * 60_000), "45m");
+        assert_eq!(fmt_period_ms(14 * 86_400_000), "2w");
     }
 
     #[test]
@@ -4873,22 +5036,7 @@ mod tests {
 
     #[test]
     fn the_report_view_filters_by_period_from_the_newest_trade() {
-        fn trade_at(closed_ms: i64, pnl: i64) -> ClosedTrade {
-            ClosedTrade {
-                side: Side::Buy,
-                quantity: Decimal::ONE,
-                entry_price: Decimal::from(100),
-                exit_price: Decimal::from(100 + pnl),
-                opened_ms: closed_ms - 1000,
-                closed_ms,
-                pnl_points: Decimal::from(pnl),
-                exit_reason: quantick_sim::ExitReason::Manual,
-                entry_agg_id: None,
-                exit_agg_id: None,
-                mae_points: None,
-                mfe_points: None,
-            }
-        }
+        let utc = TzOffset::new(0);
         let day = 86_400_000_i64;
         let mut paper = PaperTrading::new();
         paper.report = Some(LoadedHistory {
@@ -4902,7 +5050,7 @@ mod tests {
             problem_rows: 0,
         });
         paper.report_period = ReportPeriod::Week;
-        paper.ensure_report_view();
+        paper.ensure_report_view(utc);
         let view = paper.report_view.as_ref().expect("view built");
         assert_eq!(
             view.anchor_ms,
@@ -4910,14 +5058,83 @@ mod tests {
             "anchored to the newest saved trade, not a clock"
         );
         assert_eq!(view.trades.len(), 2, "the 10-day-old trade is outside 7d");
+        assert_eq!(view.hidden_before, 1, "and the view counts what it hides");
         assert_eq!(view.report.net_points, Decimal::from(5));
 
         paper.report_period = ReportPeriod::All;
-        paper.ensure_report_view();
+        paper.ensure_report_view(utc);
         assert_eq!(
             paper.report_view.as_ref().expect("rebuilt").trades.len(),
             3,
             "All sees everything again"
+        );
+    }
+
+    #[test]
+    fn all_symbols_hides_older_markets_but_says_so_and_scope_restores_them() {
+        let utc = TzOffset::new(0);
+        let day = 86_400_000_i64;
+        let mut paper = PaperTrading::new();
+        paper.report = Some(LoadedHistory {
+            rows: vec![
+                ("OLDSYM".to_owned(), trade_at(day, 5)),
+                ("NEWSYM".to_owned(), trade_at(60 * day, 7)),
+            ],
+            files: 2,
+            unreadable_files: 0,
+            problem_rows: 0,
+        });
+        paper.report_period = ReportPeriod::Month;
+        paper.ensure_report_view(utc);
+        let view = paper.report_view.as_ref().expect("view built");
+        assert_eq!(
+            view.trades.len(),
+            1,
+            "30d back from the newest trade hides the older market entirely"
+        );
+        assert_eq!(view.hidden_before, 1, "the support line can say so");
+
+        // Narrowing the combo re-anchors on the old market's own newest
+        // trade — the "my trades came back" behaviour, now spelled out.
+        paper.report = Some(LoadedHistory {
+            rows: vec![("OLDSYM".to_owned(), trade_at(day, 5))],
+            files: 1,
+            unreadable_files: 0,
+            problem_rows: 0,
+        });
+        paper.report_view = None;
+        paper.ensure_report_view(utc);
+        let view = paper.report_view.as_ref().expect("rebuilt");
+        assert_eq!(view.trades.len(), 1, "its own scope shows the old market");
+        assert_eq!(view.hidden_before, 0);
+    }
+
+    #[test]
+    fn a_close_refreshes_an_open_report_by_itself() {
+        let utc = TzOffset::new(0);
+        let mut paper = PaperTrading::new();
+        paper.set_symbol("FRESH");
+        paper.report_open = true;
+        paper.reload_report();
+        paper.ensure_report_view(utc);
+        assert!(
+            paper.report_view.as_ref().expect("view").trades.is_empty(),
+            "nothing saved yet"
+        );
+
+        paper.seed(&print(0, 100));
+        paper.market(Side::Buy);
+        paper.on_trade(&print(1, 100));
+        let events = paper.sim.apply(Command::ClosePosition);
+        paper.handle_events(events);
+        paper.on_trade(&print(2, 105));
+
+        paper.ensure_report_view(utc);
+        let view = paper.report_view.as_ref().expect("refreshed");
+        assert_eq!(
+            view.trades.len(),
+            1,
+            "the close re-read the journal without a manual refresh"
         );
     }
 

--- a/crates/app/src/paper_trading.rs
+++ b/crates/app/src/paper_trading.rs
@@ -126,6 +126,9 @@ const REPORT_MIN_HEIGHT_PX: f32 = 360.0;
 const REPORT_FOOTER_RESERVE_PX: f32 = 64.0;
 /// Width of the typed-period field beside the pills — room for "999h".
 const CUSTOM_PERIOD_FIELD_PX: f32 = 44.0;
+/// How many `.rerun-N` session names one venue-time stamp may try — far
+/// beyond any real journal, a backstop against a pathological folder.
+const MAX_SESSION_RERUNS: usize = 999;
 /// The grids' readable floor inside a squeezed window.
 const REPORT_GRID_MIN_H_PX: f32 = 80.0;
 /// Width of the equity curve's y-tick gutter.
@@ -340,6 +343,7 @@ fn fmt_period_ms(period_ms: i64) -> String {
 /// order, their aggregation, and the anchor the period was measured from.
 struct ReportView {
     period: ReportPeriod,
+    source: SourceFilter,
     /// The display timezone the view was cut with — "Today" moves with it.
     tz: TzOffset,
     /// Newest closing time in scope — what the period counts back from.
@@ -347,20 +351,78 @@ struct ReportView {
     /// Saved trades older than the window — the honest answer to "where
     /// did my old trades go": they exist, the period just stops short.
     hidden_before: usize,
+    /// Saved trades the Source filter keeps out of this view.
+    hidden_by_source: usize,
     trades: Vec<ClosedTrade>,
     report: PerformanceReport,
+}
+
+/// One journal row loaded from disk: the trade, the symbol folder it came
+/// from, and the session source its file recorded.
+#[derive(Clone)]
+struct HistoryRow {
+    symbol: String,
+    /// `None` — a file from before the source was recorded. The report's
+    /// Real view includes it: that era *was* live trading, and hiding it
+    /// would "lose" the user's history all over again.
+    source: Option<history::SessionSource>,
+    trade: ClosedTrade,
 }
 
 /// Journal rows loaded from disk, each remembering the symbol folder it
 /// came from, merged into one closing-order timeline.
 struct LoadedHistory {
-    /// `(symbol, trade)` in closing order across every file read.
-    rows: Vec<(String, ClosedTrade)>,
+    /// Rows in closing order across every file read.
+    rows: Vec<HistoryRow>,
     files: usize,
     /// Files that were not readable quantick-trades files.
     unreadable_files: usize,
     /// Rows the parser had to report as unreadable (torn tails and such).
     problem_rows: usize,
+}
+
+/// The report's session-source filter. Default `Real`: practice runs must
+/// never inflate the real track record unasked.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SourceFilter {
+    /// Live sessions, plus files from before the source was recorded.
+    Real,
+    /// Replay-driven practice sessions only.
+    Replay,
+    /// Everything, mixed.
+    All,
+}
+
+impl SourceFilter {
+    /// Every filter, in pill order.
+    const PILLS: [Self; 3] = [Self::Real, Self::Replay, Self::All];
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Real => "Real",
+            Self::Replay => "Replay",
+            Self::All => "All",
+        }
+    }
+
+    fn hover(self) -> &'static str {
+        match self {
+            Self::Real => {
+                "live sessions - files saved before quantick recorded a source count as real"
+            }
+            Self::Replay => "practice sessions driven by a market-replay recording",
+            Self::All => "live and replay together - mixed on purpose",
+        }
+    }
+
+    /// Whether a row with this recorded source belongs to the filter.
+    fn admits(self, source: Option<history::SessionSource>) -> bool {
+        match self {
+            Self::Real => source != Some(history::SessionSource::Replay),
+            Self::Replay => source == Some(history::SessionSource::Replay),
+            Self::All => true,
+        }
+    }
 }
 
 /// What the Trading tab asked of its host.
@@ -423,6 +485,9 @@ pub struct PaperTrading {
     journal_path: Option<PathBuf>,
     /// A failed journal write warns once, not once per trade.
     journal_warned: bool,
+    /// Where this session's trades come from — the tab's feed sets it,
+    /// the journal header records it.
+    session_source: history::SessionSource,
     // Order-entry form.
     qty_text: String,
     order_type: EntryKind,
@@ -447,6 +512,8 @@ pub struct PaperTrading {
     /// Report symbol filter: `None` is every symbol, `Some` one folder.
     report_symbol: Option<String>,
     report_period: ReportPeriod,
+    /// The report's session-source scope; opens on `Real`.
+    report_source: SourceFilter,
     /// What the typed-period field holds; applied on Enter, kept verbatim
     /// so a refused entry stays visible for fixing.
     report_custom_text: String,
@@ -512,6 +579,7 @@ impl PaperTrading {
             dir,
             journal_path: None,
             journal_warned: false,
+            session_source: history::SessionSource::Live,
             qty_text: "1".to_owned(),
             order_type: EntryKind::Market,
             stop_offset_text: String::new(),
@@ -526,6 +594,7 @@ impl PaperTrading {
             report_open: false,
             report_symbol: None,
             report_period: ReportPeriod::All,
+            report_source: SourceFilter::Real,
             report_custom_text: String::new(),
             report_symbols: Vec::new(),
             report: None,
@@ -575,6 +644,17 @@ impl PaperTrading {
     pub(crate) fn apply_sim_command_for_tests(&mut self, command: Command) {
         let events = self.sim.apply(command);
         self.handle_events(events);
+    }
+
+    /// Follow the tab's feed: a session is wholly live or wholly a
+    /// replay, and the journal's header records which. A change retargets
+    /// the journal so the next close opens a file honest about its
+    /// source.
+    pub fn set_session_source(&mut self, source: history::SessionSource) {
+        if self.session_source != source {
+            self.session_source = source;
+            self.journal_path = None;
+        }
     }
 
     /// Follow the app's active symbol. A change retargets the journal; the
@@ -2269,7 +2349,7 @@ impl PaperTrading {
                     .rows
                     .iter()
                     .rev()
-                    .map(|(symbol, trade)| (symbol.as_str(), trade))
+                    .map(|row| (row.symbol.as_str(), &row.trade))
                     .collect()
             })
             .unwrap_or_default();
@@ -2446,14 +2526,13 @@ impl PaperTrading {
         self.report_symbols = list_symbol_folders(&self.dir);
     }
 
-    /// Rebuild the filtered view when the period, timezone or the loaded
-    /// history changed. The anchor is the newest trade in scope, never a
-    /// clock.
+    /// Rebuild the filtered view when the period, source, timezone or the
+    /// loaded history changed. The anchor is the newest trade in scope —
+    /// after the Source filter, never a clock.
     fn ensure_report_view(&mut self, tz: TzOffset) {
-        let fresh = self
-            .report_view
-            .as_ref()
-            .is_some_and(|view| view.period == self.report_period && view.tz == tz);
+        let fresh = self.report_view.as_ref().is_some_and(|view| {
+            view.period == self.report_period && view.source == self.report_source && view.tz == tz
+        });
         if fresh {
             return;
         }
@@ -2461,22 +2540,29 @@ impl PaperTrading {
             self.report_view = None;
             return;
         };
-        let anchor_ms = history.rows.last().map(|(_, trade)| trade.closed_ms);
-        let cutoff = anchor_ms.and_then(|anchor| self.report_period.cutoff_ms(anchor, tz));
-        let trades: Vec<ClosedTrade> = history
+        let in_scope: Vec<&HistoryRow> = history
             .rows
             .iter()
-            .map(|(_, trade)| trade)
+            .filter(|row| self.report_source.admits(row.source))
+            .collect();
+        let hidden_by_source = history.rows.len().saturating_sub(in_scope.len());
+        let anchor_ms = in_scope.last().map(|row| row.trade.closed_ms);
+        let cutoff = anchor_ms.and_then(|anchor| self.report_period.cutoff_ms(anchor, tz));
+        let trades: Vec<ClosedTrade> = in_scope
+            .iter()
+            .map(|row| &row.trade)
             .filter(|trade| cutoff.is_none_or(|cutoff| trade.closed_ms >= cutoff))
             .cloned()
             .collect();
-        let hidden_before = history.rows.len().saturating_sub(trades.len());
+        let hidden_before = in_scope.len().saturating_sub(trades.len());
         let report = PerformanceReport::from_trades(&trades);
         self.report_view = Some(ReportView {
             period: self.report_period,
+            source: self.report_source,
             tz,
             anchor_ms,
             hidden_before,
+            hidden_by_source,
             trades,
             report,
         });
@@ -2636,6 +2722,19 @@ impl PaperTrading {
                 });
             ui.separator();
             ui.label(
+                egui::RichText::new("Source")
+                    .color(theme::TEXT_MUTED)
+                    .small(),
+            );
+            for source in SourceFilter::PILLS {
+                let on = self.report_source == source;
+                if pill_toggle(ui, source.label(), on, source.hover()).clicked() && !on {
+                    self.report_source = source;
+                    self.report_view = None;
+                }
+            }
+            ui.separator();
+            ui.label(
                 egui::RichText::new("Period")
                     .color(theme::TEXT_MUTED)
                     .small(),
@@ -2707,6 +2806,12 @@ impl PaperTrading {
                         text.push_str(&format!(
                             " - {} older saved trade(s) before this window",
                             view.hidden_before,
+                        ));
+                    }
+                    if view.hidden_by_source > 0 {
+                        text.push_str(&format!(
+                            " - {} trade(s) behind the Source filter",
+                            view.hidden_by_source,
                         ));
                     }
                     text
@@ -2822,17 +2927,16 @@ impl PaperTrading {
         if self.history_cache.is_none() {
             self.reload_ledger();
         }
-        let mut rows: Vec<(String, ClosedTrade)> = Vec::new();
+        let mut rows: Vec<HistoryRow> = Vec::new();
         if let Some(cache) = &self.history_cache {
             rows.extend(cache.rows.iter().cloned());
         }
-        rows.extend(
-            self.sim
-                .closed_trades()
-                .iter()
-                .map(|trade| (self.symbol.clone(), trade.clone())),
-        );
-        rows.sort_by_key(|row| (row.1.closed_ms, row.1.opened_ms));
+        rows.extend(self.sim.closed_trades().iter().map(|trade| HistoryRow {
+            symbol: self.symbol.clone(),
+            source: Some(self.session_source),
+            trade: trade.clone(),
+        }));
+        rows.sort_by_key(|row| (row.trade.closed_ms, row.trade.opened_ms));
         if rows.is_empty() {
             self.show_toast("SIM: nothing to export yet - close a trade first.".to_owned());
             return;
@@ -2946,16 +3050,12 @@ impl PaperTrading {
             return;
         }
         let folder = self.dir.join(sanitize_symbol(&self.symbol));
-        let path = self.journal_path.get_or_insert_with(|| {
-            folder.join(format!(
-                "{}.{}",
-                utc_compact(trade.closed_ms),
-                history::FILE_EXTENSION
-            ))
-        });
+        let path = self
+            .journal_path
+            .get_or_insert_with(|| free_session_path(&folder, &utc_compact(trade.closed_ms)));
         let mut text = String::new();
         if !path.exists() {
-            text.push_str(&history::write_header(&self.symbol));
+            text.push_str(&history::write_header(&self.symbol, self.session_source));
         }
         text.push_str(&history::write_trade(trade));
         let written = std::fs::create_dir_all(&folder).and_then(|()| {
@@ -3708,12 +3808,12 @@ fn load_history(dir: &Path, symbol: Option<&str>, exclude: Option<&Path>) -> Loa
                     Ok(parsed) => {
                         problem_rows += parsed.problems.len();
                         let symbol = parsed.symbol.unwrap_or_else(|| folder_symbol.clone());
-                        rows.extend(
-                            parsed
-                                .trades
-                                .into_iter()
-                                .map(|trade| (symbol.clone(), trade)),
-                        );
+                        let source = parsed.source;
+                        rows.extend(parsed.trades.into_iter().map(|trade| HistoryRow {
+                            symbol: symbol.clone(),
+                            source,
+                            trade,
+                        }));
                     }
                     Err(_) => unreadable_files += 1,
                 },
@@ -3723,7 +3823,7 @@ fn load_history(dir: &Path, symbol: Option<&str>, exclude: Option<&Path>) -> Loa
     }
     // Files are per-session; merge into one closing-order timeline so the
     // drawdown walk is honest across sessions.
-    rows.sort_by_key(|row| (row.1.closed_ms, row.1.opened_ms));
+    rows.sort_by_key(|row| (row.trade.closed_ms, row.trade.opened_ms));
     LoadedHistory {
         rows,
         files,
@@ -3736,11 +3836,7 @@ fn load_history(dir: &Path, symbol: Option<&str>, exclude: Option<&Path>) -> Loa
 /// disk to a report.
 #[cfg(test)]
 fn report_from_history(history: &LoadedHistory) -> PerformanceReport {
-    let trades: Vec<ClosedTrade> = history
-        .rows
-        .iter()
-        .map(|(_, trade)| trade.clone())
-        .collect();
+    let trades: Vec<ClosedTrade> = history.rows.iter().map(|row| row.trade.clone()).collect();
     PerformanceReport::from_trades(&trades)
 }
 
@@ -4544,24 +4640,25 @@ fn reveal_folder(path: &Path) {
 /// the machine-readable source of truth. Human-readable UTC stamps ride
 /// beside the venue epoch, decimals always use `.`, and the running
 /// equity is a column so a spreadsheet shows it without a formula.
-fn export_csv(rows: &[(String, ClosedTrade)]) -> String {
+fn export_csv(rows: &[HistoryRow]) -> String {
     let mut text = String::from(
         "symbol,side,quantity,opened_ms,opened_utc,entry_price,closed_ms,closed_utc,\
          exit_price,pnl_points,cum_pnl_points,duration_ms,exit_reason,entry_agg_id,\
-         exit_agg_id,mae_points,mfe_points\n",
+         exit_agg_id,mae_points,mfe_points,source\n",
     );
     let mut cumulative = Decimal::ZERO;
     let opt_u64 = |value: Option<u64>| value.map(|value| value.to_string()).unwrap_or_default();
     let opt_points = |value: Option<Decimal>| value.map(fmt_decimal).unwrap_or_default();
-    for (symbol, trade) in rows {
+    for row in rows {
+        let trade = &row.trade;
         cumulative = cumulative.saturating_add(trade.pnl_points);
         let side = match trade.side {
             Side::Buy => "long",
             Side::Sell => "short",
         };
         text.push_str(&format!(
-            "{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{}\n",
-            symbol.replace(',', "_"),
+            "{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{}\n",
+            row.symbol.replace(',', "_"),
             side,
             fmt_decimal(trade.quantity),
             trade.opened_ms,
@@ -4578,6 +4675,8 @@ fn export_csv(rows: &[(String, ClosedTrade)]) -> String {
             opt_u64(trade.exit_agg_id),
             opt_points(trade.mae_points),
             opt_points(trade.mfe_points),
+            // Empty when the file never recorded one — unknown, not live.
+            row.source.map(history::SessionSource::as_str).unwrap_or(""),
         ));
     }
     text
@@ -4599,6 +4698,28 @@ fn elide_path(path: &Path) -> String {
     path.file_name().map_or(text, |name| {
         format!("…{}{}", std::path::MAIN_SEPARATOR, name.to_string_lossy())
     })
+}
+
+/// The session file for `stamp` under `folder`: the plain name when free,
+/// else `stamp.rerun-N` — file names derive from venue time, so replaying
+/// the same recording twice reproduces the same stamp, and the second run
+/// must land beside the first instead of appending duplicate trades into
+/// it.
+fn free_session_path(folder: &Path, stamp: &str) -> PathBuf {
+    let plain = folder.join(format!("{stamp}.{}", history::FILE_EXTENSION));
+    if !plain.exists() {
+        return plain;
+    }
+    for rerun in 1..=MAX_SESSION_RERUNS {
+        let candidate = folder.join(format!("{stamp}.rerun-{rerun}.{}", history::FILE_EXTENSION));
+        if !candidate.exists() {
+            return candidate;
+        }
+    }
+    // A folder with a thousand same-stamp sessions is not a real journal;
+    // appending to the plain file keeps the trades at the cost of
+    // duplicates, which beats losing them.
+    plain
 }
 
 /// A journal folder of its own per host under test — tests must never
@@ -4638,6 +4759,14 @@ mod tests {
             price: Decimal::from(price),
             quantity: Decimal::ONE,
             side: Side::Buy,
+        }
+    }
+
+    fn row(symbol: &str, source: Option<history::SessionSource>, trade: ClosedTrade) -> HistoryRow {
+        HistoryRow {
+            symbol: symbol.to_owned(),
+            source,
+            trade,
         }
     }
 
@@ -4901,7 +5030,7 @@ mod tests {
             mae_points: Some(Decimal::ZERO),
             mfe_points: Some(Decimal::from(5)),
         };
-        let mut text = history::write_header("LEDGX");
+        let mut text = history::write_header("LEDGX", history::SessionSource::Live);
         text.push_str(&history::write_trade(&trade));
         std::fs::write(dir.join("LEDGX").join("20200101-000000.csv"), text)
             .expect("the earlier session file writes");
@@ -4913,9 +5042,111 @@ mod tests {
             1,
             "the live session's file is excluded, the earlier one loads"
         );
-        assert_eq!(cache.rows[0].0, "LEDGX");
-        assert_eq!(cache.rows[0].1, trade);
+        assert_eq!(cache.rows[0].symbol, "LEDGX");
+        assert_eq!(cache.rows[0].trade, trade);
+        assert_eq!(cache.rows[0].source, Some(history::SessionSource::Live));
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn a_replay_rerun_lands_beside_its_first_run_never_inside_it() {
+        let dir =
+            std::env::temp_dir().join(format!("quantick-paper-rerun-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        // The same recording replayed twice: identical prints, identical
+        // venue times, so both sessions derive the same file stamp.
+        for _ in 0..2 {
+            let mut paper = PaperTrading::new();
+            paper.dir.clone_from(&dir);
+            paper.set_symbol("RERUN");
+            paper.set_session_source(history::SessionSource::Replay);
+            paper.seed(&print(0, 100));
+            paper.market(Side::Buy);
+            paper.on_trade(&print(1, 100));
+            let events = paper.sim.apply(Command::ClosePosition);
+            paper.handle_events(events);
+            paper.on_trade(&print(2, 103));
+        }
+
+        let folder = dir.join("RERUN");
+        let mut names: Vec<String> = std::fs::read_dir(&folder)
+            .expect("the symbol folder exists")
+            .flatten()
+            .filter_map(|entry| entry.file_name().to_str().map(str::to_owned))
+            .collect();
+        names.sort();
+        assert_eq!(
+            names.len(),
+            2,
+            "the second run opened its own file instead of appending duplicates"
+        );
+        assert!(names[1].contains(".rerun-1."), "{names:?}");
+        let history = load_history(&dir, Some("RERUN"), None);
+        assert_eq!(history.rows.len(), 2);
+        assert!(
+            history
+                .rows
+                .iter()
+                .all(|row| row.source == Some(history::SessionSource::Replay)),
+            "both files carry the replay source"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn the_report_opens_on_real_and_keeps_replay_out_until_asked() {
+        let utc = TzOffset::new(0);
+        let day = 86_400_000_i64;
+        let mut paper = PaperTrading::new();
+        assert_eq!(
+            paper.report_source,
+            SourceFilter::Real,
+            "practice runs never inflate the real track record unasked"
+        );
+        paper.report = Some(LoadedHistory {
+            rows: vec![
+                row("X", Some(history::SessionSource::Live), trade_at(day, 5)),
+                row("X", None, trade_at(2 * day, 3)),
+                row(
+                    "X",
+                    Some(history::SessionSource::Replay),
+                    trade_at(3 * day, 100),
+                ),
+            ],
+            files: 3,
+            unreadable_files: 0,
+            problem_rows: 0,
+        });
+        paper.ensure_report_view(utc);
+        let view = paper.report_view.as_ref().expect("view built");
+        assert_eq!(
+            view.trades.len(),
+            2,
+            "live + unrecorded-legacy count as real"
+        );
+        assert_eq!(
+            view.hidden_by_source, 1,
+            "the replay trade sits behind the filter"
+        );
+        assert_eq!(
+            view.anchor_ms,
+            Some(2 * day),
+            "the anchor comes from the filtered scope, not the replay trade"
+        );
+        assert_eq!(view.report.net_points, Decimal::from(8));
+
+        paper.report_source = SourceFilter::Replay;
+        paper.ensure_report_view(utc);
+        let view = paper.report_view.as_ref().expect("rebuilt");
+        assert_eq!(view.trades.len(), 1, "the practice run, alone");
+        assert_eq!(view.report.net_points, Decimal::from(100));
+        assert_eq!(view.hidden_by_source, 2);
+
+        paper.report_source = SourceFilter::All;
+        paper.ensure_report_view(utc);
+        let view = paper.report_view.as_ref().expect("rebuilt");
+        assert_eq!(view.trades.len(), 3, "All mixes on purpose");
+        assert_eq!(view.hidden_by_source, 0);
     }
 
     #[test]
@@ -4935,27 +5166,32 @@ mod tests {
             mfe_points: mae.map(Decimal::from),
         };
         let rows = vec![
-            ("BTCUSDT".to_owned(), trade(1_773_666_068_000, 5, Some(2))),
-            ("WINQ26".to_owned(), trade(1_773_666_368_000, -2, None)),
+            row(
+                "BTCUSDT",
+                Some(history::SessionSource::Live),
+                trade(1_773_666_068_000, 5, Some(2)),
+            ),
+            row("WINQ26", None, trade(1_773_666_368_000, -2, None)),
         ];
         let text = export_csv(&rows);
         let lines: Vec<&str> = text.lines().collect();
         assert_eq!(lines.len(), 3, "header plus two rows");
         assert!(lines[0].starts_with("symbol,side,quantity,opened_ms,opened_utc"));
+        assert!(lines[0].ends_with(",source"), "{}", lines[0]);
         assert!(
             lines[1].contains("2026-03-16T13:01:08Z"),
             "human-readable UTC beside the epoch: {}",
             lines[1]
         );
-        assert!(lines[1].ends_with(",manual,1,2,2,2"), "{}", lines[1]);
+        assert!(lines[1].ends_with(",manual,1,2,2,2,live"), "{}", lines[1]);
         assert!(
             lines[2].contains(",3,"),
             "running equity 5 + (-2): {}",
             lines[2]
         );
         assert!(
-            lines[2].ends_with(",manual,,,,"),
-            "unknown v1 fields stay empty, never zero: {}",
+            lines[2].ends_with(",manual,,,,,"),
+            "unknown v1 fields and an unrecorded source stay empty: {}",
             lines[2]
         );
     }
@@ -5041,9 +5277,9 @@ mod tests {
         let mut paper = PaperTrading::new();
         paper.report = Some(LoadedHistory {
             rows: vec![
-                ("X".to_owned(), trade_at(10 * day, 5)),
-                ("X".to_owned(), trade_at(18 * day, -2)),
-                ("X".to_owned(), trade_at(20 * day + 3_600_000, 7)),
+                row("X", None, trade_at(10 * day, 5)),
+                row("X", None, trade_at(18 * day, -2)),
+                row("X", None, trade_at(20 * day + 3_600_000, 7)),
             ],
             files: 1,
             unreadable_files: 0,
@@ -5077,8 +5313,8 @@ mod tests {
         let mut paper = PaperTrading::new();
         paper.report = Some(LoadedHistory {
             rows: vec![
-                ("OLDSYM".to_owned(), trade_at(day, 5)),
-                ("NEWSYM".to_owned(), trade_at(60 * day, 7)),
+                row("OLDSYM", None, trade_at(day, 5)),
+                row("NEWSYM", None, trade_at(60 * day, 7)),
             ],
             files: 2,
             unreadable_files: 0,
@@ -5097,7 +5333,7 @@ mod tests {
         // Narrowing the combo re-anchors on the old market's own newest
         // trade — the "my trades came back" behaviour, now spelled out.
         paper.report = Some(LoadedHistory {
-            rows: vec![("OLDSYM".to_owned(), trade_at(day, 5))],
+            rows: vec![row("OLDSYM", None, trade_at(day, 5))],
             files: 1,
             unreadable_files: 0,
             problem_rows: 0,
@@ -5107,6 +5343,41 @@ mod tests {
         let view = paper.report_view.as_ref().expect("rebuilt");
         assert_eq!(view.trades.len(), 1, "its own scope shows the old market");
         assert_eq!(view.hidden_before, 0);
+    }
+
+    #[test]
+    fn the_report_scopes_by_symbol_folder_on_disk() {
+        let dir = std::env::temp_dir().join(format!(
+            "quantick-paper-symbols-test-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        for (symbol, id0, price) in [("AAAUSDT", 0, 100), ("BBBUSDT", 100, 200)] {
+            let mut paper = PaperTrading::new();
+            paper.dir.clone_from(&dir);
+            paper.set_symbol(symbol);
+            paper.seed(&print(id0, price));
+            paper.market(Side::Buy);
+            paper.on_trade(&print(id0 + 1, price));
+            let events = paper.sim.apply(Command::ClosePosition);
+            paper.handle_events(events);
+            paper.on_trade(&print(id0 + 2, price + 5));
+        }
+
+        assert_eq!(
+            list_symbol_folders(&dir),
+            vec!["AAAUSDT".to_owned(), "BBBUSDT".to_owned()],
+            "the combo lists every traded asset"
+        );
+        let all = load_history(&dir, None, None);
+        assert_eq!(all.rows.len(), 2, "All symbols reads both journals");
+        let symbols: Vec<&str> = all.rows.iter().map(|row| row.symbol.as_str()).collect();
+        assert_eq!(symbols, vec!["AAAUSDT", "BBBUSDT"]);
+        let one = load_history(&dir, Some("BBBUSDT"), None);
+        assert_eq!(one.rows.len(), 1, "a symbol scope reads only its folder");
+        assert_eq!(one.rows[0].symbol, "BBBUSDT");
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/crates/app/src/paper_trading.rs
+++ b/crates/app/src/paper_trading.rs
@@ -421,7 +421,10 @@ impl SourceFilter {
         match self {
             Self::Real => "Real",
             Self::Replay => "Replay",
-            Self::All => "All",
+            // Not "All": the period pills own that word on the same row,
+            // and two identical pills a hand-width apart invite the wrong
+            // click.
+            Self::All => "Both",
         }
     }
 
@@ -2452,6 +2455,20 @@ impl PaperTrading {
                 .color(theme::AMBER)
                 .small(),
             );
+        } else if self.cmd_trading.enabled {
+            // The gesture is invisible until a key is held; its one line
+            // of instructions lives where the toggle does, not in a
+            // tooltip a newcomer never hovers.
+            ui.label(
+                egui::RichText::new(format!(
+                    "hold {} over the chart to buy, {} to sell - the dashed line shows \
+                     where; click its label to place",
+                    self.cmd_trading.buy.label(),
+                    self.cmd_trading.sell.label(),
+                ))
+                .color(theme::TEXT_SUPPORT)
+                .small(),
+            );
         }
         changed
     }
@@ -3152,16 +3169,22 @@ impl PaperTrading {
                         .hint_text("2d"),
                 )
                 .on_hover_text("type a period - 45m, 12h, 2d or 1w - and press Enter");
-            if response.lost_focus() && ui.input(|input| input.key_pressed(egui::Key::Enter)) {
+            if response.lost_focus() {
                 match parse_period(&self.report_custom_text) {
+                    // A valid entry applies on blur as well as on Enter —
+                    // a typed "2d" must never do nothing quietly.
                     Some(period_ms) => {
                         self.report_period = ReportPeriod::Custom(period_ms);
                         self.report_view = None;
                     }
-                    None => self.show_toast(format!(
-                        "SIM: could not read `{}` as a period - use 45m, 12h, 2d or 1w",
-                        self.report_custom_text.trim(),
-                    )),
+                    // Only Enter earns the refusal toast: clicking away
+                    // from an abandoned half-entry is not a submission.
+                    None if ui.input(|input| input.key_pressed(egui::Key::Enter)) => self
+                        .show_toast(format!(
+                            "SIM: could not read `{}` as a period - use 45m, 12h, 2d or 1w",
+                            self.report_custom_text.trim(),
+                        )),
+                    None => {}
                 }
             }
             ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
@@ -6080,6 +6103,54 @@ mod tests {
             false,
         ));
         assert!(paper.cmd_preview.is_none(), "the toggle hides the gesture");
+    }
+
+    /// Off-screen render proof (for environments where no window can
+    /// present): the preview paints a dashed line, a label carrying
+    /// side+kind+qty, and the gutter chip with the snapped price.
+    #[test]
+    fn the_cmd_preview_paints_line_label_and_price_chip() {
+        let shift = egui::Modifiers {
+            shift: true,
+            ..Default::default()
+        };
+        let mut paper = PaperTrading::new();
+        paper.seed(&print(0, 100));
+        let (chart, scale) = chart_and_scale(80.0, 120.0);
+        paper.handle_chart_input(&cmd_frame(
+            chart,
+            &scale,
+            egui::pos2(400.0, 300.0),
+            shift,
+            false,
+        ));
+        assert!(paper.cmd_preview.is_some(), "the held key builds a preview");
+
+        let ctx = egui::Context::default();
+        let output = ctx.run(egui::RawInput::default(), |ctx| {
+            let painter = ctx.layer_painter(egui::LayerId::background());
+            let paint = PaintCtx {
+                painter: &painter,
+                chart_rect: chart,
+                tag_right: chart.right(),
+                axis_x: chart.right(),
+                scale: &scale,
+                reserved_chip_y: None,
+                pointer: Some(egui::pos2(400.0, 300.0)),
+            };
+            paper.draw_cmd_preview(&paint);
+        });
+        let shapes = format!("{:?}", output.shapes);
+        assert!(shapes.contains("BUY"), "the label names the side: {shapes}");
+        assert!(
+            shapes.contains("90"),
+            "the gutter chip carries the snapped price"
+        );
+        let segments = shapes.matches("LineSegment").count();
+        assert!(
+            segments >= 8,
+            "a dashed line paints as many short segments, got {segments}"
+        );
     }
 
     #[test]

--- a/crates/app/src/tab.rs
+++ b/crates/app/src/tab.rs
@@ -452,6 +452,13 @@ impl Tab {
         self.feed_connection = FeedConnectionState::Connecting;
         self.commands = handle.commands;
         self.replay = handle.replay;
+        // The journal records where a session's trades came from; the
+        // attached handle is the single truth for that.
+        self.paper.set_session_source(if self.replay.is_some() {
+            quantick_sim::history::SessionSource::Replay
+        } else {
+            quantick_sim::history::SessionSource::Live
+        });
         self.book_channel_closed_reported = false;
     }
 

--- a/crates/app/src/tab.rs
+++ b/crates/app/src/tab.rs
@@ -1790,6 +1790,13 @@ impl Tab {
             "opening a recorded session"
         );
 
+        // A position on the tape belongs to the session that is ending:
+        // flatten it while the journal still carries that session's
+        // source. attach() flips the source to the new feed's, and a
+        // flatten after it would file the old session's trade under the
+        // new session's name — a live trade laundered into the practice
+        // record. (reset_market_state below flattens again: a no-op.)
+        self.paper.on_timeline_reset();
         let handle = feed::spawn(feed::FeedSource::Replay(Box::new(request)), config);
         self.attach(handle);
 
@@ -1829,6 +1836,11 @@ impl Tab {
             self.reset_market_state();
             return;
         };
+        // Same ordering rule as open_replay: the flatten of a replay
+        // position must journal under the replay source, before attach()
+        // flips the journal back to live — or a practice trade counts in
+        // the real track record.
+        self.paper.on_timeline_reset();
         let handle = feed::spawn_live(provider, &self.symbol, config);
         self.attach(handle);
         self.reset_market_state();

--- a/crates/sim/src/history.rs
+++ b/crates/sim/src/history.rs
@@ -10,9 +10,15 @@
 //! ```text
 //! # quantick-trades 2
 //! # symbol=BTCUSDT
+//! # source=live
 //! opened_ms,closed_ms,side,quantity,entry_price,exit_price,pnl_points,exit_reason,entry_agg_id,exit_agg_id,mae_points,mfe_points
 //! 1700000000000,1700000060000,long,2,100.5,103.25,5.5,take_profit,41,57,1.5,6.0
 //! ```
+//!
+//! `# source=` records where the whole session's trades came from (a
+//! session is wholly live or wholly a replay). Files from before the line
+//! existed parse with [`TradeHistory::source`] `None` — unrecorded, not
+//! guessed.
 //!
 //! `side` is the position's direction (`long`/`short`); `exit_reason` uses
 //! [`ExitReason::as_str`] tokens. Timestamps are venue epoch milliseconds;
@@ -46,11 +52,45 @@ pub const HEADER: &str = "opened_ms,closed_ms,side,quantity,entry_price,exit_pri
 const HEADER_V1: &str =
     "opened_ms,closed_ms,side,quantity,entry_price,exit_price,pnl_points,exit_reason";
 
+/// Where a session's trades came from — recorded once per file, so the
+/// report can keep practice runs out of the real track record.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SessionSource {
+    /// A live venue feed was driving the tape.
+    Live,
+    /// A recorded session was driving the tape (market replay).
+    Replay,
+}
+
+impl SessionSource {
+    /// The token the `# source=` header line carries.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Live => "live",
+            Self::Replay => "replay",
+        }
+    }
+
+    /// The inverse of [`Self::as_str`]; unknown tokens are refused.
+    #[must_use]
+    pub fn parse(token: &str) -> Option<Self> {
+        match token {
+            "live" => Some(Self::Live),
+            "replay" => Some(Self::Replay),
+            _ => None,
+        }
+    }
+}
+
 /// A parsed history file.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TradeHistory {
     /// Symbol from the `# symbol=` comment, when present.
     pub symbol: Option<String>,
+    /// Session source from the `# source=` comment; `None` for files from
+    /// before the line existed (unrecorded, never guessed).
+    pub source: Option<SessionSource>,
     /// Rows that parsed, in file order (which is closing order).
     pub trades: Vec<ClosedTrade>,
     /// Rows that did not parse, reported instead of silently dropped.
@@ -80,10 +120,14 @@ impl std::fmt::Display for HistoryError {
     }
 }
 
-/// The lines that open a new history file: magic, symbol, column header.
+/// The lines that open a new history file: magic, symbol, session source,
+/// column header.
 #[must_use]
-pub fn write_header(symbol: &str) -> String {
-    format!("# {FORMAT_NAME} {FORMAT_VERSION}\n# symbol={symbol}\n{HEADER}\n")
+pub fn write_header(symbol: &str, source: SessionSource) -> String {
+    format!(
+        "# {FORMAT_NAME} {FORMAT_VERSION}\n# symbol={symbol}\n# source={}\n{HEADER}\n",
+        source.as_str()
+    )
 }
 
 /// One closed trade as one CSV line (newline included), the exact inverse
@@ -149,6 +193,7 @@ pub fn parse(text: &str) -> Result<TradeHistory, HistoryError> {
     };
 
     let mut symbol = None;
+    let mut source = None;
     let mut header_seen = false;
     let mut trades = Vec::new();
     let mut problems = Vec::new();
@@ -159,8 +204,23 @@ pub fn parse(text: &str) -> Result<TradeHistory, HistoryError> {
             continue;
         }
         if let Some(comment) = trimmed.strip_prefix('#') {
-            if let Some(value) = comment.trim().strip_prefix("symbol=") {
+            let comment = comment.trim();
+            if let Some(value) = comment.strip_prefix("symbol=") {
                 symbol = Some(value.trim().to_owned());
+            } else if let Some(value) = comment.strip_prefix("source=") {
+                match SessionSource::parse(value.trim()) {
+                    Some(parsed) => source = Some(parsed),
+                    // An unknown token stays unrecorded and is reported —
+                    // guessing "live" would launder a practice run into
+                    // the real track record.
+                    None => problems.push(HistoryProblem {
+                        line: line_number,
+                        message: format!(
+                            "unknown source `{}` - treated as unrecorded",
+                            value.trim()
+                        ),
+                    }),
+                }
             }
             continue;
         }
@@ -192,6 +252,7 @@ pub fn parse(text: &str) -> Result<TradeHistory, HistoryError> {
     }
     Ok(TradeHistory {
         symbol,
+        source,
         trades,
         problems,
     })
@@ -315,14 +376,38 @@ mod tests {
             sample(Side::Sell, -3, ExitReason::StopLoss),
             sample(Side::Buy, 0, ExitReason::Reset),
         ];
-        let mut text = write_header("BTCUSDT");
+        let mut text = write_header("BTCUSDT", SessionSource::Live);
         for trade in &trades {
             text.push_str(&write_trade(trade));
         }
         let history = parse(&text).expect("round trip parses");
         assert_eq!(history.symbol.as_deref(), Some("BTCUSDT"));
+        assert_eq!(history.source, Some(SessionSource::Live));
         assert_eq!(history.trades, trades.to_vec());
         assert!(history.problems.is_empty());
+    }
+
+    #[test]
+    fn the_session_source_round_trips_and_its_absence_stays_unrecorded() {
+        let mut text = write_header("BTCUSDT", SessionSource::Replay);
+        text.push_str(&write_trade(&sample(Side::Buy, 5, ExitReason::Manual)));
+        let history = parse(&text).expect("parses");
+        assert_eq!(history.source, Some(SessionSource::Replay));
+
+        // A file from before `# source=` existed: unrecorded, not "live".
+        let legacy = format!("# quantick-trades 2\n# symbol=X\n{HEADER}\n");
+        let history = parse(&legacy).expect("legacy files still parse");
+        assert_eq!(history.source, None, "unrecorded is not guessed");
+        assert!(history.problems.is_empty());
+    }
+
+    #[test]
+    fn an_unknown_source_token_is_reported_and_stays_unrecorded() {
+        let text = format!("# quantick-trades 2\n# symbol=X\n# source=backtest\n{HEADER}\n");
+        let history = parse(&text).expect("the file still loads");
+        assert_eq!(history.source, None);
+        assert_eq!(history.problems.len(), 1);
+        assert!(history.problems[0].message.contains("backtest"));
     }
 
     #[test]
@@ -353,7 +438,7 @@ mod tests {
             line.trim_end().ends_with("manual,,,,"),
             "unknown fields stay empty: {line}"
         );
-        let mut text = write_header("X");
+        let mut text = write_header("X", SessionSource::Live);
         text.push_str(&line);
         let history = parse(&text).expect("round trips");
         assert_eq!(history.trades[0], trade);
@@ -361,7 +446,7 @@ mod tests {
 
     #[test]
     fn a_torn_final_line_costs_one_reported_row_not_the_file() {
-        let mut text = write_header("WINQ26");
+        let mut text = write_header("WINQ26", SessionSource::Live);
         text.push_str(&write_trade(&sample(Side::Buy, 5, ExitReason::Manual)));
         // A crash mid-append leaves a partial row.
         text.push_str("1700000000000,17000");
@@ -369,8 +454,8 @@ mod tests {
         assert_eq!(history.trades.len(), 1);
         assert_eq!(history.problems.len(), 1);
         assert_eq!(
-            history.problems[0].line, 5,
-            "magic + symbol + header + row, then the tear"
+            history.problems[0].line, 6,
+            "magic + symbol + source + header + row, then the tear"
         );
         assert!(history.problems[0].message.contains("12 fields"));
     }
@@ -409,7 +494,7 @@ mod tests {
 
     #[test]
     fn unknown_exit_reason_is_a_problem_row() {
-        let mut text = write_header("X");
+        let mut text = write_header("X", SessionSource::Live);
         text.push_str("1,2,long,1,100,101,1,liquidated,,,,\n");
         let history = parse(&text).expect("file loads");
         assert!(history.trades.is_empty());
@@ -418,7 +503,7 @@ mod tests {
 
     #[test]
     fn comments_and_blank_lines_are_tolerated_between_rows() {
-        let mut text = write_header("X");
+        let mut text = write_header("X", SessionSource::Live);
         text.push('\n');
         text.push_str("# a note a human left\n");
         text.push_str(&write_trade(&sample(Side::Sell, 7, ExitReason::TakeProfit)));


### PR DESCRIPTION
Paper-trading overhaul: durable history in the user's documents folder, the performance report answering for its whole history, honest replay/real separation, a team bug hunt, and the new Cmd Trading gesture.

## What changed

**Durable history (the "my old trades are gone" fix).** The journal default and the sidecar remembering the user's pick were cwd-relative — launching from a different folder silently switched the whole history. The default home is now `Documents/Quantick/paper-trades` (new `paper_home` module; `dirs` dependency, app crate only). A one-time startup rescue copies — never moves, never deletes — the reachable legacy locations (the stored pick, the cwd-relative `paper-trades`) into the home, marked by a `.consolidated` file in the home itself so it is one-time from every launch directory; after it, a pick made in-app is a standing choice again. A clean pass is required before the pick is retired (failed or unreadable sources keep it and retry). Copies are atomic (temp-and-rename), byte-identical files are skipped (idempotent re-runs), name clashes land as `.imported-N`, and only files that parse as quantick-trades history travel. A report-window button imports any other folder manually the same way.

**Performance report.** Three verified causes of "old trades sometimes don't show": the report never re-read the journal while open (a close now reloads it); "Today" cut at UTC midnight while the ledger renders local time (it now breaks at the display timezone's midnight, and the anchor date prints on the same calendar); with "All symbols" the period anchors on the newest trade of the whole scope, hiding markets traded further back (deliberate — replay data may be years old — but the support line now counts the older saved trades before the window). The period pills gain a typed field (`45m`, `12h`, `2d`, `1w`), applied on Enter or blur; a refused entry toasts instead of silently emptying the report. Per-asset filtering (the symbol combo) is proven on disk with a two-symbol test.

**Replay vs real.** The journal header gains `# source=live|replay` (comment-level: v1/v2 files parse unchanged; absent = unrecorded, never guessed). The tab sets the source from the feed handle it attaches. The report gains a Source filter — Real | Replay | Both — defaulting to Real; unrecorded legacy files count as real (that era was live trading). Membership is decided by an exhaustive match, so a future source variant cannot fall into the real record silently. Re-running the same replay lands as `stamp.rerun-N` beside the first run instead of appending duplicates into it — including in-session re-runs (a timeline reset now ends the file session). The export carries a per-trade source column stamped with the source each trade actually closed under.

**Cmd Trading.** "Enable Cmd Trading" in the ticket (default **on** — explicitly requested by the user; noted as a deliberate exception to defaults-preserve-behaviour): hold the buy key (Shift by default) or the sell key (Ctrl) over the chart and a short dashed line hugs the right edge at the pointer's price, y-locked. Above the mark it reads Stop, below Limit, mirrored for sells — the context menu's own validity table. The label off the line's left end (side + kind + qty) highlights on hover, shows the hand cursor, and a click places the order through `place_resting`, the exact path the right-click menu uses (which is untouched). The gutter chip shows the snapped price. Keys are configurable per side (Shift/Ctrl/Alt) and persist in `paper-state.toml` (now a whole-state sidecar, read-modify-write). Paint and hit-test share one geometry, laid out against the lane-clipped band. `QUANTICK_CMD_PREVIEW=buy|sell` is the harness hook (registered in the ui-harness skill).

**Team bug hunt.** A 14-agent workflow (4 lenses → dedup → 2 adversarial skeptics per finding) confirmed 5 findings (3 unique), all fixed with regression tests: the attach-before-flatten source laundering on replay open/close; the ledger/export double-count after a journal retarget; the every-restart revocation of the picked folder. Sub-cap findings fixed in the same pass: preview paint/hit rect mismatch under the live tape lane, export source mislabeling, in-session rerun appends, the swallowed could-not-save toast, the stale report after a folder change, empty-state/Source-filter honesty, foreign-CSV planting, non-atomic copies.

## Performance impact (declared)

- **Per-frame**: the cmd preview — one modifier check when idle; one dashed line, one fixed-width tag, one gutter chip while held. Measured under a dense binance BTCUSDT tape with book + bubbles + strip + demo trades + open report, identical env both sides: `frame_cpu_ms` avg **3.16 (main control) vs 3.04 (branch, preview forced on)**, max 3.65 vs 3.27 — flat. (fps pinned at 19 on both runs: the Windows session was locked, so the compositor throttled both identically; `frame_cpu_ms` is the cost metric.)
- **Per trade-close (rare)**: journal append + path bookkeeping; report reload when the window is open (full folder re-read — same cost as the manual refresh button; worth a cache if journals grow to thousands of files).
- **Rare**: startup consolidation (one-time + a legacy-folder sweep), config/state IO, period parsing.
- **Per-depth**: untouched.

## Evidence

- 4 checks green after rebase on latest `origin/main`: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo build --workspace`, `cargo test --workspace` → **1823 passed, 0 failed**.
- Named regression tests (fail without their fix): `a_second_session_adds_a_file_and_never_touches_the_first`, `the_rescue_runs_once_and_then_the_pick_wins_again`, `an_unreadable_or_failing_pass_keeps_the_pick_and_the_rescue_pending`, `today_breaks_at_the_displayed_midnight_not_utc`, `typed_periods_parse_strictly_and_format_back`, `all_symbols_hides_older_markets_but_says_so_and_scope_restores_them`, `a_close_refreshes_an_open_report_by_itself`, `the_report_scopes_by_symbol_folder_on_disk`, `the_session_source_round_trips_and_its_absence_stays_unrecorded`, `a_replay_rerun_lands_beside_its_first_run_never_inside_it`, `an_in_session_rerun_opens_its_own_file`, `the_report_opens_on_real_and_keeps_replay_out_until_asked`, `the_cmd_gesture_previews_and_a_label_click_places_the_order`, `the_cmd_preview_paints_line_label_and_price_chip`, `a_replay_switch_flattens_under_the_session_that_owned_the_position`, `the_ledger_never_lists_this_sessions_trades_twice_after_a_retarget`, `export_rows_remember_the_source_each_trade_closed_under`.
- trader-ux-review: 3 findings, all fixed (Source pill reads "Both"; typed period applies on blur; the cmd block states its own key instructions). No open Blocker.
- arch-review: 1 finding (Real-filter membership not exhaustive), fixed in `c4b865b`. Verdict — Docking: the next capability (a new source, a new key) docks by enum variant with exhaustive matches forcing the decision; `paper_home` plugs at one point. Performance: flat per-frame (measured), everything else rare. Proof: the named tests above.

## visual-qa status (explicitly accepted defect)

Screenshot capture was **blocked by the environment**: the Windows session was locked for the entire run — PrintWindow captures white and CopyFromScreen photographs the lock backdrop (solid blue). Substitute evidence recorded instead: an off-screen render proof (`the_cmd_preview_paints_line_label_and_price_chip` asserts the dashed segments, the side label and the price chip in real egui shapes), 40+ paper-trading unit tests, and live-tape health telemetry. Screenshots should be retaken in the first unlocked session (`QUANTICK_CMD_PREVIEW=buy|sell`, `QUANTICK_DOCK_TAB=trading`, `QUANTICK_PAPER_REPORT_AUTOSTART=1`, per the ui-harness registry).

## Deferred (explicitly)

- **Prefix-aware import dedupe**: a partial backup of the same append-only session file imports as `.imported-N` and double-counts its overlap. Rare (requires a name clash with divergent content); needs a prefix-detection design.
- **`paper-state.toml` is still cwd-relative**: the dangerous half (consolidation re-triggering from another cwd) is cured by the home-side marker; relocating the sidecar itself is a follow-up.
- **Concurrent instances** share the sidecar temp file and read-modify-write without locking (settings-only damage; trade CSVs never pass through it).
- **Ledger rows don't badge replay visually** (the report separates; the ledger is navigation) — UX Consider.
- **Flake observed once** in `a_feed_declaring_an_unknown_bubble_preset_changes_nothing` across ~10 suite runs (passes isolated and in 4 consecutive full runs; pre-existing shared-state suspicion, not reproduced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGgUtv5hdwhUtukzCBHF4c
