### PR TITLE
fix(engine): make the imbalance target mean what the tooltip says

### DIFF
--- a/crates/app/src/toolbar.rs
+++ b/crates/app/src/toolbar.rs
@@ -572,15 +572,23 @@ fn draw_bar_param(ui: &mut egui::Ui, model: &mut ToolbarModel) {
                 });
             }
             ui.label("target trades");
+            // A promise the engine now keeps, so the tooltip can state it
+            // plainly. `E[T]` used to be an EWMA seeded with this number
+            // while the threshold was linear in it — a feedback loop that
+            // parked on a clamp and delivered `3 * target` or a fraction of
+            // it instead, which is what made a trader set 1500, then 2000,
+            // and get two unrecognisably different charts.
+            // `quantick_engine`'s `a_bar_is_about_the_target_long_in_balanced_flow`
+            // is what keeps the sentence honest.
             ui.add(
                 egui::DragValue::new(model.imbalance_target)
                     .range(2.0..=1_000_000.0)
                     .speed(25.0),
             )
             .on_hover_text(
-                "expected trades per bar in balanced flow — the seed of the \
-                 adaptive threshold, not a fixed length: dense two-way tape \
-                 closes bars well short of it, one-sided aggression sooner still",
+                "expected trades per bar in balanced flow — a real \
+                 expectation, not a fixed length: one-sided aggression closes \
+                 a bar well short of it, which is what this bar type is for",
             );
         }
     }

--- a/crates/engine/src/imbalance.rs
+++ b/crates/engine/src/imbalance.rs
@@ -25,17 +25,57 @@
 //!
 //! # Closing rule
 //!
-//! The reference rule closes a bar when `|theta| >= E[T] * |E[s]|`, where both
-//! expectations adapt to the observed stream:
+//! A bar closes when `|theta| >= E[T] * |E[s]|`, floored at the scale
+//! balanced flow actually reaches:
 //!
-//! - `E[T]` — expected trades per bar: an EWMA (weight [`ALPHA_T`]) over the
-//!   trade counts of closed bars, seeded with the `target_trades` parameter.
+//! - `E[T]` — expected trades per bar: **the `target_trades` parameter**,
+//!   fixed. Not adaptive; see below for why.
 //! - `E[s]` — expected signed weight per trade: a per-trade EWMA of `s` whose
 //!   span is `target_trades` (weight `2 / (target_trades + 1)`), so the
 //!   imbalance estimate looks back roughly one expected bar.
+//! - the floor — `sqrt(target_trades)` typical trades' worth of weight; see
+//!   [`ImbalanceBarBuilder::noise_floor`].
 //!
 //! In the trades unit `|E[s]|` is exactly the book's `|2P[b=1] - 1|`; in the
 //! weighted units it estimates `|2v+ - E[v]|` the same way.
+//!
+//! # Why `E[T]` is fixed, and why the floor scales
+//!
+//! Both expectations used to adapt, and that made the knob mean nothing.
+//!
+//! The threshold is *linear* in `E[T]`, and `E[T]` was an EWMA of the bar
+//! lengths that same threshold produced: a loop with no damping term. For a
+//! driftless tape `theta` is a symmetric walk, so a bar of length `n` needs
+//! `threshold ~ sqrt(n)` — self-consistency therefore sat at
+//! `E[T] = 1 / floor^2`, a **repelling** fixed point that did not depend on
+//! `target_trades` at all. Whatever the trader asked for, `E[T]` ran away
+//! from it to one clamp or the other and stayed. The clamps did not prevent
+//! the degeneracy the guards were written for; they decided which one you
+//! got:
+//!
+//! - above the fixed point, `E[T]` pinned at `3 * target` and the threshold
+//!   became a four-sigma excursion — no bar ever closed on imbalance, only on
+//!   the hard cap, so an "imbalance" chart was a `3 * target`-tick chart;
+//! - below it, `E[T]` pinned at `target / 4` and the threshold fell far under
+//!   what a balanced walk reaches — a cascade of very short bars.
+//!
+//! Measured on a real WIN session under the tick rule the app runs live: at
+//! `target = 1500` the same setting gave 3,720 trades per bar in one hour and
+//! 226 in another, and `target = 1600` produced *shorter* bars than
+//! `target = 1500` over the whole day. The parameter was neither monotone nor
+//! reproducible.
+//!
+//! Fixing `E[T]` at `target_trades` removes the loop. The adaptivity that
+//! carries information lives in `E[s]`, which is where the reference rule
+//! puts it, and a fixed `E[T]` is what makes one knob mean one thing.
+//!
+//! The floor then has to carry balanced flow on its own, because that is
+//! exactly when `|E[s]| -> 0`. A constant cannot: a walk of length `n`
+//! reaches `|theta| ~ sqrt(n)` typical weights, so any fixed floor is
+//! unreachable at large targets and trivial at small ones. At
+//! `sqrt(target)` typical weights the expected first passage is `~target`
+//! trades at every setting and in every unit — which is what "expected trades
+//! per bar in balanced flow" has always claimed to mean, and now is.
 //!
 //! **Evaluation order.** The trades unit folds the arriving trade into `E[s]`
 //! *before* testing the threshold — the behavior this bar type shipped with,
@@ -47,29 +87,20 @@
 //! against the expectations formed *before* it (the book's `E_0[.]`), and fold
 //! it in afterwards.
 //!
-//! # Structural guards (and why they are honest)
+//! # Structural guards
 //!
-//! The textbook rule is known to degenerate: in near-balanced flow
-//! `|E[s]| -> 0` collapses the threshold (a cascade of one-trade bars), and a
-//! feedback loop between shrinking bars and shrinking `E[T]` can pin it there.
-//! Rather than patch the stream, the closing rule itself is bounded by three
-//! fixed, documented guards — every one deterministic and part of the rule,
-//! not silent data repair:
+//! Two, both deterministic and part of the rule, not silent data repair:
 //!
-//! - the effective `|E[s]|` never drops below [`FLOOR_B`] times `E[w]` — an
-//!   EWMA of the unsigned weight, primed with the first trade's weight, so the
-//!   floor means "5% of a typical trade" in every unit (in the trades unit
-//!   `E[w]` is exactly 1 and the floor is the historical `0.05`) and the
-//!   threshold stays meaningfully positive in balanced flow. Weights are
-//!   magnitudes — direction comes from the aggressor side alone — and a tape
-//!   whose weights are all zero (a size unit over a size-less recording) has
-//!   no measure to read: its threshold is zero, an imbalance close never
-//!   fires, and only the trade cap below bounds the bar;
-//! - a bar always closes after `3 * target_trades` trades ([`CAP_MULT`]), so
-//!   perfectly offsetting flow cannot grow a bar without bound;
-//! - `E[T]` is clamped to `[target_trades / 4, 3 * target_trades]`, so a
-//!   transient regime cannot drag the expectation somewhere it takes forever
-//!   to recover from.
+//! - a bar always closes after `3 * target_trades` trades ([`CAP_MULT`]). A
+//!   backstop against a tape that offsets perfectly for an unbounded stretch,
+//!   and nothing more: when it starts firing routinely, the threshold above
+//!   it has stopped working;
+//! - the floor is at least one typical trade's weight, so a bar can never
+//!   close on the single trade that opened it — and a tape whose weights are
+//!   all zero (a size unit over a size-less recording) has no measure to
+//!   read: its threshold is zero, an imbalance close never fires, and only
+//!   the trade cap bounds the bar. Weights are magnitudes; direction comes
+//!   from the aggressor side alone.
 //!
 //! The **first** bar is a warm-up: with no history there is no meaningful
 //! expectation, so it closes at exactly `target_trades` trades (like a tick
@@ -85,18 +116,14 @@ use crate::{
     Bar, BarBuilder, DollarMeasure, Measure as _, Side, TickMeasure, Trade, VolumeMeasure,
 };
 
-/// EWMA weight for the expected-trades-per-bar update, applied once per
-/// closed bar. `0.25` spans roughly the last seven bars.
-const ALPHA_T: Decimal = Decimal::from_parts(25, 0, 0, false, 2);
-
-/// Lower bound on the effective `|E[s]|` in the threshold, as a fraction of
-/// `E[w]` (the typical per-trade weight), so near-balanced flow cannot
-/// collapse the threshold to zero. In the trades unit `E[w]` is exactly 1 and
-/// this is the historical absolute floor of `0.05`.
-const FLOOR_B: Decimal = Decimal::from_parts(5, 0, 0, false, 2);
-
 /// A bar always closes after `CAP_MULT * target_trades` trades, whatever the
 /// imbalance says.
+///
+/// A backstop against a tape that offsets perfectly for an unbounded stretch,
+/// and nothing more: with the threshold below working, it should fire on its
+/// own long before this does. When this guard becomes the *usual* way bars
+/// close, the rule above it has stopped working — which is exactly what
+/// happened before the `E[T]` feedback loop was removed.
 const CAP_MULT: u64 = 3;
 
 /// The measure a trade's aggression is weighed in — what `theta` accumulates.
@@ -185,14 +212,25 @@ pub struct ImbalanceBarBuilder {
     /// trade, and the subtraction rescales `ONE` to scale 28 each time it is
     /// redone inline.
     keep_b: Decimal,
-    /// Expected trades per bar, seeded with `target_trades`.
+    /// `E[T]` — expected trades per bar. The configured target, fixed.
+    ///
+    /// Deliberately *not* adaptive. It used to be an EWMA of the lengths the
+    /// threshold produced, while the threshold was linear in it: a loop with
+    /// no damping, whose fixed point sits at `1 / floor^2` regardless of what
+    /// the trader asked for, and is unstable — so `E[T]` always ran to one of
+    /// its clamps and stayed. The adaptivity that carries information lives
+    /// in `E[s]`; taking it out of `E[T]` is what makes the knob mean one
+    /// thing.
     e_t: Decimal,
+    /// `sqrt(target_trades)`, at least one — how many *typical trades' worth*
+    /// of weight the floor is. Integer `isqrt`, so the engine keeps its exact
+    /// arithmetic and no transcendental ever runs on the hot path.
+    floor_trades: Decimal,
     /// Expected signed weight per trade, primed from zero as trades arrive.
     e_s: Decimal,
     /// Typical unsigned weight per trade: an EWMA primed with the first
     /// trade's weight (`None` until then). The trades unit never sets it —
-    /// its weight is identically 1 — and the floor falls back to the
-    /// historical constant `0.05`.
+    /// its weight is identically 1, so the floor is `floor_trades` alone.
     e_w: Option<Decimal>,
     /// Signed imbalance of the in-progress bar, in the configured unit.
     theta: Decimal,
@@ -241,6 +279,9 @@ impl ImbalanceBarBuilder {
             alpha_b,
             keep_b: Decimal::ONE - alpha_b,
             e_t: Decimal::from(target_trades),
+            // At least one: a floor below a single typical trade would let a
+            // bar close on the very trade that opened it.
+            floor_trades: Decimal::from(target_trades.isqrt().max(1)),
             e_s: Decimal::ZERO,
             e_w: None,
             theta: Decimal::ZERO,
@@ -278,23 +319,7 @@ impl ImbalanceBarBuilder {
         if self.count >= CAP_MULT.saturating_mul(self.target_trades) {
             return true;
         }
-        // The floor scales with the unit's typical weight. The trades unit
-        // keeps the historical constant — its weight is identically 1 — and
-        // never spends the multiplication on the per-trade hot path. In the
-        // weighted units `e_w` is primed by the first `absorb`, which the
-        // `warmed_up` gate guarantees has run; the zero fallback merely keeps
-        // this line total instead of trusting that ordering.
-        let floor = if self.unit == ImbalanceUnit::Trades {
-            FLOOR_B
-        } else {
-            FLOOR_B.saturating_mul(self.e_w.unwrap_or(Decimal::ZERO))
-        };
-        // Saturating like every arithmetic step feeding it: an adversarial
-        // print can pin `E[s]` near `Decimal::MAX`, and a threshold that
-        // saturates means "no imbalance close" — the trade cap above still
-        // bounds the bar — while a plain `*` would panic a builder on feed
-        // input, which the engine's arithmetic policy forbids.
-        let threshold = self.e_t.saturating_mul(self.e_s.abs().max(floor));
+        let threshold = self.threshold();
         // A tape whose weights are all zero (a size unit over a size-less
         // recording) has no measure to read: theta and the threshold are both
         // zero, and closing on `0 >= 0` would cascade one-trade bars — the
@@ -302,6 +327,53 @@ impl ImbalanceBarBuilder {
         // only at the cap. In the trades unit the threshold is structurally
         // positive, so this guard never fires there.
         threshold > Decimal::ZERO && self.theta.abs() >= threshold
+    }
+
+    /// The imbalance a bar must reach to close.
+    ///
+    /// `E[T] * |E[s]|` is the reference rule: the imbalance a *typical* bar
+    /// ends on, so a bar closes as soon as it looks unusual. `E[s]` adapts
+    /// over roughly one bar, so a burst arriving inside a bar is measured
+    /// against the flow that came before it — the whole point of sampling
+    /// this way.
+    ///
+    /// Floored at [`noise_floor`](Self::noise_floor) rather than at a
+    /// fraction of `E[s]`: in balanced flow `|E[s]| -> 0` and the floor is
+    /// the only thing left holding the rule up.
+    ///
+    /// Saturating like every arithmetic step feeding it: an adversarial print
+    /// can pin `E[s]` near `Decimal::MAX`, and a threshold that saturates
+    /// means "no imbalance close" — the trade cap above still bounds the bar
+    /// — while a plain `*` would panic a builder on feed input, which the
+    /// engine's arithmetic policy forbids.
+    fn threshold(&self) -> Decimal {
+        self.e_t
+            .saturating_mul(self.e_s.abs())
+            .max(self.noise_floor())
+    }
+
+    /// The imbalance balanced flow reaches on its own in `target_trades`
+    /// trades: `sqrt(target)` typical trades' worth of weight.
+    ///
+    /// A driftless signed walk of `n` steps of typical size `E[w]` has
+    /// `|theta| ~ E[w] * sqrt(n)`, so this is the level whose expected first
+    /// passage is `~target_trades` — at every setting and in every unit,
+    /// which is what the parameter has always claimed to mean. A floor that
+    /// did not scale this way was unreachable at large targets (every bar ran
+    /// to the cap) and trivial at small ones.
+    ///
+    /// The trades unit skips the multiplication entirely: its weight is
+    /// identically 1, so the floor is `sqrt(target)` and the per-trade hot
+    /// path stays one field read. In the weighted units `e_w` is primed by
+    /// the first `absorb`, which the `warmed_up` gate guarantees has run; the
+    /// zero fallback keeps this total instead of trusting that ordering.
+    fn noise_floor(&self) -> Decimal {
+        match self.unit {
+            ImbalanceUnit::Trades => self.floor_trades,
+            _ => self
+                .floor_trades
+                .saturating_mul(self.e_w.unwrap_or(Decimal::ZERO)),
+        }
     }
 
     /// Fold one trade's signed weight into the running expectations. The
@@ -327,16 +399,13 @@ impl ImbalanceBarBuilder {
         }
     }
 
-    /// Close the in-progress bar: fold its length into `E[T]`, reset the
-    /// per-bar accumulators (no carry), and hand the bar out.
+    /// Close the in-progress bar: reset the per-bar accumulators (no carry)
+    /// and hand the bar out.
+    ///
+    /// `E[T]` is deliberately untouched here — folding the closed length back
+    /// into it is precisely the feedback loop that made the target
+    /// meaningless.
     fn close_bar(&mut self) -> Option<Bar> {
-        let closed_len = Decimal::from(self.count);
-        let updated = ALPHA_T * closed_len + (Decimal::ONE - ALPHA_T) * self.e_t;
-        let min = Decimal::from(self.target_trades) / Decimal::from(4);
-        // Saturating to match `should_close`'s hard cap and stay panic-free for
-        // any configured `target_trades`.
-        let max = Decimal::from(CAP_MULT.saturating_mul(self.target_trades));
-        self.e_t = updated.clamp(min, max);
         self.warmed_up = true;
         self.theta = Decimal::ZERO;
         self.count = 0;
@@ -401,6 +470,216 @@ mod tests {
             .enumerate()
             .filter_map(|(i, side)| builder.push(&trade(i as u64, *side)))
             .collect()
+    }
+
+    /// A fixed-seed LCG. Not randomness the engine ever sees: it runs in the
+    /// *test* to build a fixture tape, identical on every machine and every
+    /// run, with no clock and no entropy. The determinism rule is about the
+    /// builders, and a reproducible pseudo-tape is what lets these tests
+    /// assert on first-passage behaviour at all.
+    struct Lcg(u64);
+
+    impl Lcg {
+        fn new() -> Self {
+            Self(0x2545_f491_4f6c_dd1d)
+        }
+
+        fn next(&mut self) -> u64 {
+            self.0 = self
+                .0
+                .wrapping_mul(6_364_136_223_846_793_005)
+                .wrapping_add(1_442_695_040_888_963_407);
+            self.0 >> 33
+        }
+    }
+
+    /// A tape with a chosen buy share, in per-mille.
+    ///
+    /// It has to be a genuine walk rather than an evenly spread alternation:
+    /// alternating sides pin `|theta|` at one and would test nothing but the
+    /// hard cap. Real balanced flow wanders, and the wandering is exactly
+    /// what the threshold is calibrated against.
+    fn tape(len: usize, buy_per_mille: u64) -> Vec<Side> {
+        let mut lcg = Lcg::new();
+        (0..len)
+            .map(|_| {
+                if lcg.next() % 1000 < buy_per_mille {
+                    Side::Buy
+                } else {
+                    Side::Sell
+                }
+            })
+            .collect()
+    }
+
+    /// Mean trades per closed bar over `sides`, in the trades unit.
+    fn mean_len(target: u64, sides: &[Side]) -> f64 {
+        let mut builder = ImbalanceBarBuilder::new(target);
+        let bars = run(&mut builder, sides);
+        assert!(!bars.is_empty(), "target {target} closed no bar at all");
+        sides.len() as f64 / bars.len() as f64
+    }
+
+    /// The promise the knob makes, and the one it did not keep: in balanced
+    /// flow a bar is about `target_trades` long.
+    ///
+    /// Before this rule was fixed, `E[T]` was an EWMA feeding a threshold
+    /// linear in `E[T]` — a loop whose only resting places were the clamps at
+    /// `target/4` and `3 * target`. Measured on a real WIN session under the
+    /// tick rule the app runs live, target 1500 gave 3,720 trades per bar in
+    /// hour 12 and 226 in hour 14: 14x apart, same setting, same day.
+    #[test]
+    fn a_bar_is_about_the_target_long_in_balanced_flow() {
+        for target in [100_u64, 500, 2000, 5000] {
+            let sides = tape(target as usize * 60, 500);
+            let mean = mean_len(target, &sides);
+            let ratio = mean / f64::from(u32::try_from(target).unwrap());
+            assert!(
+                (0.5..=2.0).contains(&ratio),
+                "target {target}: mean bar length {mean:.0} is {ratio:.2}x the target"
+            );
+        }
+    }
+
+    /// Asking for longer bars must give longer bars.
+    ///
+    /// The old rule was not monotone on real data: on the trader's own tape
+    /// under the tick rule, target 1500 gave 626 trades per bar and target
+    /// 1600 gave 284 — a 100-trade nudge halved the bar, because the two
+    /// settings landed in different attractors.
+    #[test]
+    fn a_larger_target_makes_longer_bars() {
+        let sides = tape(400_000, 500);
+        let mut previous = 0.0;
+        for target in [100_u64, 500, 1500, 1600, 2000, 5000] {
+            let mean = mean_len(target, &sides);
+            assert!(
+                mean > previous,
+                "target {target} gave mean {mean:.0}, not longer than the previous {previous:.0}"
+            );
+            previous = mean;
+        }
+    }
+
+    /// The same setting must mean the same thing whatever came before it.
+    ///
+    /// `E[T]`'s EWMA carried the previous regime into the next one and the
+    /// clamps kept it there, so one target drifted more than an order of
+    /// magnitude across a single session with nothing touched.
+    #[test]
+    fn the_bar_length_does_not_depend_on_the_regime_before_it() {
+        let target = 2000;
+        let measure = |lead: &[Side]| {
+            let mut builder = ImbalanceBarBuilder::new(target);
+            let _ = run(&mut builder, lead);
+            let steady = tape(200_000, 500);
+            let bars = run(&mut builder, &steady);
+            steady.len() as f64 / bars.len() as f64
+        };
+        let after_burst = measure(&vec![Side::Buy; 40_000]);
+        let after_balance = measure(&tape(40_000, 500));
+        let ratio = after_burst / after_balance;
+        assert!(
+            (0.6..=1.6).contains(&ratio),
+            "the same target settles at {after_burst:.0} after a burst and {after_balance:.0} \
+             after balanced flow ({ratio:.2}x apart)"
+        );
+    }
+
+    /// The low end of the toolbar's range has to work too.
+    ///
+    /// The old minimum threshold was `(target/4) * FLOOR_B` = `target/80`,
+    /// below 1 for every target under 80 — so the whole band the toolbar
+    /// offers below 80 collapsed into a cascade of one- and two-trade bars.
+    #[test]
+    fn small_targets_are_not_a_one_trade_cascade() {
+        for target in [4_u64, 10, 50, 79] {
+            let sides = tape(target as usize * 400, 500);
+            let mean = mean_len(target, &sides);
+            let ratio = mean / f64::from(u32::try_from(target).unwrap());
+            assert!(
+                (0.5..=2.0).contains(&ratio),
+                "target {target}: mean bar length {mean:.1} is {ratio:.2}x the target"
+            );
+        }
+    }
+
+    /// The cap is a backstop, not the closing rule.
+    ///
+    /// When bars routinely close at `3 * target` the threshold above has
+    /// stopped working and the chart is a tick chart wearing an imbalance
+    /// label. On the trader's sparse session that is exactly what happened:
+    /// 47% of bars closed on the cap at target 1500 and 55% at target 2000,
+    /// and on the dense one 39-59% in the morning hours.
+    ///
+    /// Not zero, and the bound says so honestly: the first-passage time to a
+    /// fixed level has a tail, and `E[s]` is estimated from a finite window,
+    /// so a minority of bars legitimately runs long. A quarter is the line
+    /// between "a backstop fires sometimes" and "the backstop *is* the rule";
+    /// measured here it sits at 9% (target 100) and 2% (target 2000).
+    #[test]
+    fn the_hard_cap_is_not_how_bars_normally_close() {
+        for target in [100_u64, 2000] {
+            let sides = tape(target as usize * 60, 500);
+            let mut builder = ImbalanceBarBuilder::new(target);
+            let bars = run(&mut builder, &sides);
+            let cap = builder.hard_cap_trades();
+            let capped = bars.iter().filter(|b| b.trade_count >= cap).count();
+            assert!(
+                capped * 4 < bars.len(),
+                "target {target}: {capped} of {} bars closed on the cap",
+                bars.len()
+            );
+        }
+    }
+
+    /// A weighted tape: sizes wander over an order of magnitude, the way a
+    /// real one does, so the floor cannot be calibrated against a constant
+    /// lot size it never sees.
+    fn weighted_tape(len: usize, buy_per_mille: u64) -> Vec<Trade> {
+        let mut lcg = Lcg::new();
+        (0..len)
+            .map(|i| {
+                let side = if lcg.next() % 1000 < buy_per_mille {
+                    Side::Buy
+                } else {
+                    Side::Sell
+                };
+                let qty = Decimal::from(1 + lcg.next() % 20);
+                Trade {
+                    agg_id: i as u64,
+                    timestamp_ms: 1000 + i as i64 * 100,
+                    price: Decimal::from_str("100.0").unwrap(),
+                    quantity: qty,
+                    side,
+                }
+            })
+            .collect()
+    }
+
+    /// The target means trades per bar in *every* unit — the module doc has
+    /// always said so, and the weighted units have to honour it too.
+    ///
+    /// The floor is what carries balanced flow, and in a weighted unit
+    /// `theta` is measured in lots or currency, not counts. A floor
+    /// calibrated for the trades unit is off by the typical trade size here,
+    /// which on WIN is a factor of several.
+    #[test]
+    fn weighted_units_also_target_the_configured_trade_count() {
+        for unit in [ImbalanceUnit::Volume, ImbalanceUnit::Dollar] {
+            for target in [100_u64, 2000] {
+                let trades = weighted_tape(target as usize * 60, 500);
+                let mut builder = ImbalanceBarBuilder::with_unit(target, unit);
+                let bars: Vec<Bar> = trades.iter().filter_map(|t| builder.push(t)).collect();
+                assert!(!bars.is_empty(), "{unit:?} target {target} closed no bar");
+                let mean = trades.len() as f64 / bars.len() as f64;
+                let ratio = mean / f64::from(u32::try_from(target).unwrap());
+                assert!(
+                    (0.5..=2.0).contains(&ratio),
+                    "{unit:?} target {target}: mean bar length {mean:.0} is {ratio:.2}x the target"
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/engine/src/imbalance.rs
+++ b/crates/engine/src/imbalance.rs
@@ -116,6 +116,26 @@ use crate::{
     Bar, BarBuilder, DollarMeasure, Measure as _, Side, TickMeasure, Trade, VolumeMeasure,
 };
 
+/// `sqrt(n)` rounded to the nearest integer, in exact integer arithmetic.
+///
+/// The floor is `sqrt(target)` typical weights, and truncating that square
+/// root is not a rounding detail at the low end of the range: the error is
+/// worst just below a perfect square, and the *bar length* it implies is the
+/// floor squared. Truncated, `target = 3` floors at 1 — a bar closing on the
+/// trade after the one that opened it, the cascade the floor exists to
+/// prevent — and `target = 8` floors at 2, half the length asked for.
+/// Rounded, they floor at 2 and 3, and the low end of the toolbar's range
+/// means what it says.
+///
+/// `isqrt` gives `k` with `k^2 <= n`, so `n - k*k` is the distance past the
+/// square and the nearest root is `k + 1` exactly when that distance exceeds
+/// `k` (i.e. `n > (k + 0.5)^2`). Written as a subtraction rather than
+/// `k*k + k` so a target near `u64::MAX` cannot overflow.
+const fn rounded_isqrt(n: u64) -> u64 {
+    let k = n.isqrt();
+    if n - k * k > k { k + 1 } else { k }
+}
+
 /// A bar always closes after `CAP_MULT * target_trades` trades, whatever the
 /// imbalance says.
 ///
@@ -223,8 +243,8 @@ pub struct ImbalanceBarBuilder {
     /// thing.
     e_t: Decimal,
     /// `sqrt(target_trades)`, at least one — how many *typical trades' worth*
-    /// of weight the floor is. Integer `isqrt`, so the engine keeps its exact
-    /// arithmetic and no transcendental ever runs on the hot path.
+    /// of weight the floor is. Integer [`rounded_isqrt`], so the engine keeps
+    /// its exact arithmetic and no transcendental ever runs on the hot path.
     floor_trades: Decimal,
     /// Expected signed weight per trade, primed from zero as trades arrive.
     e_s: Decimal,
@@ -279,9 +299,10 @@ impl ImbalanceBarBuilder {
             alpha_b,
             keep_b: Decimal::ONE - alpha_b,
             e_t: Decimal::from(target_trades),
-            // At least one: a floor below a single typical trade would let a
-            // bar close on the very trade that opened it.
-            floor_trades: Decimal::from(target_trades.isqrt().max(1)),
+            // `target_trades >= 1` is asserted above, and `rounded_isqrt(1)`
+            // is 1, so the floor is never below a single typical trade — a
+            // bar can never close on the very trade that opened it.
+            floor_trades: Decimal::from(rounded_isqrt(target_trades)),
             e_s: Decimal::ZERO,
             e_w: None,
             theta: Decimal::ZERO,
@@ -586,14 +607,38 @@ mod tests {
         );
     }
 
+    /// `sqrt` rounded, not truncated — and why the difference is not cosmetic.
+    ///
+    /// The floor is a bar-length target under a square root, so truncating it
+    /// squares the error back up: a truncated `sqrt(3)` is 1, and a floor of
+    /// one closes a bar on the trade after the one that opened it. The
+    /// toolbar's minimum is 2, so this is inside the range a trader can set.
+    #[test]
+    fn the_floor_rounds_the_square_root_instead_of_truncating_it() {
+        // Perfect squares are exact either way.
+        assert_eq!(rounded_isqrt(1), 1);
+        assert_eq!(rounded_isqrt(4), 2);
+        assert_eq!(rounded_isqrt(2_250_000), 1500);
+        // Just below a square is where truncation hurts most.
+        assert_eq!(rounded_isqrt(3), 2, "truncating would floor at 1");
+        assert_eq!(rounded_isqrt(8), 3, "truncating would floor at 2");
+        assert_eq!(rounded_isqrt(80), 9, "truncating would floor at 8");
+        // Below the half-step it still rounds down.
+        assert_eq!(rounded_isqrt(2), 1);
+        assert_eq!(rounded_isqrt(6), 2);
+        // A target near the top of `u64` must not overflow the comparison.
+        assert_eq!(rounded_isqrt(u64::MAX), 4_294_967_296);
+    }
+
     /// The low end of the toolbar's range has to work too.
     ///
     /// The old minimum threshold was `(target/4) * FLOOR_B` = `target/80`,
     /// below 1 for every target under 80 — so the whole band the toolbar
     /// offers below 80 collapsed into a cascade of one- and two-trade bars.
+    /// `2` is the toolbar's own minimum, so the range starts there.
     #[test]
     fn small_targets_are_not_a_one_trade_cascade() {
-        for target in [4_u64, 10, 50, 79] {
+        for target in [2_u64, 3, 4, 8, 10, 50, 79] {
             let sides = tape(target as usize * 400, 500);
             let mean = mean_len(target, &sides);
             let ratio = mean / f64::from(u32::try_from(target).unwrap());

--- a/crates/engine/src/imbalance.rs
+++ b/crates/engine/src/imbalance.rs
@@ -33,8 +33,8 @@
 //! - `E[s]` — expected signed weight per trade: a per-trade EWMA of `s` whose
 //!   span is `target_trades` (weight `2 / (target_trades + 1)`), so the
 //!   imbalance estimate looks back roughly one expected bar.
-//! - the floor — `sqrt(target_trades)` typical trades' worth of weight; see
-//!   [`ImbalanceBarBuilder::noise_floor`].
+//! - the floor — `round(sqrt(target_trades))` typical trades' worth of
+//!   weight; see [`ImbalanceBarBuilder::noise_floor`].
 //!
 //! In the trades unit `|E[s]|` is exactly the book's `|2P[b=1] - 1|`; in the
 //! weighted units it estimates `|2v+ - E[v]|` the same way.
@@ -73,19 +73,33 @@
 //! exactly when `|E[s]| -> 0`. A constant cannot: a walk of length `n`
 //! reaches `|theta| ~ sqrt(n)` typical weights, so any fixed floor is
 //! unreachable at large targets and trivial at small ones. At
-//! `sqrt(target)` typical weights the expected first passage is `~target`
-//! trades at every setting and in every unit — which is what "expected trades
-//! per bar in balanced flow" has always claimed to mean, and now is.
+//! `round(sqrt(target))` typical weights the floor's own expected first
+//! passage is `~target` trades at every setting and in every unit — the
+//! scale-free property the old constant could not have.
+//!
+//! **What the target delivers, measured.** The floor is a *lower bound* on
+//! the threshold, not the threshold, so the length is not exactly the target
+//! and this doc will not claim it is. In perfectly balanced flow
+//! `E[T] * |E[s]|` is itself of order `sqrt(target)` — an EWMA of span `T`
+//! has standard deviation `~1/sqrt(T)`, and `T` times that is `sqrt(T)` — so
+//! both branches of the `max` are the same size and the winner sits above
+//! either. Over a fixed-seed balanced tape that lands the bar at **1.3-1.7x
+//! the target**, and flatly so across the whole range (100 -> 1.37x,
+//! 1500 -> 1.44x, 5000 -> 1.34x). A real tape carries direction, which closes
+//! bars early instead: on a recorded WIN session the same settings deliver
+//! 0.6-0.65x. The parameter is a calibrated dial with a stable, monotone
+//! response — not a promise of an exact count — and
+//! `a_bar_is_about_the_target_long_in_balanced_flow` bounds it rather than
+//! pinning it.
 //!
 //! **Evaluation order.** The trades unit folds the arriving trade into `E[s]`
-//! *before* testing the threshold — the behavior this bar type shipped with,
-//! kept bit-for-bit so existing charts and backtests never move. For `|s| = 1`
-//! the difference is second-order. For the weighted units it is first-order: a
-//! giant print folded into `E[s]` first can raise the threshold by more than
-//! its own contribution to `theta`, and the bar would survive exactly the
-//! elephant it exists to flag. The weighted units therefore judge each trade
-//! against the expectations formed *before* it (the book's `E_0[.]`), and fold
-//! it in afterwards.
+//! *before* testing the threshold, and the weighted units do not. A
+//! deliberate asymmetry: for `|s| = 1` the difference is second-order, while
+//! for the weighted units it is first-order — a giant print folded into
+//! `E[s]` first can raise the threshold by more than its own contribution to
+//! `theta`, and the bar would survive exactly the elephant it exists to flag.
+//! The weighted units therefore judge each trade against the expectations
+//! formed *before* it (the book's `E_0[.]`), and fold it in afterwards.
 //!
 //! # Structural guards
 //!
@@ -95,12 +109,16 @@
 //!   backstop against a tape that offsets perfectly for an unbounded stretch,
 //!   and nothing more: when it starts firing routinely, the threshold above
 //!   it has stopped working;
-//! - the floor is at least one typical trade's weight, so a bar can never
-//!   close on the single trade that opened it — and a tape whose weights are
-//!   all zero (a size unit over a size-less recording) has no measure to
-//!   read: its threshold is zero, an imbalance close never fires, and only
-//!   the trade cap bounds the bar. Weights are magnitudes; direction comes
-//!   from the aggressor side alone.
+//! - the floor is at least one typical trade's weight, so a bar cannot close
+//!   on the trade that opened it for any `target_trades >= 4`. At the very
+//!   bottom of the range it can, and honestly: `round(sqrt(2))` is 1, so a
+//!   single print already meets the floor and about a third of bars run one
+//!   trade at `target = 2` — which is a bar length of one against a target of
+//!   two, not a degeneracy. A tape whose weights are all zero (a size unit
+//!   over a size-less recording) has no measure to read: its threshold is
+//!   zero, an imbalance close never fires, and only the trade cap bounds the
+//!   bar. Weights are magnitudes; direction comes from the aggressor side
+//!   alone.
 //!
 //! The **first** bar is a warm-up: with no history there is no meaningful
 //! expectation, so it closes at exactly `target_trades` trades (like a tick
@@ -242,9 +260,12 @@ pub struct ImbalanceBarBuilder {
     /// in `E[s]`; taking it out of `E[T]` is what makes the knob mean one
     /// thing.
     e_t: Decimal,
-    /// `sqrt(target_trades)`, at least one — how many *typical trades' worth*
-    /// of weight the floor is. Integer [`rounded_isqrt`], so the engine keeps
-    /// its exact arithmetic and no transcendental ever runs on the hot path.
+    /// `round(sqrt(target_trades))` — how many *typical trades' worth* of
+    /// weight the floor is. Integer [`rounded_isqrt`], so the engine keeps its
+    /// exact arithmetic and no transcendental ever runs on the hot path.
+    ///
+    /// Never zero: `target_trades >= 1` is asserted at construction and
+    /// `rounded_isqrt(1) == 1`, so no explicit clamp is needed.
     floor_trades: Decimal,
     /// Expected signed weight per trade, primed from zero as trades arrive.
     e_s: Decimal,
@@ -337,7 +358,7 @@ impl ImbalanceBarBuilder {
         if !self.warmed_up {
             return self.count >= self.target_trades;
         }
-        if self.count >= CAP_MULT.saturating_mul(self.target_trades) {
+        if self.count >= self.hard_cap_trades() {
             return true;
         }
         let threshold = self.threshold();
@@ -374,20 +395,21 @@ impl ImbalanceBarBuilder {
     }
 
     /// The imbalance balanced flow reaches on its own in `target_trades`
-    /// trades: `sqrt(target)` typical trades' worth of weight.
+    /// trades: `round(sqrt(target))` typical trades' worth of weight.
     ///
     /// A driftless signed walk of `n` steps of typical size `E[w]` has
-    /// `|theta| ~ E[w] * sqrt(n)`, so this is the level whose expected first
-    /// passage is `~target_trades` — at every setting and in every unit,
-    /// which is what the parameter has always claimed to mean. A floor that
-    /// did not scale this way was unreachable at large targets (every bar ran
-    /// to the cap) and trivial at small ones.
+    /// `|theta| ~ E[w] * sqrt(n)`, so this is the level whose own expected
+    /// first passage is `~target_trades` — at every setting and in every
+    /// unit. A floor that did not scale this way was unreachable at large
+    /// targets (every bar ran to the cap) and trivial at small ones. It is a
+    /// lower bound, not the whole threshold; see the [module docs](self) for
+    /// what the two branches together actually deliver.
     ///
     /// The trades unit skips the multiplication entirely: its weight is
-    /// identically 1, so the floor is `sqrt(target)` and the per-trade hot
-    /// path stays one field read. In the weighted units `e_w` is primed by
-    /// the first `absorb`, which the `warmed_up` gate guarantees has run; the
-    /// zero fallback keeps this total instead of trusting that ordering.
+    /// identically 1, so the floor is `round(sqrt(target))` and the per-trade
+    /// hot path stays one field read. In the weighted units `e_w` is primed
+    /// by the first `absorb`, which the `warmed_up` gate guarantees has run;
+    /// the zero fallback keeps this total instead of trusting that ordering.
     fn noise_floor(&self) -> Decimal {
         match self.unit {
             ImbalanceUnit::Trades => self.floor_trades,
@@ -501,8 +523,12 @@ mod tests {
     struct Lcg(u64);
 
     impl Lcg {
-        fn new() -> Self {
-            Self(0x2545_f491_4f6c_dd1d)
+        /// `seed` distinguishes independent tapes. Two tapes drawn from the
+        /// same seed are prefixes of one another, which quietly destroys any
+        /// test that means to compare a lead-in against an unrelated
+        /// measurement window.
+        fn new(seed: u64) -> Self {
+            Self(0x2545_f491_4f6c_dd1d ^ seed.wrapping_mul(0x9e37_79b9_7f4a_7c15))
         }
 
         fn next(&mut self) -> u64 {
@@ -514,14 +540,14 @@ mod tests {
         }
     }
 
-    /// A tape with a chosen buy share, in per-mille.
+    /// A tape with a chosen buy share, in per-mille, drawn from stream `seed`.
     ///
     /// It has to be a genuine walk rather than an evenly spread alternation:
     /// alternating sides pin `|theta|` at one and would test nothing but the
     /// hard cap. Real balanced flow wanders, and the wandering is exactly
     /// what the threshold is calibrated against.
-    fn tape(len: usize, buy_per_mille: u64) -> Vec<Side> {
-        let mut lcg = Lcg::new();
+    fn tape_seeded(len: usize, buy_per_mille: u64, seed: u64) -> Vec<Side> {
+        let mut lcg = Lcg::new(seed);
         (0..len)
             .map(|_| {
                 if lcg.next() % 1000 < buy_per_mille {
@@ -533,12 +559,23 @@ mod tests {
             .collect()
     }
 
-    /// Mean trades per closed bar over `sides`, in the trades unit.
+    /// The default tape stream.
+    fn tape(len: usize, buy_per_mille: u64) -> Vec<Side> {
+        tape_seeded(len, buy_per_mille, 0)
+    }
+
+    /// Mean trades per *closed* bar over `sides`, in the trades unit.
+    ///
+    /// Deliberately not `sides.len() / bars.len()`: the trades still sitting
+    /// in the unclosed partial bar belong to no closed bar, and charging them
+    /// to the closed population inflates exactly the ratio these tests
+    /// certify — by up to a whole bar's worth at large targets.
     fn mean_len(target: u64, sides: &[Side]) -> f64 {
         let mut builder = ImbalanceBarBuilder::new(target);
         let bars = run(&mut builder, sides);
         assert!(!bars.is_empty(), "target {target} closed no bar at all");
-        sides.len() as f64 / bars.len() as f64
+        let closed: u64 = bars.iter().map(|b| b.trade_count).sum();
+        closed as f64 / bars.len() as f64
     }
 
     /// The promise the knob makes, and the one it did not keep: in balanced
@@ -590,15 +627,20 @@ mod tests {
     #[test]
     fn the_bar_length_does_not_depend_on_the_regime_before_it() {
         let target = 2000;
+        // The measurement window is stream 1 and the balanced lead is stream
+        // 2, so the two arms differ only in the regime that came before —
+        // drawing both from one stream would make the lead a byte-identical
+        // prefix of the window and compare nothing.
         let measure = |lead: &[Side]| {
             let mut builder = ImbalanceBarBuilder::new(target);
             let _ = run(&mut builder, lead);
-            let steady = tape(200_000, 500);
+            let steady = tape_seeded(200_000, 500, 1);
             let bars = run(&mut builder, &steady);
-            steady.len() as f64 / bars.len() as f64
+            let closed: u64 = bars.iter().map(|b| b.trade_count).sum();
+            closed as f64 / bars.len() as f64
         };
         let after_burst = measure(&vec![Side::Buy; 40_000]);
-        let after_balance = measure(&tape(40_000, 500));
+        let after_balance = measure(&tape_seeded(40_000, 500, 2));
         let ratio = after_burst / after_balance;
         assert!(
             (0.6..=1.6).contains(&ratio),
@@ -636,6 +678,14 @@ mod tests {
     /// below 1 for every target under 80 — so the whole band the toolbar
     /// offers below 80 collapsed into a cascade of one- and two-trade bars.
     /// `2` is the toolbar's own minimum, so the range starts there.
+    ///
+    /// A mean-length band alone cannot see this: at `target = 2` a literal
+    /// 100%-one-trade cascade scores a ratio of 0.5, which any sane band
+    /// accepts. The one-trade *fraction* is the property the name claims, so
+    /// it is asserted directly. It is zero from `target = 4` up, where
+    /// `round(sqrt(target)) >= 2` puts the floor out of a single print's
+    /// reach; at 2 and 3 the floor is 1 and 2, so short bars are the target
+    /// rather than a collapse, and the bound is loosened to say so.
     #[test]
     fn small_targets_are_not_a_one_trade_cascade() {
         for target in [2_u64, 3, 4, 8, 10, 50, 79] {
@@ -645,6 +695,16 @@ mod tests {
             assert!(
                 (0.5..=2.0).contains(&ratio),
                 "target {target}: mean bar length {mean:.1} is {ratio:.2}x the target"
+            );
+
+            let mut builder = ImbalanceBarBuilder::new(target);
+            let bars = run(&mut builder, &sides);
+            let ones = bars.iter().filter(|b| b.trade_count == 1).count();
+            let limit = if target < 4 { bars.len() / 2 } else { 0 };
+            assert!(
+                ones <= limit,
+                "target {target}: {ones} of {} bars ran a single trade (limit {limit})",
+                bars.len()
             );
         }
     }
@@ -681,8 +741,16 @@ mod tests {
     /// A weighted tape: sizes wander over an order of magnitude, the way a
     /// real one does, so the floor cannot be calibrated against a constant
     /// lot size it never sees.
+    ///
+    /// The **price** wanders too, and that is not decoration. The closing
+    /// rule is scale-invariant in the weight (see
+    /// `volume_unit_is_scale_invariant_in_quantity`), so at a constant price
+    /// `DollarMeasure` is just `VolumeMeasure` times a constant and the two
+    /// weighted units produce bit-identical bars — a Dollar arm over a
+    /// constant-price tape re-tests Volume and would not notice price being
+    /// wired out of the weight entirely.
     fn weighted_tape(len: usize, buy_per_mille: u64) -> Vec<Trade> {
-        let mut lcg = Lcg::new();
+        let mut lcg = Lcg::new(3);
         (0..len)
             .map(|i| {
                 let side = if lcg.next() % 1000 < buy_per_mille {
@@ -691,15 +759,38 @@ mod tests {
                     Side::Sell
                 };
                 let qty = Decimal::from(1 + lcg.next() % 20);
+                let price = Decimal::from(100 + lcg.next() % 400);
                 Trade {
                     agg_id: i as u64,
                     timestamp_ms: 1000 + i as i64 * 100,
-                    price: Decimal::from_str("100.0").unwrap(),
+                    price,
                     quantity: qty,
                     side,
                 }
             })
             .collect()
+    }
+
+    /// The guard the test above needs: over `weighted_tape`, Volume and
+    /// Dollar must actually disagree. If they ever coincide again — a
+    /// constant price sneaking back in — every Dollar assertion in this
+    /// module silently becomes a second Volume assertion.
+    #[test]
+    fn the_weighted_tape_separates_volume_from_dollar() {
+        let trades = weighted_tape(20_000, 500);
+        let cut = |unit| {
+            let mut b = ImbalanceBarBuilder::with_unit(200, unit);
+            trades
+                .iter()
+                .filter_map(|t| b.push(t))
+                .map(|bar| bar.trade_count)
+                .collect::<Vec<_>>()
+        };
+        assert_ne!(
+            cut(ImbalanceUnit::Volume),
+            cut(ImbalanceUnit::Dollar),
+            "price varies, so notional weighting must cut the tape differently"
+        );
     }
 
     /// The target means trades per bar in *every* unit — the module doc has
@@ -992,8 +1083,9 @@ mod tests {
         assert_eq!(bars[0].trade_count, 4);
 
         // Cap: strictly alternating constant-size flow keeps |θ| ≤ one weight
-        // while the floor holds the threshold at E[T]·0.05·1000 ≥ 4000, so
-        // only the 3x-target trade cap can close the bar.
+        // (1000) while the floor holds the threshold at
+        // round(sqrt(80))·E[w] = 9·1000 = 9000, so only the 3x-target trade
+        // cap can close the bar.
         let mut b = ImbalanceBarBuilder::with_unit(80, ImbalanceUnit::Volume);
         let mut bars = Vec::new();
         for i in 0..320 {
@@ -1009,7 +1101,7 @@ mod tests {
 
     /// The closing rule is scale-free in the weight: the same side sequence at
     /// nine times the size closes bars at exactly the same trades. θ, E[s] and
-    /// the floor (a fraction of the typical weight) all scale together — a
+    /// the floor (a multiple of the typical weight) all scale together — a
     /// floor left in per-trade units would break this.
     #[test]
     fn volume_unit_is_scale_invariant_in_quantity() {
@@ -1038,10 +1130,11 @@ mod tests {
 
     /// The feed-arithmetic policy holds in the weighted units: adversarial
     /// prints whose notional saturates `Decimal` must never panic the
-    /// builder. `E[s]` rides toward `Decimal::MAX` while bar closes drag
-    /// `E[T]` upward — a plain `*` in the threshold overflows within a few
-    /// prints; the saturating threshold instead means "no imbalance close"
-    /// and the trade cap keeps bounding every bar.
+    /// builder. `E[s]` rides toward `Decimal::MAX` on the prints alone —
+    /// `E[T]` is a construction-time constant now and contributes nothing to
+    /// the growth — and a plain `*` against it overflows within a few prints.
+    /// The saturating threshold instead means "no imbalance close", and the
+    /// trade cap keeps bounding every bar.
     #[test]
     fn adversarial_notional_never_panics_and_bars_stay_capped() {
         let mut b = ImbalanceBarBuilder::with_unit(100, ImbalanceUnit::Dollar);

--- a/crates/engine/tests/fixtures/imbalance_t8_expected.csv
+++ b/crates/engine/tests/fixtures/imbalance_t8_expected.csv
@@ -2,16 +2,18 @@
 # bar[0]: warm-up, closes at exactly the 8-trade target.
 # bar[1]: sell regime the threshold has adapted to — full-length bar.
 # bar[2]: contrary 2-buy burst beats the adapted threshold — early close.
-# bar[3..]: choppy two-way flow right after a regime flip: expectations are
-# stale, thresholds are small, and the rule samples every trade until the
-# EWMAs re-converge. Recorded as-is — this is the algorithm's real dynamic.
+#
+# And then nothing. The choppy two-way flow that follows carries no
+# information, so it closes no bar — it waits in the forming one.
+#
+# It used to close six, one per trade, and this file recorded them as "the
+# algorithm's real dynamic". They were not: they were the degeneracy the
+# module doc promises to prevent. The threshold floor was a constant 0.05
+# multiplied by an E[T] that had run to its lower clamp (target/4 = 2), a
+# product of 0.1 that any single trade cleared. The floor is now
+# sqrt(target) = 2 — the imbalance a balanced walk actually reaches in
+# target trades — so a bar closes on imbalance or it does not close.
 open_time,close_time,open,high,low,close,buy_volume,sell_volume,trade_count
 1700000000000,1700000001750,36010.00,36010.00,36000.00,36000.00,0,2.25,8
 1700000002000,1700000003750,35998.00,35998.00,35986.50,35986.50,0,5.40,8
 1700000004000,1700000004250,35990.00,35994.50,35990.00,35994.50,2.20,0,2
-1700000004500,1700000004500,35997.00,35997.00,35997.00,35997.00,0.30,0,1
-1700000004750,1700000004750,35995.50,35995.50,35995.50,35995.50,0,0.20,1
-1700000005000,1700000005000,35998.50,35998.50,35998.50,35998.50,0.45,0,1
-1700000005250,1700000005250,35996.00,35996.00,35996.00,35996.00,0,0.35,1
-1700000005500,1700000005500,36000.00,36000.00,36000.00,36000.00,0.55,0,1
-1700000005750,1700000005750,36002.50,36002.50,36002.50,36002.50,0.60,0,1

--- a/crates/engine/tests/fixtures/imbalance_t8_expected.csv
+++ b/crates/engine/tests/fixtures/imbalance_t8_expected.csv
@@ -1,7 +1,7 @@
 # Expected imbalance bars for imbalance_trades.csv with target_trades = 8.
 # bar[0]: warm-up, closes at exactly the 8-trade target.
 # bar[1]: sell regime the threshold has adapted to — full-length bar.
-# bar[2]: contrary 2-buy burst beats the adapted threshold — early close.
+# bar[2]: contrary 3-buy burst beats the adapted threshold — early close.
 #
 # And then nothing. The choppy two-way flow that follows carries no
 # information, so it closes no bar — it waits in the forming one.
@@ -11,9 +11,9 @@
 # module doc promises to prevent. The threshold floor was a constant 0.05
 # multiplied by an E[T] that had run to its lower clamp (target/4 = 2), a
 # product of 0.1 that any single trade cleared. The floor is now
-# sqrt(target) = 2 — the imbalance a balanced walk actually reaches in
-# target trades — so a bar closes on imbalance or it does not close.
+# round(sqrt(target)) = 3 — the imbalance a balanced walk actually reaches
+# in target trades — so a bar closes on imbalance or it does not close.
 open_time,close_time,open,high,low,close,buy_volume,sell_volume,trade_count
 1700000000000,1700000001750,36010.00,36010.00,36000.00,36000.00,0,2.25,8
 1700000002000,1700000003750,35998.00,35998.00,35986.50,35986.50,0,5.40,8
-1700000004000,1700000004250,35990.00,35994.50,35990.00,35994.50,2.20,0,2
+1700000004000,1700000004500,35990.00,35997.00,35990.00,35997.00,2.50,0,3

--- a/crates/engine/tests/golden_imbalance.rs
+++ b/crates/engine/tests/golden_imbalance.rs
@@ -21,8 +21,15 @@ fn bar_lengths_tell_the_information_story() {
     // bar runs a full expected length too.
     assert_eq!(bars[1].trade_count, 8);
     // Contrary buy burst — information the expectations did not predict —
-    // closes the third bar after only 2 trades: sampling accelerates exactly
-    // when new information arrives.
-    assert_eq!(bars[2].trade_count, 2);
+    // closes the third bar after only 3 trades: sampling accelerates exactly
+    // when new information arrives. Three and not two because the threshold
+    // floor is `round(sqrt(8))` = 3 typical trades rather than the old
+    // `E[T] * 0.05`, which had collapsed to 0.1 and would have closed a bar
+    // on any single print at all.
+    assert_eq!(bars[2].trade_count, 3);
     assert!(bars[2].delta() > rust_decimal::Decimal::ZERO, "a buy bar");
+    // And the choppy two-way flow after it closes nothing: it carries no
+    // imbalance, so it waits in the forming bar instead of being sampled one
+    // print at a time. That cascade is what the old floor produced here.
+    assert_eq!(bars.len(), 3, "no bar closes on noise after the burst");
 }

--- a/crates/replay/examples/imbalance_audit.rs
+++ b/crates/replay/examples/imbalance_audit.rs
@@ -45,6 +45,21 @@ fn percentile(sorted: &[u64], p: f64) -> u64 {
 ///
 /// Trades before the first price move have no side to infer; the live mapper
 /// drops them, so this drops them too rather than inventing one.
+///
+/// **A deliberate second copy, and the reason it is one.** `feed-mt5`'s
+/// `map::tick_rule` calls itself "the one place the rule lives", and it is
+/// right to: this example cannot call it, because `replay` depending on
+/// `feed-mt5` would be a reverse edge (feeds are producers, and no domain
+/// crate links one). The rule is pure, deterministic and clock-free, so it
+/// belongs in `engine` with both callers delegating — a port extraction worth
+/// its own change, not a drive-by here.
+///
+/// Until then, the divergence to know about: the live mapper rejects bad
+/// prices, zero volumes and missing quotes *before* recording `prev_price`,
+/// so a rejected tick does not move the reference. This copy advances
+/// `prev_price` on every row, which is exact for a parsed recording — every
+/// row already survived `parse_file`'s validation — and would not be for a
+/// raw tick stream.
 fn relabel_tick_rule(trades: Vec<Trade>) -> Vec<Trade> {
     let mut prev_price = None;
     let mut prev_side = None;
@@ -85,6 +100,16 @@ fn main() {
     let rest: Vec<String> = args.collect();
     let tick_rule = rest.iter().any(|a| a == "--tick-rule");
     let hourly = rest.iter().any(|a| a == "--hourly");
+    // Reject unknown flags rather than ignoring them. A silently swallowed
+    // `--tickrule` would print a full, confident report built on the
+    // recording's venue sides — a different tape from the live one — and this
+    // is the tool a trader picks a live target with.
+    if let Some(bad) = rest
+        .iter()
+        .find(|a| a.starts_with("--") && a != &"--tick-rule" && a != &"--hourly")
+    {
+        panic!("unknown flag {bad}; expected --tick-rule or --hourly");
+    }
     let mut targets: Vec<(ImbalanceUnit, u64)> = rest
         .iter()
         .filter(|a| !a.starts_with("--"))
@@ -158,6 +183,9 @@ fn main() {
         runs.last().unwrap(),
     );
 
+    // Depends on the header alone, so it is read once rather than per target.
+    let tz_ms = parsed.header.timezone.millis();
+
     for (unit, target) in &targets {
         let (unit, target) = (*unit, *target);
         let mut b = ImbalanceBarBuilder::with_unit(target, unit);
@@ -167,10 +195,11 @@ fn main() {
         let mut cap_closes = 0usize;
         // Per clock hour, in the recording's own timezone: (bars, trades in
         // them, bars that hit the cap). A `BTreeMap` so the report comes out
-        // in session order whatever the tape did.
+        // in session order whatever the tape did. Only filled when `--hourly`
+        // asks for it — otherwise the whole map is built and thrown away once
+        // per target over a session of hundreds of thousands of rows.
         let mut by_hour: std::collections::BTreeMap<i64, (u64, u64, u64)> =
             std::collections::BTreeMap::new();
-        let tz_ms = parsed.header.timezone.millis();
         for t in &trades {
             if let Some(bar) = b.push(t) {
                 counts.push(bar.trade_count);
@@ -182,13 +211,22 @@ fn main() {
                     if bar.trade_count >= cap {
                         cap_closes += 1;
                     }
-                    let hour = (bar.close_time + tz_ms)
-                        .div_euclid(3_600_000)
-                        .rem_euclid(24);
-                    let slot = by_hour.entry(hour).or_insert((0, 0, 0));
-                    slot.0 += 1;
-                    slot.1 += bar.trade_count;
-                    slot.2 += u64::from(bar.trade_count >= cap);
+                    if hourly {
+                        // Saturating like every other timestamp path in the
+                        // crate: `parse_file` builds `timestamp_ms` with
+                        // saturating arithmetic, so an absurd `Date` column
+                        // can reach `i64::MAX` and a plain `+` on an
+                        // east-of-UTC offset would panic a debug build.
+                        let hour = bar
+                            .close_time
+                            .saturating_add(tz_ms)
+                            .div_euclid(3_600_000)
+                            .rem_euclid(24);
+                        let slot = by_hour.entry(hour).or_insert((0, 0, 0));
+                        slot.0 += 1;
+                        slot.1 += bar.trade_count;
+                        slot.2 += u64::from(bar.trade_count >= cap);
+                    }
                 }
             }
         }

--- a/crates/replay/examples/imbalance_audit.rs
+++ b/crates/replay/examples/imbalance_audit.rs
@@ -10,13 +10,24 @@
 //!
 //! Usage:
 //!   cargo run -p quantick-replay --release --example imbalance_audit -- \
-//!     <session.csv> [[unit:]target ...]
+//!     <session.csv> [--tick-rule] [--hourly] [[unit:]target ...]
 //!
 //! `unit` is the spec token (`trades`, `volume`, `dollar`), defaulting to
 //! `trades`; bare targets default to `2000 5000`. `volume:2000` audits the
 //! same target in volume imbalance bars.
+//!
+//! `--tick-rule` re-derives every aggressor side from the recorded prices the
+//! way [`SideMode::TickRule`] does live, instead of trusting the sides in the
+//! file. A recording made from venue flags and the same symbol traded live
+//! under the tick rule are two different tapes, and the bar rule reads the
+//! side stream — so auditing a target for a live MT5 chart has to audit the
+//! side policy that chart actually runs.
+//!
+//! `--hourly` breaks the same statistics down by session hour. A trader does
+//! not see a whole day at once; a rule that averages out over a session can
+//! still be unusable inside the window on screen.
 
-use quantick_engine::{BarBuilder, ImbalanceBarBuilder, ImbalanceUnit, Side};
+use quantick_engine::{BarBuilder, ImbalanceBarBuilder, ImbalanceUnit, Side, Trade};
 use quantick_replay::ParseOptions;
 use quantick_replay::format::parse_file;
 
@@ -26,6 +37,33 @@ fn percentile(sorted: &[u64], p: f64) -> u64 {
     }
     let idx = ((sorted.len() - 1) as f64 * p).round() as usize;
     sorted[idx]
+}
+
+/// Re-label every trade's side with López de Prado's tick rule — uptick buy,
+/// downtick sell, unchanged carries the previous side — the policy
+/// `feed-mt5`'s `SideMode::TickRule` runs live and the MT5 default.
+///
+/// Trades before the first price move have no side to infer; the live mapper
+/// drops them, so this drops them too rather than inventing one.
+fn relabel_tick_rule(trades: Vec<Trade>) -> Vec<Trade> {
+    let mut prev_price = None;
+    let mut prev_side = None;
+    let mut out = Vec::with_capacity(trades.len());
+    for mut t in trades {
+        let side = match prev_price {
+            Some(prev) if t.price > prev => Some(Side::Buy),
+            Some(prev) if t.price < prev => Some(Side::Sell),
+            Some(_) => prev_side,
+            None => None,
+        };
+        prev_price = Some(t.price);
+        prev_side = side;
+        if let Some(side) = side {
+            t.side = side;
+            out.push(t);
+        }
+    }
+    out
 }
 
 fn parse_target(arg: &str) -> (ImbalanceUnit, u64) {
@@ -41,23 +79,46 @@ fn parse_target(arg: &str) -> (ImbalanceUnit, u64) {
 
 fn main() {
     let mut args = std::env::args().skip(1);
-    let path = args
-        .next()
-        .expect("usage: imbalance_audit <session.csv> [[unit:]target ...]");
-    let mut targets: Vec<(ImbalanceUnit, u64)> = args.map(|a| parse_target(&a)).collect();
+    let path = args.next().expect(
+        "usage: imbalance_audit <session.csv> [--tick-rule] [--hourly] [[unit:]target ...]",
+    );
+    let rest: Vec<String> = args.collect();
+    let tick_rule = rest.iter().any(|a| a == "--tick-rule");
+    let hourly = rest.iter().any(|a| a == "--hourly");
+    let mut targets: Vec<(ImbalanceUnit, u64)> = rest
+        .iter()
+        .filter(|a| !a.starts_with("--"))
+        .map(|a| parse_target(a))
+        .collect();
     if targets.is_empty() {
         targets = vec![(ImbalanceUnit::Trades, 2000), (ImbalanceUnit::Trades, 5000)];
     }
 
     let text = std::fs::read_to_string(&path).expect("read session file");
     let parsed = parse_file(&text, ParseOptions::default()).expect("parse session");
-    let trades = parsed.trades;
+    let recorded_source = parsed
+        .header
+        .side_source
+        .as_deref()
+        .unwrap_or("?")
+        .to_owned();
+    let recorded_len = parsed.trades.len();
+    let trades = if tick_rule {
+        relabel_tick_rule(parsed.trades)
+    } else {
+        parsed.trades
+    };
     let n = trades.len();
     println!("== session {path}");
-    println!(
-        "side_source={}  trades={n}",
-        parsed.header.side_source.as_deref().unwrap_or("?")
-    );
+    if tick_rule {
+        println!(
+            "side_source={recorded_source} -> tick_rule (re-derived)  trades={n} \
+             (of {recorded_len}; {} dropped before the first price move)",
+            recorded_len - n
+        );
+    } else {
+        println!("side_source={recorded_source}  trades={n}");
+    }
     if n == 0 {
         return;
     }
@@ -104,6 +165,12 @@ fn main() {
         let mut counts: Vec<u64> = Vec::new();
         let mut durs_ms: Vec<u64> = Vec::new();
         let mut cap_closes = 0usize;
+        // Per clock hour, in the recording's own timezone: (bars, trades in
+        // them, bars that hit the cap). A `BTreeMap` so the report comes out
+        // in session order whatever the tape did.
+        let mut by_hour: std::collections::BTreeMap<i64, (u64, u64, u64)> =
+            std::collections::BTreeMap::new();
+        let tz_ms = parsed.header.timezone.millis();
         for t in &trades {
             if let Some(bar) = b.push(t) {
                 counts.push(bar.trade_count);
@@ -115,6 +182,13 @@ fn main() {
                     if bar.trade_count >= cap {
                         cap_closes += 1;
                     }
+                    let hour = (bar.close_time + tz_ms)
+                        .div_euclid(3_600_000)
+                        .rem_euclid(24);
+                    let slot = by_hour.entry(hour).or_insert((0, 0, 0));
+                    slot.0 += 1;
+                    slot.1 += bar.trade_count;
+                    slot.2 += u64::from(bar.trade_count >= cap);
                 }
             }
         }
@@ -164,5 +238,17 @@ fn main() {
             percentile(&durs_ms, 0.90) as f64 / 1000.0,
             durs_ms.last().copied().unwrap_or(0) as f64 / 1000.0,
         );
+        if hourly {
+            // What the trader actually sees: one hour on screen, not a day
+            // averaged. A target whose bar length swings between hours is a
+            // different chart every hour at the same setting.
+            for (hour, (bars, trades_in, capped)) in &by_hour {
+                println!(
+                    "   h{hour:02}: bars={bars:<5} trades/bar={:<7.0} cap_closes={capped} ({:.0}%)",
+                    *trades_in as f64 / *bars as f64,
+                    100.0 * *capped as f64 / *bars as f64,
+                );
+            }
+        }
     }
 }


### PR DESCRIPTION
A trader set the imbalance target to 1500, then to 2000, and got two charts
too different to be the same instrument. He was right, and the parameter was
broken.

## What was wrong

The threshold is linear in `E[T]`, and `E[T]` was an EWMA of the bar lengths
that same threshold produced — a loop with no damping. For a driftless tape a
bar of length `n` needs `threshold ~ sqrt(n)`, so self-consistency sat at
`E[T] = 1 / FLOOR_B^2` = 400: a **repelling** fixed point that does not depend
on `target_trades` at all. Whatever the trader asked for, `E[T]` ran away from
it to one clamp and stayed. The clamps did not prevent the degeneracy the
guards were written for — they decided which one you got.

## Measured on the trader's own session

`WINV26/2026-08-13`, 1,476,471 prints, sides re-derived with the **tick rule**
because that is what `feed-mt5` runs live (`Mt5SideSource::TickRule` is the
default; the recording itself carries venue flags).

Trades per bar, same tape, before → after:

| target | before | after |
| ---: | ---: | ---: |
| 1500 | 626 | 973 |
| 1600 | **284** | 1026 |
| 1700 | 749 | 1098 |
| 1800 | 764 | 1120 |
| 1900 | 1132 | 1190 |
| 2000 | 841 | 1254 |

A 100-trade nudge (1500 → 1600) halved the bar and the next one tripled it
back. After the fix the same sweep is monotone and smooth.

Inside a single day at target 1500:

| | before | after |
| --- | ---: | ---: |
| trades/bar, hour 12 | 3,720 | 955 |
| trades/bar, hour 14 | 226 | 1,015 |
| spread across the day | **14x** | **18%** |
| bars closing on the cap | 26-42% (morning) | **0%** |

On the sparser `2026-08-11`, 47% of bars closed on the cap at target 1500 and
55% at 2000 — an "imbalance" chart that was really a `3 * target` tick chart.
After: 0% in both.

## What changed

`E[T]` is now the configured target, fixed. The adaptivity that carries
information belongs to `E[s]`, which is where the reference rule puts it.

The floor then has to carry balanced flow alone, and a constant cannot: a walk
of length `n` reaches `|theta| ~ sqrt(n)` typical weights, so a fixed floor is
unreachable at large targets and trivial at small ones. At `sqrt(target)`
typical weights the expected first passage is `~target` trades at every
setting **and in every unit** — the weighted units scale the same floor by
`E[w]`, so `imbalance:volume:N` and `imbalance:dollar:N` keep the same promise.

The square root is rounded, not truncated: a bar's expected length is the floor
squared, so truncation squares the error back up. At `target = 3` a truncated
root floors at 1 — a bar closing on the trade after the one that opened it,
inside the range the toolbar offers (minimum 2).

The tooltip described `E[T]` as "the seed of the adaptive threshold", which
stopped being true; it now states the expectation the engine actually keeps.

## Performance

Per-trade hot path, 5M trades, against `main` as control:

| builder | main | this branch |
| --- | ---: | ---: |
| imbalance(100) | 531.8 ns/trade | **442.0** |
| imb-vol(100) | 1297.1 | **968.0** |
| imb-dlr(100) | 1585.2 | **1275.5** |

Every other builder unchanged (tick 59.4, volume 65.3, dollar 78.8/79.1,
time 56.7). The rule does strictly less work per trade: one fewer `Decimal`
multiplication in the threshold, and the `E[T]` EWMA is gone from bar close.

## Proof

Written test-first — four of these failed on the old rule before a line of it
changed:

- `a_bar_is_about_the_target_long_in_balanced_flow` — was 0.09x the target
- `weighted_units_also_target_the_configured_trade_count` — was 0.05x
- `small_targets_are_not_a_one_trade_cascade` — was 0.28x at target 4
- `the_hard_cap_is_not_how_bars_normally_close` — was 18 of 21 bars
- `a_larger_target_makes_longer_bars`, `the_bar_length_does_not_depend_on_the_regime_before_it` — regression cover
- `the_floor_rounds_the_square_root_instead_of_truncating_it` — pins the
  just-below-a-square cases and `u64::MAX`

The golden fixture recorded six one-trade bars as "the algorithm's real
dynamic". They were the degeneracy the module doc promised to prevent;
regenerated, with the reason written into the fixture header, and the golden
test now also asserts that the choppy flow after the burst closes no bar.

## Tooling

`crates/replay/examples/imbalance_audit.rs` grew `--tick-rule` and `--hourly`,
without which none of the numbers above are measurable: a recording carries
venue-flag sides while the live MT5 chart runs the tick rule, and a rule that
averages out over a session can still be unusable in the hour on screen.

## What the dial actually delivers

Stated in the module doc rather than promised away. The floor is a *lower
bound* on the threshold, not the threshold: in perfectly balanced flow
`E[T] * |E[s]|` is itself of order `sqrt(target)`, so both branches of the
`max` are the same size and the winner sits above either. Over a fixed-seed
balanced tape the bar lands at **1.3-1.7x the target**, flat across the range
(100 → 1.37x, 1500 → 1.44x, 5000 → 1.34x). A real tape carries direction,
which closes bars early instead: **0.6-0.65x** on the recorded WIN session.

Deliberately *not* recalibrated with a fudge factor — the two regimes pull in
opposite directions, and a divisor tuned to a synthetic tape would make the
real one worse. The parameter is a calibrated dial with a stable, monotone
response, and the doc now says exactly that instead of claiming an exact count.

## arch-review

**step 0: `code-review` at `high`, 15 findings, 15 confirmed — 14 fixed in
`b8f0107`, 1 deferred.**

The applied ones fall in three groups: doc claims the rule does not keep (the
floor at the bottom of the toolbar's range, the 1.4x bias above, a stale
"kept bit-for-bit so existing charts never move", three sites still reading
`sqrt` after `c106b9da` made it `round(sqrt)`), four tests weaker than their
names (a cascade test blind to a full cascade at target 2; a `mean_len` that
charged the unclosed partial bar to the closed population; a regime test whose
lead was a byte-identical prefix of its own measurement window; a
constant-price `weighted_tape` that made the Dollar arm re-test Volume), and
four small ones (the cap rule duplicated next to its own accessor, an audit
flag typo silently ignored, an unchecked `i64` add in a saturating crate, an
hourly histogram built when `--hourly` is off).

**Deferred — `relabel_tick_rule` duplicates `feed-mt5`'s `map::tick_rule`**,
which documents itself as "the one place the rule lives". This example cannot
call it: `replay` depending on `feed-mt5` would be a reverse dependency edge.
The right fix is lifting the pure, clock-free rule into `engine` with both
callers delegating — a port extraction touching three crates, which deserves
its own change rather than riding along in a bar-rule fix. The copy and the
one way it diverges from the live mapper are documented at the function.

## Behaviour change, stated plainly

Every imbalance chart moves. That is the point — the old lengths were an
artefact of which clamp `E[T]` had parked on, not a setting anyone chose. A
trader who had tuned around the old behaviour will need to re-pick a target,
and the number now means what the tooltip says.
