### PR TITLE
feat: imbalance bar units - trades, volume, dollar

### DIFF
--- a/crates/app/config/feeds.toml
+++ b/crates/app/config/feeds.toml
@@ -29,7 +29,8 @@ default_symbol = "BTCUSDT"
 #                   it never overrides a layout chosen from View → Layout.
 #   default_bars  — optional: the bar spec a tab on this feed opens on, as
 #                   "kind:parameter" — time:1m, tick:50, volume:5,
-#                   dollar:500000, imbalance:100. Sets the flow pane's opening
+#                   dollar:500000, imbalance:100 (also imbalance:volume:500 /
+#                   imbalance:dollar:500). Sets the flow pane's opening
 #                   spec; with a time-showing default_layout and a time spec,
 #                   the timeframe pane opens on that interval too. A spec that
 #                   does not parse is refused at load, like any config error.

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -1937,6 +1937,7 @@ impl QuantickApp {
             dollar_notional: &mut pane.dollar_notional,
             time_interval_ms: &mut pane.time_interval_ms,
             imbalance_target: &mut pane.imbalance_target,
+            imbalance_unit: &mut pane.imbalance_unit,
             history_step: &mut tab.history_step,
             history_trades: tab.history_trades,
             capabilities,

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -8319,6 +8319,35 @@ plot(close)
         assert!(!app.active_tab().loading.is_active(LoadingTask::BarRebuild));
     }
 
+    /// The unit chips write one field and nothing else: a unit-only change
+    /// is a whole spec change, and the same two settle frames every selector
+    /// gets must re-cut the series.
+    #[test]
+    fn switching_only_the_imbalance_unit_recuts_the_series() {
+        let (mut app, _evt_tx, _cmd_rx, _book_tx) = test_app();
+        app.active_tab_mut().flow_pane.kind = crate::state::BarKind::Imbalance;
+        app.active_tab_mut().apply_spec_changes();
+        app.active_tab_mut().apply_spec_changes();
+        assert_eq!(
+            app.active_tab().flow_pane.state.spec(),
+            &BarSpec::Imbalance(crate::state::ImbalanceUnit::Trades, 100),
+            "the kind switch lands on the default trades unit first"
+        );
+
+        app.active_tab_mut().flow_pane.imbalance_unit = crate::state::ImbalanceUnit::Volume;
+        app.active_tab_mut().apply_spec_changes();
+        assert!(
+            app.active_tab().loading.is_active(LoadingTask::BarRebuild),
+            "the arming frame shows the rebuild overlay"
+        );
+        app.active_tab_mut().apply_spec_changes();
+        assert_eq!(
+            app.active_tab().flow_pane.state.spec(),
+            &BarSpec::Imbalance(crate::state::ImbalanceUnit::Volume, 100),
+            "a unit-only change rebuilds the series"
+        );
+    }
+
     #[test]
     fn a_still_moving_selector_keeps_deferring_the_rebuild() {
         let (mut app, _evt_tx, _cmd_rx, _book_tx) = test_app();

--- a/crates/app/src/config.rs
+++ b/crates/app/src/config.rs
@@ -478,6 +478,7 @@ pub struct FeedConfig {
     pub default_layout: Option<DeclaredLayout>,
     /// The bar spec a tab on this feed opens on, as `kind:parameter` —
     /// `time:1m`, `tick:50`, `volume:5`, `dollar:500000`, `imbalance:100`
+    /// (also `imbalance:volume:500` / `imbalance:dollar:500`)
     /// (see `crate::state::BarSpec::parse`). It sets the flow pane's opening
     /// spec; when [`default_layout`](Self::default_layout) shows a time pane
     /// and this names a time spec, that pane opens on its interval too.

--- a/crates/app/src/footprint_series.rs
+++ b/crates/app/src/footprint_series.rs
@@ -121,7 +121,7 @@ impl FootprintSeries {
 mod tests {
     use super::*;
     use crate::state::{BarSpec, ChartState};
-    use quantick_engine::Side;
+    use quantick_engine::{ImbalanceUnit, Side};
     use std::str::FromStr as _;
 
     fn dec(s: &str) -> Decimal {
@@ -162,7 +162,7 @@ mod tests {
             BarSpec::Volume(dec("4")),
             BarSpec::Dollar(dec("500")),
             BarSpec::Time(1000),
-            BarSpec::Imbalance(3),
+            BarSpec::Imbalance(ImbalanceUnit::Trades, 3),
         ];
         for spec in specs {
             let label = format!("{spec:?}");

--- a/crates/app/src/pane.rs
+++ b/crates/app/src/pane.rs
@@ -41,7 +41,7 @@ use crate::orderflow::{
 use crate::orderflow_view::{OrderflowView, VisibleBarTimeline};
 use crate::paper_trading::{ChartInput, PaperTrading};
 use crate::price_view::PriceView;
-use crate::state::{BarKind, BarSpec, ChartState};
+use crate::state::{BarKind, BarSpec, ChartState, ImbalanceUnit};
 use crate::style::ChartStyle;
 use crate::theme;
 use crate::timezone::TzOffset;
@@ -901,6 +901,7 @@ pub struct ChartPane {
     pub dollar_notional: f64,
     pub time_interval_ms: i64,
     pub imbalance_target: u64,
+    pub imbalance_unit: ImbalanceUnit,
 
     // Pan/zoom navigation over the bar series. It owns the history pane only:
     // the live lane is a band of screen to its right that answers to nothing
@@ -1093,12 +1094,16 @@ impl ChartPane {
         // (audit QW2): the same 1m the split's time pane opens on.
         let mut time_interval_ms = crate::time_header::DEFAULT_INTERVAL_MS;
         let mut imbalance_target = 100;
+        let mut imbalance_unit = ImbalanceUnit::Trades;
         match &spec {
             BarSpec::Tick(n) => tick_n = *n,
             BarSpec::Volume(u) => volume_units = u.to_f64().unwrap_or(volume_units),
             BarSpec::Dollar(d) => dollar_notional = d.to_f64().unwrap_or(dollar_notional),
             BarSpec::Time(ms) => time_interval_ms = *ms,
-            BarSpec::Imbalance(target) => imbalance_target = *target,
+            BarSpec::Imbalance(unit, target) => {
+                imbalance_unit = *unit;
+                imbalance_target = *target;
+            }
         }
 
         Self {
@@ -1129,6 +1134,7 @@ impl ChartPane {
             dollar_notional,
             time_interval_ms,
             imbalance_target,
+            imbalance_unit,
             viewport: Viewport::new(),
             last_lane_divider_x: None,
             last_chart_rect: None,
@@ -1213,7 +1219,10 @@ impl ChartPane {
                 self.dollar_notional = notional.to_f64().unwrap_or(self.dollar_notional);
             }
             BarSpec::Time(ms) => self.time_interval_ms = *ms,
-            BarSpec::Imbalance(target) => self.imbalance_target = *target,
+            BarSpec::Imbalance(unit, target) => {
+                self.imbalance_unit = *unit;
+                self.imbalance_target = *target;
+            }
         }
         self.state.set_spec(spec);
     }
@@ -1869,7 +1878,9 @@ impl ChartPane {
             BarKind::Volume => BarSpec::Volume(dec_from_f64(self.volume_units)),
             BarKind::Dollar => BarSpec::Dollar(dec_from_f64(self.dollar_notional)),
             BarKind::Time => BarSpec::Time(self.time_interval_ms.max(1)),
-            BarKind::Imbalance => BarSpec::Imbalance(self.imbalance_target.max(1)),
+            BarKind::Imbalance => {
+                BarSpec::Imbalance(self.imbalance_unit, self.imbalance_target.max(1))
+            }
         }
     }
 

--- a/crates/app/src/state.rs
+++ b/crates/app/src/state.rs
@@ -10,6 +10,9 @@
 //! No egui, no async here, so the ingest, dispatch and rebuild logic is
 //! unit-tested in CI.
 
+/// Re-exported so every consumer of the bar vocabulary finds the imbalance
+/// unit next to [`BarSpec`], not off in the engine.
+pub use quantick_engine::ImbalanceUnit;
 use quantick_engine::{
     Bar, BarBuilder, BarFootprint, BarProgress, DollarBarBuilder, ImbalanceBarBuilder,
     TickBarBuilder, TimeBarBuilder, Trade, VolumeBarBuilder,
@@ -59,11 +62,14 @@ impl BarKind {
     /// Whether this rule measures traded size, and so needs a venue that
     /// prints one.
     ///
-    /// Tick, time and imbalance bars all count *events*: imbalance sums a
-    /// signed ±1 per trade (López de Prado's tick imbalance bars), never a
-    /// quantity. They stay meaningful on a quote-driven feed. Volume and dollar
-    /// bars do not — fed one synthetic unit per tick, a "volume 500" bar is a
-    /// 500-tick bar wearing a misleading label.
+    /// Tick, time and imbalance bars all count *events*: imbalance in its
+    /// default trades unit sums a signed ±1 per trade (López de Prado's tick
+    /// imbalance bars), never a quantity. They stay meaningful on a
+    /// quote-driven feed. Volume and dollar bars do not — fed one synthetic
+    /// unit per tick, a "volume 500" bar is a 500-tick bar wearing a
+    /// misleading label. The imbalance *kind* answers for that default: its
+    /// volume/dollar units measure size too, and the toolbar's unit selector
+    /// gates them per feed exactly as this method gates the kinds.
     #[must_use]
     pub fn needs_traded_volume(self) -> bool {
         match self {
@@ -96,8 +102,10 @@ pub enum BarSpec {
     /// N milliseconds per bar. The interval a control may ask for is bounded
     /// by [`MIN_TIME_INTERVAL_MS`]..=[`MAX_TIME_INTERVAL_MS`].
     Time(i64),
-    /// Target trades per bar for the adaptive imbalance rule.
-    Imbalance(u64),
+    /// The adaptive imbalance rule: the measure θ accumulates (trades, volume
+    /// or dollar — López de Prado's TIB/VIB/DIB) and the target trades per
+    /// bar, which counts trades in every unit.
+    Imbalance(ImbalanceUnit, u64),
 }
 
 impl BarSpec {
@@ -109,7 +117,7 @@ impl BarSpec {
             BarSpec::Volume(_) => BarKind::Volume,
             BarSpec::Dollar(_) => BarKind::Dollar,
             BarSpec::Time(_) => BarKind::Time,
-            BarSpec::Imbalance(_) => BarKind::Imbalance,
+            BarSpec::Imbalance(..) => BarKind::Imbalance,
         }
     }
 
@@ -122,7 +130,9 @@ impl BarSpec {
             BarSpec::Volume(units) => Box::new(VolumeBarBuilder::new(*units)),
             BarSpec::Dollar(notional) => Box::new(DollarBarBuilder::new(*notional)),
             BarSpec::Time(ms) => Box::new(TimeBarBuilder::new(*ms)),
-            BarSpec::Imbalance(target) => Box::new(ImbalanceBarBuilder::new(*target)),
+            BarSpec::Imbalance(unit, target) => {
+                Box::new(ImbalanceBarBuilder::with_unit(*target, *unit))
+            }
         }
     }
 
@@ -147,7 +157,13 @@ impl BarSpec {
             BarSpec::Volume(u) => format!("volume({u})"),
             BarSpec::Dollar(d) => format!("dollar({d})"),
             BarSpec::Time(ms) => format!("time({})", fmt_time_interval(*ms)),
-            BarSpec::Imbalance(target) => format!("imbalance({target})"),
+            BarSpec::Imbalance(ImbalanceUnit::Trades, target) => format!("imbalance({target})"),
+            BarSpec::Imbalance(ImbalanceUnit::Volume, target) => {
+                format!("imbalance(volume {target})")
+            }
+            BarSpec::Imbalance(ImbalanceUnit::Dollar, target) => {
+                format!("imbalance(dollar {target})")
+            }
         }
     }
 
@@ -166,14 +182,24 @@ impl BarSpec {
             BarSpec::Volume(units) => format!("volume:{units}"),
             BarSpec::Dollar(notional) => format!("dollar:{notional}"),
             BarSpec::Time(ms) => format!("time:{}", fmt_time_interval(*ms)),
-            BarSpec::Imbalance(target) => format!("imbalance:{target}"),
+            // The trades unit keeps its historical short form, so every spec
+            // a workspace saved before units existed still reads back as the
+            // same chart.
+            BarSpec::Imbalance(ImbalanceUnit::Trades, target) => format!("imbalance:{target}"),
+            BarSpec::Imbalance(ImbalanceUnit::Volume, target) => {
+                format!("imbalance:volume:{target}")
+            }
+            BarSpec::Imbalance(ImbalanceUnit::Dollar, target) => {
+                format!("imbalance:dollar:{target}")
+            }
         }
     }
 
     /// Parse a `kind:parameter` spec string, the form `default_bars` uses in
     /// the feeds configuration: `tick:50`, `volume:5`, `dollar:500000`,
-    /// `imbalance:100`, `time:1m` (also `time:30s`, `time:1h`, `time:1500ms`
-    /// or a bare millisecond count).
+    /// `imbalance:100` (also `imbalance:volume:500` / `imbalance:dollar:500`
+    /// to pick what θ accumulates), `time:1m` (also `time:30s`, `time:1h`,
+    /// `time:1500ms` or a bare millisecond count).
     ///
     /// Every rule a UI control enforces holds here too — a positive
     /// parameter, and a time interval inside
@@ -205,7 +231,33 @@ impl BarSpec {
         };
         match kind {
             "tick" => Ok(BarSpec::Tick(positive_count("tick")?)),
-            "imbalance" => Ok(BarSpec::Imbalance(positive_count("imbalance")?)),
+            "imbalance" => {
+                // The parameter is `target` or `unit:target`. The unit picks
+                // what θ accumulates; the target counts trades in every unit.
+                let (unit, target) = match param.split_once(':') {
+                    None => (ImbalanceUnit::Trades, param),
+                    Some((unit, target)) => {
+                        let unit = match unit.trim() {
+                            "trades" => ImbalanceUnit::Trades,
+                            "volume" => ImbalanceUnit::Volume,
+                            "dollar" => ImbalanceUnit::Dollar,
+                            other => {
+                                return Err(format!(
+                                    "unknown imbalance unit '{other}'; one of trades, \
+                                     volume, dollar"
+                                ));
+                            }
+                        };
+                        (unit, target.trim())
+                    }
+                };
+                match target.parse::<u64>() {
+                    Ok(n) if n > 0 => Ok(BarSpec::Imbalance(unit, n)),
+                    _ => Err(format!(
+                        "imbalance bars need a positive whole trade target, got '{target}'"
+                    )),
+                }
+            }
             "volume" => Ok(BarSpec::Volume(positive_decimal("volume")?)),
             "dollar" => Ok(BarSpec::Dollar(positive_decimal("dollar")?)),
             "time" => {
@@ -626,7 +678,9 @@ mod tests {
     fn every_bar_spec_survives_the_config_round_trip() {
         for spec in [
             BarSpec::Tick(50),
-            BarSpec::Imbalance(100),
+            BarSpec::Imbalance(ImbalanceUnit::Trades, 100),
+            BarSpec::Imbalance(ImbalanceUnit::Volume, 500),
+            BarSpec::Imbalance(ImbalanceUnit::Dollar, 2500),
             BarSpec::Volume(dec("5.25")),
             BarSpec::Dollar(dec("500000")),
             BarSpec::Time(60_000),
@@ -649,7 +703,23 @@ mod tests {
     #[test]
     fn bar_specs_parse_in_the_config_vocabulary() {
         assert_eq!(BarSpec::parse("tick:50"), Ok(BarSpec::Tick(50)));
-        assert_eq!(BarSpec::parse("imbalance:100"), Ok(BarSpec::Imbalance(100)));
+        assert_eq!(
+            BarSpec::parse("imbalance:100"),
+            Ok(BarSpec::Imbalance(ImbalanceUnit::Trades, 100)),
+            "the pre-units short form still names tick imbalance bars"
+        );
+        assert_eq!(
+            BarSpec::parse("imbalance:trades:100"),
+            Ok(BarSpec::Imbalance(ImbalanceUnit::Trades, 100))
+        );
+        assert_eq!(
+            BarSpec::parse("imbalance:volume:500"),
+            Ok(BarSpec::Imbalance(ImbalanceUnit::Volume, 500))
+        );
+        assert_eq!(
+            BarSpec::parse("imbalance:dollar:2500"),
+            Ok(BarSpec::Imbalance(ImbalanceUnit::Dollar, 2500))
+        );
         assert_eq!(BarSpec::parse("volume:5"), Ok(BarSpec::Volume(dec("5"))));
         assert_eq!(
             BarSpec::parse("volume:0.5"),
@@ -701,6 +771,10 @@ mod tests {
             "volume:0",
             "dollar:nope",
             "imbalance:1.5",
+            "imbalance:volume:0",
+            "imbalance:volume:1.5",
+            "imbalance:notional:500",
+            "imbalance:volume:",
             "time:0",
             "time:50ms",
             "time:25h",
@@ -728,8 +802,9 @@ mod tests {
         // only fake them.
         assert!(BarKind::Volume.needs_traded_volume());
         assert!(BarKind::Dollar.needs_traded_volume());
-        // The other three count events, not quantity — imbalance included: it
-        // sums a signed ±1 per trade, so it stays honest on a quote feed.
+        // The other three count events, not quantity — imbalance answering
+        // for its default trades unit, which sums a signed ±1 per trade; the
+        // unit selector gates its volume/dollar units per feed.
         assert!(!BarKind::Tick.needs_traded_volume());
         assert!(!BarKind::Time.needs_traded_volume());
         assert!(!BarKind::Imbalance.needs_traded_volume());
@@ -764,7 +839,9 @@ mod tests {
             BarSpec::Volume(dec("1.0")),
             BarSpec::Dollar(dec("100")),
             BarSpec::Time(1),
-            BarSpec::Imbalance(1),
+            BarSpec::Imbalance(ImbalanceUnit::Trades, 1),
+            BarSpec::Imbalance(ImbalanceUnit::Volume, 1),
+            BarSpec::Imbalance(ImbalanceUnit::Dollar, 1),
         ] {
             let kind = spec.kind();
             let mut builder = spec.build();

--- a/crates/app/src/state.rs
+++ b/crates/app/src/state.rs
@@ -158,12 +158,7 @@ impl BarSpec {
             BarSpec::Dollar(d) => format!("dollar({d})"),
             BarSpec::Time(ms) => format!("time({})", fmt_time_interval(*ms)),
             BarSpec::Imbalance(ImbalanceUnit::Trades, target) => format!("imbalance({target})"),
-            BarSpec::Imbalance(ImbalanceUnit::Volume, target) => {
-                format!("imbalance(volume {target})")
-            }
-            BarSpec::Imbalance(ImbalanceUnit::Dollar, target) => {
-                format!("imbalance(dollar {target})")
-            }
+            BarSpec::Imbalance(unit, target) => format!("imbalance({} {target})", unit.as_str()),
         }
     }
 
@@ -186,12 +181,7 @@ impl BarSpec {
             // a workspace saved before units existed still reads back as the
             // same chart.
             BarSpec::Imbalance(ImbalanceUnit::Trades, target) => format!("imbalance:{target}"),
-            BarSpec::Imbalance(ImbalanceUnit::Volume, target) => {
-                format!("imbalance:volume:{target}")
-            }
-            BarSpec::Imbalance(ImbalanceUnit::Dollar, target) => {
-                format!("imbalance:dollar:{target}")
-            }
+            BarSpec::Imbalance(unit, target) => format!("imbalance:{}:{target}", unit.as_str()),
         }
     }
 
@@ -236,18 +226,14 @@ impl BarSpec {
                 // what θ accumulates; the target counts trades in every unit.
                 let (unit, target) = match param.split_once(':') {
                     None => (ImbalanceUnit::Trades, param),
-                    Some((unit, target)) => {
-                        let unit = match unit.trim() {
-                            "trades" => ImbalanceUnit::Trades,
-                            "volume" => ImbalanceUnit::Volume,
-                            "dollar" => ImbalanceUnit::Dollar,
-                            other => {
-                                return Err(format!(
-                                    "unknown imbalance unit '{other}'; one of trades, \
-                                     volume, dollar"
-                                ));
-                            }
-                        };
+                    Some((token, target)) => {
+                        let token = token.trim();
+                        let unit = ImbalanceUnit::parse_token(token).ok_or_else(|| {
+                            format!(
+                                "unknown imbalance unit '{token}'; one of trades, \
+                                 volume, dollar"
+                            )
+                        })?;
                         (unit, target.trim())
                     }
                 };

--- a/crates/app/src/toolbar.rs
+++ b/crates/app/src/toolbar.rs
@@ -53,6 +53,10 @@ const W_BARS: f32 = 160.0;
 const W_BAR_PARAM: f32 = 150.0;
 /// The time kind's parameter row: four preset chips plus the custom drag.
 const W_TIME_PARAM: f32 = 260.0;
+/// The imbalance kind's parameter row: three unit chips plus the target
+/// label and drag. Underestimating this makes the collapse plan draw a row
+/// wider than it budgeted instead of folding it.
+const W_IMBALANCE_PARAM: f32 = 330.0;
 /// The `+ older ▾` split button.
 const W_HISTORY: f32 = 100.0;
 /// The LAYERS icon group (bubbles, heatmap, live strip, indicators).
@@ -182,6 +186,7 @@ pub fn trade_width(paper: &PaperTradeModel) -> f32 {
 pub fn param_width(kind: BarKind) -> f32 {
     match kind {
         BarKind::Time => W_TIME_PARAM,
+        BarKind::Imbalance => W_IMBALANCE_PARAM,
         _ => W_BAR_PARAM,
     }
 }

--- a/crates/app/src/toolbar.rs
+++ b/crates/app/src/toolbar.rs
@@ -21,7 +21,7 @@ use egui_phosphor::regular as icons;
 
 use crate::config::FeedCapabilities;
 use crate::dock::DockTab;
-use crate::state::BarKind;
+use crate::state::{BarKind, ImbalanceUnit};
 use crate::theme;
 use crate::widgets::{IconButton, TOOLBAR_ICON};
 
@@ -221,6 +221,9 @@ pub struct ToolbarModel<'a> {
     pub time_interval_ms: &'a mut i64,
     /// Parameter for [`BarKind::Imbalance`].
     pub imbalance_target: &'a mut u64,
+    /// What θ accumulates for [`BarKind::Imbalance`]: trades, volume or
+    /// dollar (López de Prado's TIB/VIB/DIB).
+    pub imbalance_unit: &'a mut ImbalanceUnit,
     /// Trades pulled per "+ older" click.
     pub history_step: &'a mut usize,
     /// Trades backfilled so far, for the history menu readout.
@@ -539,12 +542,50 @@ fn draw_bar_param(ui: &mut egui::Ui, model: &mut ToolbarModel) {
             });
         }
         BarKind::Imbalance => {
+            // The unit picks what θ accumulates; the target counts trades in
+            // every unit. Size-measuring units are offered only where the
+            // venue prints a real size, mirroring the kind combo's gate.
+            let traded_volume = model.capabilities.traded_volume;
+            for (unit, label, hover) in [
+                (
+                    ImbalanceUnit::Trades,
+                    "trades",
+                    "θ sums ±1 per trade — tick imbalance bars",
+                ),
+                (
+                    ImbalanceUnit::Volume,
+                    "volume",
+                    "θ sums ±quantity — volume imbalance bars",
+                ),
+                (
+                    ImbalanceUnit::Dollar,
+                    "dollar",
+                    "θ sums ±(price × quantity) — dollar imbalance bars",
+                ),
+            ] {
+                let usable = traded_volume || unit == ImbalanceUnit::Trades;
+                ui.add_enabled_ui(usable, |ui| {
+                    let chip = ui
+                        .selectable_value(model.imbalance_unit, unit, label)
+                        .on_hover_text(hover);
+                    if !usable {
+                        chip.on_disabled_hover_text(
+                            "this source quotes prices but prints no traded volume",
+                        );
+                    }
+                });
+            }
             ui.label("target trades");
-            ui.add(egui::DragValue::new(model.imbalance_target).range(2.0..=5000.0))
-                .on_hover_text(
-                    "expected trades per bar in balanced flow; \
-                     one-sided aggression closes bars sooner",
-                );
+            ui.add(
+                egui::DragValue::new(model.imbalance_target)
+                    .range(2.0..=1_000_000.0)
+                    .speed(25.0),
+            )
+            .on_hover_text(
+                "expected trades per bar in balanced flow — the seed of the \
+                 adaptive threshold, not a fixed length: dense two-way tape \
+                 closes bars well short of it, one-sided aggression sooner still",
+            );
         }
     }
 }
@@ -557,7 +598,11 @@ fn param_summary(model: &ToolbarModel) -> String {
         BarKind::Volume => format!("{:.1}", model.volume_units),
         BarKind::Dollar => format!("{:.0}", model.dollar_notional),
         BarKind::Time => crate::state::fmt_time_interval(*model.time_interval_ms),
-        BarKind::Imbalance => model.imbalance_target.to_string(),
+        BarKind::Imbalance => match *model.imbalance_unit {
+            ImbalanceUnit::Trades => model.imbalance_target.to_string(),
+            ImbalanceUnit::Volume => format!("volume {}", model.imbalance_target),
+            ImbalanceUnit::Dollar => format!("dollar {}", model.imbalance_target),
+        },
     }
 }
 
@@ -1074,6 +1119,7 @@ mod tests {
         let mut dollar_notional = 500_000.0_f64;
         let mut time_interval_ms = 1_000_i64;
         let mut imbalance_target = 100_u64;
+        let mut imbalance_unit = ImbalanceUnit::Trades;
         let mut history_step = 2_000_usize;
         for replaying in [false, true] {
             for _ in 0..2 {
@@ -1094,6 +1140,7 @@ mod tests {
                         dollar_notional: &mut dollar_notional,
                         time_interval_ms: &mut time_interval_ms,
                         imbalance_target: &mut imbalance_target,
+                        imbalance_unit: &mut imbalance_unit,
                         history_step: &mut history_step,
                         history_trades: 1_000,
                         capabilities: FeedCapabilities {
@@ -1153,6 +1200,7 @@ mod tests {
         let mut dollar_notional = 500_000.0_f64;
         let mut time_interval_ms = 60_000_i64;
         let mut imbalance_target = 100_u64;
+        let mut imbalance_unit = ImbalanceUnit::Trades;
         let mut history_step = 2_000_usize;
         // Wide enough that the §6 plan folds nothing — the point is the
         // inline chip row, not the overflow menu.
@@ -1179,6 +1227,7 @@ mod tests {
                     dollar_notional: &mut dollar_notional,
                     time_interval_ms: &mut time_interval_ms,
                     imbalance_target: &mut imbalance_target,
+                    imbalance_unit: &mut imbalance_unit,
                     history_step: &mut history_step,
                     history_trades: 1_000,
                     capabilities: FeedCapabilities {
@@ -1231,6 +1280,7 @@ mod tests {
         let mut dollar_notional = 500_000.0_f64;
         let mut time_interval_ms = 1_000_i64;
         let mut imbalance_target = 100_u64;
+        let mut imbalance_unit = ImbalanceUnit::Trades;
         let mut history_step = 2_000_usize;
         // Every kind, including the two the feed cannot back: selecting one is
         // still possible from config or a previous session, and the toolbar
@@ -1251,6 +1301,7 @@ mod tests {
                         dollar_notional: &mut dollar_notional,
                         time_interval_ms: &mut time_interval_ms,
                         imbalance_target: &mut imbalance_target,
+                        imbalance_unit: &mut imbalance_unit,
                         history_step: &mut history_step,
                         history_trades: 200_000,
                         capabilities: FeedCapabilities {
@@ -1292,6 +1343,7 @@ mod tests {
         let mut dollar_notional = 500_000.0_f64;
         let mut time_interval_ms = 1_000_i64;
         let mut imbalance_target = 100_u64;
+        let mut imbalance_unit = ImbalanceUnit::Trades;
         let mut history_step = 2_000_usize;
         let mut painted = String::new();
         // Wide enough that the §6 plan folds nothing — the point is the
@@ -1318,6 +1370,7 @@ mod tests {
                     dollar_notional: &mut dollar_notional,
                     time_interval_ms: &mut time_interval_ms,
                     imbalance_target: &mut imbalance_target,
+                    imbalance_unit: &mut imbalance_unit,
                     history_step: &mut history_step,
                     history_trades: 1_000,
                     capabilities: FeedCapabilities {

--- a/crates/app/src/toolbar.rs
+++ b/crates/app/src/toolbar.rs
@@ -551,27 +551,18 @@ fn draw_bar_param(ui: &mut egui::Ui, model: &mut ToolbarModel) {
             // every unit. Size-measuring units are offered only where the
             // venue prints a real size, mirroring the kind combo's gate.
             let traded_volume = model.capabilities.traded_volume;
-            for (unit, label, hover) in [
-                (
-                    ImbalanceUnit::Trades,
-                    "trades",
-                    "θ sums ±1 per trade — tick imbalance bars",
-                ),
-                (
-                    ImbalanceUnit::Volume,
-                    "volume",
-                    "θ sums ±quantity — volume imbalance bars",
-                ),
-                (
-                    ImbalanceUnit::Dollar,
-                    "dollar",
-                    "θ sums ±(price × quantity) — dollar imbalance bars",
-                ),
-            ] {
+            for unit in ImbalanceUnit::ALL {
+                // The chip label is the unit's own spec token, so what the
+                // trader clicks is the word the spec string says.
+                let hover = match unit {
+                    ImbalanceUnit::Trades => "θ sums ±1 per trade — tick imbalance bars",
+                    ImbalanceUnit::Volume => "θ sums ±quantity — volume imbalance bars",
+                    ImbalanceUnit::Dollar => "θ sums ±(price × quantity) — dollar imbalance bars",
+                };
                 let usable = traded_volume || unit == ImbalanceUnit::Trades;
                 ui.add_enabled_ui(usable, |ui| {
                     let chip = ui
-                        .selectable_value(model.imbalance_unit, unit, label)
+                        .selectable_value(model.imbalance_unit, unit, unit.as_str())
                         .on_hover_text(hover);
                     if !usable {
                         chip.on_disabled_hover_text(
@@ -605,8 +596,7 @@ fn param_summary(model: &ToolbarModel) -> String {
         BarKind::Time => crate::state::fmt_time_interval(*model.time_interval_ms),
         BarKind::Imbalance => match *model.imbalance_unit {
             ImbalanceUnit::Trades => model.imbalance_target.to_string(),
-            ImbalanceUnit::Volume => format!("volume {}", model.imbalance_target),
-            ImbalanceUnit::Dollar => format!("dollar {}", model.imbalance_target),
+            unit => format!("{} {}", unit.as_str(), model.imbalance_target),
         },
     }
 }

--- a/crates/backtest/src/bars.rs
+++ b/crates/backtest/src/bars.rs
@@ -83,18 +83,14 @@ impl BarSpec {
                 // the target counts trades in every unit.
                 let (unit, target) = match param.split_once(':') {
                     None => (ImbalanceUnit::Trades, param),
-                    Some((unit, target)) => {
-                        let unit = match unit.trim() {
-                            "trades" => ImbalanceUnit::Trades,
-                            "volume" => ImbalanceUnit::Volume,
-                            "dollar" => ImbalanceUnit::Dollar,
-                            other => {
-                                return Err(format!(
-                                    "unknown imbalance unit '{other}'; one of trades, \
-                                     volume, dollar"
-                                ));
-                            }
-                        };
+                    Some((token, target)) => {
+                        let token = token.trim();
+                        let unit = ImbalanceUnit::parse_token(token).ok_or_else(|| {
+                            format!(
+                                "unknown imbalance unit '{token}'; one of trades, \
+                                 volume, dollar"
+                            )
+                        })?;
                         (unit, target.trim())
                     }
                 };
@@ -123,8 +119,7 @@ impl BarSpec {
             Self::Dollar(d) => format!("dollar({})", d.normalize()),
             Self::Time(ms) => format!("time({})", fmt_interval(ms)),
             Self::Imbalance(ImbalanceUnit::Trades, target) => format!("imbalance({target})"),
-            Self::Imbalance(ImbalanceUnit::Volume, target) => format!("imbalance(volume {target})"),
-            Self::Imbalance(ImbalanceUnit::Dollar, target) => format!("imbalance(dollar {target})"),
+            Self::Imbalance(unit, target) => format!("imbalance({} {target})", unit.as_str()),
         }
     }
 }

--- a/crates/backtest/src/bars.rs
+++ b/crates/backtest/src/bars.rs
@@ -1,7 +1,8 @@
 //! Which bar rule a run uses, as a string a person can type.
 //!
 //! The vocabulary is deliberately the one the chart already speaks —
-//! `tick:100`, `volume:5`, `dollar:500000`, `time:1m`, `imbalance:2500` —
+//! `tick:100`, `volume:5`, `dollar:500000`, `time:1m`, `imbalance:2500`,
+//! `imbalance:volume:2500`, `imbalance:dollar:2500` —
 //! so the spec a trader reads off a tab is the spec they hand to a backtest.
 //! It is re-implemented here rather than shared because the chart's copy
 //! lives in `quantick-app`, and a headless harness that linked the desktop
@@ -11,8 +12,8 @@
 //! engine's public surface, not a line item of this harness.
 
 use quantick_engine::{
-    BarBuilder, DollarBarBuilder, ImbalanceBarBuilder, TickBarBuilder, TimeBarBuilder,
-    VolumeBarBuilder,
+    BarBuilder, DollarBarBuilder, ImbalanceBarBuilder, ImbalanceUnit, TickBarBuilder,
+    TimeBarBuilder, VolumeBarBuilder,
 };
 use rust_decimal::Decimal;
 
@@ -27,8 +28,10 @@ pub enum BarSpec {
     Dollar(Decimal),
     /// N milliseconds per bar.
     Time(i64),
-    /// Target trades per bar for the adaptive imbalance rule.
-    Imbalance(u64),
+    /// The adaptive imbalance rule: what θ accumulates (trades, volume or
+    /// dollar) and the target trades per bar, which counts trades in every
+    /// unit.
+    Imbalance(ImbalanceUnit, u64),
 }
 
 impl BarSpec {
@@ -41,7 +44,7 @@ impl BarSpec {
             Self::Volume(units) => Box::new(VolumeBarBuilder::new(units)),
             Self::Dollar(notional) => Box::new(DollarBarBuilder::new(notional)),
             Self::Time(ms) => Box::new(TimeBarBuilder::new(ms)),
-            Self::Imbalance(target) => Box::new(ImbalanceBarBuilder::new(target)),
+            Self::Imbalance(unit, target) => Box::new(ImbalanceBarBuilder::with_unit(target, unit)),
         }
     }
 
@@ -74,7 +77,34 @@ impl BarSpec {
         };
         match kind {
             "tick" => Ok(Self::Tick(positive_count("tick")?)),
-            "imbalance" => Ok(Self::Imbalance(positive_count("imbalance")?)),
+            "imbalance" => {
+                // The parameter is `target` or `unit:target` — the same two
+                // forms the chart accepts. The unit picks what θ accumulates;
+                // the target counts trades in every unit.
+                let (unit, target) = match param.split_once(':') {
+                    None => (ImbalanceUnit::Trades, param),
+                    Some((unit, target)) => {
+                        let unit = match unit.trim() {
+                            "trades" => ImbalanceUnit::Trades,
+                            "volume" => ImbalanceUnit::Volume,
+                            "dollar" => ImbalanceUnit::Dollar,
+                            other => {
+                                return Err(format!(
+                                    "unknown imbalance unit '{other}'; one of trades, \
+                                     volume, dollar"
+                                ));
+                            }
+                        };
+                        (unit, target.trim())
+                    }
+                };
+                match target.parse::<u64>() {
+                    Ok(n) if n > 0 => Ok(Self::Imbalance(unit, n)),
+                    _ => Err(format!(
+                        "imbalance bars need a positive whole trade target, got '{target}'"
+                    )),
+                }
+            }
             "volume" => Ok(Self::Volume(positive_decimal("volume")?)),
             "dollar" => Ok(Self::Dollar(positive_decimal("dollar")?)),
             "time" => Ok(Self::Time(parse_interval(param)?)),
@@ -92,7 +122,9 @@ impl BarSpec {
             Self::Volume(u) => format!("volume({})", u.normalize()),
             Self::Dollar(d) => format!("dollar({})", d.normalize()),
             Self::Time(ms) => format!("time({})", fmt_interval(ms)),
-            Self::Imbalance(target) => format!("imbalance({target})"),
+            Self::Imbalance(ImbalanceUnit::Trades, target) => format!("imbalance({target})"),
+            Self::Imbalance(ImbalanceUnit::Volume, target) => format!("imbalance(volume {target})"),
+            Self::Imbalance(ImbalanceUnit::Dollar, target) => format!("imbalance(dollar {target})"),
         }
     }
 }
@@ -138,7 +170,22 @@ mod tests {
     fn every_kind_round_trips_through_its_summary() {
         let cases = [
             ("tick:100", BarSpec::Tick(100)),
-            ("imbalance:2500", BarSpec::Imbalance(2500)),
+            (
+                "imbalance:2500",
+                BarSpec::Imbalance(ImbalanceUnit::Trades, 2500),
+            ),
+            (
+                "imbalance:trades:2500",
+                BarSpec::Imbalance(ImbalanceUnit::Trades, 2500),
+            ),
+            (
+                "imbalance:volume:500",
+                BarSpec::Imbalance(ImbalanceUnit::Volume, 500),
+            ),
+            (
+                "imbalance:dollar:2500",
+                BarSpec::Imbalance(ImbalanceUnit::Dollar, 2500),
+            ),
             ("volume:5", BarSpec::Volume(Decimal::from(5u64))),
             ("dollar:500000", BarSpec::Dollar(Decimal::from(500_000u64))),
             ("time:1m", BarSpec::Time(60_000)),

--- a/crates/backtest/src/main.rs
+++ b/crates/backtest/src/main.rs
@@ -152,7 +152,8 @@ fn usage() -> String {
   --to <YYYY-MM-DD>        last session day, inclusive
   --limit <n>              stop after n sessions
   --bars <kind:parameter>  tick:100 (default), volume:5, dollar:500000,
-                           time:1m, imbalance:2500
+                           time:1m, imbalance:2500 (also imbalance:volume:2500,
+                           imbalance:dollar:2500)
   --strategy <name>        which rule to run (default {default}):{strategies}
   --fast <n> --slow <n>    EMA lengths for the built-in cross \
 ({DEFAULT_FAST_EMA} / {DEFAULT_SLOW_EMA})

--- a/crates/engine/benches/hot_path.rs
+++ b/crates/engine/benches/hot_path.rs
@@ -14,8 +14,8 @@ use std::hint::black_box;
 use std::time::Instant;
 
 use quantick_engine::{
-    BarBuilder, DollarBarBuilder, ImbalanceBarBuilder, Side, TickBarBuilder, TimeBarBuilder, Trade,
-    VolumeBarBuilder,
+    BarBuilder, DollarBarBuilder, ImbalanceBarBuilder, ImbalanceUnit, Side, TickBarBuilder,
+    TimeBarBuilder, Trade, VolumeBarBuilder,
 };
 use rust_decimal::Decimal;
 
@@ -81,4 +81,14 @@ fn main() {
     );
     bench("time(1000ms)", TimeBarBuilder::new(1000), &trades);
     bench("imbalance(100)", ImbalanceBarBuilder::new(100), &trades);
+    bench(
+        "imb-vol(100)",
+        ImbalanceBarBuilder::with_unit(100, ImbalanceUnit::Volume),
+        &trades,
+    );
+    bench(
+        "imb-dlr(100)",
+        ImbalanceBarBuilder::with_unit(100, ImbalanceUnit::Dollar),
+        &trades,
+    );
 }

--- a/crates/engine/src/imbalance.rs
+++ b/crates/engine/src/imbalance.rs
@@ -1,40 +1,66 @@
 //! Imbalance bars — close a bar when aggressor imbalance exceeds a dynamic
 //! threshold.
 //!
-//! Tick imbalance bars (López de Prado, *Advances in Financial Machine
-//! Learning*, ch. 2) sample by **information arrival** rather than by raw
-//! activity: each trade contributes a signed tick `b = +1` (taker buy) or
-//! `b = -1` (taker sell), and the bar closes when the running imbalance
-//! `theta = sum(b)` becomes unusually large relative to what recent history
-//! says is normal. Balanced two-way flow produces long bars; a one-sided burst
-//! of aggression — new information hitting the market — closes a bar almost
-//! immediately, so the sampling rate itself tracks information flow.
+//! Imbalance bars (López de Prado, *Advances in Financial Machine Learning*,
+//! ch. 2) sample by **information arrival** rather than by raw activity: each
+//! trade contributes a signed weight `s = ±w` (positive for a taker buy), and
+//! the bar closes when the running imbalance `theta = sum(s)` becomes
+//! unusually large relative to what recent history says is normal. Balanced
+//! two-way flow produces long bars; a one-sided burst of aggression — new
+//! information hitting the market — closes a bar almost immediately, so the
+//! sampling rate itself tracks information flow.
+//!
+//! # Units
+//!
+//! [`ImbalanceUnit`] picks the weight `w`, giving the book's three variants:
+//!
+//! - `Trades` — `w = 1`: tick imbalance bars (TIB), the historical behavior.
+//! - `Volume` — `w = quantity`: volume imbalance bars (VIB).
+//! - `Dollar` — `w = price * quantity`: dollar imbalance bars (DIB).
+//!
+//! Everything counted in *trades* — the warm-up length, the hard cap and the
+//! `E[T]` expectation — stays in trades for every unit, exactly as in the
+//! book, where `T` is always the tick count of the bar. The unit changes what
+//! `theta` accumulates, not what the target parameter means.
 //!
 //! # Closing rule
 //!
-//! The reference rule closes a bar when `|theta| >= E[T] * |E[b]|`, where both
+//! The reference rule closes a bar when `|theta| >= E[T] * |E[s]|`, where both
 //! expectations adapt to the observed stream:
 //!
 //! - `E[T]` — expected trades per bar: an EWMA (weight [`ALPHA_T`]) over the
 //!   trade counts of closed bars, seeded with the `target_trades` parameter.
-//! - `E[b]` — expected signed tick: a per-trade EWMA of `b` whose span is
-//!   `target_trades` (weight `2 / (target_trades + 1)`), so the imbalance
-//!   estimate looks back roughly one expected bar.
+//! - `E[s]` — expected signed weight per trade: a per-trade EWMA of `s` whose
+//!   span is `target_trades` (weight `2 / (target_trades + 1)`), so the
+//!   imbalance estimate looks back roughly one expected bar.
 //!
-//! `|2P[b=1] - 1|` in the book is exactly `|E[b]|`; the EWMA estimates it
-//! directly.
+//! In the trades unit `|E[s]|` is exactly the book's `|2P[b=1] - 1|`; in the
+//! weighted units it estimates `|2v+ - E[v]|` the same way.
+//!
+//! **Evaluation order.** The trades unit folds the arriving trade into `E[s]`
+//! *before* testing the threshold — the behavior this bar type shipped with,
+//! kept bit-for-bit so existing charts and backtests never move. For `|s| = 1`
+//! the difference is second-order. For the weighted units it is first-order: a
+//! giant print folded into `E[s]` first can raise the threshold by more than
+//! its own contribution to `theta`, and the bar would survive exactly the
+//! elephant it exists to flag. The weighted units therefore judge each trade
+//! against the expectations formed *before* it (the book's `E_0[.]`), and fold
+//! it in afterwards.
 //!
 //! # Structural guards (and why they are honest)
 //!
 //! The textbook rule is known to degenerate: in near-balanced flow
-//! `|E[b]| -> 0` collapses the threshold (a cascade of one-trade bars), and a
+//! `|E[s]| -> 0` collapses the threshold (a cascade of one-trade bars), and a
 //! feedback loop between shrinking bars and shrinking `E[T]` can pin it there.
 //! Rather than patch the stream, the closing rule itself is bounded by three
 //! fixed, documented guards — every one deterministic and part of the rule,
 //! not silent data repair:
 //!
-//! - the effective `|E[b]|` never drops below [`FLOOR_B`], so the threshold
-//!   stays meaningfully positive in balanced flow;
+//! - the effective `|E[s]|` never drops below [`FLOOR_B`] times `E[w]` — an
+//!   EWMA of the unsigned weight, primed with the first trade's weight, so the
+//!   floor means "5% of a typical trade" in every unit (in the trades unit
+//!   `E[w]` is exactly 1 and the floor is the historical `0.05`) and the
+//!   threshold stays meaningfully positive in balanced flow;
 //! - a bar always closes after `3 * target_trades` trades ([`CAP_MULT`]), so
 //!   perfectly offsetting flow cannot grow a bar without bound;
 //! - `E[T]` is clamped to `[target_trades / 4, 3 * target_trades]`, so a
@@ -57,20 +83,53 @@ use crate::{Bar, BarBuilder, Side, Trade};
 /// closed bar. `0.25` spans roughly the last seven bars.
 const ALPHA_T: Decimal = Decimal::from_parts(25, 0, 0, false, 2);
 
-/// Lower bound on the effective `|E[b]|` in the threshold, so near-balanced
-/// flow cannot collapse the threshold to zero.
+/// Lower bound on the effective `|E[s]|` in the threshold, as a fraction of
+/// `E[w]` (the typical per-trade weight), so near-balanced flow cannot
+/// collapse the threshold to zero. In the trades unit `E[w]` is exactly 1 and
+/// this is the historical absolute floor of `0.05`.
 const FLOOR_B: Decimal = Decimal::from_parts(5, 0, 0, false, 2);
 
 /// A bar always closes after `CAP_MULT * target_trades` trades, whatever the
 /// imbalance says.
 const CAP_MULT: u64 = 3;
 
-/// Builds tick imbalance bars: a bar closes when `|theta|` — the running sum
-/// of signed ticks — reaches the adaptive threshold `E[T] * |E[b]|`.
+/// The measure a trade's aggression is weighed in — what `theta` accumulates.
 ///
-/// See the [module docs](self) for the closing rule, the warm-up bar and the
-/// structural guards. Feed trades in order with [`push`](BarBuilder::push);
-/// the in-progress bar is available via [`partial`](BarBuilder::partial).
+/// See the [module docs](self): the unit changes the weight `w` of each
+/// signed contribution, never the meaning of the `target_trades` parameter
+/// (warm-up, cap and `E[T]` count trades in every unit).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ImbalanceUnit {
+    /// `w = 1` — tick imbalance bars, the historical behavior.
+    Trades,
+    /// `w = quantity` — volume imbalance bars.
+    Volume,
+    /// `w = price * quantity` — dollar imbalance bars.
+    Dollar,
+}
+
+impl ImbalanceUnit {
+    /// The unsigned weight this trade contributes to `theta`.
+    ///
+    /// Saturating: a notional beyond `Decimal`'s range clamps instead of
+    /// panicking, matching the engine-wide feed-arithmetic policy.
+    fn weight(self, trade: &Trade) -> Decimal {
+        match self {
+            Self::Trades => Decimal::ONE,
+            Self::Volume => trade.quantity,
+            Self::Dollar => trade.price.saturating_mul(trade.quantity),
+        }
+    }
+}
+
+/// Builds imbalance bars: a bar closes when `|theta|` — the running sum of
+/// signed per-trade weights in the configured [`ImbalanceUnit`] — reaches the
+/// adaptive threshold `E[T] * |E[s]|`.
+///
+/// See the [module docs](self) for the closing rule, the units, the warm-up
+/// bar and the structural guards. Feed trades in order with
+/// [`push`](BarBuilder::push); the in-progress bar is available via
+/// [`partial`](BarBuilder::partial).
 ///
 /// Like every builder, whole trades only: the trade that crosses the
 /// threshold closes the bar it belongs to, and neither the imbalance nor the
@@ -78,13 +137,20 @@ const CAP_MULT: u64 = 3;
 #[derive(Debug, Clone)]
 pub struct ImbalanceBarBuilder {
     target_trades: u64,
-    /// Per-trade EWMA weight for `E[b]`: `2 / (target_trades + 1)`.
+    /// What `theta` accumulates: signed ticks, volume or notional.
+    unit: ImbalanceUnit,
+    /// Per-trade EWMA weight for `E[s]` and `E[w]`: `2 / (target_trades + 1)`.
     alpha_b: Decimal,
     /// Expected trades per bar, seeded with `target_trades`.
     e_t: Decimal,
-    /// Expected signed tick, primed from zero as trades arrive.
-    e_b: Decimal,
-    /// Signed tick imbalance of the in-progress bar.
+    /// Expected signed weight per trade, primed from zero as trades arrive.
+    e_s: Decimal,
+    /// Typical unsigned weight per trade: an EWMA primed with the first
+    /// trade's weight (`None` until then). The trades unit never sets it —
+    /// its weight is identically 1 — and the floor falls back to the
+    /// historical constant `0.05`.
+    e_w: Option<Decimal>,
+    /// Signed imbalance of the in-progress bar, in the configured unit.
     theta: Decimal,
     /// Trades in the in-progress bar.
     count: u64,
@@ -108,15 +174,29 @@ impl ImbalanceBarBuilder {
     /// rule.
     #[must_use]
     pub fn new(target_trades: u64) -> Self {
+        Self::with_unit(target_trades, ImbalanceUnit::Trades)
+    }
+
+    /// Create a builder whose `theta` accumulates in `unit` — trades gives
+    /// the book's tick imbalance bars, volume and dollar the weighted
+    /// variants. `target_trades` keeps the same meaning in every unit.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `target_trades == 0`, exactly like [`new`](Self::new).
+    #[must_use]
+    pub fn with_unit(target_trades: u64, unit: ImbalanceUnit) -> Self {
         assert!(
             target_trades >= 1,
             "imbalance bar target_trades must be >= 1, got {target_trades}"
         );
         Self {
             target_trades,
+            unit,
             alpha_b: Decimal::from(2) / Decimal::from(target_trades.saturating_add(1)),
             e_t: Decimal::from(target_trades),
-            e_b: Decimal::ZERO,
+            e_s: Decimal::ZERO,
+            e_w: None,
             theta: Decimal::ZERO,
             count: 0,
             warmed_up: false,
@@ -130,7 +210,13 @@ impl ImbalanceBarBuilder {
         self.target_trades
     }
 
-    /// Does the in-progress bar close on the trade just folded in?
+    /// The measure `theta` accumulates in.
+    #[must_use]
+    pub fn unit(&self) -> ImbalanceUnit {
+        self.unit
+    }
+
+    /// Does the in-progress bar close, given the current expectations?
     fn should_close(&self) -> bool {
         if !self.warmed_up {
             return self.count >= self.target_trades;
@@ -138,8 +224,37 @@ impl ImbalanceBarBuilder {
         if self.count >= CAP_MULT.saturating_mul(self.target_trades) {
             return true;
         }
-        let threshold = self.e_t * self.e_b.abs().max(FLOOR_B);
+        // `e_w` is `None` exactly in the trades unit, whose typical weight is
+        // identically 1 — the floor multiplication would buy nothing on the
+        // per-trade hot path.
+        let floor = match self.e_w {
+            None => FLOOR_B,
+            Some(typical) => FLOOR_B.saturating_mul(typical),
+        };
+        let threshold = self.e_t * self.e_s.abs().max(floor);
         self.theta.abs() >= threshold
+    }
+
+    /// Fold one trade's signed weight into the running expectations.
+    fn absorb(&mut self, s: Decimal, w: Decimal) {
+        let keep = Decimal::ONE - self.alpha_b;
+        self.e_s = self
+            .alpha_b
+            .saturating_mul(s)
+            .saturating_add(keep.saturating_mul(self.e_s));
+        // The trades unit skips the typical-weight EWMA: `w` is identically 1,
+        // so the update is two Decimal multiplications per trade spent
+        // computing 1 — measurably slower on the hot path (bench: 2x) for a
+        // floor `should_close` can use as a constant instead.
+        if self.unit != ImbalanceUnit::Trades {
+            self.e_w = Some(match self.e_w {
+                None => w,
+                Some(prev) => self
+                    .alpha_b
+                    .saturating_mul(w)
+                    .saturating_add(keep.saturating_mul(prev)),
+            });
+        }
     }
 
     /// Close the in-progress bar: fold its length into `E[T]`, reset the
@@ -166,18 +281,27 @@ impl BarBuilder for ImbalanceBarBuilder {
             Some(bar) => bar.extend(trade),
         }
         self.count += 1;
-        let b = match trade.side {
-            Side::Buy => Decimal::ONE,
-            Side::Sell => -Decimal::ONE,
+        let w = self.unit.weight(trade);
+        let s = match trade.side {
+            Side::Buy => w,
+            Side::Sell => -w,
         };
-        self.theta = self.theta.saturating_add(b);
-        self.e_b = self.alpha_b * b + (Decimal::ONE - self.alpha_b) * self.e_b;
+        self.theta = self.theta.saturating_add(s);
 
-        if self.should_close() {
-            self.close_bar()
+        // Per-unit evaluation order, pinned by tests and explained in the
+        // module docs: trades folds the trade into the expectations first
+        // (the shipped behavior, kept bit-exact); the weighted units judge
+        // the trade against the expectations formed before it.
+        let close = if self.unit == ImbalanceUnit::Trades {
+            self.absorb(s, w);
+            self.should_close()
         } else {
-            None
-        }
+            let close = self.should_close();
+            self.absorb(s, w);
+            close
+        };
+
+        if close { self.close_bar() } else { None }
     }
 
     fn partial(&self) -> Option<&Bar> {
@@ -319,5 +443,180 @@ mod tests {
         assert!(b.progress().is_none());
         run(&mut b, &[Side::Buy, Side::Buy, Side::Sell]);
         assert!(b.progress().is_none());
+    }
+
+    // ---- units: volume / dollar imbalance (VIB / DIB) ----
+
+    /// A trade with an explicit quantity, at the fixture price of 100.
+    fn sized(agg_id: u64, side: Side, qty: &str) -> Trade {
+        Trade {
+            quantity: Decimal::from_str(qty).unwrap(),
+            ..trade(agg_id, side)
+        }
+    }
+
+    /// A trade with an explicit quantity and price.
+    fn priced(agg_id: u64, side: Side, qty: &str, price: &str) -> Trade {
+        Trade {
+            price: Decimal::from_str(price).unwrap(),
+            ..sized(agg_id, side, qty)
+        }
+    }
+
+    #[test]
+    fn unit_accessor_reports_configured_unit() {
+        assert_eq!(
+            ImbalanceBarBuilder::new(10).unit(),
+            ImbalanceUnit::Trades,
+            "the one-argument constructor keeps the historical tick unit"
+        );
+        assert_eq!(
+            ImbalanceBarBuilder::with_unit(10, ImbalanceUnit::Dollar).unit(),
+            ImbalanceUnit::Dollar
+        );
+    }
+
+    /// `with_unit(_, Trades)` is the same builder `new` always was: same tape
+    /// in, bit-identical bars out — existing charts and backtests must not
+    /// move by a single trade.
+    #[test]
+    fn with_unit_trades_is_bit_exact_with_new() {
+        let tape: Vec<Trade> = (0..200)
+            .map(|i| {
+                let side = if (i * 7 + 3) % 11 < 5 {
+                    Side::Buy
+                } else {
+                    Side::Sell
+                };
+                let qty = format!("{}.5", (i % 9) + 1);
+                let price = format!("{}", 100 + (i % 13));
+                priced(i as u64, side, &qty, &price)
+            })
+            .collect();
+        let mut legacy = ImbalanceBarBuilder::new(7);
+        let mut trades_unit = ImbalanceBarBuilder::with_unit(7, ImbalanceUnit::Trades);
+        let a: Vec<Bar> = tape.iter().filter_map(|t| legacy.push(t)).collect();
+        let b: Vec<Bar> = tape.iter().filter_map(|t| trades_unit.push(t)).collect();
+        assert!(a.len() >= 3, "fixture must actually close bars");
+        assert_eq!(a, b);
+        assert_eq!(legacy.partial(), trades_unit.partial());
+    }
+
+    /// Volume imbalance weighs θ by traded size: after a one-sided warm-up
+    /// (E[s] = -0.8704 per trade, E[T] = 4, threshold 4·0.8704 = 3.4816) a
+    /// half-lot contrary print stays inside the bar, a ten-lot elephant closes
+    /// it on the spot. Same rule, same tape shape — only the size differs.
+    ///
+    /// The elephant case also pins the evaluation order for weighted units:
+    /// the trade is judged against the expectations formed *before* it. Folding
+    /// the ten-lot into E[s] first would lift the threshold to
+    /// 4·|0.4·10 + 0.6·(-0.8704)| = 13.911 and the bar would absurdly survive
+    /// its own elephant.
+    #[test]
+    fn volume_unit_closes_on_size_not_on_count() {
+        let warmup: Vec<Trade> = (0..4).map(|i| sized(i, Side::Sell, "1")).collect();
+
+        let mut small = ImbalanceBarBuilder::with_unit(4, ImbalanceUnit::Volume);
+        for t in &warmup {
+            small.push(t);
+        }
+        assert!(
+            small.push(&sized(10, Side::Buy, "0.5")).is_none(),
+            "a half-lot contrary print is not information; the bar stays open"
+        );
+
+        let mut elephant = ImbalanceBarBuilder::with_unit(4, ImbalanceUnit::Volume);
+        for t in &warmup {
+            elephant.push(t);
+        }
+        let bar = elephant
+            .push(&sized(10, Side::Buy, "10"))
+            .expect("a ten-lot contrary elephant closes the bar immediately");
+        assert_eq!(bar.trade_count, 1);
+    }
+
+    /// Dollar imbalance weighs θ by notional: with the warm-up at price 100
+    /// (threshold 4·87.04 = 348.16), the same one-lot contrary print stays
+    /// inside the bar at price 300 and closes it at price 400 — price is part
+    /// of the weight, not just quantity.
+    #[test]
+    fn dollar_unit_closes_on_notional_not_on_count() {
+        let warmup: Vec<Trade> = (0..4).map(|i| priced(i, Side::Sell, "1", "100")).collect();
+
+        let mut cheap = ImbalanceBarBuilder::with_unit(4, ImbalanceUnit::Dollar);
+        for t in &warmup {
+            cheap.push(t);
+        }
+        assert!(
+            cheap.push(&priced(10, Side::Buy, "1", "300")).is_none(),
+            "300 notional is under the 348.16 threshold; the bar stays open"
+        );
+
+        let mut rich = ImbalanceBarBuilder::with_unit(4, ImbalanceUnit::Dollar);
+        for t in &warmup {
+            rich.push(t);
+        }
+        let bar = rich
+            .push(&priced(10, Side::Buy, "1", "400"))
+            .expect("400 notional beats the threshold and closes the bar");
+        assert_eq!(bar.trade_count, 1);
+    }
+
+    /// The warm-up bar and the hard cap count *trades* in every unit: huge
+    /// quantities neither shorten the warm-up nor dodge the cap.
+    #[test]
+    fn weighted_units_keep_warmup_and_cap_in_trade_counts() {
+        // Warm-up: four 1000-lot buys close at exactly the 4-trade target.
+        let mut b = ImbalanceBarBuilder::with_unit(4, ImbalanceUnit::Volume);
+        let mut bars = Vec::new();
+        for i in 0..4 {
+            bars.extend(b.push(&sized(i, Side::Buy, "1000")));
+        }
+        assert_eq!(bars.len(), 1);
+        assert_eq!(bars[0].trade_count, 4);
+
+        // Cap: strictly alternating constant-size flow keeps |θ| ≤ one weight
+        // while the floor holds the threshold at E[T]·0.05·1000 ≥ 4000, so
+        // only the 3x-target trade cap can close the bar.
+        let mut b = ImbalanceBarBuilder::with_unit(80, ImbalanceUnit::Volume);
+        let mut bars = Vec::new();
+        for i in 0..320 {
+            let side = if i % 2 == 0 { Side::Buy } else { Side::Sell };
+            bars.extend(b.push(&sized(i, side, "1000")));
+        }
+        assert_eq!(bars[0].trade_count, 80, "warm-up closes at target");
+        assert_eq!(
+            bars[1].trade_count, 240,
+            "balanced heavy flow runs to the 3x-target cap, never past it"
+        );
+    }
+
+    /// The closing rule is scale-free in the weight: the same side sequence at
+    /// nine times the size closes bars at exactly the same trades. θ, E[s] and
+    /// the floor (a fraction of the typical weight) all scale together — a
+    /// floor left in per-trade units would break this.
+    #[test]
+    fn volume_unit_is_scale_invariant_in_quantity() {
+        let sides: Vec<Side> = (0..300)
+            .map(|i| {
+                if (i * 7 + 3) % 11 < 5 {
+                    Side::Buy
+                } else {
+                    Side::Sell
+                }
+            })
+            .collect();
+        let close_points = |qty: &str| -> Vec<u64> {
+            let mut b = ImbalanceBarBuilder::with_unit(12, ImbalanceUnit::Volume);
+            sides
+                .iter()
+                .enumerate()
+                .filter_map(|(i, side)| b.push(&sized(i as u64, *side, qty)))
+                .map(|bar| bar.trade_count)
+                .collect()
+        };
+        let ones = close_points("1");
+        assert!(ones.len() >= 3, "fixture must actually close bars");
+        assert_eq!(ones, close_points("9"));
     }
 }

--- a/crates/engine/src/imbalance.rs
+++ b/crates/engine/src/imbalance.rs
@@ -60,7 +60,11 @@
 //!   EWMA of the unsigned weight, primed with the first trade's weight, so the
 //!   floor means "5% of a typical trade" in every unit (in the trades unit
 //!   `E[w]` is exactly 1 and the floor is the historical `0.05`) and the
-//!   threshold stays meaningfully positive in balanced flow;
+//!   threshold stays meaningfully positive in balanced flow. Weights are
+//!   magnitudes — direction comes from the aggressor side alone — and a tape
+//!   whose weights are all zero (a size unit over a size-less recording) has
+//!   no measure to read: its threshold is zero, an imbalance close never
+//!   fires, and only the trade cap below bounds the bar;
 //! - a bar always closes after `3 * target_trades` trades ([`CAP_MULT`]), so
 //!   perfectly offsetting flow cannot grow a bar without bound;
 //! - `E[T]` is clamped to `[target_trades / 4, 3 * target_trades]`, so a
@@ -77,7 +81,9 @@
 
 use rust_decimal::Decimal;
 
-use crate::{Bar, BarBuilder, Side, Trade};
+use crate::{
+    Bar, BarBuilder, DollarMeasure, Measure as _, Side, TickMeasure, Trade, VolumeMeasure,
+};
 
 /// EWMA weight for the expected-trades-per-bar update, applied once per
 /// closed bar. `0.25` spans roughly the last seven bars.
@@ -109,15 +115,49 @@ pub enum ImbalanceUnit {
 }
 
 impl ImbalanceUnit {
-    /// The unsigned weight this trade contributes to `theta`.
+    /// Every unit, in the order the UI offers them.
+    pub const ALL: [Self; 3] = [Self::Trades, Self::Volume, Self::Dollar];
+
+    /// The spec token this unit is written as (`imbalance:volume:500`) —
+    /// one vocabulary, owned here, so the chart and the backtest cannot
+    /// drift apart on what a unit is called.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Trades => "trades",
+            Self::Volume => "volume",
+            Self::Dollar => "dollar",
+        }
+    }
+
+    /// Parse a spec token back into a unit — the inverse of
+    /// [`as_str`](Self::as_str). `None` for anything else; the caller owns
+    /// the error message its spec dialect wants.
+    #[must_use]
+    pub fn parse_token(token: &str) -> Option<Self> {
+        match token {
+            "trades" => Some(Self::Trades),
+            "volume" => Some(Self::Volume),
+            "dollar" => Some(Self::Dollar),
+            _ => None,
+        }
+    }
+
+    /// The unsigned weight this trade contributes to `theta`: the magnitude
+    /// of the engine's per-trade measures (tick / volume / dollar — one
+    /// definition each, delegated, never re-derived here).
     ///
-    /// Saturating: a notional beyond `Decimal`'s range clamps instead of
-    /// panicking, matching the engine-wide feed-arithmetic policy.
+    /// Magnitude on purpose: direction comes from the aggressor side alone,
+    /// so a signed-size export (negative quantity or price) can neither flip
+    /// a print's side nor drive the `E[w]` floor negative. Saturating via
+    /// the measures ([`Trade::notional`]): a notional beyond `Decimal`'s
+    /// range clamps instead of panicking, the engine-wide feed-arithmetic
+    /// policy.
     fn weight(self, trade: &Trade) -> Decimal {
         match self {
-            Self::Trades => Decimal::ONE,
-            Self::Volume => trade.quantity,
-            Self::Dollar => trade.price.saturating_mul(trade.quantity),
+            Self::Trades => TickMeasure.of(trade),
+            Self::Volume => VolumeMeasure.of(trade).abs(),
+            Self::Dollar => DollarMeasure.of(trade).abs(),
         }
     }
 }
@@ -141,6 +181,10 @@ pub struct ImbalanceBarBuilder {
     unit: ImbalanceUnit,
     /// Per-trade EWMA weight for `E[s]` and `E[w]`: `2 / (target_trades + 1)`.
     alpha_b: Decimal,
+    /// `1 - alpha_b`, precomputed once — the EWMA updates read it on every
+    /// trade, and the subtraction rescales `ONE` to scale 28 each time it is
+    /// redone inline.
+    keep_b: Decimal,
     /// Expected trades per bar, seeded with `target_trades`.
     e_t: Decimal,
     /// Expected signed weight per trade, primed from zero as trades arrive.
@@ -190,10 +234,12 @@ impl ImbalanceBarBuilder {
             target_trades >= 1,
             "imbalance bar target_trades must be >= 1, got {target_trades}"
         );
+        let alpha_b = Decimal::from(2) / Decimal::from(target_trades.saturating_add(1));
         Self {
             target_trades,
             unit,
-            alpha_b: Decimal::from(2) / Decimal::from(target_trades.saturating_add(1)),
+            alpha_b,
+            keep_b: Decimal::ONE - alpha_b,
             e_t: Decimal::from(target_trades),
             e_s: Decimal::ZERO,
             e_w: None,
@@ -216,6 +262,14 @@ impl ImbalanceBarBuilder {
         self.unit
     }
 
+    /// The hard cap: a bar always closes at this many trades, whatever the
+    /// imbalance says. Exposed so a consumer reporting *why* bars closed
+    /// (the replay audit example) reads the rule instead of guessing it.
+    #[must_use]
+    pub fn hard_cap_trades(&self) -> u64 {
+        CAP_MULT.saturating_mul(self.target_trades)
+    }
+
     /// Does the in-progress bar close, given the current expectations?
     fn should_close(&self) -> bool {
         if !self.warmed_up {
@@ -224,35 +278,51 @@ impl ImbalanceBarBuilder {
         if self.count >= CAP_MULT.saturating_mul(self.target_trades) {
             return true;
         }
-        // `e_w` is `None` exactly in the trades unit, whose typical weight is
-        // identically 1 — the floor multiplication would buy nothing on the
-        // per-trade hot path.
-        let floor = match self.e_w {
-            None => FLOOR_B,
-            Some(typical) => FLOOR_B.saturating_mul(typical),
+        // The floor scales with the unit's typical weight. The trades unit
+        // keeps the historical constant — its weight is identically 1 — and
+        // never spends the multiplication on the per-trade hot path. In the
+        // weighted units `e_w` is primed by the first `absorb`, which the
+        // `warmed_up` gate guarantees has run; the zero fallback merely keeps
+        // this line total instead of trusting that ordering.
+        let floor = if self.unit == ImbalanceUnit::Trades {
+            FLOOR_B
+        } else {
+            FLOOR_B.saturating_mul(self.e_w.unwrap_or(Decimal::ZERO))
         };
-        let threshold = self.e_t * self.e_s.abs().max(floor);
-        self.theta.abs() >= threshold
+        // Saturating like every arithmetic step feeding it: an adversarial
+        // print can pin `E[s]` near `Decimal::MAX`, and a threshold that
+        // saturates means "no imbalance close" — the trade cap above still
+        // bounds the bar — while a plain `*` would panic a builder on feed
+        // input, which the engine's arithmetic policy forbids.
+        let threshold = self.e_t.saturating_mul(self.e_s.abs().max(floor));
+        // A tape whose weights are all zero (a size unit over a size-less
+        // recording) has no measure to read: theta and the threshold are both
+        // zero, and closing on `0 >= 0` would cascade one-trade bars — the
+        // exact degeneration the floor exists to prevent. Such a bar closes
+        // only at the cap. In the trades unit the threshold is structurally
+        // positive, so this guard never fires there.
+        threshold > Decimal::ZERO && self.theta.abs() >= threshold
     }
 
-    /// Fold one trade's signed weight into the running expectations.
-    fn absorb(&mut self, s: Decimal, w: Decimal) {
-        let keep = Decimal::ONE - self.alpha_b;
+    /// Fold one trade's signed weight into the running expectations. The
+    /// unsigned weight is `s.abs()` by construction — deriving it here keeps
+    /// the two from ever being passed inconsistently.
+    fn absorb(&mut self, s: Decimal) {
         self.e_s = self
             .alpha_b
             .saturating_mul(s)
-            .saturating_add(keep.saturating_mul(self.e_s));
-        // The trades unit skips the typical-weight EWMA: `w` is identically 1,
-        // so the update is two Decimal multiplications per trade spent
-        // computing 1 — measurably slower on the hot path (bench: 2x) for a
-        // floor `should_close` can use as a constant instead.
+            .saturating_add(self.keep_b.saturating_mul(self.e_s));
+        // The trades unit skips the typical-weight EWMA: its weight is
+        // identically 1, so `should_close` uses a constant floor instead and
+        // the per-trade hot path saves these two multiplications.
         if self.unit != ImbalanceUnit::Trades {
+            let w = s.abs();
             self.e_w = Some(match self.e_w {
                 None => w,
                 Some(prev) => self
                     .alpha_b
                     .saturating_mul(w)
-                    .saturating_add(keep.saturating_mul(prev)),
+                    .saturating_add(self.keep_b.saturating_mul(prev)),
             });
         }
     }
@@ -293,11 +363,11 @@ impl BarBuilder for ImbalanceBarBuilder {
         // (the shipped behavior, kept bit-exact); the weighted units judge
         // the trade against the expectations formed before it.
         let close = if self.unit == ImbalanceUnit::Trades {
-            self.absorb(s, w);
+            self.absorb(s);
             self.should_close()
         } else {
             let close = self.should_close();
-            self.absorb(s, w);
+            self.absorb(s);
             close
         };
 
@@ -474,11 +544,33 @@ mod tests {
             ImbalanceBarBuilder::with_unit(10, ImbalanceUnit::Dollar).unit(),
             ImbalanceUnit::Dollar
         );
+        assert_eq!(
+            ImbalanceBarBuilder::new(10).hard_cap_trades(),
+            30,
+            "the cap accessor reports the same 3x rule should_close enforces"
+        );
     }
 
-    /// `with_unit(_, Trades)` is the same builder `new` always was: same tape
-    /// in, bit-identical bars out — existing charts and backtests must not
-    /// move by a single trade.
+    /// The token vocabulary is owned here so every consumer speaks it; the
+    /// round trip pins that emitting and parsing cannot drift apart.
+    #[test]
+    fn unit_tokens_round_trip() {
+        for unit in ImbalanceUnit::ALL {
+            assert_eq!(ImbalanceUnit::parse_token(unit.as_str()), Some(unit));
+        }
+        assert_eq!(ImbalanceUnit::parse_token("notional"), None);
+        assert_eq!(
+            ImbalanceUnit::parse_token("Trades"),
+            None,
+            "tokens are exact"
+        );
+    }
+
+    /// `new` must stay a pure delegation to `with_unit(_, Trades)`: if a
+    /// refactor ever gives it a code path of its own, the two builders here
+    /// diverge and this test catches it. It cannot certify the *historical*
+    /// behavior — both sides run today's code — that guarantee belongs to the
+    /// untouched golden fixture in `tests/golden_imbalance.rs`.
     #[test]
     fn with_unit_trades_is_bit_exact_with_new() {
         let tape: Vec<Trade> = (0..200)
@@ -618,5 +710,72 @@ mod tests {
         let ones = close_points("1");
         assert!(ones.len() >= 3, "fixture must actually close bars");
         assert_eq!(ones, close_points("9"));
+    }
+
+    /// The feed-arithmetic policy holds in the weighted units: adversarial
+    /// prints whose notional saturates `Decimal` must never panic the
+    /// builder. `E[s]` rides toward `Decimal::MAX` while bar closes drag
+    /// `E[T]` upward — a plain `*` in the threshold overflows within a few
+    /// prints; the saturating threshold instead means "no imbalance close"
+    /// and the trade cap keeps bounding every bar.
+    #[test]
+    fn adversarial_notional_never_panics_and_bars_stay_capped() {
+        let mut b = ImbalanceBarBuilder::with_unit(100, ImbalanceUnit::Dollar);
+        for i in 0..100 {
+            b.push(&priced(i, Side::Sell, "1", "100"));
+        }
+        let giant = Decimal::MAX.to_string();
+        let mut bars = Vec::new();
+        for i in 0..300 {
+            let side = if i % 2 == 0 { Side::Buy } else { Side::Sell };
+            bars.extend(b.push(&priced(100 + i, side, &giant, &giant)));
+        }
+        assert!(!bars.is_empty(), "the stream still produces bars");
+        for bar in &bars {
+            assert!(bar.trade_count <= 300, "no bar may exceed the hard cap");
+        }
+    }
+
+    /// A size unit over a tape that prints no size (every weight zero) has
+    /// no measure to read, so it must not cascade one-trade bars — the
+    /// degeneration the floor exists to prevent. Only the trade cap closes
+    /// such a bar.
+    #[test]
+    fn zero_weight_tape_closes_on_the_cap_not_in_cascade() {
+        let mut b = ImbalanceBarBuilder::with_unit(4, ImbalanceUnit::Volume);
+        let mut bars = Vec::new();
+        for i in 0..40 {
+            let side = if i % 2 == 0 { Side::Buy } else { Side::Sell };
+            bars.extend(b.push(&sized(i, side, "0")));
+        }
+        assert_eq!(bars[0].trade_count, 4, "warm-up still counts trades");
+        assert!(bars.len() >= 3, "the cap keeps the stream producing bars");
+        for bar in &bars[1..] {
+            assert_eq!(
+                bar.trade_count, 12,
+                "a measureless bar closes only at the 3x-target cap"
+            );
+        }
+    }
+
+    /// A signed export (negative price or quantity) weighs by magnitude:
+    /// direction comes from the aggressor side alone, so two taker buys
+    /// always reinforce theta — one of them printed negative must not cancel
+    /// the other out (nor drive the `E[w]` floor negative).
+    #[test]
+    fn signed_prints_weigh_as_magnitude_not_as_direction() {
+        let mut b = ImbalanceBarBuilder::with_unit(4, ImbalanceUnit::Dollar);
+        for i in 0..4 {
+            b.push(&priced(i, Side::Sell, "1", "100"));
+        }
+        // Threshold after the all-sell warm-up: 4 * 87.04 = 348.16.
+        assert!(
+            b.push(&priced(10, Side::Buy, "1", "300")).is_none(),
+            "one 300-notional buy is under the threshold"
+        );
+        let bar = b
+            .push(&priced(11, Side::Buy, "1", "-300"))
+            .expect("a second buy adds |-300| to theta; cancelling to zero would deny the close");
+        assert_eq!(bar.trade_count, 2);
     }
 }

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -41,7 +41,7 @@ pub use footprint::{
     BarFootprint, DEFAULT_LEVEL_CAP, Extreme, FootprintBuilder, FootprintLevel, Imbalance,
     StackedZone,
 };
-pub use imbalance::ImbalanceBarBuilder;
+pub use imbalance::{ImbalanceBarBuilder, ImbalanceUnit};
 pub use profile::{ValueArea, VolumeProfile};
 pub use threshold::{Measure, ThresholdBarBuilder};
 pub use tick::{TickBarBuilder, TickMeasure};

--- a/crates/replay/examples/imbalance_audit.rs
+++ b/crates/replay/examples/imbalance_audit.rs
@@ -4,14 +4,19 @@
 //! the tape, not on the target alone, and the honest way to pick a target is
 //! to measure it against the session you trade. This example replays a
 //! recorded session straight through `ImbalanceBarBuilder` at one or more
-//! targets and prints the closed-bar length distribution, plus the tape's
-//! side-run structure that drives the closing speed.
+//! targets — in any of the three units — and prints the closed-bar length
+//! distribution, plus the tape's side-run structure that drives the closing
+//! speed.
 //!
 //! Usage:
 //!   cargo run -p quantick-replay --release --example imbalance_audit -- \
-//!     <session.csv> [target ...]        (targets default to 2000 5000)
+//!     <session.csv> [[unit:]target ...]
+//!
+//! `unit` is the spec token (`trades`, `volume`, `dollar`), defaulting to
+//! `trades`; bare targets default to `2000 5000`. `volume:2000` audits the
+//! same target in volume imbalance bars.
 
-use quantick_engine::{BarBuilder, ImbalanceBarBuilder, Side};
+use quantick_engine::{BarBuilder, ImbalanceBarBuilder, ImbalanceUnit, Side};
 use quantick_replay::ParseOptions;
 use quantick_replay::format::parse_file;
 
@@ -23,16 +28,25 @@ fn percentile(sorted: &[u64], p: f64) -> u64 {
     sorted[idx]
 }
 
+fn parse_target(arg: &str) -> (ImbalanceUnit, u64) {
+    let (unit, target) = match arg.split_once(':') {
+        None => (ImbalanceUnit::Trades, arg),
+        Some((token, target)) => (
+            ImbalanceUnit::parse_token(token).expect("unit must be one of trades, volume, dollar"),
+            target,
+        ),
+    };
+    (unit, target.parse().expect("target must be u64"))
+}
+
 fn main() {
     let mut args = std::env::args().skip(1);
     let path = args
         .next()
-        .expect("usage: imbalance_audit <session.csv> [target ...]");
-    let mut targets: Vec<u64> = args
-        .map(|a| a.parse().expect("target must be u64"))
-        .collect();
+        .expect("usage: imbalance_audit <session.csv> [[unit:]target ...]");
+    let mut targets: Vec<(ImbalanceUnit, u64)> = args.map(|a| parse_target(&a)).collect();
     if targets.is_empty() {
-        targets = vec![2000, 5000];
+        targets = vec![(ImbalanceUnit::Trades, 2000), (ImbalanceUnit::Trades, 5000)];
     }
 
     let text = std::fs::read_to_string(&path).expect("read session file");
@@ -41,7 +55,7 @@ fn main() {
     let n = trades.len();
     println!("== session {path}");
     println!(
-        "side_source={:?}  trades={n}",
+        "side_source={}  trades={n}",
         parsed.header.side_source.as_deref().unwrap_or("?")
     );
     if n == 0 {
@@ -68,33 +82,49 @@ fn main() {
     runs.push(run_len);
     let mean_run = n as f64 / runs.len() as f64;
     runs.sort_unstable();
+    // A one-trade session has no previous side to compare against; print the
+    // fact instead of the NaN the division would produce.
+    let same_side_frac = if n >= 2 {
+        format!("{:.3}", same_side as f64 / (n - 1) as f64)
+    } else {
+        "n/a".to_owned()
+    };
     println!(
-        "span={span_min:.0}min  buy_frac={:.3}  P(same side as prev)={:.3}  runs: mean={mean_run:.1} p50={} p90={} max={}",
+        "span={span_min:.0}min  buy_frac={:.3}  P(same side as prev)={same_side_frac}  runs: mean={mean_run:.1} p50={} p90={} max={}",
         buys as f64 / n as f64,
-        same_side as f64 / (n - 1) as f64,
         percentile(&runs, 0.5),
         percentile(&runs, 0.9),
         runs.last().unwrap(),
     );
 
-    for target in &targets {
-        let target = *target;
-        let mut b = ImbalanceBarBuilder::new(target);
+    for (unit, target) in &targets {
+        let (unit, target) = (*unit, *target);
+        let mut b = ImbalanceBarBuilder::with_unit(target, unit);
+        let cap = b.hard_cap_trades();
         let mut counts: Vec<u64> = Vec::new();
         let mut durs_ms: Vec<u64> = Vec::new();
         let mut cap_closes = 0usize;
         for t in &trades {
             if let Some(bar) = b.push(t) {
                 counts.push(bar.trade_count);
-                durs_ms.push((bar.close_time - bar.open_time).max(0) as u64);
-                if bar.trade_count >= 3 * target {
-                    cap_closes += 1;
+                // The warm-up bar answers a fixed rule, not the adaptive one;
+                // keep every statistic below to the same post-warm-up
+                // population.
+                if counts.len() > 1 {
+                    durs_ms.push((bar.close_time - bar.open_time).max(0) as u64);
+                    if bar.trade_count >= cap {
+                        cap_closes += 1;
+                    }
                 }
             }
         }
         let bars = counts.len();
+        let label = match unit {
+            ImbalanceUnit::Trades => format!("{target}"),
+            _ => format!("{}:{target}", unit.as_str()),
+        };
         if bars == 0 {
-            println!("-- target={target}: no closed bars (partial only)");
+            println!("-- target={label}: no closed bars (partial only)");
             continue;
         }
         let warmup = counts[0];
@@ -107,10 +137,14 @@ fn main() {
         } else {
             adaptive.iter().sum::<u64>() as f64 / adaptive.len() as f64
         };
-        println!(
-            "-- target={target}: bars={bars} (warmup={warmup})  bars/min={:.1}",
-            bars as f64 / span_min
-        );
+        // A sub-minute recording makes a per-minute rate meaningless; say so
+        // rather than printing `inf`.
+        let bars_per_min = if span_min > 0.0 {
+            format!("{:.1}", adaptive.len() as f64 / span_min)
+        } else {
+            "n/a".to_owned()
+        };
+        println!("-- target={label}: bars={bars} (warmup={warmup})  bars/min={bars_per_min}");
         println!(
             "   trades/bar after warmup: mean={mean:.0} min={} p10={} p50={} p90={} max={}  cap_closes={cap_closes} ({:.1}%)",
             sorted.first().copied().unwrap_or(0),
@@ -118,7 +152,11 @@ fn main() {
             percentile(&sorted, 0.50),
             percentile(&sorted, 0.90),
             sorted.last().copied().unwrap_or(0),
-            100.0 * cap_closes as f64 / bars as f64,
+            if adaptive.is_empty() {
+                0.0
+            } else {
+                100.0 * cap_closes as f64 / adaptive.len() as f64
+            },
         );
         println!(
             "   bar duration: p50={:.1}s p90={:.1}s max={:.1}s",

--- a/crates/replay/examples/imbalance_audit.rs
+++ b/crates/replay/examples/imbalance_audit.rs
@@ -1,0 +1,130 @@
+//! Audit an imbalance-bar target against a recorded session.
+//!
+//! The imbalance rule is adaptive: how long its bars actually run depends on
+//! the tape, not on the target alone, and the honest way to pick a target is
+//! to measure it against the session you trade. This example replays a
+//! recorded session straight through `ImbalanceBarBuilder` at one or more
+//! targets and prints the closed-bar length distribution, plus the tape's
+//! side-run structure that drives the closing speed.
+//!
+//! Usage:
+//!   cargo run -p quantick-replay --release --example imbalance_audit -- \
+//!     <session.csv> [target ...]        (targets default to 2000 5000)
+
+use quantick_engine::{BarBuilder, ImbalanceBarBuilder, Side};
+use quantick_replay::ParseOptions;
+use quantick_replay::format::parse_file;
+
+fn percentile(sorted: &[u64], p: f64) -> u64 {
+    if sorted.is_empty() {
+        return 0;
+    }
+    let idx = ((sorted.len() - 1) as f64 * p).round() as usize;
+    sorted[idx]
+}
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let path = args
+        .next()
+        .expect("usage: imbalance_audit <session.csv> [target ...]");
+    let mut targets: Vec<u64> = args
+        .map(|a| a.parse().expect("target must be u64"))
+        .collect();
+    if targets.is_empty() {
+        targets = vec![2000, 5000];
+    }
+
+    let text = std::fs::read_to_string(&path).expect("read session file");
+    let parsed = parse_file(&text, ParseOptions::default()).expect("parse session");
+    let trades = parsed.trades;
+    let n = trades.len();
+    println!("== session {path}");
+    println!(
+        "side_source={:?}  trades={n}",
+        parsed.header.side_source.as_deref().unwrap_or("?")
+    );
+    if n == 0 {
+        return;
+    }
+    let span_min = (trades.last().unwrap().timestamp_ms - trades.first().unwrap().timestamp_ms)
+        as f64
+        / 60_000.0;
+
+    // Tape structure: how one-sided and how run-heavy is this stream?
+    let buys = trades.iter().filter(|t| t.side == Side::Buy).count();
+    let mut same_side = 0usize;
+    let mut runs: Vec<u64> = Vec::new();
+    let mut run_len = 1u64;
+    for w in trades.windows(2) {
+        if w[1].side == w[0].side {
+            same_side += 1;
+            run_len += 1;
+        } else {
+            runs.push(run_len);
+            run_len = 1;
+        }
+    }
+    runs.push(run_len);
+    let mean_run = n as f64 / runs.len() as f64;
+    runs.sort_unstable();
+    println!(
+        "span={span_min:.0}min  buy_frac={:.3}  P(same side as prev)={:.3}  runs: mean={mean_run:.1} p50={} p90={} max={}",
+        buys as f64 / n as f64,
+        same_side as f64 / (n - 1) as f64,
+        percentile(&runs, 0.5),
+        percentile(&runs, 0.9),
+        runs.last().unwrap(),
+    );
+
+    for target in &targets {
+        let target = *target;
+        let mut b = ImbalanceBarBuilder::new(target);
+        let mut counts: Vec<u64> = Vec::new();
+        let mut durs_ms: Vec<u64> = Vec::new();
+        let mut cap_closes = 0usize;
+        for t in &trades {
+            if let Some(bar) = b.push(t) {
+                counts.push(bar.trade_count);
+                durs_ms.push((bar.close_time - bar.open_time).max(0) as u64);
+                if bar.trade_count >= 3 * target {
+                    cap_closes += 1;
+                }
+            }
+        }
+        let bars = counts.len();
+        if bars == 0 {
+            println!("-- target={target}: no closed bars (partial only)");
+            continue;
+        }
+        let warmup = counts[0];
+        let adaptive = &counts[1..];
+        let mut sorted: Vec<u64> = adaptive.to_vec();
+        sorted.sort_unstable();
+        durs_ms.sort_unstable();
+        let mean = if adaptive.is_empty() {
+            0.0
+        } else {
+            adaptive.iter().sum::<u64>() as f64 / adaptive.len() as f64
+        };
+        println!(
+            "-- target={target}: bars={bars} (warmup={warmup})  bars/min={:.1}",
+            bars as f64 / span_min
+        );
+        println!(
+            "   trades/bar after warmup: mean={mean:.0} min={} p10={} p50={} p90={} max={}  cap_closes={cap_closes} ({:.1}%)",
+            sorted.first().copied().unwrap_or(0),
+            percentile(&sorted, 0.10),
+            percentile(&sorted, 0.50),
+            percentile(&sorted, 0.90),
+            sorted.last().copied().unwrap_or(0),
+            100.0 * cap_closes as f64 / bars as f64,
+        );
+        println!(
+            "   bar duration: p50={:.1}s p90={:.1}s max={:.1}s",
+            percentile(&durs_ms, 0.50) as f64 / 1000.0,
+            percentile(&durs_ms, 0.90) as f64 / 1000.0,
+            durs_ms.last().copied().unwrap_or(0) as f64 / 1000.0,
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Imbalance bars gain the López de Prado unit family: what θ accumulates is now selectable — trades (TIB, the historical behavior), volume (VIB) or dollar (DIB) — in the engine, the chart toolbar and the backtest spec vocabulary. The UI target cap rises from 5 000 to 1 000 000, which is what actually gates a slower imbalance chart on a dense tape.

- `engine`: `ImbalanceUnit{Trades,Volume,Dollar}` + `ImbalanceBarBuilder::with_unit`; `new()` unchanged and bit-exact (golden fixtures untouched and green). Weighted units judge each trade against the expectations formed *before* it (the book's E₀), so an elephant print cannot inflate the very threshold it should trip; the trades unit keeps its shipped fold-then-test order bit-for-bit. The `|E[s]|` floor becomes relative — 5% of E[w], the EWMA of typical trade weight — keeping the rule scale-free in the weight (pinned by test). Weights delegate to the engine's existing `Measure` implementations and are magnitudes: direction comes from the aggressor side alone. `ImbalanceUnit` owns the spec-token vocabulary (`as_str`/`parse_token`), and the builder exposes `hard_cap_trades()`.
- `app`: unit chips inline in the toolbar, gated per feed by `FeedCapabilities.traded_volume` (a source that prints no real size offers no size-measuring unit); specs `imbalance:volume:N` / `imbalance:dollar:N` parse and persist, `imbalance:N` remains the short form so every pre-units workspace reads back unchanged.
- `backtest`: same spec vocabulary in its parallel parser, round-trip tested.
- `replay`: new `imbalance_audit` example — replays a recorded session through the builder at one or more `[unit:]target` specs and prints the closed-bar length distribution plus the tape's side-run structure.

## Audit verdict: the "faster now" chart was never a bug

Replaying the recorded WINV26 sessions through the engine (`imbalance_audit`):

| session | tape | target | median bar |
| --- | --- | --- | --- |
| 2026-08-11 | 118 k trades, buy 0.577 (directional) | 2 000 | 2 033 trades / ~8 min |
| 2026-08-13 | 1.48 M trades, buy 0.511 (dense, balanced) | 2 000 | 113 trades / 1.7 s |
| 2026-08-13 | same | 5 000 | 339 trades / 5.1 s (min 63 = the floor) |
| 2026-07-01 | 3.8 k trades (thin) | 5 000 | no closed bars — the rule invents nothing |

Same engine, unchanged since #55 — the closing rule is adaptive, so a dense balanced tape drives E[b] to the 0.05 floor and E[T] to its lower clamp, making the effective rule |θ| ≥ target/80. Sampling speeding up on an information-dense tape is the imbalance bar working as designed; the fix for "I want slower bars" is a larger target, which the old 5 000 UI cap forbade and this PR frees.

## Arch-review

step 0: code-review at high — 10 finder angles + coordinator, ~40 raw findings, deduplicated to 13 themes; after adversarial verification: 2 confirmed Blockers, 6 Should-fixes accepted, the rest refuted as pre-existing repo policy or deliberate design. All accepted findings are fixed in this branch:

- **Blocker (fixed)** — `should_close`'s threshold used the panicking `*` on operands the weighted units let ride toward `Decimal::MAX`; an adversarial print could panic the builder against the engine's never-panic feed policy. Now `saturating_mul`, with a regression test feeding `Decimal::MAX` notionals.
- **Blocker (fixed)** — the relative floor collapsed to zero on a tape whose weights are all zero (a size unit over a size-less recording), cascading one-trade bars; and a signed export (negative quantity/price) flipped the print's aggressor sign and drove the floor negative. Weights are now magnitudes (`.abs()`, doc'd), and a zero threshold means "no imbalance close" — only the trade cap closes a measureless bar. Both pinned by tests.
- Should-fixes (all applied): `weight()` delegates to the existing `TickMeasure`/`VolumeMeasure`/`DollarMeasure` (one definition of each measure, `Trade::notional`'s saturation policy inherited, not copied); the unit token vocabulary lives once on `ImbalanceUnit` (`as_str`/`parse_token`) instead of twice in app and backtest; the audit example now audits all three units, reads the cap via `hard_cap_trades()` instead of a hardcoded `3 *`, and guards its NaN/inf divisions with consistent post-warm-up populations; `keep_b = 1 − α` precomputed once (bit-identical, one fewer Decimal rescale per trade); the bit-exactness test's docstring now claims what it proves (new ≡ with_unit(Trades) delegation — the historical guarantee is the untouched golden fixture).

Verification: `cargo fmt` / `clippy -D warnings` / `build` / `test --workspace` green on the branch after the fixes (1 312 engine tests, 6 new fixtures for the units + 3 pinning the review fixes). Bench after the fixes, same run: trades unit 532.4 ns/trade (vs 551.3 pre-fix and 545.5 on main — `keep_b` paid for the unit branch), imb-vol 1 299.8, imb-dlr 1 758.3 (+10% on the opt-in dollar path, the cost of the saturating/magnitude ops that remove the panic). The single-measure builders are untouched.

Sanity of the new units on the real 2026-08-13 tape (1.48 M trades): `volume:5000` median 225 trades/bar and `dollar:5000` median 224 — near-identical to each other (intraday index notional ≈ volume) and a touch faster-sampling than `trades:5000` (median 339), as size-weighted information should be.

Deferred, with reasons:

- Capability gating of specs stays UI-side: `imbalance:volume:N` from config or a restored workspace runs on a feed without real traded volume, exactly as `volume:5` always has — pre-existing repo policy, not a regression of this branch. Follow-up if wanted: a `BarSpec`-level `needs_traded_volume` consulted where specs are applied.
- The per-unit evaluation order (trades folds-then-tests; weighted units test-then-fold) is deliberate: it keeps every existing tick-imbalance chart and backtest bit-identical while giving the new units the book's E₀ semantics. Documented in the module docs; a reviewer proposal to migrate all units to E₀ and regenerate the golden was considered and declined.
- Toolbar width estimates (`W_IMBALANCE_PARAM`, the folded label in `W_BARS`), the chips' visual language vs the time presets, and the drag `speed(25)` trade-off need eyes on pixels: visual-qa is BLOCKED — launching the app requires Camilo's authorization (standing rule); trader-ux-review ran instead (no Blocker; its one Should-fix, the collapse-plan width, is fixed in e3b6d7e).
- The chip-gating predicate (`traded_volume || unit == Trades`) is covered by the paint smoke test only — the same coverage level as the pre-existing kind-combo gate one function up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
