### PR TITLE
feat(strategy): retest-limit entry on region cuts + replay no-fire fixes

### DIFF
--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -5330,10 +5330,18 @@ impl QuantickApp {
             self.request_delete_selected(now);
         }
         if keys.undo {
-            self.drawing_pane_mut().drawings.undo();
+            let pane = self.drawing_pane_mut();
+            pane.drawings.undo();
+            // Undoing a rectangle's placement takes its drawing away from
+            // any armed instance without passing through the removal
+            // funnel; the sweep keeps a resting bot order from outliving
+            // its badge (redo below, and delete-all, share the risk).
+            pane.sweep_strategy_orphans();
         }
         if keys.redo {
-            self.drawing_pane_mut().drawings.redo();
+            let pane = self.drawing_pane_mut();
+            pane.drawings.redo();
+            pane.sweep_strategy_orphans();
         }
         if keys.lock
             && let Some(index) = self.drawing_pane().drawings.selected()
@@ -5445,7 +5453,11 @@ impl QuantickApp {
             self.toast_undo_rect = undo_rect;
         }
         if undo_clicked {
-            self.drawing_pane_mut().drawings.undo();
+            let pane = self.drawing_pane_mut();
+            pane.drawings.undo();
+            // Same orphan risk as the keyboard undo: the drawing an armed
+            // instance rides may just have been taken away.
+            pane.sweep_strategy_orphans();
             self.toast = None;
         }
     }
@@ -6609,7 +6621,11 @@ impl QuantickApp {
         });
         self.drawing_manager_open = open;
         if delete_all {
-            let deleted = self.drawing_pane_mut().drawings.delete_all();
+            let pane = self.drawing_pane_mut();
+            let deleted = pane.drawings.delete_all();
+            // Every armed instance just lost its drawing at once; sweep
+            // them now so no resting bot order outlives its badge.
+            pane.sweep_strategy_orphans();
             if deleted > 0 {
                 self.toast = Some(Toast {
                     message: "All drawings deleted.".into(),
@@ -7135,7 +7151,7 @@ impl QuantickApp {
             );
         };
         let tab = self.active_tab_mut();
-        {
+        let replaced_cleanup = {
             let pane = tab.pane_mut(side);
             // Re-validate everything the menu's gate promised: this is also
             // the seam a future programmatic caller (the NL layer) comes
@@ -7162,30 +7178,19 @@ impl QuantickApp {
             if target.hidden || pane.drawings.all_hidden() {
                 return Err("unhide the drawing first — an armed region stays visible".to_owned());
             }
-            // A region whose drawn span already ended can never fire again:
-            // every future bar closes past its right anchor, and the badge
-            // would show "armed" over a bot that is structurally done — the
-            // silent halt the named disarms exist to prevent. Refused with
-            // the fix in hand. An extended rectangle never expires right.
-            let extends_right = target
-                .payload
-                .as_any()
-                .downcast_ref::<drawings::RectanglePayload>()
-                .is_some_and(|payload| payload.extend_right);
-            if !extends_right
-                && let [a, b] = target.points.as_slice()
-                && pane.closed_slots() > 0
-            {
-                #[allow(clippy::cast_precision_loss)]
-                let newest = (pane.closed_slots() - 1) as f32;
-                if a.bar.max(b.bar) < newest {
-                    return Err(
-                        "the region ends before the newest bar, so nothing can ever fire — \
-                         stretch it past the right edge, or turn on \"extend right\" in its \
-                         Region settings"
-                            .to_owned(),
-                    );
-                }
+            // A region whose drawn span can no longer cover a future bar
+            // can never fire: the badge would show "armed" over a bot that
+            // is structurally done — the silent halt the named disarms
+            // exist to prevent. One predicate, shared with re-arm and the
+            // evaluation sweep (`Pane::strategy_region_can_fire`), refuses
+            // it with the fix in hand.
+            if !pane.strategy_region_can_fire(drawing) {
+                return Err(
+                    "the region ends before the next bar, so nothing can ever fire — \
+                     stretch it past the right edge, or turn on \"extend right\" in its \
+                     Region settings"
+                        .to_owned(),
+                );
             }
             let mut armed = quantick_strategy::ArmedStrategy::new(
                 params,
@@ -7197,19 +7202,18 @@ impl QuantickApp {
             // declares its own depth (`warmup_bars`), and the pane keeps
             // venue-prefix candles out: they measure another ruler
             // entirely (a 1-minute body dwarfs a tick-bar body).
-            let warmup = quantick_strategy::Region::new(
-                rust_decimal::Decimal::ZERO,
-                rust_decimal::Decimal::ZERO,
-            );
-            for bar in pane.strategy_warmup_bars(armed.trigger().warmup_bars()) {
-                let _ = armed.on_closed_bar(&bar, &warmup, false, false);
-            }
+            armed.warm(&pane.strategy_warmup_bars(armed.trigger().warmup_bars()));
             pane.strategies
                 .arm(crate::strategy_anchors::AnchoredInstance {
                     drawing,
                     preset: preset_label,
                     armed,
-                });
+                })
+        };
+        for command in replaced_cleanup {
+            // Arming over an instance with a pending entry sweeps that
+            // entry — a resting order must never outlive its bot.
+            let _ = tab.paper.apply_strategy_command(command);
         }
         tab.paper.set_bot_listening(true);
         Ok(())
@@ -8035,8 +8039,13 @@ impl QuantickApp {
         self.draw_strategy_popup(ctx);
         // The menus above may have disarmed a bot over a resting retest
         // limit; its cancel goes to the simulator on this same frame, not
-        // on the next print.
-        self.active_tab_mut().apply_strategy_cleanup();
+        // on the next print. Every tab, not just the active one: a menu
+        // click and a tab switch can land on the same frame, and the old
+        // tab's feed keeps running — its cancel must not sit stranded
+        // until the tab is looked at again.
+        for tab in &mut self.tabs {
+            tab.apply_strategy_cleanup();
+        }
         self.draw_toast(ctx, now);
         // Both are window chrome reading the active tab, like the notice card
         // and the transport strip: they speak for one market at a time.
@@ -11178,13 +11187,38 @@ plot(close)
             crate::strategy_presets::StoredPreset::starting_point(quantick_engine::Side::Buy);
         let refused = app
             .arm_strategy_instance(pane::PaneSide::Flow, drawing, &form, "dead".to_owned())
-            .expect_err("a region ending before the newest bar cannot arm");
+            .expect_err("a region ending before the next bar cannot arm");
         assert!(
             refused.contains("extend right"),
             "the refusal hands over the fix: {refused}"
         );
 
-        // The same drawing with extend right on arms fine.
+        // The boundary the guard once let through: a right anchor exactly
+        // on the newest *closed* bar (slot 15 of 16) still cannot cover
+        // the next bar to close (slot 16) — refused, not armed dead.
+        {
+            let pane = &mut app.active_tab_mut().flow_pane;
+            pane.drawings
+                .place(rectangle, drawings::ChartPoint::at(0.0, 99.0));
+            pane.drawings
+                .place(rectangle, drawings::ChartPoint::at(15.0, 101.0));
+        }
+        let boundary = app.active_tab().flow_pane.drawings.items()[1].id;
+        app.arm_strategy_instance(pane::PaneSide::Flow, boundary, &form, "edge".to_owned())
+            .expect_err("a span ending on the newest closed bar covers no future bar");
+        // One anchored past the next slot arms fine without extend right.
+        {
+            let pane = &mut app.active_tab_mut().flow_pane;
+            pane.drawings
+                .place(rectangle, drawings::ChartPoint::at(0.0, 99.0));
+            pane.drawings
+                .place(rectangle, drawings::ChartPoint::at(16.0, 101.0));
+        }
+        let alive = app.active_tab().flow_pane.drawings.items()[2].id;
+        app.arm_strategy_instance(pane::PaneSide::Flow, alive, &form, "ok".to_owned())
+            .expect("a span covering the next slot arms");
+
+        // The same dead drawing with extend right on arms fine.
         {
             let pane = &mut app.active_tab_mut().flow_pane;
             let index = pane.drawings.index_of(drawing).expect("drawing lives");
@@ -11197,6 +11231,75 @@ plot(close)
         }
         app.arm_strategy_instance(pane::PaneSide::Flow, drawing, &form, "live".to_owned())
             .expect("extend right keeps the region alive, so arming is honest");
+    }
+
+    /// Delete-all (and by the same sweep, undo/redo) must not leave a
+    /// resting bot order behind when the drawings vanish outside the
+    /// per-drawing removal funnel.
+    #[test]
+    fn delete_all_sweeps_the_armed_instances_pending_entries() {
+        fn print(app: &mut QuantickApp, id: &mut u64, price: &str) {
+            *id += 1;
+            let trade = quantick_engine::Trade {
+                agg_id: *id,
+                timestamp_ms: 1_700_000_000_000 + *id as i64 * 100,
+                price: rust_decimal::Decimal::from_str_exact(price).unwrap(),
+                quantity: rust_decimal::Decimal::ONE,
+                side: quantick_engine::Side::Buy,
+            };
+            app.active_tab_mut()
+                .ingest_live_trade_at(&trade, trade.timestamp_ms);
+        }
+        fn bar(app: &mut QuantickApp, id: &mut u64, open: &str, close: &str) {
+            for _ in 0..49 {
+                print(app, id, open);
+            }
+            print(app, id, close);
+        }
+
+        let (mut app, _events, _commands, _book) = test_app();
+        let rectangle = drawings::DRAWING_TOOLS
+            .into_iter()
+            .find(|tool| tool.id() == "rectangle")
+            .expect("the rectangle tool is registered");
+        {
+            let pane = &mut app.active_tab_mut().flow_pane;
+            pane.drawings
+                .place(rectangle, drawings::ChartPoint::at(0.0, 105.0));
+            pane.drawings
+                .place(rectangle, drawings::ChartPoint::at(30.0, 115.0));
+        }
+        let drawing = app.active_tab().flow_pane.drawings.items()[0].id;
+        let mut form =
+            crate::strategy_presets::StoredPreset::starting_point(quantick_engine::Side::Sell);
+        form.window = 3;
+        form.min_body = "0".to_owned();
+        form.on_break = "retest_limit".to_owned();
+        app.arm_strategy_instance(pane::PaneSide::Flow, drawing, &form, "BF".to_owned())
+            .expect("the form compiles");
+        let mut id = 0u64;
+        bar(&mut app, &mut id, "110", "109");
+        bar(&mut app, &mut id, "109", "108");
+        bar(&mut app, &mut id, "108", "104");
+        assert_eq!(
+            app.active_tab().paper.working_orders().len(),
+            1,
+            "the retest limit rests"
+        );
+
+        // Delete every drawing the way the manager's button does, then run
+        // the same-frame sweep + drain the tab applies.
+        {
+            let pane = &mut app.active_tab_mut().flow_pane;
+            pane.drawings.delete_all();
+            pane.sweep_strategy_orphans();
+        }
+        app.active_tab_mut().apply_strategy_cleanup();
+        assert!(
+            app.active_tab().paper.working_orders().is_empty(),
+            "no resting bot order outlives its badge"
+        );
+        assert!(app.active_tab().flow_pane.strategies.is_empty());
     }
 
     /// The user's retest flow end to end in the app: a sell preset with the
@@ -11295,6 +11398,99 @@ plot(close)
             }
         );
         assert_eq!(instance.armed.status_line(), "target hit before retest");
+    }
+
+    /// The resting retest limit never trades against a hand: if the trader
+    /// opens a manual position while the order rests, the fill moment
+    /// stands the order down — the trader's position and bracket survive
+    /// untouched, and the badge says why the bot declined.
+    #[test]
+    fn a_resting_retest_limit_stands_down_over_a_manual_position() {
+        fn print(app: &mut QuantickApp, id: &mut u64, price: &str) {
+            *id += 1;
+            let trade = quantick_engine::Trade {
+                agg_id: *id,
+                timestamp_ms: 1_700_000_000_000 + *id as i64 * 100,
+                price: rust_decimal::Decimal::from_str_exact(price).unwrap(),
+                quantity: rust_decimal::Decimal::ONE,
+                side: quantick_engine::Side::Buy,
+            };
+            app.active_tab_mut()
+                .ingest_live_trade_at(&trade, trade.timestamp_ms);
+        }
+        fn bar(app: &mut QuantickApp, id: &mut u64, open: &str, close: &str) {
+            for _ in 0..49 {
+                print(app, id, open);
+            }
+            print(app, id, close);
+        }
+
+        let (mut app, _events, _commands, _book) = test_app();
+        let rectangle = drawings::DRAWING_TOOLS
+            .into_iter()
+            .find(|tool| tool.id() == "rectangle")
+            .expect("the rectangle tool is registered");
+        {
+            let pane = &mut app.active_tab_mut().flow_pane;
+            pane.drawings
+                .place(rectangle, drawings::ChartPoint::at(0.0, 105.0));
+            pane.drawings
+                .place(rectangle, drawings::ChartPoint::at(30.0, 115.0));
+        }
+        let drawing = app.active_tab().flow_pane.drawings.items()[0].id;
+        let mut form =
+            crate::strategy_presets::StoredPreset::starting_point(quantick_engine::Side::Sell);
+        form.window = 3;
+        form.min_body = "0".to_owned();
+        form.on_break = "retest_limit".to_owned();
+        app.arm_strategy_instance(pane::PaneSide::Flow, drawing, &form, "BF retest".to_owned())
+            .expect("the retest form compiles");
+
+        let mut id = 0u64;
+        bar(&mut app, &mut id, "110", "109");
+        bar(&mut app, &mut id, "109", "108");
+        bar(&mut app, &mut id, "108", "104");
+        assert_eq!(app.active_tab().paper.working_orders().len(), 1);
+
+        // The trader buys at market while the bot's limit rests.
+        app.active_tab_mut().paper.apply_sim_command_for_tests(
+            quantick_sim::Command::PlaceMarket {
+                side: quantick_engine::Side::Buy,
+                quantity: Decimal::ONE,
+                bracket: quantick_sim::Bracket::none(),
+            },
+        );
+        print(&mut app, &mut id, "104");
+        assert!(
+            app.active_tab().paper.position_summary().is_some(),
+            "the manual long filled"
+        );
+
+        // The tape returns to the edge: the bot's fill moment finds the
+        // account occupied and stands down instead of netting the trader's
+        // long closed.
+        print(&mut app, &mut id, "105");
+        let tab = app.active_tab();
+        assert!(
+            tab.paper.working_orders().is_empty(),
+            "the bot's order stood down"
+        );
+        assert!(
+            tab.paper.position_summary().is_some(),
+            "the trader's long survives untouched"
+        );
+        let instance = tab
+            .flow_pane
+            .strategies
+            .for_drawing(drawing)
+            .expect("instance");
+        assert_eq!(
+            instance.armed.state(),
+            &quantick_strategy::ArmedState::Disarmed {
+                reason: quantick_strategy::DisarmReason::AccountOccupied
+            }
+        );
+        assert_eq!(instance.armed.status_line(), "stood down — account busy");
     }
 
     /// Two instances co-triggered by one closed bar must not stack: the
@@ -11776,6 +11972,7 @@ plot(close)
                 price,
                 bracket: quantick_sim::Bracket::none(),
                 cancel_at: None,
+                flat_only: false,
             });
         assert_eq!(app.active_tab().paper.working_orders().len(), 1);
         run_frame(&mut app, &ctx);
@@ -11833,6 +12030,7 @@ plot(close)
                 price,
                 bracket: quantick_sim::Bracket::none(),
                 cancel_at: None,
+                flat_only: false,
             });
         run_frame(&mut app, &ctx);
         run_frame(&mut app, &ctx);

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -5236,7 +5236,7 @@ impl QuantickApp {
                 // The instance dies with its drawing, immediately — not on
                 // the next closed bar, which a quiet tape may never bring.
                 if let Some((id, _)) = &doomed {
-                    self.drawing_pane_mut().strategies.remove_for_drawing(*id);
+                    self.drawing_pane_mut().remove_strategy_for_drawing(*id);
                 }
                 let name = doomed.map(|(_, label)| label);
                 let message = name.map_or_else(
@@ -5895,7 +5895,7 @@ impl QuantickApp {
             };
             if self.drawing_pane_mut().drawings.delete_selected(true) == DeleteOutcome::Deleted {
                 if let Some(id) = doomed {
-                    self.drawing_pane_mut().strategies.remove_for_drawing(id);
+                    self.drawing_pane_mut().remove_strategy_for_drawing(id);
                 }
                 self.toast = Some(Toast {
                     message: "Drawing deleted.".into(),
@@ -7162,26 +7162,47 @@ impl QuantickApp {
             if target.hidden || pane.drawings.all_hidden() {
                 return Err("unhide the drawing first — an armed region stays visible".to_owned());
             }
+            // A region whose drawn span already ended can never fire again:
+            // every future bar closes past its right anchor, and the badge
+            // would show "armed" over a bot that is structurally done — the
+            // silent halt the named disarms exist to prevent. Refused with
+            // the fix in hand. An extended rectangle never expires right.
+            let extends_right = target
+                .payload
+                .as_any()
+                .downcast_ref::<drawings::RectanglePayload>()
+                .is_some_and(|payload| payload.extend_right);
+            if !extends_right
+                && let [a, b] = target.points.as_slice()
+                && pane.closed_slots() > 0
+            {
+                #[allow(clippy::cast_precision_loss)]
+                let newest = (pane.closed_slots() - 1) as f32;
+                if a.bar.max(b.bar) < newest {
+                    return Err(
+                        "the region ends before the newest bar, so nothing can ever fire — \
+                         stretch it past the right edge, or turn on \"extend right\" in its \
+                         Region settings"
+                            .to_owned(),
+                    );
+                }
+            }
             let mut armed = quantick_strategy::ArmedStrategy::new(
                 params,
                 Box::new(quantick_strategy::ForceTrigger::new(force.clone())),
             );
             // Warm the ruler on the bars the chart is already showing —
             // armed means armed now, not after another twenty bars of
-            // warmup the trader cannot see the reason for. Only bars this
-            // app cut from prints: venue prefix candles measure another
-            // ruler entirely (a 1-minute body dwarfs a tick-bar body), so
-            // the warmup starts at the seam.
-            let slots = pane.slots();
-            let first_live = pane.seam_slot();
+            // warmup the trader cannot see the reason for. The trigger
+            // declares its own depth (`warmup_bars`), and the pane keeps
+            // venue-prefix candles out: they measure another ruler
+            // entirely (a 1-minute body dwarfs a tick-bar body).
             let warmup = quantick_strategy::Region::new(
                 rust_decimal::Decimal::ZERO,
                 rust_decimal::Decimal::ZERO,
             );
-            for slot in slots.saturating_sub(force.window).max(first_live)..slots {
-                if let Some(bar) = pane.closed_bar(slot).cloned() {
-                    let _ = armed.on_closed_bar(&bar, &warmup, false, false);
-                }
+            for bar in pane.strategy_warmup_bars(armed.trigger().warmup_bars()) {
+                let _ = armed.on_closed_bar(&bar, &warmup, false, false);
             }
             pane.strategies
                 .arm(crate::strategy_anchors::AnchoredInstance {
@@ -7309,6 +7330,22 @@ impl QuantickApp {
                     .changed()
                 {
                     popup.form.rearm = if auto { "auto" } else { "one_shot" }.to_owned();
+                }
+                let mut retest = popup.form.on_break == "retest_limit";
+                if ui
+                    .checkbox(
+                        &mut retest,
+                        "on a cut: rest a limit at the region edge until the target",
+                    )
+                    .on_hover_text(
+                        "a trigger bar closing beyond the region in the trade's direction \
+                         rests a limit at the edge it cut — the retest entry — bracketed \
+                         off the bar; the order removes itself if the bar's projected \
+                         target trades first. Off = a cut holds fire, as before.",
+                    )
+                    .changed()
+                {
+                    popup.form.on_break = if retest { "retest_limit" } else { "ignore" }.to_owned();
                 }
                 ui.separator();
                 ui.horizontal(|ui| {
@@ -7996,6 +8033,10 @@ impl QuantickApp {
         self.draw_drawing_inspector(ctx, now);
         self.draw_drawing_manager(ctx, now);
         self.draw_strategy_popup(ctx);
+        // The menus above may have disarmed a bot over a resting retest
+        // limit; its cancel goes to the simulator on this same frame, not
+        // on the next print.
+        self.active_tab_mut().apply_strategy_cleanup();
         self.draw_toast(ctx, now);
         // Both are window chrome reading the active tab, like the notice card
         // and the transport strip: they speak for one market at a time.
@@ -10898,6 +10939,364 @@ plot(close)
         );
     }
 
+    /// The replay-seek trap: a disarm that reset the ruler (timeline reset,
+    /// bar-spec change, market switch) used to leave "re-armed" silently
+    /// meaning "warming up for another N bars", so a force bar right after
+    /// the seek never fired. The pane's re-arm re-warms the ruler from the
+    /// bars the chart already shows; a bare kernel re-arm does not.
+    #[test]
+    fn rearm_after_a_series_reset_rewarms_the_ruler_from_the_chart() {
+        fn print(app: &mut QuantickApp, id: &mut u64, price: &str) {
+            *id += 1;
+            let trade = quantick_engine::Trade {
+                agg_id: *id,
+                timestamp_ms: 1_700_000_000_000 + *id as i64 * 100,
+                price: rust_decimal::Decimal::from_str_exact(price).unwrap(),
+                quantity: rust_decimal::Decimal::ONE,
+                side: quantick_engine::Side::Buy,
+            };
+            app.active_tab_mut()
+                .ingest_live_trade_at(&trade, trade.timestamp_ms);
+        }
+        fn bar(app: &mut QuantickApp, id: &mut u64, open: &str, close: &str) {
+            for _ in 0..49 {
+                print(app, id, open);
+            }
+            print(app, id, close);
+        }
+        fn state_of(
+            app: &QuantickApp,
+            drawing: drawings::DrawingId,
+        ) -> quantick_strategy::ArmedState {
+            app.active_tab()
+                .flow_pane
+                .strategies
+                .for_drawing(drawing)
+                .expect("instance")
+                .armed
+                .state()
+                .clone()
+        }
+
+        let (mut app, _events, _commands, _book) = test_app();
+        let rectangle = drawings::DRAWING_TOOLS
+            .into_iter()
+            .find(|tool| tool.id() == "rectangle")
+            .expect("the rectangle tool is registered");
+        {
+            let pane = &mut app.active_tab_mut().flow_pane;
+            pane.drawings
+                .place(rectangle, drawings::ChartPoint::at(0.0, 100.0));
+            pane.drawings
+                .place(rectangle, drawings::ChartPoint::at(60.0, 110.0));
+        }
+        let drawing = app.active_tab().flow_pane.drawings.items()[0].id;
+        let mut form =
+            crate::strategy_presets::StoredPreset::starting_point(quantick_engine::Side::Buy);
+        form.window = 3;
+        form.min_body = "0".to_owned();
+        app.arm_strategy_instance(pane::PaneSide::Flow, drawing, &form, "test BF".to_owned())
+            .expect("the form compiles and the drawing exists");
+
+        // Two quiet bars on the chart, then the series "changes" under the
+        // ruler (the disarm reason a bar-spec change or replay seek names).
+        let mut id = 0u64;
+        bar(&mut app, &mut id, "100", "101");
+        bar(&mut app, &mut id, "101", "102");
+        {
+            let pane = &mut app.active_tab_mut().flow_pane;
+            let _ = pane
+                .strategies
+                .for_drawing_mut(drawing)
+                .expect("instance")
+                .armed
+                .disarm(quantick_strategy::DisarmReason::BarSpecChanged);
+            // The pane's re-arm: kernel re-arm (which resets the ruler)
+            // plus the re-warm from the chart's own closed bars.
+            pane.rearm_strategy_for_drawing(drawing);
+        }
+        assert_eq!(
+            state_of(&app, drawing),
+            quantick_strategy::ArmedState::Armed
+        );
+
+        // The very next force bar fires: bodies 1, 1 re-warmed the window,
+        // and this bar's body 4 makes ratio 2 on a full window of 3.
+        bar(&mut app, &mut id, "102", "106");
+        assert!(
+            matches!(
+                state_of(&app, drawing),
+                quantick_strategy::ArmedState::Fired { .. }
+            ),
+            "the first eligible force bar after the re-arm fires; got {:?}",
+            state_of(&app, drawing)
+        );
+    }
+
+    /// An extended rectangle's region never expires off its right anchor;
+    /// an unextended one holds fire past it and the badge names the gate.
+    #[test]
+    fn extend_right_keeps_the_region_active_past_the_drawn_end() {
+        fn print(app: &mut QuantickApp, id: &mut u64, price: &str) {
+            *id += 1;
+            let trade = quantick_engine::Trade {
+                agg_id: *id,
+                timestamp_ms: 1_700_000_000_000 + *id as i64 * 100,
+                price: rust_decimal::Decimal::from_str_exact(price).unwrap(),
+                quantity: rust_decimal::Decimal::ONE,
+                side: quantick_engine::Side::Buy,
+            };
+            app.active_tab_mut()
+                .ingest_live_trade_at(&trade, trade.timestamp_ms);
+        }
+        fn bar(app: &mut QuantickApp, id: &mut u64, open: &str, close: &str) {
+            for _ in 0..49 {
+                print(app, id, open);
+            }
+            print(app, id, close);
+        }
+
+        let (mut app, _events, _commands, _book) = test_app();
+        let rectangle = drawings::DRAWING_TOOLS
+            .into_iter()
+            .find(|tool| tool.id() == "rectangle")
+            .expect("the rectangle tool is registered");
+        {
+            let pane = &mut app.active_tab_mut().flow_pane;
+            // The drawn span ends at slot 2; the force bars land past it.
+            pane.drawings
+                .place(rectangle, drawings::ChartPoint::at(0.0, 100.0));
+            pane.drawings
+                .place(rectangle, drawings::ChartPoint::at(2.0, 110.0));
+        }
+        let drawing = app.active_tab().flow_pane.drawings.items()[0].id;
+        let mut form =
+            crate::strategy_presets::StoredPreset::starting_point(quantick_engine::Side::Buy);
+        form.window = 3;
+        form.min_body = "0".to_owned();
+        app.arm_strategy_instance(pane::PaneSide::Flow, drawing, &form, "test BF".to_owned())
+            .expect("arming before any bar closed skips the span guard");
+
+        let mut id = 0u64;
+        bar(&mut app, &mut id, "100", "101");
+        bar(&mut app, &mut id, "101", "102");
+        bar(&mut app, &mut id, "102", "103");
+        // Slot 3, past the drawn end: a force bar in price, held in time —
+        // and the badge says exactly which gate held it.
+        bar(&mut app, &mut id, "103", "107");
+        {
+            let instance = app
+                .active_tab()
+                .flow_pane
+                .strategies
+                .for_drawing(drawing)
+                .expect("instance");
+            assert_eq!(
+                instance.armed.state(),
+                &quantick_strategy::ArmedState::Armed,
+                "past the right anchor the region is inactive"
+            );
+            assert_eq!(
+                instance.armed.status_line(),
+                "armed · trigger held: region not active on this bar"
+            );
+        }
+
+        // Turn on extend right — the drawn band now runs to the chart's
+        // edge, and the region with it.
+        {
+            let pane = &mut app.active_tab_mut().flow_pane;
+            let index = pane.drawings.index_of(drawing).expect("drawing lives");
+            pane.drawings.items_mut()[index]
+                .payload
+                .as_any_mut()
+                .downcast_mut::<drawings::RectanglePayload>()
+                .expect("a rectangle carries a rectangle payload")
+                .extend_right = true;
+        }
+        // Three quiet bars drain the held force bar's body out of the
+        // window (back to an average of 1), then a fresh buy force bar
+        // closes at 110 — inside the price band, far past the drawn end.
+        bar(&mut app, &mut id, "107", "108");
+        bar(&mut app, &mut id, "108", "107");
+        bar(&mut app, &mut id, "107", "106");
+        bar(&mut app, &mut id, "106", "110");
+        assert!(
+            matches!(
+                app.active_tab()
+                    .flow_pane
+                    .strategies
+                    .for_drawing(drawing)
+                    .expect("instance")
+                    .armed
+                    .state(),
+                quantick_strategy::ArmedState::Fired { .. }
+            ),
+            "with extend right on, the region stays active past the drawn end"
+        );
+    }
+
+    /// Arming a region whose drawn span already ended is refused with the
+    /// fix in hand — "armed" over a structurally dead region is the silent
+    /// halt the named disarms exist to prevent.
+    #[test]
+    fn arming_a_region_that_already_ended_is_refused() {
+        fn print(app: &mut QuantickApp, id: &mut u64, price: &str) {
+            *id += 1;
+            let trade = quantick_engine::Trade {
+                agg_id: *id,
+                timestamp_ms: 1_700_000_000_000 + *id as i64 * 100,
+                price: rust_decimal::Decimal::from_str_exact(price).unwrap(),
+                quantity: rust_decimal::Decimal::ONE,
+                side: quantick_engine::Side::Buy,
+            };
+            app.active_tab_mut()
+                .ingest_live_trade_at(&trade, trade.timestamp_ms);
+        }
+
+        let (mut app, _events, _commands, _book) = test_app();
+        // Sixteen closed Tick(50) bars, so "the newest bar" is slot 15.
+        let mut id = 0u64;
+        for _ in 0..16 {
+            for _ in 0..50 {
+                print(&mut app, &mut id, "100");
+            }
+        }
+        let rectangle = drawings::DRAWING_TOOLS
+            .into_iter()
+            .find(|tool| tool.id() == "rectangle")
+            .expect("the rectangle tool is registered");
+        {
+            let pane = &mut app.active_tab_mut().flow_pane;
+            pane.drawings
+                .place(rectangle, drawings::ChartPoint::at(0.0, 99.0));
+            pane.drawings
+                .place(rectangle, drawings::ChartPoint::at(4.0, 101.0));
+        }
+        let drawing = app.active_tab().flow_pane.drawings.items()[0].id;
+        let form =
+            crate::strategy_presets::StoredPreset::starting_point(quantick_engine::Side::Buy);
+        let refused = app
+            .arm_strategy_instance(pane::PaneSide::Flow, drawing, &form, "dead".to_owned())
+            .expect_err("a region ending before the newest bar cannot arm");
+        assert!(
+            refused.contains("extend right"),
+            "the refusal hands over the fix: {refused}"
+        );
+
+        // The same drawing with extend right on arms fine.
+        {
+            let pane = &mut app.active_tab_mut().flow_pane;
+            let index = pane.drawings.index_of(drawing).expect("drawing lives");
+            pane.drawings.items_mut()[index]
+                .payload
+                .as_any_mut()
+                .downcast_mut::<drawings::RectanglePayload>()
+                .expect("a rectangle carries a rectangle payload")
+                .extend_right = true;
+        }
+        app.arm_strategy_instance(pane::PaneSide::Flow, drawing, &form, "live".to_owned())
+            .expect("extend right keeps the region alive, so arming is honest");
+    }
+
+    /// The user's retest flow end to end in the app: a sell preset with the
+    /// retest option armed on a region, a force bar cutting below it, the
+    /// limit resting at the cut edge — then the tape reaching the target
+    /// first, the order removing itself, and the badge saying so.
+    #[test]
+    fn a_cut_with_the_retest_preset_rests_a_limit_and_cancels_at_the_target() {
+        fn print(app: &mut QuantickApp, id: &mut u64, price: &str) {
+            *id += 1;
+            let trade = quantick_engine::Trade {
+                agg_id: *id,
+                timestamp_ms: 1_700_000_000_000 + *id as i64 * 100,
+                price: rust_decimal::Decimal::from_str_exact(price).unwrap(),
+                quantity: rust_decimal::Decimal::ONE,
+                side: quantick_engine::Side::Buy,
+            };
+            app.active_tab_mut()
+                .ingest_live_trade_at(&trade, trade.timestamp_ms);
+        }
+        fn bar(app: &mut QuantickApp, id: &mut u64, open: &str, close: &str) {
+            for _ in 0..49 {
+                print(app, id, open);
+            }
+            print(app, id, close);
+        }
+
+        let (mut app, _events, _commands, _book) = test_app();
+        let rectangle = drawings::DRAWING_TOOLS
+            .into_iter()
+            .find(|tool| tool.id() == "rectangle")
+            .expect("the rectangle tool is registered");
+        {
+            let pane = &mut app.active_tab_mut().flow_pane;
+            pane.drawings
+                .place(rectangle, drawings::ChartPoint::at(0.0, 105.0));
+            pane.drawings
+                .place(rectangle, drawings::ChartPoint::at(30.0, 115.0));
+        }
+        let drawing = app.active_tab().flow_pane.drawings.items()[0].id;
+        let mut form =
+            crate::strategy_presets::StoredPreset::starting_point(quantick_engine::Side::Sell);
+        form.window = 3;
+        form.min_body = "0".to_owned();
+        form.on_break = "retest_limit".to_owned();
+        app.arm_strategy_instance(pane::PaneSide::Flow, drawing, &form, "BF retest".to_owned())
+            .expect("the retest form compiles");
+
+        let mut id = 0u64;
+        bar(&mut app, &mut id, "110", "109");
+        bar(&mut app, &mut id, "109", "108");
+        // Body 4 over average (1+1+4)/3 = 2: force, closing below the 105
+        // edge. The bar's range is 4 (prints at 108 and 104): TP 100.
+        bar(&mut app, &mut id, "108", "104");
+        {
+            let tab = app.active_tab();
+            assert_eq!(
+                tab.paper.working_orders().len(),
+                1,
+                "the retest limit rests at the cut edge"
+            );
+            let instance = tab
+                .flow_pane
+                .strategies
+                .for_drawing(drawing)
+                .expect("instance");
+            assert!(
+                matches!(
+                    instance.armed.state(),
+                    quantick_strategy::ArmedState::Fired { retest: true, .. }
+                ),
+                "the instance narrates a resting retest, got {:?}",
+                instance.armed.state()
+            );
+        }
+
+        // The tape walks straight down through the projected target (100):
+        // the order removes itself — no fill, no trade — and the one-shot
+        // instance stops with the reason on the badge.
+        print(&mut app, &mut id, "100");
+        let tab = app.active_tab();
+        assert!(
+            tab.paper.working_orders().is_empty(),
+            "the target print removed the resting limit"
+        );
+        assert!(tab.paper.is_flat(), "no trade happened");
+        let instance = tab
+            .flow_pane
+            .strategies
+            .for_drawing(drawing)
+            .expect("instance");
+        assert_eq!(
+            instance.armed.state(),
+            &quantick_strategy::ArmedState::Disarmed {
+                reason: quantick_strategy::DisarmReason::TargetBeforeRetest
+            }
+        );
+        assert_eq!(instance.armed.status_line(), "target hit before retest");
+    }
+
     /// Two instances co-triggered by one closed bar must not stack: the
     /// first one's *queued* entry already occupies the account, so the
     /// second holds fire — "at most one live operation per chart" is a
@@ -11376,6 +11775,7 @@ plot(close)
                 quantity: Decimal::ONE,
                 price,
                 bracket: quantick_sim::Bracket::none(),
+                cancel_at: None,
             });
         assert_eq!(app.active_tab().paper.working_orders().len(), 1);
         run_frame(&mut app, &ctx);
@@ -11432,6 +11832,7 @@ plot(close)
                 quantity: Decimal::ONE,
                 price,
                 bracket: quantick_sim::Bracket::none(),
+                cancel_at: None,
             });
         run_frame(&mut app, &ctx);
         run_frame(&mut app, &ctx);

--- a/crates/app/src/drawings/mod.rs
+++ b/crates/app/src/drawings/mod.rs
@@ -900,6 +900,11 @@ register_drawing_tools!(
 // region), in the `frvp::TOOL_ID` idiom.
 pub use rectangle::TOOL_ID as RECTANGLE_TOOL_ID;
 
+// The rectangle's payload, re-exported for the strategy seat too: whether
+// the drawn band extends right decides whether an armed region ever
+// expires off its right anchor.
+pub use rectangle::RectanglePayload;
+
 // The profile drawing's payload types, re-exported for `crate::frvp` — the
 // refresh pass that folds engine ladders into the cache the paint reads.
 pub use fixed_range_profile::{FrvpCache, FrvpCacheKey, FrvpEmpty, FrvpPayload};

--- a/crates/app/src/drawings/rectangle.rs
+++ b/crates/app/src/drawings/rectangle.rs
@@ -1,16 +1,94 @@
+use std::any::Any;
+
 use eframe::egui;
 use egui_phosphor::regular as icons;
+use serde::{Deserialize, Serialize};
 
 use super::shape_core::SHAPES_FAMILY;
 use super::{
-    DrawContext, DrawingStyle, DrawingToolImpl, ToolFamily, ToolShortcut, drawing_fill,
-    drawing_stroke,
+    DrawContext, Drawing, DrawingPayload, DrawingStyle, DrawingToolImpl, PresetHost, ToolFamily,
+    ToolShortcut, drawing_fill, drawing_stroke,
 };
 
 /// Registry id, named like `frvp::TOOL_ID` for the callers that gate on
 /// this one shape (the strategy seat does: two anchors honestly bound a
 /// price region).
 pub const TOOL_ID: &str = "rectangle";
+
+/// On-disk preset shape. Only the tool-owned config travels; coordinates
+/// never do.
+const PRESET_FORMAT_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+struct RectanglePresetData {
+    version: u32,
+    #[serde(default)]
+    extend_right: bool,
+}
+
+/// The rectangle's own state beyond anchors and style.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct RectanglePayload {
+    /// Keep the band running to the chart's right edge, whatever the second
+    /// anchor says — the "this zone holds until further notice" reading. The
+    /// anchors are untouched, so switching it off restores exactly the span
+    /// that was drawn. An armed strategy reads this too: with it on, the
+    /// region never expires off the right anchor.
+    pub extend_right: bool,
+}
+
+impl DrawingPayload for RectanglePayload {
+    fn clone_box(&self) -> Box<dyn DrawingPayload> {
+        Box::new(self.clone())
+    }
+    fn eq_dyn(&self, other: &dyn DrawingPayload) -> bool {
+        other
+            .as_any()
+            .downcast_ref::<Self>()
+            .is_some_and(|other| self == other)
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+    fn export_preset(&self) -> Option<toml::Value> {
+        toml::Value::try_from(RectanglePresetData {
+            version: PRESET_FORMAT_VERSION,
+            extend_right: self.extend_right,
+        })
+        .ok()
+    }
+    fn import_preset(&mut self, value: &toml::Value) -> bool {
+        let Ok(data) = RectanglePresetData::deserialize(value.clone()) else {
+            return false;
+        };
+        if data.version != PRESET_FORMAT_VERSION {
+            return false;
+        }
+        self.extend_right = data.extend_right;
+        true
+    }
+}
+
+/// The rectangle's screen span: its two anchor corners, run to the chart's
+/// right edge when the payload extends it. Paint and hit-test share this so
+/// the clickable area is exactly the painted one.
+fn screen_rect(points: &[egui::Pos2], chart_rect: egui::Rect, payload: &RectanglePayload) -> egui::Rect {
+    let mut rect = egui::Rect::from_two_pos(points[0], points[1]);
+    if payload.extend_right {
+        rect.max.x = rect.max.x.max(chart_rect.right());
+    }
+    rect
+}
+
+fn payload_of<'a>(ctxt: &'a DrawContext<'_>) -> &'a RectanglePayload {
+    ctxt.payload
+        .as_any()
+        .downcast_ref::<RectanglePayload>()
+        .expect("a rectangle always carries a rectangle payload")
+}
 
 pub(super) static TOOL: Rectangle = Rectangle;
 
@@ -47,16 +125,40 @@ impl DrawingToolImpl for Rectangle {
     fn supports_fill(&self) -> bool {
         true
     }
+    fn default_payload(&self) -> Box<dyn DrawingPayload> {
+        Box::new(RectanglePayload::default())
+    }
+    fn extra_tab(&self) -> Option<&'static str> {
+        Some("Region")
+    }
+    fn draw_extra_tab(
+        &self,
+        ui: &mut egui::Ui,
+        drawing: &mut Drawing,
+        _host: &mut dyn PresetHost,
+    ) -> bool {
+        let payload = drawing
+            .payload
+            .as_any_mut()
+            .downcast_mut::<RectanglePayload>()
+            .expect("a rectangle always carries a rectangle payload");
+        ui.checkbox(&mut payload.extend_right, "extend right")
+            .on_hover_text(
+                "run the band to the chart's right edge until further notice — an armed \
+                 strategy then keeps watching past the drawn end instead of expiring there",
+            )
+            .changed()
+    }
     fn paint(
         &self,
         painter: &egui::Painter,
-        _chart_rect: egui::Rect,
+        chart_rect: egui::Rect,
         style: DrawingStyle,
         points: &[egui::Pos2],
-        _ctxt: &DrawContext<'_>,
+        ctxt: &DrawContext<'_>,
     ) {
         if points.len() == 2 {
-            let rect = egui::Rect::from_two_pos(points[0], points[1]);
+            let rect = screen_rect(points, chart_rect, payload_of(ctxt));
             painter.rect_filled(rect, egui::Rounding::ZERO, drawing_fill(style));
             painter.rect_stroke(
                 rect,
@@ -67,7 +169,7 @@ impl DrawingToolImpl for Rectangle {
     }
     fn hit_test(
         &self,
-        _chart_rect: egui::Rect,
+        chart_rect: egui::Rect,
         points: &[egui::Pos2],
         position: egui::Pos2,
         radius_px: f32,
@@ -76,7 +178,7 @@ impl DrawingToolImpl for Rectangle {
         if points.len() != 2 {
             return false;
         }
-        let rect = egui::Rect::from_two_pos(points[0], points[1]);
+        let rect = screen_rect(points, chart_rect, payload_of(ctxt));
         if !rect.expand(radius_px).contains(position) {
             return false;
         }

--- a/crates/app/src/pane.rs
+++ b/crates/app/src/pane.rs
@@ -1013,6 +1013,11 @@ pub struct ChartPane {
     /// The drawing whose "Add strategy…" was clicked; the app drains it
     /// and opens the arming dialog over this pane.
     pub(crate) strategy_popup_request: Option<drawings::DrawingId>,
+    /// Simulator commands the drawing menu owes the paper host — cancelling
+    /// a resting retest limit on disarm/removal. The pane cannot reach the
+    /// tab's simulator from inside the menu, so the tab drains this on the
+    /// same frame ([`crate::tab::TabState::apply_strategy_cleanup`]).
+    strategy_cleanup: Vec<quantick_sim::Command>,
 
     /// User drawings live entirely in the app overlay layer, never in market
     /// state, so chart/backtest/bot determinism stays untouched.
@@ -1186,6 +1191,7 @@ impl ChartPane {
             strategies: crate::strategy_anchors::StrategyAnchors::default(),
             strategy_pending: Vec::new(),
             strategy_popup_request: None,
+            strategy_cleanup: Vec::new(),
             drawings: Drawings::default(),
             drawing_hover: None,
             drawing_band_hint: None,
@@ -1976,7 +1982,7 @@ impl ChartPane {
                     // The instance dies with its drawing, immediately — not
                     // on the next closed bar, which a quiet tape may never
                     // bring.
-                    self.strategies.remove_for_drawing(doomed);
+                    self.remove_strategy_for_drawing(doomed);
                 }
                 self.context_menu_drawing = None;
                 ui.close_menu();
@@ -2078,7 +2084,7 @@ impl ChartPane {
                 .color(theme::TEXT_MUTED),
         );
         let state = instance.armed.state().clone();
-        use quantick_strategy::ArmedState;
+        use quantick_strategy::{ArmedState, DisarmReason};
         match state {
             ArmedState::Armed | ArmedState::InPosition => {
                 let disarm = ui.button("Disarm").on_hover_text(
@@ -2089,7 +2095,8 @@ impl ChartPane {
                 if disarm.clicked()
                     && let Some(instance) = self.strategies.for_drawing_mut(id)
                 {
-                    instance.armed.disarm(quantick_strategy::DisarmReason::User);
+                    let cleanup = instance.armed.disarm(DisarmReason::User);
+                    self.strategy_cleanup.extend(cleanup);
                     ui.close_menu();
                 }
             }
@@ -2111,15 +2118,29 @@ impl ChartPane {
                     );
                 #[cfg(test)]
                 self.drawing_menu_rects.push(("Re-arm", rearm.rect));
-                if rearm.clicked()
-                    && let Some(instance) = self.strategies.for_drawing_mut(id)
-                {
-                    instance.armed.rearm();
+                if rearm.clicked() {
+                    self.rearm_strategy_for_drawing(id);
                     ui.close_menu();
                 }
             }
-            // Fired lives for exactly one print; nothing to offer on it.
-            ArmedState::Fired { .. } => {}
+            ArmedState::Fired { retest: true, .. } => {
+                // A resting retest limit can wait for hours; the trader
+                // must be able to call it off from the same menu.
+                let disarm = ui
+                    .button("Disarm")
+                    .on_hover_text("cancel the resting retest limit and stop watching");
+                #[cfg(test)]
+                self.drawing_menu_rects.push(("Disarm", disarm.rect));
+                if disarm.clicked()
+                    && let Some(instance) = self.strategies.for_drawing_mut(id)
+                {
+                    let cleanup = instance.armed.disarm(DisarmReason::User);
+                    self.strategy_cleanup.extend(cleanup);
+                    ui.close_menu();
+                }
+            }
+            // A market entry lives for exactly one print; nothing to offer.
+            ArmedState::Fired { retest: false, .. } => {}
         }
         let remove = ui.button("Remove strategy").on_hover_text(
             "detach the bot from this drawing; an open operation keeps its position and bracket",
@@ -2128,9 +2149,83 @@ impl ChartPane {
         self.drawing_menu_rects
             .push(("Remove strategy", remove.rect));
         if remove.clicked() {
-            self.strategies.remove_for_drawing(id);
+            self.remove_strategy_for_drawing(id);
             ui.close_menu();
         }
+    }
+
+    /// Re-arm the instance riding `drawing`, re-warming its ruler when the
+    /// disarm named a *rebuilt series* (a replay seek, a bar-spec change, a
+    /// market switch reset the trigger's window). Without the re-warm,
+    /// "re-armed" silently means "warming up for another twenty bars" — the
+    /// replay-seek trap where force bars right after a seek never fire.
+    pub(crate) fn rearm_strategy_for_drawing(&mut self, drawing: drawings::DrawingId) {
+        use quantick_strategy::{ArmedState, DisarmReason};
+        let Some(instance) = self.strategies.for_drawing(drawing) else {
+            return;
+        };
+        let series_changed = matches!(
+            instance.armed.state(),
+            ArmedState::Disarmed {
+                reason: DisarmReason::TimelineReset
+                    | DisarmReason::BarSpecChanged
+                    | DisarmReason::MarketChanged
+            }
+        );
+        if let Some(instance) = self.strategies.for_drawing_mut(drawing) {
+            instance.armed.rearm();
+        }
+        if series_changed {
+            self.rewarm_strategy_trigger(drawing);
+        }
+    }
+
+    /// Feed the last `warmup_bars` closed bars of the live series back into
+    /// an instance's trigger, gates shut — the arm-time warmup, repeated
+    /// after a rearm whose disarm reset the ruler. Venue-prefix candles are
+    /// excluded for the same reason as at arm time: they measure another
+    /// ruler entirely.
+    fn rewarm_strategy_trigger(&mut self, id: drawings::DrawingId) {
+        let Some(instance) = self.strategies.for_drawing(id) else {
+            return;
+        };
+        let bars = self.strategy_warmup_bars(instance.armed.trigger().warmup_bars());
+        let warmup = quantick_strategy::Region::new(
+            rust_decimal::Decimal::ZERO,
+            rust_decimal::Decimal::ZERO,
+        );
+        let Some(instance) = self.strategies.for_drawing_mut(id) else {
+            return;
+        };
+        for bar in &bars {
+            let _ = instance.armed.on_closed_bar(bar, &warmup, false, false);
+        }
+    }
+
+    /// The last `want` closed bars of the live series — never venue-prefix
+    /// candles, whose bodies measure another ruler — for warming a strategy
+    /// trigger at arm or re-arm time.
+    pub fn strategy_warmup_bars(&self, want: usize) -> Vec<quantick_engine::Bar> {
+        let slots = self.slots();
+        let first_live = self.seam_slot();
+        (slots.saturating_sub(want).max(first_live)..slots)
+            .filter_map(|slot| self.closed_bar(slot).cloned())
+            .collect()
+    }
+
+    /// Drain the cleanup commands the drawing menu queued; the tab applies
+    /// them to the paper host on this same frame.
+    #[must_use]
+    pub fn take_strategy_cleanup(&mut self) -> Vec<quantick_sim::Command> {
+        std::mem::take(&mut self.strategy_cleanup)
+    }
+
+    /// Remove the instance riding `drawing` and queue the sweep of its
+    /// pending entry — every "the bot dies with its drawing" path funnels
+    /// through here so none of them can orphan a resting retest limit.
+    pub(crate) fn remove_strategy_for_drawing(&mut self, drawing: drawings::DrawingId) {
+        let cleanup = self.strategies.remove_for_drawing(drawing);
+        self.strategy_cleanup.extend(cleanup);
     }
 
     /// The bar spec implied by the current selector state.
@@ -2584,9 +2679,18 @@ impl ChartPane {
             return None;
         };
         let region = quantick_strategy::Region::new(dec_from_f64(a.price), dec_from_f64(b.price));
+        // An extended rectangle runs to the chart's right edge until
+        // further notice, and its region does too — otherwise the bot
+        // silently expires at the drawn end while the band visibly keeps
+        // going (the replay trap this option exists to close).
+        let extend_right = drawing
+            .payload
+            .as_any()
+            .downcast_ref::<drawings::RectanglePayload>()
+            .is_some_and(|payload| payload.extend_right);
         #[allow(clippy::cast_precision_loss)]
         let slot = slot as f32;
-        let active = slot >= a.bar.min(b.bar) && slot <= a.bar.max(b.bar);
+        let active = slot >= a.bar.min(b.bar) && (extend_right || slot <= a.bar.max(b.bar));
         Some((region, active))
     }
 

--- a/crates/app/src/pane.rs
+++ b/crates/app/src/pane.rs
@@ -2086,10 +2086,16 @@ impl ChartPane {
         let state = instance.armed.state().clone();
         use quantick_strategy::{ArmedState, DisarmReason};
         match state {
-            ArmedState::Armed | ArmedState::InPosition => {
-                let disarm = ui.button("Disarm").on_hover_text(
-                    "stop watching; an open operation keeps its position and bracket — yours to manage",
-                );
+            // One Disarm arm for every state that can be called off — a
+            // resting retest limit included (it can wait for hours). Only
+            // the hover varies; the cleanup plumbing must never fork.
+            ArmedState::Armed | ArmedState::InPosition | ArmedState::Fired { retest: true, .. } => {
+                let hover = if matches!(state, ArmedState::Fired { .. }) {
+                    "cancel the resting retest limit and stop watching"
+                } else {
+                    "stop watching; an open operation keeps its position and bracket — yours to manage"
+                };
+                let disarm = ui.button("Disarm").on_hover_text(hover);
                 #[cfg(test)]
                 self.drawing_menu_rects.push(("Disarm", disarm.rect));
                 if disarm.clicked()
@@ -2102,40 +2108,29 @@ impl ChartPane {
             }
             ArmedState::Done | ArmedState::Disarmed { .. } => {
                 // A drawing with no footing on this market/series cannot be
-                // honestly re-armed: the instance would show "armed" while
-                // the region test refuses it forever — the silent halt the
+                // honestly re-armed — and neither can a region whose drawn
+                // span already ended: the instance would show "armed" while
+                // the region test refuses it forever, the silent halt the
                 // named disarms exist to prevent.
                 let footed = {
                     let drawing = &self.drawings.items()[index];
                     !drawing.foreign_market && !drawing.off_series
                 };
+                let span_alive = self.strategy_region_can_fire(id);
                 let rearm = ui
-                    .add_enabled(footed, egui::Button::new("Re-arm"))
+                    .add_enabled(footed && span_alive, egui::Button::new("Re-arm"))
                     .on_hover_text("watch this region again with the same parameters")
-                    .on_disabled_hover_text(
+                    .on_disabled_hover_text(if footed {
+                        "the region ends before the next bar — stretch it right, or turn on \
+                         \"extend right\" in its Region settings"
+                    } else {
                         "this drawing belongs to another market or lost its series — redraw the \
-                         region here first",
-                    );
+                         region here first"
+                    });
                 #[cfg(test)]
                 self.drawing_menu_rects.push(("Re-arm", rearm.rect));
                 if rearm.clicked() {
                     self.rearm_strategy_for_drawing(id);
-                    ui.close_menu();
-                }
-            }
-            ArmedState::Fired { retest: true, .. } => {
-                // A resting retest limit can wait for hours; the trader
-                // must be able to call it off from the same menu.
-                let disarm = ui
-                    .button("Disarm")
-                    .on_hover_text("cancel the resting retest limit and stop watching");
-                #[cfg(test)]
-                self.drawing_menu_rects.push(("Disarm", disarm.rect));
-                if disarm.clicked()
-                    && let Some(instance) = self.strategies.for_drawing_mut(id)
-                {
-                    let cleanup = instance.armed.disarm(DisarmReason::User);
-                    self.strategy_cleanup.extend(cleanup);
                     ui.close_menu();
                 }
             }
@@ -2160,17 +2155,13 @@ impl ChartPane {
     /// "re-armed" silently means "warming up for another twenty bars" — the
     /// replay-seek trap where force bars right after a seek never fire.
     pub(crate) fn rearm_strategy_for_drawing(&mut self, drawing: drawings::DrawingId) {
-        use quantick_strategy::{ArmedState, DisarmReason};
+        use quantick_strategy::ArmedState;
         let Some(instance) = self.strategies.for_drawing(drawing) else {
             return;
         };
         let series_changed = matches!(
             instance.armed.state(),
-            ArmedState::Disarmed {
-                reason: DisarmReason::TimelineReset
-                    | DisarmReason::BarSpecChanged
-                    | DisarmReason::MarketChanged
-            }
+            ArmedState::Disarmed { reason } if reason.resets_series()
         );
         if let Some(instance) = self.strategies.for_drawing_mut(drawing) {
             instance.armed.rearm();
@@ -2181,25 +2172,65 @@ impl ChartPane {
     }
 
     /// Feed the last `warmup_bars` closed bars of the live series back into
-    /// an instance's trigger, gates shut — the arm-time warmup, repeated
-    /// after a rearm whose disarm reset the ruler. Venue-prefix candles are
-    /// excluded for the same reason as at arm time: they measure another
-    /// ruler entirely.
+    /// an instance's trigger — the arm-time warmup, repeated after a rearm
+    /// whose disarm reset the ruler. Venue-prefix candles are excluded for
+    /// the same reason as at arm time: they measure another ruler entirely.
     fn rewarm_strategy_trigger(&mut self, id: drawings::DrawingId) {
         let Some(instance) = self.strategies.for_drawing(id) else {
             return;
         };
         let bars = self.strategy_warmup_bars(instance.armed.trigger().warmup_bars());
-        let warmup = quantick_strategy::Region::new(
-            rust_decimal::Decimal::ZERO,
-            rust_decimal::Decimal::ZERO,
-        );
         let Some(instance) = self.strategies.for_drawing_mut(id) else {
             return;
         };
-        for bar in &bars {
-            let _ = instance.armed.on_closed_bar(bar, &warmup, false, false);
+        instance.armed.warm(&bars);
+    }
+
+    /// Whether the drawing's drawn span can still cover a future closed
+    /// bar — the liveness half of [`Self::strategy_region`]'s `active`
+    /// test, shared by arming, re-arming and the menu so the three cannot
+    /// drift. The next bar to close lands at slot `closed_slots()`, so an
+    /// unextended region needs its right anchor at or past that slot; an
+    /// extended one never expires right.
+    pub(crate) fn strategy_region_can_fire(&self, id: drawings::DrawingId) -> bool {
+        let Some(index) = self.drawings.index_of(id) else {
+            return false;
+        };
+        let drawing = &self.drawings.items()[index];
+        let extend_right = drawing
+            .payload
+            .as_any()
+            .downcast_ref::<drawings::RectanglePayload>()
+            .is_some_and(|payload| payload.extend_right);
+        if extend_right {
+            return true;
         }
+        let [a, b] = drawing.points.as_slice() else {
+            return false;
+        };
+        #[allow(clippy::cast_precision_loss)]
+        let next_slot = self.closed_slots() as f32;
+        a.bar.max(b.bar) >= next_slot
+    }
+
+    /// Sweep instances whose drawing no longer exists — for the deletion
+    /// paths that cannot call [`Self::remove_strategy_for_drawing`] with an
+    /// id in hand (delete-all, undo, redo), so no path leaves a resting bot
+    /// order with no badge over it. Cleanup is queued for the tab's
+    /// same-frame drain like the menu's.
+    pub(crate) fn sweep_strategy_orphans(&mut self) {
+        if self.strategies.is_empty() {
+            return;
+        }
+        let alive: Vec<drawings::DrawingId> = self
+            .strategies
+            .instances
+            .iter()
+            .map(|instance| instance.drawing)
+            .filter(|id| self.drawings.index_of(*id).is_some())
+            .collect();
+        let cleanup = self.strategies.drop_orphans(|id| alive.contains(&id));
+        self.strategy_cleanup.extend(cleanup);
     }
 
     /// The last `want` closed bars of the live series — never venue-prefix

--- a/crates/app/src/paper_trading.rs
+++ b/crates/app/src/paper_trading.rs
@@ -1490,7 +1490,7 @@ impl PaperTrading {
             // side and what kind of order waits there. The price is the
             // chip's job, and the id only matters once you mean to act on
             // it, so both wait for the open form.
-            let text = if expanded {
+            let mut text = if expanded {
                 format!(
                     "#{} {} {} {} @ {}",
                     order.id.0,
@@ -1507,6 +1507,11 @@ impl PaperTrading {
                     fmt_decimal(order.quantity),
                 )
             };
+            // An order that can remove itself says so: without this, a
+            // retest limit vanishing at its target reads as a glitch.
+            if expanded && let Some(cancel) = order.cancel_at {
+                text.push_str(&format!(" · cancels @ {}", fmt_decimal(cancel)));
+            }
             // The ✕ is painted exactly when the press-side offers it —
             // one value, read twice, never two formulas.
             ctx.chip_tag(y, theme::ACCENT, &text, open.is_some_and(|tag| tag.cancel));
@@ -3010,15 +3015,21 @@ impl PaperTrading {
                         .monospace()
                         .color(side_color(order.side)),
                 );
+                let mut line = format!(
+                    "{} {} @ {}",
+                    kind_short(order.kind),
+                    fmt_decimal(order.quantity),
+                    order.price.map_or_else(String::new, fmt_decimal),
+                );
+                // The self-cancel level rides the row — an order that can
+                // vanish on its own never does so unannounced.
+                if let Some(cancel) = order.cancel_at {
+                    line.push_str(&format!(" · cancels @ {}", fmt_decimal(cancel)));
+                }
                 ui.label(
-                    egui::RichText::new(format!(
-                        "{} {} @ {}",
-                        kind_short(order.kind),
-                        fmt_decimal(order.quantity),
-                        order.price.map_or_else(String::new, fmt_decimal),
-                    ))
-                    .monospace()
-                    .color(theme::TEXT_PRIMARY),
+                    egui::RichText::new(line)
+                        .monospace()
+                        .color(theme::TEXT_PRIMARY),
                 );
                 ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                     if ui

--- a/crates/app/src/paper_trading.rs
+++ b/crates/app/src/paper_trading.rs
@@ -1076,6 +1076,7 @@ impl PaperTrading {
                     quantity: Decimal::ONE,
                     price,
                     bracket: Bracket::none(),
+                    cancel_at: None,
                 });
                 self.handle_events(events);
             }
@@ -1165,6 +1166,7 @@ impl PaperTrading {
                 quantity: Decimal::ONE,
                 price: mark.saturating_sub(offset.saturating_add(offset)),
                 bracket: Bracket::none(),
+                cancel_at: None,
             },
             260 => Command::PlaceMarket {
                 side: Side::Sell,
@@ -2304,6 +2306,7 @@ impl PaperTrading {
                 quantity,
                 price,
                 bracket,
+                cancel_at: None,
             },
             EntryKind::Stop => Command::PlaceStop {
                 side,
@@ -7669,6 +7672,7 @@ mod tests {
             quantity: Decimal::ONE,
             price: Decimal::from(95),
             bracket: Bracket::none(),
+            cancel_at: None,
         });
         paper.handle_events(events);
         // The trap that used to swallow every chart click.

--- a/crates/app/src/paper_trading.rs
+++ b/crates/app/src/paper_trading.rs
@@ -1077,6 +1077,7 @@ impl PaperTrading {
                     price,
                     bracket: Bracket::none(),
                     cancel_at: None,
+                    flat_only: false,
                 });
                 self.handle_events(events);
             }
@@ -1167,6 +1168,7 @@ impl PaperTrading {
                 price: mark.saturating_sub(offset.saturating_add(offset)),
                 bracket: Bracket::none(),
                 cancel_at: None,
+                flat_only: false,
             },
             260 => Command::PlaceMarket {
                 side: Side::Sell,
@@ -2312,6 +2314,7 @@ impl PaperTrading {
                 price,
                 bracket,
                 cancel_at: None,
+                flat_only: false,
             },
             EntryKind::Stop => Command::PlaceStop {
                 side,
@@ -3952,6 +3955,25 @@ impl PaperTrading {
                             trade.exit_reason.as_str().replace('_', " "),
                         ));
                     }
+                }
+                // The two cancels the *tape* performs, not a hand: a
+                // working-order chip vanishing with no narration reads as
+                // a glitch, so these toast like every other simulator act
+                // the trader did not click.
+                SimEvent::Cancelled {
+                    order,
+                    reason: quantick_sim::CancelReason::PriceTouched,
+                } => {
+                    self.show_toast(format!("SIM cancelled {}: target traded first", order.id));
+                }
+                SimEvent::Cancelled {
+                    order,
+                    reason: quantick_sim::CancelReason::AccountOccupied,
+                } => {
+                    self.show_toast(format!(
+                        "SIM stood down {}: account busy at its price",
+                        order.id
+                    ));
                 }
                 _ => {}
             }
@@ -7684,6 +7706,7 @@ mod tests {
             price: Decimal::from(95),
             bracket: Bracket::none(),
             cancel_at: None,
+            flat_only: false,
         });
         paper.handle_events(events);
         // The trap that used to swallow every chart click.

--- a/crates/app/src/strategy_anchors.rs
+++ b/crates/app/src/strategy_anchors.rs
@@ -8,6 +8,7 @@
 //! already carries one replaces it, so a rectangle never hides a stack of
 //! bots behind one badge.
 
+use quantick_sim::Command;
 use quantick_strategy::{ArmedState, ArmedStrategy, DisarmReason};
 
 use crate::drawings::DrawingId;
@@ -58,24 +59,49 @@ impl StrategyAnchors {
     /// Remove the instance riding `drawing`, whatever its state. The
     /// caller deleted the drawing or dismissed the strategy: a live
     /// operation's position and bracket stay in the simulator, now the
-    /// human's to manage — the honest reading of "I deleted the bot".
-    pub fn remove_for_drawing(&mut self, drawing: DrawingId) {
-        self.instances
-            .retain(|instance| instance.drawing != drawing);
+    /// human's to manage — the honest reading of "I deleted the bot". A
+    /// *pending* entry is different — nothing filled, nobody owns it — so
+    /// the returned commands sweep it; apply them to the simulator.
+    #[must_use = "apply the returned cleanup commands to the simulator"]
+    pub fn remove_for_drawing(&mut self, drawing: DrawingId) -> Vec<Command> {
+        let mut cleanup = Vec::new();
+        self.instances.retain(|instance| {
+            if instance.drawing != drawing {
+                return true;
+            }
+            cleanup.extend(pending_entry_cleanup(&instance.armed));
+            false
+        });
+        cleanup
     }
 
     /// Disarm every instance with one shared reason — the timeline reset /
-    /// spec change / market switch sweeps.
-    pub fn disarm_all(&mut self, reason: DisarmReason) {
+    /// spec change / market switch sweeps. The returned commands sweep any
+    /// pending entries (the kernel returns none under a timeline reset,
+    /// where the simulator's own reset already cancels them by name).
+    #[must_use = "apply the returned cleanup commands to the simulator"]
+    pub fn disarm_all(&mut self, reason: DisarmReason) -> Vec<Command> {
+        let mut cleanup = Vec::new();
         for instance in &mut self.instances {
-            instance.armed.disarm(reason);
+            cleanup.extend(instance.armed.disarm(reason));
         }
+        cleanup
     }
 
     /// Drop instances whose drawing no longer exists (deleted from any
-    /// surface). Run once per evaluation sweep, never per frame.
-    pub fn drop_orphans(&mut self, exists: impl Fn(DrawingId) -> bool) {
-        self.instances.retain(|instance| exists(instance.drawing));
+    /// surface). Run once per evaluation sweep, never per frame. Sweeps
+    /// pending entries like [`Self::remove_for_drawing`].
+    #[must_use = "apply the returned cleanup commands to the simulator"]
+    pub fn drop_orphans(&mut self, exists: impl Fn(DrawingId) -> bool) -> Vec<Command> {
+        let mut cleanup = Vec::new();
+        self.instances.retain(|instance| {
+            if exists(instance.drawing) {
+                return true;
+            }
+            cleanup.extend(pending_entry_cleanup(&instance.armed));
+            false
+        });
+        cleanup
     }
 
     /// How many instances are actively watching (armed or mid-operation) —
@@ -94,6 +120,18 @@ impl StrategyAnchors {
     }
 }
 
+/// The cleanup an instance leaving the anchors owes the simulator: its
+/// pending entry, if one is still resting or queued. Removal is not a
+/// [`DisarmReason`], so the kernel's disarm sweep cannot cover this path.
+fn pending_entry_cleanup(armed: &ArmedStrategy) -> Option<Command> {
+    match armed.state() {
+        ArmedState::Fired {
+            order_id: Some(id), ..
+        } => Some(Command::CancelOrder { id: *id }),
+        _ => None,
+    }
+}
+
 /// Badge text for one instance state — the on-chart label next to the
 /// drawing. Colors are the paint site's business (`theme`); words are
 /// decided here so every surface says the same thing.
@@ -101,7 +139,10 @@ impl StrategyAnchors {
 pub fn badge_text(instance: &AnchoredInstance) -> String {
     match instance.armed.state() {
         ArmedState::Armed => format!("⚡ {}", instance.preset),
-        ArmedState::Fired { .. } => format!("⚡ {} · fired", instance.preset),
+        ArmedState::Fired { retest: false, .. } => format!("⚡ {} · fired", instance.preset),
+        ArmedState::Fired { retest: true, .. } => {
+            format!("⚡ {} · retest resting", instance.preset)
+        }
         ArmedState::InPosition => format!("⚡ {} · in position", instance.preset),
         ArmedState::Done => format!("⚡ {} · done", instance.preset),
         ArmedState::Disarmed { reason } => {
@@ -128,6 +169,7 @@ mod tests {
                     tp_mult: Decimal::ONE,
                     sl_mult: Decimal::ONE,
                     rearm: Rearm::OneShot,
+                    on_break: quantick_strategy::BreakPolicy::Ignore,
                 },
                 Box::new(ForceTrigger::new(ForceParams::default_band())),
             ),
@@ -146,11 +188,88 @@ mod tests {
             "re-arming replaced, not stacked"
         );
 
-        anchors.drop_orphans(|id| id == DrawingId(2));
+        let cleanup = anchors.drop_orphans(|id| id == DrawingId(2));
         assert_eq!(anchors.instances.len(), 1);
         assert_eq!(anchors.instances[0].drawing, DrawingId(2));
+        assert!(cleanup.is_empty(), "armed instances have nothing pending");
 
-        anchors.remove_for_drawing(DrawingId(2));
+        let cleanup = anchors.remove_for_drawing(DrawingId(2));
+        assert!(anchors.is_empty());
+        assert!(cleanup.is_empty());
+    }
+
+    /// An instance whose entry is still pending leaves a cancel behind when
+    /// its drawing (and with it the badge) goes away — a resting bot order
+    /// with no bot is the one thing removal must not orphan.
+    #[test]
+    fn removal_sweeps_the_pending_entry() {
+        use quantick_sim::{Bracket, Command, EntryKind, Order, OrderId, SimEvent};
+
+        fn bar(open: i64, close: i64) -> quantick_engine::Bar {
+            quantick_engine::Bar {
+                open_time: 0,
+                close_time: 0,
+                open: Decimal::from(open),
+                high: Decimal::from(open.max(close)) + Decimal::ONE,
+                low: Decimal::from(open.min(close)) - Decimal::ONE,
+                close: Decimal::from(close),
+                buy_volume: Decimal::ONE,
+                sell_volume: Decimal::ONE,
+                trade_count: 2,
+            }
+        }
+
+        // A 3-bar ruler that fires on the third bar (body 4 over average 2).
+        let mut riding = AnchoredInstance {
+            drawing: DrawingId(3),
+            preset: "test".to_owned(),
+            armed: ArmedStrategy::new(
+                StrategyParams {
+                    side: Side::Buy,
+                    quantity: Decimal::ONE,
+                    tp_mult: Decimal::ONE,
+                    sl_mult: Decimal::ONE,
+                    rearm: Rearm::OneShot,
+                    on_break: quantick_strategy::BreakPolicy::Ignore,
+                },
+                Box::new(ForceTrigger::new(ForceParams {
+                    window: 3,
+                    min_factor: "1.5".parse().expect("fixture"),
+                    max_factor: "2.5".parse().expect("fixture"),
+                    min_body: Decimal::ZERO,
+                })),
+            ),
+        };
+        let region = quantick_strategy::Region::new(Decimal::from(100), Decimal::from(110));
+        let _ = riding
+            .armed
+            .on_closed_bar(&bar(100, 101), &region, true, true);
+        let _ = riding
+            .armed
+            .on_closed_bar(&bar(101, 102), &region, true, true);
+        let commands = riding
+            .armed
+            .on_closed_bar(&bar(102, 106), &region, true, true);
+        assert_eq!(commands.len(), 1, "the fixture fires: {commands:?}");
+        let _ = riding.armed.on_sim_events(&[SimEvent::Placed(Order {
+            id: OrderId(11),
+            side: Side::Buy,
+            kind: EntryKind::Market,
+            price: None,
+            quantity: Decimal::ONE,
+            bracket: Bracket::none(),
+            cancel_at: None,
+            placed_ms: 0,
+        })]);
+
+        let mut anchors = StrategyAnchors::default();
+        anchors.arm(riding);
+        let cleanup = anchors.remove_for_drawing(DrawingId(3));
+        assert_eq!(
+            cleanup,
+            vec![Command::CancelOrder { id: OrderId(11) }],
+            "removing the bot sweeps its pending entry"
+        );
         assert!(anchors.is_empty());
     }
 
@@ -161,7 +280,11 @@ mod tests {
         anchors.arm(instance(DrawingId(2)));
         assert_eq!(anchors.watching(), 2);
 
-        anchors.disarm_all(DisarmReason::TimelineReset);
+        let cleanup = anchors.disarm_all(DisarmReason::TimelineReset);
+        assert!(
+            cleanup.is_empty(),
+            "the simulator's reset owns those cancellations"
+        );
         assert_eq!(anchors.watching(), 0);
         for i in &anchors.instances {
             assert_eq!(

--- a/crates/app/src/strategy_anchors.rs
+++ b/crates/app/src/strategy_anchors.rs
@@ -50,10 +50,22 @@ impl StrategyAnchors {
     }
 
     /// Attach `instance`, replacing any instance already on its drawing.
-    pub fn arm(&mut self, instance: AnchoredInstance) {
-        self.instances
-            .retain(|existing| existing.drawing != instance.drawing);
+    /// The replaced instance's pending entry is swept like every other way
+    /// an instance leaves the anchors — the mouse path cannot reach a
+    /// replace over `Fired` (the menu offers no "Add strategy…" then), but
+    /// the programmatic seam can, and it must not orphan a resting order.
+    #[must_use = "apply the returned cleanup commands to the simulator"]
+    pub fn arm(&mut self, instance: AnchoredInstance) -> Vec<Command> {
+        let mut cleanup = Vec::new();
+        self.instances.retain(|existing| {
+            if existing.drawing != instance.drawing {
+                return true;
+            }
+            cleanup.extend(existing.armed.pending_entry_cancel());
+            false
+        });
         self.instances.push(instance);
+        cleanup
     }
 
     /// Remove the instance riding `drawing`, whatever its state. The
@@ -69,7 +81,7 @@ impl StrategyAnchors {
             if instance.drawing != drawing {
                 return true;
             }
-            cleanup.extend(pending_entry_cleanup(&instance.armed));
+            cleanup.extend(instance.armed.pending_entry_cancel());
             false
         });
         cleanup
@@ -98,7 +110,7 @@ impl StrategyAnchors {
             if exists(instance.drawing) {
                 return true;
             }
-            cleanup.extend(pending_entry_cleanup(&instance.armed));
+            cleanup.extend(instance.armed.pending_entry_cancel());
             false
         });
         cleanup
@@ -117,18 +129,6 @@ impl StrategyAnchors {
                 )
             })
             .count()
-    }
-}
-
-/// The cleanup an instance leaving the anchors owes the simulator: its
-/// pending entry, if one is still resting or queued. Removal is not a
-/// [`DisarmReason`], so the kernel's disarm sweep cannot cover this path.
-fn pending_entry_cleanup(armed: &ArmedStrategy) -> Option<Command> {
-    match armed.state() {
-        ArmedState::Fired {
-            order_id: Some(id), ..
-        } => Some(Command::CancelOrder { id: *id }),
-        _ => None,
     }
 }
 
@@ -179,9 +179,9 @@ mod tests {
     #[test]
     fn one_instance_per_drawing_and_orphans_die_with_their_drawing() {
         let mut anchors = StrategyAnchors::default();
-        anchors.arm(instance(DrawingId(1)));
-        anchors.arm(instance(DrawingId(2)));
-        anchors.arm(instance(DrawingId(1)));
+        let _ = anchors.arm(instance(DrawingId(1)));
+        let _ = anchors.arm(instance(DrawingId(2)));
+        let _ = anchors.arm(instance(DrawingId(1)));
         assert_eq!(
             anchors.instances.len(),
             2,
@@ -259,11 +259,12 @@ mod tests {
             quantity: Decimal::ONE,
             bracket: Bracket::none(),
             cancel_at: None,
+            flat_only: false,
             placed_ms: 0,
         })]);
 
         let mut anchors = StrategyAnchors::default();
-        anchors.arm(riding);
+        let _ = anchors.arm(riding);
         let cleanup = anchors.remove_for_drawing(DrawingId(3));
         assert_eq!(
             cleanup,
@@ -273,11 +274,85 @@ mod tests {
         assert!(anchors.is_empty());
     }
 
+    /// Arming over an instance whose entry is still pending sweeps that
+    /// entry too — the programmatic seam must not orphan a resting order
+    /// by replacing its bot.
+    #[test]
+    fn arming_over_a_pending_entry_sweeps_it() {
+        use quantick_sim::{Bracket, Command, EntryKind, Order, OrderId, SimEvent};
+
+        fn bar(open: i64, close: i64) -> quantick_engine::Bar {
+            quantick_engine::Bar {
+                open_time: 0,
+                close_time: 0,
+                open: Decimal::from(open),
+                high: Decimal::from(open.max(close)) + Decimal::ONE,
+                low: Decimal::from(open.min(close)) - Decimal::ONE,
+                close: Decimal::from(close),
+                buy_volume: Decimal::ONE,
+                sell_volume: Decimal::ONE,
+                trade_count: 2,
+            }
+        }
+
+        let mut riding = AnchoredInstance {
+            drawing: DrawingId(5),
+            preset: "test".to_owned(),
+            armed: ArmedStrategy::new(
+                StrategyParams {
+                    side: Side::Buy,
+                    quantity: Decimal::ONE,
+                    tp_mult: Decimal::ONE,
+                    sl_mult: Decimal::ONE,
+                    rearm: Rearm::OneShot,
+                    on_break: quantick_strategy::BreakPolicy::Ignore,
+                },
+                Box::new(ForceTrigger::new(ForceParams {
+                    window: 3,
+                    min_factor: "1.5".parse().expect("fixture"),
+                    max_factor: "2.5".parse().expect("fixture"),
+                    min_body: Decimal::ZERO,
+                })),
+            ),
+        };
+        let region = quantick_strategy::Region::new(Decimal::from(100), Decimal::from(110));
+        let _ = riding
+            .armed
+            .on_closed_bar(&bar(100, 101), &region, true, true);
+        let _ = riding
+            .armed
+            .on_closed_bar(&bar(101, 102), &region, true, true);
+        let _ = riding
+            .armed
+            .on_closed_bar(&bar(102, 106), &region, true, true);
+        let _ = riding.armed.on_sim_events(&[SimEvent::Placed(Order {
+            id: OrderId(21),
+            side: Side::Buy,
+            kind: EntryKind::Market,
+            price: None,
+            quantity: Decimal::ONE,
+            bracket: Bracket::none(),
+            cancel_at: None,
+            flat_only: false,
+            placed_ms: 0,
+        })]);
+
+        let mut anchors = StrategyAnchors::default();
+        let _ = anchors.arm(riding);
+        let cleanup = anchors.arm(instance(DrawingId(5)));
+        assert_eq!(
+            cleanup,
+            vec![Command::CancelOrder { id: OrderId(21) }],
+            "the replaced instance's pending entry is swept"
+        );
+        assert_eq!(anchors.instances.len(), 1, "replaced, not stacked");
+    }
+
     #[test]
     fn disarm_all_names_the_reason_and_watching_counts_live_states() {
         let mut anchors = StrategyAnchors::default();
-        anchors.arm(instance(DrawingId(1)));
-        anchors.arm(instance(DrawingId(2)));
+        let _ = anchors.arm(instance(DrawingId(1)));
+        let _ = anchors.arm(instance(DrawingId(2)));
         assert_eq!(anchors.watching(), 2);
 
         let cleanup = anchors.disarm_all(DisarmReason::TimelineReset);

--- a/crates/app/src/strategy_presets.rs
+++ b/crates/app/src/strategy_presets.rs
@@ -21,7 +21,7 @@ use quantick_engine::Side;
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 
-use quantick_strategy::{ForceParams, Rearm, StrategyParams};
+use quantick_strategy::{BreakPolicy, ForceParams, Rearm, StrategyParams};
 
 /// Environment override for the bank's location.
 pub const STRATEGIES_ENV: &str = "QUANTICK_STRATEGY_PRESETS";
@@ -65,6 +65,13 @@ pub struct StoredPreset {
     pub sl_mult: String,
     /// `one_shot` (default, the over-fire guard) or `auto`.
     pub rearm: String,
+    /// What a trigger bar cutting through the region does: `ignore`
+    /// (default — hold fire, the behaviour before the option existed) or
+    /// `retest_limit` (rest a limit at the cut edge, cancelled at the
+    /// bar's projected target). Optional for the same vintage reason as
+    /// `min_body`, which is why the version does not move.
+    #[serde(default = "ignore_break")]
+    pub on_break: String,
 }
 
 impl StoredPreset {
@@ -89,6 +96,7 @@ impl StoredPreset {
             tp_mult: "1.0".to_owned(),
             sl_mult: "1.0".to_owned(),
             rearm: "one_shot".to_owned(),
+            on_break: "ignore".to_owned(),
         }
     }
 
@@ -108,6 +116,11 @@ impl StoredPreset {
         let rearm = match self.rearm.as_str() {
             "one_shot" => Rearm::OneShot,
             "auto" => Rearm::Auto,
+            _ => return None,
+        };
+        let on_break = match self.on_break.as_str() {
+            "ignore" => BreakPolicy::Ignore,
+            "retest_limit" => BreakPolicy::RetestLimit,
             _ => return None,
         };
         let quantity = Decimal::from_str(&self.quantity).ok()?;
@@ -135,6 +148,7 @@ impl StoredPreset {
             tp_mult: Decimal::from_str(&self.tp_mult).ok()?,
             sl_mult: Decimal::from_str(&self.sl_mult).ok()?,
             rearm,
+            on_break,
         };
         let force = ForceParams {
             window: self.window as usize,
@@ -156,6 +170,12 @@ pub fn side_token(side: Side) -> &'static str {
 /// existed read as "floor off".
 fn zero_points() -> String {
     "0".to_owned()
+}
+
+/// Serde default for [`StoredPreset::on_break`]: rows from before the field
+/// existed read as "hold fire on a cut", the old behaviour.
+fn ignore_break() -> String {
+    "ignore".to_owned()
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -319,11 +339,16 @@ mod tests {
         .unwrap();
         let bank = StrategyBank::load_from(&path);
         let preset = bank.get("BF antiga").expect("old row reads");
-        let (_, force) = preset.to_kernel().expect("and still compiles");
+        let (params, force) = preset.to_kernel().expect("and still compiles");
         assert_eq!(
             force.min_body,
             Decimal::ZERO,
             "absent floor means off, not refused"
+        );
+        assert_eq!(
+            params.on_break,
+            BreakPolicy::Ignore,
+            "absent break policy means the old hold-fire behaviour"
         );
         std::fs::remove_file(&path).ok();
 
@@ -359,6 +384,16 @@ mod tests {
             unknown.to_kernel().is_none(),
             "a trigger this build cannot execute is refused, not approximated"
         );
+        let mut unknown_break = StoredPreset::starting_point(Side::Sell);
+        unknown_break.on_break = "chase".to_owned();
+        assert!(
+            unknown_break.to_kernel().is_none(),
+            "a break policy this build cannot execute is refused, not approximated"
+        );
+        let mut retest = StoredPreset::starting_point(Side::Sell);
+        retest.on_break = "retest_limit".to_owned();
+        let (params, _) = retest.to_kernel().expect("the retest policy compiles");
+        assert_eq!(params.on_break, BreakPolicy::RetestLimit);
 
         // The ruler's own limits are contract too: a zero window is not
         // clamped into meaning, a giant one is not an allocation request,

--- a/crates/app/src/tab.rs
+++ b/crates/app/src/tab.rs
@@ -1248,8 +1248,11 @@ impl Tab {
             pane.drawings.mark_market_changed();
             // The regions those instances watched belong to the market that
             // just left; a bot must never fire on a level from another
-            // instrument. Disarmed by name, never silently dropped.
-            pane.strategies
+            // instrument. Disarmed by name, never silently dropped. Their
+            // pending entries need no sweep of ours: the paper reset a few
+            // lines down cancels every order with the honest `reset` label.
+            let _ = pane
+                .strategies
                 .disarm_all(quantick_strategy::DisarmReason::MarketChanged);
             let _ = pane.take_strategy_bars();
         }
@@ -1504,10 +1507,16 @@ impl Tab {
                 pane.reanchor_drawings(old_slots);
                 // The strategies do not follow: the body average that
                 // defines a force bar means something else under another
-                // bar spec, so the instances disarm and say why.
-                pane.strategies
+                // bar spec, so the instances disarm and say why. The tape
+                // itself continues, so any pending bot entry is swept here
+                // and now — through the same funnel manual orders use.
+                let cleanup = pane
+                    .strategies
                     .disarm_all(quantick_strategy::DisarmReason::BarSpecChanged);
                 let _ = pane.take_strategy_bars();
+                for command in cleanup {
+                    let _ = self.paper.apply_strategy_command(command);
+                }
                 self.drop_overlay_gestures();
             }
         }
@@ -1690,7 +1699,12 @@ impl Tab {
                     .map(|instance| instance.drawing)
                     .filter(|id| pane.drawings.index_of(*id).is_some())
                     .collect();
-                pane.strategies.drop_orphans(|id| alive.contains(&id));
+                let orphan_cleanup = pane.strategies.drop_orphans(|id| alive.contains(&id));
+                for command in orphan_cleanup {
+                    // A dead drawing's bot must not leave its entry resting
+                    // with no badge over it; swept through the same funnel.
+                    let _ = paper.apply_strategy_command(command);
+                }
             }
             for (bar, slot) in &bars {
                 for index in 0..pane.strategies.instances.len() {
@@ -1723,6 +1737,19 @@ impl Tab {
         paper.set_bot_listening(watching > 0);
     }
 
+    /// Apply the cleanup commands the panes' drawing menus queued this
+    /// frame — a disarm or removal over a resting retest limit cancels the
+    /// order. Runs on the UI frame that clicked, not on the next print: a
+    /// cancel that waits for the market to move may lose the race to it.
+    pub fn apply_strategy_cleanup(&mut self) {
+        let paper = &mut self.paper;
+        for pane in std::iter::once(&mut self.flow_pane).chain(self.time_pane.as_mut()) {
+            for command in pane.take_strategy_cleanup() {
+                let _ = paper.apply_strategy_command(command);
+            }
+        }
+    }
+
     /// Throw away everything loaded and wait for the source to refill it.
     ///
     /// Sent by a source that rewound — seeking a replay, for instance. The
@@ -1738,8 +1765,11 @@ impl Tab {
             pane.last_lane_divider_x = None;
             // Judgements armed on the old timeline do not carry into the
             // rebuilt one — the same honesty rule the simulator's flatten
-            // follows, with the reason on the badge.
-            pane.strategies
+            // follows, with the reason on the badge. No cleanup commands
+            // come back under this reason: `paper.on_timeline_reset` below
+            // sweeps every order with the honest `reset` label.
+            let _ = pane
+                .strategies
                 .disarm_all(quantick_strategy::DisarmReason::TimelineReset);
         }
         self.drop_overlay_gestures();

--- a/crates/backtest/src/main.rs
+++ b/crates/backtest/src/main.rs
@@ -152,6 +152,10 @@ struct Args {
     script: Option<PathBuf>,
     plot: usize,
     region: Option<RegionSpec>,
+    /// Force-region only: on a bar cutting through the region, rest a limit
+    /// at the cut edge (cancelled at the bar's target) instead of holding
+    /// fire — the chart's "retest limit" option, measured headless.
+    retest_limit: bool,
     quantity: Decimal,
     protection: Protection,
     write_trades: Option<PathBuf>,
@@ -205,6 +209,9 @@ fn usage() -> String {
   --region <low:high:side> the force-region strategy's price band and the
                            side it hunts (buy|sell); auto re-arms so every
                            qualifying bar in the recording is measured
+  --retest-limit           force-region: a bar cutting through the region
+                           rests a limit at the cut edge, cancelled if the
+                           bar's projected target trades first
   --quantity <n>           contracts per entry (default {DEFAULT_QUANTITY})
   --stop <points>          protective stop distance from the entry mark
   --target <points>        protective target distance from the entry mark
@@ -230,6 +237,7 @@ fn parse_args() -> Result<Args, String> {
         script: None,
         plot: 0,
         region: None,
+        retest_limit: false,
         quantity: DEFAULT_QUANTITY,
         protection: Protection::default(),
         write_trades: None,
@@ -266,6 +274,7 @@ fn parse_args() -> Result<Args, String> {
             "--confirm-flow" => args.confirm_flow = true,
             "--script" => args.script = Some(PathBuf::from(value()?)),
             "--region" => args.region = Some(RegionSpec::parse(&value()?)?),
+            "--retest-limit" => args.retest_limit = true,
             "--plot" => {
                 let text = value()?;
                 args.plot = text
@@ -298,6 +307,12 @@ fn parse_args() -> Result<Args, String> {
              shorter is the same signal read backwards",
             args.fast, args.slow
         ));
+    }
+    if args.retest_limit && args.strategy != Some(StrategyKind::ForceRegion) {
+        return Err(
+            "--retest-limit belongs to the force-region strategy — pass --region <low:high:side>"
+                .to_owned(),
+        );
     }
     if let (Some(from), Some(to)) = (args.from, args.to)
         && from > to
@@ -577,6 +592,11 @@ fn build_strategy(args: &Args) -> Result<Box<dyn Strategy>, String> {
                     // The harness measures: every qualifying bar in the
                     // recording counts, so the instance re-arms itself.
                     rearm: quantick_strategy::Rearm::Auto,
+                    on_break: if args.retest_limit {
+                        quantick_strategy::BreakPolicy::RetestLimit
+                    } else {
+                        quantick_strategy::BreakPolicy::Ignore
+                    },
                 },
                 quantick_strategy::ForceParams::default_band(),
             )))

--- a/crates/backtest/src/report.rs
+++ b/crates/backtest/src/report.rs
@@ -84,6 +84,14 @@ pub fn render_session(run: &SessionRun) -> String {
             quantity.normalize()
         );
     }
+    if run.resting_at_end > 0 {
+        let _ = writeln!(
+            out,
+            "  {} entry order(s) still resting at the last print — never filled, \
+             never cancelled; the recording ended first",
+            run.resting_at_end
+        );
+    }
     out
 }
 
@@ -234,7 +242,7 @@ fn push_metrics(out: &mut String, report: &PerformanceReport) {
 }
 
 fn push_anomalies(out: &mut String, anomalies: &Anomalies) {
-    if anomalies.is_clean() {
+    if anomalies.is_clean() && anomalies.cancels.is_empty() {
         return;
     }
     let detail = |counts: &std::collections::BTreeMap<&'static str, u64>| {
@@ -260,6 +268,18 @@ fn push_anomalies(out: &mut String, anomalies: &Anomalies) {
             "brackets dropped",
             anomalies.dropped_brackets(),
             detail(&anomalies.brackets_dropped)
+        );
+    }
+    if !anomalies.cancels.is_empty() {
+        // Not a refusal: the retest policy's self-cancels land here, and a
+        // zero-trade run with a hundred `price_touched` rows is a policy
+        // that kept declining, not a tape with no cuts.
+        let _ = writeln!(
+            out,
+            "  {:<LABEL_WIDTH$}{} ({})",
+            "order cancels",
+            anomalies.cancellations(),
+            detail(&anomalies.cancels)
         );
     }
 }

--- a/crates/backtest/src/run.rs
+++ b/crates/backtest/src/run.rs
@@ -94,6 +94,7 @@ pub fn reject_code(reason: &RejectReason) -> &'static str {
         RejectReason::PriceNotPositive => "price_not_positive",
         RejectReason::LimitOnWrongSide(_) => "limit_on_wrong_side",
         RejectReason::StopOnWrongSide(_) => "stop_on_wrong_side",
+        RejectReason::CancelAtOnWrongSide(_) => "cancel_at_on_wrong_side",
         RejectReason::StopLossOnWrongSide(_) => "stop_loss_on_wrong_side",
         RejectReason::TakeProfitOnWrongSide(_) => "take_profit_on_wrong_side",
         RejectReason::NoPosition => "no_position",

--- a/crates/backtest/src/run.rs
+++ b/crates/backtest/src/run.rs
@@ -35,6 +35,11 @@ pub struct Anomalies {
     /// Protective prices dropped at fill time — the tape had already run
     /// past the level between the command and the fill — by reason code.
     pub brackets_dropped: BTreeMap<&'static str, u64>,
+    /// Orders removed without filling, by reason code. Not a failure: the
+    /// retest policy's self-cancels (`price_touched`, `account_occupied`)
+    /// land here, and without them a zero-trade run under `--retest-limit`
+    /// is indistinguishable from "no cut ever happened".
+    pub cancels: BTreeMap<&'static str, u64>,
 }
 
 impl Anomalies {
@@ -50,7 +55,15 @@ impl Anomalies {
         self.brackets_dropped.values().sum()
     }
 
-    /// True when the run produced no refusal of any kind.
+    /// Total orders removed without filling.
+    #[must_use]
+    pub fn cancellations(&self) -> u64 {
+        self.cancels.values().sum()
+    }
+
+    /// True when the run produced no refusal of any kind. Cancels are not
+    /// refusals — an order standing down by its own rule is the rule
+    /// working — so they do not dirty a run.
     #[must_use]
     pub fn is_clean(&self) -> bool {
         self.rejected.is_empty() && self.brackets_dropped.is_empty()
@@ -64,6 +77,9 @@ impl Anomalies {
         for (code, count) in &other.brackets_dropped {
             *self.brackets_dropped.entry(code).or_default() += count;
         }
+        for (code, count) in &other.cancels {
+            *self.cancels.entry(code).or_default() += count;
+        }
     }
 
     fn observe(&mut self, event: &SimEvent) {
@@ -76,6 +92,9 @@ impl Anomalies {
                     .brackets_dropped
                     .entry(reject_code(reason))
                     .or_default() += 1;
+            }
+            SimEvent::Cancelled { reason, .. } => {
+                *self.cancels.entry(cancel_code(reason)).or_default() += 1;
             }
             _ => {}
         }
@@ -99,6 +118,20 @@ pub fn reject_code(reason: &RejectReason) -> &'static str {
         RejectReason::TakeProfitOnWrongSide(_) => "take_profit_on_wrong_side",
         RejectReason::NoPosition => "no_position",
         RejectReason::UnknownOrder(_) => "unknown_order",
+    }
+}
+
+/// A stable snake_case token per cancellation, same contract as
+/// [`reject_code`].
+#[must_use]
+pub fn cancel_code(reason: &quantick_sim::CancelReason) -> &'static str {
+    use quantick_sim::CancelReason;
+    match reason {
+        CancelReason::User => "user",
+        CancelReason::Flatten => "flatten",
+        CancelReason::Reset => "reset",
+        CancelReason::PriceTouched => "price_touched",
+        CancelReason::AccountOccupied => "account_occupied",
     }
 }
 
@@ -130,6 +163,11 @@ pub struct SessionRun {
     /// facing, because "a trade was left open" and "a *short* was left open
     /// into a rally" are not the same warning.
     pub open_at_end: Option<(Side, Decimal)>,
+    /// Entry orders still resting when the recording ended — the retest
+    /// limit's analogue of `open_at_end`: silently dropping it would make
+    /// "the order never filled" and "the order was still waiting" read the
+    /// same in the report.
+    pub resting_at_end: usize,
 }
 
 /// Run one strategy over one recorded session.
@@ -220,6 +258,7 @@ pub fn run_session(session: &Session, spec: BarSpec, strategy: &mut dyn Strategy
         open_at_end: sim
             .position()
             .map(|position| (position.side, position.quantity)),
+        resting_at_end: sim.orders().len(),
     }
 }
 

--- a/crates/backtest/tests/harness.rs
+++ b/crates/backtest/tests/harness.rs
@@ -307,6 +307,7 @@ fn refusals_are_counted_not_swallowed() {
                 price: Decimal::from(10_000),
                 bracket: quantick_sim::Bracket::none(),
                 cancel_at: None,
+                flat_only: false,
             },
         ),
     ]);

--- a/crates/backtest/tests/harness.rs
+++ b/crates/backtest/tests/harness.rs
@@ -166,6 +166,7 @@ fn the_force_region_kernel_walks_a_full_operation_under_the_harness() {
             tp_mult: Decimal::ONE,
             sl_mult: Decimal::ONE,
             rearm: Rearm::OneShot,
+            on_break: quantick_strategy::BreakPolicy::Ignore,
         },
         ForceParams {
             window: 3,
@@ -305,6 +306,7 @@ fn refusals_are_counted_not_swallowed() {
                 // Far above the market: a buy limit there fills instantly.
                 price: Decimal::from(10_000),
                 bracket: quantick_sim::Bracket::none(),
+                cancel_at: None,
             },
         ),
     ]);

--- a/crates/sim/src/events.rs
+++ b/crates/sim/src/events.rs
@@ -88,6 +88,10 @@ pub enum CancelReason {
     Flatten,
     /// A session reset discarded it.
     Reset,
+    /// The tape traded at or through the order's cancel-at price before the
+    /// order filled — the move the order was waiting to fade completed
+    /// without it, so the order removed itself as instructed.
+    PriceTouched,
 }
 
 /// Why a command was refused. Messages are written for a beginner: they say
@@ -104,6 +108,9 @@ pub enum RejectReason {
     LimitOnWrongSide(Side),
     /// A stop at or through the market would trigger immediately.
     StopOnWrongSide(Side),
+    /// A cancel-at price on the fill side of the market would cancel the
+    /// order immediately (or race its own fill).
+    CancelAtOnWrongSide(Side),
     /// A stop loss on the profit side of the reference price.
     StopLossOnWrongSide(Side),
     /// A take profit on the losing side of the reference price.
@@ -147,6 +154,18 @@ impl std::fmt::Display for RejectReason {
                 write!(
                     f,
                     "a sell stop must sit below the market (it chases weakness) - to sell above the market use a limit"
+                )
+            }
+            Self::CancelAtOnWrongSide(Side::Buy) => {
+                write!(
+                    f,
+                    "a buy limit's cancel-at price must sit above the market - it names the move that makes waiting pointless; below the market it would cancel the order instantly"
+                )
+            }
+            Self::CancelAtOnWrongSide(Side::Sell) => {
+                write!(
+                    f,
+                    "a sell limit's cancel-at price must sit below the market - it names the move that makes waiting pointless; above the market it would cancel the order instantly"
                 )
             }
             Self::StopLossOnWrongSide(Side::Buy) => {

--- a/crates/sim/src/events.rs
+++ b/crates/sim/src/events.rs
@@ -92,6 +92,10 @@ pub enum CancelReason {
     /// order filled — the move the order was waiting to fade completed
     /// without it, so the order removed itself as instructed.
     PriceTouched,
+    /// A flat-only order's price was reached while a position was open:
+    /// filling would have traded against (or piled onto) a position the
+    /// order's owner never accounted for, so it stood down instead.
+    AccountOccupied,
 }
 
 /// Why a command was refused. Messages are written for a beginner: they say

--- a/crates/sim/src/lib.rs
+++ b/crates/sim/src/lib.rs
@@ -28,6 +28,13 @@
 //! is rejected with advice rather than silently filled — a didactic
 //! simulator teaches the difference instead of papering over it.
 //!
+//! A **limit with a cancel-at price** ([`Command::PlaceLimit`]'s
+//! `cancel_at`) removes itself, unfilled, on a print trading at or through
+//! that level ([`CancelReason::PriceTouched`]) — "the move completed
+//! without the retest, so stop waiting for one". Validation keeps the
+//! cancel level on the far side of the market from the limit price, so no
+//! single print can ever satisfy both fill and cancel.
+//!
 //! A protective level attached to a market or stop entry is re-checked
 //! against the *actual* fill price: validation ran against the mark, but
 //! the fill lands on a later print, and when the tape outran the level in

--- a/crates/sim/src/lib.rs
+++ b/crates/sim/src/lib.rs
@@ -35,6 +35,13 @@
 //! cancel level on the far side of the market from the limit price, so no
 //! single print can ever satisfy both fill and cancel.
 //!
+//! A **flat-only limit** ([`Command::PlaceLimit`]'s `flat_only`) fills only
+//! into an account with no open position: if its fill print arrives while
+//! one is open, the order stands down instead
+//! ([`CancelReason::AccountOccupied`]). The strategy kernel rests its
+//! entries this way — an order placed under a flat-account promise must
+//! never net a position a human opened while it rested.
+//!
 //! A protective level attached to a market or stop entry is re-checked
 //! against the *actual* fill price: validation ran against the mark, but
 //! the fill lands on a later print, and when the tape outran the level in

--- a/crates/sim/src/order.rs
+++ b/crates/sim/src/order.rs
@@ -87,6 +87,13 @@ pub struct Order {
     /// validation keeps it on the far side of the market from the limit
     /// price, so no single print can ever satisfy both fill and cancel.
     pub cancel_at: Option<Decimal>,
+    /// Fill only into an account with no open position: if the print that
+    /// would fill this order arrives while a position is open, the order
+    /// cancels instead ([`crate::CancelReason::AccountOccupied`]). The
+    /// strategy kernel sets this on its resting entries — an order whose
+    /// reason to exist assumed a flat account must never execute against a
+    /// position a human opened while it rested.
+    pub flat_only: bool,
     /// Venue time of the last print seen when the order was placed. The
     /// simulator has no clock of its own.
     pub placed_ms: i64,

--- a/crates/sim/src/order.rs
+++ b/crates/sim/src/order.rs
@@ -80,6 +80,13 @@ pub struct Order {
     pub price: Option<Decimal>,
     pub quantity: Decimal,
     pub bracket: Bracket,
+    /// Price-cancel level for a resting limit: a print trading at or
+    /// through it before the order fills removes the order
+    /// ([`crate::CancelReason::PriceTouched`]) — "cancel the retest entry
+    /// once the move completes without it". Only limit entries carry one;
+    /// validation keeps it on the far side of the market from the limit
+    /// price, so no single print can ever satisfy both fill and cancel.
+    pub cancel_at: Option<Decimal>,
     /// Venue time of the last print seen when the order was placed. The
     /// simulator has no clock of its own.
     pub placed_ms: i64,

--- a/crates/sim/src/simulator.rs
+++ b/crates/sim/src/simulator.rs
@@ -70,6 +70,12 @@ pub enum Command {
         /// the market from `price` — above it for a buy, below it for a
         /// sell — so fill and cancel can never share a print.
         cancel_at: Option<Decimal>,
+        /// Fill only into an account with no open position; if the fill
+        /// print arrives while one is open, the order cancels instead
+        /// ([`CancelReason::AccountOccupied`]). For entries whose owner
+        /// (the strategy kernel) promised never to trade against a
+        /// position it did not open.
+        flat_only: bool,
     },
     /// Arm at `trigger` until the tape trades at or through it, then fill
     /// at that print's price.
@@ -307,6 +313,16 @@ impl Simulator {
                 _ => None,
             };
             match fill_at {
+                // A flat-only order whose moment arrives over an open
+                // position stands down at that moment — never before it
+                // (the position may close first), never after (filling
+                // would trade against a position its owner never saw).
+                Some(_) if order.flat_only && self.position.is_some() => {
+                    events.push(SimEvent::Cancelled {
+                        order,
+                        reason: CancelReason::AccountOccupied,
+                    });
+                }
                 Some(at) => self.fill_entry_at(&order, at, trade, &mut events),
                 None => kept.push(order),
             }
@@ -388,6 +404,7 @@ impl Simulator {
                     quantity,
                     bracket,
                     None,
+                    false,
                     mark.timestamp_ms,
                 );
                 let placed = SimEvent::Placed(order.clone());
@@ -400,6 +417,7 @@ impl Simulator {
                 price,
                 bracket,
                 cancel_at,
+                flat_only,
             } => {
                 let mark = self.mark.ok_or(RejectReason::NoMarketPrice)?;
                 require_positive_quantity(quantity)?;
@@ -417,6 +435,7 @@ impl Simulator {
                     quantity,
                     bracket,
                     cancel_at,
+                    flat_only,
                     mark.timestamp_ms,
                 );
                 let placed = SimEvent::Placed(order.clone());
@@ -441,6 +460,7 @@ impl Simulator {
                     quantity,
                     bracket,
                     None,
+                    false,
                     mark.timestamp_ms,
                 );
                 let placed = SimEvent::Placed(order.clone());
@@ -558,6 +578,7 @@ impl Simulator {
         quantity: Decimal,
         bracket: Bracket,
         cancel_at: Option<Decimal>,
+        flat_only: bool,
         placed_ms: i64,
     ) -> Order {
         self.next_id += 1;
@@ -569,6 +590,7 @@ impl Simulator {
             quantity,
             bracket,
             cancel_at,
+            flat_only,
             placed_ms,
         }
     }
@@ -1016,6 +1038,7 @@ mod tests {
             price: dec(95),
             bracket: Bracket::none(),
             cancel_at: None,
+            flat_only: false,
         });
         assert!(
             fills(&sim.on_trade(&print(1, 96))).is_empty(),
@@ -1040,6 +1063,7 @@ mod tests {
             price: dec(100),
             bracket: Bracket::none(),
             cancel_at: None,
+            flat_only: false,
         });
         assert_eq!(
             events,
@@ -1064,6 +1088,7 @@ mod tests {
             price: dec(100),
             bracket: Bracket::none(),
             cancel_at: Some(dec(88)),
+            flat_only: false,
         });
         // Prints between the two levels leave the order resting.
         assert!(sim.on_trade(&print(1, 94)).is_empty());
@@ -1097,6 +1122,7 @@ mod tests {
                 take_profit: Some(dec(88)),
             },
             cancel_at: Some(dec(88)),
+            flat_only: false,
         });
         // The tape returns to the edge before reaching the target: a normal
         // limit fill at its own price, bracket armed, cancel-at forgotten.
@@ -1125,6 +1151,7 @@ mod tests {
             price: dec(100),
             bracket: Bracket::none(),
             cancel_at: Some(dec(112)),
+            flat_only: false,
         });
         let events = sim.on_trade(&print(1, 112));
         assert!(
@@ -1145,9 +1172,84 @@ mod tests {
             price: dec(100),
             bracket: Bracket::none(),
             cancel_at: Some(dec(112)),
+            flat_only: false,
         });
         let events = sim.on_trade(&print(1, 100));
         assert_eq!(fills(&events).len(), 1, "the retest fills as usual");
+    }
+
+    /// A flat-only order's moment arriving over an open position stands the
+    /// order down instead of filling it — the position a human opened while
+    /// the order rested is never traded against, closed, or re-bracketed.
+    #[test]
+    fn a_flat_only_limit_stands_down_when_its_moment_finds_a_position() {
+        let mut sim = seeded(95);
+        sim.apply(Command::PlaceLimit {
+            side: Side::Sell,
+            quantity: Decimal::ONE,
+            price: dec(100),
+            bracket: Bracket {
+                stop_loss: Some(dec(104)),
+                take_profit: Some(dec(88)),
+            },
+            cancel_at: Some(dec(88)),
+            flat_only: true,
+        });
+        // A human buys at market while the order rests.
+        sim.apply(Command::PlaceMarket {
+            side: Side::Buy,
+            quantity: dec(2),
+            bracket: Bracket::none(),
+        });
+        sim.on_trade(&print(1, 96));
+        assert_eq!(sim.position().expect("manual long").quantity, dec(2));
+
+        // The tape returns to the edge: the flat-only order stands down —
+        // no fill, and the human's position is untouched.
+        let events = sim.on_trade(&print(2, 100));
+        assert!(
+            matches!(
+                events.as_slice(),
+                [SimEvent::Cancelled {
+                    reason: CancelReason::AccountOccupied,
+                    ..
+                }]
+            ),
+            "the occupied account cancels the flat-only order: {events:?}"
+        );
+        let position = sim.position().expect("the human's long survives");
+        assert_eq!(position.side, Side::Buy);
+        assert_eq!(position.quantity, dec(2));
+        assert_eq!(position.stop_loss, None, "their bracket is untouched");
+        assert!(sim.orders().is_empty());
+    }
+
+    /// The stand-down judges the *fill moment*, not history: a position
+    /// that opened and closed while the order rested changes nothing.
+    #[test]
+    fn a_position_that_closed_before_the_moment_does_not_stand_the_order_down() {
+        let mut sim = seeded(95);
+        sim.apply(Command::PlaceLimit {
+            side: Side::Sell,
+            quantity: Decimal::ONE,
+            price: dec(100),
+            bracket: Bracket::none(),
+            cancel_at: None,
+            flat_only: true,
+        });
+        sim.apply(Command::PlaceMarket {
+            side: Side::Buy,
+            quantity: Decimal::ONE,
+            bracket: Bracket::none(),
+        });
+        sim.on_trade(&print(1, 96));
+        sim.apply(Command::ClosePosition);
+        sim.on_trade(&print(2, 97));
+        assert!(sim.position().is_none(), "the round trip closed");
+
+        let events = sim.on_trade(&print(3, 100));
+        assert_eq!(fills(&events).len(), 1, "flat again, the order fills");
+        assert_eq!(sim.position().expect("short opened").side, Side::Sell);
     }
 
     /// A cancel-at level on the fill side of the market would cancel
@@ -1162,6 +1264,7 @@ mod tests {
             price: dec(100),
             bracket: Bracket::none(),
             cancel_at: Some(dec(97)),
+            flat_only: false,
         });
         assert_eq!(
             events,
@@ -1178,6 +1281,7 @@ mod tests {
             price: dec(100),
             bracket: Bracket::none(),
             cancel_at: Some(Decimal::ZERO),
+            flat_only: false,
         });
         assert_eq!(
             events,
@@ -1472,6 +1576,7 @@ mod tests {
             price: dec(95),
             bracket: Bracket::none(),
             cancel_at: None,
+            flat_only: false,
         });
         let events = sim.apply(Command::Flatten);
         assert!(
@@ -1559,6 +1664,7 @@ mod tests {
             price: dec(95),
             bracket: Bracket::none(),
             cancel_at: None,
+            flat_only: false,
         });
         let id = sim.orders()[0].id;
         let events = sim.apply(Command::ModifyOrder { id, price: dec(93) });
@@ -1592,6 +1698,7 @@ mod tests {
             price: dec(95),
             bracket: Bracket::none(),
             cancel_at: None,
+            flat_only: false,
         });
         let id = sim.orders()[0].id;
         let events = sim.apply(Command::ModifyOrder {
@@ -1626,6 +1733,7 @@ mod tests {
             price: dec(90),
             bracket: Bracket::none(),
             cancel_at: None,
+            flat_only: false,
         });
         sim.on_trade(&print(2, 104));
 
@@ -1670,6 +1778,7 @@ mod tests {
             price: Decimal::ZERO,
             bracket: Bracket::none(),
             cancel_at: None,
+            flat_only: false,
         });
         assert_eq!(
             events,
@@ -1893,6 +2002,7 @@ mod tests {
                             take_profit: Some(dec(104)),
                         },
                         cancel_at: None,
+                        flat_only: false,
                     }) {
                         log.push(format!("{event:?}"));
                     }

--- a/crates/sim/src/simulator.rs
+++ b/crates/sim/src/simulator.rs
@@ -64,6 +64,12 @@ pub enum Command {
         quantity: Decimal,
         price: Decimal,
         bracket: Bracket,
+        /// Optional price-cancel level: a print trading at or through it
+        /// before the fill removes the order
+        /// ([`CancelReason::PriceTouched`]). Must sit on the far side of
+        /// the market from `price` — above it for a buy, below it for a
+        /// sell — so fill and cancel can never share a print.
+        cancel_at: Option<Decimal>,
     },
     /// Arm at `trigger` until the tape trades at or through it, then fill
     /// at that print's price.
@@ -269,7 +275,10 @@ impl Simulator {
             }
         }
 
-        // 3) Resting orders, in placement order.
+        // 3) Resting orders, in placement order. The cancel-at check comes
+        //    first, but never races the fill: placement validation keeps the
+        //    two levels on opposite sides of the market, so one print price
+        //    cannot satisfy both.
         let resting = std::mem::take(&mut self.resting);
         let mut kept = Vec::with_capacity(resting.len());
         for order in resting {
@@ -278,6 +287,18 @@ impl Simulator {
                 kept.push(order);
                 continue;
             };
+            let price_cancelled = order.kind == EntryKind::Limit
+                && order.cancel_at.is_some_and(|cancel| match order.side {
+                    Side::Buy => price >= cancel,
+                    Side::Sell => price <= cancel,
+                });
+            if price_cancelled {
+                events.push(SimEvent::Cancelled {
+                    order,
+                    reason: CancelReason::PriceTouched,
+                });
+                continue;
+            }
             let fill_at = match (order.kind, order.side) {
                 (EntryKind::Limit, Side::Buy) if price <= level => Some(level),
                 (EntryKind::Limit, Side::Sell) if price >= level => Some(level),
@@ -366,6 +387,7 @@ impl Simulator {
                     None,
                     quantity,
                     bracket,
+                    None,
                     mark.timestamp_ms,
                 );
                 let placed = SimEvent::Placed(order.clone());
@@ -377,18 +399,24 @@ impl Simulator {
                 quantity,
                 price,
                 bracket,
+                cancel_at,
             } => {
                 let mark = self.mark.ok_or(RejectReason::NoMarketPrice)?;
                 require_positive_quantity(quantity)?;
                 require_positive_price(price)?;
                 validate_limit_side(side, price, mark.price)?;
                 validate_bracket(side, price, bracket)?;
+                if let Some(cancel) = cancel_at {
+                    require_positive_price(cancel)?;
+                    validate_cancel_at_side(side, cancel, mark.price)?;
+                }
                 let order = self.make_order(
                     side,
                     EntryKind::Limit,
                     Some(price),
                     quantity,
                     bracket,
+                    cancel_at,
                     mark.timestamp_ms,
                 );
                 let placed = SimEvent::Placed(order.clone());
@@ -412,6 +440,7 @@ impl Simulator {
                     Some(trigger),
                     quantity,
                     bracket,
+                    None,
                     mark.timestamp_ms,
                 );
                 let placed = SimEvent::Placed(order.clone());
@@ -517,6 +546,10 @@ impl Simulator {
         }
     }
 
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "one order has one natural field list; bundling it into a struct would name nothing"
+    )]
     fn make_order(
         &mut self,
         side: Side,
@@ -524,6 +557,7 @@ impl Simulator {
         price: Option<Decimal>,
         quantity: Decimal,
         bracket: Bracket,
+        cancel_at: Option<Decimal>,
         placed_ms: i64,
     ) -> Order {
         self.next_id += 1;
@@ -534,6 +568,7 @@ impl Simulator {
             price,
             quantity,
             bracket,
+            cancel_at,
             placed_ms,
         }
     }
@@ -827,6 +862,22 @@ fn validate_limit_side(side: Side, price: Decimal, mark: Decimal) -> Result<(), 
     }
 }
 
+/// A limit's cancel-at level must sit on the far side of the market from
+/// the limit price — above it for a buy (which rests below), below it for a
+/// sell. That keeps the two levels on opposite sides of every future print,
+/// so no single print can both fill and cancel the order.
+fn validate_cancel_at_side(side: Side, cancel: Decimal, mark: Decimal) -> Result<(), RejectReason> {
+    let far_side = match side {
+        Side::Buy => cancel > mark,
+        Side::Sell => cancel < mark,
+    };
+    if far_side {
+        Ok(())
+    } else {
+        Err(RejectReason::CancelAtOnWrongSide(side))
+    }
+}
+
 /// A stop must arm beyond the market: a buy above it, a sell below it.
 fn validate_stop_side(side: Side, trigger: Decimal, mark: Decimal) -> Result<(), RejectReason> {
     let arms = match side {
@@ -964,6 +1015,7 @@ mod tests {
             quantity: Decimal::ONE,
             price: dec(95),
             bracket: Bracket::none(),
+            cancel_at: None,
         });
         assert!(
             fills(&sim.on_trade(&print(1, 96))).is_empty(),
@@ -987,12 +1039,150 @@ mod tests {
             quantity: Decimal::ONE,
             price: dec(100),
             bracket: Bracket::none(),
+            cancel_at: None,
         });
         assert_eq!(
             events,
             vec![SimEvent::Rejected(RejectReason::LimitOnWrongSide(
                 Side::Buy
             ))]
+        );
+    }
+
+    /// The retest scenario the strategy kernel places: the market broke
+    /// below a region, a sell limit rests at the broken edge, and the
+    /// cancel-at level names the projected target below. Whichever the tape
+    /// reaches first decides the order's fate.
+    #[test]
+    fn a_print_through_the_cancel_at_level_removes_the_limit_unfilled() {
+        // Market at 95 after a break: sell limit back up at 100 (the region
+        // edge), cancelled if 88 (the target) trades first.
+        let mut sim = seeded(95);
+        sim.apply(Command::PlaceLimit {
+            side: Side::Sell,
+            quantity: Decimal::ONE,
+            price: dec(100),
+            bracket: Bracket::none(),
+            cancel_at: Some(dec(88)),
+        });
+        // Prints between the two levels leave the order resting.
+        assert!(sim.on_trade(&print(1, 94)).is_empty());
+        assert_eq!(sim.orders().len(), 1);
+
+        // The tape gaps through the target: the order goes, no fill.
+        let events = sim.on_trade(&print(2, 87));
+        assert!(
+            matches!(
+                events.as_slice(),
+                [SimEvent::Cancelled {
+                    reason: CancelReason::PriceTouched,
+                    ..
+                }]
+            ),
+            "the target print cancels the resting limit: {events:?}"
+        );
+        assert!(sim.orders().is_empty());
+        assert!(sim.position().is_none());
+    }
+
+    #[test]
+    fn the_retest_fill_still_wins_when_the_tape_returns_first() {
+        let mut sim = seeded(95);
+        sim.apply(Command::PlaceLimit {
+            side: Side::Sell,
+            quantity: Decimal::ONE,
+            price: dec(100),
+            bracket: Bracket {
+                stop_loss: Some(dec(104)),
+                take_profit: Some(dec(88)),
+            },
+            cancel_at: Some(dec(88)),
+        });
+        // The tape returns to the edge before reaching the target: a normal
+        // limit fill at its own price, bracket armed, cancel-at forgotten.
+        let events = sim.on_trade(&print(1, 100));
+        let filled = fills(&events);
+        assert_eq!(filled.len(), 1);
+        assert_eq!(filled[0].price, dec(100));
+        let position = sim.position().expect("short opened at the edge");
+        assert_eq!(position.side, Side::Sell);
+        assert_eq!(position.take_profit, Some(dec(88)));
+
+        // The later target print is now the position's take profit, not a
+        // cancel of anything.
+        let events = sim.on_trade(&print(2, 88));
+        assert_eq!(fills(&events).len(), 1);
+        assert!(sim.position().is_none());
+    }
+
+    /// Mirrored for a buy: the limit rests below, the cancel-at sits above.
+    #[test]
+    fn a_buy_retest_limit_cancels_upward_and_fills_downward() {
+        let mut sim = seeded(105);
+        sim.apply(Command::PlaceLimit {
+            side: Side::Buy,
+            quantity: Decimal::ONE,
+            price: dec(100),
+            bracket: Bracket::none(),
+            cancel_at: Some(dec(112)),
+        });
+        let events = sim.on_trade(&print(1, 112));
+        assert!(
+            matches!(
+                events.as_slice(),
+                [SimEvent::Cancelled {
+                    reason: CancelReason::PriceTouched,
+                    ..
+                }]
+            ),
+            "the upward target print cancels the buy limit: {events:?}"
+        );
+
+        let mut sim = seeded(105);
+        sim.apply(Command::PlaceLimit {
+            side: Side::Buy,
+            quantity: Decimal::ONE,
+            price: dec(100),
+            bracket: Bracket::none(),
+            cancel_at: Some(dec(112)),
+        });
+        let events = sim.on_trade(&print(1, 100));
+        assert_eq!(fills(&events).len(), 1, "the retest fills as usual");
+    }
+
+    /// A cancel-at level on the fill side of the market would cancel
+    /// instantly (or race its own fill) — refused with advice, like every
+    /// other level the simulator cannot honestly hold.
+    #[test]
+    fn a_cancel_at_on_the_wrong_side_is_rejected_whole() {
+        let mut sim = seeded(95);
+        let events = sim.apply(Command::PlaceLimit {
+            side: Side::Sell,
+            quantity: Decimal::ONE,
+            price: dec(100),
+            bracket: Bracket::none(),
+            cancel_at: Some(dec(97)),
+        });
+        assert_eq!(
+            events,
+            vec![SimEvent::Rejected(RejectReason::CancelAtOnWrongSide(
+                Side::Sell
+            ))],
+            "a sell's cancel-at above the market is refused"
+        );
+        assert!(sim.orders().is_empty());
+
+        let events = sim.apply(Command::PlaceLimit {
+            side: Side::Sell,
+            quantity: Decimal::ONE,
+            price: dec(100),
+            bracket: Bracket::none(),
+            cancel_at: Some(Decimal::ZERO),
+        });
+        assert_eq!(
+            events,
+            vec![SimEvent::Rejected(RejectReason::PriceNotPositive)],
+            "a non-positive cancel-at is refused"
         );
     }
 
@@ -1281,6 +1471,7 @@ mod tests {
             quantity: dec(1),
             price: dec(95),
             bracket: Bracket::none(),
+            cancel_at: None,
         });
         let events = sim.apply(Command::Flatten);
         assert!(
@@ -1367,6 +1558,7 @@ mod tests {
             quantity: dec(1),
             price: dec(95),
             bracket: Bracket::none(),
+            cancel_at: None,
         });
         let id = sim.orders()[0].id;
         let events = sim.apply(Command::ModifyOrder { id, price: dec(93) });
@@ -1399,6 +1591,7 @@ mod tests {
             quantity: dec(1),
             price: dec(95),
             bracket: Bracket::none(),
+            cancel_at: None,
         });
         let id = sim.orders()[0].id;
         let events = sim.apply(Command::ModifyOrder {
@@ -1432,6 +1625,7 @@ mod tests {
             quantity: dec(1),
             price: dec(90),
             bracket: Bracket::none(),
+            cancel_at: None,
         });
         sim.on_trade(&print(2, 104));
 
@@ -1475,6 +1669,7 @@ mod tests {
             quantity: Decimal::ONE,
             price: Decimal::ZERO,
             bracket: Bracket::none(),
+            cancel_at: None,
         });
         assert_eq!(
             events,
@@ -1697,6 +1892,7 @@ mod tests {
                             stop_loss: Some(dec(90)),
                             take_profit: Some(dec(104)),
                         },
+                        cancel_at: None,
                     }) {
                         log.push(format!("{event:?}"));
                     }

--- a/crates/strategy/src/armed.rs
+++ b/crates/strategy/src/armed.rs
@@ -27,6 +27,24 @@ pub enum Rearm {
     Auto,
 }
 
+/// What the instance does when the trigger bar cuts *through* the region —
+/// same side, region active, but the close beyond the region's edge in the
+/// trade's direction. Closing inside still fires at market; closing beyond
+/// the *opposite* edge never fires at all.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum BreakPolicy {
+    /// Hold fire, exactly as before this option existed. The default.
+    #[default]
+    Ignore,
+    /// Rest a limit at the cut edge — the price the tape must revisit to
+    /// retest the region — bracketed off the trigger bar like the market
+    /// entry would have been, and cancelled if the tape reaches the bar's
+    /// projected take profit before returning. With no take-profit leg
+    /// there is no target to reach, so the order rests until it fills or
+    /// the instance disarms.
+    RetestLimit,
+}
+
 /// The preset half of an instance: everything a strategy bank row stores.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StrategyParams {
@@ -41,6 +59,8 @@ pub struct StrategyParams {
     /// Zero or negative means "no stop leg".
     pub sl_mult: Decimal,
     pub rearm: Rearm,
+    /// What a region-cutting trigger bar does. See [`BreakPolicy`].
+    pub on_break: BreakPolicy,
 }
 
 /// Why an instance stopped watching the market.
@@ -67,6 +87,12 @@ pub enum DisarmReason {
     /// that lost its protection mid-flight is not the operation that was
     /// armed.
     ProtectionDropped,
+    /// The retest limit was cancelled by its own cancel-at level: the tape
+    /// reached the trigger bar's projected target before returning to the
+    /// region edge. The move completed without the retest — no trade
+    /// happened, and a one-shot instance stops and says so rather than
+    /// pretending an operation ran.
+    TargetBeforeRetest,
 }
 
 impl DisarmReason {
@@ -81,6 +107,7 @@ impl DisarmReason {
             Self::EntryRejected(_) => "entry rejected",
             Self::EntryCancelled => "entry cancelled",
             Self::ProtectionDropped => "protection dropped — closed",
+            Self::TargetBeforeRetest => "target hit before retest",
         }
     }
 }
@@ -94,6 +121,11 @@ pub enum ArmedState {
     /// is filled in when the simulator acknowledges placement.
     Fired {
         order_id: Option<OrderId>,
+        /// `true` when the entry is a resting retest limit at the region
+        /// edge (which may wait a long time and cancel itself at the
+        /// target) rather than a market order meeting the next print.
+        /// Badges narrate the difference; the machine walks the same path.
+        retest: bool,
     },
     /// The entry filled; the operation is live until the account is flat
     /// again (its bracket, a manual close — the instance does not care
@@ -183,14 +215,24 @@ impl ArmedStrategy {
         if self.state != ArmedState::Armed {
             return Vec::new();
         }
+        // Every gate that holds a seen trigger names itself in the note, so
+        // the badge never shows a bare "armed" over a force bar that did
+        // nothing — the mystery that reads as a broken bot. A bar with no
+        // signal clears the note and lets the trigger's own status narrate.
         let Some(signal) = signal else {
+            self.note = None;
             return Vec::new();
         };
-        if signal.side != self.params.side
-            || !region_active
-            || !region.contains(signal.reference)
-            || !account_flat
-        {
+        if signal.side != self.params.side {
+            self.note = Some("trigger held: opposite side");
+            return Vec::new();
+        }
+        if !region_active {
+            self.note = Some("trigger held: region not active on this bar");
+            return Vec::new();
+        }
+        if !account_flat {
+            self.note = Some("trigger held: account not flat");
             return Vec::new();
         }
         let Some(bracket) = project_bracket(
@@ -205,12 +247,61 @@ impl ArmedStrategy {
             self.note = Some("projection invalid — held fire");
             return Vec::new();
         };
+        if region.contains(signal.reference) {
+            self.note = None;
+            self.state = ArmedState::Fired {
+                order_id: None,
+                retest: false,
+            };
+            return vec![Command::PlaceMarket {
+                side: self.params.side,
+                quantity: self.params.quantity,
+                bracket,
+            }];
+        }
+        // The close sits outside the region. A cut — beyond the edge in the
+        // trade's own direction — may still become a retest limit at that
+        // edge; beyond the opposite edge it is just a miss.
+        let edge = match self.params.side {
+            Side::Sell if signal.reference < region.low() => Some(region.low()),
+            Side::Buy if signal.reference > region.high() => Some(region.high()),
+            _ => None,
+        };
+        let (BreakPolicy::RetestLimit, Some(edge)) = (self.params.on_break, edge) else {
+            self.note = Some("trigger held: closed outside region");
+            return Vec::new();
+        };
+        // The projected legs anchor on the trigger bar, but the entry now
+        // prices at the edge: a leg that does not clear the edge would be
+        // dropped (or rejected) by the simulator, and "never fire
+        // unprotected" makes that a reason to hold, not to fire bare.
+        let legs_clear_edge = match self.params.side {
+            Side::Sell => {
+                bracket.stop_loss.is_none_or(|level| level > edge)
+                    && bracket.take_profit.is_none_or(|level| level < edge)
+            }
+            Side::Buy => {
+                bracket.stop_loss.is_none_or(|level| level < edge)
+                    && bracket.take_profit.is_none_or(|level| level > edge)
+            }
+        };
+        if !legs_clear_edge {
+            self.note = Some("retest bracket does not clear the edge — held fire");
+            return Vec::new();
+        }
         self.note = None;
-        self.state = ArmedState::Fired { order_id: None };
-        vec![Command::PlaceMarket {
+        self.state = ArmedState::Fired {
+            order_id: None,
+            retest: true,
+        };
+        vec![Command::PlaceLimit {
             side: self.params.side,
             quantity: self.params.quantity,
+            price: edge,
             bracket,
+            // The projected target doubles as the order's expiry: the move
+            // completing without the retest removes the reason to enter.
+            cancel_at: bracket.take_profit,
         }]
     }
 
@@ -238,27 +329,54 @@ impl ArmedStrategy {
         let mut commands = Vec::new();
         for event in events {
             match (&self.state, event) {
-                (ArmedState::Fired { order_id: None }, SimEvent::Placed(order)) => {
+                (
+                    ArmedState::Fired {
+                        order_id: None,
+                        retest,
+                    },
+                    SimEvent::Placed(order),
+                ) => {
                     self.state = ArmedState::Fired {
                         order_id: Some(order.id),
+                        retest: *retest,
                     };
                 }
-                (ArmedState::Fired { order_id: None }, SimEvent::Rejected(reason)) => {
+                (ArmedState::Fired { order_id: None, .. }, SimEvent::Rejected(reason)) => {
                     self.state = ArmedState::Disarmed {
                         reason: DisarmReason::EntryRejected(*reason),
                     };
                 }
-                (ArmedState::Fired { order_id: Some(id) }, SimEvent::Filled(fill))
-                    if fill.role == quantick_sim::FillRole::Entry(*id) =>
-                {
+                (
+                    ArmedState::Fired {
+                        order_id: Some(id), ..
+                    },
+                    SimEvent::Filled(fill),
+                ) if fill.role == quantick_sim::FillRole::Entry(*id) => {
                     self.state = ArmedState::InPosition;
                     my_fill_in_batch = true;
                 }
-                (ArmedState::Fired { order_id: Some(id) }, SimEvent::Cancelled { order, .. })
-                    if order.id == *id =>
-                {
-                    self.state = ArmedState::Disarmed {
-                        reason: DisarmReason::EntryCancelled,
+                (
+                    ArmedState::Fired {
+                        order_id: Some(id), ..
+                    },
+                    SimEvent::Cancelled { order, reason },
+                ) if order.id == *id => {
+                    self.state = match reason {
+                        // The order's own cancel-at level: the tape reached
+                        // the projected target before the retest. No trade
+                        // happened — an auto instance goes straight back to
+                        // hunting, a one-shot stops with the reason named.
+                        quantick_sim::CancelReason::PriceTouched => match self.params.rearm {
+                            Rearm::Auto => ArmedState::Armed,
+                            Rearm::OneShot => ArmedState::Disarmed {
+                                reason: DisarmReason::TargetBeforeRetest,
+                            },
+                        },
+                        // A human hand (or a reset) swept the entry away;
+                        // the bot does not insist.
+                        _ => ArmedState::Disarmed {
+                            reason: DisarmReason::EntryCancelled,
+                        },
                     };
                 }
                 (ArmedState::InPosition, SimEvent::BracketDropped { .. }) if my_fill_in_batch => {
@@ -279,8 +397,30 @@ impl ArmedStrategy {
     /// Stop watching, with the reason the badge will show. An in-position
     /// instance hands its operation to the human: the position and its
     /// bracket live on in the simulator untouched.
-    pub fn disarm(&mut self, reason: DisarmReason) {
+    ///
+    /// A *pending* entry is different — the bot asked for it and no human
+    /// ever saw it fill, so the instance sweeps it on the way out: the
+    /// returned commands cancel it, and the caller applies them to the
+    /// simulator. (Under [`DisarmReason::TimelineReset`] the simulator's
+    /// own reset is already cancelling everything with the honest reason,
+    /// so nothing is returned — a second cancel would only address an id
+    /// that no longer exists.) Before retest limits a pending entry lived
+    /// for exactly one print; now it can rest for hours, which is what
+    /// makes the sweep worth commanding.
+    #[must_use = "apply the returned cleanup commands to the simulator"]
+    pub fn disarm(&mut self, reason: DisarmReason) -> Vec<Command> {
+        let cleanup = match (&self.state, reason) {
+            (_, DisarmReason::TimelineReset) => Vec::new(),
+            (
+                ArmedState::Fired {
+                    order_id: Some(id), ..
+                },
+                _,
+            ) => vec![Command::CancelOrder { id: *id }],
+            _ => Vec::new(),
+        };
         self.state = ArmedState::Disarmed { reason };
+        cleanup
     }
 
     /// Re-arm from `Done` or `Disarmed`. A live operation (`Fired`,
@@ -317,7 +457,10 @@ impl ArmedStrategy {
                 Some(note) => format!("armed · {note}"),
                 None => format!("armed · {}", self.trigger.status()),
             },
-            ArmedState::Fired { .. } => "fired · waiting for fill".to_owned(),
+            ArmedState::Fired { retest: false, .. } => "fired · waiting for fill".to_owned(),
+            ArmedState::Fired { retest: true, .. } => {
+                "retest limit resting at the edge · cancels at target".to_owned()
+            }
             ArmedState::InPosition => "in position".to_owned(),
             ArmedState::Done => "done · one shot".to_owned(),
             ArmedState::Disarmed { reason } => reason.label().to_owned(),
@@ -401,6 +544,7 @@ mod tests {
             tp_mult: Decimal::ONE,
             sl_mult: Decimal::ONE,
             rearm: Rearm::OneShot,
+            on_break: BreakPolicy::Ignore,
         }
     }
 
@@ -449,7 +593,13 @@ mod tests {
                 },
             }]
         );
-        assert_eq!(instance.state(), &ArmedState::Fired { order_id: None });
+        assert_eq!(
+            instance.state(),
+            &ArmedState::Fired {
+                order_id: None,
+                retest: false
+            }
+        );
     }
 
     #[test]
@@ -508,7 +658,7 @@ mod tests {
 
         // Disarmed instances keep their window warm but never fire.
         let mut instance = force_instance(Side::Buy);
-        instance.disarm(DisarmReason::User);
+        let _ = instance.disarm(DisarmReason::User);
         assert!(warm_then_force(&mut instance, &region).is_empty());
         instance.rearm();
         // The window is already warm: the next force bar fires immediately.
@@ -533,13 +683,15 @@ mod tests {
             price: None,
             quantity: Decimal::ONE,
             bracket: Bracket::none(),
+            cancel_at: None,
             placed_ms: 0,
         };
         let _ = instance.on_sim_events(&[SimEvent::Placed(order.clone())]);
         assert_eq!(
             instance.state(),
             &ArmedState::Fired {
-                order_id: Some(OrderId(7))
+                order_id: Some(OrderId(7)),
+                retest: false
             }
         );
 
@@ -592,6 +744,7 @@ mod tests {
             price: None,
             quantity: Decimal::ONE,
             bracket: Bracket::none(),
+            cancel_at: None,
             placed_ms: 0,
         })]);
         let _ = instance.on_sim_events(&[SimEvent::Filled(quantick_sim::Fill {
@@ -637,6 +790,7 @@ mod tests {
             price: None,
             quantity: Decimal::ONE,
             bracket: Bracket::none(),
+            cancel_at: None,
             placed_ms: 0,
         };
         let _ = instance.on_sim_events(&[SimEvent::Placed(order.clone())]);
@@ -739,6 +893,7 @@ mod tests {
             price: None,
             quantity: Decimal::ONE,
             bracket: Bracket::none(),
+            cancel_at: None,
             placed_ms: 0,
         };
         let _ = instance.on_sim_events(&[SimEvent::Placed(order)]);
@@ -779,6 +934,7 @@ mod tests {
             price: None,
             quantity: Decimal::ONE,
             bracket: Bracket::none(),
+            cancel_at: None,
             placed_ms: 0,
         })]);
         let commands = bystander.on_sim_events(&[SimEvent::BracketDropped {
@@ -799,7 +955,7 @@ mod tests {
         let mut instance = force_instance(Side::Buy);
         instance.on_closed_bar(&bar("100", "101"), &region, true, true);
         instance.on_closed_bar(&bar("101", "102"), &region, true, true);
-        instance.disarm(DisarmReason::BarSpecChanged);
+        let _ = instance.disarm(DisarmReason::BarSpecChanged);
         instance.rearm();
         assert_eq!(instance.state(), &ArmedState::Armed);
         assert_eq!(instance.trigger().status(), "waiting for bars 0/3");
@@ -808,7 +964,7 @@ mod tests {
         // next force bar fires without a fresh warmup.
         let mut instance = force_instance(Side::Buy);
         warm_then_force(&mut instance, &region);
-        instance.disarm(DisarmReason::User);
+        let _ = instance.disarm(DisarmReason::User);
         instance.rearm();
         let commands = instance.on_closed_bar(&bar("102", "107.6"), &region, true, true);
         assert_eq!(
@@ -816,5 +972,348 @@ mod tests {
             1,
             "a user disarm keeps the warm window: {commands:?}"
         );
+    }
+
+    // ---- the break/retest policy ----
+
+    fn retest_instance(side: Side) -> ArmedStrategy {
+        ArmedStrategy::new(
+            StrategyParams {
+                on_break: BreakPolicy::RetestLimit,
+                ..params(side)
+            },
+            Box::new(ForceTrigger::new(ForceParams {
+                window: 3,
+                min_factor: dec("1.5"),
+                max_factor: dec("2.5"),
+                min_body: Decimal::ZERO,
+            })),
+        )
+    }
+
+    /// Warm the window, then close a body-4 sell force bar at 104, cutting
+    /// below the 105–115 region. Range 6 (high 109, low 103): the bracket
+    /// anchored on the bar is SL 110 / TP 98.
+    fn warm_then_sell_cut(instance: &mut ArmedStrategy, region: &Region) -> Vec<Command> {
+        assert!(
+            instance
+                .on_closed_bar(&bar("110", "109"), region, true, true)
+                .is_empty()
+        );
+        assert!(
+            instance
+                .on_closed_bar(&bar("109", "108"), region, true, true)
+                .is_empty()
+        );
+        instance.on_closed_bar(&bar("108", "104"), region, true, true)
+    }
+
+    #[test]
+    fn a_sell_cut_below_the_region_rests_a_retest_limit_at_the_cut_edge() {
+        let region = Region::new(dec("105"), dec("115"));
+        let mut instance = retest_instance(Side::Sell);
+        let commands = warm_then_sell_cut(&mut instance, &region);
+        assert_eq!(
+            commands,
+            vec![Command::PlaceLimit {
+                side: Side::Sell,
+                quantity: Decimal::ONE,
+                price: dec("105"),
+                bracket: Bracket {
+                    stop_loss: Some(dec("110")),
+                    take_profit: Some(dec("98")),
+                },
+                cancel_at: Some(dec("98")),
+            }],
+            "the limit rests at the cut edge, bracketed off the trigger bar, \
+             expiring at the bar's own target"
+        );
+        assert_eq!(
+            instance.state(),
+            &ArmedState::Fired {
+                order_id: None,
+                retest: true
+            }
+        );
+        assert!(instance.status_line().starts_with("retest limit resting"));
+    }
+
+    #[test]
+    fn a_buy_cut_above_the_region_mirrors_the_retest() {
+        let region = Region::new(dec("90"), dec("100"));
+        let mut instance = retest_instance(Side::Buy);
+        instance.on_closed_bar(&bar("95", "96"), &region, true, true);
+        instance.on_closed_bar(&bar("96", "97"), &region, true, true);
+        let commands = instance.on_closed_bar(&bar("97", "101"), &region, true, true);
+        // Close 101, range 6 (high 102, low 96): TP 107, SL 95, edge 100.
+        assert_eq!(
+            commands,
+            vec![Command::PlaceLimit {
+                side: Side::Buy,
+                quantity: Decimal::ONE,
+                price: dec("100"),
+                bracket: Bracket {
+                    stop_loss: Some(dec("95")),
+                    take_profit: Some(dec("107")),
+                },
+                cancel_at: Some(dec("107")),
+            }]
+        );
+    }
+
+    /// Default off: the cut holds fire exactly as before the option
+    /// existed, and the badge names the gate instead of staying mute.
+    #[test]
+    fn the_default_policy_ignores_the_cut_and_names_the_gate() {
+        let region = Region::new(dec("105"), dec("115"));
+        let mut instance = ArmedStrategy::new(
+            params(Side::Sell),
+            Box::new(ForceTrigger::new(ForceParams {
+                window: 3,
+                min_factor: dec("1.5"),
+                max_factor: dec("2.5"),
+                min_body: Decimal::ZERO,
+            })),
+        );
+        assert!(warm_then_sell_cut(&mut instance, &region).is_empty());
+        assert_eq!(instance.state(), &ArmedState::Armed);
+        assert_eq!(
+            instance.status_line(),
+            "armed · trigger held: closed outside region"
+        );
+    }
+
+    /// A close beyond the *opposite* edge is a miss, never a retest: a sell
+    /// bar closing above the region has not cut anything downward.
+    #[test]
+    fn a_cut_beyond_the_opposite_edge_never_arms_a_retest() {
+        let region = Region::new(dec("90"), dec("100"));
+        let mut instance = retest_instance(Side::Sell);
+        instance.on_closed_bar(&bar("110", "109"), &region, true, true);
+        instance.on_closed_bar(&bar("109", "108"), &region, true, true);
+        // A body-4 sell force bar closing at 104 — above the whole region.
+        let commands = instance.on_closed_bar(&bar("108", "104"), &region, true, true);
+        assert!(commands.is_empty());
+        assert_eq!(instance.state(), &ArmedState::Armed);
+    }
+
+    /// The option only changes what a *cut* does: a close inside the region
+    /// still fires the market entry.
+    #[test]
+    fn inside_the_region_still_fires_at_market_with_retest_on() {
+        let region = Region::new(dec("100"), dec("110"));
+        let mut instance = retest_instance(Side::Buy);
+        let commands = warm_then_force(&mut instance, &region);
+        assert!(
+            matches!(commands.as_slice(), [Command::PlaceMarket { .. }]),
+            "a close inside the region is the market path: {commands:?}"
+        );
+    }
+
+    fn retest_order(id: u64) -> quantick_sim::Order {
+        quantick_sim::Order {
+            id: OrderId(id),
+            side: Side::Sell,
+            kind: quantick_sim::EntryKind::Limit,
+            price: Some(dec("105")),
+            quantity: Decimal::ONE,
+            bracket: Bracket {
+                stop_loss: Some(dec("110")),
+                take_profit: Some(dec("98")),
+            },
+            cancel_at: Some(dec("98")),
+            placed_ms: 0,
+        }
+    }
+
+    /// The tape reaching the target first cancels the order by price: no
+    /// trade happened, so one-shot stops with the reason named and auto
+    /// goes straight back to hunting.
+    #[test]
+    fn the_target_cancel_walks_by_rearm_policy() {
+        let region = Region::new(dec("105"), dec("115"));
+
+        let mut one_shot = retest_instance(Side::Sell);
+        warm_then_sell_cut(&mut one_shot, &region);
+        let order = retest_order(4);
+        let _ = one_shot.on_sim_events(&[SimEvent::Placed(order.clone())]);
+        let _ = one_shot.on_sim_events(&[SimEvent::Cancelled {
+            order,
+            reason: quantick_sim::CancelReason::PriceTouched,
+        }]);
+        assert_eq!(
+            one_shot.state(),
+            &ArmedState::Disarmed {
+                reason: DisarmReason::TargetBeforeRetest
+            }
+        );
+        assert_eq!(one_shot.status_line(), "target hit before retest");
+
+        let mut auto = ArmedStrategy::new(
+            StrategyParams {
+                rearm: Rearm::Auto,
+                on_break: BreakPolicy::RetestLimit,
+                ..params(Side::Sell)
+            },
+            Box::new(ForceTrigger::new(ForceParams {
+                window: 3,
+                min_factor: dec("1.5"),
+                max_factor: dec("2.5"),
+                min_body: Decimal::ZERO,
+            })),
+        );
+        warm_then_sell_cut(&mut auto, &region);
+        let order = retest_order(5);
+        let _ = auto.on_sim_events(&[SimEvent::Placed(order.clone())]);
+        let _ = auto.on_sim_events(&[SimEvent::Cancelled {
+            order,
+            reason: quantick_sim::CancelReason::PriceTouched,
+        }]);
+        assert_eq!(
+            auto.state(),
+            &ArmedState::Armed,
+            "auto re-arms and keeps hunting after the target kills the order"
+        );
+    }
+
+    /// A human sweep (flatten / cancel-all) of the resting retest limit is
+    /// still the old story: the bot does not insist.
+    #[test]
+    fn a_swept_retest_limit_disarms_as_entry_cancelled() {
+        let region = Region::new(dec("105"), dec("115"));
+        let mut instance = retest_instance(Side::Sell);
+        warm_then_sell_cut(&mut instance, &region);
+        let order = retest_order(6);
+        let _ = instance.on_sim_events(&[SimEvent::Placed(order.clone())]);
+        let _ = instance.on_sim_events(&[SimEvent::Cancelled {
+            order,
+            reason: quantick_sim::CancelReason::Flatten,
+        }]);
+        assert_eq!(
+            instance.state(),
+            &ArmedState::Disarmed {
+                reason: DisarmReason::EntryCancelled
+            }
+        );
+    }
+
+    #[test]
+    fn the_retest_fill_walks_to_in_position() {
+        let region = Region::new(dec("105"), dec("115"));
+        let mut instance = retest_instance(Side::Sell);
+        warm_then_sell_cut(&mut instance, &region);
+        let _ = instance.on_sim_events(&[SimEvent::Placed(retest_order(7))]);
+        let fill = quantick_sim::Fill {
+            timestamp_ms: 9,
+            agg_id: 30,
+            side: Side::Sell,
+            price: dec("105"),
+            quantity: Decimal::ONE,
+            role: quantick_sim::FillRole::Entry(OrderId(7)),
+        };
+        let _ = instance.on_sim_events(&[SimEvent::Filled(fill)]);
+        assert_eq!(instance.state(), &ArmedState::InPosition);
+    }
+
+    /// Disarming over a resting entry sweeps it: the returned commands
+    /// cancel the order the bot placed — except under a timeline reset,
+    /// where the simulator's own reset already cancels everything with the
+    /// honest reason.
+    #[test]
+    fn disarm_sweeps_the_pending_retest_limit() {
+        let region = Region::new(dec("105"), dec("115"));
+        let mut instance = retest_instance(Side::Sell);
+        warm_then_sell_cut(&mut instance, &region);
+        let _ = instance.on_sim_events(&[SimEvent::Placed(retest_order(8))]);
+        let commands = instance.disarm(DisarmReason::User);
+        assert_eq!(commands, vec![Command::CancelOrder { id: OrderId(8) }]);
+
+        let mut instance = retest_instance(Side::Sell);
+        warm_then_sell_cut(&mut instance, &region);
+        let _ = instance.on_sim_events(&[SimEvent::Placed(retest_order(9))]);
+        let commands = instance.disarm(DisarmReason::TimelineReset);
+        assert!(
+            commands.is_empty(),
+            "the simulator's reset owns that cancellation"
+        );
+    }
+
+    /// A projected leg that does not clear the entry edge would be dropped
+    /// at fill time — so it holds fire instead, and says why.
+    #[test]
+    fn a_bracket_leg_that_does_not_clear_the_edge_holds_fire() {
+        let region = Region::new(dec("105"), dec("115"));
+        let mut instance = ArmedStrategy::new(
+            StrategyParams {
+                sl_mult: dec("0.1"),
+                on_break: BreakPolicy::RetestLimit,
+                ..params(Side::Sell)
+            },
+            Box::new(ForceTrigger::new(ForceParams {
+                window: 3,
+                min_factor: dec("1.5"),
+                max_factor: dec("2.5"),
+                min_body: Decimal::ZERO,
+            })),
+        );
+        // SL = 104 + 0.1 × 6 = 104.6, below the 105 edge a short entered
+        // there needs it above.
+        assert!(warm_then_sell_cut(&mut instance, &region).is_empty());
+        assert_eq!(instance.state(), &ArmedState::Armed);
+        assert_eq!(
+            instance.status_line(),
+            "armed · retest bracket does not clear the edge — held fire"
+        );
+    }
+
+    /// Every gate that holds a seen trigger names itself, and the note
+    /// clears on the next signal-less bar so the ruler narrates again.
+    #[test]
+    fn held_triggers_name_their_gate_on_the_badge() {
+        let region = Region::new(dec("100"), dec("110"));
+
+        // Opposite side: a buy force bar for a sell instance.
+        let mut instance = force_instance(Side::Sell);
+        warm_then_force(&mut instance, &region);
+        assert_eq!(
+            instance.status_line(),
+            "armed · trigger held: opposite side"
+        );
+
+        // Region not active on this bar.
+        let mut instance = force_instance(Side::Buy);
+        instance.on_closed_bar(&bar("100", "101"), &region, true, true);
+        instance.on_closed_bar(&bar("101", "102"), &region, true, true);
+        instance.on_closed_bar(&bar("102", "106"), &region, false, true);
+        assert_eq!(
+            instance.status_line(),
+            "armed · trigger held: region not active on this bar"
+        );
+
+        // Account not flat.
+        let mut instance = force_instance(Side::Buy);
+        instance.on_closed_bar(&bar("100", "101"), &region, true, true);
+        instance.on_closed_bar(&bar("101", "102"), &region, true, true);
+        instance.on_closed_bar(&bar("102", "106"), &region, true, false);
+        assert_eq!(
+            instance.status_line(),
+            "armed · trigger held: account not flat"
+        );
+
+        // The next quiet bar clears the note: the ruler speaks again.
+        instance.on_closed_bar(&bar("106", "107"), &region, true, true);
+        assert!(
+            instance.status_line().starts_with("armed · quiet"),
+            "a signal-less bar hands the badge back to the ruler: {}",
+            instance.status_line()
+        );
+    }
+
+    /// The force ruler declares its own warmup depth, so a consumer can
+    /// re-warm it from the series after a reset instead of hardcoding 20.
+    #[test]
+    fn the_force_trigger_declares_its_warmup_depth() {
+        let instance = force_instance(Side::Buy);
+        assert_eq!(instance.trigger().warmup_bars(), 3);
     }
 }

--- a/crates/strategy/src/armed.rs
+++ b/crates/strategy/src/armed.rs
@@ -93,9 +93,29 @@ pub enum DisarmReason {
     /// happened, and a one-shot instance stops and says so rather than
     /// pretending an operation ran.
     TargetBeforeRetest,
+    /// The retest limit stood down at its own fill moment because a
+    /// position was open — a human traded while the order rested, and a
+    /// bot never trades against an open manual position. No fill, no
+    /// trade; the badge says why the opportunity was declined.
+    AccountOccupied,
 }
 
 impl DisarmReason {
+    /// Whether the disarm named a *rebuilt series* — a timeline reset, a
+    /// bar-spec change, a market switch. Re-arming after one resets the
+    /// trigger's window (an average blending two tapes judges with a ruler
+    /// no chart shows), and the consumer re-warms it from its own series.
+    /// One list, shared by the kernel's [`ArmedStrategy::rearm`] and the
+    /// chart's re-warm, so a new series-changing reason cannot reset the
+    /// ruler while silently skipping the re-warm.
+    #[must_use]
+    pub fn resets_series(&self) -> bool {
+        matches!(
+            self,
+            Self::TimelineReset | Self::BarSpecChanged | Self::MarketChanged
+        )
+    }
+
     /// Short badge label; the full story goes in tooltips.
     #[must_use]
     pub fn label(&self) -> &'static str {
@@ -108,6 +128,7 @@ impl DisarmReason {
             Self::EntryCancelled => "entry cancelled",
             Self::ProtectionDropped => "protection dropped — closed",
             Self::TargetBeforeRetest => "target hit before retest",
+            Self::AccountOccupied => "stood down — account busy",
         }
     }
 }
@@ -302,6 +323,13 @@ impl ArmedStrategy {
             // The projected target doubles as the order's expiry: the move
             // completing without the retest removes the reason to enter.
             cancel_at: bracket.take_profit,
+            // The flat gate held at fire time, but this order can rest for
+            // hours: if a human opens a position while it waits, filling
+            // would trade against that position — so the simulator stands
+            // the order down at its own fill moment instead. "A bot never
+            // trades against an open manual position" has to survive the
+            // resting window, not just the trigger bar.
+            flat_only: true,
         }]
     }
 
@@ -372,6 +400,17 @@ impl ArmedStrategy {
                                 reason: DisarmReason::TargetBeforeRetest,
                             },
                         },
+                        // The order stood down because a human's position
+                        // occupied the account at its fill moment. An auto
+                        // instance returns to hunting (its fire gate will
+                        // hold until the account is clean again); one shot
+                        // stops with the reason on the badge.
+                        quantick_sim::CancelReason::AccountOccupied => match self.params.rearm {
+                            Rearm::Auto => ArmedState::Armed,
+                            Rearm::OneShot => ArmedState::Disarmed {
+                                reason: DisarmReason::AccountOccupied,
+                            },
+                        },
                         // A human hand (or a reset) swept the entry away;
                         // the bot does not insist.
                         _ => ArmedState::Disarmed {
@@ -407,17 +446,27 @@ impl ArmedStrategy {
     /// that no longer exists.) Before retest limits a pending entry lived
     /// for exactly one print; now it can rest for hours, which is what
     /// makes the sweep worth commanding.
+    /// The cancel for this instance's still-pending entry, if one is
+    /// resting or queued. One definition of "what the instance owes the
+    /// simulator on the way out", shared by [`Self::disarm`] and every
+    /// removal path in the consumer — two copies of this match would drift
+    /// over the money path.
+    #[must_use]
+    pub fn pending_entry_cancel(&self) -> Option<Command> {
+        match &self.state {
+            ArmedState::Fired {
+                order_id: Some(id), ..
+            } => Some(Command::CancelOrder { id: *id }),
+            _ => None,
+        }
+    }
+
     #[must_use = "apply the returned cleanup commands to the simulator"]
     pub fn disarm(&mut self, reason: DisarmReason) -> Vec<Command> {
-        let cleanup = match (&self.state, reason) {
-            (_, DisarmReason::TimelineReset) => Vec::new(),
-            (
-                ArmedState::Fired {
-                    order_id: Some(id), ..
-                },
-                _,
-            ) => vec![Command::CancelOrder { id: *id }],
-            _ => Vec::new(),
+        let cleanup = if matches!(reason, DisarmReason::TimelineReset) {
+            Vec::new()
+        } else {
+            self.pending_entry_cancel().into_iter().collect()
         };
         self.state = ArmedState::Disarmed { reason };
         cleanup
@@ -427,26 +476,36 @@ impl ArmedStrategy {
     /// `InPosition`) cannot be re-armed over; `Armed` is already armed.
     ///
     /// When the disarm reason says the *series itself* changed under the
-    /// ruler — a rebuilt timeline, another bar spec, another market — the
-    /// trigger's running window is reset too: an average blending bodies
-    /// from two different tapes would judge with a ruler no chart shows.
-    /// The honest cost is a fresh warmup, and the badge narrates it.
+    /// ruler ([`DisarmReason::resets_series`]) the trigger's running window
+    /// is reset too: an average blending bodies from two different tapes
+    /// would judge with a ruler no chart shows. The honest cost is a fresh
+    /// warmup — which the consumer can pay down with [`Self::warm`] — and
+    /// the badge narrates whatever remains.
     pub fn rearm(&mut self) {
         match &self.state {
-            ArmedState::Disarmed {
-                reason:
-                    DisarmReason::TimelineReset
-                    | DisarmReason::BarSpecChanged
-                    | DisarmReason::MarketChanged,
-            } => {
+            ArmedState::Disarmed { reason } if reason.resets_series() => {
                 self.trigger.reset();
+                self.note = None;
                 self.state = ArmedState::Armed;
             }
             ArmedState::Done | ArmedState::Disarmed { .. } => {
+                self.note = None;
                 self.state = ArmedState::Armed;
             }
             ArmedState::Armed | ArmedState::Fired { .. } | ArmedState::InPosition => {}
         }
+    }
+
+    /// Feed already-closed bars to the trigger only — the arm-time (and
+    /// post-reset re-arm) warmup. The state machine and its gates never
+    /// see these bars: they closed before the instance existed, so a force
+    /// bar among them must warm the ruler without stamping a "trigger
+    /// held" note about a judgement that never happened.
+    pub fn warm(&mut self, bars: &[Bar]) {
+        for bar in bars {
+            let _ = self.trigger.on_closed_bar(bar);
+        }
+        self.note = None;
     }
 
     /// One line for the on-chart badge.
@@ -458,8 +517,14 @@ impl ArmedStrategy {
                 None => format!("armed · {}", self.trigger.status()),
             },
             ArmedState::Fired { retest: false, .. } => "fired · waiting for fill".to_owned(),
+            // Only promise the self-cancel when the order actually carries
+            // one: without a take-profit leg there is no target level.
             ArmedState::Fired { retest: true, .. } => {
-                "retest limit resting at the edge · cancels at target".to_owned()
+                if self.params.tp_mult > Decimal::ZERO {
+                    "retest limit resting at the edge · cancels at target".to_owned()
+                } else {
+                    "retest limit resting at the edge · until filled or disarmed".to_owned()
+                }
             }
             ArmedState::InPosition => "in position".to_owned(),
             ArmedState::Done => "done · one shot".to_owned(),
@@ -684,6 +749,7 @@ mod tests {
             quantity: Decimal::ONE,
             bracket: Bracket::none(),
             cancel_at: None,
+            flat_only: false,
             placed_ms: 0,
         };
         let _ = instance.on_sim_events(&[SimEvent::Placed(order.clone())]);
@@ -745,6 +811,7 @@ mod tests {
             quantity: Decimal::ONE,
             bracket: Bracket::none(),
             cancel_at: None,
+            flat_only: false,
             placed_ms: 0,
         })]);
         let _ = instance.on_sim_events(&[SimEvent::Filled(quantick_sim::Fill {
@@ -791,6 +858,7 @@ mod tests {
             quantity: Decimal::ONE,
             bracket: Bracket::none(),
             cancel_at: None,
+            flat_only: false,
             placed_ms: 0,
         };
         let _ = instance.on_sim_events(&[SimEvent::Placed(order.clone())]);
@@ -894,6 +962,7 @@ mod tests {
             quantity: Decimal::ONE,
             bracket: Bracket::none(),
             cancel_at: None,
+            flat_only: false,
             placed_ms: 0,
         };
         let _ = instance.on_sim_events(&[SimEvent::Placed(order)]);
@@ -935,6 +1004,7 @@ mod tests {
             quantity: Decimal::ONE,
             bracket: Bracket::none(),
             cancel_at: None,
+            flat_only: false,
             placed_ms: 0,
         })]);
         let commands = bystander.on_sim_events(&[SimEvent::BracketDropped {
@@ -1024,6 +1094,7 @@ mod tests {
                     take_profit: Some(dec("98")),
                 },
                 cancel_at: Some(dec("98")),
+                flat_only: true,
             }],
             "the limit rests at the cut edge, bracketed off the trigger bar, \
              expiring at the bar's own target"
@@ -1057,6 +1128,7 @@ mod tests {
                     take_profit: Some(dec("107")),
                 },
                 cancel_at: Some(dec("107")),
+                flat_only: true,
             }]
         );
     }
@@ -1122,6 +1194,7 @@ mod tests {
                 take_profit: Some(dec("98")),
             },
             cancel_at: Some(dec("98")),
+            flat_only: true,
             placed_ms: 0,
         }
     }
@@ -1174,6 +1247,52 @@ mod tests {
             &ArmedState::Armed,
             "auto re-arms and keeps hunting after the target kills the order"
         );
+    }
+
+    /// The stand-down (the simulator declined the fill because a human's
+    /// position occupied the account) walks like the target cancel: named
+    /// stop for one-shot, straight back to hunting for auto.
+    #[test]
+    fn the_stand_down_walks_by_rearm_policy() {
+        let region = Region::new(dec("105"), dec("115"));
+
+        let mut one_shot = retest_instance(Side::Sell);
+        warm_then_sell_cut(&mut one_shot, &region);
+        let order = retest_order(14);
+        let _ = one_shot.on_sim_events(&[SimEvent::Placed(order.clone())]);
+        let _ = one_shot.on_sim_events(&[SimEvent::Cancelled {
+            order,
+            reason: quantick_sim::CancelReason::AccountOccupied,
+        }]);
+        assert_eq!(
+            one_shot.state(),
+            &ArmedState::Disarmed {
+                reason: DisarmReason::AccountOccupied
+            }
+        );
+        assert_eq!(one_shot.status_line(), "stood down — account busy");
+
+        let mut auto = ArmedStrategy::new(
+            StrategyParams {
+                rearm: Rearm::Auto,
+                on_break: BreakPolicy::RetestLimit,
+                ..params(Side::Sell)
+            },
+            Box::new(ForceTrigger::new(ForceParams {
+                window: 3,
+                min_factor: dec("1.5"),
+                max_factor: dec("2.5"),
+                min_body: Decimal::ZERO,
+            })),
+        );
+        warm_then_sell_cut(&mut auto, &region);
+        let order = retest_order(15);
+        let _ = auto.on_sim_events(&[SimEvent::Placed(order.clone())]);
+        let _ = auto.on_sim_events(&[SimEvent::Cancelled {
+            order,
+            reason: quantick_sim::CancelReason::AccountOccupied,
+        }]);
+        assert_eq!(auto.state(), &ArmedState::Armed);
     }
 
     /// A human sweep (flatten / cancel-all) of the resting retest limit is

--- a/crates/strategy/src/force.rs
+++ b/crates/strategy/src/force.rs
@@ -88,6 +88,15 @@ pub enum BarVerdict {
         ratio: Decimal,
     },
     Force(ForceBar),
+    /// Ratio inside the band but body under the absolute floor — the bar
+    /// the *relative* ruler would call force and the elephant gate holds.
+    /// Distinct from [`BarVerdict::Quiet`] so the badge can say which rule
+    /// held it: "quiet 1.7×" over a bar visibly inside the band reads as a
+    /// broken ruler.
+    UnderFloor {
+        ratio: Decimal,
+        body: Decimal,
+    },
     /// Body above the band — too big to chase.
     Exhaustion {
         side: Side,
@@ -175,7 +184,9 @@ impl ForceWindow {
         let (min, max) = ordered_band(&self.params);
         if ratio > max {
             BarVerdict::Exhaustion { side, ratio }
-        } else if ratio >= min && body >= self.params.min_body {
+        } else if ratio < min {
+            BarVerdict::Quiet { ratio }
+        } else if body >= self.params.min_body {
             BarVerdict::Force(ForceBar {
                 side,
                 body,
@@ -183,9 +194,10 @@ impl ForceWindow {
                 ratio,
             })
         } else {
-            // Inside the band but under the absolute floor is still quiet:
-            // a ratio without a size is not an elephant.
-            BarVerdict::Quiet { ratio }
+            // Inside the band but under the absolute floor: a ratio without
+            // a size is not an elephant — and the verdict says which rule
+            // held it, because "quiet" over a band-clearing bar is a lie.
+            BarVerdict::UnderFloor { ratio, body }
         }
     }
 }
@@ -350,12 +362,16 @@ mod tests {
             max_factor: dec("2.5"),
             min_body: dec("100"),
         });
-        // Bodies 30, 30, then 60: ratio 1.5 — band says force, floor says no.
+        // Bodies 30, 30, then 60: ratio 1.5 — band says force, floor says
+        // no, and the verdict names the floor rather than calling it quiet.
         gated.classify(&bar("100", "130"));
         gated.classify(&bar("130", "160"));
         assert_eq!(
             gated.classify(&bar("160", "220")),
-            BarVerdict::Quiet { ratio: dec("1.5") },
+            BarVerdict::UnderFloor {
+                ratio: dec("1.5"),
+                body: dec("60"),
+            },
             "60 points of body is not an elephant under a 100-point floor"
         );
 

--- a/crates/strategy/src/lib.rs
+++ b/crates/strategy/src/lib.rs
@@ -23,13 +23,20 @@
 //! the average body), and later rulers — the operational document's BEI is
 //! the expected next tenant — dock beside it without surgery on the state
 //! machine.
+//!
+//! A trigger bar that closes *inside* the region fires a market entry. One
+//! that cuts **through** the region — closing beyond its edge in the
+//! trade's own direction — follows [`BreakPolicy`]: hold fire (the
+//! default), or rest a limit at the cut edge, bracketed off the trigger
+//! bar and cancelled if the tape reaches the bar's projected target before
+//! returning for the retest.
 
 mod armed;
 mod force;
 mod region;
 mod trigger;
 
-pub use armed::{ArmedState, ArmedStrategy, DisarmReason, Rearm, StrategyParams};
+pub use armed::{ArmedState, ArmedStrategy, BreakPolicy, DisarmReason, Rearm, StrategyParams};
 pub use force::{BarVerdict, ForceBar, ForceParams, ForceWindow};
 pub use region::Region;
 pub use trigger::{ForceTrigger, Signal, Trigger};

--- a/crates/strategy/src/trigger.rs
+++ b/crates/strategy/src/trigger.rs
@@ -40,6 +40,16 @@ pub trait Trigger {
     /// exists (a rebuilt timeline, another bar spec, another market). A
     /// stateless trigger may keep the default no-op.
     fn reset(&mut self) {}
+
+    /// How many recent closed bars re-warm this ruler after a [`reset`]
+    /// (or a fresh arm) — the consumer replays that many from its series,
+    /// gates shut, so "armed" means armed *now* instead of after another
+    /// unexplained warmup. A stateless trigger needs none.
+    ///
+    /// [`reset`]: Self::reset
+    fn warmup_bars(&self) -> usize {
+        0
+    }
 }
 
 /// The force-bar trigger: fires on a bar the [`ForceWindow`] rules force.
@@ -86,6 +96,10 @@ impl Trigger for ForceTrigger {
         self.last = None;
     }
 
+    fn warmup_bars(&self) -> usize {
+        self.window.params().window
+    }
+
     fn status(&self) -> String {
         match &self.last {
             None => format!("waiting for bars 0/{}", self.window.params().window),
@@ -94,6 +108,11 @@ impl Trigger for ForceTrigger {
             Some(BarVerdict::NoSide) => "doji — no side".to_owned(),
             Some(BarVerdict::Quiet { ratio }) => format!("quiet {}×", round_ratio(*ratio)),
             Some(BarVerdict::Force(force)) => format!("force {}×", round_ratio(force.ratio)),
+            Some(BarVerdict::UnderFloor { ratio, body }) => {
+                // The band said force; the absolute floor said no. Saying
+                // "quiet" here would hide the one number the trader needs.
+                format!("{}× in band · body {body} under floor", round_ratio(*ratio))
+            }
             Some(BarVerdict::Exhaustion { ratio, .. }) => {
                 format!("exhaustion {}×", round_ratio(*ratio))
             }

--- a/crates/strategy/tests/full_operation.rs
+++ b/crates/strategy/tests/full_operation.rs
@@ -217,6 +217,7 @@ fn the_retest_fills_at_the_edge_and_rides_to_the_target() {
                 take_profit: Some(dec("100")),
             },
             cancel_at: Some(dec("100")),
+            flat_only: true,
         }]
     );
     assert_eq!(outcome.closed.len(), 1, "the retest round-tripped");

--- a/crates/strategy/tests/full_operation.rs
+++ b/crates/strategy/tests/full_operation.rs
@@ -62,6 +62,7 @@ fn run() -> RunOutcome {
             tp_mult: Decimal::ONE,
             sl_mult: Decimal::ONE,
             rearm: Rearm::OneShot,
+            on_break: quantick_strategy::BreakPolicy::Ignore,
         },
         Box::new(ForceTrigger::new(ForceParams {
             window: 3,
@@ -139,4 +140,123 @@ fn the_same_tape_produces_the_same_run_twice() {
     assert_eq!(first.closed, second.closed);
     assert_eq!(first.final_state, second.final_state);
     assert_eq!(first.status, second.status);
+}
+
+/// The retest walk: a sell force bar cuts below the region, the kernel
+/// rests a limit at the cut edge, and the tape decides — return to the edge
+/// (fill, bracket, take profit) or reach the target first (the order goes,
+/// no trade). Two prints per tick bar, exactly like [`tape`].
+///
+/// Bars: 110→109, 109→108 (warmup), then 108→104 — body 4 over average
+/// (1+1+4)/3 = 2, force 2×, closing below the 105 edge. That bar's range is
+/// 4 (high 108, low 104): SL 108, TP 100, entry edge 105, cancel-at 100.
+fn run_retest(after_cut: &[&str]) -> RunOutcome {
+    let region = Region::new(dec("105"), dec("115"));
+    let mut instance = ArmedStrategy::new(
+        StrategyParams {
+            side: Side::Sell,
+            quantity: Decimal::ONE,
+            tp_mult: Decimal::ONE,
+            sl_mult: Decimal::ONE,
+            rearm: Rearm::OneShot,
+            on_break: quantick_strategy::BreakPolicy::RetestLimit,
+        },
+        Box::new(ForceTrigger::new(ForceParams {
+            window: 3,
+            min_factor: dec("1.5"),
+            max_factor: dec("2.5"),
+            min_body: Decimal::ZERO,
+        })),
+    );
+    let mut sim = Simulator::new();
+    let mut builder = TickBarBuilder::new(2);
+    let mut commands = Vec::new();
+
+    let prints: Vec<Trade> = ["110", "109", "109", "108", "108", "104"]
+        .iter()
+        .chain(after_cut)
+        .enumerate()
+        .map(|(i, price)| trade(i as u64, price))
+        .collect();
+    for print in prints {
+        let events = sim.on_trade(&print);
+        let _ = instance.on_sim_events(&events);
+        if let Some(bar) = builder.push(&print) {
+            let flat = sim.position().is_none();
+            for command in instance.on_closed_bar(&bar, &region, true, flat) {
+                commands.push(command);
+                let events = sim.apply(command);
+                let _ = instance.on_sim_events(&events);
+            }
+        }
+    }
+
+    RunOutcome {
+        commands,
+        closed: sim.closed_trades().to_vec(),
+        final_state: instance.state().clone(),
+        status: instance.status_line(),
+    }
+}
+
+#[test]
+fn the_retest_fills_at_the_edge_and_rides_to_the_target() {
+    // The tape returns to the edge (105 fills the resting sell limit),
+    // then walks down through the target (100 = the position's take
+    // profit).
+    let outcome = run_retest(&["104.5", "105", "101", "100"]);
+
+    assert_eq!(
+        outcome.commands,
+        vec![Command::PlaceLimit {
+            side: Side::Sell,
+            quantity: Decimal::ONE,
+            price: dec("105"),
+            bracket: quantick_sim::Bracket {
+                stop_loss: Some(dec("108")),
+                take_profit: Some(dec("100")),
+            },
+            cancel_at: Some(dec("100")),
+        }]
+    );
+    assert_eq!(outcome.closed.len(), 1, "the retest round-tripped");
+    let trade = &outcome.closed[0];
+    assert_eq!(trade.entry_price, dec("105"), "filled at the edge itself");
+    assert_eq!(trade.exit_price, dec("100"));
+    assert_eq!(trade.exit_reason, ExitReason::TakeProfit);
+    assert_eq!(trade.pnl_points, dec("5"));
+    assert_eq!(outcome.final_state, ArmedState::Done, "one shot, then done");
+}
+
+#[test]
+fn the_target_first_removes_the_order_and_no_trade_happens() {
+    // The tape never returns: it walks straight down through the target.
+    // The print at 100 cancels the resting limit by price.
+    let outcome = run_retest(&["102", "100"]);
+
+    assert_eq!(outcome.commands.len(), 1, "the limit was placed");
+    assert!(
+        outcome.closed.is_empty(),
+        "no fill, no trade: {:?}",
+        outcome.closed
+    );
+    assert_eq!(
+        outcome.final_state,
+        ArmedState::Disarmed {
+            reason: quantick_strategy::DisarmReason::TargetBeforeRetest
+        }
+    );
+    assert_eq!(outcome.status, "target hit before retest");
+}
+
+#[test]
+fn the_retest_tape_produces_the_same_run_twice() {
+    for after_cut in [&["104.5", "105", "101", "100"][..], &["102", "100"][..]] {
+        let first = run_retest(after_cut);
+        let second = run_retest(after_cut);
+        assert_eq!(first.commands, second.commands);
+        assert_eq!(first.closed, second.closed);
+        assert_eq!(first.final_state, second.final_state);
+        assert_eq!(first.status, second.status);
+    }
 }


### PR DESCRIPTION
A força bar strategy armed on a rectangle used to lose the trade whenever the trigger bar cut through the region and closed beyond it — and during replay, several silent paths made force bars "inside the region" never execute. This branch adds the retest-limit entry policy and closes every silent no-fire path found on the way.

## What changed

**Retest-limit entry (`BreakPolicy::RetestLimit`, default off)**
- A force bar on the instance's side that closes beyond the region edge *in the trade's direction* rests a `PlaceLimit` at the cut edge (Sell: `region.low`; Buy: `region.high`), bracketed off the trigger bar exactly like the market entry would have been.
- The order carries a sim-level `cancel_at` price — the bar's projected take profit. A print trading at or through it before the fill removes the order (`CancelReason::PriceTouched`): "the move completed without the retest". One-shot instances disarm as `TargetBeforeRetest` (badge: *target hit before retest*); auto instances go straight back to hunting. Placement validation keeps `cancel_at` on the far side of the market from the limit price, so no single print can ever satisfy both fill and cancel.
- The order is also `flat_only`: if its fill print arrives while **any** position is open (the trader traded while it rested), the simulator stands it down (`CancelReason::AccountOccupied`) instead of netting the trader's position — "a bot never trades against an open manual position" survives the resting window with a zero-width race by construction, and the badge says *stood down — account busy*.
- A projected leg that would not clear the entry edge holds fire instead of firing a bracket the fill would drop.
- Exposed everywhere the strategy already lives: `StoredPreset.on_break` (serde vintage default keeps old banks valid), the arming-dialog checkbox, and `--retest-limit` on the backtest's force-region strategy. The backtest counts order cancels by reason and reports an entry still resting at the last print, so a zero-trade `--retest-limit` run is interpretable.

**Replay no-fire bugs**
1. **Re-arm was cold**: after a seek/bar-spec/market disarm the kernel resets the ruler; re-arming now re-warms it from the chart's own closed bars (`Trigger::warmup_bars` + `ArmedStrategy::warm`), so the first eligible force bar after a seek fires instead of silently warming up for another 20 bars.
2. **The region expired silently at the right anchor**: the rectangle gains an `extend_right` payload (persisted in presets, painted to the chart edge, honoured by `strategy_region`); region liveness lives once in `Pane::strategy_region_can_fire`, shared by arming (refused with the fix in the message), menu re-arm (disabled with the reason) and evaluation.
3. **The badge lied by omission**: `BarVerdict::UnderFloor` separates "band cleared but body under the elephant floor" from `Quiet`, and every gate that holds a seen trigger names itself on the status line (`trigger held: opposite side / region not active on this bar / account not flat / closed outside region`). This also surfaces the common replay case where a forgotten manual order blocks all bots via the clean-account gate.

**Cleanup discipline**: a pending bot entry can no longer be orphaned by any path — disarm, removal, drop-orphans, delete-all, undo/redo, toast-undo, and arming over an existing instance all sweep it (one definition: `ArmedStrategy::pending_entry_cancel`), the menus queue the sweep and every tab drains it same-frame (a same-frame tab switch used to strand the cancel). Under a timeline reset the simulator's own reset keeps ownership, labeled `reset`.

**Honest surfaces**: an order that can remove itself announces its level (`cancels @ <price>` on the expanded chart tag and the orders-panel row), tape-driven cancels toast (*target traded first* / *account busy at its price*), and the resting badge only promises a self-cancel when the order actually carries one (`tp_mult 0` ⇒ *until filled or disarmed*).

## Evidence

- New tests: 6 sim (cancel-at fill/cancel race both sides, wrong-side rejection, flat-only stand-down, position-closed-before-the-moment), 13 kernel (cut detection both sides, default-off regression, opposite-edge miss, rearm-policy walks for the price cancel and the stand-down, disarm sweep, edge-clearing guard, gate naming, warmup declaration), 3 golden integration walks (retest fill → TP, target-first → no trade, determinism ×2), 6 app (rearm re-warms, extend-right past the drawn end, dead/boundary-region arming refused, end-to-end retest flow, stand-down over a manual position, delete-all sweep), plus anchors (removal/arm-replace sweeps) and preset-vintage coverage.
- `cargo test --workspace`: 62 suites, 0 failures. Four checks green at HEAD: `fmt --check`, `clippy --workspace --all-targets -D warnings`, `build --workspace`, `test --workspace`.

## Performance

| Touched path | Rate | Cost |
| --- | --- | --- |
| Sim resting-order scan (`on_trade` step 3) | per trade | +1 cancel-at branch per resting order; +1 `flat_only && position` check at the fill moment; no allocation |
| Kernel gates/notes (`on_closed_bar`) | per closed bar | O(1), notes are `&'static str` |
| `strategy_region` payload downcast | per closed bar × instance | one dynamic downcast |
| Rectangle paint/hit-test extend | per frame per rectangle | one `max()` |
| Order tag `cancels @` suffix | per frame per pending order with `cancel_at` (expanded tag only) | one push onto an existing per-frame `format!` |
| Backtest cancel counters | per cancelled order | one BTreeMap bump |
| Arm/re-arm warmup, dialog, presets, sweeps on delete/undo | rare | clarity wins |

Headless bench (release backtest, WINV26 2026-08-12, 1,398,935 prints, force-region `171000:171500:sell`, 3 runs each under the same machine conditions, `prints_per_second` from `BACKTEST_DONE`):

- `main` control: 1,839k / 1,875k / 1,860k → median **1,860k prints/s**
- branch, policy off (same workload): 1,896k / 1,896k / 1,905k → median **1,896k prints/s** — flat (≤2%, within run noise)
- branch, `--retest-limit` on: 1,871k / 1,886k / 1,886k → median **1,886k prints/s**

## Review gates

- **arch-review** — step 0: `code-review` at `high`, 16 findings verified (10 finder angles + a gap sweep; refuted candidates documented in the review output). All 16 resolved in `0a19f543`/this branch except one deliberately deferred:
  - *Resolved highlights*: flat-only stand-down (the one authority finding — a resting bot limit could net a manual position opened while it rested); orphaned resting orders via delete-all/undo/redo/arm-replace; strategy cleanup stranded on a same-frame tab switch; arm guard off-by-one at the newest closed bar; re-arm missing the span guard; false held-fire notes from warmup; status promising a self-cancel that did not exist; silent tape-driven cancels; backtest blind to the policy it measures; and the dedups (one region-liveness predicate, one pending-entry sweep, one series-changed list, one warm path).
  - *Deferred*: the four new app tests re-declare the local `print`/`bar` fixture helpers instead of sharing one module — the file's two pre-existing strategy tests use the same per-test-local idiom, so unifying all of them is follow-up hygiene, not part of this change.
- **trader-ux-review** (Rafa/Marina/Duda over the five affected flows): no Blockers, no Should-fixes. Three Considers, deferred deliberately: (1) "cut" in the checkbox label is jargon — mitigated by the full-sentence hover; (2) the held-fire note is read from the drawing menu/status, not the compact badge — the badge stays minimal by design; (3) the extended rectangle's hit area inherits the existing fill-visibility rule.
- **visual-qa**: BLOCKED — launching app instances requires explicit authorization in this environment (project memory `no-agent-app-launches`), so no screenshots were captured. The changed surfaces are reachable for later QA via existing hooks: `QUANTICK_STRATEGY_DEMO=popup` (arming dialog with the new checkbox), `QUANTICK_STRATEGY_DEMO=1` + `QUANTICK_CONTEXT_MENU=chart` (badge and per-drawing menu), rectangle settings → Region tab.
- **ui-harness**: no new surface without a hook — the changed surfaces (dialog, badge, drawing menu, order tags, rectangle Region tab) are all behind the existing hooks listed above.

## Known limits (deliberate, documented)

- The resting order does not follow the rectangle if the region is moved after the cut; disarm and re-arm to re-place it.
- A plain market `Fired` still offers no menu verb (it lives for exactly one print); the resting retest `Fired` offers Disarm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
