### PR TITLE
feat(app): inverted chart — flip by axis drag or the axis menu

### DIFF
--- a/.claude/skills/ui-harness/SKILL.md
+++ b/.claude/skills/ui-harness/SKILL.md
@@ -149,6 +149,15 @@ Landing with the popup-position goal (`feat/inspector-position-memory`):
 
 Once merged, move it into the table above.
 
+Landing with the inverted chart goal (`feat/inverted-chart`):
+
+| Hook | Reaches |
+| --- | --- |
+| `QUANTICK_INVERTED=1` | the chart **upside down** — low prices at the top — through the very setter the axis menu's "Inverted chart" checkbox calls (`PriceView::set_inverted`). The state is otherwise reached by a long price-gutter drag past the flip threshold (`FLIP_SPAN_FACTOR`, 40 auto-fit spans), a gesture no scripted run can perform. Every price-mapped layer turns over together — candles, wicks, axis labels, drawings, footprint, heatmap, bubbles, live strip, paper lines — so this is the frame that audits all of them at once. Anything but `1` leaves the chart the right way up |
+| `QUANTICK_CONTEXT_MENU=axis` | the **price axis's own context menu** (the Inverted chart toggle), via the same scripted right-click path as `chart`/`tape` — the click lands on the gutter rect the draw published (`last_price_gutter`), never on a guessed pixel. `scale` is an alias |
+
+Once merged, move these into the table above.
+
 Landing with the parked-context-bar fix (`fix/popup-position-every-tool`):
 
 | Hook | Reaches |

--- a/.claude/skills/ui-harness/SKILL.md
+++ b/.claude/skills/ui-harness/SKILL.md
@@ -153,7 +153,7 @@ Landing with the inverted chart goal (`feat/inverted-chart`):
 
 | Hook | Reaches |
 | --- | --- |
-| `QUANTICK_INVERTED=1` | the chart **upside down** — low prices at the top — through the very setter the axis menu's "Inverted chart" checkbox calls (`PriceView::set_inverted`). The state is otherwise reached by a long price-gutter drag past the flip threshold (`FLIP_SPAN_FACTOR`, 40 auto-fit spans), a gesture no scripted run can perform. Every price-mapped layer turns over together — candles, wicks, axis labels, drawings, footprint, heatmap, bubbles, live strip, paper lines — so this is the frame that audits all of them at once. Anything but `1` leaves the chart the right way up |
+| `QUANTICK_INVERTED=1` | the chart **upside down** — low prices at the top — through the very setter the axis menu's "Inverted chart" checkbox calls (`PriceView::set_inverted`), on **both panes** of a split layout so no surface is silently audited the right way up. The state is otherwise reached by a long price-gutter drag to the flip threshold (`FLIP_SPAN_FACTOR`, 40 auto-fit spans) plus a second pull, a gesture no scripted run can perform. Every price-mapped layer turns over together — candles, wicks, axis labels, drawings, footprint, heatmap, bubbles, live strip, paper lines, trade paint — so this is the frame that audits all of them at once. Anything but `1` leaves the chart the right way up |
 | `QUANTICK_CONTEXT_MENU=axis` | the **price axis's own context menu** (the Inverted chart toggle), via the same scripted right-click path as `chart`/`tape` — the click lands on the gutter rect the draw published (`last_price_gutter`), never on a guessed pixel. `scale` is an alias |
 
 Once merged, move these into the table above.

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -17434,6 +17434,29 @@ plot(close)
         );
     }
 
+    /// The arrows speak the screen's language: upside down, ArrowUp still
+    /// moves the object up — which on an inverted chart means a lower price.
+    #[test]
+    fn arrow_nudges_follow_the_screen_when_the_chart_is_inverted() {
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        run_frame(&mut app, &ctx);
+        app.toolrail
+            .arm(Tool::Drawing(drawing_tool("horizontal-line")));
+        click_chart(&mut app, &ctx, egui::pos2(700.0, 300.0));
+        let start = app.active_tab().flow_pane.drawings.items()[0].points[0];
+
+        app.active_tab_mut().flow_pane.price_view.set_inverted(true);
+        // One frame so the bands are re-carved with the new orientation —
+        // the nudge reads the band the last frame published.
+        run_frame(&mut app, &ctx);
+        run_frame_with_events(&mut app, &ctx, vec![key_press(egui::Key::ArrowUp)]);
+        assert!(
+            app.active_tab().flow_pane.drawings.items()[0].points[0].price < start.price,
+            "upside down, up on screen is a lower price"
+        );
+    }
+
     #[test]
     fn the_repeat_pin_keeps_the_drawing_tool_armed() {
         let (mut app, _commands) = app_with_history(200);

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -18,7 +18,6 @@ use eframe::egui;
 use egui_phosphor::regular as icons;
 
 use crate::candle_view::draw_style_window;
-use crate::chart::PriceScale;
 use crate::chart_layers::{self, ChartLayer};
 use crate::config::AppConfig;
 use crate::dock::{Dock, DockEnv, DockTab};
@@ -611,6 +610,8 @@ enum ContextMenuPane {
     Chart,
     /// The rolling tape, right of it.
     Tape,
+    /// The price gutter — the axis's own menu (Inverted chart).
+    Axis,
 }
 
 impl ContextMenuPane {
@@ -620,6 +621,7 @@ impl ContextMenuPane {
         match value.trim().to_ascii_lowercase().as_str() {
             "chart" | "candles" => Some(Self::Chart),
             "tape" | "lane" => Some(Self::Tape),
+            "axis" | "scale" => Some(Self::Axis),
             _ => None,
         }
     }
@@ -1446,6 +1448,12 @@ impl QuantickApp {
         // column's footprint). Same code path as the toolbar toggle.
         if std::env::var("QUANTICK_BUBBLES_AUTOSTART").is_ok_and(|value| value == "1") {
             app.active_tab_mut().tape_mut().set_bubbles_enabled(true);
+        }
+        // The chart upside down, through the very setter the axis menu's
+        // checkbox calls. The inverted frame is otherwise only reachable by
+        // a long axis drag no scripted run can perform.
+        if std::env::var("QUANTICK_INVERTED").is_ok_and(|value| value.trim() == "1") {
+            app.active_tab_mut().flow_pane.price_view.set_inverted(true);
         }
         // The right-click itself, on the pane it names. The two panes open
         // different menus now, so a capture has to say which canvas it is
@@ -6135,11 +6143,9 @@ impl QuantickApp {
     /// focused pane, which is where the selection lives.
     fn drawing_bbox_on_screen(&self, chart: egui::Rect, index: usize) -> Option<egui::Rect> {
         let total = self.drawing_pane().slots();
-        let (auto_lo, auto_hi) = self.drawing_pane().last_auto_range?;
-        let (lo, hi) = self.drawing_pane().price_view.resolve((auto_lo, auto_hi));
-        let scale = PriceScale::from_range(
-            lo,
-            hi,
+        let auto = self.drawing_pane().last_auto_range?;
+        let scale = self.drawing_pane().price_view.scale(
+            auto,
             self.drawing_pane().last_chart_top,
             self.drawing_pane().last_chart_top + self.drawing_pane().last_chart_height,
         );
@@ -6873,13 +6879,19 @@ impl QuantickApp {
     /// there is no tape menu to open where there is no tape.
     fn scripted_context_menu_pos(&self, pane: ContextMenuPane) -> Option<egui::Pos2> {
         let flow = &self.active_tab().flow_pane;
+        // The axis's menu lives on the gutter, off the canvas entirely — the
+        // draw publishes that band the same way it publishes the divider.
+        if pane == ContextMenuPane::Axis {
+            return Some(flow.last_price_gutter?.center());
+        }
         let rect = flow.last_chart_rect?;
         let divider = flow.last_lane_divider_x;
         let x = match (pane, divider) {
             (ContextMenuPane::Tape, Some(divider)) => (divider + rect.right()) / 2.0,
             (ContextMenuPane::Tape, None) => return None,
-            (ContextMenuPane::Chart, Some(divider)) => (rect.left() + divider) / 2.0,
-            (ContextMenuPane::Chart, None) => rect.center().x,
+            // Axis returned above; anything else is the candles' canvas.
+            (_, Some(divider)) => (rect.left() + divider) / 2.0,
+            (_, None) => rect.center().x,
         };
         Some(egui::pos2(x, rect.center().y))
     }
@@ -8431,6 +8443,7 @@ impl QuantickApp {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::chart::PriceScale;
 
     use rust_decimal::Decimal;
     use tokio::sync::mpsc;
@@ -9079,6 +9092,157 @@ mod tests {
             "and the pane never felt it"
         );
         assert!(pane_is_auto(&app, flow));
+    }
+
+    /// The trader's own gesture for turning the chart over: keep dragging the
+    /// price gutter down and the candles shrink, flatten and flip. The same
+    /// motion carried on grows them upside down, and the opposite pull turns
+    /// the chart back — one continuous loop, no menu needed.
+    #[test]
+    fn dragging_the_price_gutter_through_the_flip_turns_the_chart_over() {
+        let (mut app, _cmd_rx) = app_with_history(200);
+        let ctx = egui::Context::default();
+        run_frame(&mut app, &ctx);
+
+        let gutter = app
+            .active_tab()
+            .flow_pane
+            .last_price_gutter
+            .expect("the draw published the gutter");
+        assert!(!app.active_tab().flow_pane.price_view.is_inverted());
+
+        // One long pull down: exp(600/150) ≈ 54.6× expansion, past the 40×
+        // flip threshold in a single gesture.
+        drag_chart(
+            &mut app,
+            &ctx,
+            gutter.center(),
+            gutter.center() + egui::vec2(0.0, 600.0),
+        );
+        assert!(
+            app.active_tab().flow_pane.price_view.is_inverted(),
+            "the drag crossed the threshold and flipped the chart"
+        );
+
+        // Upside down, the same downward motion grows the chart back. The
+        // dummy auto range is never read: the flip took manual control.
+        let span = |app: &QuantickApp| {
+            let (lo, hi) = app.active_tab().flow_pane.price_view.resolve((0.0, 0.0));
+            hi - lo
+        };
+        let flat = span(&app);
+        drag_chart(
+            &mut app,
+            &ctx,
+            gutter.center(),
+            gutter.center() + egui::vec2(0.0, 150.0),
+        );
+        assert!(
+            span(&app) < flat,
+            "inverted, dragging down compresses the span (bigger candles): {flat} -> {}",
+            span(&app)
+        );
+        assert!(app.active_tab().flow_pane.price_view.is_inverted());
+
+        // And the opposite pull shrinks it until it flips back to normal.
+        drag_chart(
+            &mut app,
+            &ctx,
+            gutter.center(),
+            gutter.center() - egui::vec2(0.0, 900.0),
+        );
+        assert!(
+            !app.active_tab().flow_pane.price_view.is_inverted(),
+            "the way back crosses the same threshold"
+        );
+    }
+
+    /// `QUANTICK_CONTEXT_MENU=axis` reaches the price axis's own menu: the
+    /// scripted right-click lands on the gutter itself, published by the
+    /// draw — never a guess about where the axis probably is.
+    #[test]
+    fn the_axis_menu_hook_lands_on_the_gutter() {
+        assert_eq!(
+            ContextMenuPane::from_env_value("axis"),
+            Some(ContextMenuPane::Axis)
+        );
+        assert_eq!(
+            ContextMenuPane::from_env_value("scale"),
+            Some(ContextMenuPane::Axis)
+        );
+
+        let (mut app, _cmd_rx) = app_with_history(50);
+        let ctx = egui::Context::default();
+        assert_eq!(
+            app.scripted_context_menu_pos(ContextMenuPane::Axis),
+            None,
+            "no draw yet, so no gutter to click"
+        );
+        run_frame(&mut app, &ctx);
+        let gutter = app
+            .active_tab()
+            .flow_pane
+            .last_price_gutter
+            .expect("the draw published the gutter");
+        let position = app
+            .scripted_context_menu_pos(ContextMenuPane::Axis)
+            .expect("one frame published it");
+        assert!(gutter.contains(position));
+        let chart = app
+            .active_tab()
+            .flow_pane
+            .last_chart_rect
+            .expect("the canvas laid out");
+        assert!(
+            position.x > chart.right(),
+            "the axis, not the canvas: {position:?} vs {chart:?}"
+        );
+    }
+
+    /// The discrete way to turn the chart over: right-click on the price
+    /// gutter opens the axis's own menu, with the Inverted chart toggle in
+    /// it. The canvas keeps its layer menu; the axis speaks for the scale.
+    #[test]
+    fn right_clicking_the_price_gutter_offers_inverted_chart() {
+        let (mut app, _cmd_rx) = app_with_history(50);
+        let ctx = egui::Context::default();
+        run_frame(&mut app, &ctx);
+        let target = app
+            .active_tab()
+            .flow_pane
+            .last_price_gutter
+            .expect("the draw published the gutter")
+            .center();
+        run_frame_with_events(
+            &mut app,
+            &ctx,
+            vec![
+                egui::Event::PointerMoved(target),
+                egui::Event::PointerButton {
+                    pos: target,
+                    button: egui::PointerButton::Secondary,
+                    pressed: true,
+                    modifiers: egui::Modifiers::default(),
+                },
+            ],
+        );
+        run_frame_with_events(
+            &mut app,
+            &ctx,
+            vec![egui::Event::PointerButton {
+                pos: target,
+                button: egui::PointerButton::Secondary,
+                pressed: false,
+                modifiers: egui::Modifiers::default(),
+            }],
+        );
+        // The menu is an egui Area: it lays out on the frame after the click
+        // that opened it, so the settled frame is the one to read.
+        let texts = painted_text(&run_frame(&mut app, &ctx));
+        assert!(
+            texts.iter().any(|text| text == "Inverted chart"),
+            "the axis menu is on screen: {texts:?}"
+        );
     }
 
     /// A drawing tool takes the *primary button*, never the chart.

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -17499,6 +17499,29 @@ plot(close)
         );
     }
 
+    /// The time pane a split builds inherits the orientation of the chart it
+    /// splits away from. It is built a frame after the layout change, so the
+    /// boot's `QUANTICK_INVERTED` hook fires before it exists — without the
+    /// inheritance a scripted inverted capture is silently half-inverted.
+    #[test]
+    fn a_time_pane_born_into_an_inverted_tab_opens_upside_down() {
+        let (mut app, _cmd_rx) = app_with_history(50);
+        let ctx = egui::Context::default();
+        app.active_tab_mut().flow_pane.price_view.set_inverted(true);
+        app.active_tab_mut().set_layout(CanvasLayout::TimeAndFlow);
+        run_frame(&mut app, &ctx);
+        run_frame(&mut app, &ctx);
+        let time_pane = app
+            .active_tab()
+            .time_pane
+            .as_ref()
+            .expect("the split built a time pane");
+        assert!(
+            time_pane.price_view.is_inverted(),
+            "the second view keeps the market the way the trader has it"
+        );
+    }
+
     #[test]
     fn the_repeat_pin_keeps_the_drawing_tool_armed() {
         let (mut app, _commands) = app_with_history(200);

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -1451,9 +1451,16 @@ impl QuantickApp {
         }
         // The chart upside down, through the very setter the axis menu's
         // checkbox calls. The inverted frame is otherwise only reachable by
-        // a long axis drag no scripted run can perform.
+        // a long axis drag no scripted run can perform. Both panes of a
+        // split layout: the hook exists so one capture audits every
+        // price-mapped surface at once, and a half-inverted frame would
+        // silently audit the time pane the right way up.
         if std::env::var("QUANTICK_INVERTED").is_ok_and(|value| value.trim() == "1") {
-            app.active_tab_mut().flow_pane.price_view.set_inverted(true);
+            let tab = app.active_tab_mut();
+            tab.flow_pane.price_view.set_inverted(true);
+            if let Some(time_pane) = tab.time_pane.as_mut() {
+                time_pane.price_view.set_inverted(true);
+            }
         }
         // The right-click itself, on the pane it names. The two panes open
         // different menus now, so a capture has to say which canvas it is
@@ -2033,6 +2040,16 @@ impl QuantickApp {
         // Cmd trading is app-wide (the trades-dir rule): a new tab starts
         // with the settings every other tab already carries.
         let cmd_trading = self.active_tab().paper.cmd_trading();
+        // Orientation travels with the working state the new tab inherits —
+        // a market opened to compare against the active one is only
+        // comparable the same way up. Per pane; a pane the source tab does
+        // not have follows its flow chart.
+        let flow_inverted = self.active_tab().flow_pane.price_view.is_inverted();
+        let time_inverted = self
+            .active_tab()
+            .time_pane
+            .as_ref()
+            .map_or(flow_inverted, |pane| pane.price_view.is_inverted());
         let mut tab = Tab::new(id, pane_ids(id), feed_id, symbol, spec, feed, trades_dir);
         tab.paper.set_cmd_trading(cmd_trading);
         self.tabs.push(tab);
@@ -2057,6 +2074,13 @@ impl QuantickApp {
         }
         if let Some(px) = self.scripted_candle_width {
             self.active_tab_mut().flow_pane.viewport.set_px_per_bar(px);
+        }
+        // After the declared layout ran: that is what decides whether the
+        // new tab has a time pane to orient at all.
+        let tab = self.active_tab_mut();
+        tab.flow_pane.price_view.set_inverted(flow_inverted);
+        if let Some(time_pane) = tab.time_pane.as_mut() {
+            time_pane.price_view.set_inverted(time_inverted);
         }
     }
 
@@ -9111,8 +9135,19 @@ mod tests {
             .expect("the draw published the gutter");
         assert!(!app.active_tab().flow_pane.price_view.is_inverted());
 
-        // One long pull down: exp(600/150) ≈ 54.6× expansion, past the 40×
-        // flip threshold in a single gesture.
+        // One violent pull down flattens the chart to the flip threshold —
+        // still upright, whatever the speed of the flick...
+        drag_chart(
+            &mut app,
+            &ctx,
+            gutter.center(),
+            gutter.center() + egui::vec2(0.0, 600.0),
+        );
+        assert!(
+            !app.active_tab().flow_pane.price_view.is_inverted(),
+            "the first pull only flattens"
+        );
+        // ...and the next pull turns it over.
         drag_chart(
             &mut app,
             &ctx,
@@ -9121,7 +9156,7 @@ mod tests {
         );
         assert!(
             app.active_tab().flow_pane.price_view.is_inverted(),
-            "the drag crossed the threshold and flipped the chart"
+            "the second pull crossed the threshold and flipped the chart"
         );
 
         // Upside down, the same downward motion grows the chart back. The
@@ -9144,12 +9179,19 @@ mod tests {
         );
         assert!(app.active_tab().flow_pane.price_view.is_inverted());
 
-        // And the opposite pull shrinks it until it flips back to normal.
+        // And the opposite motion shrinks it back to the threshold, where
+        // the following pull turns it upright again.
         drag_chart(
             &mut app,
             &ctx,
             gutter.center(),
             gutter.center() - egui::vec2(0.0, 900.0),
+        );
+        drag_chart(
+            &mut app,
+            &ctx,
+            gutter.center(),
+            gutter.center() - egui::vec2(0.0, 300.0),
         );
         assert!(
             !app.active_tab().flow_pane.price_view.is_inverted(),

--- a/crates/app/src/bands.rs
+++ b/crates/app/src/bands.rs
@@ -95,6 +95,10 @@ pub struct PriceBand {
     /// Top and bottom of the candles' plot, which the scale maps onto.
     pub top: f32,
     pub bottom: f32,
+    /// Whether the candles are drawn upside down. The band's scale has to
+    /// carry it, or a drawing would anchor at the mirror of the price the
+    /// click named.
+    pub inverted: bool,
 }
 
 /// Carve one chart pane into its bands.
@@ -118,9 +122,9 @@ pub fn carve(
     out.push(Band {
         key: DrawingBand::Price,
         rect: price.rect,
-        scale: price
-            .range
-            .map(|(lo, hi)| PriceScale::from_range(lo, hi, price.top, price.bottom)),
+        scale: price.range.map(|(lo, hi)| {
+            PriceScale::from_range(lo, hi, price.top, price.bottom).with_inverted(price.inverted)
+        }),
         label: Arc::clone(price_label),
         refusal: (price.range.is_none()).then_some(WARMING_BAND_REFUSAL),
     });

--- a/crates/app/src/chart.rs
+++ b/crates/app/src/chart.rs
@@ -21,13 +21,17 @@ pub fn to_f64(price: rust_decimal::Decimal) -> f64 {
 /// Vertical price → y-pixel mapping, auto-scaled to a price range.
 ///
 /// `hi` maps to `top` (smaller y, screen coordinates grow downward) and `lo`
-/// maps to `bottom`.
+/// maps to `bottom` — unless the scale is [inverted](Self::with_inverted),
+/// when low prices ride at the top: the trader's upside-down view. Orientation
+/// lives here, at the one place price becomes pixels, so every layer reading
+/// this scale turns over together and none can be flipped alone.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct PriceScale {
     lo: f64,
     hi: f64,
     top: f32,
     bottom: f32,
+    inverted: bool,
 }
 
 impl PriceScale {
@@ -59,6 +63,7 @@ impl PriceScale {
             hi: hi + pad,
             top,
             bottom,
+            inverted: false,
         })
     }
 
@@ -67,7 +72,7 @@ impl PriceScale {
     /// auto-fitting the visible bars.
     #[must_use]
     pub fn from_range(lo: f64, hi: f64, top: f32, bottom: f32) -> Self {
-        // Guard against an inverted or zero span.
+        // Guard against a reversed or zero span.
         let (lo, hi) = if hi > lo {
             (lo, hi)
         } else {
@@ -78,10 +83,29 @@ impl PriceScale {
             hi,
             top,
             bottom,
+            inverted: false,
         }
     }
 
+    /// The same scale turned upside down when `inverted`: `lo` maps to `top`
+    /// and `hi` to `bottom`. `(lo, hi)` stay ordered as prices — orientation
+    /// is how the range meets the screen, not a property of the range.
+    #[must_use]
+    pub fn with_inverted(mut self, inverted: bool) -> Self {
+        self.inverted = inverted;
+        self
+    }
+
+    /// Whether low prices ride at the top of the pane.
+    #[must_use]
+    pub fn is_inverted(&self) -> bool {
+        self.inverted
+    }
+
     /// Pixels per unit of price, computed from the f64 range directly.
+    ///
+    /// Positive either way up: orientation never changes the density, and the
+    /// consumers (row heights, LOD ladders) want a size, not a direction.
     ///
     /// Never derive this by subtracting two `y()` values: `y` returns f32,
     /// and at an index-future price the pixel position of price 0 sits a
@@ -105,7 +129,11 @@ impl PriceScale {
         if span.abs() < f64::EPSILON {
             return f32::midpoint(self.top, self.bottom);
         }
-        let frac = ((self.hi - price) / span) as f32;
+        let frac = if self.inverted {
+            ((price - self.lo) / span) as f32
+        } else {
+            ((self.hi - price) / span) as f32
+        };
         self.top + frac * (self.bottom - self.top)
     }
 
@@ -117,8 +145,12 @@ impl PriceScale {
         if height.abs() < f32::EPSILON {
             return f64::midpoint(self.lo, self.hi);
         }
-        let frac = f64::from((y - self.top) / height); // 0 at top (hi), 1 at bottom (lo)
-        self.hi - frac * (self.hi - self.lo)
+        let frac = f64::from((y - self.top) / height); // 0 at top, 1 at bottom
+        if self.inverted {
+            self.lo + frac * (self.hi - self.lo)
+        } else {
+            self.hi - frac * (self.hi - self.lo)
+        }
     }
 
     /// The padded `(lo, hi)` price range this scale covers.
@@ -285,8 +317,13 @@ pub fn candle_geometry(
 
     let high_y = safe_scaled_y(scale, bar.high);
     let low_y = safe_scaled_y(scale, bar.low);
-    let upper_top = high_y.min(body.top);
-    let lower_bottom = low_y.max(body.bottom);
+    // Screen-space extremes rather than the price names: on an inverted scale
+    // the high's pixel sits *below* the body, and reading "upper" from
+    // `bar.high` alone would drop both wicks.
+    let wick_top = high_y.min(low_y);
+    let wick_bottom = high_y.max(low_y);
+    let upper_top = wick_top.min(body.top);
+    let lower_bottom = wick_bottom.max(body.bottom);
     let upper_wick = (upper_top < body.top).then_some(VerticalSegment {
         x: xc,
         top: upper_top,
@@ -787,6 +824,46 @@ mod tests {
     }
 
     #[test]
+    fn an_inverted_scale_maps_low_to_the_top() {
+        let scale = PriceScale::from_range(100.0, 110.0, 0.0, 100.0).with_inverted(true);
+        assert!(scale.is_inverted());
+        assert!((scale.y(100.0) - 0.0).abs() < 0.001);
+        assert!((scale.y(110.0) - 100.0).abs() < 0.001);
+        assert!((scale.y(105.0) - 50.0).abs() < 0.001);
+        // The range stays ordered as prices; orientation is not a reversal
+        // of the bounds.
+        assert_eq!(scale.range(), (100.0, 110.0));
+        assert!(scale.px_per_price() > 0.0, "density has no orientation");
+    }
+
+    #[test]
+    fn price_at_is_the_inverse_of_y_upside_down() {
+        let scale = PriceScale::from_range(100.0, 110.0, 0.0, 100.0).with_inverted(true);
+        for price in [100.0, 103.0, 107.5, 110.0] {
+            let y = scale.y(price);
+            assert!(
+                (scale.price_at(y) - price).abs() < 1e-6,
+                "price_at(y({price})) != {price}"
+            );
+        }
+    }
+
+    #[test]
+    fn wicks_survive_the_flip() {
+        // high 110 / low 90 around a 100–105 body, upside down: the low's
+        // wick rides above the body on screen, the high's below.
+        let scale = PriceScale::from_range(90.0, 110.0, 0.0, 200.0).with_inverted(true);
+        let bar = ohlc("100.0", "110.0", "90.0", "105.0");
+        let geometry = candle_geometry(&scale, &bar, 50.0, 4.0, 1.0);
+        let upper = geometry.upper_wick.expect("the low's wick, on top");
+        let lower = geometry.lower_wick.expect("the high's wick, below");
+        assert!((upper.top - scale.y(90.0)).abs() < 0.001);
+        assert!((upper.bottom - geometry.body.top).abs() < 0.001);
+        assert!((lower.top - geometry.body.bottom).abs() < 0.001);
+        assert!((lower.bottom - scale.y(110.0)).abs() < 0.001);
+    }
+
+    #[test]
     fn nice_ticks_are_round_and_in_range() {
         let ticks = nice_ticks(100.0, 110.0, 5);
         assert!(!ticks.is_empty());
@@ -1017,6 +1094,7 @@ mod tests {
             hi: f64::INFINITY,
             top: f32::NAN,
             bottom: f32::INFINITY,
+            inverted: false,
         };
         let geometry = candle_geometry(
             &invalid_scale,

--- a/crates/app/src/chart.rs
+++ b/crates/app/src/chart.rs
@@ -137,6 +137,21 @@ impl PriceScale {
         self.top + frac * (self.bottom - self.top)
     }
 
+    /// The screen band covering the price interval between `a` and `b`
+    /// (either order): `(top_y, bottom_y)` with `top_y <= bottom_y`,
+    /// whichever way up the scale is.
+    ///
+    /// The one way to turn two prices into a rect's vertical edges.
+    /// Hand-rolling `(y(hi), y(lo))` reads correctly upright and produces a
+    /// negative — silently dropped — rect upside down, which is how three
+    /// layers vanished the first time the chart flipped.
+    #[must_use]
+    pub fn band(&self, a: f64, b: f64) -> (f32, f32) {
+        let ya = self.y(a);
+        let yb = self.y(b);
+        (ya.min(yb), ya.max(yb))
+    }
+
     /// The price at a given y-pixel — the inverse of [`y`](PriceScale::y), for a
     /// crosshair readout.
     #[must_use]

--- a/crates/app/src/drawings/fixed_range_profile.rs
+++ b/crates/app/src/drawings/fixed_range_profile.rs
@@ -668,10 +668,23 @@ impl DrawingToolImpl for FixedRangeProfile {
                     && value_area.is_some_and(|area| bucket >= area.val && bucket <= area.vah)
             };
             let fill_limit = if outline_active { cut_x } else { None };
+            // A display row spans from the bucket's base price toward its
+            // higher edge — which way that is on screen follows the scale's
+            // orientation, so the rows tile the same price intervals either
+            // way up.
+            let row_edges = |bucket: i64| {
+                let base = ctxt.scale.y(to_f64(profile.bucket_price(bucket)));
+                let far = if ctxt.scale.is_inverted() {
+                    base + height
+                } else {
+                    base - height
+                };
+                (base, far)
+            };
             for (&bucket, level) in profile.levels() {
-                let y_bottom = ctxt.scale.y(to_f64(profile.bucket_price(bucket)));
-                let y_top = y_bottom - height;
-                if y_bottom < chart_rect.top() || y_top > chart_rect.bottom() {
+                let (y_base, y_far) = row_edges(bucket);
+                let (row_top, row_bottom) = (y_base.min(y_far), y_base.max(y_far));
+                if row_bottom < chart_rect.top() || row_top > chart_rect.bottom() {
                     continue;
                 }
                 #[allow(clippy::cast_possible_truncation)]
@@ -699,8 +712,8 @@ impl DrawingToolImpl for FixedRangeProfile {
                     let buy_tip = (left + buy_width).min(fill_tip);
                     painter.rect_filled(
                         egui::Rect::from_min_max(
-                            egui::pos2(left, y_top),
-                            egui::pos2(buy_tip, y_bottom),
+                            egui::pos2(left, row_top),
+                            egui::pos2(buy_tip, row_bottom),
                         ),
                         egui::Rounding::ZERO,
                         theme::BUY.gamma_multiply(alpha),
@@ -708,8 +721,8 @@ impl DrawingToolImpl for FixedRangeProfile {
                     if fill_tip > buy_tip {
                         painter.rect_filled(
                             egui::Rect::from_min_max(
-                                egui::pos2(buy_tip, y_top),
-                                egui::pos2(fill_tip, y_bottom),
+                                egui::pos2(buy_tip, row_top),
+                                egui::pos2(fill_tip, row_bottom),
                             ),
                             egui::Rounding::ZERO,
                             theme::SELL.gamma_multiply(alpha),
@@ -718,8 +731,8 @@ impl DrawingToolImpl for FixedRangeProfile {
                 } else {
                     painter.rect_filled(
                         egui::Rect::from_min_max(
-                            egui::pos2(left, y_top),
-                            egui::pos2(fill_tip, y_bottom),
+                            egui::pos2(left, row_top),
+                            egui::pos2(fill_tip, row_bottom),
                         ),
                         egui::Rounding::ZERO,
                         style.color.gamma_multiply(alpha),
@@ -735,11 +748,14 @@ impl DrawingToolImpl for FixedRangeProfile {
             // filled and outlined halves read as one object.
             if outline_active && let Some(base) = cut_x {
                 let mut segments: Vec<SilhouetteSegment> = Vec::new();
-                let mut previous: Option<(i64, f32, f32)> = None; // bucket, tip x, top y
+                // bucket, tip x, y of the row's far (higher-price) edge —
+                // which is the next row's base edge, either way up.
+                let mut previous: Option<(i64, f32, f32)> = None;
                 for (&bucket, level) in profile.levels() {
-                    let y_bottom = ctxt.scale.y(to_f64(profile.bucket_price(bucket)));
-                    let y_top = y_bottom - height;
-                    if y_bottom < chart_rect.top() || y_top > chart_rect.bottom() {
+                    let (y_base, y_far) = row_edges(bucket);
+                    if y_base.max(y_far) < chart_rect.top()
+                        || y_base.min(y_far) > chart_rect.bottom()
+                    {
                         continue;
                     }
                     #[allow(clippy::cast_possible_truncation)]
@@ -749,43 +765,43 @@ impl DrawingToolImpl for FixedRangeProfile {
                     let ex = (left + width).max(base);
                     let row_in_va = in_va(bucket);
                     match previous {
-                        Some((prev_bucket, prev_ex, prev_top)) if prev_bucket + 1 == bucket => {
+                        Some((prev_bucket, prev_ex, prev_far)) if prev_bucket + 1 == bucket => {
                             // Contiguous rows: one horizontal at the shared
                             // boundary, from tip to tip.
                             segments.push(SilhouetteSegment {
-                                from: egui::pos2(prev_ex, prev_top),
-                                to: egui::pos2(ex, y_bottom),
+                                from: egui::pos2(prev_ex, prev_far),
+                                to: egui::pos2(ex, y_base),
                                 in_va: row_in_va,
                             });
                         }
                         other => {
                             // A gap (or the first row): close the previous
                             // run down to the boundary and open this one.
-                            if let Some((_, prev_ex, prev_top)) = other {
+                            if let Some((_, prev_ex, prev_far)) = other {
                                 segments.push(SilhouetteSegment {
-                                    from: egui::pos2(prev_ex, prev_top),
-                                    to: egui::pos2(base, prev_top),
+                                    from: egui::pos2(prev_ex, prev_far),
+                                    to: egui::pos2(base, prev_far),
                                     in_va: row_in_va,
                                 });
                             }
                             segments.push(SilhouetteSegment {
-                                from: egui::pos2(base, y_bottom),
-                                to: egui::pos2(ex, y_bottom),
+                                from: egui::pos2(base, y_base),
+                                to: egui::pos2(ex, y_base),
                                 in_va: row_in_va,
                             });
                         }
                     }
                     segments.push(SilhouetteSegment {
-                        from: egui::pos2(ex, y_bottom),
-                        to: egui::pos2(ex, y_top),
+                        from: egui::pos2(ex, y_base),
+                        to: egui::pos2(ex, y_far),
                         in_va: row_in_va,
                     });
-                    previous = Some((bucket, ex, y_top));
+                    previous = Some((bucket, ex, y_far));
                 }
-                if let Some((_, prev_ex, prev_top)) = previous {
+                if let Some((_, prev_ex, prev_far)) = previous {
                     segments.push(SilhouetteSegment {
-                        from: egui::pos2(prev_ex, prev_top),
-                        to: egui::pos2(base, prev_top),
+                        from: egui::pos2(prev_ex, prev_far),
+                        to: egui::pos2(base, prev_far),
                         in_va: false,
                     });
                 }

--- a/crates/app/src/drawings/mark_core.rs
+++ b/crates/app/src/drawings/mark_core.rs
@@ -140,9 +140,16 @@ fn size_of(ctxt: &DrawContext<'_>) -> f32 {
 ///
 /// `anchor` is the bar's extreme; the whole shape hangs off it in pixels, so
 /// this is also the function that decides "outside the candle" and the one a
-/// test can ask about without a chart.
-pub(super) fn outline(anchor: egui::Pos2, direction: Direction, size_px: f32) -> Vec<egui::Pos2> {
-    let sign = direction.sign();
+/// test can ask about without a chart. `inverted` mirrors the hang: the
+/// anchor is a *price* extreme, and upside down the outside of the candle is
+/// the other screen direction.
+pub(super) fn outline(
+    anchor: egui::Pos2,
+    direction: Direction,
+    size_px: f32,
+    inverted: bool,
+) -> Vec<egui::Pos2> {
+    let sign = direction.sign() * if inverted { -1.0 } else { 1.0 };
     let head = size_px * HEAD_SHARE;
     let head_half = size_px * HEAD_HALF_WIDTH;
     let shaft_half = size_px * SHAFT_HALF_WIDTH;
@@ -172,7 +179,7 @@ pub(super) fn paint(
     let Some(anchor) = points.first() else {
         return;
     };
-    let outline = outline(*anchor, direction, size_of(ctxt));
+    let outline = outline(*anchor, direction, size_of(ctxt), ctxt.scale.is_inverted());
     if ctxt.halo {
         // The halo pass paints stroke geometry only, like every other tool.
         painter.add(egui::Shape::closed_line(
@@ -201,7 +208,7 @@ pub(super) fn hit_test(
         return false;
     };
     let size = size_of(ctxt);
-    let outline = outline(*anchor, direction, size);
+    let outline = outline(*anchor, direction, size, ctxt.scale.is_inverted());
     // The bounding box of the shape, grown by the grab radius. A mark is
     // small and solid; asking a trader to hit a triangle's true edge on a
     // moving chart would make it the hardest object on the canvas to grab.
@@ -219,8 +226,8 @@ mod tests {
     #[test]
     fn an_up_mark_hangs_below_its_anchor_and_a_down_mark_above() {
         let anchor = egui::pos2(100.0, 200.0);
-        let up = outline(anchor, Direction::Up, DEFAULT_MARK_PX);
-        let down = outline(anchor, Direction::Down, DEFAULT_MARK_PX);
+        let up = outline(anchor, Direction::Up, DEFAULT_MARK_PX, false);
+        let down = outline(anchor, Direction::Down, DEFAULT_MARK_PX, false);
         assert!(
             up.iter().all(|point| point.y > anchor.y),
             "an up mark clears the low it hangs from: {up:?}"
@@ -231,11 +238,29 @@ mod tests {
         );
     }
 
+    /// Upside down the anchor's price extreme sits on the other side of the
+    /// candle, so the whole glyph mirrors — without this the stamp paints
+    /// straight across the bar it marks.
+    #[test]
+    fn an_inverted_chart_mirrors_the_hang() {
+        let anchor = egui::pos2(100.0, 200.0);
+        let up = outline(anchor, Direction::Up, DEFAULT_MARK_PX, true);
+        let down = outline(anchor, Direction::Down, DEFAULT_MARK_PX, true);
+        assert!(
+            up.iter().all(|point| point.y < anchor.y),
+            "inverted, the up mark hangs above the low's pixel: {up:?}"
+        );
+        assert!(
+            down.iter().all(|point| point.y > anchor.y),
+            "and the down mark below the high's: {down:?}"
+        );
+    }
+
     #[test]
     fn the_mark_never_touches_the_candle_it_is_about() {
         for direction in [Direction::Up, Direction::Down] {
             let anchor = egui::pos2(0.0, 0.0);
-            let nearest = outline(anchor, direction, MIN_MARK_PX)
+            let nearest = outline(anchor, direction, MIN_MARK_PX, false)
                 .into_iter()
                 .map(|point| (point.y - anchor.y).abs())
                 .fold(f32::INFINITY, f32::min);
@@ -252,8 +277,8 @@ mod tests {
         // input to its geometry is the chosen size, so there is nowhere for
         // a scale factor to enter.
         let anchor = egui::pos2(50.0, 50.0);
-        let small = outline(anchor, Direction::Up, MIN_MARK_PX);
-        let large = outline(anchor, Direction::Up, MAX_MARK_PX);
+        let small = outline(anchor, Direction::Up, MIN_MARK_PX, false);
+        let large = outline(anchor, Direction::Up, MAX_MARK_PX, false);
         let height = |shape: &[egui::Pos2]| {
             shape
                 .iter()
@@ -267,7 +292,7 @@ mod tests {
 
     #[test]
     fn the_arrow_is_a_head_on_a_shaft() {
-        let outline = outline(egui::pos2(0.0, 0.0), Direction::Up, DEFAULT_MARK_PX);
+        let outline = outline(egui::pos2(0.0, 0.0), Direction::Up, DEFAULT_MARK_PX, false);
         assert_eq!(outline.len(), 7, "tip, two shoulders, two waists, two feet");
         let widest = outline
             .iter()

--- a/crates/app/src/footprint_render.rs
+++ b/crates/app/src/footprint_render.rs
@@ -756,9 +756,7 @@ fn zones_of(
 /// would give every rect a negative height.
 fn row_band(frame: &LayerFrame<'_>, row: i64, row_group: f64) -> (f32, f32) {
     let low = row as f64 * row_group;
-    let a = frame.scale.y(low + row_group);
-    let b = frame.scale.y(low);
-    (a.min(b), a.max(b))
+    frame.scale.band(low, low + row_group)
 }
 
 fn side_color(side: Side) -> egui::Color32 {
@@ -812,8 +810,13 @@ fn draw_bar(
         && level >= DetailLevel::Profile
         && let (Some(&first), Some(&last)) = (rows.keys().next(), rows.keys().next_back())
     {
-        let (_, bar_bottom) = row_band(frame, first, row_group);
-        let (bar_top, _) = row_band(frame, last, row_group);
+        // Composed from both rows' screen bands, not from the price names:
+        // upside down the highest bucket renders lowest, and reading "top"
+        // off it would hand the rect a negative height.
+        let (first_top, first_bottom) = row_band(frame, first, row_group);
+        let (last_top, last_bottom) = row_band(frame, last, row_group);
+        let bar_top = first_top.min(last_top);
+        let bar_bottom = first_bottom.max(last_bottom);
         let reach = (frame.half - 1.0).max(1.0);
         painter.rect_filled(
             egui::Rect::from_min_max(
@@ -1166,8 +1169,13 @@ fn draw_poc_dot(frame: &LayerFrame<'_>, xc: f32, row: i64, row_group: f64) {
 }
 
 fn draw_zone_mark(frame: &LayerFrame<'_>, mark: &ZoneMark, row_group: f64) {
-    let (top, _) = row_band(frame, mark.high_bucket, row_group);
-    let (_, bottom) = row_band(frame, mark.low_bucket, row_group);
+    // Composed from both rows' screen bands: upside down the high bucket
+    // renders below the low one, and reading "top" off it would hand both
+    // rects a negative height (see the Split backdrop above).
+    let (high_top, high_bottom) = row_band(frame, mark.high_bucket, row_group);
+    let (low_top, low_bottom) = row_band(frame, mark.low_bucket, row_group);
+    let top = high_top.min(low_top);
+    let bottom = high_bottom.max(low_bottom);
     let left = (frame.x_center)(mark.first_slot) - frame.half;
     let right = (frame.x_center)(mark.last_slot) + frame.half;
     // A zone is memory: it outlives its bars to the right edge as a hairline,

--- a/crates/app/src/footprint_render.rs
+++ b/crates/app/src/footprint_render.rs
@@ -746,11 +746,15 @@ fn zones_of(
 }
 
 /// Pixel band of display row `row` (rows are `row_group` of price tall).
+///
+/// Ordered on screen, not by price: on an inverted scale the row's high edge
+/// is the *lower* pixel, and a band handed out as `(high_edge, low_edge)`
+/// would give every rect a negative height.
 fn row_band(frame: &LayerFrame<'_>, row: i64, row_group: f64) -> (f32, f32) {
     let low = row as f64 * row_group;
-    let top = frame.scale.y(low + row_group);
-    let bottom = frame.scale.y(low);
-    (top, bottom)
+    let a = frame.scale.y(low + row_group);
+    let b = frame.scale.y(low);
+    (a.min(b), a.max(b))
 }
 
 fn side_color(side: Side) -> egui::Color32 {
@@ -1076,10 +1080,7 @@ fn draw_bar(
     // beside a merged row must be that row's own number. The "x" suffix
     // keeps it out of the price vocabulary.
     if level == DetailLevel::Detailed && frame.config.extreme_ratio_badge {
-        for (extreme, align, offset) in [
-            (Extreme::Low, egui::Align2::CENTER_TOP, 3.0),
-            (Extreme::High, egui::Align2::CENTER_BOTTOM, -3.0),
-        ] {
+        for extreme in [Extreme::Low, Extreme::High] {
             let cell = match extreme {
                 Extreme::Low => rows.iter().next(),
                 Extreme::High => rows.iter().next_back(),
@@ -1108,10 +1109,18 @@ fn draw_bar(
             } else {
                 Side::Sell
             };
-            let low = row as f64 * row_group;
-            let y = match extreme {
-                Extreme::Low => frame.scale.y(low) + offset,
-                Extreme::High => frame.scale.y(low + row_group) + offset,
+            // The badge sits *outside* the bar's extent — which end of the row
+            // that is on screen follows the scale's orientation, so the chip
+            // never lands on the ladder it is describing.
+            let (band_top, band_bottom) = row_band(frame, row, row_group);
+            let outward_down = match extreme {
+                Extreme::Low => !frame.scale.is_inverted(),
+                Extreme::High => frame.scale.is_inverted(),
+            };
+            let (align, y) = if outward_down {
+                (egui::Align2::CENTER_TOP, band_bottom + 3.0)
+            } else {
+                (egui::Align2::CENTER_BOTTOM, band_top - 3.0)
             };
             let text = format!("{:.1}x", ratio_value.to_f64().unwrap_or(0.0));
             let galley =

--- a/crates/app/src/footprint_render.rs
+++ b/crates/app/src/footprint_render.rs
@@ -136,6 +136,10 @@ const PROFILE_COLOR: egui::Color32 = egui::Color32::from_gray(0xD8);
 /// on a short bar without swallowing the whole half.
 const MIN_CHIP_PX: f32 = 14.0;
 
+/// Gap between an extreme-ratio badge and the row it describes, in pixels —
+/// just off the bar's end, never on the ladder itself.
+const EXTREME_BADGE_GAP_PX: f32 = 3.0;
+
 /// How far above the chart's bottom edge the per-bar delta totals sit —
 /// clear of the legend line below them.
 const TOTALS_STRIP_OFFSET_Y: f32 = 22.0;
@@ -1118,9 +1122,9 @@ fn draw_bar(
                 Extreme::High => frame.scale.is_inverted(),
             };
             let (align, y) = if outward_down {
-                (egui::Align2::CENTER_TOP, band_bottom + 3.0)
+                (egui::Align2::CENTER_TOP, band_bottom + EXTREME_BADGE_GAP_PX)
             } else {
-                (egui::Align2::CENTER_BOTTOM, band_top - 3.0)
+                (egui::Align2::CENTER_BOTTOM, band_top - EXTREME_BADGE_GAP_PX)
             };
             let text = format!("{:.1}x", ratio_value.to_f64().unwrap_or(0.0));
             let galley =

--- a/crates/app/src/indicator_render.rs
+++ b/crates/app/src/indicator_render.rs
@@ -1042,14 +1042,18 @@ fn draw_shape_markers(
             continue;
         }
         let cx = x.x(row);
+        // Above/below are *screen* words, so the anchor reads the extents'
+        // screen extremes rather than their price names: upside down the
+        // high's pixel is the bar's bottom edge, and keying off it would
+        // plant the marker inside the candle with above/below swapped.
         let cy = match marker.location {
             MarkerLocation::Absolute => y_of(value),
             MarkerLocation::AboveBar => match bar_extents(row) {
-                Some((high_y, _)) => high_y - MARKER_GAP_PX,
+                Some((a, b)) => a.min(b) - MARKER_GAP_PX,
                 None => continue,
             },
             MarkerLocation::BelowBar => match bar_extents(row) {
-                Some((_, low_y)) => low_y + MARKER_GAP_PX,
+                Some((a, b)) => a.max(b) + MARKER_GAP_PX,
                 None => continue,
             },
         };

--- a/crates/app/src/orderflow_render.rs
+++ b/crates/app/src/orderflow_render.rs
@@ -989,6 +989,11 @@ pub(crate) struct ProjectedLayout<'a> {
     /// the chart. `0.0` means the frame has no lane and the candles own the
     /// whole chart.
     pub(crate) lane_width_px: f32,
+    /// Whether the chart is upside down. The projection speaks in fractions
+    /// of the price window and knows nothing of orientation; the flip happens
+    /// here, at the same boundary where the candles' own scale flips, so the
+    /// map, the bubbles and the bars they sit on turn over together.
+    pub(crate) inverted: bool,
 }
 
 impl<'a> ProjectedLayout<'a> {
@@ -1012,7 +1017,15 @@ impl<'a> ProjectedLayout<'a> {
             } else {
                 0.0
             },
+            inverted: false,
         }
+    }
+
+    /// The same layout upside down when `inverted` — see the field's note.
+    #[must_use]
+    pub(crate) fn with_inverted(mut self, inverted: bool) -> Self {
+        self.inverted = inverted;
+        self
     }
 
     #[must_use]
@@ -1148,7 +1161,9 @@ impl<'a> ProjectedLayout<'a> {
 
     #[must_use]
     fn y(self, normalized: f64) -> f32 {
-        self.chart_rect.top() + finite_unit_f64(normalized) as f32 * self.chart_rect.height()
+        let unit = finite_unit_f64(normalized) as f32;
+        let unit = if self.inverted { 1.0 - unit } else { unit };
+        self.chart_rect.top() + unit * self.chart_rect.height()
     }
 
     #[must_use]

--- a/crates/app/src/orderflow_render.rs
+++ b/crates/app/src/orderflow_render.rs
@@ -3781,6 +3781,19 @@ mod tests {
         );
     }
 
+    /// Orientation flips the price fraction and nothing else: y mirrors
+    /// around the canvas's middle, x — time — never moves.
+    #[test]
+    fn an_inverted_layout_mirrors_normalized_y() {
+        let viewport = Viewport::new();
+        let rect = egui::Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(800.0, 400.0));
+        let layout = ProjectedLayout::new(rect, &viewport, 2, 0, 2, 0.0);
+        let flipped = layout.with_inverted(true);
+        assert_eq!(layout.y(0.25), 100.0);
+        assert_eq!(flipped.y(0.25), 300.0);
+        assert_eq!(flipped.x(0.5), layout.x(0.5), "time never turns over");
+    }
+
     /// The key starts below whatever already owns the canvas's top-left
     /// corner. It used to clear a constant 22 px — the chart header alone —
     /// and printed straight through the indicator chips stacked under it.

--- a/crates/app/src/orderflow_render.rs
+++ b/crates/app/src/orderflow_render.rs
@@ -298,12 +298,15 @@ pub(crate) fn theme_bubble_rgb(theme: HeatmapTheme) -> ThemeBubbleRgb {
 /// Vertical nudge, in pixels, that keeps the two sides off the same row.
 ///
 /// Buy aggression lifts the ask, sell aggression hits the bid, so buys sit
-/// slightly above the print and sells slightly below. Screen y grows downward.
-const fn side_offset_y(side: Side, offset: f32) -> f32 {
-    match side {
+/// on the ask's side of the print and sells on the bid's. That is a *price*
+/// direction: `inverted` mirrors the nudge with the chart, or the separation
+/// would assert the opposite book side upside down. Screen y grows downward.
+const fn side_offset_y(side: Side, offset: f32, inverted: bool) -> f32 {
+    let toward_ask = match side {
         Side::Buy => -offset,
         Side::Sell => offset,
-    }
+    };
+    if inverted { -toward_ask } else { toward_ask }
 }
 
 /// Interior alpha of a hollow bubble, as a fraction of the configured fill
@@ -1520,7 +1523,15 @@ pub(crate) fn draw_liquidity_events(painter: &egui::Painter, context: &RenderCon
         }
         // Follow the bubble's own vertical nudge, so the carved gap stays
         // centred on the bubble that will be drawn over it.
-        let center = center + egui::vec2(0.0, side_offset_y(trade.side, style.bubbles.side_offset));
+        let center = center
+            + egui::vec2(
+                0.0,
+                side_offset_y(
+                    trade.side,
+                    style.bubbles.side_offset,
+                    context.layout.inverted,
+                ),
+            );
         let r = bubble_radius(
             trade.size,
             style.bubbles.min_radius,
@@ -1690,6 +1701,9 @@ pub(crate) fn draw_aggression_bubbles(painter: &egui::Painter, context: &RenderC
     // price and a lopsided one leans the way its dominant side would.
     // A print is drawn only inside its own pane: one panned off the right of
     // the candles is out of sight, not on top of the tape.
+    // The lean is toward the dominant side's book half — a price direction,
+    // so it mirrors with the chart like side_offset_y does.
+    let lean_sign = if context.layout.inverted { 1.0 } else { -1.0 };
     let center_of = |trade: &AggressionPrimitive| {
         let center = egui::pos2(context.layout.x(trade.x), context.layout.y(trade.y));
         let lean = (finite_unit(trade.buy_share) - 0.5) * 2.0;
@@ -1697,7 +1711,7 @@ pub(crate) fn draw_aggression_bubbles(painter: &egui::Painter, context: &RenderC
             .layout
             .pane(trade.x)
             .contains(center)
-            .then(|| center + egui::vec2(0.0, -lean * bubbles.side_offset))
+            .then(|| center + egui::vec2(0.0, lean_sign * lean * bubbles.side_offset))
     };
     // The live lane has room the compressed history does not, which is the
     // whole reason it gets a radius range of its own.
@@ -3240,13 +3254,17 @@ mod tests {
     #[test]
     fn buy_and_sell_bubbles_are_nudged_to_opposite_sides() {
         // Screen y grows downward: buys sit above the print, sells below.
-        assert!(side_offset_y(Side::Buy, 4.0) < 0.0);
-        assert!(side_offset_y(Side::Sell, 4.0) > 0.0);
-        assert_eq!(side_offset_y(Side::Buy, 0.0), 0.0);
+        assert!(side_offset_y(Side::Buy, 4.0, false) < 0.0);
+        assert!(side_offset_y(Side::Sell, 4.0, false) > 0.0);
+        assert_eq!(side_offset_y(Side::Buy, 0.0, false), 0.0);
         assert_eq!(
-            side_offset_y(Side::Buy, 4.0).abs(),
-            side_offset_y(Side::Sell, 4.0).abs()
+            side_offset_y(Side::Buy, 4.0, false).abs(),
+            side_offset_y(Side::Sell, 4.0, false).abs()
         );
+        // The nudge names a book side, not a screen side: upside down it
+        // mirrors with the chart.
+        assert!(side_offset_y(Side::Buy, 4.0, true) > 0.0);
+        assert!(side_offset_y(Side::Sell, 4.0, true) < 0.0);
     }
 
     /// Paint through `draw` off-screen and return the shapes it emitted.
@@ -3314,7 +3332,8 @@ mod tests {
             draw_bubble(
                 painter,
                 BubbleMark {
-                    center: at + egui::vec2(0.0, side_offset_y(Side::Buy, bubbles.side_offset)),
+                    center: at
+                        + egui::vec2(0.0, side_offset_y(Side::Buy, bubbles.side_offset, false)),
                     radius,
                     side: Side::Buy,
                     size: PREVIEW_LARGE_PRINT_SIZE,
@@ -3705,7 +3724,8 @@ mod tests {
             draw_bubble(
                 painter,
                 BubbleMark {
-                    center: at + egui::vec2(0.0, side_offset_y(Side::Buy, bubbles.side_offset)),
+                    center: at
+                        + egui::vec2(0.0, side_offset_y(Side::Buy, bubbles.side_offset, false)),
                     radius,
                     side: Side::Buy,
                     size: PREVIEW_LARGE_PRINT_SIZE,
@@ -4408,8 +4428,8 @@ mod tests {
     fn a_pie_leans_with_its_buy_share() {
         let offset = 4.0;
         let lean = |buy_share: f32| -((finite_unit(buy_share) - 0.5) * 2.0) * offset;
-        assert_eq!(lean(1.0), side_offset_y(Side::Buy, offset));
-        assert_eq!(lean(0.0), side_offset_y(Side::Sell, offset));
+        assert_eq!(lean(1.0), side_offset_y(Side::Buy, offset, false));
+        assert_eq!(lean(0.0), side_offset_y(Side::Sell, offset, false));
         assert_eq!(lean(0.5), 0.0);
         assert!(lean(0.75) < 0.0 && lean(0.75) > lean(1.0));
     }

--- a/crates/app/src/orderflow_view.rs
+++ b/crates/app/src/orderflow_view.rs
@@ -679,7 +679,8 @@ impl OrderflowView {
     }
 
     /// Draw resting liquidity, coverage gaps and factual liquidity changes
-    /// behind the candle layer.
+    /// behind the candle layer. `inverted` is the candles' own orientation,
+    /// so the map turns over with the bars it sits behind.
     #[allow(clippy::too_many_arguments)]
     pub fn draw_background(
         &self,
@@ -690,6 +691,7 @@ impl OrderflowView {
         frame: &VisibleOrderflow,
         canvas_background: egui::Color32,
         lane_width_px: f32,
+        inverted: bool,
     ) {
         let layout = ProjectedLayout::new(
             chart_rect,
@@ -698,7 +700,8 @@ impl OrderflowView {
             frame.first_bar_index,
             frame.slot_count,
             lane_width_px,
-        );
+        )
+        .with_inverted(inverted);
         let style = OrderflowRenderStyle::from_config(&self.config, canvas_background);
         let context = RenderContext::new(&frame.projection, layout, &style);
         draw_heatmap_background(painter, &context);
@@ -708,6 +711,8 @@ impl OrderflowView {
 
     /// Draw factual aggressive prints over the candles. The canvas's key is
     /// not part of this pass — see [`draw_legend`](Self::draw_legend).
+    /// `inverted` is the candles' own orientation, as in
+    /// [`draw_background`](Self::draw_background).
     #[allow(clippy::too_many_arguments)]
     pub fn draw_aggressions(
         &self,
@@ -718,6 +723,7 @@ impl OrderflowView {
         frame: &VisibleOrderflow,
         canvas_background: egui::Color32,
         lane_width_px: f32,
+        inverted: bool,
     ) {
         let layout = ProjectedLayout::new(
             chart_rect,
@@ -726,7 +732,8 @@ impl OrderflowView {
             frame.first_bar_index,
             frame.slot_count,
             lane_width_px,
-        );
+        )
+        .with_inverted(inverted);
         let style = OrderflowRenderStyle::from_config(&self.config, canvas_background);
         let context = RenderContext::new(&frame.projection, layout, &style);
         draw_aggression_bubbles(painter, &context);
@@ -868,11 +875,14 @@ impl OrderflowView {
                 } else {
                     bucket_width
                 };
-                let top = scale.y((row.price_bucket + row_span).to_f64().unwrap_or(f64::NAN));
-                let bottom = scale.y(row.price_bucket.to_f64().unwrap_or(f64::NAN));
-                if !top.is_finite() || !bottom.is_finite() {
+                // Ordered on screen, not by price: on an inverted scale the
+                // row's higher edge is the lower pixel.
+                let a = scale.y((row.price_bucket + row_span).to_f64().unwrap_or(f64::NAN));
+                let b = scale.y(row.price_bucket.to_f64().unwrap_or(f64::NAN));
+                if !a.is_finite() || !b.is_finite() {
                     continue;
                 }
+                let (top, bottom) = (a.min(b), a.max(b));
                 let buy_extent = normalized_area_size(row.buy, reference) * half_width;
                 if buy_extent > 0.0 {
                     let rect = egui::Rect::from_min_max(
@@ -2721,6 +2731,7 @@ mod tests {
                             &frame,
                             egui::Color32::BLACK,
                             0.0,
+                            false,
                         );
                     }
                 });

--- a/crates/app/src/pane.rs
+++ b/crates/app/src/pane.rs
@@ -445,7 +445,7 @@ fn pane_pan_gesture(
             if delta != 0.0 && height > 1.0 {
                 let (lo, hi) = view.resolve(auto);
                 let per_px = (hi - lo) / f64::from(height);
-                view.pan(f64::from(delta) * per_px, auto);
+                view.pan_screen(f64::from(delta), per_px, auto);
             }
         }
     }
@@ -482,13 +482,23 @@ struct PaneGesture {
 ///
 /// `auto` is the range the last frame fitted; `None` means nothing has been
 /// computed to scale yet, and only the reset stays available.
+///
+/// `flips` is the price gutter's privilege: an expanding drag past the flip
+/// threshold turns the chart upside down ([`PriceView::drag_zoom`]), and the
+/// drag's sense mirrors with it — the same downward drag that flattened the
+/// chart grows it again past the flip. Indicator gutters pass `false`: a
+/// pane's values have no upside down. The wheel never flips on either.
+///
+/// Returns the band's response, so the price gutter can hang its context menu
+/// off the very region the gesture owns.
 fn axis_zoom_gesture(
     ui: &egui::Ui,
     id: egui::Id,
     band: egui::Rect,
     view: &mut PriceView,
     auto: Option<(f64, f64)>,
-) {
+    flips: bool,
+) -> egui::Response {
     let response = ui.interact(band, id, egui::Sense::click_and_drag());
     // The cursor is the affordance (audit F5): nothing else on the band says
     // it scales, mirroring the lane divider's own rule that the pointer's
@@ -500,14 +510,22 @@ fn axis_zoom_gesture(
         view.reset();
     }
     let Some(auto) = auto else {
-        return;
+        return response;
     };
     if response.dragged() {
-        // Drag up → compress the span (a taller trace); down → expand it.
-        view.zoom(
-            f64::from(response.drag_delta().y / AXIS_ZOOM_DRAG_PX).exp(),
-            auto,
-        );
+        // Drag up → compress the span (a taller trace); down → expand it —
+        // mirrored once the chart is upside down.
+        let sense = if flips && view.is_inverted() {
+            -1.0
+        } else {
+            1.0
+        };
+        let factor = f64::from(sense * response.drag_delta().y / AXIS_ZOOM_DRAG_PX).exp();
+        if flips {
+            view.drag_zoom(factor, auto);
+        } else {
+            view.zoom(factor, auto);
+        }
     }
     if response.hovered() {
         let scroll = ui.input(|input| input.raw_scroll_delta.y);
@@ -515,6 +533,7 @@ fn axis_zoom_gesture(
             view.zoom(f64::from(-scroll / AXIS_ZOOM_SCROLL_PX).exp(), auto);
         }
     }
+    response
 }
 
 /// Wheel travel that doubles or halves what a time axis shows.
@@ -915,6 +934,10 @@ pub struct ChartPane {
     // right-click of `QUANTICK_CONTEXT_MENU` — and computing the geometry a
     // second time is how two answers start to disagree.
     pub last_chart_rect: Option<egui::Rect>,
+    // The price gutter of the last draw, published for the same reason: the
+    // scripted right-click of `QUANTICK_CONTEXT_MENU=axis` needs a point that
+    // is really on the axis, not a guess about where the gutter probably is.
+    pub last_price_gutter: Option<egui::Rect>,
     // The automatic tape window at the last draw — the recent bars' typical
     // duration. Only the menu reads it, and only to state what "follows the
     // bars" currently amounts to; the drawing itself is handed the resolved
@@ -1167,6 +1190,7 @@ impl ChartPane {
             viewport: Viewport::new(),
             last_lane_divider_x: None,
             last_chart_rect: None,
+            last_price_gutter: None,
             last_lane_reference_ms: None,
             context_menu_on_tape: false,
             lane_rungs: 0,
@@ -2619,7 +2643,12 @@ impl ChartPane {
         self.history_prefix.clear();
         self.state = ChartState::new(self.current_spec());
         self.viewport = Viewport::new();
+        // Framing dies with the series; orientation is the trader's standing
+        // choice about the view, not about these bars — it survives the way
+        // the drawings do.
+        let inverted = self.price_view.is_inverted();
         self.price_view = PriceView::new();
+        self.price_view.set_inverted(inverted);
         self.last_auto_range = None;
         self.hover_pos = None;
         // Bars queued for the strategies belong to the series that just
@@ -4131,8 +4160,12 @@ impl ChartPane {
                             // Per *band* height: a pane is a fraction of the
                             // chart's, and dividing by the candles' would move
                             // a CVD level by a fraction of the distance the
-                            // pointer travelled.
-                            let delta_value = -f64::from(travel.y / band.rect.height()) * (hi - lo);
+                            // pointer travelled. The sign follows the band's
+                            // orientation — the object tracks the pointer,
+                            // not the price axis.
+                            let sign = if scale.is_inverted() { 1.0 } else { -1.0 };
+                            let delta_value =
+                                sign * f64::from(travel.y / band.rect.height()) * (hi - lo);
                             self.drawings.translate_selected(delta_bar, delta_value);
                             // Market time is what every other pane reads the
                             // object through; a move that left it behind
@@ -4220,7 +4253,8 @@ impl ChartPane {
             {
                 let (lo, hi) = self.price_view.resolve(auto);
                 let price_per_px = (hi - lo) / f64::from(height);
-                self.price_view.pan(f64::from(drag.y) * price_per_px, auto);
+                self.price_view
+                    .pan_screen(f64::from(drag.y), price_per_px, auto);
             }
         }
         // Not while a tool is armed: two placement clicks in a row are two
@@ -4280,7 +4314,8 @@ impl ChartPane {
                 {
                     let (lo, hi) = self.price_view.resolve(auto);
                     let price_per_px = (hi - lo) / f64::from(height);
-                    self.price_view.pan(f64::from(delta.y) * price_per_px, auto);
+                    self.price_view
+                        .pan_screen(f64::from(delta.y), price_per_px, auto);
                 }
                 ui.ctx().set_cursor_icon(egui::CursorIcon::Grabbing);
             }
@@ -4380,13 +4415,32 @@ impl ChartPane {
 
         // Right price gutter: the candles' own axis gesture. It spans their
         // height only — the bands below belong to the panes.
-        axis_zoom_gesture(
+        let price_gutter = axis_zoom_gesture(
             ui,
             self.interaction_id("price_nav"),
             areas.price_gutter,
             &mut self.price_view,
             auto,
+            true,
         );
+        // The axis's own menu: about the scale, not the canvas — the layer
+        // menu stays the canvas's right-click. One entry today; anything else
+        // the axis learns to do belongs here with it.
+        price_gutter.context_menu(|ui| {
+            let mut inverted = self.price_view.is_inverted();
+            if ui
+                .checkbox(&mut inverted, "Inverted chart")
+                .on_hover_text(
+                    "flip the chart upside down — low prices at the top. \
+                     Also reached by dragging the axis down until the bars \
+                     flatten and turn over",
+                )
+                .clicked()
+            {
+                self.price_view.set_inverted(inverted);
+                ui.close_menu();
+            }
+        });
 
         // The same gesture, once per pane, over the gutter band beside it.
         // Keyed by slot *and* pane id: slots are allocated per pane, so a
@@ -4414,6 +4468,7 @@ impl ChartPane {
                 *gutter,
                 &mut view.scale,
                 view.last_auto,
+                false,
             );
             if !body.collapsed {
                 // The body moves the scale the gutter scales. Registered after
@@ -4612,6 +4667,7 @@ impl ChartPane {
         // Indicator panes claimed the bottom band inside `plot_split`, so the
         // rect the candles scale to is the same one the input handler uses.
         let chart_rect = areas.chart;
+        self.last_price_gutter = Some(areas.price_gutter);
         let pane_rects = areas.indicator_panes.clone();
         if total == 0 {
             painter.text(
@@ -4710,8 +4766,9 @@ impl ChartPane {
             return;
         };
         let auto_range = auto_scale.range();
-        let (lo, hi) = self.price_view.resolve(auto_range);
-        let scale = PriceScale::from_range(lo, hi, chart_rect.top(), chart_rect.bottom());
+        let scale = self
+            .price_view
+            .scale(auto_range, chart_rect.top(), chart_rect.bottom());
 
         let cw = self.viewport.candle_width();
         let half = chrome.style.candles.body_half_width(cw);
@@ -4772,6 +4829,7 @@ impl ChartPane {
                 frame,
                 canvas_background,
                 lane_width_px,
+                self.price_view.is_inverted(),
             );
         }
 
@@ -5067,6 +5125,7 @@ impl ChartPane {
                 frame,
                 canvas_background,
                 lane_width_px,
+                self.price_view.is_inverted(),
             );
         }
 
@@ -5519,6 +5578,7 @@ impl ChartPane {
                     .map(|auto| self.price_view.resolve(auto)),
                 top: areas.chart.top(),
                 bottom: areas.chart.bottom(),
+                inverted: self.price_view.is_inverted(),
             },
             &self.indicators,
             areas,
@@ -5655,11 +5715,9 @@ impl ChartPane {
     /// while it has no price range to project against.
     fn last_projection(&self) -> Option<(egui::Rect, f32, usize, PriceScale)> {
         let chart = self.last_chart_area?;
-        let (auto_lo, auto_hi) = self.last_auto_range?;
-        let (lo, hi) = self.price_view.resolve((auto_lo, auto_hi));
-        let scale = PriceScale::from_range(
-            lo,
-            hi,
+        let auto = self.last_auto_range?;
+        let scale = self.price_view.scale(
+            auto,
             self.last_chart_top,
             self.last_chart_top + self.last_chart_height,
         );

--- a/crates/app/src/pane.rs
+++ b/crates/app/src/pane.rs
@@ -7471,6 +7471,26 @@ mod tests {
         ));
     }
 
+    /// The drawings read the candles through the band's scale, so the band
+    /// has to carry the chart's orientation: without it a click would anchor
+    /// at the mirror of the price under the pointer.
+    #[test]
+    fn the_price_band_scale_turns_over_with_the_chart() {
+        let mut pane = ChartPane::flow(1, BarSpec::Tick(50), "TESTUSDT".to_owned());
+        pane.last_auto_range = Some((100.0, 110.0));
+        let areas = test_areas(&pane, TEST_PLOT);
+        let upright = pane.bands(&areas)[0].scale.expect("a range is set");
+        assert!(!upright.is_inverted());
+
+        pane.price_view.set_inverted(true);
+        let scale = pane.bands(&areas)[0].scale.expect("a range is set");
+        assert!(scale.is_inverted(), "the band mirrors the candles");
+        assert!(
+            scale.y(100.0) < scale.y(110.0),
+            "low prices ride at the top of the band"
+        );
+    }
+
     /// Two instances of one kind are told apart by ordinal, in add order.
     #[test]
     fn two_panes_of_the_same_kind_get_different_keys() {

--- a/crates/app/src/pane.rs
+++ b/crates/app/src/pane.rs
@@ -5691,8 +5691,13 @@ impl ChartPane {
     pub fn selected_value_per_px(&self) -> Option<f64> {
         let drawing = self.drawings.items().get(self.drawings.selected()?)?;
         let band = bands::band_of(&self.last_bands, drawing)?;
-        let (lo, hi) = band.scale?.range();
-        Some((hi - lo) / f64::from(band.rect.height().max(1.0)))
+        let scale = band.scale?;
+        let (lo, hi) = scale.range();
+        let per_px = (hi - lo) / f64::from(band.rect.height().max(1.0));
+        // Signed for the *screen* gesture: an upward step raises the value on
+        // an upright band and lowers it on an inverted one, so the arrows
+        // keep moving the object the way the key points.
+        Some(if scale.is_inverted() { -per_px } else { per_px })
     }
 
     /// The band drawings live in: the candles minus the live lane.

--- a/crates/app/src/pane.rs
+++ b/crates/app/src/pane.rs
@@ -512,7 +512,11 @@ fn axis_zoom_gesture(
     let Some(auto) = auto else {
         return response;
     };
-    if response.dragged() {
+    // Primary only: the band now also answers a right-click with its context
+    // menu, and egui's `dragged()` counts any button — an unfiltered check
+    // would let a slipped right-press zoom (or, on the price gutter, flip)
+    // the chart while swallowing the menu it was aiming for.
+    if response.dragged_by(egui::PointerButton::Primary) {
         // Drag up → compress the span (a taller trace); down → expand it —
         // mirrored once the chart is upside down.
         let sense = if flips && view.is_inverted() {
@@ -4918,8 +4922,10 @@ impl ChartPane {
                 .is_some_and(OrderflowView::depth_visible)
         {
             let clear_bar = |xc: f32, bar: &quantick_engine::Bar| {
-                let top = scale.y(bar.high.to_f64().unwrap_or(0.0));
-                let bottom = scale.y(bar.low.to_f64().unwrap_or(0.0));
+                let (top, bottom) = scale.band(
+                    bar.high.to_f64().unwrap_or(0.0),
+                    bar.low.to_f64().unwrap_or(0.0),
+                );
                 clip.rect_filled(
                     egui::Rect::from_min_max(
                         egui::pos2(xc - half, top),

--- a/crates/app/src/paper_trading.rs
+++ b/crates/app/src/paper_trading.rs
@@ -2497,10 +2497,14 @@ impl PaperTrading {
         if delta.abs() < CREATE_DECIDE_THRESHOLD_PX {
             return;
         }
-        // On screen, up is negative y; up is the profit side for a long.
+        // The leg is chosen by *price*, not by screen direction: on an
+        // inverted chart up is the loss side for a long, and reading pixels
+        // would hand the pull the wrong leg.
+        let above_entry =
+            scale.price_at(pointer_y) > position.avg_price.to_f64().unwrap_or_default();
         let profit_side = match position.side {
-            Side::Buy => delta < 0.0,
-            Side::Sell => delta > 0.0,
+            Side::Buy => above_entry,
+            Side::Sell => !above_entry,
         };
         self.drag = if profit_side {
             if position.take_profit.is_none() {

--- a/crates/app/src/paper_trading.rs
+++ b/crates/app/src/paper_trading.rs
@@ -1852,17 +1852,23 @@ impl PaperTrading {
                 // own geometry, so a revealed handle is always pressable.
                 let entry_center =
                     clamp_tag_center(entry_y, ctx.chart_rect.top(), ctx.chart_rect.bottom());
+                // Each handle sits on its leg's *price* side of the entry,
+                // mapped through the chart's orientation: upside down the TP
+                // handle keeps pointing at take-profit prices instead of
+                // trading places with the stop's — the same price-not-pixels
+                // rule `decide_pending_leg` follows.
+                let flip = ctx.scale.is_inverted();
                 let legs = [
                     (
                         position.stop_loss.is_none(),
                         "SL",
-                        position.side == Side::Sell,
+                        (position.side == Side::Sell) != flip,
                         theme::SELL,
                     ),
                     (
                         position.take_profit.is_none(),
                         "TP",
-                        position.side == Side::Buy,
+                        (position.side == Side::Buy) != flip,
                         theme::BUY,
                     ),
                 ];
@@ -2317,15 +2323,26 @@ impl PaperTrading {
         if close_button_rect(tag_right, entry_center).contains(pointer) {
             return Some(PaperControl::ClosePosition);
         }
+        // Same orientation mapping as the paint's `legs`: the hit-test and
+        // the pixels must name the same handle or a press acts on the leg
+        // the trader was not looking at.
         if position.take_profit.is_none()
-            && bracket_handle_rect(tag_right, entry_center, position.side == Side::Buy)
-                .contains(pointer)
+            && bracket_handle_rect(
+                tag_right,
+                entry_center,
+                (position.side == Side::Buy) != scale.is_inverted(),
+            )
+            .contains(pointer)
         {
             return Some(PaperControl::HandleTakeProfit);
         }
         if position.stop_loss.is_none()
-            && bracket_handle_rect(tag_right, entry_center, position.side == Side::Sell)
-                .contains(pointer)
+            && bracket_handle_rect(
+                tag_right,
+                entry_center,
+                (position.side == Side::Sell) != scale.is_inverted(),
+            )
+            .contains(pointer)
         {
             return Some(PaperControl::HandleStopLoss);
         }

--- a/crates/app/src/price_view.rs
+++ b/crates/app/src/price_view.rs
@@ -22,6 +22,17 @@ use crate::chart::PriceScale;
 /// legitimate ask that must not turn the chart over.
 pub const FLIP_SPAN_FACTOR: f64 = 40.0;
 
+/// How far back inside [`FLIP_SPAN_FACTOR`] the span must contract before the
+/// drag may flip again.
+///
+/// A flip parks the window at the threshold, where any expanding pixel would
+/// cross it again: without this band a hand tremor at the boundary would
+/// strobe the chart's orientation at frame rate. 5% is ~8px of gutter travel
+/// (`AXIS_ZOOM_DRAG_PX · ln(1/0.95)`) — beyond any tremor, and invisible
+/// inside the ~550px gesture that reaches the threshold at all (the bars are
+/// equally flat at 95% and 100% of forty auto-fit spans).
+pub const FLIP_REARM_FRACTION: f64 = 0.95;
+
 /// The vertical price view: auto-fit or a manual price range, either way up.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct PriceView {
@@ -29,6 +40,10 @@ pub struct PriceView {
     manual: Option<(f64, f64)>,
     /// Upside down: low prices at the top of the pane.
     inverted: bool,
+    /// A drag flip just happened and the span still sits at the threshold:
+    /// further expanding drags do nothing until a real contraction re-arms
+    /// the flip ([`FLIP_REARM_FRACTION`]).
+    flip_parked: bool,
 }
 
 impl PriceView {
@@ -115,32 +130,53 @@ impl PriceView {
         self.manual = Some((center - half, center + half));
     }
 
-    /// [`Self::zoom`] for the gutter drag: expanding past [`FLIP_SPAN_FACTOR`]
+    /// [`Self::zoom`] for the gutter drag: expanding to [`FLIP_SPAN_FACTOR`]
     /// auto-fit spans flips the chart upside down instead of shrinking it
     /// further.
     ///
-    /// Crossing the threshold parks the span *at* the threshold — the
-    /// increment that crossed is consumed by the flip, so the size the eye
-    /// reads is continuous through it. A window some other gesture already
-    /// pushed wider (the wheel zooms without flipping) keeps its span and only
+    /// Below the threshold an expanding drag walks *up to* it, never through:
+    /// however fast the flick, the chart flattens first and turns over on the
+    /// next pull, so the flip always lands where nothing legible is left to
+    /// mirror — the documented [`FLIP_SPAN_FACTOR`] contract. After a flip
+    /// the boundary is parked until a real contraction re-arms it
+    /// ([`FLIP_REARM_FRACTION`]), so a hand tremor at the threshold cannot
+    /// strobe the orientation. A window some other gesture already pushed
+    /// wider (the wheel zooms without a ceiling) keeps its span and only
     /// turns over: snapping it back to the threshold would jump.
     pub fn drag_zoom(&mut self, factor: f64, auto: (f64, f64)) {
         if factor <= 0.0 || !factor.is_finite() {
             return;
         }
         let auto_span = auto.1 - auto.0;
-        if factor > 1.0 && auto_span > 0.0 {
-            let (lo, hi) = self.resolve(auto);
-            let flip_span = auto_span * FLIP_SPAN_FACTOR;
-            if (hi - lo) * factor >= flip_span {
-                self.inverted = !self.inverted;
-                let center = f64::midpoint(lo, hi);
-                let half = (hi - lo).max(flip_span) / 2.0;
-                self.manual = Some((center - half, center + half));
-                return;
+        // The boundary zone: at 99% of the threshold and beyond the chart is
+        // equally flat, so this one band is both where an expanding drag
+        // flips and what a contraction must leave to re-arm — and comparing
+        // against the zone rather than the exact threshold keeps a span the
+        // cap parked one float ulp short of it from missing the flip.
+        let flip_zone = auto_span * FLIP_SPAN_FACTOR * FLIP_REARM_FRACTION;
+        if factor <= 1.0 || auto_span <= 0.0 {
+            // Contracting: a plain zoom — and once the span drops back out
+            // of the boundary zone, the next crossing may flip again.
+            self.zoom(factor, auto);
+            if auto_span > 0.0 {
+                let (lo, hi) = self.resolve(auto);
+                if hi - lo < flip_zone {
+                    self.flip_parked = false;
+                }
             }
+            return;
         }
-        self.zoom(factor, auto);
+        let (lo, hi) = self.resolve(auto);
+        let span = hi - lo;
+        if span >= flip_zone {
+            if !self.flip_parked {
+                self.inverted = !self.inverted;
+                self.flip_parked = true;
+            }
+            return;
+        }
+        let flip_span = auto_span * FLIP_SPAN_FACTOR;
+        self.zoom(factor.min(flip_span / span), auto);
     }
 }
 
@@ -212,24 +248,59 @@ mod tests {
     }
 
     #[test]
-    fn an_expanding_drag_past_the_threshold_flips_and_parks_at_it() {
+    fn the_drag_flattens_to_the_threshold_and_flips_on_the_next_pull() {
         let mut v = PriceView::new();
-        // span 10 × 41 crosses 40 auto-spans (400): flip, span parked at 400.
-        v.drag_zoom(41.0, AUTO);
-        assert!(v.is_inverted());
+        // One violent flick: capped at the 40-auto-span threshold (400),
+        // still upright — the chart flattens first, whatever the speed.
+        v.drag_zoom(1000.0, AUTO);
+        assert!(!v.is_inverted());
         let (lo, hi) = v.resolve(AUTO);
-        assert!((lo - -95.0).abs() < 1e-9 && (hi - 305.0).abs() < 1e-9);
+        assert!(
+            ((hi - lo) - 400.0).abs() < 1e-9,
+            "capped at the threshold: {lo}..{hi}"
+        );
+        // The next expanding increment is the flip, keeping the span.
+        v.drag_zoom(1.01, AUTO);
+        assert!(v.is_inverted());
+        assert_eq!(v.resolve(AUTO), (lo, hi));
     }
 
     #[test]
     fn the_opposite_drag_flips_back() {
         let mut v = PriceView::new();
-        v.drag_zoom(41.0, AUTO);
+        v.drag_zoom(1000.0, AUTO);
+        v.drag_zoom(1.01, AUTO);
         assert!(v.is_inverted());
-        // Inverted, the gutter feeds the mirrored sense: the drag back toward
-        // normal expands the span again, crossing the same threshold.
-        v.drag_zoom(1.1, AUTO);
-        assert!(!v.is_inverted(), "the second crossing turns it back over");
+        // The gesture carries on: the mirrored sense contracts, growing the
+        // upside-down chart and re-arming the flip.
+        v.drag_zoom(0.5, AUTO);
+        // The way back expands to the threshold again — the first crossing
+        // only flattens, the next pull turns it upright.
+        v.drag_zoom(1000.0, AUTO);
+        assert!(v.is_inverted(), "the first crossing only flattens");
+        v.drag_zoom(1.01, AUTO);
+        assert!(!v.is_inverted());
+    }
+
+    #[test]
+    fn a_tremor_at_the_boundary_cannot_strobe_the_orientation() {
+        let mut v = PriceView::new();
+        v.drag_zoom(1000.0, AUTO);
+        v.drag_zoom(1.01, AUTO); // flip, parked
+        assert!(v.is_inverted());
+        // ±1px of hand tremor at the parked boundary: expanding pixels find
+        // the flip parked, and a 1px contraction stays inside the re-arm
+        // band — the chart must not turn over again.
+        for _ in 0..10 {
+            v.drag_zoom((1.0 / 150.0_f64).exp(), AUTO);
+            v.drag_zoom((-1.0 / 150.0_f64).exp(), AUTO);
+            assert!(v.is_inverted(), "still upside down");
+        }
+        // A real contraction re-arms; the next crossing flips back.
+        v.drag_zoom(0.9, AUTO);
+        v.drag_zoom(1000.0, AUTO);
+        v.drag_zoom(1.01, AUTO);
+        assert!(!v.is_inverted());
     }
 
     #[test]

--- a/crates/app/src/price_view.rs
+++ b/crates/app/src/price_view.rs
@@ -1,16 +1,34 @@
-//! Manual price-axis control (vertical pan and zoom).
+//! Manual price-axis control (vertical pan, zoom and orientation).
 //!
 //! By default the price axis auto-fits the visible bars. Once the user drags the
 //! chart vertically (pan) or drags the price gutter (zoom), the axis switches to
 //! an explicit `(lo, hi)` range that holds as new bars arrive — TradingView
-//! behaviour — until reset back to auto-fit. This is the pure state behind that,
-//! unit-tested in CI.
+//! behaviour — until reset back to auto-fit. The view also owns which way up
+//! the chart is: an expanding drag that flattens the bars past
+//! [`FLIP_SPAN_FACTOR`] flips it upside down, and the axis menu's
+//! "Inverted chart" toggle flips it outright. This is the pure state behind
+//! all of that, unit-tested in CI.
 
-/// The vertical price view: auto-fit, or a manual price range.
+use crate::chart::PriceScale;
+
+/// How many auto-fit spans wide the price window can be stretched before an
+/// expanding drag flips the chart upside down instead of shrinking it further.
+///
+/// At 40× the visible bars occupy 1/40 — under 3% — of the pane: flat to the
+/// eye. Flipping there mirrors nothing legible, so the drag reads as one
+/// continuous motion — shrink, flatten, grow again upside down. Only the drag
+/// flips ([`PriceView::drag_zoom`]); the wheel zooms without a ceiling
+/// ([`PriceView::zoom`]), because zooming far out to read a wide range is a
+/// legitimate ask that must not turn the chart over.
+pub const FLIP_SPAN_FACTOR: f64 = 40.0;
+
+/// The vertical price view: auto-fit or a manual price range, either way up.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct PriceView {
     /// `Some((lo, hi))` when the user has taken manual control; `None` auto-fits.
     manual: Option<(f64, f64)>,
+    /// Upside down: low prices at the top of the pane.
+    inverted: bool,
 }
 
 impl PriceView {
@@ -26,13 +44,42 @@ impl PriceView {
         self.manual.is_none()
     }
 
+    /// Whether the chart is upside down.
+    #[must_use]
+    pub fn is_inverted(&self) -> bool {
+        self.inverted
+    }
+
+    /// Turn the chart upside down, or back. The one named door to the
+    /// orientation: the axis menu's checkbox, the drag crossing the flip
+    /// threshold ([`Self::drag_zoom`]) and the `QUANTICK_INVERTED` hook all
+    /// pass through here.
+    pub fn set_inverted(&mut self, inverted: bool) {
+        self.inverted = inverted;
+    }
+
     /// The `(lo, hi)` range to display: the manual range if set, else `auto`.
     #[must_use]
     pub fn resolve(&self, auto: (f64, f64)) -> (f64, f64) {
         self.manual.unwrap_or(auto)
     }
 
+    /// The frame's price→pixel mapping in one call: the resolved range over
+    /// `[top, bottom]`, carrying this view's orientation — so no caller can
+    /// rebuild the scale and forget the chart is upside down.
+    #[must_use]
+    pub fn scale(&self, auto: (f64, f64), top: f32, bottom: f32) -> PriceScale {
+        let (lo, hi) = self.resolve(auto);
+        PriceScale::from_range(lo, hi, top, bottom).with_inverted(self.inverted)
+    }
+
     /// Return to auto-fitting the visible bars.
+    ///
+    /// Framing only: an upside-down chart double-clicked back to auto-fit
+    /// stays upside down. Orientation is a standing choice with doors of its
+    /// own — the axis menu's toggle and the opposite drag — and a reset that
+    /// also turned the chart over would make the panic gesture mean two
+    /// things at once.
     pub fn reset(&mut self) {
         self.manual = None;
     }
@@ -47,6 +94,15 @@ impl PriceView {
         self.manual = Some((lo + delta, hi + delta));
     }
 
+    /// Pan by a screen drag instead of a price delta: positive `delta_px`
+    /// drags the picture down. The pixel→price conversion flips with the
+    /// orientation, so the candles follow the pointer whichever way up the
+    /// chart is.
+    pub fn pan_screen(&mut self, delta_px: f64, price_per_px: f64, auto: (f64, f64)) {
+        let sign = if self.inverted { -1.0 } else { 1.0 };
+        self.pan(delta_px * price_per_px * sign, auto);
+    }
+
     /// Zoom the price span by `factor` around its centre: `> 1` expands the span
     /// (smaller candles), `< 1` compresses it (bigger candles).
     pub fn zoom(&mut self, factor: f64, auto: (f64, f64)) {
@@ -57,6 +113,34 @@ impl PriceView {
         let center = f64::midpoint(lo, hi);
         let half = ((hi - lo) / 2.0 * factor).max(1e-9);
         self.manual = Some((center - half, center + half));
+    }
+
+    /// [`Self::zoom`] for the gutter drag: expanding past [`FLIP_SPAN_FACTOR`]
+    /// auto-fit spans flips the chart upside down instead of shrinking it
+    /// further.
+    ///
+    /// Crossing the threshold parks the span *at* the threshold — the
+    /// increment that crossed is consumed by the flip, so the size the eye
+    /// reads is continuous through it. A window some other gesture already
+    /// pushed wider (the wheel zooms without flipping) keeps its span and only
+    /// turns over: snapping it back to the threshold would jump.
+    pub fn drag_zoom(&mut self, factor: f64, auto: (f64, f64)) {
+        if factor <= 0.0 || !factor.is_finite() {
+            return;
+        }
+        let auto_span = auto.1 - auto.0;
+        if factor > 1.0 && auto_span > 0.0 {
+            let (lo, hi) = self.resolve(auto);
+            let flip_span = auto_span * FLIP_SPAN_FACTOR;
+            if (hi - lo) * factor >= flip_span {
+                self.inverted = !self.inverted;
+                let center = f64::midpoint(lo, hi);
+                let half = (hi - lo).max(flip_span) / 2.0;
+                self.manual = Some((center - half, center + half));
+                return;
+            }
+        }
+        self.zoom(factor, auto);
     }
 }
 
@@ -70,6 +154,7 @@ mod tests {
     fn auto_by_default() {
         let v = PriceView::new();
         assert!(v.is_auto());
+        assert!(!v.is_inverted());
         assert_eq!(v.resolve(AUTO), AUTO);
     }
 
@@ -112,6 +197,97 @@ mod tests {
         v.pan(f64::NAN, AUTO);
         v.zoom(0.0, AUTO);
         v.zoom(-1.0, AUTO);
+        v.drag_zoom(0.0, AUTO);
+        v.drag_zoom(f64::NAN, AUTO);
         assert!(v.is_auto(), "no-op operations don't take manual control");
+        assert!(!v.is_inverted(), "no-op operations don't flip");
+    }
+
+    #[test]
+    fn drag_zoom_below_the_threshold_is_a_zoom() {
+        let mut v = PriceView::new();
+        v.drag_zoom(2.0, AUTO);
+        assert!(!v.is_inverted());
+        assert_eq!(v.resolve(AUTO), (95.0, 115.0));
+    }
+
+    #[test]
+    fn an_expanding_drag_past_the_threshold_flips_and_parks_at_it() {
+        let mut v = PriceView::new();
+        // span 10 × 41 crosses 40 auto-spans (400): flip, span parked at 400.
+        v.drag_zoom(41.0, AUTO);
+        assert!(v.is_inverted());
+        let (lo, hi) = v.resolve(AUTO);
+        assert!((lo - -95.0).abs() < 1e-9 && (hi - 305.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn the_opposite_drag_flips_back() {
+        let mut v = PriceView::new();
+        v.drag_zoom(41.0, AUTO);
+        assert!(v.is_inverted());
+        // Inverted, the gutter feeds the mirrored sense: the drag back toward
+        // normal expands the span again, crossing the same threshold.
+        v.drag_zoom(1.1, AUTO);
+        assert!(!v.is_inverted(), "the second crossing turns it back over");
+    }
+
+    #[test]
+    fn a_span_the_wheel_pushed_past_the_threshold_flips_without_jumping() {
+        let mut v = PriceView::new();
+        // The wheel zooms without flipping — even far past the threshold.
+        v.zoom(60.0, AUTO);
+        assert!(!v.is_inverted());
+        let before = v.resolve(AUTO);
+        // The next expanding drag flips, keeping the span it found.
+        v.drag_zoom(1.01, AUTO);
+        assert!(v.is_inverted());
+        assert_eq!(v.resolve(AUTO), before, "no snap back to the threshold");
+    }
+
+    #[test]
+    fn a_contracting_drag_never_flips() {
+        let mut v = PriceView::new();
+        v.zoom(60.0, AUTO); // wider than the threshold already
+        v.drag_zoom(0.5, AUTO);
+        assert!(!v.is_inverted());
+    }
+
+    #[test]
+    fn reset_keeps_orientation() {
+        let mut v = PriceView::new();
+        v.set_inverted(true);
+        v.pan(5.0, AUTO);
+        v.reset();
+        assert!(v.is_auto());
+        assert!(v.is_inverted(), "auto-fit is framing, not orientation");
+    }
+
+    #[test]
+    fn pan_screen_follows_the_pointer_either_way_up() {
+        let mut v = PriceView::new();
+        // Normal: dragging the picture down means higher prices enter from
+        // the top — the window shifts up.
+        v.pan_screen(10.0, 1.0, AUTO);
+        assert_eq!(v.resolve(AUTO), (110.0, 120.0));
+
+        let mut v = PriceView::new();
+        v.set_inverted(true);
+        // Inverted, the same downward drag shifts the window the other way.
+        v.pan_screen(10.0, 1.0, AUTO);
+        assert_eq!(v.resolve(AUTO), (90.0, 100.0));
+    }
+
+    #[test]
+    fn scale_carries_the_orientation() {
+        let mut v = PriceView::new();
+        v.set_inverted(true);
+        let scale = v.scale(AUTO, 0.0, 100.0);
+        assert!(scale.is_inverted());
+        assert!(
+            (scale.y(100.0) - 0.0).abs() < f32::EPSILON,
+            "lo maps to the top when inverted"
+        );
+        assert!((scale.y(110.0) - 100.0).abs() < f32::EPSILON);
     }
 }

--- a/crates/app/src/tab.rs
+++ b/crates/app/src/tab.rs
@@ -978,8 +978,13 @@ impl Tab {
         );
         // The pane opens looking like the one it splits away from: a user who
         // switched the crosshair off is not asking for it back by opening a
-        // second view of the same market.
+        // second view of the same market. Orientation is part of that look —
+        // an upside-down market does not turn back over by being given a
+        // second view, and the boot's QUANTICK_INVERTED hook fires before
+        // this pane exists at all.
         pane.hidden_layers = self.flow_pane.hidden_layers.clone();
+        pane.price_view
+            .set_inverted(self.flow_pane.price_view.is_inverted());
         self.time_pane = Some(pane);
         self.loading.end(LoadingTask::BarRebuild);
         // The pane exists now, so there is something for a prefix to go in

--- a/crates/app/src/trade_paint.rs
+++ b/crates/app/src/trade_paint.rs
@@ -130,7 +130,15 @@ pub(crate) fn draw(
             CONNECTOR_DASH_PX,
             CONNECTOR_GAP_PX,
         ));
-        draw_entry_mark(&painter, frame.background, entry, trade, color, is_selected);
+        draw_entry_mark(
+            &painter,
+            frame.background,
+            entry,
+            trade,
+            color,
+            is_selected,
+            frame.scale.is_inverted(),
+        );
         draw_exit_mark(&painter, frame.background, exit, color, is_selected);
         marks.push(Mark {
             position: entry,
@@ -189,7 +197,12 @@ fn endpoints(
 }
 
 /// A filled triangle pointing the trade's way, its apex one gap off the
-/// entry price: under the level for a long, above it for a short.
+/// entry price: on the price side below the level for a long, above it for a
+/// short. The glyph mirrors with the chart (`inverted`): this triangle is the
+/// only carrier of trade direction — the hue says win or loss — and a fixed
+/// screen offset would read every long as a short the moment the chart turns
+/// over.
+#[allow(clippy::too_many_arguments)]
 fn draw_entry_mark(
     painter: &egui::Painter,
     background: egui::Color32,
@@ -197,18 +210,16 @@ fn draw_entry_mark(
     trade: &ClosedTrade,
     color: egui::Color32,
     selected: bool,
+    inverted: bool,
 ) {
     let long = trade.side == Side::Buy;
-    let apex_y = if long {
-        at.y + MARKER_GAP_PX
-    } else {
-        at.y - MARKER_GAP_PX
-    };
-    let base_y = if long {
-        apex_y + ENTRY_MARKER_H_PX
-    } else {
-        apex_y - ENTRY_MARKER_H_PX
-    };
+    // +1 points the apex toward higher screen y; the product mirrors the
+    // whole glyph when the chart is upside down.
+    let side_sign = if long { 1.0 } else { -1.0 };
+    let orientation = if inverted { -1.0 } else { 1.0 };
+    let sign = side_sign * orientation;
+    let apex_y = at.y + sign * MARKER_GAP_PX;
+    let base_y = apex_y + sign * ENTRY_MARKER_H_PX;
     let half = ENTRY_MARKER_W_PX / 2.0;
     let points = vec![
         egui::pos2(at.x, apex_y),


### PR DESCRIPTION
## What

Two doors to an upside-down chart (low prices at the top), per the session mission:

- **Continuous (drag)**: dragging the price gutter down shrinks the candles until they flatten at `FLIP_SPAN_FACTOR` (40 auto-fit spans — under 3% of the pane, flat to the eye); the next pull turns the chart over. Upside down the drag's sense mirrors, so the same downward motion grows the inverted chart, and the opposite pull flattens and turns it upright again — one continuous loop. The wheel never flips (zooming far out stays legitimate). A flip parks until a real contraction re-arms it (`FLIP_REARM_FRACTION`), so a hand tremor at the boundary cannot strobe the orientation.
- **Discrete (menu)**: right-click on the price gutter opens the axis's own context menu with an **Inverted chart** toggle.

## How

Orientation lives in `PriceView` (`set_inverted` — the one named setter the menu, the gesture and the hook all call) and is carried by `PriceScale` at the single price→pixel boundary plus `ProjectedLayout` at the orderflow's normalized boundary, so candles, wicks, axis labels, crosshair, drawings, footprint, heatmap, bubbles, live strip, paper lines and trade paint all turn over together. `PriceScale::band(a, b)` is the new screen-ordered primitive that makes the negative-rect class of bug unwritable. Consumers that assumed the upright orientation were made orientation-agnostic (wicks, footprint rows/backdrop/zones/badges, fixed-range profile rows, live-strip histogram, body pans, drawing translate/nudge, paper bracket handles and leg choice, Pine above/below-bar markers, arrow marks, trade-paint triangles, bubble side nudge).

Orientation survives series resets, is inherited by tabs opened from the + picker, and a time pane born into a split inherits the flow chart's orientation (it is built a frame after the layout change, after the boot hooks fire). It is deliberately **not** persisted (below).

## Agent surface

- `QUANTICK_INVERTED=1` — opens upside down through the menu's own setter, both panes of a split layout.
- `QUANTICK_CONTEXT_MENU=axis` — the scripted right-click lands on the gutter rect the draw publishes (`last_price_gutter`).
- Registered in `.claude/skills/ui-harness/SKILL.md` (goal-scoped table).

## arch-review

step 0: code-review at **high**, 15 findings (23 verified candidates), all verified against HEAD at the time; **13 fixed** (`90da38c9`, `503ef707`), **2 deferred**:

1. **Orientation not persisted in `ui-state`** — deliberate: no view framing (manual pan/zoom included) is persisted today, and a restart opening auto-fit and upright is coherent. If wanted, `SavedTab.inverted` is a small follow-up.
2. **No scripted door to the time pane's own axis menu** — the *state* is reachable (`QUANTICK_INVERTED`, plus birth inheritance); the menu popup itself only opens on the flow gutter's scripted click today.

One further fix landed after the review, found by the visual-qa capture below: `cd867e9b` (time pane born into an inverted tab now opens upside down, harness-tested). The `arch-review-ok` marker was re-recorded for that HEAD.

## Performance — measured

Same recorded tape (WINQ26 · 2026-07-22, replay at 8×, ~840 trades/s, bubbles+live strip on), off-screen, 42 steady-state `APP_HEALTH_SUMMARY` samples per cell, release builds:

| cell | fps (med/min) | frame_avg | **frame_cpu med** | frame_cpu max | worst med | bubbles med |
| --- | --- | --- | --- | --- | --- | --- |
| `main` upright (control) | 59 / 59 | 16.68 ms | **1.90 ms** | 2.16 ms | 23.99 ms | 249 |
| branch upright | 59 / 59 | 16.68 ms | **1.93 ms** | 2.15 ms | 24.09 ms | 249 |
| branch inverted | 59 / 59 | 16.68 ms | **1.95 ms** | 2.41 ms | 24.06 ms | 249 |

Identical load across cells (249 bubbles median, same tape). The 0.03–0.05 ms deltas on frame_cpu are noise; fps and frame_avg are vsync-pinned and identical. **Flat.**

## Visual QA — run

Off-screen captures (SWP_NOACTIVATE, scratchpad stores, deterministic replay), read against the defect checklist:

- **upright control** — PASS (baseline for the mirror).
- **inverted + bubbles/strip** — PASS: axis labels ascending downward, the same tape mirrored exactly, wicks present, bubbles riding their candles, last-price chip at the mirrored level.
- **inverted + footprint (Detailed, 80px candles)** — PASS: ladders inside the candle outlines, backdrop present (no bleed-through), extreme-ratio badge outside its row, POC and delta totals in place.
- **inverted + axis menu** — PASS: the context menu opens on the gutter with "Inverted chart" checked.
- **inverted + paper demo** — PASS: paper gutter chips at price-coherent positions on the inverted axis, `SIM +30 pts · flat` reporting.
- **inverted + drawings demo** — PASS: rectangle region, measure label and anchored VWAP all projected onto the inverted candles.
- **Defect found and fixed**: the time pane of the split stayed upright under `QUANTICK_INVERTED` (it is born a frame after the boot hooks) — `cd867e9b`, with a harness test that fails without the fix. The re-capture proving both panes visually is pending a free desktop (the session locked mid-run; the behaviour is test-proven).

## Proof

Four checks green on the workspace (fmt, clippy -D warnings, build, test — 1482 tests, 0 failures). New tests: flip mechanics incl. flattening cap, re-arm hysteresis and tremor immunity (`price_view`), inverted mapping + roundtrip + wick survival (`chart`), band-scale orientation (`pane`), orderflow layout mirror, inverted keyboard nudge, real gutter-drag flip loop, axis-hook position and menu presence, time-pane birth inheritance (`app`), mirrored arrow-mark hang (`mark_core`), book-side bubble nudge (`orderflow_render`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WsUbPxdbRUy7QV4EQK7MLP