### PR TITLE
feat(tape): a fita é um painel, e responde por si

### DIFF
--- a/.claude/skills/ui-harness/SKILL.md
+++ b/.claude/skills/ui-harness/SKILL.md
@@ -121,8 +121,10 @@ Landing with the tape-configuration goal (`feat/tape-own-config`):
 
 | Hook | Reaches |
 | --- | --- |
-| `QUANTICK_TAPE_LAYERS=<list>` | what the **tape** draws, now that it is switched apart from the candles: comma-separated `heatmap`, `bubbles`, `no-heatmap`, `no-bubbles`, or `none` for a bare tape. Each entry calls the setter the tape menu's checkbox calls, and an unlisted layer is left as it was. The state the split exists for — `QUANTICK_BUBBLES_AUTOSTART=1` with `QUANTICK_TAPE_LAYERS=no-bubbles`, or the reverse — is reachable no other way, because the tape's menu is a right-click no scripted run can perform |
+| `QUANTICK_TAPE_LAYERS=<list>` | what the **tape** draws, now that it is switched apart from the candles: comma-separated `heatmap`, `bubbles`, `no-heatmap`, `no-bubbles`, or `none` for a bare tape. Each entry calls the setter the tape menu's checkbox calls, and an unlisted layer is left as it was. The state the split exists for — `QUANTICK_BUBBLES_AUTOSTART=1` with `QUANTICK_TAPE_LAYERS=no-bubbles`, or the reverse — is set here directly; use `QUANTICK_CONTEXT_MENU=tape` when the menu itself is what needs photographing |
 | `QUANTICK_TAPE_WINDOW=<auto\|90s\|2min\|120000ms>` | how much market time the tape shows: `auto` follows the bars (the default), a duration pins it. Accepts `s`, `m`/`min`, `ms` or bare milliseconds; anything else is refused rather than guessed, so a typo photographs the default instead of an invented window. This is what makes the "bubbles stay visible longer" state capturable at all — otherwise it depends on how fast the bars happen to be closing |
+
+| `QUANTICK_CONTEXT_MENU=<chart\|tape>` | the right-click menu open on that pane, once, on the first frame that has drawn a canvas. The two panes now open **different** menus, so "open the context menu" is no longer one instruction. The click is delivered as a real secondary-button event through the app's own input path (`raw_input_hook`) rather than by reaching into egui's menu state — what opens is exactly what a trader's click opens. `tape` yields nothing on a canvas with no lane, and an unrecognised value opens nothing rather than the wrong pane's menu |
 
 Once merged, move them into the table above.
 

--- a/.claude/skills/ui-harness/SKILL.md
+++ b/.claude/skills/ui-harness/SKILL.md
@@ -117,6 +117,15 @@ Landing with the paper-trading overhaul (`feat/paper-trading-overhaul`):
 
 Once merged, move it into the table above.
 
+Landing with the tape-configuration goal (`feat/tape-own-config`):
+
+| Hook | Reaches |
+| --- | --- |
+| `QUANTICK_TAPE_LAYERS=<list>` | what the **tape** draws, now that it is switched apart from the candles: comma-separated `heatmap`, `bubbles`, `no-heatmap`, `no-bubbles`, or `none` for a bare tape. Each entry calls the setter the tape menu's checkbox calls, and an unlisted layer is left as it was. The state the split exists for — `QUANTICK_BUBBLES_AUTOSTART=1` with `QUANTICK_TAPE_LAYERS=no-bubbles`, or the reverse — is reachable no other way, because the tape's menu is a right-click no scripted run can perform |
+| `QUANTICK_TAPE_WINDOW=<auto\|90s\|2min\|120000ms>` | how much market time the tape shows: `auto` follows the bars (the default), a duration pins it. Accepts `s`, `m`/`min`, `ms` or bare milliseconds; anything else is refused rather than guessed, so a typo photographs the default instead of an invented window. This is what makes the "bubbles stay visible longer" state capturable at all — otherwise it depends on how fast the bars happen to be closing |
+
+Once merged, move them into the table above.
+
 For a screen that represents the user's real setup, enable the trio:
 `QUANTICK_BOOK_AUTOSTART` + `QUANTICK_BUBBLES_AUTOSTART` +
 `QUANTICK_LIVE_STRIP_AUTOSTART`, with a preset from `config/bubbles.toml`

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -841,6 +841,13 @@ pub struct QuantickApp {
     /// once the canvas has drawn once — so the menu opens exactly once and
     /// then behaves like any menu a hand opened.
     scripted_context_menu: Option<ContextMenuPane>,
+    /// Where the scripted press landed, until its release goes out.
+    ///
+    /// A real right-click spans frames: the button goes down, the app draws,
+    /// and only then does it come up. Delivering both halves in one frame
+    /// makes the menu open and close in the same pass, which is why a scripted
+    /// click has to hold the button for a frame like a hand does.
+    scripted_context_menu_release: Option<egui::Pos2>,
     scripted_candle_width: Option<f32>,
     /// `QUANTICK_INDICATOR_SETTINGS`: open the settings dialog for the
     /// first indicator once its inputs have arrived from the worker. Armed
@@ -1089,6 +1096,7 @@ impl QuantickApp {
             footprint_preset_draft: String::new(),
             scripted_footprint: false,
             scripted_context_menu: None,
+            scripted_context_menu_release: None,
             scripted_indicator_settings: false,
             scripted_candle_width: None,
             style: ChartStyle::default(),
@@ -5606,6 +5614,17 @@ impl eframe::App for QuantickApp {
     /// the first. So the hook supplies the click itself, on the pane it names,
     /// and every line after that is the code a trader's own click runs.
     fn raw_input_hook(&mut self, _ctx: &egui::Context, raw_input: &mut egui::RawInput) {
+        // Second frame: the button comes up where it went down, and the menu
+        // that opened on the press stays open.
+        if let Some(position) = self.scripted_context_menu_release.take() {
+            raw_input.events.push(egui::Event::PointerButton {
+                pos: position,
+                button: egui::PointerButton::Secondary,
+                pressed: false,
+                modifiers: egui::Modifiers::default(),
+            });
+            return;
+        }
         let Some(pane) = self.scripted_context_menu else {
             return;
         };
@@ -5615,17 +5634,12 @@ impl eframe::App for QuantickApp {
             return;
         };
         self.scripted_context_menu = None;
+        self.scripted_context_menu_release = Some(position);
         raw_input.events.push(egui::Event::PointerMoved(position));
         raw_input.events.push(egui::Event::PointerButton {
             pos: position,
             button: egui::PointerButton::Secondary,
             pressed: true,
-            modifiers: egui::Modifiers::default(),
-        });
-        raw_input.events.push(egui::Event::PointerButton {
-            pos: position,
-            button: egui::PointerButton::Secondary,
-            pressed: false,
             modifiers: egui::Modifiers::default(),
         });
     }

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -589,19 +589,6 @@ fn parse_tape_window(value: &str) -> Option<LaneWindow> {
     })
 }
 
-/// Format a duration in milliseconds for the lane's time axis, in the unit a
-/// human would read it in.
-pub fn fmt_window(milliseconds: i64) -> String {
-    let milliseconds = milliseconds.max(0);
-    if milliseconds < 1_000 {
-        format!("{milliseconds} ms")
-    } else if milliseconds < 60_000 {
-        format!("{:.1} s", milliseconds as f64 / 1_000.0)
-    } else {
-        format!("{:.1} min", milliseconds as f64 / 60_000.0)
-    }
-}
-
 /// Format a UTC epoch-millisecond timestamp as `HH:MM:SS` in the display
 /// timezone `tz`, for the time axis.
 pub fn fmt_time(ms: i64, tz: TzOffset) -> String {
@@ -7588,10 +7575,15 @@ mod tests {
 
     #[test]
     fn the_lane_axis_reads_its_window_in_a_human_unit() {
-        assert_eq!(fmt_window(800), "800 ms");
-        assert_eq!(fmt_window(8_000), "8.0 s");
-        assert_eq!(fmt_window(90_000), "1.5 min");
-        assert_eq!(fmt_window(-1), "0 ms");
+        use crate::orderflow::format_window_ms;
+        // One duration, one wording. The tape's axis and the menu that sets
+        // its window sit a hand's width apart, so "1.5 min" under the tape
+        // while the menu reads "1 min 30 s" is two languages for one number.
+        assert_eq!(format_window_ms(800), "800 ms");
+        assert_eq!(format_window_ms(8_000), "8 s");
+        assert_eq!(format_window_ms(90_000), "1 min 30 s");
+        assert_eq!(format_window_ms(120_000), "2 min");
+        assert_eq!(format_window_ms(-1), "0 ms");
     }
 
     /// A minimal one-feed, two-symbol config for the app tests.

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -37,6 +37,7 @@ use crate::indicators::state_file::{self, SavedIndicator, SavedInput, SavedKind,
 use crate::loading::{self, LoadingTask};
 use crate::metrics::{self, FrameStats};
 use crate::notice_card;
+use crate::orderflow::LaneWindow;
 use crate::pane::{self, ChartPane, DRAWING_ANCHOR_RADIUS_PX, PaneSide};
 use crate::replay_view::{ReplayAction, ReplayView};
 use crate::state::BarSpec;
@@ -529,6 +530,38 @@ fn fmt_progress(progress: &quantick_engine::BarProgress, unit: &str) -> String {
         progress.done.normalize(),
         progress.target.normalize()
     )
+}
+
+/// Read a tape window off `QUANTICK_TAPE_WINDOW`.
+///
+/// `auto` follows the bars; a duration pins it, in the units a human would
+/// type (`90s`, `2min`, `120000ms`, or bare milliseconds). `None` for anything
+/// else, so a typo leaves the tape at its default rather than photographing an
+/// invented window. The value is clamped by the setter, not here — one owner
+/// for the drawable range.
+fn parse_tape_window(value: &str) -> Option<LaneWindow> {
+    let value = value.trim().to_ascii_lowercase();
+    if value == "auto" {
+        return Some(LaneWindow::default());
+    }
+    let (number, scale) = if let Some(rest) = value.strip_suffix("ms") {
+        (rest, 1)
+    } else if let Some(rest) = value.strip_suffix("min") {
+        (rest, 60_000)
+    } else if let Some(rest) = value.strip_suffix('m') {
+        (rest, 60_000)
+    } else if let Some(rest) = value.strip_suffix('s') {
+        (rest, 1_000)
+    } else {
+        (value.as_str(), 1)
+    };
+    let parsed = number.trim().parse::<f64>().ok()?;
+    if !parsed.is_finite() || parsed <= 0.0 {
+        return None;
+    }
+    Some(LaneWindow::Fixed {
+        ms: (parsed * f64::from(scale)).round() as i64,
+    })
 }
 
 /// Format a duration in milliseconds for the lane's time axis, in the unit a
@@ -1205,6 +1238,46 @@ impl QuantickApp {
         // column's footprint). Same code path as the toolbar toggle.
         if std::env::var("QUANTICK_BUBBLES_AUTOSTART").is_ok_and(|value| value == "1") {
             app.active_tab_mut().tape_mut().set_bubbles_enabled(true);
+        }
+        // The tape's own switches. The two panes are configured apart and the
+        // tape's menu is a right-click a scripted run cannot perform, so the
+        // state behind it needs a door of its own — the state, not a second
+        // way of drawing it: each entry calls the very setter the menu's
+        // checkbox calls. Unlisted layers stay as they were, which is what
+        // keeps this hook from being a second opinion about the whole tape.
+        if let Ok(value) = std::env::var("QUANTICK_TAPE_LAYERS") {
+            let wanted: Vec<&str> = value
+                .split(',')
+                .map(str::trim)
+                .filter(|entry| !entry.is_empty())
+                .collect();
+            let tape = app.active_tab_mut().tape_mut();
+            if wanted.contains(&"none") {
+                tape.set_lane_depth_visible(false);
+                tape.set_lane_bubbles_enabled(false);
+            } else {
+                for entry in wanted {
+                    match entry {
+                        "heatmap" => tape.set_lane_depth_visible(true),
+                        "bubbles" => tape.set_lane_bubbles_enabled(true),
+                        "no-heatmap" => tape.set_lane_depth_visible(false),
+                        "no-bubbles" => tape.set_lane_bubbles_enabled(false),
+                        // A typo leaves the tape alone rather than guessing at
+                        // a layer: a capture of the wrong state is worse than
+                        // a capture of the default one.
+                        _ => {}
+                    }
+                }
+            }
+        }
+        // How much market time the tape shows: `auto` follows the bars, a
+        // duration pins it (`90s`, `2min`, `120000ms`, or bare milliseconds).
+        // Nonsense is refused rather than guessed at, so a typo photographs
+        // the default instead of an invented window.
+        if let Ok(value) = std::env::var("QUANTICK_TAPE_WINDOW")
+            && let Some(window) = parse_tape_window(value.trim())
+        {
+            app.active_tab_mut().tape_mut().set_live_lane_window(window);
         }
         // Same convenience for the candle footprint — the same field the
         // pane's layer menu writes, so a validation run sees exactly what a
@@ -8634,6 +8707,34 @@ plot(close)
             "an unavailable layer is still listed, just not switchable"
         );
         std::fs::remove_file(&path).ok();
+    }
+
+    /// The tape's window hook reads what a human would type, and refuses
+    /// everything else rather than guessing — a capture of the wrong state is
+    /// worse than a capture of the default one.
+    #[test]
+    fn the_tape_window_hook_reads_durations_and_refuses_nonsense() {
+        assert_eq!(parse_tape_window("auto"), Some(LaneWindow::default()));
+        assert_eq!(parse_tape_window("  AUTO "), Some(LaneWindow::default()));
+        for (typed, ms) in [
+            ("15s", 15_000),
+            ("90s", 90_000),
+            ("1min", 60_000),
+            ("2min", 120_000),
+            ("2m", 120_000),
+            ("1.5min", 90_000),
+            ("120000ms", 120_000),
+            ("120000", 120_000),
+        ] {
+            assert_eq!(
+                parse_tape_window(typed),
+                Some(LaneWindow::Fixed { ms }),
+                "{typed}"
+            );
+        }
+        for refused in ["", "soon", "2 hours", "-5s", "0", "0s", "NaN", "infs"] {
+            assert_eq!(parse_tape_window(refused), None, "{refused}");
+        }
     }
 
     /// A right-click on the tape configures the tape. The candles' layers do

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -532,6 +532,31 @@ fn fmt_progress(progress: &quantick_engine::BarProgress, unit: &str) -> String {
     )
 }
 
+/// Which pane a scripted right-click should land on.
+///
+/// The two panes now open different menus, so "open the context menu" is no
+/// longer one instruction — a capture has to say which canvas it is asking
+/// about.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ContextMenuPane {
+    /// The candles, left of the divider.
+    Chart,
+    /// The rolling tape, right of it.
+    Tape,
+}
+
+impl ContextMenuPane {
+    /// Read one off `QUANTICK_CONTEXT_MENU`; `None` for anything else, so a
+    /// typo opens no menu rather than the wrong one.
+    fn from_env_value(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "chart" | "candles" => Some(Self::Chart),
+            "tape" | "lane" => Some(Self::Tape),
+            _ => None,
+        }
+    }
+}
+
 /// Read a tape window off `QUANTICK_TAPE_WINDOW`.
 ///
 /// `auto` follows the bars; a duration pins it, in the units a human would
@@ -823,6 +848,12 @@ pub struct QuantickApp {
     /// autostart) get them too: `QUANTICK_FOOTPRINT_AUTOSTART` and
     /// `QUANTICK_CANDLE_WIDTH`.
     scripted_footprint: bool,
+    /// Which pane a scripted run asked to right-click, until the click lands.
+    ///
+    /// Cleared by the first frame that can honour it — the divider only exists
+    /// once the canvas has drawn once — so the menu opens exactly once and
+    /// then behaves like any menu a hand opened.
+    scripted_context_menu: Option<ContextMenuPane>,
     scripted_candle_width: Option<f32>,
     /// `QUANTICK_INDICATOR_SETTINGS`: open the settings dialog for the
     /// first indicator once its inputs have arrived from the worker. Armed
@@ -1070,6 +1101,7 @@ impl QuantickApp {
             indicator_presets_path,
             footprint_preset_draft: String::new(),
             scripted_footprint: false,
+            scripted_context_menu: None,
             scripted_indicator_settings: false,
             scripted_candle_width: None,
             style: ChartStyle::default(),
@@ -1239,6 +1271,15 @@ impl QuantickApp {
         if std::env::var("QUANTICK_BUBBLES_AUTOSTART").is_ok_and(|value| value == "1") {
             app.active_tab_mut().tape_mut().set_bubbles_enabled(true);
         }
+        // The right-click itself, on the pane it names. The two panes open
+        // different menus now, so a capture has to say which canvas it is
+        // asking about; the click is delivered through the app's own input
+        // path (see `raw_input_hook`), never by reaching into egui's menu
+        // state, so what opens is what a trader's click opens.
+        app.scripted_context_menu = std::env::var("QUANTICK_CONTEXT_MENU")
+            .ok()
+            .and_then(|value| ContextMenuPane::from_env_value(&value));
+
         // The tape's own switches. The two panes are configured apart and the
         // tape's menu is a right-click a scripted run cannot perform, so the
         // state behind it needs a door of its own — the state, not a second
@@ -5540,12 +5581,66 @@ impl QuantickApp {
     }
 }
 
+impl QuantickApp {
+    /// Where a scripted right-click should land to reach `pane`'s menu.
+    ///
+    /// Mid-height, and mid-pane horizontally, off the geometry the draw
+    /// published — so the click lands on the canvas rather than on the axis,
+    /// the legend or the divider handle. `None` until the pane has drawn once
+    /// (no divider yet), and `None` for the tape on a canvas that has none:
+    /// there is no tape menu to open where there is no tape.
+    fn scripted_context_menu_pos(&self, pane: ContextMenuPane) -> Option<egui::Pos2> {
+        let flow = &self.active_tab().flow_pane;
+        let rect = flow.last_chart_rect?;
+        let divider = flow.last_lane_divider_x;
+        let x = match (pane, divider) {
+            (ContextMenuPane::Tape, Some(divider)) => (divider + rect.right()) / 2.0,
+            (ContextMenuPane::Tape, None) => return None,
+            (ContextMenuPane::Chart, Some(divider)) => (rect.left() + divider) / 2.0,
+            (ContextMenuPane::Chart, None) => rect.center().x,
+        };
+        Some(egui::pos2(x, rect.center().y))
+    }
+}
+
 impl eframe::App for QuantickApp {
     fn update(&mut self, ctx: &egui::Context, frame: &mut eframe::Frame) {
         if let Some(cpu) = frame.info().cpu_usage {
             self.cpu_frames.record(cpu * 1000.0);
         }
         self.draw_frame(ctx, Instant::now());
+    }
+
+    /// The one place a scripted run can put a pointer event into the app.
+    ///
+    /// A context menu opens on a real right-click and on nothing else — there
+    /// is no "open the menu" call to reach for, and reaching into egui's menu
+    /// state to fake one would be a second activation path that drifts from
+    /// the first. So the hook supplies the click itself, on the pane it names,
+    /// and every line after that is the code a trader's own click runs.
+    fn raw_input_hook(&mut self, _ctx: &egui::Context, raw_input: &mut egui::RawInput) {
+        let Some(pane) = self.scripted_context_menu else {
+            return;
+        };
+        // The divider is published by the draw, so the first frame has none:
+        // wait for it rather than guess where the tape is.
+        let Some(position) = self.scripted_context_menu_pos(pane) else {
+            return;
+        };
+        self.scripted_context_menu = None;
+        raw_input.events.push(egui::Event::PointerMoved(position));
+        raw_input.events.push(egui::Event::PointerButton {
+            pos: position,
+            button: egui::PointerButton::Secondary,
+            pressed: true,
+            modifiers: egui::Modifiers::default(),
+        });
+        raw_input.events.push(egui::Event::PointerButton {
+            pos: position,
+            button: egui::PointerButton::Secondary,
+            pressed: false,
+            modifiers: egui::Modifiers::default(),
+        });
     }
 }
 
@@ -8707,6 +8802,69 @@ plot(close)
             "an unavailable layer is still listed, just not switchable"
         );
         std::fs::remove_file(&path).ok();
+    }
+
+    /// The two panes open different menus, so the scripted right-click has to
+    /// name one — and refuse anything it does not recognise, since opening the
+    /// wrong pane's menu photographs a defect that is not there.
+    #[test]
+    fn the_context_menu_hook_names_a_pane_or_opens_nothing() {
+        assert_eq!(
+            ContextMenuPane::from_env_value("tape"),
+            Some(ContextMenuPane::Tape)
+        );
+        assert_eq!(
+            ContextMenuPane::from_env_value(" LANE "),
+            Some(ContextMenuPane::Tape)
+        );
+        assert_eq!(
+            ContextMenuPane::from_env_value("chart"),
+            Some(ContextMenuPane::Chart)
+        );
+        assert_eq!(
+            ContextMenuPane::from_env_value("candles"),
+            Some(ContextMenuPane::Chart)
+        );
+        for refused in ["", "1", "true", "both", "pane"] {
+            assert_eq!(ContextMenuPane::from_env_value(refused), None, "{refused}");
+        }
+    }
+
+    /// The scripted click lands on the canvas of the pane it names, and asks
+    /// for nothing that is not on screen: no draw yet means no geometry, and a
+    /// canvas with no tape has no tape menu to open.
+    #[test]
+    fn the_scripted_click_lands_on_the_pane_it_names() {
+        let (mut app, _events, _commands, _book) = test_app();
+        assert_eq!(
+            app.scripted_context_menu_pos(ContextMenuPane::Tape),
+            None,
+            "nothing has drawn yet, so there is no geometry to click"
+        );
+
+        let rect = egui::Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(1000.0, 400.0));
+        {
+            let pane = &mut app.active_tab_mut().flow_pane;
+            pane.last_chart_rect = Some(rect);
+            pane.last_lane_divider_x = Some(700.0);
+        }
+        let tape = app
+            .scripted_context_menu_pos(ContextMenuPane::Tape)
+            .expect("a drawn tape can be clicked");
+        assert!(tape.x > 700.0 && tape.x < 1000.0, "{tape:?}");
+        let chart = app
+            .scripted_context_menu_pos(ContextMenuPane::Chart)
+            .expect("and so can the candles");
+        assert!(chart.x > 0.0 && chart.x < 700.0, "{chart:?}");
+        assert!(rect.contains(tape) && rect.contains(chart));
+
+        // No lane: the candles still answer, the tape has nothing to open.
+        app.active_tab_mut().flow_pane.last_lane_divider_x = None;
+        assert_eq!(app.scripted_context_menu_pos(ContextMenuPane::Tape), None);
+        assert!(
+            app.scripted_context_menu_pos(ContextMenuPane::Chart)
+                .is_some()
+        );
     }
 
     /// The tape's window hook reads what a human would type, and refuses

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -8636,6 +8636,64 @@ plot(close)
         std::fs::remove_file(&path).ok();
     }
 
+    /// A right-click on the tape configures the tape. The candles' layers do
+    /// not vanish with it — they move one submenu away — because the tape is
+    /// also where a trader right-clicks to trade, and a menu that answered
+    /// only for the tape would take order entry and the drawing tools with it.
+    #[test]
+    fn a_right_click_on_the_tape_configures_the_tape_without_losing_the_chart() {
+        let dir = std::env::temp_dir().join(format!("quantick-tape-menu-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("scratch dir");
+        let path = dir.join("chart-layers.toml");
+        let _ = std::fs::remove_file(&path);
+
+        let ctx = egui::Context::default();
+        let screen = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(400.0, 700.0));
+        let (mut app, _events, _commands, _book) = test_app();
+        app.chart_layers_path = path.clone();
+
+        let menu_frame = |app: &mut QuantickApp, on_tape: bool| {
+            with_flow_pane(app, |pane, chrome| {
+                pane.aim_context_menu_at_tape(on_tape);
+                let _ = ctx.run(
+                    egui::RawInput {
+                        screen_rect: Some(screen),
+                        ..Default::default()
+                    },
+                    |ctx| {
+                        egui::CentralPanel::default()
+                            .show(ctx, |ui| pane.draw_layer_menu(ui, chrome));
+                    },
+                );
+            });
+        };
+
+        // The candles' own menu is exactly the menu it always was.
+        menu_frame(&mut app, false);
+        assert_eq!(
+            app.active_tab().flow_pane.layer_menu_rects.len(),
+            ChartLayer::ALL.len(),
+            "a click on the candles still lists every chart layer up front"
+        );
+
+        // The tape's menu answers for the tape: the chart's checkboxes sit
+        // behind the submenu button rather than laid out at the top level.
+        menu_frame(&mut app, true);
+        assert!(
+            app.active_tab().flow_pane.layer_menu_rects.is_empty(),
+            "the chart's switches move into the submenu, so none are laid out yet"
+        );
+
+        // And back: aiming at the candles restores the full list, so the two
+        // menus cannot leak into each other across frames.
+        menu_frame(&mut app, false);
+        assert_eq!(
+            app.active_tab().flow_pane.layer_menu_rects.len(),
+            ChartLayer::ALL.len()
+        );
+        std::fs::remove_file(&path).ok();
+    }
+
     /// §11 keeps the tape on the flow pane, so the time pane's menu says the
     /// flow layers are drawn elsewhere instead of offering dead switches.
     #[test]

--- a/crates/app/src/bubble_presets.rs
+++ b/crates/app/src/bubble_presets.rs
@@ -89,7 +89,9 @@ pub struct BubblePreset {
     /// Every visual choice for the bubbles themselves.
     #[serde(default)]
     pub bubbles: BubbleStyle,
-    /// The live lane's own width, clustering and radius scale.
+    /// The live lane's own width, window, clustering and radius scale — how
+    /// the tape *looks*, never whether its layers are drawn. See
+    /// [`Self::apply_to`].
     #[serde(default)]
     pub live_lane: LiveLaneStyle,
 }
@@ -106,12 +108,20 @@ impl BubblePreset {
             region_rows: config.bubble_region_rows,
             region_ms: config.bubble_region_ms,
             bubbles: config.bubbles.clone(),
-            live_lane: config.live_lane.clone(),
+            live_lane: LiveLaneStyle {
+                // A preset is a look, so it records none of the tape's
+                // visibility. Captured, these would come back as an
+                // instruction to switch layers on the next time the look is
+                // chosen — the one thing `apply_to` promises never to do.
+                show_depth: None,
+                show_aggressions: None,
+                ..config.live_lane.clone()
+            },
         }
     }
 
     /// Apply this preset over `config`, touching nothing outside the panel —
-    /// and never the layer's own switch.
+    /// and never a layer's own switch, on either pane.
     pub fn apply_to(&self, config: &mut HeatmapConfig) {
         config.bubble_cluster_ms = self.cluster_ms;
         config.bubble_dust_merge_ms = self.dust_merge_ms;
@@ -119,7 +129,17 @@ impl BubblePreset {
         config.bubble_region_rows = self.region_rows;
         config.bubble_region_ms = self.region_ms;
         config.bubbles = self.bubbles.clone();
+        // The lane's visibility is not the preset's to carry: choosing a look
+        // may not blank the tape, and a preset file edited by hand may not
+        // switch layers on behind the trader. Everything else in the lane's
+        // style is exactly what the preset stored.
+        let visibility = (
+            config.live_lane.show_depth,
+            config.live_lane.show_aggressions,
+        );
         config.live_lane = self.live_lane.clone();
+        config.live_lane.show_depth = visibility.0;
+        config.live_lane.show_aggressions = visibility.1;
     }
 }
 
@@ -590,6 +610,54 @@ mod tests {
 
         config.bubbles.side_offset = 0.0;
         assert_ne!(BubblePreset::capture("mine", &config), preset);
+    }
+
+    /// A preset is a look. Now that the tape's visibility lives in the same
+    /// struct as its style, choosing one may not blank the tape — nor switch
+    /// its layers back on behind the trader.
+    #[test]
+    fn a_preset_carries_the_tapes_look_and_never_its_visibility() {
+        let mut config = HeatmapConfig::default();
+        config.live_lane.radius_scale = 2.0;
+        config.live_lane.window = crate::orderflow::LaneWindow::Fixed { ms: 120_000 };
+        // Captured while the tape was cleared...
+        config.live_lane.show_depth = Some(false);
+        config.live_lane.show_aggressions = Some(false);
+        let preset = BubblePreset::capture("mine", &config);
+        assert_eq!(
+            preset.live_lane.show_depth, None,
+            "a look records no switch"
+        );
+        assert_eq!(preset.live_lane.show_aggressions, None);
+
+        // ...and applied over a tape that is drawing: the look lands, the
+        // visibility does not move.
+        let mut other = HeatmapConfig::default();
+        other.live_lane.show_depth = Some(true);
+        other.live_lane.show_aggressions = Some(true);
+        preset.apply_to(&mut other);
+        assert!(
+            (other.live_lane.radius_scale - 2.0).abs() < 1e-6,
+            "the look lands"
+        );
+        assert_eq!(
+            other.live_lane.window,
+            crate::orderflow::LaneWindow::Fixed { ms: 120_000 }
+        );
+        assert_eq!(
+            other.live_lane.show_depth,
+            Some(true),
+            "choosing a look may not blank the tape"
+        );
+        assert_eq!(other.live_lane.show_aggressions, Some(true));
+
+        // A hand-edited preset file cannot switch a layer on either.
+        let mut sneaky = preset.clone();
+        sneaky.live_lane.show_depth = Some(true);
+        let mut cleared = HeatmapConfig::default();
+        cleared.live_lane.show_depth = Some(false);
+        sneaky.apply_to(&mut cleared);
+        assert_eq!(cleared.live_lane.show_depth, Some(false));
     }
 
     #[test]

--- a/crates/app/src/chart_layers.rs
+++ b/crates/app/src/chart_layers.rs
@@ -181,10 +181,16 @@ impl ChartLayer {
     /// Hover text: what disappears, and what keeps running while it is hidden.
     pub(crate) const fn hint(self) -> &'static str {
         match self {
+            // Both of these name the candles explicitly, and say where the
+            // other copy is: the tape has switches of its own, so a trader who
+            // clears the candles and still sees the book rolling on the tape
+            // is looking at a setting, not at a bug.
             Self::Heatmap => {
-                "resting depth behind the candles. Recording never stops, so hiding it loses no history"
+                "resting depth behind the candles. Recording never stops, so hiding it loses no                  history. The tape keeps its own copy of this switch — right-click the tape to                  reach it"
             }
-            Self::Bubbles => "confirmed executions from the trade stream, drawn where they printed",
+            Self::Bubbles => {
+                "confirmed executions from the trade stream, drawn where they printed, on the                  candles. The tape keeps its own copy of this switch — right-click the tape to                  reach it"
+            }
             Self::Footprint => {
                 "the buy/sell split at each price inside every candle. Detail follows zoom: \
                  numbers close in, profile and highlight marks further out. The violet line \

--- a/crates/app/src/orderflow/config.rs
+++ b/crates/app/src/orderflow/config.rs
@@ -181,6 +181,13 @@ pub const MIN_LIVE_LANE_WINDOW_MS: i64 = 200;
 /// Most market time a zoomed-out lane will show. A tape is the recent past;
 /// past a quarter of an hour the chart's own history says it better.
 pub const MAX_LIVE_LANE_WINDOW_MS: i64 = 900_000;
+/// The fixed tape windows the lane's menu offers, in exchange milliseconds.
+///
+/// Round durations a trader already thinks in, not a sample of the accepted
+/// range: the point of a preset is that it is chosen without reading a number.
+/// Anything else is reachable through the custom entry, which accepts the
+/// whole [`MIN_LIVE_LANE_WINDOW_MS`]..=[`MAX_LIVE_LANE_WINDOW_MS`] band.
+pub const LANE_WINDOW_PRESETS_MS: [i64; 5] = [15_000, 30_000, 60_000, 120_000, 300_000];
 /// Default multiplier applied to the bubble radii inside the live lane.
 pub const DEFAULT_LIVE_LANE_RADIUS_SCALE: f32 = 1.0;
 /// Bounds accepted for the live lane's radius multiplier.
@@ -652,16 +659,187 @@ fn finite_clamp(value: f32, low: f32, high: f32, fallback: f32) -> f32 {
     }
 }
 
+/// How much market time the tape shows.
+///
+/// One number, one owner. The lane is a fixed band of screen, so its window is
+/// what decides how fast a print crosses it — and there is exactly one way to
+/// ask for that, phrased in one of two languages:
+///
+/// - [`Auto`](Self::Auto) follows the bars: the tape holds roughly one bar's
+///   worth of flow whatever the instrument or the bar type, and the zoom
+///   scales that reference. This is what the lane has always done, and it
+///   stays the default.
+/// - [`Fixed`](Self::Fixed) pins an amount of market time and ignores what the
+///   bars are doing. On an activity-sampled series a burst closes bars faster
+///   than a human reads prints, and a trader who wants the last two minutes in
+///   front of them is asking for two minutes, not for a multiplier.
+///
+/// The gesture over the tape edits whichever language is in force — the zoom
+/// in `Auto`, the milliseconds in `Fixed` — so dragging never silently
+/// switches modes.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum LaneWindow {
+    /// Follows the recent bars' typical duration, scaled by `zoom`.
+    Auto {
+        /// `1.0` fits about one bar's worth of market time in the band. Above
+        /// one shows less time (prints run across faster and further apart),
+        /// below one shows more (they crowd together and cluster).
+        zoom: f32,
+    },
+    /// A fixed amount of market time, whatever the bars do.
+    Fixed {
+        /// Exchange milliseconds shown in the band.
+        ms: i64,
+    },
+}
+
+impl Default for LaneWindow {
+    fn default() -> Self {
+        Self::Auto {
+            zoom: DEFAULT_LIVE_LANE_ZOOM,
+        }
+    }
+}
+
+impl LaneWindow {
+    /// Clamp into a range the renderer can use.
+    pub fn sanitize(&mut self) {
+        match self {
+            Self::Auto { zoom } => {
+                *zoom = finite_clamp(
+                    *zoom,
+                    MIN_LIVE_LANE_ZOOM,
+                    MAX_LIVE_LANE_ZOOM,
+                    DEFAULT_LIVE_LANE_ZOOM,
+                );
+            }
+            Self::Fixed { ms } => {
+                *ms = (*ms).clamp(MIN_LIVE_LANE_WINDOW_MS, MAX_LIVE_LANE_WINDOW_MS);
+            }
+        }
+    }
+
+    /// Market time the lane shows, given the automatic reference — the recent
+    /// bars' typical duration ([`reserved_span_ms`](super::reserved_span_ms)).
+    ///
+    /// Both modes end in the same clamp: a session-long reference cannot turn
+    /// the tape into a second chart, and a burst cannot make it an instant
+    /// wide, whichever language asked for the window.
+    #[must_use]
+    pub fn resolve_ms(self, reference_ms: i64) -> i64 {
+        let window = match self {
+            Self::Auto { zoom } => {
+                let zoom = if zoom.is_finite() {
+                    zoom.clamp(MIN_LIVE_LANE_ZOOM, MAX_LIVE_LANE_ZOOM)
+                } else {
+                    DEFAULT_LIVE_LANE_ZOOM
+                };
+                (reference_ms.max(1) as f64 / f64::from(zoom)).round() as i64
+            }
+            Self::Fixed { ms } => ms,
+        };
+        window.clamp(MIN_LIVE_LANE_WINDOW_MS, MAX_LIVE_LANE_WINDOW_MS)
+    }
+
+    /// How the resolved window compares to the automatic reference.
+    ///
+    /// The factor the clustering window is divided by, so a cluster covers a
+    /// constant *distance on screen* rather than a constant amount of time. In
+    /// `Auto` it works out to the zoom itself; in `Fixed` it is whatever the
+    /// pinned window is worth against the same reference — which is what keeps
+    /// a two-minute tape from drawing as a smear.
+    #[must_use]
+    fn cluster_scale(self, reference_ms: i64) -> f64 {
+        reference_ms.max(1) as f64 / self.resolve_ms(reference_ms).max(1) as f64
+    }
+
+    /// Apply a multiplicative zoom gesture, in whichever language is in force.
+    ///
+    /// `> 1` shows less market time in the same band, `< 1` more. A gesture
+    /// never changes the mode: pinning two minutes and then scrolling gives a
+    /// different fixed window, not a return to following the bars.
+    pub fn zoom_by(&mut self, factor: f32) {
+        if !factor.is_finite() || factor <= 0.0 {
+            return;
+        }
+        match self {
+            Self::Auto { zoom } => *zoom *= factor,
+            Self::Fixed { ms } => {
+                *ms = ((*ms as f64 / f64::from(factor)).round() as i64)
+                    .clamp(MIN_LIVE_LANE_WINDOW_MS, MAX_LIVE_LANE_WINDOW_MS);
+            }
+        }
+    }
+}
+
+/// A duration as a trader reads it: `8 s`, `1 min`, `1 min 30 s`, `250 ms`.
+///
+/// Sub-second windows keep their milliseconds because that is the only place
+/// the number carries information; past a minute the seconds are dropped when
+/// they are zero, so a preset reads as the round number it was chosen as.
+#[must_use]
+pub fn format_window_ms(ms: i64) -> String {
+    let ms = ms.max(0);
+    if ms < 1_000 {
+        return format!("{ms} ms");
+    }
+    let seconds = ms / 1_000;
+    let (minutes, seconds) = (seconds / 60, seconds % 60);
+    match (minutes, seconds) {
+        (0, seconds) => format!("{seconds} s"),
+        (minutes, 0) => format!("{minutes} min"),
+        (minutes, seconds) => format!("{minutes} min {seconds} s"),
+    }
+}
+
+/// How a tape window reads in a menu.
+///
+/// `reference_ms` is the automatic reference, when the caller knows it. The
+/// automatic entry states the duration it currently works out to whenever it
+/// is supplied: "auto" alone names a policy, and a trader choosing between it
+/// and `30 s` is comparing durations, so the one number that would let them
+/// compare has no business being the one number hidden.
+#[must_use]
+pub fn lane_window_label(window: LaneWindow, reference_ms: Option<i64>) -> String {
+    match window {
+        LaneWindow::Auto { .. } => reference_ms.map_or_else(
+            || "auto".to_owned(),
+            |reference| {
+                format!(
+                    "auto (≈ {})",
+                    format_window_ms(window.resolve_ms(reference))
+                )
+            },
+        ),
+        LaneWindow::Fixed { ms } => format_window_ms(ms),
+    }
+}
+
+/// Whether a menu entry names the window already in force.
+///
+/// Two `Auto`s match whatever their zoom, so selecting the automatic entry
+/// while already following the bars cannot quietly reset a zoom the trader
+/// set; two `Fixed`s have to name the same duration.
+#[must_use]
+pub fn same_lane_window(current: LaneWindow, option: LaneWindow) -> bool {
+    match (current, option) {
+        (LaneWindow::Auto { .. }, LaneWindow::Auto { .. }) => true,
+        (LaneWindow::Fixed { ms: current }, LaneWindow::Fixed { ms: option }) => current == option,
+        _ => false,
+    }
+}
+
 /// How the rolling tape past the last bar is drawn.
 ///
 /// The live lane is a pane of its own, pinned to the right edge of the chart:
 /// history is compressed into equal-width bar slots that pan and zoom, the lane
 /// is a fixed band of screen showing a fixed window of market time that always
 /// ends at now. Being its own pane is what earns it settings of its own — how
-/// wide it is, how much time fits in it, and how big its bubbles are, none of
-/// which the candles beside it get a say in.
+/// wide it is, how much time fits in it, how big its bubbles are, and which of
+/// the two flow layers it draws, none of which the candles beside it get a say
+/// in.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(default)]
+#[serde(from = "LiveLaneStyleRepr", into = "LiveLaneStyleRepr")]
 pub struct LiveLaneStyle {
     /// Width of the lane as a share of the chart.
     ///
@@ -672,17 +850,13 @@ pub struct LiveLaneStyle {
     /// a print enters at the right edge and slides left at the same speed. A
     /// bar closing changes neither, so nothing on the tape ever jumps.
     pub width_share: f32,
-    /// Zoom of the lane's time window, against the recent bars' typical
-    /// duration.
+    /// How much market time fits in the band: following the bars, or pinned.
     ///
-    /// `1.0` fits about one bar's worth of market time in the band. Zooming in
-    /// (`> 1`) shows less time in the same width, so prints run across it
-    /// faster and further apart; zooming out (`< 1`) shows more, so they crowd
-    /// together — and the clustering window follows the span
+    /// The clustering window follows whatever this resolves to
     /// ([`effective_cluster_ms`](Self::effective_cluster_ms)), which is what
-    /// turns that crowd into fewer, bigger marks instead of a smear.
-    pub time_zoom: f32,
-    /// Clustering window applied to prints inside the lane, before the zoom
+    /// turns a crowded tape into fewer, bigger marks instead of a smear.
+    pub window: LaneWindow,
+    /// Clustering window applied to prints inside the lane, before the window
     /// scales it.
     ///
     /// `None` inherits [`HeatmapConfig::bubble_cluster_ms`]. A shorter window
@@ -693,16 +867,108 @@ pub struct LiveLaneStyle {
     pub radius_scale: f32,
     /// Whether the lane's boundary and the live-edge line are drawn.
     pub show_marks: bool,
+    /// Whether the depth map is drawn *on the tape*. `None` follows the
+    /// chart's own switch ([`HeatmapConfig::show_depth`]).
+    ///
+    /// Each pane answers for its own canvas: the compressed history is read
+    /// one way and the rolling tape another, and a trader who wants the
+    /// candles clean does not thereby want the book hidden where the book is
+    /// actually being read. `None` is what every file written before the lane
+    /// had a switch of its own says, and it is why such a file opens drawing
+    /// exactly what it drew — hiding the chart's layer used to hide the tape's
+    /// with it, and inheritance keeps that true until the trader says
+    /// otherwise.
+    pub show_depth: Option<bool>,
+    /// Whether aggression bubbles are drawn *on the tape*. `None` follows the
+    /// chart's own switch ([`HeatmapConfig::show_aggressions`]). Same
+    /// inheritance rule as [`show_depth`](Self::show_depth).
+    pub show_aggressions: Option<bool>,
 }
 
 impl Default for LiveLaneStyle {
     fn default() -> Self {
         Self {
             width_share: DEFAULT_LIVE_LANE_SHARE,
-            time_zoom: DEFAULT_LIVE_LANE_ZOOM,
+            window: LaneWindow::default(),
             cluster_ms: None,
             radius_scale: DEFAULT_LIVE_LANE_RADIUS_SCALE,
             show_marks: true,
+            show_depth: None,
+            show_aggressions: None,
+        }
+    }
+}
+
+/// What a [`LiveLaneStyle`] looks like on disk.
+///
+/// The window is one field in memory and two on disk, and the split is
+/// deliberate: `time_zoom` is the name every preset written before this mode
+/// existed already uses, so reading one back has to find it where it was left.
+/// `window_ms` is absent from all of them, which is exactly the sentence "this
+/// lane follows the bars" — the mode a file from before the choice existed is
+/// in.
+///
+/// Nothing outside serialization sees this type. [`LaneWindow`] stays the only
+/// owner of the number in memory, so no two fields can disagree about how much
+/// market time the tape is showing.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+struct LiveLaneStyleRepr {
+    width_share: f32,
+    time_zoom: f32,
+    window_ms: Option<i64>,
+    cluster_ms: Option<i64>,
+    radius_scale: f32,
+    show_marks: bool,
+    show_depth: Option<bool>,
+    show_aggressions: Option<bool>,
+}
+
+impl Default for LiveLaneStyleRepr {
+    fn default() -> Self {
+        Self::from(LiveLaneStyle::default())
+    }
+}
+
+impl From<LiveLaneStyleRepr> for LiveLaneStyle {
+    fn from(repr: LiveLaneStyleRepr) -> Self {
+        Self {
+            width_share: repr.width_share,
+            // A pinned window is the explicit choice; without one the file is
+            // asking to follow the bars, at whatever zoom it recorded.
+            window: repr.window_ms.map_or(
+                LaneWindow::Auto {
+                    zoom: repr.time_zoom,
+                },
+                |ms| LaneWindow::Fixed { ms },
+            ),
+            cluster_ms: repr.cluster_ms,
+            radius_scale: repr.radius_scale,
+            show_marks: repr.show_marks,
+            show_depth: repr.show_depth,
+            show_aggressions: repr.show_aggressions,
+        }
+    }
+}
+
+impl From<LiveLaneStyle> for LiveLaneStyleRepr {
+    fn from(style: LiveLaneStyle) -> Self {
+        // Pinning a window parks the zoom at its default rather than keeping
+        // the last one: "automatic" means the bars decide, and a remembered
+        // multiplier waiting to reappear is not that.
+        let (time_zoom, window_ms) = match style.window {
+            LaneWindow::Auto { zoom } => (zoom, None),
+            LaneWindow::Fixed { ms } => (DEFAULT_LIVE_LANE_ZOOM, Some(ms)),
+        };
+        Self {
+            width_share: style.width_share,
+            time_zoom,
+            window_ms,
+            cluster_ms: style.cluster_ms,
+            radius_scale: style.radius_scale,
+            show_marks: style.show_marks,
+            show_depth: style.show_depth,
+            show_aggressions: style.show_aggressions,
         }
     }
 }
@@ -716,12 +982,7 @@ impl LiveLaneStyle {
             MAX_LIVE_LANE_SHARE,
             DEFAULT_LIVE_LANE_SHARE,
         );
-        self.time_zoom = finite_clamp(
-            self.time_zoom,
-            MIN_LIVE_LANE_ZOOM,
-            MAX_LIVE_LANE_ZOOM,
-            DEFAULT_LIVE_LANE_ZOOM,
-        );
+        self.window.sanitize();
         self.radius_scale = finite_clamp(
             self.radius_scale,
             MIN_LIVE_LANE_RADIUS_SCALE,
@@ -760,34 +1021,27 @@ impl LiveLaneStyle {
     /// recent bars' typical duration).
     #[must_use]
     pub fn window_ms(&self, reference_ms: i64) -> i64 {
-        let zoom = if self.time_zoom.is_finite() {
-            self.time_zoom.clamp(MIN_LIVE_LANE_ZOOM, MAX_LIVE_LANE_ZOOM)
-        } else {
-            DEFAULT_LIVE_LANE_ZOOM
-        };
-        let window = reference_ms.max(1) as f64 / f64::from(zoom);
-        (window.round() as i64).clamp(MIN_LIVE_LANE_WINDOW_MS, MAX_LIVE_LANE_WINDOW_MS)
+        self.window.resolve_ms(reference_ms)
     }
 
-    /// Clustering window for prints inside the lane, given history's own.
+    /// Clustering window for prints inside the lane, given history's own and
+    /// the automatic reference the lane's window is measured against.
     ///
-    /// Scaled by the same zoom as the window itself, so a cluster covers a
+    /// Scaled by the same factor as the window itself, so a cluster covers a
     /// constant *distance on screen* rather than a constant amount of time:
-    /// zooming out gathers the crowd it creates into fewer, bigger bubbles
-    /// instead of piling prints on top of each other.
+    /// a wider window gathers the crowd it creates into fewer, bigger bubbles
+    /// instead of piling prints on top of each other. The factor comes from
+    /// the resolved window rather than from the zoom, which is what lets a
+    /// pinned two-minute tape cluster like the zoomed-out tape it is.
     #[must_use]
-    pub fn effective_cluster_ms(&self, history_cluster_ms: i64) -> i64 {
+    pub fn effective_cluster_ms(&self, history_cluster_ms: i64, reference_ms: i64) -> i64 {
         let base = self.cluster_ms.unwrap_or(history_cluster_ms).max(0);
         if base == 0 {
-            // One bubble per print, at every zoom: raw is a choice, not a size.
+            // One bubble per print, at every window: raw is a choice, not a
+            // size.
             return 0;
         }
-        let zoom = if self.time_zoom.is_finite() {
-            self.time_zoom.clamp(MIN_LIVE_LANE_ZOOM, MAX_LIVE_LANE_ZOOM)
-        } else {
-            DEFAULT_LIVE_LANE_ZOOM
-        };
-        let scaled = (base as f64 / f64::from(zoom)).round() as i64;
+        let scaled = (base as f64 / self.window.cluster_scale(reference_ms)).round() as i64;
         scaled.clamp(1, MAX_BUBBLE_CLUSTER_MS)
     }
 
@@ -1026,6 +1280,43 @@ impl HeatmapConfig {
         self.enabled && self.show_depth
     }
 
+    /// Whether the depth map is drawn on the tape.
+    ///
+    /// Capture still gates it — a map with nothing recorded behind it is not a
+    /// map on either pane — but the *display* choice is the lane's own, falling
+    /// back to the chart's while the lane has not made one
+    /// ([`LiveLaneStyle::show_depth`]).
+    #[must_use]
+    pub fn lane_depth_visible(&self) -> bool {
+        self.enabled && self.live_lane.show_depth.unwrap_or(self.show_depth)
+    }
+
+    /// Whether aggression bubbles are drawn on the tape. No capture gate: the
+    /// bubbles are built from the trade stream the chart already consumes.
+    #[must_use]
+    pub fn lane_aggressions_visible(&self) -> bool {
+        self.live_lane
+            .show_aggressions
+            .unwrap_or(self.show_aggressions)
+    }
+
+    /// Whether any pane still draws the depth map.
+    ///
+    /// What decides that the projection has to keep building depth primitives:
+    /// hiding the map on the candles while the tape still shows it is a change
+    /// of view, never a reason to stop producing what the tape is reading.
+    #[must_use]
+    pub fn depth_visible_anywhere(&self) -> bool {
+        self.depth_visible() || self.lane_depth_visible()
+    }
+
+    /// Whether any pane still draws the aggression bubbles. Same rule as
+    /// [`depth_visible_anywhere`](Self::depth_visible_anywhere).
+    #[must_use]
+    pub fn aggressions_visible_anywhere(&self) -> bool {
+        self.show_aggressions || self.lane_aggressions_visible()
+    }
+
     /// Whether any order-flow layer asks for a projection.
     ///
     /// The depth map and the aggression bubbles are independent: either one
@@ -1039,7 +1330,9 @@ impl HeatmapConfig {
     /// hidden.
     #[must_use]
     pub fn any_layer_enabled(&self) -> bool {
-        self.depth_visible() || self.show_aggressions || self.projection_demand
+        self.depth_visible_anywhere()
+            || self.aggressions_visible_anywhere()
+            || self.projection_demand
     }
 
     /// Whether displayed-liquidity reductions need to be computed at all.
@@ -1134,7 +1427,7 @@ mod tests {
         assert_eq!(
             config
                 .live_lane
-                .effective_cluster_ms(config.bubble_cluster_ms),
+                .effective_cluster_ms(config.bubble_cluster_ms, 8_000),
             DEFAULT_BUBBLE_CLUSTER_MS
         );
         assert_eq!(
@@ -1189,10 +1482,12 @@ mod tests {
             },
             live_lane: LiveLaneStyle {
                 width_share: f32::NAN,
-                time_zoom: 900.0,
+                window: LaneWindow::Auto { zoom: 900.0 },
                 cluster_ms: Some(i64::MIN),
                 radius_scale: 900.0,
                 show_marks: true,
+                show_depth: None,
+                show_aggressions: None,
             },
             liquidity_correlation_ms: i64::MIN,
             max_history_runs: 0,
@@ -1216,7 +1511,12 @@ mod tests {
         assert_eq!(config.bubbles.opacity, DEFAULT_BUBBLE_OPACITY);
         assert_eq!(config.bubbles.max_radius, MAX_BUBBLE_MAX_RADIUS);
         assert_eq!(config.live_lane.width_share, DEFAULT_LIVE_LANE_SHARE);
-        assert_eq!(config.live_lane.time_zoom, MAX_LIVE_LANE_ZOOM);
+        assert_eq!(
+            config.live_lane.window,
+            LaneWindow::Auto {
+                zoom: MAX_LIVE_LANE_ZOOM
+            }
+        );
         assert_eq!(config.live_lane.cluster_ms, Some(0));
         assert_eq!(config.live_lane.radius_scale, MAX_LIVE_LANE_RADIUS_SCALE);
         assert_eq!(config.liquidity_correlation_ms, 0);
@@ -1274,47 +1574,348 @@ mod tests {
             ..LiveLaneStyle::default()
         };
         assert_eq!(default.window_ms(reference), 8_000);
-        assert_eq!(default.effective_cluster_ms(DEFAULT_BUBBLE_CLUSTER_MS), 100);
+        assert_eq!(
+            default.effective_cluster_ms(DEFAULT_BUBBLE_CLUSTER_MS, reference),
+            100
+        );
 
         // Zoomed out: four times the market time in the same band, and a
         // cluster four times as long — so a cluster keeps its width on screen.
         let out = LiveLaneStyle {
-            time_zoom: 0.25,
+            window: LaneWindow::Auto { zoom: 0.25 },
             ..default.clone()
         };
         assert_eq!(out.window_ms(reference), 32_000);
-        assert_eq!(out.effective_cluster_ms(DEFAULT_BUBBLE_CLUSTER_MS), 400);
+        assert_eq!(
+            out.effective_cluster_ms(DEFAULT_BUBBLE_CLUSTER_MS, reference),
+            400
+        );
 
         // Zoomed in: a quarter of the time, a quarter of the window.
         let into = LiveLaneStyle {
-            time_zoom: 4.0,
+            window: LaneWindow::Auto { zoom: 4.0 },
             ..default.clone()
         };
         assert_eq!(into.window_ms(reference), 2_000);
-        assert_eq!(into.effective_cluster_ms(DEFAULT_BUBBLE_CLUSTER_MS), 25);
+        assert_eq!(
+            into.effective_cluster_ms(DEFAULT_BUBBLE_CLUSTER_MS, reference),
+            25
+        );
 
         // Raw is a choice, not a size: it survives every zoom.
         let raw = LiveLaneStyle {
             cluster_ms: Some(0),
-            time_zoom: MIN_LIVE_LANE_ZOOM,
+            window: LaneWindow::Auto {
+                zoom: MIN_LIVE_LANE_ZOOM,
+            },
             ..LiveLaneStyle::default()
         };
-        assert_eq!(raw.effective_cluster_ms(DEFAULT_BUBBLE_CLUSTER_MS), 0);
+        assert_eq!(
+            raw.effective_cluster_ms(DEFAULT_BUBBLE_CLUSTER_MS, reference),
+            0
+        );
 
         // Bounds hold whatever the bars did: a session-long reference cannot
         // turn the tape into a second chart, and a burst cannot make it an
         // instant wide.
         let out = LiveLaneStyle {
-            time_zoom: MIN_LIVE_LANE_ZOOM,
+            window: LaneWindow::Auto {
+                zoom: MIN_LIVE_LANE_ZOOM,
+            },
             ..LiveLaneStyle::default()
         };
         assert_eq!(out.window_ms(i64::MAX), MAX_LIVE_LANE_WINDOW_MS);
         let into = LiveLaneStyle {
-            time_zoom: MAX_LIVE_LANE_ZOOM,
+            window: LaneWindow::Auto {
+                zoom: MAX_LIVE_LANE_ZOOM,
+            },
             ..LiveLaneStyle::default()
         };
         assert_eq!(into.window_ms(1), MIN_LIVE_LANE_WINDOW_MS);
-        assert_eq!(into.effective_cluster_ms(1), 1);
+        assert_eq!(into.effective_cluster_ms(1, 8_000), 1);
+    }
+
+    /// A pinned window is a window like any other: it resolves whatever the
+    /// bars do, and the clustering scales with it exactly as the zoom's does.
+    /// Without that second half a two-minute tape draws two minutes of prints
+    /// at a tape's density, which is a smear.
+    #[test]
+    fn a_pinned_window_ignores_the_bars_and_clusters_like_the_width_it_is() {
+        let reference = 8_000; // a typical bar of eight seconds
+        let pinned = LiveLaneStyle {
+            window: LaneWindow::Fixed { ms: 120_000 },
+            cluster_ms: Some(100),
+            ..LiveLaneStyle::default()
+        };
+        // Two minutes is two minutes, whatever the bars are doing...
+        assert_eq!(pinned.window_ms(reference), 120_000);
+        assert_eq!(pinned.window_ms(1), 120_000);
+        assert_eq!(pinned.window_ms(600_000), 120_000);
+        // ...and fifteen times the automatic window gathers fifteen times the
+        // market time into each mark.
+        assert_eq!(
+            pinned.effective_cluster_ms(DEFAULT_BUBBLE_CLUSTER_MS, reference),
+            1_500
+        );
+        // Past the clustering ceiling the scaling stops rather than running
+        // away: a mark may gather a crowd, never a whole tape.
+        let widest = LiveLaneStyle {
+            window: LaneWindow::Fixed {
+                ms: MAX_LIVE_LANE_WINDOW_MS,
+            },
+            ..pinned.clone()
+        };
+        assert_eq!(
+            widest.effective_cluster_ms(DEFAULT_BUBBLE_CLUSTER_MS, reference),
+            MAX_BUBBLE_CLUSTER_MS
+        );
+        let modest = LiveLaneStyle {
+            window: LaneWindow::Fixed { ms: 16_000 },
+            ..pinned.clone()
+        };
+        assert_eq!(
+            modest.effective_cluster_ms(DEFAULT_BUBBLE_CLUSTER_MS, reference),
+            200,
+            "twice the automatic window, twice the cluster"
+        );
+        // A narrower pinned window buys detail, the same way zooming in does.
+        let narrow = LiveLaneStyle {
+            window: LaneWindow::Fixed { ms: 4_000 },
+            ..pinned.clone()
+        };
+        assert_eq!(
+            narrow.effective_cluster_ms(DEFAULT_BUBBLE_CLUSTER_MS, reference),
+            50
+        );
+        // A wider tape always gathers more than a narrower one — the property
+        // the numbers above are examples of.
+        assert!(
+            modest.effective_cluster_ms(DEFAULT_BUBBLE_CLUSTER_MS, reference)
+                > narrow.effective_cluster_ms(DEFAULT_BUBBLE_CLUSTER_MS, reference)
+        );
+        // Raw is a choice, not a size: it survives a pinned window too.
+        let raw = LiveLaneStyle {
+            cluster_ms: Some(0),
+            ..pinned
+        };
+        assert_eq!(
+            raw.effective_cluster_ms(DEFAULT_BUBBLE_CLUSTER_MS, reference),
+            0
+        );
+
+        // Absurd durations are clamped to what the tape can draw, both ends.
+        let mut wild = LiveLaneStyle {
+            window: LaneWindow::Fixed { ms: i64::MAX },
+            ..LiveLaneStyle::default()
+        };
+        wild.sanitize();
+        assert_eq!(
+            wild.window,
+            LaneWindow::Fixed {
+                ms: MAX_LIVE_LANE_WINDOW_MS
+            }
+        );
+        let mut tiny = LiveLaneStyle {
+            window: LaneWindow::Fixed { ms: 0 },
+            ..LiveLaneStyle::default()
+        };
+        tiny.sanitize();
+        assert_eq!(
+            tiny.window,
+            LaneWindow::Fixed {
+                ms: MIN_LIVE_LANE_WINDOW_MS
+            }
+        );
+    }
+
+    /// The gesture over the tape edits whichever language the window is in,
+    /// and never swaps the language underneath the trader.
+    #[test]
+    fn a_zoom_gesture_never_changes_which_mode_the_tape_is_in() {
+        let mut following = LaneWindow::default();
+        following.zoom_by(2.0);
+        assert_eq!(following, LaneWindow::Auto { zoom: 2.0 });
+
+        let mut pinned = LaneWindow::Fixed { ms: 60_000 };
+        pinned.zoom_by(2.0);
+        assert_eq!(
+            pinned,
+            LaneWindow::Fixed { ms: 30_000 },
+            "zooming in halves the pinned window; it does not return to automatic"
+        );
+        pinned.zoom_by(0.5);
+        assert_eq!(pinned, LaneWindow::Fixed { ms: 60_000 });
+
+        // A pinned window cannot be dragged out of the drawable range.
+        let mut floor = LaneWindow::Fixed {
+            ms: MIN_LIVE_LANE_WINDOW_MS,
+        };
+        floor.zoom_by(1_000.0);
+        assert_eq!(
+            floor,
+            LaneWindow::Fixed {
+                ms: MIN_LIVE_LANE_WINDOW_MS
+            }
+        );
+
+        // A meaningless gesture is refused rather than applied as garbage.
+        let mut untouched = LaneWindow::Fixed { ms: 60_000 };
+        untouched.zoom_by(f32::NAN);
+        untouched.zoom_by(0.0);
+        untouched.zoom_by(-1.0);
+        assert_eq!(untouched, LaneWindow::Fixed { ms: 60_000 });
+    }
+
+    /// A menu that offers "auto" against "30 s" is asking the trader to
+    /// compare durations, so the automatic entry has to state the one it
+    /// currently amounts to.
+    #[test]
+    fn the_automatic_entry_states_the_duration_it_currently_works_out_to() {
+        let following = LaneWindow::default();
+        assert_eq!(lane_window_label(following, Some(8_000)), "auto (≈ 8 s)");
+        assert_eq!(
+            lane_window_label(following, Some(90_000)),
+            "auto (≈ 1 min 30 s)"
+        );
+        // With no bars to measure, it names the policy rather than inventing
+        // a number.
+        assert_eq!(lane_window_label(following, None), "auto");
+        // A zoomed automatic window reports what it shows, not the reference.
+        let zoomed = LaneWindow::Auto { zoom: 4.0 };
+        assert_eq!(lane_window_label(zoomed, Some(8_000)), "auto (≈ 2 s)");
+
+        for (ms, expected) in [
+            (250, "250 ms"),
+            (15_000, "15 s"),
+            (60_000, "1 min"),
+            (120_000, "2 min"),
+            (300_000, "5 min"),
+        ] {
+            assert_eq!(
+                lane_window_label(LaneWindow::Fixed { ms }, Some(8_000)),
+                expected
+            );
+        }
+        // Every preset the menu offers reads as the round number it was
+        // chosen as.
+        for ms in LANE_WINDOW_PRESETS_MS {
+            let label = lane_window_label(LaneWindow::Fixed { ms }, Some(8_000));
+            assert!(!label.contains("ms"), "{label} is not how a trader says it");
+        }
+
+        // Selecting the automatic entry while already following the bars must
+        // not reset a zoom the trader set; a preset only matches its own
+        // duration.
+        assert!(same_lane_window(zoomed, LaneWindow::default()));
+        assert!(same_lane_window(
+            LaneWindow::Fixed { ms: 60_000 },
+            LaneWindow::Fixed { ms: 60_000 }
+        ));
+        assert!(!same_lane_window(
+            LaneWindow::Fixed { ms: 60_000 },
+            LaneWindow::Fixed { ms: 30_000 }
+        ));
+        assert!(!same_lane_window(zoomed, LaneWindow::Fixed { ms: 60_000 }));
+    }
+
+    /// Every preset written before the tape had a window mode says "follow the
+    /// bars" by saying nothing, and has to keep drawing what it drew.
+    #[test]
+    fn a_file_from_before_the_mode_existed_opens_exactly_as_it_did() {
+        let old: LiveLaneStyle = toml::from_str(
+            "width_share = 0.4\ntime_zoom = 2.0\nradius_scale = 1.5\nshow_marks = false\n",
+        )
+        .unwrap();
+        assert_eq!(old.window, LaneWindow::Auto { zoom: 2.0 });
+        assert_eq!(
+            old.window_ms(8_000),
+            4_000,
+            "the same window it always drew"
+        );
+        assert!((old.width_share - 0.4).abs() < 1e-6);
+        assert!(!old.show_marks);
+        // And the two panes still move together, because the lane has not been
+        // asked for anything of its own.
+        assert_eq!(old.show_depth, None);
+        assert_eq!(old.show_aggressions, None);
+
+        // A file this build writes round-trips, in both languages.
+        for window in [
+            LaneWindow::default(),
+            LaneWindow::Auto { zoom: 0.5 },
+            LaneWindow::Fixed { ms: 120_000 },
+        ] {
+            let style = LiveLaneStyle {
+                window,
+                show_depth: Some(false),
+                show_aggressions: Some(true),
+                ..LiveLaneStyle::default()
+            };
+            let text = toml::to_string(&style).unwrap();
+            assert_eq!(toml::from_str::<LiveLaneStyle>(&text).unwrap(), style);
+        }
+
+        // Pinning parks the zoom at its default rather than hoarding the last
+        // one: "automatic" means the bars decide, not that a multiplier is
+        // waiting to reappear.
+        let pinned = LiveLaneStyle {
+            window: LaneWindow::Fixed { ms: 60_000 },
+            ..LiveLaneStyle::default()
+        };
+        let text = toml::to_string(&pinned).unwrap();
+        assert!(text.contains("window_ms = 60000"), "{text}");
+        assert!(text.contains("time_zoom = 1.0"), "{text}");
+    }
+
+    /// The two panes are switched apart, and neither switch may starve the
+    /// other pane of the projection that feeds it.
+    #[test]
+    fn hiding_a_layer_on_one_pane_leaves_the_other_drawing_and_fed() {
+        let mut config = HeatmapConfig {
+            enabled: true,
+            show_depth: true,
+            show_aggressions: true,
+            ..HeatmapConfig::default()
+        };
+        // Inheriting: one switch, both panes — exactly as before the lane had
+        // switches of its own.
+        assert!(config.depth_visible() && config.lane_depth_visible());
+        assert!(config.show_aggressions && config.lane_aggressions_visible());
+
+        // The candles go quiet, the tape keeps both layers.
+        config.show_depth = false;
+        config.show_aggressions = false;
+        config.live_lane.show_depth = Some(true);
+        config.live_lane.show_aggressions = Some(true);
+        assert!(!config.depth_visible(), "the candles are clear");
+        assert!(config.lane_depth_visible(), "the tape still has the book");
+        assert!(config.lane_aggressions_visible(), "and the prints");
+        assert!(
+            config.any_layer_enabled(),
+            "a tape nobody switched off may not lose the projection that feeds it"
+        );
+
+        // The other way round: the tape is cleared, the candles keep drawing.
+        config.show_depth = true;
+        config.live_lane.show_depth = Some(false);
+        config.live_lane.show_aggressions = Some(false);
+        assert!(config.depth_visible() && !config.lane_depth_visible());
+        assert!(config.any_layer_enabled());
+
+        // Only with every pane's every layer off does the pipeline stand down
+        // — and a surface that is not a layer can still hold it open.
+        config.show_depth = false;
+        assert!(!config.any_layer_enabled());
+        config.projection_demand = true;
+        assert!(config.any_layer_enabled());
+
+        // Capture still gates the map on both panes: a map with nothing
+        // recorded behind it is not a map anywhere.
+        config.projection_demand = false;
+        config.enabled = false;
+        config.show_depth = true;
+        config.live_lane.show_depth = Some(true);
+        assert!(!config.depth_visible() && !config.lane_depth_visible());
     }
 
     #[test]
@@ -1325,7 +1926,10 @@ mod tests {
             radius_scale: 2.0,
             ..LiveLaneStyle::default()
         };
-        assert_eq!(tuned.effective_cluster_ms(DEFAULT_BUBBLE_CLUSTER_MS), 50);
+        assert_eq!(
+            tuned.effective_cluster_ms(DEFAULT_BUBBLE_CLUSTER_MS, 8_000),
+            50
+        );
         let (min, max) = tuned.scaled_radii(&bubbles);
         assert!((min - bubbles.min_radius * 2.0).abs() < 1e-4);
         assert!((max - bubbles.max_radius * 2.0).abs() < 1e-4);

--- a/crates/app/src/orderflow/mod.rs
+++ b/crates/app/src/orderflow/mod.rs
@@ -19,9 +19,11 @@ pub mod timeline;
 pub use config::{
     BubbleRenderMode, BubbleSizeReference, BubbleStyle, ConsumptionMark, DisplayGrouping,
     GOLDEN_ANGLE, HeatmapConfig, HeatmapTheme, INV_PHI, INV_PHI_2, INV_PHI_3, IntensityMode,
-    LiveLaneStyle, MAX_BUBBLE_MAX_RADIUS, MAX_BUBBLE_MIN_RADIUS, MAX_LIVE_LANE_RADIUS_SCALE,
-    MAX_LIVE_LANE_SHARE, MAX_LIVE_LANE_ZOOM, MIN_BUBBLE_MAX_RADIUS, MIN_LIVE_LANE_RADIUS_SCALE,
-    MIN_LIVE_LANE_SHARE, MIN_LIVE_LANE_ZOOM,
+    LANE_WINDOW_PRESETS_MS, LaneWindow, LiveLaneStyle, MAX_BUBBLE_MAX_RADIUS,
+    MAX_BUBBLE_MIN_RADIUS, MAX_LIVE_LANE_RADIUS_SCALE, MAX_LIVE_LANE_SHARE,
+    MAX_LIVE_LANE_WINDOW_MS, MAX_LIVE_LANE_ZOOM, MIN_BUBBLE_MAX_RADIUS, MIN_LIVE_LANE_RADIUS_SCALE,
+    MIN_LIVE_LANE_SHARE, MIN_LIVE_LANE_WINDOW_MS, MIN_LIVE_LANE_ZOOM, format_window_ms,
+    lane_window_label, same_lane_window,
 };
 #[allow(unused_imports)]
 pub use grouping::{

--- a/crates/app/src/orderflow/projection.rs
+++ b/crates/app/src/orderflow/projection.rs
@@ -1163,9 +1163,12 @@ fn cluster_tier(
             tape_prints,
             coverage,
             grouping,
-            config
-                .live_lane
-                .effective_cluster_ms(config.bubble_cluster_ms),
+            config.live_lane.effective_cluster_ms(
+                config.bubble_cluster_ms,
+                // No lane means no tape prints to cluster, so the reference
+                // only has to be a number the scale can divide by.
+                timeline.lane_reference_ms().unwrap_or(1),
+            ),
         ),
         slot: cluster_aggressions(slot_prints, coverage, grouping, config.bubble_cluster_ms),
     }
@@ -1383,6 +1386,7 @@ mod tests {
         Some(crate::orderflow::LiveEdge {
             now_ms,
             window_ms: crate::orderflow::reserved_span_ms(closed),
+            reference_ms: crate::orderflow::reserved_span_ms(closed),
             on_newest_bar: true,
         })
     }
@@ -1463,6 +1467,7 @@ mod tests {
             Some(crate::orderflow::LiveEdge {
                 now_ms: 3_900,
                 window_ms: 1_500,
+                reference_ms: 1_500,
                 on_newest_bar: true,
             }),
         );
@@ -1520,6 +1525,7 @@ mod tests {
             Some(crate::orderflow::LiveEdge {
                 now_ms: 3_900,
                 window_ms: 1_500,
+                reference_ms: 1_500,
                 on_newest_bar: true,
             }),
         );
@@ -1581,6 +1587,7 @@ mod tests {
             Some(crate::orderflow::LiveEdge {
                 now_ms: 3_900,
                 window_ms: 1_500,
+                reference_ms: 1_500,
                 on_newest_bar: true,
             }),
         );
@@ -1642,6 +1649,7 @@ mod tests {
             Some(crate::orderflow::LiveEdge {
                 now_ms: 3_900,
                 window_ms: 1_500,
+                reference_ms: 1_500,
                 on_newest_bar: true,
             }),
         );
@@ -1700,6 +1708,7 @@ mod tests {
                     // A lane wide enough to cover more than one bar, which is
                     // what makes the seam fall inside a bar rather than on it.
                     window_ms: 1_500,
+                    reference_ms: 1_500,
                     on_newest_bar: true,
                 }),
             );
@@ -2267,6 +2276,7 @@ mod tests {
                 Some(crate::orderflow::LiveEdge {
                     now_ms: 20_000,
                     window_ms: 5_000,
+                    reference_ms: 5_000,
                     on_newest_bar: true,
                 }),
             ),

--- a/crates/app/src/orderflow/timeline.rs
+++ b/crates/app/src/orderflow/timeline.rs
@@ -79,6 +79,7 @@ pub fn reserved_span_ms(closed: &[Bar]) -> i64 {
 struct Lane {
     start_ms: i64,
     end_ms: i64,
+    reference_ms: i64,
 }
 
 /// One bar slot and the market time it represents.
@@ -101,6 +102,15 @@ pub struct LiveEdge {
     pub now_ms: i64,
     /// Market time the lane shows, ending at [`now_ms`](Self::now_ms).
     pub window_ms: i64,
+    /// The automatic reference [`window_ms`](Self::window_ms) was resolved
+    /// against: the recent bars' typical duration ([`reserved_span_ms`]).
+    ///
+    /// Carried beside the resolved window rather than recomputed, because the
+    /// two together say how far the tape is from its automatic size — and that
+    /// ratio is what the lane's clustering scales by. Without it a pinned
+    /// window would have nothing to be wide *relative to*, and the clustering
+    /// would need a magic constant standing in for the bars.
+    pub reference_ms: i64,
     /// Whether the last bar supplied is the newest bar of the series.
     ///
     /// Only then may its slot be stretched to the live edge. The lane is
@@ -162,6 +172,7 @@ impl BarTimeline {
         let lane = live.map(|edge| Lane {
             start_ms: edge.now_ms.saturating_sub(edge.window_ms.max(1)),
             end_ms: edge.now_ms,
+            reference_ms: edge.reference_ms,
         });
         Self { slots, lane }
     }
@@ -175,6 +186,14 @@ impl BarTimeline {
     #[must_use]
     pub fn lane_start_ms(&self) -> Option<i64> {
         Some(self.lane?.start_ms)
+    }
+
+    /// The automatic reference the lane's window was resolved against, for
+    /// whoever has to scale something by how far the tape is from following
+    /// the bars. `None` when this timeline follows no live edge.
+    #[must_use]
+    pub fn lane_reference_ms(&self) -> Option<i64> {
+        Some(self.lane?.reference_ms)
     }
 
     /// Position of the live edge, which is the lane's right edge whenever a
@@ -383,6 +402,7 @@ mod tests {
         Some(LiveEdge {
             now_ms,
             window_ms: reserved_span_ms(closed),
+            reference_ms: reserved_span_ms(closed),
             on_newest_bar: true,
         })
     }
@@ -551,6 +571,7 @@ mod tests {
             Some(LiveEdge {
                 now_ms: 100_000,
                 window_ms: 10_000,
+                reference_ms: 10_000,
                 on_newest_bar: false,
             }),
         );
@@ -584,6 +605,7 @@ mod tests {
                 Some(LiveEdge {
                     now_ms: 25_000,
                     window_ms,
+                    reference_ms: window_ms,
                     on_newest_bar: true,
                 }),
             );

--- a/crates/app/src/orderflow_engine.rs
+++ b/crates/app/src/orderflow_engine.rs
@@ -1179,8 +1179,11 @@ impl BookEngine {
             health: self.health(),
             // Gated on visibility, not on capture: the live tail and the strip
             // are pixels, and a recorder nobody is watching must not pay for
-            // them.
-            live_end_ms: if self.config.depth_visible() {
+            // them. Visibility on *either* pane — this instant is what anchors
+            // the tape, so answering it from the candles' switch alone would
+            // let clearing the candles take the whole tape with it, bubbles
+            // and all.
+            live_end_ms: if self.config.depth_visible_anywhere() {
                 self.history.latest_book_ms()
             } else {
                 None

--- a/crates/app/src/orderflow_engine.rs
+++ b/crates/app/src/orderflow_engine.rs
@@ -969,22 +969,24 @@ impl BookEngine {
     }
 
     /// The live edge this frame's lane runs to, and how much market time it
-    /// shows: the recent bars' typical duration, scaled by the lane's own zoom.
+    /// shows: the recent bars' typical duration, put through the lane's own
+    /// window setting.
     ///
-    /// The zoom is the user's, and it is applied here rather than in the
+    /// The setting is the user's, and it is applied here rather than in the
     /// timeline because the timeline draws the window it is handed — the
-    /// automatic reference is only the default the knob starts from.
+    /// automatic reference is only what the choice starts from, and it travels
+    /// alongside the answer so the tape's clustering can tell how far from it
+    /// the trader went.
     #[must_use]
     fn live_edge(&self, request: &ProjectionRequest) -> Option<LiveEdge> {
         if !request.lane {
             return None;
         }
+        let reference_ms = reserved_span_ms(&request.closed);
         Some(LiveEdge {
             now_ms: self.history.latest_book_ms()?,
-            window_ms: self
-                .config
-                .live_lane
-                .window_ms(reserved_span_ms(&request.closed)),
+            window_ms: self.config.live_lane.window_ms(reference_ms),
+            reference_ms,
             on_newest_bar: request.on_newest_bar,
         })
     }

--- a/crates/app/src/orderflow_render.rs
+++ b/crates/app/src/orderflow_render.rs
@@ -73,11 +73,22 @@ pub(crate) struct OrderflowRenderStyle {
     pub(crate) live_lane: LiveLaneStyle,
     pub(crate) show_gap_labels: bool,
     pub(crate) show_legend: bool,
-    /// Whether the L2 depth layer is active. The legend only advertises keys
-    /// for layers that can actually draw something.
+    /// Whether the L2 depth layer is active over the candles. The legend only
+    /// advertises keys for layers that can actually draw something.
     pub(crate) depth_layer: bool,
-    /// Whether the aggression layer is active.
+    /// Whether the aggression layer is active over the candles.
     pub(crate) aggression_layer: bool,
+    /// Whether the L2 depth layer is active on the tape.
+    ///
+    /// The two panes are switched apart because they are read apart: the
+    /// compressed history answers "where has size been resting", the rolling
+    /// tape answers "what is resting there right now". A trader clearing the
+    /// candles to read structure is not thereby asking to lose the book where
+    /// the book is being watched.
+    pub(crate) lane_depth_layer: bool,
+    /// Whether the aggression layer is active on the tape. Same reasoning as
+    /// [`lane_depth_layer`](Self::lane_depth_layer).
+    pub(crate) lane_aggression_layer: bool,
     /// Per-layer display switches, mirroring the config flags. The projection
     /// no longer filters the aggression primitives — several surfaces read
     /// them — so for those two switches this is where the decision is made
@@ -135,6 +146,8 @@ impl Default for OrderflowRenderStyle {
             show_legend: true,
             depth_layer: true,
             aggression_layer: true,
+            lane_depth_layer: true,
+            lane_aggression_layer: true,
             show_liquidity: true,
             show_buy: true,
             show_sell: true,
@@ -162,6 +175,8 @@ impl OrderflowRenderStyle {
             show_legend: config.show_legend,
             depth_layer: config.depth_visible(),
             aggression_layer: config.show_aggressions,
+            lane_depth_layer: config.lane_depth_visible(),
+            lane_aggression_layer: config.lane_aggressions_visible(),
             show_liquidity: config.show_liquidity,
             show_buy: config.show_buy_aggressions,
             show_sell: config.show_sell_aggressions,
@@ -1107,6 +1122,30 @@ impl<'a> ProjectedLayout<'a> {
         self.chart_rect
     }
 
+    /// The region a layer switched on for `chart`, `lane` or both may paint.
+    ///
+    /// `None` when neither pane draws it, which is the whole layer switched
+    /// off. Returning a region rather than filtering primitives is what keeps
+    /// a run that crosses the divider honest: a resting level that has been
+    /// there since before the tape's window opened is one continuous band, and
+    /// hiding the map over the candles has to cut it at the divider, not drop
+    /// it. It is also free — one clip rect per frame, instead of a test per
+    /// cell on the densest layer the chart draws.
+    #[must_use]
+    fn layer_clip(self, chart: bool, lane: bool) -> Option<egui::Rect> {
+        match (chart, lane) {
+            (true, true) => Some(self.chart_rect),
+            // With no lane there is only one pane, and it is the chart's.
+            (true, false) => Some(if self.lane_left_x().is_some() {
+                self.history_rect()
+            } else {
+                self.chart_rect
+            }),
+            (false, true) => self.lane_left_x().is_some().then(|| self.lane_rect()),
+            (false, false) => None,
+        }
+    }
+
     #[must_use]
     fn y(self, normalized: f64) -> f32 {
         self.chart_rect.top() + finite_unit_f64(normalized) as f32 * self.chart_rect.height()
@@ -1188,7 +1227,15 @@ impl<'a> RenderContext<'a> {
         let projection = self.projection;
         let both_sides = style.show_buy && style.show_sell;
         projection.aggressions.iter().filter(move |mark| {
-            if !style.aggression_layer {
+            // Which pane a print belongs to is the projection's own answer —
+            // the same one that clustered it on the tape's window rather than
+            // history's — so the switch is read from the mark, never inferred
+            // a second time from its position.
+            if !(if mark.live {
+                style.lane_aggression_layer
+            } else {
+                style.aggression_layer
+            }) {
                 return false;
             }
             // A mark carrying both sides — a merged cluster, or a bar summary
@@ -1213,7 +1260,15 @@ impl<'a> RenderContext<'a> {
 pub(crate) fn draw_heatmap_background(painter: &egui::Painter, context: &RenderContext<'_>) {
     let style = context.style.sanitized();
     let palette = Palette::for_theme(style.theme);
-    let clip = painter.with_clip_rect(context.layout.chart_rect);
+    // Each pane answers for its own canvas, and a run that crosses the divider
+    // is cut at it rather than dropped.
+    let Some(region) = context
+        .layout
+        .layer_clip(style.depth_layer, style.lane_depth_layer)
+    else {
+        return;
+    };
+    let clip = painter.with_clip_rect(region);
     let mut mesh = egui::Mesh::default();
     mesh.vertices
         .reserve(context.projection.cells.len().saturating_mul(8));
@@ -1601,10 +1656,12 @@ pub(crate) fn draw_liquidity_events(painter: &egui::Painter, context: &RenderCon
 /// keeps the "aggression consuming the book" legible even when price is going
 /// sideways and the prints stack into a horizontal band.
 pub(crate) fn draw_aggression_bubbles(painter: &egui::Painter, context: &RenderContext<'_>) {
-    // Off, this pass has nothing to do: the frame still carries every cluster
-    // (the strip reads them), so without this it would clip, sanitize and walk
-    // up to `max_aggression_primitives` marks per frame to draw none of them.
-    if !context.style.aggression_layer {
+    // Off on *both* panes, this pass has nothing to do: the frame still
+    // carries every cluster (the strip reads them), so without this it would
+    // clip, sanitize and walk up to `max_aggression_primitives` marks per
+    // frame to draw none of them. One pane still drawing keeps the pass —
+    // dropping out on the candles' switch alone would blank the tape with it.
+    if !context.style.aggression_layer && !context.style.lane_aggression_layer {
         return;
     }
     let style = context.style.sanitized();
@@ -4168,6 +4225,130 @@ mod tests {
         );
         assert!(layout.history_rect().right() <= divider);
         assert!(layout.lane_rect().left() >= divider);
+    }
+
+    /// The candles and the tape are switched apart: clearing a layer on one
+    /// pane leaves the other drawing exactly what it drew. This is the pixel
+    /// half of the promise — the config half is
+    /// `hiding_a_layer_on_one_pane_leaves_the_other_drawing_and_fed`.
+    #[test]
+    fn a_layer_switched_off_on_one_pane_still_draws_on_the_other() {
+        let viewport = Viewport::new();
+        let rect = egui::Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(1000.0, 400.0));
+        // Three bar slots plus a 300 px lane: the divider lands on x = 700.
+        let layout = ProjectedLayout::new(rect, &viewport, 3, 0, 4, 300.0);
+
+        // One print on each pane, from the same projection, so the only thing
+        // that can separate them is the switch under test.
+        let mut projection = HeatmapProjection::empty(
+            true,
+            crate::orderflow::EffectiveGrouping::resolve(
+                crate::orderflow::DisplayGrouping::Native,
+                rust_decimal::Decimal::ONE,
+                rust_decimal::Decimal::from(100),
+            ),
+        );
+        for (x, live) in [(0.4_f64, false), (0.9_f64, true)] {
+            projection.aggressions.push(AggressionPrimitive {
+                agg_id: 1,
+                agg_ids: vec![1],
+                generation: None,
+                side: Side::Buy,
+                consumed_side: BookSide::Ask,
+                quantity: rust_decimal::Decimal::ONE,
+                buy_share: 1.0,
+                live,
+                price_bucket: rust_decimal::Decimal::ONE,
+                price_span: rust_decimal::Decimal::ONE,
+                trade_count: 1,
+                first_timestamp_ms: 0,
+                last_timestamp_ms: 0,
+                matched_quantity: rust_decimal::Decimal::ZERO,
+                matched_fraction: 0.0,
+                liquidity_event_ids: Vec::new(),
+                x,
+                y: 0.5,
+                size: 1.0,
+            });
+        }
+
+        let drawn = |chart: bool, lane: bool| {
+            let style = OrderflowRenderStyle {
+                aggression_layer: chart,
+                lane_aggression_layer: lane,
+                bubbles: BubbleStyle {
+                    min_radius: 20.0,
+                    max_radius: 20.0,
+                    detail_min_radius: 100.0, // cheap dots: one circle per print
+                    hollow_small_buys: false,
+                    halo_strength: 0.0,
+                    trail_length: 0.0,
+                    show_quantity_labels: false,
+                    show_trade_count: false,
+                    ..BubbleStyle::default()
+                },
+                ..OrderflowRenderStyle::default()
+            };
+            let context = RenderContext::new(&projection, layout, &style);
+            let counted = context.bubbles().count();
+            (
+                counted,
+                painted(|painter| draw_aggression_bubbles(painter, &context)),
+            )
+        };
+
+        let (both, _) = drawn(true, true);
+        assert_eq!(both, 2, "with both panes on, both prints draw");
+
+        // The candles are cleared. The tape's print survives — the whole ask.
+        let (tape_only, marks) = drawn(false, true);
+        assert_eq!(
+            tape_only, 1,
+            "the tape keeps drawing with the candles clear"
+        );
+        assert!(
+            marks.contains(&format!("{:?}", layout.lane_rect())),
+            "and it is the tape's print that survived: {marks}"
+        );
+
+        // And the other way round.
+        let (chart_only, marks) = drawn(true, false);
+        assert_eq!(chart_only, 1);
+        assert!(
+            marks.contains(&format!("{:?}", layout.history_rect())),
+            "the candle-pane print is the one left: {marks}"
+        );
+
+        assert_eq!(drawn(false, false).0, 0, "both off draws nothing");
+    }
+
+    /// The depth map is switched per pane by the region it may paint, not by
+    /// dropping cells: a resting level that has been there since before the
+    /// tape's window opened is one continuous band across the divider, and
+    /// hiding the map over the candles has to cut it there rather than lose it.
+    #[test]
+    fn the_depth_map_is_cut_at_the_divider_rather_than_dropped() {
+        let viewport = Viewport::new();
+        let rect = egui::Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(1000.0, 400.0));
+        let layout = ProjectedLayout::new(rect, &viewport, 3, 0, 4, 300.0);
+        let divider = layout.lane_left_x().expect("a lane has a boundary");
+
+        assert_eq!(layout.layer_clip(true, true), Some(layout.chart_rect));
+        assert_eq!(layout.layer_clip(true, false), Some(layout.history_rect()));
+        assert_eq!(layout.layer_clip(false, true), Some(layout.lane_rect()));
+        assert_eq!(layout.layer_clip(false, false), None);
+        // The two regions meet at the divider and neither reaches past it, so
+        // a band crossing it is cut, never doubled or dropped.
+        assert!(layout.layer_clip(true, false).unwrap().right() <= divider);
+        assert!(layout.layer_clip(false, true).unwrap().left() >= divider);
+
+        // A canvas with no tape has one pane, and it is the candles'. The
+        // lane's switch cannot blank a chart that has no lane.
+        let laneless = ProjectedLayout::new(rect, &viewport, 3, 0, 4, 0.0);
+        assert!(laneless.lane_left_x().is_none());
+        assert_eq!(laneless.layer_clip(true, false), Some(laneless.chart_rect));
+        assert_eq!(laneless.layer_clip(true, true), Some(laneless.chart_rect));
+        assert_eq!(laneless.layer_clip(false, true), None);
     }
 
     /// The two sides never both get the side nudge: an even split sits on the

--- a/crates/app/src/orderflow_render.rs
+++ b/crates/app/src/orderflow_render.rs
@@ -1792,33 +1792,40 @@ pub(crate) fn draw_aggression_bubbles(painter: &egui::Painter, context: &RenderC
 /// the bubbles switch for aggression) *and* its own display switch is on.
 /// Announcing anything else would describe a chart the viewer is not looking
 /// at — the legend is a key for what is on screen, not a feature list.
+///
+/// "On screen" means either pane. The canvas holds two of them and the layers
+/// are switched apart, so a key withheld because the candles are clear would
+/// deny a mark the tape is drawing right now — the legend has one canvas to
+/// describe, not one pane of it.
 fn legend_entries(
     style: &OrderflowRenderStyle,
     liquidity_label: String,
 ) -> Vec<(LegendGlyph, String)> {
+    let depth = style.depth_layer || style.lane_depth_layer;
+    let aggression = style.aggression_layer || style.lane_aggression_layer;
     let mut entries = Vec::new();
-    if style.depth_layer && style.show_liquidity {
+    if depth && style.show_liquidity {
         entries.push((LegendGlyph::Heat, liquidity_label));
     }
-    if style.aggression_layer && style.show_buy {
+    if aggression && style.show_buy {
         entries.push((LegendGlyph::Buy, "buy aggression".to_owned()));
     }
-    if style.aggression_layer && style.show_sell {
+    if aggression && style.show_sell {
         entries.push((LegendGlyph::Sell, "sell aggression".to_owned()));
     }
-    if style.depth_layer && style.show_aligned {
+    if depth && style.show_aligned {
         entries.push((
             LegendGlyph::Aligned,
             "aggression-aligned depletion".to_owned(),
         ));
     }
-    if style.depth_layer && style.show_unattributed {
+    if depth && style.show_unattributed {
         entries.push((
             LegendGlyph::DepthOnly,
             "L2 reduction (unattributed)".to_owned(),
         ));
     }
-    if style.depth_layer && style.show_gaps {
+    if depth && style.show_gaps {
         entries.push((LegendGlyph::Gap, "L2 gap".to_owned()));
     }
     entries
@@ -3853,14 +3860,30 @@ mod tests {
         );
 
         // Family switches still trump the per-layer ones: without L2 capture
-        // no depth entry may appear, whatever its individual flag says.
+        // no depth entry may appear, whatever its individual flag says. The
+        // family is now both panes — the key describes the canvas, not one
+        // pane of it.
         let mut bubbles_only = all.clone();
         bubbles_only.depth_layer = false;
+        bubbles_only.lane_depth_layer = false;
         assert_eq!(labels(&bubbles_only), ["buy aggression", "sell aggression"]);
+
+        // A layer the candles have switched off but the tape still draws keeps
+        // its key: withholding it would deny a mark that is on screen.
+        let mut tape_only = all.clone();
+        tape_only.depth_layer = false;
+        tape_only.aggression_layer = false;
+        assert_eq!(
+            labels(&tape_only),
+            labels(&all),
+            "the tape alone still earns every key"
+        );
 
         let mut nothing = all;
         nothing.depth_layer = false;
         nothing.aggression_layer = false;
+        nothing.lane_depth_layer = false;
+        nothing.lane_aggression_layer = false;
         assert!(labels(&nothing).is_empty());
     }
 

--- a/crates/app/src/orderflow_view.rs
+++ b/crates/app/src/orderflow_view.rs
@@ -22,9 +22,11 @@ use crate::live_strip;
 use crate::orderflow::projection::normalized_area_size;
 use crate::orderflow::{
     BubbleRenderMode, BubbleSizeReference, ConsumptionMark, DisplayGrouping, HeatmapConfig,
-    HeatmapTheme, IntensityMode, MAX_BUBBLE_MAX_RADIUS, MAX_BUBBLE_MIN_RADIUS,
-    MAX_LIVE_LANE_RADIUS_SCALE, MAX_LIVE_LANE_SHARE, MAX_LIVE_LANE_ZOOM, MIN_BUBBLE_MAX_RADIUS,
-    MIN_LIVE_LANE_RADIUS_SCALE, MIN_LIVE_LANE_SHARE, MIN_LIVE_LANE_ZOOM, reserved_span_ms,
+    HeatmapTheme, IntensityMode, LANE_WINDOW_PRESETS_MS, LaneWindow, MAX_BUBBLE_MAX_RADIUS,
+    MAX_BUBBLE_MIN_RADIUS, MAX_LIVE_LANE_RADIUS_SCALE, MAX_LIVE_LANE_SHARE,
+    MAX_LIVE_LANE_WINDOW_MS, MAX_LIVE_LANE_ZOOM, MIN_BUBBLE_MAX_RADIUS, MIN_LIVE_LANE_RADIUS_SCALE,
+    MIN_LIVE_LANE_SHARE, MIN_LIVE_LANE_WINDOW_MS, MIN_LIVE_LANE_ZOOM, format_window_ms,
+    lane_window_label, reserved_span_ms, same_lane_window,
 };
 use crate::orderflow_engine::{
     BookPublished, CaptureStatus, OrderflowHealth, ProjectionRequest, VisibleOrderflow,
@@ -195,44 +197,95 @@ impl OrderflowView {
         self.config.enabled
     }
 
-    /// Whether the depth map is drawn: recording *and* not hidden.
+    /// Whether the depth map is drawn on the candles: recording *and* not
+    /// hidden.
     #[must_use]
     pub fn depth_visible(&self) -> bool {
         self.config.depth_visible()
     }
 
-    /// Show or hide the depth map without touching L2 capture.
+    /// Show or hide the depth map over the candles, without touching L2
+    /// capture.
     ///
     /// No feed command is involved: the recorder keeps running, so turning the
     /// map back on repaints the retained past instead of opening a gap in it.
+    ///
+    /// The tape is not touched either. While it was inheriting this switch it
+    /// is first handed the value it was drawing, so hiding the map over the
+    /// candles leaves the tape showing exactly what it showed — which is the
+    /// whole point of the two panes having switches of their own.
     pub fn set_depth_visible(&mut self, visible: bool) {
         if self.config.show_depth == visible {
             return;
         }
         let before = self.config.clone();
+        let lane_was = self.config.lane_depth_visible();
         self.config.show_depth = visible;
-        if !visible {
+        self.config.live_lane.show_depth.get_or_insert(lane_was);
+        if !self.config.depth_visible_anywhere() {
             // Drop the local frame immediately; the worker clears its own.
             self.published.frame = None;
         }
         self.commit_config_changes(before);
     }
 
-    /// Whether the aggression layer is on. Independent of the depth map: it
-    /// reads the trade stream the chart already consumes.
+    /// Whether the aggression layer is on over the candles. Independent of the
+    /// depth map: it reads the trade stream the chart already consumes.
     #[must_use]
     pub fn bubbles_enabled(&self) -> bool {
         self.config.show_aggressions
     }
 
-    /// Toggle the aggression layer without touching L2 capture. No feed
-    /// command is needed — aggregate trades already flow for the candles.
+    /// Toggle the aggression layer over the candles, without touching L2
+    /// capture. No feed command is needed — aggregate trades already flow for
+    /// the candles. The tape keeps what it was drawing, as with the depth map.
     pub fn set_bubbles_enabled(&mut self, enabled: bool) {
         if self.config.show_aggressions == enabled {
             return;
         }
         let before = self.config.clone();
+        let lane_was = self.config.lane_aggressions_visible();
         self.config.show_aggressions = enabled;
+        self.config
+            .live_lane
+            .show_aggressions
+            .get_or_insert(lane_was);
+        self.commit_config_changes(before);
+    }
+
+    /// Whether the depth map is drawn on the tape.
+    #[must_use]
+    pub fn lane_depth_visible(&self) -> bool {
+        self.config.lane_depth_visible()
+    }
+
+    /// Show or hide the depth map on the tape alone. Capture is untouched, and
+    /// so are the candles.
+    pub fn set_lane_depth_visible(&mut self, visible: bool) {
+        if self.config.lane_depth_visible() == visible {
+            return;
+        }
+        let before = self.config.clone();
+        self.config.live_lane.show_depth = Some(visible);
+        if !self.config.depth_visible_anywhere() {
+            self.published.frame = None;
+        }
+        self.commit_config_changes(before);
+    }
+
+    /// Whether aggression bubbles are drawn on the tape.
+    #[must_use]
+    pub fn lane_bubbles_enabled(&self) -> bool {
+        self.config.lane_aggressions_visible()
+    }
+
+    /// Toggle the aggression bubbles on the tape alone.
+    pub fn set_lane_bubbles_enabled(&mut self, enabled: bool) {
+        if self.config.lane_aggressions_visible() == enabled {
+            return;
+        }
+        let before = self.config.clone();
+        self.config.live_lane.show_aggressions = Some(enabled);
         self.commit_config_changes(before);
     }
 
@@ -378,12 +431,36 @@ impl OrderflowView {
     /// Zoom the lane's time window by a multiplicative factor: `> 1` shows
     /// less market time in the same band (prints run faster and further
     /// apart), `< 1` shows more (prints crowd together and cluster).
+    ///
+    /// The gesture speaks whichever language the window is in — the zoom while
+    /// it follows the bars, the milliseconds while it is pinned — and never
+    /// changes which one that is. Dragging a pinned tape gives a different
+    /// pinned tape, not a silent return to automatic.
     pub fn zoom_live_lane(&mut self, factor: f32) {
         if !factor.is_finite() || factor <= 0.0 {
             return;
         }
         let before = self.config.clone();
-        self.config.live_lane.time_zoom *= factor;
+        self.config.live_lane.window.zoom_by(factor);
+        self.commit_config_changes(before);
+    }
+
+    /// How much market time the tape shows, and in which language it was
+    /// asked for.
+    #[must_use]
+    pub fn live_lane_window(&self) -> LaneWindow {
+        self.config.live_lane.window
+    }
+
+    /// Choose how the tape's window is decided: a preset, a custom duration,
+    /// or back to following the bars.
+    pub fn set_live_lane_window(&mut self, window: LaneWindow) {
+        if self.config.live_lane.window == window {
+            return;
+        }
+        let before = self.config.clone();
+        self.config.live_lane.window = window;
+        self.config.live_lane.window.sanitize();
         self.commit_config_changes(before);
     }
 
@@ -1021,20 +1098,69 @@ impl OrderflowView {
                     "how much of the chart the rolling tape takes, up to half of it. Also set by dragging the divider on the chart; measured against the chart, not the candle, so zooming the time axis changes how many bars fit beside the tape and never how much room it gets",
                 );
                 ui.horizontal(|ui| {
-                    ui.label("time zoom");
-                    ui.add(
-                        egui::Slider::new(
-                            &mut lane.time_zoom,
-                            MIN_LIVE_LANE_ZOOM..=MAX_LIVE_LANE_ZOOM,
-                        )
-                        .logarithmic(true)
-                        .suffix("×"),
-                    );
+                    ui.label("window");
+                    egui::ComboBox::from_id_salt("bubble_live_lane_window")
+                        .selected_text(lane_window_label(lane.window, None))
+                        .show_ui(ui, |ui| {
+                            let mut choose = |ui: &mut egui::Ui, option: LaneWindow| {
+                                // Selecting the mode the lane is already in must
+                                // not overwrite the number it is carrying, so
+                                // the entry compares modes and assigns whole
+                                // values only when the mode actually changes.
+                                let selected = same_lane_window(lane.window, option);
+                                if ui
+                                    .selectable_label(selected, lane_window_label(option, None))
+                                    .clicked()
+                                    && !selected
+                                {
+                                    lane.window = option;
+                                }
+                            };
+                            choose(ui, LaneWindow::default());
+                            for ms in LANE_WINDOW_PRESETS_MS {
+                                choose(ui, LaneWindow::Fixed { ms });
+                            }
+                        });
                 })
                 .response
                 .on_hover_text(
-                    "how much market time fits in the tape, against the recent bars' typical duration. Zoom in and prints run across it faster and further apart; zoom out and more time crowds in — the clustering window follows, so they gather into fewer, bigger bubbles. Also set by dragging the time strip under the tape",
+                    "how much market time fits in the tape. Following the bars keeps roughly one bar's worth of flow in the band whatever the instrument; a fixed window shows that much time however fast the bars are closing, which is what a burst calls for. The clustering window follows either way, so a crowded tape gathers into fewer, bigger bubbles instead of a smear",
                 );
+                // One row, whichever language the window is in: the zoom while
+                // it follows the bars, the duration while it is pinned.
+                match &mut lane.window {
+                    LaneWindow::Auto { zoom } => {
+                        ui.horizontal(|ui| {
+                            ui.label("zoom");
+                            ui.add(
+                                egui::Slider::new(zoom, MIN_LIVE_LANE_ZOOM..=MAX_LIVE_LANE_ZOOM)
+                                    .logarithmic(true)
+                                    .suffix("×"),
+                            );
+                        })
+                        .response
+                        .on_hover_text(
+                            "the recent bars' typical duration, scaled. Zoom in and prints run across the tape faster and further apart; zoom out and more time crowds in. Also set by dragging the time strip under the tape",
+                        );
+                    }
+                    LaneWindow::Fixed { ms } => {
+                        ui.horizontal(|ui| {
+                            ui.label("duration");
+                            ui.add(
+                                egui::Slider::new(
+                                    ms,
+                                    MIN_LIVE_LANE_WINDOW_MS..=MAX_LIVE_LANE_WINDOW_MS,
+                                )
+                                .logarithmic(true)
+                                .custom_formatter(|value, _| format_window_ms(value as i64)),
+                            );
+                        })
+                        .response
+                        .on_hover_text(
+                            "market time pinned in the tape, whatever the bars do. Also set by dragging the time strip under the tape",
+                        );
+                    }
+                }
                 ui.horizontal(|ui| {
                     ui.label("cluster");
                     egui::ComboBox::from_id_salt("bubble_live_lane_cluster")
@@ -1950,6 +2076,80 @@ mod tests {
     use crate::orderflow::{BubbleSizeReference, BubbleStyle};
     use quantick_orderbook::{BookCoverage, BookDelta, BookLevel, BookSnapshot};
 
+    /// The ask, in one test: switch a layer off on the chart and keep seeing
+    /// it on the tape. While the tape is inheriting, the chart's switch hands
+    /// it the value it was drawing before moving, so clearing the candles
+    /// never takes the tape's copy with it.
+    #[test]
+    fn clearing_the_candles_leaves_the_tape_drawing_what_it_was_drawing() {
+        let mut view = OrderflowView::new("BTCUSDT");
+        view.config.enabled = true;
+        view.config.show_depth = true;
+        view.config.show_aggressions = true;
+        // Nothing asked of the lane yet: one switch, both panes.
+        assert_eq!(view.config.live_lane.show_depth, None);
+        assert!(view.depth_visible() && view.lane_depth_visible());
+        assert!(view.bubbles_enabled() && view.lane_bubbles_enabled());
+
+        view.set_depth_visible(false);
+        view.set_bubbles_enabled(false);
+        assert!(!view.depth_visible(), "the candles are clear");
+        assert!(!view.bubbles_enabled());
+        assert!(
+            view.lane_depth_visible(),
+            "and the tape still has the book — the whole point"
+        );
+        assert!(view.lane_bubbles_enabled(), "and the prints");
+        assert!(
+            view.config.depth_visible_anywhere(),
+            "a frame the tape is still reading may not be dropped under it"
+        );
+
+        // The tape is switched on its own, and the candles do not follow.
+        view.set_lane_bubbles_enabled(false);
+        assert!(!view.lane_bubbles_enabled() && !view.bubbles_enabled());
+        view.set_bubbles_enabled(true);
+        assert!(
+            view.bubbles_enabled() && !view.lane_bubbles_enabled(),
+            "the candles come back alone once the tape has an answer of its own"
+        );
+    }
+
+    /// The tape's window is one field, reachable from the menu and the dock,
+    /// and a gesture edits whichever language it is in.
+    #[test]
+    fn the_tape_window_is_one_field_whichever_door_it_is_set_from() {
+        let mut view = OrderflowView::new("BTCUSDT");
+        assert_eq!(view.live_lane_window(), LaneWindow::default());
+
+        view.set_live_lane_window(LaneWindow::Fixed { ms: 120_000 });
+        assert_eq!(view.live_lane_window(), LaneWindow::Fixed { ms: 120_000 });
+        assert_eq!(
+            view.config.live_lane.window,
+            LaneWindow::Fixed { ms: 120_000 },
+            "the menu and the dock read the same field"
+        );
+        // A pinned tape shows that much market time whatever the bars did.
+        assert_eq!(view.live_lane_window_ms(&[]), 120_000);
+
+        // The gesture edits the pinned duration and does not fall back to
+        // following the bars.
+        view.zoom_live_lane(2.0);
+        assert_eq!(view.live_lane_window(), LaneWindow::Fixed { ms: 60_000 });
+
+        // An out-of-range choice is clamped rather than stored to be drawn.
+        view.set_live_lane_window(LaneWindow::Fixed { ms: i64::MAX });
+        assert_eq!(
+            view.live_lane_window(),
+            LaneWindow::Fixed {
+                ms: MAX_LIVE_LANE_WINDOW_MS
+            }
+        );
+
+        view.set_live_lane_window(LaneWindow::default());
+        assert_eq!(view.live_lane_window(), LaneWindow::default());
+    }
+
     /// Lay the dock tabs out for real, off-screen, so a broken nested layout
     /// or a duplicated widget id fails here instead of on the chart. Both tabs
     /// are drawn in the same frame: their widget ids must not collide.
@@ -2007,10 +2207,12 @@ mod tests {
             },
             live_lane: LiveLaneStyle {
                 width_share: 0.5,
-                time_zoom: 2.0,
+                window: LaneWindow::Auto { zoom: 2.0 },
                 cluster_ms: Some(50),
                 radius_scale: 1.6,
                 show_marks: true,
+                show_depth: None,
+                show_aggressions: None,
             },
         });
         assert!(view.apply_preset("wide"), "a stored name applies");
@@ -2019,7 +2221,7 @@ mod tests {
         assert_eq!(view.config.bubble_dust_merge_ms, 3_000);
         assert!(view.config.bubble_candle_summary);
         assert_eq!(view.config.live_lane.width_share, 0.5);
-        assert_eq!(view.config.live_lane.time_zoom, 2.0);
+        assert_eq!(view.config.live_lane.window, LaneWindow::Auto { zoom: 2.0 });
         assert_eq!(view.config.live_lane.cluster_ms, Some(50));
         assert_eq!(view.presets.active, "wide");
         assert_eq!(view.preset_name_draft, "wide");
@@ -2163,9 +2365,19 @@ mod tests {
         assert_eq!(view.live_lane_window_ms(&bars), unzoomed);
 
         view.zoom_live_lane(1_000.0);
-        assert_eq!(view.config.live_lane.time_zoom, MAX_LIVE_LANE_ZOOM);
+        assert_eq!(
+            view.config.live_lane.window,
+            LaneWindow::Auto {
+                zoom: MAX_LIVE_LANE_ZOOM
+            }
+        );
         view.zoom_live_lane(1e-6);
-        assert_eq!(view.config.live_lane.time_zoom, MIN_LIVE_LANE_ZOOM);
+        assert_eq!(
+            view.config.live_lane.window,
+            LaneWindow::Auto {
+                zoom: MIN_LIVE_LANE_ZOOM
+            }
+        );
 
         let steady = view.config.live_lane.clone();
         view.zoom_live_lane(0.0);

--- a/crates/app/src/orderflow_view.rs
+++ b/crates/app/src/orderflow_view.rs
@@ -384,7 +384,11 @@ impl OrderflowView {
     /// map is on screen. Marks the live edge inside the forming bar's lane.
     #[must_use]
     pub fn live_end_ms(&mut self) -> Option<i64> {
-        if !self.config.depth_visible() {
+        // Either pane: this instant is the tape's anchor, so answering it from
+        // the candles' own switch would make hiding the map over the candles
+        // delete the tape itself — the band, its bubbles and its strip — which
+        // is the opposite of each pane answering for its own canvas.
+        if !self.config.depth_visible_anywhere() {
             return None;
         }
         self.sync_published();
@@ -2113,6 +2117,34 @@ mod tests {
             view.bubbles_enabled() && !view.lane_bubbles_enabled(),
             "the candles come back alone once the tape has an answer of its own"
         );
+    }
+
+    /// Hiding the map over the candles must not delete the tape. The lane is
+    /// anchored on the live instant, and that instant used to be answered from
+    /// the candles' switch alone — so clearing them took the band, its bubbles
+    /// and its strip with it, which is the whole defect this split exists to
+    /// remove.
+    #[test]
+    fn clearing_the_candles_does_not_delete_the_tape_itself() {
+        let mut view = OrderflowView::new("BTCUSDT");
+        view.config.enabled = true;
+        view.config.show_depth = true;
+        assert!(view.config.depth_visible_anywhere());
+
+        // Candles clear, tape keeps the map: the anchor survives, so there is
+        // still a lane to draw on.
+        view.set_depth_visible(false);
+        assert!(!view.config.depth_visible());
+        assert!(
+            view.config.depth_visible_anywhere(),
+            "the tape still draws the map, so the lane still has an anchor"
+        );
+
+        // Both panes clear: nothing is drawing the map anywhere, and the lane
+        // stands down as it always did.
+        view.set_lane_depth_visible(false);
+        assert!(!view.config.depth_visible_anywhere());
+        assert_eq!(view.live_end_ms(), None);
     }
 
     /// The tape's window is one field, reachable from the menu and the dock,

--- a/crates/app/src/orderflow_view.rs
+++ b/crates/app/src/orderflow_view.rs
@@ -221,7 +221,14 @@ impl OrderflowView {
         let before = self.config.clone();
         let lane_was = self.config.lane_depth_visible();
         self.config.show_depth = visible;
-        self.config.live_lane.show_depth.get_or_insert(lane_was);
+        // Only *hiding* hands the tape a value of its own. Switching the map
+        // back on while the tape is still inheriting has to leave it
+        // inheriting, or turning the candles' map on would pin the tape to
+        // whatever it happened to show a moment ago — the trader never asked
+        // the two to part company, so they must not.
+        if !visible {
+            self.config.live_lane.show_depth.get_or_insert(lane_was);
+        }
         if !self.config.depth_visible_anywhere() {
             // Drop the local frame immediately; the worker clears its own.
             self.published.frame = None;
@@ -246,10 +253,13 @@ impl OrderflowView {
         let before = self.config.clone();
         let lane_was = self.config.lane_aggressions_visible();
         self.config.show_aggressions = enabled;
-        self.config
-            .live_lane
-            .show_aggressions
-            .get_or_insert(lane_was);
+        // Hiding parts them; showing does not. See `set_depth_visible`.
+        if !enabled {
+            self.config
+                .live_lane
+                .show_aggressions
+                .get_or_insert(lane_was);
+        }
         self.commit_config_changes(before);
     }
 
@@ -2109,6 +2119,24 @@ mod tests {
             "a frame the tape is still reading may not be dropped under it"
         );
 
+        // Switching a layer back on while the tape is still inheriting leaves
+        // it inheriting: the trader never parted the two, so turning the
+        // candles' layer on brings the tape's with it. Pinning the tape here
+        // is how a layer switched on at startup came back with the tape's own
+        // entry unticked.
+        let mut fresh = OrderflowView::new("BTCUSDT");
+        fresh.config.enabled = true;
+        assert!(!fresh.bubbles_enabled() && !fresh.lane_bubbles_enabled());
+        fresh.set_bubbles_enabled(true);
+        assert_eq!(
+            fresh.config.live_lane.show_aggressions, None,
+            "showing does not part the panes"
+        );
+        assert!(fresh.lane_bubbles_enabled(), "so the tape follows along");
+        fresh.set_depth_visible(true);
+        assert_eq!(fresh.config.live_lane.show_depth, None);
+        assert!(fresh.lane_depth_visible());
+
         // The tape is switched on its own, and the candles do not follow.
         view.set_lane_bubbles_enabled(false);
         assert!(!view.lane_bubbles_enabled() && !view.bubbles_enabled());
@@ -2510,9 +2538,22 @@ mod tests {
         assert_eq!(frame.projection.aggressions.len(), 1);
         assert!(frame.projection.cells.is_empty(), "no map without capture");
 
-        // Turning the bubbles off closes the pipeline again — nobody is left
-        // reading it.
+        // Turning the bubbles off over the candles does *not* close the
+        // pipeline: the tape draws them too, and it was never asked to stop.
+        // This is the split's whole point — the projection now answers to both
+        // panes, so it stands down only when neither is reading it.
         view.set_bubbles_enabled(false);
+        assert!(view.lane_bubbles_enabled(), "the tape kept them");
+        assert!(
+            view.project_visible(visible_timeline(&bars), true, true, (98.0, 102.0))
+                .is_some(),
+            "a tape nobody switched off may not lose the frame that feeds it"
+        );
+
+        // Switching the tape's own copy off too leaves nobody reading, and the
+        // pipeline closes exactly as it always did.
+        view.set_lane_bubbles_enabled(false);
+        view.flush_for_test();
         assert!(
             view.project_visible(visible_timeline(&bars), true, true, (98.0, 102.0))
                 .is_none()

--- a/crates/app/src/pane.rs
+++ b/crates/app/src/pane.rs
@@ -36,6 +36,10 @@ use crate::indicator_worker::{
     IndicatorCommand, IndicatorSource, IndicatorWorker, MAX_LANE_RUNGS, SlotId,
 };
 use crate::indicators::{IndicatorViews, MIN_PANE_HEIGHT_PX, PaneSizing};
+use crate::orderflow::{
+    LANE_WINDOW_PRESETS_MS, LaneWindow, MAX_LIVE_LANE_WINDOW_MS, MIN_LIVE_LANE_WINDOW_MS,
+    lane_window_label, reserved_span_ms, same_lane_window,
+};
 use crate::orderflow_view::{OrderflowView, VisibleBarTimeline};
 use crate::paper_trading::{ChartInput, PaperTrading};
 use crate::price_view::PriceView;
@@ -856,6 +860,15 @@ pub struct ChartPane {
     // Where the history pane ended last frame — the lane's divider, and the
     // handle that resizes it. The input pass runs before the draw computes it.
     pub last_lane_divider_x: Option<f32>,
+    // The automatic tape window at the last draw — the recent bars' typical
+    // duration. Only the menu reads it, and only to state what "follows the
+    // bars" currently amounts to; the drawing itself is handed the resolved
+    // window, never this.
+    last_lane_reference_ms: Option<i64>,
+    // Whether the right-click that opened the menu landed on the tape rather
+    // than on the candles. The two panes are configured apart, so the menu has
+    // to know which one was asked.
+    context_menu_on_tape: bool,
     // How many rungs the lane was wide enough for at the last draw, and so
     // how finely the next publish samples the forming bar across it. `0` when
     // there is no lane: the worker then walks no ladder and the panes draw
@@ -1060,6 +1073,8 @@ impl ChartPane {
             imbalance_target,
             viewport: Viewport::new(),
             last_lane_divider_x: None,
+            last_lane_reference_ms: None,
+            context_menu_on_tape: false,
             lane_rungs: 0,
             price_view: PriceView::new(),
             last_auto_range: None,
@@ -1397,40 +1412,25 @@ impl ChartPane {
     /// The indicator entries drive `IndicatorViews::toggle_hidden` — the same
     /// state the toolbar's eye writes — so an indicator hidden here shows as
     /// hidden there, and the indicator state file remains its single home.
-    pub fn draw_layer_menu(&mut self, ui: &mut egui::Ui, chrome: &mut PaneChrome<'_>) {
-        // The trade section rides on top, on the pane that owns order
-        // entry, anchored at the price the right-click landed on.
-        if chrome.paper_owns_input
-            && let Some(price) = self.context_menu_price
-        {
-            chrome.paper.context_trade_actions(ui, price);
-            ui.separator();
-        }
-        // Tools that place at the bar under the right-click (the anchored
-        // VWAP's TradingView gesture) declare their entry on the registry;
-        // the click was already resolved per tool, snap rules included, so
-        // the menu only offers what the capture could honestly anchor.
-        if !self.context_menu_places.is_empty() {
-            let places = std::mem::take(&mut self.context_menu_places);
-            for &(tool, point) in &places {
-                let label = tool
-                    .context_menu_label()
-                    .expect("only declaring tools were captured");
-                if ui.button(label).on_hover_text(tool.hover_text()).clicked() {
-                    self.place_drawing_point(tool, &DrawingBand::Price, point, chrome);
-                    ui.close_menu();
-                }
-            }
-            self.context_menu_places = places;
-            ui.separator();
-        }
-        ui.label(
-            egui::RichText::new("chart layers")
-                .size(11.0)
-                .color(theme::TEXT_MUTED),
-        );
-        #[cfg(test)]
-        self.layer_menu_rects.clear();
+    /// Aim the next menu at one pane or the other, as a right-click would.
+    #[cfg(test)]
+    pub(crate) fn aim_context_menu_at_tape(&mut self, on_tape: bool) {
+        self.context_menu_on_tape = on_tape;
+    }
+
+    /// Whether a click at this x belongs to the tape rather than the candles.
+    ///
+    /// Read off the divider the draw already published, never a second copy of
+    /// the lane's geometry — the two could then disagree, and the menu would
+    /// configure a pane the trader did not click. A canvas with no lane has no
+    /// divider, and every click on it is the candles'.
+    #[must_use]
+    fn click_on_tape(&self, x: f32) -> bool {
+        self.last_lane_divider_x.is_some_and(|divider| x >= divider)
+    }
+
+    /// The candles' layer checkboxes: the list the menu has always shown.
+    fn draw_chart_layer_entries(&mut self, ui: &mut egui::Ui, chrome: &mut PaneChrome<'_>) {
         for layer in ChartLayer::ALL {
             let blocked = self.layer_blocked(layer, chrome.capabilities);
             let mut visible = self.layer_visible(layer, chrome.style);
@@ -1466,6 +1466,162 @@ impl ChartPane {
                     }
                 });
             }
+        }
+    }
+
+    /// What the tape draws, and how much market time it shows.
+    ///
+    /// Reached by right-clicking the tape itself, which is the only place
+    /// these choices are about. Every entry writes the lane's own field, so
+    /// the dock's copy of the same settings and this one can never disagree.
+    fn draw_tape_menu_section(&mut self, ui: &mut egui::Ui) {
+        let Some(orderflow) = self.orderflow.as_mut() else {
+            return;
+        };
+        ui.label(
+            egui::RichText::new("tape")
+                .size(11.0)
+                .color(theme::TEXT_MUTED),
+        );
+
+        let mut depth = orderflow.lane_depth_visible();
+        if ui
+            .checkbox(&mut depth, ChartLayer::Heatmap.label())
+            .on_hover_text(
+                "resting depth on the tape. Switched apart from the candles': clearing the \
+                 chart to read structure does not hide the book where the book is being watched",
+            )
+            .changed()
+        {
+            orderflow.set_lane_depth_visible(depth);
+        }
+
+        let mut bubbles = orderflow.lane_bubbles_enabled();
+        if ui
+            .checkbox(&mut bubbles, ChartLayer::Bubbles.label())
+            .on_hover_text(
+                "confirmed executions rolling through the tape, drawn where they printed",
+            )
+            .changed()
+        {
+            orderflow.set_lane_bubbles_enabled(bubbles);
+        }
+
+        let reference_ms = self.last_lane_reference_ms;
+        let current = orderflow.live_lane_window();
+        let mut chosen = None;
+        ui.menu_button(
+            format!("tape window: {}", lane_window_label(current, reference_ms)),
+            |ui| {
+                let mut entry = |ui: &mut egui::Ui, option: LaneWindow| {
+                    if ui
+                        .selectable_label(
+                            same_lane_window(current, option),
+                            lane_window_label(option, reference_ms),
+                        )
+                        .clicked()
+                    {
+                        chosen = Some(option);
+                        ui.close_menu();
+                    }
+                };
+                entry(ui, LaneWindow::default());
+                ui.separator();
+                for ms in LANE_WINDOW_PRESETS_MS {
+                    entry(ui, LaneWindow::Fixed { ms });
+                }
+                ui.separator();
+                // Custom: the same number the presets set, typed. Seconds
+                // rather than milliseconds because that is the unit the choice
+                // is made in; the field clamps to what the tape can draw.
+                let mut seconds = match current {
+                    LaneWindow::Fixed { ms } => ms,
+                    LaneWindow::Auto { .. } => reference_ms
+                        .map_or(MIN_LIVE_LANE_WINDOW_MS, |reference| {
+                            current.resolve_ms(reference)
+                        }),
+                } as f64
+                    / 1_000.0;
+                ui.horizontal(|ui| {
+                    ui.label("custom");
+                    if ui
+                        .add(
+                            egui::DragValue::new(&mut seconds)
+                                .speed(1.0)
+                                .range(
+                                    (MIN_LIVE_LANE_WINDOW_MS as f64 / 1_000.0)
+                                        ..=(MAX_LIVE_LANE_WINDOW_MS as f64 / 1_000.0),
+                                )
+                                .suffix(" s"),
+                        )
+                        .changed()
+                    {
+                        chosen = Some(LaneWindow::Fixed {
+                            ms: (seconds * 1_000.0).round() as i64,
+                        });
+                    }
+                });
+            },
+        )
+        .response
+        .on_hover_text(
+            "how much market time the tape shows. Following the bars keeps roughly one bar's \
+             worth of flow in the band whatever the instrument; a fixed window shows that much \
+             time however fast the bars are closing, so prints stay readable through a burst",
+        );
+        if let Some(window) = chosen {
+            orderflow.set_live_lane_window(window);
+        }
+    }
+
+    pub fn draw_layer_menu(&mut self, ui: &mut egui::Ui, chrome: &mut PaneChrome<'_>) {
+        // The trade section rides on top, on the pane that owns order
+        // entry, anchored at the price the right-click landed on.
+        if chrome.paper_owns_input
+            && let Some(price) = self.context_menu_price
+        {
+            chrome.paper.context_trade_actions(ui, price);
+            ui.separator();
+        }
+        // Tools that place at the bar under the right-click (the anchored
+        // VWAP's TradingView gesture) declare their entry on the registry;
+        // the click was already resolved per tool, snap rules included, so
+        // the menu only offers what the capture could honestly anchor.
+        if !self.context_menu_places.is_empty() {
+            let places = std::mem::take(&mut self.context_menu_places);
+            for &(tool, point) in &places {
+                let label = tool
+                    .context_menu_label()
+                    .expect("only declaring tools were captured");
+                if ui.button(label).on_hover_text(tool.hover_text()).clicked() {
+                    self.place_drawing_point(tool, &DrawingBand::Price, point, chrome);
+                    ui.close_menu();
+                }
+            }
+            self.context_menu_places = places;
+            ui.separator();
+        }
+        #[cfg(test)]
+        self.layer_menu_rects.clear();
+        // The tape is a pane of its own and is configured as one: a right-click
+        // on it answers for it, and the candles' own layers stay one submenu
+        // away rather than disappearing. A click on the candles sees exactly
+        // the menu it always saw.
+        if self.context_menu_on_tape {
+            self.draw_tape_menu_section(ui);
+            ui.separator();
+            ui.menu_button("chart layers", |ui| {
+                self.draw_chart_layer_entries(ui, chrome);
+            })
+            .response
+            .on_hover_text("what the candles beside the tape draw");
+        } else {
+            ui.label(
+                egui::RichText::new("chart layers")
+                    .size(11.0)
+                    .color(theme::TEXT_MUTED),
+            );
+            self.draw_chart_layer_entries(ui, chrome);
         }
 
         // Borrowed straight from the view list — no per-frame copy of the
@@ -2908,6 +3064,7 @@ impl ChartPane {
             // projection `drawing_point_at` owns, each with the tool's own
             // snap — the anchored VWAP's candle magnet included.
             let history_right = self.last_lane_divider_x.unwrap_or(areas.chart.right());
+            self.context_menu_on_tape = self.click_on_tape(position.x);
             self.context_menu_places.clear();
             for tool in drawings::DRAWING_TOOLS {
                 if tool.context_menu_label().is_none() {
@@ -4292,6 +4449,12 @@ impl ChartPane {
                 split_time_strip(areas.time_strip, self.last_lane_divider_x).1,
                 orderflow.live_lane_window_ms(closed),
             );
+            // The automatic reference this frame, kept for the tape's menu:
+            // the entry that says "follows the bars" has to be able to say
+            // what that works out to, and the menu is drawn without the bars
+            // in reach. Recorded from the same bars the axis was just drawn
+            // from, so the label and the axis can never disagree.
+            self.last_lane_reference_ms = Some(reserved_span_ms(closed));
         }
         // The way back from history (audit F6), painted over the strip's
         // labels on the same geometry the input path registered.
@@ -5419,6 +5582,28 @@ mod tests {
     /// being the depth map or the bubbles, so each of them alone has to keep
     /// it running — otherwise the lane sits reserved and unmarked (a band you
     /// cannot tell from a dead feed) while its menu entry reads as on.
+    /// The two panes are configured apart, so the right-click has to say which
+    /// one it landed on — and it says so from the divider the draw published,
+    /// not from a second copy of the lane's geometry.
+    #[test]
+    fn a_right_click_is_the_tapes_only_on_the_tapes_side_of_the_divider() {
+        let mut pane = ChartPane::flow(1, BarSpec::Tick(50), "TESTUSDT".to_owned());
+
+        // No lane drawn yet: there is one pane, and every click is its.
+        assert!(!pane.click_on_tape(0.0));
+        assert!(!pane.click_on_tape(999.0));
+
+        pane.last_lane_divider_x = Some(700.0);
+        assert!(!pane.click_on_tape(699.9), "the candles' last pixel");
+        assert!(pane.click_on_tape(700.0), "the divider belongs to the tape");
+        assert!(pane.click_on_tape(880.0), "and so does everything past it");
+
+        // A lane that goes away takes its side of the question with it: no
+        // click may configure a tape that is no longer drawn.
+        pane.last_lane_divider_x = None;
+        assert!(!pane.click_on_tape(880.0));
+    }
+
     #[test]
     fn the_strip_and_the_lane_marks_each_keep_the_projection_alive() {
         let mut pane = ChartPane::flow(1, BarSpec::Tick(50), "TESTUSDT".to_owned());

--- a/crates/app/src/pane.rs
+++ b/crates/app/src/pane.rs
@@ -860,6 +860,11 @@ pub struct ChartPane {
     // Where the history pane ended last frame — the lane's divider, and the
     // handle that resizes it. The input pass runs before the draw computes it.
     pub last_lane_divider_x: Option<f32>,
+    // The canvas the last draw used. Published for the same reason the divider
+    // is: something outside the draw needs a point on this pane — the scripted
+    // right-click of `QUANTICK_CONTEXT_MENU` — and computing the geometry a
+    // second time is how two answers start to disagree.
+    pub last_chart_rect: Option<egui::Rect>,
     // The automatic tape window at the last draw — the recent bars' typical
     // duration. Only the menu reads it, and only to state what "follows the
     // bars" currently amounts to; the drawing itself is handed the resolved
@@ -1073,6 +1078,7 @@ impl ChartPane {
             imbalance_target,
             viewport: Viewport::new(),
             last_lane_divider_x: None,
+            last_chart_rect: None,
             last_lane_reference_ms: None,
             context_menu_on_tape: false,
             lane_rungs: 0,
@@ -3895,6 +3901,7 @@ impl ChartPane {
         // zoom inside it exactly as they did when it was the whole chart.
         self.last_lane_divider_x =
             crate::orderflow_render::lane_divider_x(chart_rect, lane_width_px);
+        self.last_chart_rect = Some(chart_rect);
         self.lane_rungs = lane_rungs(
             self.last_lane_divider_x
                 .map_or(0.0, |divider| chart_rect.right() - divider),

--- a/crates/app/src/pane.rs
+++ b/crates/app/src/pane.rs
@@ -20,9 +20,7 @@ use rust_decimal::Decimal;
 use rust_decimal::prelude::{FromPrimitive as _, ToPrimitive as _};
 use smallvec::SmallVec;
 
-use crate::app::{
-    PlotAreas, fmt_time_as, fmt_window, gesture_hits_lane, plot_split, split_time_strip,
-};
+use crate::app::{PlotAreas, fmt_time_as, gesture_hits_lane, plot_split, split_time_strip};
 use crate::bands::{self, Band, BandLabel, Bands};
 use crate::candle_view::draw_candle;
 use crate::chart::{self, PriceScale};
@@ -38,7 +36,7 @@ use crate::indicator_worker::{
 use crate::indicators::{IndicatorViews, MIN_PANE_HEIGHT_PX, PaneSizing};
 use crate::orderflow::{
     LANE_WINDOW_PRESETS_MS, LaneWindow, MAX_LIVE_LANE_WINDOW_MS, MIN_LIVE_LANE_WINDOW_MS,
-    lane_window_label, reserved_span_ms, same_lane_window,
+    format_window_ms, lane_window_label, reserved_span_ms, same_lane_window,
 };
 use crate::orderflow_view::{OrderflowView, VisibleBarTimeline};
 use crate::paper_trading::{ChartInput, PaperTrading};
@@ -4585,7 +4583,7 @@ impl ChartPane {
         painter.text(
             strip.center(),
             egui::Align2::CENTER_CENTER,
-            format!("tape · {}", fmt_window(window_ms)),
+            format!("tape · {}", format_window_ms(window_ms)),
             egui::FontId::monospace(10.0),
             theme::TEXT_MUTED,
         );


### PR DESCRIPTION
## O que muda

A fita ao vivo já tinha configurações próprias — largura, zoom, clusterização, raio das bolhas — mas não as duas chaves que decidem se ela desenha alguma coisa. `L2 heatmap` e `aggression bubbles` eram um interruptor só para os dois painéis, então limpar as velas para ler estrutura cegava a fita, que é justamente onde o book é observado.

Agora cada painel responde pelo próprio canvas, e o botão direito na fita configura a fita.

**A janela da fita vira uma escolha.** O que existia era um multiplicador (`time_zoom`) sobre a duração típica das barras. Numa rajada as barras fecham mais rápido do que um humano lê prints, e quem quer os últimos dois minutos na frente está pedindo dois minutos, não um multiplicador. `LaneWindow::Auto{zoom}` segue as barras como sempre; `Fixed{ms}` fixa o tempo.

## Decisões de desenho

**Um dono para o número.** `time_zoom` e um override de janela lado a lado seriam dois donos do mesmo valor. Em memória existe só `LaneWindow`. Em disco a divisão continua, porque `time_zoom` é o nome que todo preset já escrito usa e a ausência de `window_ms` é exatamente a frase "esta fita segue as barras" — o modo em que está qualquer arquivo anterior a esta escolha.

**Herança em vez de default.** As chaves do tape são `Option<bool>`: `None` segue a chave do gráfico. É o que todo arquivo antigo diz, e é por isso que ele abre desenhando o que desenhava. Esconder uma camada nas velas primeiro entrega ao tape o valor que ele estava desenhando, então os dois só se separam quando o trader os separa.

**A clusterização escala pela janela resolvida, não pelo zoom.** Sem isso uma fita fixa de 2 min desenha dois minutos de prints na densidade de uma fita — um borrão. `LiveEdge` carrega a referência automática ao lado da janela resolvida: sem essa razão, uma janela fixa não tem contra o que ser larga, e a clusterização precisaria de uma constante mágica no lugar das barras.

**Profundidade é recortada no divisor, não descartada.** Um nível apoiado desde antes da janela da fita é uma faixa contínua; esconder o mapa nas velas corta no divisor em vez de perder a faixa. Um clip rect por frame, nenhum teste por célula — a camada mais densa que o gráfico desenha não paga nada por isto.

## Performance

Classificação por taxa de cada caminho tocado:

| Caminho | Taxa | O que mudou |
|---|---|---|
| `RenderContext::bubbles()` | per-frame × bolha | um `select` sobre `mark.live` no lugar de um bool constante |
| early-return das bolhas | per-frame | `&&` em vez de `!` — só sai cedo quando nenhum painel desenha |
| `draw_heatmap_background` | per-frame | um `layer_clip` por frame (não por célula); ganha um early-return novo |
| `legend_entries` | per-frame | dois `\|\|` sobre no máximo 6 entradas |
| `effective_cluster_ms` | por frame de projeção | uma divisão a mais |
| `LiveEdge` | por frame de projeção | +8 bytes na struct; `reserved_span_ms` continua sendo chamado uma vez |
| `LaneWindow` (serde, sanitize, rótulos) | raro | clareza livre |

**Nada per-trade, nada per-depth.** Nenhuma alocação nova em caminho quente, nenhum `HashMap`, nenhuma varredura extra.

Medição sob fita gravada (`APP_HEALTH_SUMMARY`, mesma sessão de 68,9 MB, release): fps 59 e `frame_avg` 16,68 ms nos dois builds — presos ao vsync, como esperado. `frame_cpu` mediano 1,94 ms na branch com 431 bolhas medianas contra 2,47 ms no controle em `main` com 146. **A comparação não é limpa**: as duas execuções pegaram trechos diferentes da fita e havia outra instância do app disputando a GPU. O que ela sustenta é a ausência de regressão grosseira — a branch desenhou cerca de 3× mais marcas por frame sem gastar mais CPU —, não uma medição pareada. Uma comparação pareada exigiria a máquina em repouso.

## Verificação

- `cargo fmt --all -- --check` · `cargo clippy --workspace --all-targets -- -D warnings` · `cargo build --workspace` · `cargo test --workspace` — os quatro com exit 0, sobre `main` atualizado (a branch está em cima de `41750e6`).
- **1839 testes**, 0 falhas. Onze novos cobrem cada critério: separação por painel na config e nos pixels, projeção que sobrevive ao switch, hit-test do divisor, `LaneWindow` nos dois modos, rótulos, gesto, clusterização, arquivo antigo, preset e os parsers dos hooks.
- Os testes de `window_ms` que já existiam passam **sem mudança de expectativa** — só a forma de construir mudou.

## `arch-review` — 4 achados, todos corrigidos

1. **Preset passou a carregar visibilidade** (quase blocker). `BubblePreset` copia `LiveLaneStyle` inteira, então mover as chaves para lá fez um preset de aparência ligar e desligar camadas — o que o próprio doc promete nunca fazer, e config ativando feature pela mera presença. Captura não grava visibilidade, aplicação preserva a que estava.
2. **Legenda negava chaves de marcas em tela.** Ela descreve o canvas, e o canvas tem dois painéis.
3. **Early-return das bolhas apagaria a fita inteira.** Pego pelo teste antes de sair do worktree.
4. **Limpar as velas apagava a fita** — não uma camada dela, a fita. A âncora da lane vinha da chave de profundidade das velas, então esconder o mapa levava junto a banda, as bolhas e o strip. Encontrado ao tentar fotografar a separação: o painel com o mapa escondido não tinha fita alguma para configurar separadamente.

## `trader-ux-review` — 2 Should-fix, ambos corrigidos

1. **Duas línguas para a mesma duração.** O eixo dizia `1.5 min` enquanto o menu que a define dizia `1 min 30 s`, a um palmo um do outro — e a segunda forma foi criada por este branch. `fmt_window` eliminada; uma função só.
2. **Rótulos idênticos, escopos diferentes.** Os hints do menu do gráfico agora nomeiam as velas e apontam onde está o gêmeo.

**Consider, deliberadamente adiado:** com as duas camadas do tape desligadas, a banda continua reservada e vazia — o trader esperaria recuperar os 35% de tela. Recuperar isso mexe na largura da lane, que é configuração própria e arrastável; fora do escopo desta missão.

## `ui-harness`

Três hooks novos, registrados na skill, todos pelo caminho que o controle manual usa:

- `QUANTICK_TAPE_LAYERS=<heatmap,bubbles,no-heatmap,no-bubbles,none>`
- `QUANTICK_TAPE_WINDOW=<auto|90s|2min|120000ms>`
- `QUANTICK_CONTEXT_MENU=<chart|tape>` — o menu de contexto abre com clique direito e nada mais, então o hook entrega o clique via `raw_input_hook` do eframe em vez de mexer no estado de menu do egui: o que abre é o que o clique do trader abre.

## `visual-qa` — 6 de 6 superfícies PASS

As primeiras tentativas saíram em branco (`fps=19`, `frame_avg` 51 ms, `frame_cpu` 2,2 ms) — janela ocluída pelo trabalho do dono da máquina, não regressão de render. Em vez de disputar o foco, a janela passou a ser **movida para fora da área visível** com `SWP_NOACTIVATE`: o DWM continua compondo, o `PrintWindow` entrega frame real, e nada aparece na frente de quem está usando o computador. Todas as capturas seguintes: `fps=59`, 682–889 cores distintas.

| # | Superfície | Veredito |
|---|---|---|
| 1 | baseline (feed ao vivo, book ativo) | PASS |
| 2 | velas limpas + fita com book e bolhas | PASS — o pedido, com o corte limpo no divisor |
| 3 | velas com as camadas + fita limpa | PASS — o inverso |
| 4 | `tape window = 2 min` | PASS — o eixo lê `tape · 2 min` |
| 5 | menu do tape | PASS — seção `tape`, `tape window: auto (≈ 37 s)`, `chart layers ▸` |
| 6 | menu do gráfico | PASS — as 16 camadas listadas direto, sem regressão |

**Dois defeitos foram encontrados pelas capturas, não pelos testes:**

1. **A entrada de bolhas do tape aparecia desmarcada** com as bolhas ligadas nas velas e o tape nunca configurado à parte. O copy-on-write rodava em toda mudança, então ligar uma camada a partir do estado desligado entregava ao tape o valor de um instante antes — desligado — e o prendia ali. Só esconder precisa separar os painéis; mostrar tem de deixar o tape herdando.
2. **O menu do gráfico não abria** pelo hook: o clique sintético entregava press e release no mesmo frame, e o egui abre o menu no release. Um clique real dura um frame; o hook agora também.

Com o primeiro corrigido, uma expectativa existente muda **deliberadamente**: desligar as bolhas sobre as velas não fecha mais a projeção, porque a fita continua desenhando e ninguém pediu que ela parasse. Aquele teste passava antes apenas por causa do defeito 1 — o tape estava preso em desligado, então de fato não sobrava ninguém lendo. Ele agora afirma as duas metades: um painel lendo mantém o frame, nenhum painel lendo o fecha.

*Artefato conhecido da técnica:* capturas off-screen deixam um retângulo não composto no canto inferior esquerdo (a barra de ferramentas). É da captura, não do app — a captura on-screen da baseline não o tem.

## Blast radius

12 arquivos editados, 0 criados. É uma mudança de forma, não uma capacidade nova: o discriminador entre os dois painéis já existia no render (`layout.in_lane`, `AggressionPrimitive::live`) e a lane já tinha struct de estilo própria. O que faltava era o interruptor, e ele foi para dentro da struct que já era dona daquele painel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SAhZZqvAZSa74ZLx7ur1ed

