### PR TITLE
fix(mt5): bring the replay download back — the export summary read two names that did not exist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,19 @@ jobs:
         # touches them, so they get their own step. Hermetic: the suite builds
         # its own throwaway repos and never reads this checkout.
         run: sh .claude/hooks/guardrails_test.sh
+      - name: Python tooling lint
+        # The MetaTrader bridge and the session exporter are Python, so not one
+        # of the cargo steps below can see them. An undefined name reached main
+        # on 2026-08-13 and killed every replay download for a day, because
+        # Python resolves names only when the line runs and that line runs on a
+        # logged-in terminal nobody has in CI. `--select F` is pyflakes' rule
+        # set — the one that catches a name that cannot resolve — and it runs
+        # before the slow steps so this class of bug fails in seconds.
+        run: pipx run ruff check --select F tools/mt5/ bridge/mt5/
+      - name: Exporter tests
+        # Drives export_session.py end to end against a fake terminal: no
+        # MetaTrader, no network, no credentials, nothing to install.
+        run: python3 tools/mt5/test_export_session.py
       - name: Install desktop GUI dependencies
         # quantick-app (egui/eframe + winit) needs these to build/link on Linux.
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ Every change must pass all four checks before commit — no exceptions:
 3. `cargo build --workspace`
 4. `cargo test --workspace`
 
-CI (`.github/workflows/ci.yml`) enforces the same four checks on every PR and on pushes to `main`. After pushing a PR, watch CI with `gh pr checks <n> --watch` and fix any failure before requesting review or merging. A PR with red CI is never merged.
+CI (`.github/workflows/ci.yml`) enforces the same four checks on every PR and on pushes to `main`, plus two the workspace cannot see: `ruff check --select F` over `tools/mt5/` and `bridge/mt5/`, and `python3 tools/mt5/test_export_session.py`. The MetaTrader bridge and the session exporter are Python — cargo never compiles them, and an undefined name there ships silently. Run both locally when you touch either folder. After pushing a PR, watch CI with `gh pr checks <n> --watch` and fix any failure before requesting review or merging. A PR with red CI is never merged.
 
 ## Workflow
 

--- a/tools/mt5/export_session.py
+++ b/tools/mt5/export_session.py
@@ -399,7 +399,10 @@ def export_tape(
         )
         raise SystemExit(4)
 
-    if flags_are_one_sided(flag_buys, flag_sells):
+    # Held rather than re-asked below: the summary has to report what was
+    # *decided*, and asking the predicate twice is how the two drift apart.
+    one_sided_flags = flags_are_one_sided(flag_buys, flag_sells)
+    if one_sided_flags:
         # The flags are untrustworthy for this whole day. Re-derive every side
         # with the tick rule — uptick bought, downtick sold, unchanged keeps
         # the last direction — the same safe default the live bridge charts
@@ -477,11 +480,14 @@ def export_tape(
         )
         written += 1
 
+    # Zero when the flags were thrown away: on a stamped day the venue answered
+    # for every print and none of those answers survived into the file, so
+    # reporting the count it stamped would credit it for work the tick rule did.
     emit(
         "EXPORT_TAPE_SIDES",
         symbol=symbol,
         side_source=side_source,
-        venue_flagged=0 if one_sided_flags else flagged,
+        venue_flagged=0 if one_sided_flags else flag_buys + flag_sells,
         inferred=inferred_sides,
     )
 

--- a/tools/mt5/test_export_session.py
+++ b/tools/mt5/test_export_session.py
@@ -136,7 +136,21 @@ def tick(time_ms, price, flags, bid=0.0, ask=0.0, volume=1.0):
     }
 
 
+#: The clock every B3 broker's server runs on, seconds from UTC.
+B3_UTC_OFFSET_S = -10_800
+
+#: Price decimals for the mini index: it trades in whole points.
+WIN_PRICE_DIGITS = 0
+
 Export = namedtuple("Export", "body written events relative")
+Refusal = namedtuple("Refusal", "exit_code events files_written")
+
+
+def read_events(captured):
+    """The JSON diagnostics from a captured stderr, in order."""
+    return [
+        json.loads(line) for line in captured.getvalue().splitlines() if line.strip()
+    ]
 
 
 def run_export(ticks, symbol="WINV26", day="2026-08-12"):
@@ -150,13 +164,34 @@ def run_export(ticks, symbol="WINV26", day="2026-08-12"):
     with tempfile.TemporaryDirectory() as tmp:
         out = Path(tmp)
         with contextlib.redirect_stderr(captured):
-            path, written = export_tape(FakeMt5(ticks), symbol, day, -10_800, 0, out)
+            path, written = export_tape(
+                FakeMt5(ticks), symbol, day, B3_UTC_OFFSET_S, WIN_PRICE_DIGITS, out
+            )
         body = path.read_text(encoding="utf-8")
         relative = path.relative_to(out).as_posix()
-    events = [
-        json.loads(line) for line in captured.getvalue().splitlines() if line.strip()
-    ]
-    return Export(body, written, events, relative)
+    return Export(body, written, read_events(captured), relative)
+
+
+def run_refusal(ticks, symbol="WINV26", day="2026-08-12"):
+    """Drive `export_tape` on a day it must refuse.
+
+    Returns the exit code it stopped with, what it said, and every file it
+    left behind — which has to be none: a refusal that writes half a tape is
+    a day the session browser would offer and the trader could not use.
+    """
+    captured = io.StringIO()
+    exit_code = None
+    with tempfile.TemporaryDirectory() as tmp:
+        out = Path(tmp)
+        with contextlib.redirect_stderr(captured):
+            try:
+                export_tape(
+                    FakeMt5(ticks), symbol, day, B3_UTC_OFFSET_S, WIN_PRICE_DIGITS, out
+                )
+            except SystemExit as stop:
+                exit_code = stop.code
+        files_written = sorted(path.name for path in out.rglob("*") if path.is_file())
+    return Refusal(exit_code, read_events(captured), files_written)
 
 
 def one_event(events, code):
@@ -167,8 +202,9 @@ def one_event(events, code):
 
 
 def data_rows(body):
-    """The tape's rows, without its six header lines."""
-    return [line for line in body.splitlines() if line and not line.startswith("#")][1:]
+    """The tape's prints: everything past the `#` block and the column line."""
+    declared = [line for line in body.splitlines() if line and not line.startswith("#")]
+    return declared[1:]
 
 
 def test_a_flagged_day_reaches_disk_with_its_sides_declared():
@@ -224,12 +260,28 @@ def test_a_stamped_day_is_rederived_and_credits_the_venue_with_nothing():
 
 def test_a_day_with_no_prints_refuses_instead_of_writing_an_empty_tape():
     # A quote-only day (COPY_TICKS_TRADE lets those through) is not a session.
-    try:
-        run_export([tick(1_786_000_000_000, 0.0, TICK_FLAG_BUY, 172255.0, 172260.0)])
-    except SystemExit as exit_code:
-        assert exit_code.code == 4
-    else:
-        raise AssertionError("a tape with no print must not be written")
+    refusal = run_refusal(
+        [tick(1_786_000_000_000, 0.0, TICK_FLAG_BUY, 172255.0, 172260.0)]
+    )
+
+    assert refusal.exit_code == 4
+    assert refusal.files_written == [], "a refused day must leave nothing behind"
+    assert one_event(refusal.events, "EXPORT_TAPE_EMPTY")["fix"]
+
+
+def test_a_terminal_that_serves_no_ticks_names_the_day_and_the_next_step():
+    # `copy_ticks_range` answers None when the terminal holds no tick history
+    # for the symbol — the likeliest remaining failure on a contract that has
+    # just started trading, and the one a trader can actually act on by
+    # opening its chart once.
+    refusal = run_refusal(None)
+
+    assert refusal.exit_code == 4
+    assert refusal.files_written == []
+    failure = one_event(refusal.events, "EXPORT_TAPE_FAILED")
+    assert failure["day"] == "2026-08-12"
+    assert failure["symbol"] == "WINV26"
+    assert "chart" in failure["fix"], "the fix must be something to go and do"
 
 
 if __name__ == "__main__":

--- a/tools/mt5/test_export_session.py
+++ b/tools/mt5/test_export_session.py
@@ -1,15 +1,26 @@
-"""Tests for the pure side-inference policy in export_session.py.
+"""Tests for export_session.py: the side-inference policy, and the export
+itself driven end to end against a fake terminal.
 
-The repo's CI is cargo-only, so these do not run there; they exist so the
-policy can be proven without a logged-in terminal. Run either way:
+They prove the exporter without a logged-in MetaTrader, which is what lets CI
+run them. Run either way:
 
     python tools/mt5/test_export_session.py
     python -m pytest tools/mt5/test_export_session.py
 """
 
+import contextlib
+import io
+import json
+import tempfile
+from collections import namedtuple
 from datetime import datetime, timezone
+from pathlib import Path
 
 from export_session import (
+    ONE_SIDED_PROOF_PRINTS,
+    TICK_FLAG_BUY,
+    TICK_FLAG_SELL,
+    export_tape,
     fill_missing_sides,
     flags_are_one_sided,
     rederive_sides,
@@ -87,6 +98,138 @@ def test_spread_side_is_evidence_or_nothing():
     assert spread_side(99.0, 99.0, 100.0) == "S"
     assert spread_side(99.5, 99.0, 100.0) == ""
     assert spread_side(100.0, 0.0, 0.0) == ""
+
+
+class FakeMt5:
+    """The slice of the MetaTrader5 package `export_tape` actually touches.
+
+    Small on purpose: a fake that grows past what the code under test calls
+    stops being evidence and starts being a second implementation to maintain.
+    """
+
+    COPY_TICKS_TRADE = 2
+
+    def __init__(self, ticks):
+        self._ticks = ticks
+        self.asked_for = None
+
+    def copy_ticks_range(self, symbol, start, end, flags):
+        self.asked_for = (symbol, start, end, flags)
+        return self._ticks
+
+    def last_error(self):
+        return (0, "no error")
+
+
+def tick(time_ms, price, flags, bid=0.0, ask=0.0, volume=1.0):
+    """One row shaped like MT5's tick array, keyed the way export_tape reads it."""
+    return {
+        "time_msc": time_ms,
+        "last": price,
+        "bid": bid,
+        "ask": ask,
+        "volume": volume,
+        # The terminal reports 0.0 when it has no real volume; export_tape then
+        # falls back to `volume`, and both paths must stay exercised.
+        "volume_real": 0.0,
+        "flags": flags,
+    }
+
+
+Export = namedtuple("Export", "body written events relative")
+
+
+def run_export(ticks, symbol="WINV26", day="2026-08-12"):
+    """Drive `export_tape` end to end against a fake terminal.
+
+    Returns what landed on disk, how many prints it holds, the JSON
+    diagnostics it emitted, and where the file was written relative to the
+    output folder.
+    """
+    captured = io.StringIO()
+    with tempfile.TemporaryDirectory() as tmp:
+        out = Path(tmp)
+        with contextlib.redirect_stderr(captured):
+            path, written = export_tape(FakeMt5(ticks), symbol, day, -10_800, 0, out)
+        body = path.read_text(encoding="utf-8")
+        relative = path.relative_to(out).as_posix()
+    events = [
+        json.loads(line) for line in captured.getvalue().splitlines() if line.strip()
+    ]
+    return Export(body, written, events, relative)
+
+
+def one_event(events, code):
+    """The single diagnostic with this code, or an assertion about why not."""
+    matches = [event for event in events if event["event_code"] == code]
+    assert len(matches) == 1, f"expected one {code}, saw {len(matches)}"
+    return matches[0]
+
+
+def data_rows(body):
+    """The tape's rows, without its six header lines."""
+    return [line for line in body.splitlines() if line and not line.startswith("#")][1:]
+
+
+def test_a_flagged_day_reaches_disk_with_its_sides_declared():
+    # The regression test for the export that died between 2026-08-13 and this
+    # fix: the summary line sits between the last formatted row and the write,
+    # so a name that does not exist there means no file is ever written. Every
+    # test above this one covers a pure helper — none of them calls export_tape,
+    # which is exactly why a NameError shipped.
+    export = run_export(
+        [
+            tick(1_786_000_000_000, 172260.0, TICK_FLAG_BUY, 172255.0, 172260.0),
+            tick(1_786_000_001_000, 172255.0, TICK_FLAG_SELL, 172255.0, 172260.0),
+            # No flag, and priced inside the spread: nothing to read it off but
+            # the side before it.
+            tick(1_786_000_002_000, 172258.0, 0, 172255.0, 172260.0),
+        ]
+    )
+
+    assert export.relative == "WINV26/2026-08-12.csv"
+    assert export.written == 3
+    assert len(data_rows(export.body)) == 3
+    # One print was inferred, so the file must not claim the venue answered.
+    assert "# side_source=venue_flags_with_bid_ask_fallback" in export.body
+    summary = one_event(export.events, "EXPORT_TAPE_SIDES")
+    assert summary["venue_flagged"] == 2
+    assert summary["inferred"] == 1
+    written = one_event(export.events, "EXPORT_TAPE_WRITTEN")
+    assert written["ticks"] == 3
+    assert written["bytes"] > 0
+
+
+def test_a_stamped_day_is_rederived_and_credits_the_venue_with_nothing():
+    # The B3 broker stamps BUY on every print. The whole day is re-derived, and
+    # the summary must not credit the venue for answers that never reached the
+    # file — 0, not the count it stamped.
+    export = run_export(
+        [
+            tick(1_786_000_000_000 + index * 100, 172000.0 + index % 7, TICK_FLAG_BUY)
+            for index in range(ONE_SIDED_PROOF_PRINTS + 1)
+        ]
+    )
+
+    assert "# side_source=tick_rule" in export.body
+    summary = one_event(export.events, "EXPORT_TAPE_SIDES")
+    assert summary["venue_flagged"] == 0, "no stamped flag survived into the file"
+    assert summary["inferred"] == export.written
+    assert one_event(export.events, "EXPORT_TAPE_SIDES_ONE_SIDED")["flag_buys"] == (
+        ONE_SIDED_PROOF_PRINTS + 1
+    )
+    # The tick rule found both sides in a market that only ever printed BUY.
+    assert {row.split(",")[-1] for row in data_rows(export.body)} == {"B", "S"}
+
+
+def test_a_day_with_no_prints_refuses_instead_of_writing_an_empty_tape():
+    # A quote-only day (COPY_TICKS_TRADE lets those through) is not a session.
+    try:
+        run_export([tick(1_786_000_000_000, 0.0, TICK_FLAG_BUY, 172255.0, 172260.0)])
+    except SystemExit as exit_code:
+        assert exit_code.code == 4
+    else:
+        raise AssertionError("a tape with no print must not be written")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## The bug

Downloading a replay session from MetaTrader has been dead since **2026-08-13
11:33**. Every attempt failed the same way, and the app could only report what
it saw: *"MetaTrader 5 stopped with code 1"*.

`tools/mt5/export_session.py:484` read

```python
venue_flagged=0 if one_sided_flags else flagged,
```

Neither name exists in `export_tape`. `flagged` is a local inside
`flags_are_one_sided`; `one_sided_flags` was never written at all — the
predicate was called inline in the `if`, so its result had no name to be read
back from. Python resolves names when the line runs, so the file imports, parses
and lints-by-eye fine, then raises `NameError` at the worst possible moment:
**after** the entire tape has been read and formatted in memory, and **one line
before** `write_atomically`. Tens of millions of ticks were fetched and thrown
away, every time, without a byte reaching disk.

Introduced by `0976ec3d` — the commit that taught the exporter to distrust a
broker that stamps BUY on every print. Good policy, one typo.

The user's disk dates it exactly: the last tape that landed is
`quantick-data/WINV26/2026-08-12.csv`, written **2026-08-13 01:29** — nine hours
before that commit.

### Why nothing caught it

- `--probe` never reaches the line, so the calendar kept filling in and the
  feature looked alive right up to the download button.
- The four checks are cargo-only. Nothing in this repo ever ran the exporter.
- `tools/mt5/test_export_session.py` covered the pure side-inference helpers and
  never called `export_tape` — the one function with a terminal in its signature.

## The fix

1. Hold the predicate's answer in `one_sided_flags` instead of asking it twice,
   and report `flag_buys + flag_sells` — zero when the flags were thrown away,
   because on a stamped day no venue answer survives into the file and crediting
   the venue for the tick rule's work would be a small lie in a diagnostic whose
   whole job is data honesty.
2. A test that drives `export_tape` end to end against a fake `MetaTrader5`
   (a class with `copy_ticks_range`, `last_error` and one constant), covering
   both branches and the refusal on a day with no prints. **It fails with the
   `NameError` on `main`** — verified by running it against `git show
   main:tools/mt5/export_session.py`.
3. CI runs `ruff check --select F` over `tools/mt5/` and `bridge/mt5/`, plus the
   exporter tests — before the slow steps, so this class of bug fails in seconds
   instead of on a trader's machine. `--select F` is pyflakes' rule set: the one
   that catches a name that cannot resolve.

## Evidence

| Check | Result |
| --- | --- |
| `ruff check --select F tools/mt5/ bridge/mt5/` | `All checks passed!` (2 × F821 before) |
| `python tools/mt5/test_export_session.py` | 9 passed; the new one fails on `main` with `NameError: name 'one_sided_flags' is not defined` |
| `cargo fmt --all -- --check` | exit 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | exit 0 |
| `cargo build --workspace` | exit 0 |
| `cargo test --workspace` | exit 0 |

### Against the real terminal (XP, WINV26)

Not a simulation — the fixed exporter run against the logged-in MT5:

```
--probe --symbol WINV26      → 83 days, 2026-04-17 … 2026-08-14
--day 2026-08-13             → EXPORT_TAPE_SIDES venue_flagged=1476508 inferred=0
                               EXPORT_TAPE_WRITTEN ticks=1476508 bytes=72752069
                               EXPORT_CONTEXT_WRITTEN sessions=5 complete=true
                               EXPORT_DONE, exit 0
```

The tape then loads through `quantick-replay` itself: 1 476 508 trades, 9h28m
span, 2 820 context candles, `complete=true`. Sides came out 754 123 B / 722 385
S — a real market, so `venue_flags` was the honest declaration for that day.

Replay was never broken: `scan()` over the user's folder lists **26 playable
sessions, 0 rejected**, WINV26 included. There was simply nothing new to play.

## Performance impact

Every touched path is **rare**: `export_tape` runs once per download in a
separate one-shot process, and the CI steps are build-time. No per-trade,
per-depth or per-frame code is edited, so no fps evidence is owed.

## arch-review

Run over `git diff main...HEAD`. Findings and resolutions are in the thread
below.

### Deferred, not part of this fix

The XP terminal puts the **daily band limits** in the `bid`/`ask` fields of
trade ticks — e.g. `bid=187950, ask=153780` against a price of `170665`, bid
above ask and both far outside the day's range. `spread_side` therefore reads
`price >= ask` as true for essentially every print and would answer "B" to any
print the venue left unflagged. It costs nothing today (`inferred=0` on the days
checked), but it is a fallback that cannot fail loudly, and it deserves its own
issue: an inverted book is evidence of nothing and should be treated as no
quote at all.
