### PR TITLE
feat(app): ferramentas que lembram, um Fib desenhado do primeiro clique e notas digitadas onde vivem

### DIFF
--- a/.claude/GOAL-archive-fib-defaults-and-inline-text.md
+++ b/.claude/GOAL-archive-fib-defaults-and-inline-text.md
@@ -56,3 +56,35 @@ worktree `../quantick-worktrees/feat-fib-defaults-and-inline-text`
    e **trader-ux-review** sem Blocker em aberto.
 9. **PR aberto** com as evidências e o blast radius (arquivos adicionados vs.
    editados) no corpo. Merge não faz parte da missão.
+
+## Evidência (fechamento)
+
+1. **Ícone** ✔ — `IconDots` no port (default `&[]`), duas Fib declaram 2 e 3
+   âncoras; testes `icon_dots_stay_in_the_unit_square_and_only_accompany_strokes`
+   e o contrato dos strokes. Lido no tamanho real e redesenhado depois da
+   primeira captura (4 linhas em 14 px eram uma mancha).
+2. **Retração a partir do primeiro clique** ✔ — `Extend::for_kind`;
+   `a_retracement_being_dragged_draws_from_the_first_click`,
+   `an_extension_still_projects_from_its_last_anchor`,
+   `each_fib_kind_opens_reaching_current_price_from_its_own_start`. Captura do
+   arrasto com `QUANTICK_DRAWING_DRAFT=1`.
+3. **Padrão salvável** ✔ — `save_tool_default` / `reset_tool_default` /
+   `has_saved_default` + slot `config` no `PresetStore`; round-trip, absence,
+   arquivo antigo, fluxo completo com um segundo host (`MemoryPresetHost`) e
+   precedência do preset nomeado. Capturas das abas Levels e Style.
+4. **Texto inline** ✔ — `inline_text` / `set_inline_text` / `holds_text` no
+   port; editor com moldura, flip e clamp; duplo clique reabre; undo de uma
+   entrada; identidade de aba/pane. Seis testes, hook `QUANTICK_TEXT_NOTE`.
+5. **Quatro checks** ✔ — fmt/clippy/build/test verdes (1477 no app).
+6. **Performance** ✔ — `frame_cpu_ms` mediana: main 2,747 / 2,658 ms contra
+   branch 2,744 / 2,769 ms, alternado A/B/A/B, 22 objetos, fps 59 nas quatro.
+   A corrida mais cara da branch teve tape 3,6× mais denso (3,05 vs 0,84
+   trades/s).
+7. **arch-review** ✔ — step 0 (`code-review high`) trouxe 15 achados; 13
+   corrigidos, 1 deferido (persistência 2–3 gravações por clique, caminho
+   raro), 1 já corrigido antes do relatório chegar.
+8. **visual-qa / trader-ux-review** ✔ — 5 superfícies capturadas com fps 58–59;
+   3 defeitos achados e corrigidos (placeholder duplicado, campo sem moldura,
+   rótulo ambíguo), 1 achado de UX corrigido (o reset não dizia que limpa a
+   escolha de preset padrão).
+9. **PR** — aberto no fim desta sessão.

--- a/.claude/GOAL.md
+++ b/.claude/GOAL.md
@@ -1,0 +1,58 @@
+# GOAL — ferramentas que param de pedir retrabalho
+
+**Missão**: quatro incômodos das ferramentas de desenho, num só passe — o
+ícone do Fibonacci lê como o do TradingView, a retração desenha a partir do
+**primeiro** clique (hoje as linhas nascem no segundo), a configuração de uma
+ferramenta (níveis, cores, rótulos, estilo) pode ser salva como padrão e
+restaurada de fábrica com um clique, e a nota de texto abre já digitável com
+sua barra de configuração embaixo.
+
+Branch: `feat/fib-defaults-and-inline-text` ·
+worktree `../quantick-worktrees/feat-fib-defaults-and-inline-text`
+
+## O que o levantamento em `main` já provou
+
+- `fib.rs:450 level_price` **já** põe 0 no ponto solto e 1 no ponto inicial —
+  a numeração da imagem já é a de hoje. O que trai é o span: `Extend::Forward`
+  é o default (`fib.rs:148`) e projeta `(âncora mais à direita → borda)`, ou
+  seja, as linhas nascem no segundo clique.
+- O preview do draft **já** completa a geometria com o ponto sob o cursor
+  (`pane.rs:6119-6124`), então os níveis aparecem durante o arrasto — mas do
+  cursor para a direita, não do primeiro clique até ele.
+- `PresetHost` já guarda estilo padrão por ferramenta e preset **nomeado**
+  padrão (`mod.rs:113-134`, aplicados em `pane.rs:3410`). Falta o gesto de um
+  clique: salvar a configuração inteira como padrão sem batizar preset.
+- `FibPayload::export_preset` (`fib.rs:378`) já serializa níveis, cores,
+  banda, rótulos e `extend` — o template pedido cabe nele.
+- A nota de texto hoje só é editável pelo inspector (`text.rs:opens_settings_on_place`).
+
+## Critérios de aceite
+
+1. **Ícone**: Fib retracement e Fib extension no trilho, no flyout e no
+   favorito desenham as âncoras como o TradingView. O dado novo é do
+   registro (port de ícone), nunca um caso especial no chrome; teste de
+   contrato cobre todo ícone declarado.
+2. **Retração a partir do primeiro clique**: durante o arrasto e no objeto
+   pronto, os níveis correm do primeiro clique até o segundo ponto. Teste
+   headless fixa o default por `FibKind`; screenshot com
+   `QUANTICK_DRAWING_DRAFT` prova o preview em voo.
+3. **Padrão salvável**: um clique grava a configuração completa da ferramenta
+   (níveis, cor por nível, rótulos, `extend`, banda, estilo) como padrão de
+   novos objetos, e outro restaura o de fábrica. Objetos já na tela nunca são
+   repintados por isso. Round-trip provado no `PresetStore`, aplicação provada
+   na criação, e um host falso segundo implementador testado.
+4. **Texto inline**: colocar a nota abre o campo na âncora com o cursor já
+   dentro e a barra de configuração embaixo; o que se digita vai para o
+   payload; Esc/clique fora encerra sem perder o texto. Hook de env alcança a
+   superfície.
+5. **Quatro checks verdes** após rebase em `origin/main` atualizado.
+6. **Impacto de performance declarado** por caminho tocado (per-frame: paint
+   do Fib e da nota; raro: store de presets e chrome do inspector), com
+   `APP_HEALTH_SUMMARY` (fps / frame_avg) da branch contra um controle em
+   `main` na mesma janela.
+7. **arch-review** rodado sobre `git diff main...HEAD`, todo Blocker e
+   Should-fix resolvido — ou deferido explicitamente no corpo do PR.
+8. **visual-qa** com todas as superfícies PASS (ou defeito aceito por escrito)
+   e **trader-ux-review** sem Blocker em aberto.
+9. **PR aberto** com as evidências e o blast radius (arquivos adicionados vs.
+   editados) no corpo. Merge não faz parte da missão.

--- a/.claude/skills/ui-harness/SKILL.md
+++ b/.claude/skills/ui-harness/SKILL.md
@@ -178,6 +178,15 @@ Landing with the tape-configuration goal (`feat/tape-own-config`):
 
 Once merged, move them into the table above.
 
+Landing with the drawing-defaults goal (`feat/fib-defaults-and-inline-text`):
+
+| Hook | Reaches |
+| --- | --- |
+| `QUANTICK_TEXT_NOTE=1` | a note placed in the middle of the window with its **on-chart editor open** — the field where the words will be read, caret already in it, with the selection's context bar beside it. The editor exists only between a placement and the next click elsewhere, so no click-free launch could photograph it; the hook goes through the same two calls a click makes (`place_with` then `begin_inline_text_edit`), never a parallel path |
+| `QUANTICK_DRAWING_INSPECTOR_TAB=<style\|extra\|coordinates>` | which tab the properties panel opens on. `extra` is the tool-owned one — a Fib's **Levels** editor, where the ratios, the per-level colours and the two default controls ("Save as default" / "Reset to factory") live. Pair with `QUANTICK_DRAWING_INSPECTOR=1` and `QUANTICK_DRAWINGS_DEMO_SELECT=fib-retracement`. An unknown value leaves the default tab rather than guessing |
+
+Once merged, move them into the table above.
+
 Landing with the tape-switch goal (`feat/tape-chart-switch`):
 
 | Hook | Reaches |

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -68,6 +68,31 @@ const FIRST_TAB_ID: u64 = 0;
 const fn pane_ids(tab: u64) -> (u64, u64) {
     (tab * 2, tab * 2 + 1)
 }
+/// The note being typed on the chart: which object, and how it looked before
+/// the first keystroke.
+///
+/// The baseline rides here rather than in the collection's gesture
+/// coalescing, and that is not a style choice: the inspector, the context bar
+/// and every drag share that one gesture slot, and any of them closing theirs
+/// while a note is being typed would swallow the note's undo entry — leaving
+/// Ctrl+Z to take back the *placement* instead of the words. Same shape as
+/// `inspector_edit_baseline`, same reason.
+struct InlineTextEdit {
+    index: usize,
+    before: drawings::Drawing,
+}
+
+/// Id of the on-chart note editor's floating area. One editor at a time —
+/// the keyboard has one caret.
+const INLINE_TEXT_AREA_ID: &str = "inline-text-editor";
+/// What an empty note's field says before anything is typed.
+const INLINE_TEXT_HINT: &str = "Add text";
+/// Width of the field. Wide enough for a sentence, narrow enough that it does
+/// not cover the price it is annotating.
+const INLINE_TEXT_WIDTH_PX: f32 = 180.0;
+/// Type size the editor falls back to when the tool declares none.
+const INLINE_TEXT_FALLBACK_PX: f32 = 12.0;
+
 /// How much of the newest chart the `QUANTICK_DRAWINGS_DEMO` hook spreads its
 /// objects across. Close to what a default viewport shows, so every object
 /// lands on screen — a demo the camera cannot see proves nothing.
@@ -226,9 +251,9 @@ enum SavedDefault {
 impl SavedDefault {
     const fn message(self) -> &'static str {
         match self {
-            Self::OneTool => "Saved - new drawings of this tool open with this look.",
-            Self::EveryTool => "Saved - every new drawing opens with this look.",
-            Self::Forgotten => "Forgotten - this tool goes back to the built-in look.",
+            Self::OneTool => "Saved - new drawings of this tool open configured like this one.",
+            Self::EveryTool => "Saved - every new drawing opens with this colour, width and fill.",
+            Self::Forgotten => "Reset - this tool goes back to how it opened out of the box.",
         }
     }
 }
@@ -792,6 +817,16 @@ pub struct QuantickApp {
     /// the placement just made. The request survives that and is applied on
     /// the far side of it.
     pending_open_settings: bool,
+    /// Raised by a placement whose tool holds words: the object just made
+    /// wants the caret. Consumed by [`Self::draw_inline_text_editor`] on the
+    /// same frame, which turns it into `inline_text_edit`.
+    pending_text_edit: bool,
+    /// The `QUANTICK_TEXT_NOTE` hook: place a note and open its editor on the
+    /// first drawn frame. See [`Self::apply_text_note_hook`].
+    pending_text_note: bool,
+    /// The note being typed on the chart — the on-chart editor's whole
+    /// state. See [`InlineTextEdit`].
+    inline_text_edit: Option<InlineTextEdit>,
     inspector_moved: bool,
     inspector_last_selection: Option<usize>,
     /// The selected object's context bar: the floating row of icons that
@@ -1199,6 +1234,9 @@ impl QuantickApp {
             inspector_pinned: false,
             inspector_open: false,
             pending_open_settings: false,
+            pending_text_edit: false,
+            pending_text_note: false,
+            inline_text_edit: None,
             inspector_moved: false,
             inspector_last_selection: None,
             context_bar: drawings::context_bar::ContextBar::default(),
@@ -1368,6 +1406,11 @@ impl QuantickApp {
         if let Ok(family_id) = std::env::var("QUANTICK_TOOLBOX_FLYOUT") {
             app.toolrail.request_flyout(family_id.trim().to_owned());
         }
+        // The on-chart note editor exists only between a placement and the
+        // first click elsewhere, so no click-free launch could photograph it
+        // without a hook — the same gap `QUANTICK_DRAWING_DRAFT` fills for a
+        // half-placed object.
+        app.pending_text_note = std::env::var("QUANTICK_TEXT_NOTE").is_ok_and(|value| value == "1");
         app.pending_drawing_demo = std::env::var("QUANTICK_DRAWINGS_DEMO")
             .is_ok_and(|value| matches!(value.as_str(), "1" | "bands"));
         // How many anchors of the armed tool are already down when the run
@@ -5416,6 +5459,14 @@ impl QuantickApp {
                 // no pointer over it to arm or grab with.
             } else if self.drawing_delete_confirm {
                 self.drawing_delete_confirm = false;
+            } else if self.inline_text_edit.is_some() {
+                // A note being typed is its own layer, and it has to be one:
+                // egui clears widget focus at the top of the frame Escape
+                // arrives on, so by the time this stack runs the editor no
+                // longer looks focused — and without a layer of its own the
+                // press fell straight through to "drop the selection",
+                // taking away the context bar for the note just written.
+                self.end_inline_text_edit();
             } else if self.drawing_pane().drawings.draft().is_some() {
                 self.drawing_pane_mut().drawings.cancel_draft();
                 self.toolrail.arm(Tool::Pointer);
@@ -5878,18 +5929,21 @@ impl QuantickApp {
                 ui.horizontal(|ui| {
                     let style = drawing.style;
                     if ui
-                        .button("This tool")
+                        .button("Save as default")
                         .on_hover_text(format!(
-                            "New {} objects open with this colour, width and fill",
+                            "New {} objects open configured exactly like this one",
                             tool.name().to_lowercase()
                         ))
                         .clicked()
                     {
-                        drawing_presets.set_default_style(tool.id(), Some(style));
+                        drawings::save_tool_default(drawing_presets, drawing);
                         actions.saved_default = Some(SavedDefault::OneTool);
                     }
+                    // Style only, and that is not a shortcut: a Fib's level
+                    // list means nothing to a rectangle, so the one property
+                    // every tool shares is the only one this can carry.
                     if ui
-                        .button("All tools")
+                        .button("Colour on all tools")
                         .on_hover_text("Every new drawing opens with this colour, width and fill")
                         .clicked()
                     {
@@ -5898,16 +5952,16 @@ impl QuantickApp {
                         }
                         actions.saved_default = Some(SavedDefault::EveryTool);
                     }
-                    if drawing_presets.default_style(tool.id()).is_some()
+                    if drawings::has_saved_default(drawing_presets, tool)
                         && ui
-                            .button("Forget")
+                            .button("Reset to factory")
                             .on_hover_text(format!(
-                                "New {} objects go back to the built-in look",
+                                "New {} objects go back to how they opened out of the box",
                                 tool.name().to_lowercase()
                             ))
                             .clicked()
                     {
-                        drawing_presets.set_default_style(tool.id(), None);
+                        drawings::reset_tool_default(drawing_presets, tool);
                         actions.saved_default = Some(SavedDefault::Forgotten);
                     }
                 });
@@ -6183,6 +6237,195 @@ impl QuantickApp {
             self.commit_inspector_gesture();
         }
         Some((index, self.drawing_pane().drawings.items()[index].clone()))
+    }
+
+    /// Put the caret in a note, on the chart — the one call that opens the
+    /// editor, whether a placement, a double click or a script asked for it.
+    ///
+    /// Refused for an object that holds no words or is locked: a locked
+    /// object's geometry and content are both protected, and an editor that
+    /// opened and then dropped every keystroke would be worse than none.
+    fn begin_inline_text_edit(&mut self, index: usize) -> bool {
+        let Some(drawing) = self.drawing_pane().drawings.items().get(index) else {
+            return false;
+        };
+        if drawing.locked || drawing.tool.inline_text(drawing.payload.as_ref()).is_none() {
+            return false;
+        }
+        // Typing is one edit: the note as it stands is kept here and recorded
+        // when the editor closes, so undo takes back the note, not the last
+        // letter of it.
+        let before = drawing.clone();
+        self.drawing_pane_mut().drawings.select(Some(index));
+        self.inline_text_edit = Some(InlineTextEdit { index, before });
+        true
+    }
+
+    /// Close the editor, keeping whatever was typed and recording it as the
+    /// one edit it was.
+    fn end_inline_text_edit(&mut self) {
+        let Some(edit) = self.inline_text_edit.take() else {
+            return;
+        };
+        self.drawing_pane_mut()
+            .drawings
+            .record_edit_of(edit.index, edit.before);
+    }
+
+    /// Which note is being typed on the chart right now — what a second
+    /// operator reads to know the keyboard belongs to an object.
+    #[must_use]
+    pub fn inline_text_editing(&self) -> Option<usize> {
+        self.inline_text_edit.as_ref().map(|edit| edit.index)
+    }
+
+    /// The on-chart note editor: a field where the words will be, opened by
+    /// the placement that made the note.
+    ///
+    /// The panel used to be the only way in, which put the note under the
+    /// pointer and the field that fills it on the far side of the screen. The
+    /// context bar the selection already raises carries the rest — colour,
+    /// type size, lock, delete — so what was missing was never a panel, only
+    /// a caret.
+    fn draw_inline_text_editor(&mut self, ctx: &egui::Context) {
+        // A placement that asked for the caret gets it here, on the frame it
+        // happened: the object it made is the selected one.
+        if std::mem::take(&mut self.pending_text_edit)
+            && let Some(index) = self.drawing_pane().drawings.selected()
+        {
+            self.begin_inline_text_edit(index);
+        }
+        let Some(index) = self.inline_text_editing() else {
+            return;
+        };
+        // The object can go away underneath the editor — undo, delete, a tab
+        // switch — and the selection can move to another one. Either way the
+        // editor is over, and it must not write into whatever now sits at
+        // that index.
+        if self.drawing_pane().drawings.selected() != Some(index) {
+            self.end_inline_text_edit();
+            return;
+        }
+        let Some(chart) = self.drawing_pane().last_chart_area else {
+            self.end_inline_text_edit();
+            return;
+        };
+        let Some(bbox) = self.drawing_bbox_on_screen(chart, index) else {
+            self.end_inline_text_edit();
+            return;
+        };
+        let Some(drawing) = self.drawing_pane().drawings.items().get(index) else {
+            self.end_inline_text_edit();
+            return;
+        };
+        let tool = drawing.tool;
+        let Some(text) = tool.inline_text(drawing.payload.as_ref()) else {
+            self.end_inline_text_edit();
+            return;
+        };
+        // Read once, and only what the field needs: this runs every frame the
+        // editor is open, and the drawing behind it carries a boxed payload.
+        let mut buffer = text.to_owned();
+        let before = buffer.clone();
+        let size_px = tool
+            .glyph_size(drawing)
+            .map_or(INLINE_TEXT_FALLBACK_PX, |size| size.px);
+        let color = drawing.style.color;
+        let locked = drawing.locked;
+        if locked {
+            self.end_inline_text_edit();
+            return;
+        }
+
+        // Anchored where the words are painted, so the field opens over the
+        // object rather than beside it: the note is typed exactly where it
+        // will be read.
+        let inner = egui::Area::new(egui::Id::new(INLINE_TEXT_AREA_ID))
+            .order(egui::Order::Foreground)
+            .fixed_pos(egui::pos2(bbox.left(), bbox.bottom()))
+            .pivot(egui::Align2::LEFT_BOTTOM)
+            .show(ctx, |ui| {
+                let response = ui.add(
+                    egui::TextEdit::multiline(&mut buffer)
+                        .font(egui::FontId::proportional(size_px))
+                        .text_color(color)
+                        .hint_text(INLINE_TEXT_HINT)
+                        .desired_rows(1)
+                        .desired_width(INLINE_TEXT_WIDTH_PX),
+                );
+                // The caret on the first frame: a field that opens unfocused
+                // asks for a click nobody was told about.
+                if !response.has_focus() && ui.memory(|memory| memory.focused().is_none()) {
+                    response.request_focus();
+                }
+                response
+            })
+            .inner;
+
+        if buffer != before {
+            let text = buffer.clone();
+            if let Some(drawing) = self.drawing_pane_mut().drawings.items_mut().get_mut(index) {
+                tool.set_inline_text(drawing.payload.as_mut(), text);
+            }
+        }
+        // Escape and clicking away both mean "done" — and Escape must not
+        // also fall through to the escape stack, which would drop the
+        // selection the bar is hanging off.
+        let escaped = inner.has_focus() && ctx.input(|input| input.key_pressed(egui::Key::Escape));
+        if escaped {
+            ctx.memory_mut(|memory| memory.surrender_focus(inner.id));
+        }
+        if escaped || inner.lost_focus() {
+            self.end_inline_text_edit();
+        }
+    }
+
+    /// The `QUANTICK_TEXT_NOTE` hook: place a note in the middle of the
+    /// window and open its editor, through the same two calls a click makes.
+    fn apply_text_note_hook(&mut self) {
+        if !self.pending_text_note {
+            return;
+        }
+        let Some(tool) = drawings::DRAWING_TOOLS
+            .into_iter()
+            .find(|tool| tool.holds_text())
+        else {
+            return;
+        };
+        let (point, ready) = {
+            let pane = &self.active_tab().flow_pane;
+            let slots = pane.slots();
+            if pane.last_chart_area.is_none() || slots == 0 {
+                return;
+            }
+            let close = pane
+                .closed_bar(slots.saturating_sub(1))
+                .and_then(|bar| rust_decimal::prelude::ToPrimitive::to_f64(&bar.close))
+                .unwrap_or(1.0);
+            let centre = pane
+                .last_auto_range
+                .filter(|(lo, hi)| hi > lo)
+                .map_or(close, |(lo, hi)| (lo + hi) / 2.0);
+            let visible = DEMO_VISIBLE_SLOTS.min(slots);
+            let slot = (slots - visible / 2).min(slots.saturating_sub(1));
+            (
+                drawings::ChartPoint::at_time(slot as f32 + 0.5, centre, pane.slot_open_time(slot)),
+                true,
+            )
+        };
+        debug_assert!(ready);
+        self.pending_text_note = false;
+        // Through the same door the click path uses, saved defaults and all.
+        let fresh = drawings::new_drawing_from_defaults(&self.drawing_presets, tool);
+        let placed = self.active_tab_mut().flow_pane.drawings.place_with(
+            tool,
+            &drawings::DrawingBand::Price,
+            point,
+            |_| fresh,
+        );
+        if placed && let Some(index) = self.drawing_pane().drawings.selected() {
+            self.begin_inline_text_edit(index);
+        }
     }
 
     /// The selected object's context bar.
@@ -7952,6 +8195,7 @@ impl QuantickApp {
         self.apply_scripted_view();
         self.apply_drawing_demo();
         self.apply_drawing_draft();
+        self.apply_text_note_hook();
         self.apply_venue_history_demo();
         self.apply_frvp_demo();
         self.apply_avwap_demo();
@@ -8154,7 +8398,7 @@ impl QuantickApp {
                         active_tab,
                         toolrail,
                         drawing_presets,
-                        pending_open_settings,
+                        pending_text_edit,
                         style,
                         tz,
                         layer_actions,
@@ -8164,7 +8408,7 @@ impl QuantickApp {
                     let mut chrome = CanvasChrome {
                         toolrail,
                         presets: drawing_presets,
-                        open_settings: pending_open_settings,
+                        begin_text_edit: pending_text_edit,
                         style,
                         tz: *tz,
                         capabilities,
@@ -8186,6 +8430,7 @@ impl QuantickApp {
         // Floating drawing controls must be registered after the opaque
         // central canvas so they stay in front of the chart.
         self.draw_drawing_context_bar(ctx, now);
+        self.draw_inline_text_editor(ctx);
         self.draw_drawing_inspector(ctx, now);
         self.draw_drawing_manager(ctx, now);
         self.draw_strategy_popup(ctx);
@@ -10500,7 +10745,7 @@ plot(close)
             active_tab,
             toolrail,
             drawing_presets,
-            pending_open_settings,
+            pending_text_edit,
             style,
             tz,
             layer_actions,
@@ -10511,7 +10756,7 @@ plot(close)
         let mut chrome = pane::PaneChrome {
             toolrail,
             presets: drawing_presets,
-            open_settings: pending_open_settings,
+            begin_text_edit: pending_text_edit,
             style,
             tz: *tz,
             symbol: &tab.symbol,
@@ -12896,28 +13141,32 @@ plot(close)
         }
     }
 
-    /// A Fib level is something price is *going* to meet. Drawn only between
-    /// the anchors, an extension's targets sit to the left of the leg that
-    /// projects them — backwards on its face — and they disappear behind the
-    /// tape the moment the market moves on. Reported from the running build.
+    /// A Fib level is something price is *going* to meet, so every kind opens
+    /// running to the right edge — a level nobody can see at current price is
+    /// not a level. Where the lines *begin* is the part that differs, and it
+    /// is the tool's question, not one shared default:
+    ///
+    /// - a retracement is read across the leg it measures, so it begins at
+    ///   the first anchor and the levels fill in under the pointer during the
+    ///   drag (reported from the running build: starting at the last anchor
+    ///   put every line on the far side of the cursor);
+    /// - an extension projects what comes *after* its last anchor, so drawing
+    ///   its targets back over the measured leg is backwards on its face.
     #[test]
-    fn fib_levels_project_forward_from_the_swing_by_default() {
+    fn each_fib_kind_opens_reaching_current_price_from_its_own_start() {
         use crate::drawings::fib::{Extend, FibPayload};
-        assert_eq!(
-            Extend::default(),
-            Extend::Forward,
-            "a level nobody can see at current price is not a level"
-        );
-        for tool in ["fib-retracement", "fib-extension"] {
+        for (tool, expected) in [
+            ("fib-retracement", Extend::Right),
+            ("fib-extension", Extend::Forward),
+        ] {
             let payload = drawing_tool(tool).default_payload();
             let fib = payload
                 .as_any()
                 .downcast_ref::<FibPayload>()
                 .expect("the fib tools carry a fib payload");
             assert_eq!(
-                fib.extend,
-                Extend::Forward,
-                "{tool} must open projecting forward from its last point"
+                fib.extend, expected,
+                "{tool} must open with the span its own question asks for"
             );
         }
     }
@@ -16275,32 +16524,141 @@ plot(close)
         }
     }
 
-    /// A text note is placed *empty* and its words live in the panel. Left to
-    /// the context bar alone, the trader gets a grey "Note" and a row of
-    /// style icons with no way in.
+    /// A text note is placed *empty*, and its words are its content — so the
+    /// caret goes into the object, on the chart, on the frame it lands. It
+    /// used to open the settings panel instead, which put the field on the
+    /// far side of the screen from the note being written.
     #[test]
-    fn placing_a_text_note_opens_the_panel_that_takes_its_words() {
+    fn placing_a_text_note_opens_the_editor_in_the_note_itself() {
         let (mut app, _commands) = app_with_history(200);
         let ctx = egui::Context::default();
         run_frame(&mut app, &ctx);
-        assert!(!app.inspector_open);
+        assert_eq!(app.inline_text_editing(), None);
 
         arm_drawing_from_toolbox(&mut app, &ctx, "text");
         click_chart(&mut app, &ctx, egui::pos2(700.0, 300.0));
         run_frame(&mut app, &ctx);
+        let index = app
+            .inline_text_editing()
+            .expect("the one tool that arrives empty takes the caret");
+        assert_eq!(
+            app.active_tab().flow_pane.drawings.items()[index].tool.id(),
+            "text"
+        );
         assert!(
-            app.inspector_open,
-            "the one tool that arrives empty opens the field that fills it"
+            ctx.memory(|memory| memory.focused().is_some()),
+            "the field opens focused: a caret nobody can see is a click nobody was told about"
+        );
+        assert!(
+            !app.inspector_open,
+            "the panel is no longer how a note is written"
         );
 
-        // …and no other tool does: the panel staying shut is the whole point.
-        app.inspector_open = false;
+        // …and no other tool takes the caret: the keyboard stays with the
+        // chart for everything whose content is geometry.
         arm_drawing_from_toolbox(&mut app, &ctx, "horizontal-line");
         click_chart(&mut app, &ctx, egui::pos2(640.0, 320.0));
         run_frame(&mut app, &ctx);
-        assert!(
-            !app.inspector_open,
-            "a line is complete when it is drawn; it gets the bar, not the panel"
+        assert_eq!(
+            app.inline_text_editing(),
+            None,
+            "a line is complete when it is drawn; it gets the bar, not a caret"
+        );
+    }
+
+    /// What is typed lands in the object, and Escape closes the editor
+    /// without eating the words — nor the selection the context bar hangs
+    /// off, which is the row that styles the note that was just written.
+    #[test]
+    fn typing_into_the_on_chart_editor_fills_the_note_and_escape_keeps_it() {
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        run_frame(&mut app, &ctx);
+        arm_drawing_from_toolbox(&mut app, &ctx, "text");
+        click_chart(&mut app, &ctx, egui::pos2(700.0, 300.0));
+        run_frame(&mut app, &ctx);
+        let index = app.inline_text_editing().expect("the editor is open");
+
+        run_frame_with_events(
+            &mut app,
+            &ctx,
+            vec![egui::Event::Text("daily high".to_owned())],
+        );
+        run_frame(&mut app, &ctx);
+        let note = |app: &QuantickApp| -> String {
+            let drawing = &app.active_tab().flow_pane.drawings.items()[index];
+            drawing
+                .tool
+                .inline_text(drawing.payload.as_ref())
+                .unwrap_or_default()
+                .to_owned()
+        };
+        assert_eq!(note(&app), "daily high", "the words reach the object");
+
+        run_frame_with_events(
+            &mut app,
+            &ctx,
+            vec![egui::Event::Key {
+                key: egui::Key::Escape,
+                physical_key: None,
+                pressed: true,
+                repeat: false,
+                modifiers: egui::Modifiers::NONE,
+            }],
+        );
+        run_frame(&mut app, &ctx);
+        assert_eq!(app.inline_text_editing(), None, "Escape closes the editor");
+        assert_eq!(note(&app), "daily high", "and keeps what was typed");
+        assert_eq!(
+            app.active_tab().flow_pane.drawings.selected(),
+            Some(index),
+            "the note stays selected, so its context bar is still there"
+        );
+    }
+
+    /// Typing is one edit, not one per keystroke: undo takes the note back,
+    /// not the last letter of it.
+    #[test]
+    fn undo_after_typing_takes_the_whole_note_back() {
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        run_frame(&mut app, &ctx);
+        arm_drawing_from_toolbox(&mut app, &ctx, "text");
+        click_chart(&mut app, &ctx, egui::pos2(700.0, 300.0));
+        run_frame(&mut app, &ctx);
+        let index = app.inline_text_editing().expect("the editor is open");
+
+        for word in ["swing ", "low"] {
+            run_frame_with_events(&mut app, &ctx, vec![egui::Event::Text(word.to_owned())]);
+        }
+        run_frame(&mut app, &ctx);
+        // Close the editor: the typing gesture commits with it.
+        app.end_inline_text_edit();
+        assert!(app.active_tab_mut().flow_pane.drawings.undo());
+        let drawing = &app.active_tab().flow_pane.drawings.items()[index];
+        assert_eq!(
+            drawing.tool.inline_text(drawing.payload.as_ref()),
+            Some(""),
+            "one undo, the whole note"
+        );
+    }
+
+    /// The `QUANTICK_TEXT_NOTE` hook reaches the editor without a hand: it
+    /// places a note and opens it through the very calls a click makes, so a
+    /// screenshot of this state is a screenshot of the real surface.
+    #[test]
+    fn the_text_note_hook_opens_the_editor_without_a_click() {
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        run_frame(&mut app, &ctx);
+        app.pending_text_note = true;
+        run_frame(&mut app, &ctx);
+        let index = app
+            .inline_text_editing()
+            .expect("the hook opened the editor");
+        assert_eq!(
+            app.active_tab().flow_pane.drawings.items()[index].tool.id(),
+            "text"
         );
     }
 

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -5756,18 +5756,29 @@ impl QuantickApp {
                 // would hand the trader back the very position they discarded.
                 self.inspector_position_dirty = true;
             } else if bar.dragged() {
-                // Where the window actually is, in preference to where it is
-                // remembered: the two differ whenever the pane is too small
-                // for the parked point and the host is drawing a clamped copy.
-                // Dragging the clamped window from the un-clamped point would
-                // make it jump the whole difference on the first pixel of
-                // movement — and the trader is dragging what they can see.
-                let position = ui
-                    .ctx()
-                    .memory(|memory| memory.area_rect(egui::Id::new("drawing_inspector")))
-                    .map(|rect| rect.min)
-                    .or(self.inspector_pos);
-                match position {
+                // The gesture starts from where the window actually is, in
+                // preference to where it is remembered: the two differ
+                // whenever the pane is too small for the parked point and the
+                // host is drawing a clamped copy. Dragging the clamped window
+                // from the un-clamped point would make it jump the whole
+                // difference on the first pixel — and the trader is dragging
+                // what they can see.
+                if bar.drag_started()
+                    && let Some(drawn) = ui
+                        .ctx()
+                        .memory(|memory| memory.area_rect(egui::Id::new("drawing_inspector")))
+                        .map(|rect| rect.min)
+                {
+                    self.inspector_pos = Some(drawn);
+                }
+                // From there the delta accumulates on the *remembered* point,
+                // never on the drawn one. The window is positioned from
+                // `inspector_pos` before this bar is laid out, so the drawn
+                // rect is always one frame behind it: adding this frame's
+                // delta to that rect throws the previous frame's away, and
+                // the popup travels at half the speed of the hand — which is
+                // what "ela treme" was, reported from the running app.
+                match self.inspector_pos {
                     Some(position) => self.place_inspector_by_hand(position + bar.drag_delta()),
                     // No position to move yet — the window has not been laid
                     // out. The hand is still down, so the flag alone records
@@ -13251,22 +13262,20 @@ plot(close)
         }
     }
 
-    /// A Fib level is something price is *going* to meet, so every kind opens
-    /// running to the right edge — a level nobody can see at current price is
-    /// not a level. Where the lines *begin* is the part that differs, and it
-    /// is the tool's question, not one shared default:
+    /// The two Fib tools ask different questions, so they open with different
+    /// spans — this is not one shared default:
     ///
-    /// - a retracement is read across the leg it measures, so it begins at
-    ///   the first anchor and the levels fill in under the pointer during the
-    ///   drag (reported from the running build: starting at the last anchor
-    ///   put every line on the far side of the cursor);
+    /// - a retracement measures how much of *one move* was given back, so its
+    ///   lines live between its own anchors and end where the trader stopped
+    ///   dragging ("a linha deve ir até o ponto onde eu tô traçando e não ir
+    ///   para o infinito", reported from the running build);
     /// - an extension projects what comes *after* its last anchor, so drawing
     ///   its targets back over the measured leg is backwards on its face.
     #[test]
-    fn each_fib_kind_opens_reaching_current_price_from_its_own_start() {
+    fn each_fib_kind_opens_with_the_span_its_own_question_asks_for() {
         use crate::drawings::fib::{Extend, FibPayload};
         for (tool, expected) in [
-            ("fib-retracement", Extend::Right),
+            ("fib-retracement", Extend::Anchors),
             ("fib-extension", Extend::Forward),
         ] {
             let payload = drawing_tool(tool).default_payload();
@@ -15375,6 +15384,78 @@ plot(close)
             progressive_history: true,
             inspector_position: position,
         }
+    }
+
+    /// Reported from the running app: "a pop Fib Retracement settings, quando
+    /// eu mexo ela e movo ela para algum lugar ela treme."
+    ///
+    /// A drag is many frames, not one. Each frame the popup has to end up
+    /// exactly where the pointer put it — if the position it is drawn at and
+    /// the position the next frame's delta is added to disagree, the window
+    /// oscillates around the pointer instead of following it.
+    #[test]
+    fn dragging_the_popup_follows_the_pointer_without_shaking() {
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        run_frame(&mut app, &ctx);
+        draw_horizontal_line(&mut app, &ctx, 320.0);
+        open_inspector(&mut app, &ctx);
+
+        let popup = ctx
+            .memory(|memory| memory.area_rect(egui::Id::new("drawing_inspector")))
+            .expect("the properties popup is open");
+        let grip = egui::pos2(popup.left() + 60.0, popup.top() + 14.0);
+        let start = popup.min;
+
+        // Press, then walk the pointer one step at a time, reading where the
+        // window actually landed on every frame of the gesture.
+        run_frame_with_events(
+            &mut app,
+            &ctx,
+            vec![egui::Event::PointerMoved(grip), pointer_button(grip, true)],
+        );
+        const STEP: f32 = 8.0;
+        const STEPS: usize = 6;
+        let mut drawn = Vec::with_capacity(STEPS);
+        for step in 1..=STEPS {
+            let at = grip + egui::vec2(STEP * step as f32, STEP * step as f32);
+            run_frame_with_events(&mut app, &ctx, vec![egui::Event::PointerMoved(at)]);
+            drawn.push(
+                ctx.memory(|memory| memory.area_rect(egui::Id::new("drawing_inspector")))
+                    .expect("still open")
+                    .min,
+            );
+        }
+        let travel = egui::vec2(STEP * STEPS as f32, STEP * STEPS as f32);
+        let end = grip + travel;
+        run_frame_with_events(&mut app, &ctx, vec![pointer_button(end, false)]);
+        // One more frame: the window is positioned from the remembered point
+        // at the top of a frame, so the last step of a gesture lands on the
+        // frame after it. That single frame of lag is how an immediate-mode
+        // window works; losing *steps* is the bug.
+        run_frame(&mut app, &ctx);
+
+        // Monotonic: every frame of a one-way drag moves the window the same
+        // way the pointer went, never back.
+        for pair in drawn.windows(2) {
+            assert!(
+                pair[1].x >= pair[0].x - 0.5 && pair[1].y >= pair[0].y - 0.5,
+                "the popup went backwards mid-drag: {drawn:?}"
+            );
+        }
+        // Every step arrives: the hand moved `travel`, so the window did too.
+        // It used to arrive at half of it — the delta was being added to the
+        // rect the window was *drawn* at, which is one frame behind the point
+        // the next delta is added to, so each frame discarded the last one.
+        let settled = ctx
+            .memory(|memory| memory.area_rect(egui::Id::new("drawing_inspector")))
+            .expect("still open")
+            .min;
+        assert!(
+            (settled.x - (start.x + travel.x)).abs() <= 1.0
+                && (settled.y - (start.y + travel.y)).abs() <= 1.0,
+            "the popup should have travelled {travel:?} from {start:?}, settled at {settled:?}"
+        );
     }
 
     /// Put a horizontal line on the chart at that height and leave it there.

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -1469,6 +1469,20 @@ impl QuantickApp {
         // unreachable from a launch — a drag is the only way to set one, and a
         // capture run has no hand. Nonsense is refused rather than guessed, so
         // a typo photographs automatic placement instead of an invented pixel.
+        // Which tab the panel opens on. The panel is one hook away, but its
+        // tool-owned tab — where a Fib's levels and colours are built, and
+        // where the two default controls sit — is a click deeper, and a
+        // capture has no hand for it.
+        if let Ok(tab) = std::env::var("QUANTICK_DRAWING_INSPECTOR_TAB") {
+            match tab.trim() {
+                "style" => app.inspector_tab = InspectorTab::Style,
+                "extra" => app.inspector_tab = InspectorTab::Extra,
+                "coordinates" => app.inspector_tab = InspectorTab::Coordinates,
+                // Refused rather than guessed: a typo shows the default tab,
+                // never a confident capture of the wrong one.
+                other => tracing::warn!(tab = other, "unknown drawing inspector tab"),
+            }
+        }
         if let Some(position) = std::env::var("QUANTICK_DRAWING_INSPECTOR_POS")
             .ok()
             .and_then(|value| parse_point(&value))
@@ -6345,20 +6359,34 @@ impl QuantickApp {
             .fixed_pos(egui::pos2(bbox.left(), bbox.bottom()))
             .pivot(egui::Align2::LEFT_BOTTOM)
             .show(ctx, |ui| {
-                let response = ui.add(
-                    egui::TextEdit::multiline(&mut buffer)
-                        .font(egui::FontId::proportional(size_px))
-                        .text_color(color)
-                        .hint_text(INLINE_TEXT_HINT)
-                        .desired_rows(1)
-                        .desired_width(INLINE_TEXT_WIDTH_PX),
-                );
-                // The caret on the first frame: a field that opens unfocused
-                // asks for a click nobody was told about.
-                if !response.has_focus() && ui.memory(|memory| memory.focused().is_none()) {
-                    response.request_focus();
-                }
-                response
+                // A frame around it, in the accent: over a candle chart an
+                // unframed field is a rectangle of dark on dark, and the one
+                // thing this surface has to say is "the keyboard is here
+                // now". The fill is opaque for the same reason — words typed
+                // over wicks are words nobody can read back.
+                egui::Frame::none()
+                    .fill(theme::CHROME)
+                    .stroke(egui::Stroke::new(1.0_f32, theme::ACCENT))
+                    .rounding(egui::Rounding::same(3.0))
+                    .inner_margin(egui::Margin::symmetric(4.0, 2.0))
+                    .show(ui, |ui| {
+                        let response = ui.add(
+                            egui::TextEdit::multiline(&mut buffer)
+                                .font(egui::FontId::proportional(size_px))
+                                .text_color(color)
+                                .hint_text(INLINE_TEXT_HINT)
+                                .desired_rows(1)
+                                .frame(false)
+                                .desired_width(INLINE_TEXT_WIDTH_PX),
+                        );
+                        // The caret on the first frame: a field that opens
+                        // unfocused asks for a click nobody was told about.
+                        if !response.has_focus() && ui.memory(|memory| memory.focused().is_none()) {
+                            response.request_focus();
+                        }
+                        response
+                    })
+                    .inner
             })
             .inner;
 
@@ -8388,6 +8416,11 @@ impl QuantickApp {
         // Same one-per-frame resolution for the side-honesty label the
         // footprint legend carries.
         let side_inferred = self.active_tab().side_note(&self.config).is_some();
+        // Told before the canvas paints, not after: the object holding the
+        // words the editor is showing must stand down on the *same* frame,
+        // or the note flashes its placeholder under the field for one.
+        let editing = self.inline_text_editing();
+        self.drawing_pane_mut().content_editing = editing;
         egui::CentralPanel::default()
             .frame(egui::Frame::none().fill(bg))
             .show(ctx, |ui| {
@@ -16640,6 +16673,34 @@ plot(close)
             drawing.tool.inline_text(drawing.payload.as_ref()),
             Some(""),
             "one undo, the whole note"
+        );
+    }
+
+    /// One note, one placeholder. The object paints "Note" when it is empty
+    /// and the field offers "Add text" — stacked, they read as two objects,
+    /// which is what the first capture of this editor showed. The object
+    /// stands down for as long as the field is holding its words.
+    #[test]
+    fn the_note_stops_painting_itself_while_its_editor_is_open() {
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        run_frame(&mut app, &ctx);
+        arm_drawing_from_toolbox(&mut app, &ctx, "text");
+        click_chart(&mut app, &ctx, egui::pos2(700.0, 300.0));
+        let painted = painted_text(&run_frame(&mut app, &ctx));
+        assert!(app.inline_text_editing().is_some(), "the editor is open");
+        assert!(
+            !painted.iter().any(|text| text == "Note"),
+            "the object's placeholder must not sit over the field: {painted:?}"
+        );
+
+        // Closed again, the object is the only thing holding the words — so
+        // an empty note goes back to saying it is there.
+        app.end_inline_text_edit();
+        let painted = painted_text(&run_frame(&mut app, &ctx));
+        assert!(
+            painted.iter().any(|text| text == "Note"),
+            "an empty note must stay findable once nothing is editing it: {painted:?}"
         );
     }
 

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -77,7 +77,15 @@ const fn pane_ids(tab: u64) -> (u64, u64) {
 /// while a note is being typed would swallow the note's undo entry — leaving
 /// Ctrl+Z to take back the *placement* instead of the words. Same shape as
 /// `inspector_edit_baseline`, same reason.
+///
+/// And the same *shape*, down to the tab and pane: an index alone identifies
+/// nothing once there are two panes, let alone two tabs. Switching tabs with
+/// an editor open would otherwise record the note's undo entry against
+/// whatever object happened to sit at that index on the tab now in front —
+/// swapping an unrelated drawing for a copy of the note on the next Ctrl+Z.
 struct InlineTextEdit {
+    tab: u64,
+    side: PaneSide,
     index: usize,
     before: drawings::Drawing,
 }
@@ -92,6 +100,11 @@ const INLINE_TEXT_HINT: &str = "Add text";
 const INLINE_TEXT_WIDTH_PX: f32 = 180.0;
 /// Type size the editor falls back to when the tool declares none.
 const INLINE_TEXT_FALLBACK_PX: f32 = 12.0;
+/// Line height as a multiple of the type size, and the frame's own vertical
+/// padding — together, how tall the one-line field stands. Used to decide
+/// whether it still fits above the anchor.
+const INLINE_TEXT_LINE_FACTOR: f32 = 1.4;
+const INLINE_TEXT_FRAME_PAD_PX: f32 = 10.0;
 
 /// How much of the newest chart the `QUANTICK_DRAWINGS_DEMO` hook spreads its
 /// objects across. Close to what a default viewport shows, so every object
@@ -5473,7 +5486,7 @@ impl QuantickApp {
                 // no pointer over it to arm or grab with.
             } else if self.drawing_delete_confirm {
                 self.drawing_delete_confirm = false;
-            } else if self.inline_text_edit.is_some() {
+            } else if self.inline_text_editing().is_some() {
                 // A note being typed is its own layer, and it has to be one:
                 // egui clears widget focus at the top of the frame Escape
                 // arrives on, so by the time this stack runs the editor no
@@ -5970,7 +5983,11 @@ impl QuantickApp {
                         && ui
                             .button("Reset to factory")
                             .on_hover_text(format!(
-                                "New {} objects go back to how they opened out of the box",
+                                concat!(
+                                    "New {} objects go back to how they opened ",
+                                    "out of the box. Clears the default preset ",
+                                    "choice too; saved presets are kept"
+                                ),
                                 tool.name().to_lowercase()
                             ))
                             .clicked()
@@ -6259,11 +6276,13 @@ impl QuantickApp {
     /// Refused for an object that holds no words or is locked: a locked
     /// object's geometry and content are both protected, and an editor that
     /// opened and then dropped every keystroke would be worse than none.
-    fn begin_inline_text_edit(&mut self, index: usize) -> bool {
+    pub fn begin_inline_text_edit(&mut self, index: usize) -> bool {
+        let tab = self.active_tab().id;
+        let side = self.active_tab().drawing_side();
         let Some(drawing) = self.drawing_pane().drawings.items().get(index) else {
             return false;
         };
-        if drawing.locked || drawing.tool.inline_text(drawing.payload.as_ref()).is_none() {
+        if drawing.locked || !drawing.tool.holds_text() {
             return false;
         }
         // Typing is one edit: the note as it stands is kept here and recorded
@@ -6271,19 +6290,48 @@ impl QuantickApp {
         // letter of it.
         let before = drawing.clone();
         self.drawing_pane_mut().drawings.select(Some(index));
-        self.inline_text_edit = Some(InlineTextEdit { index, before });
+        self.inline_text_edit = Some(InlineTextEdit {
+            tab,
+            side,
+            index,
+            before,
+        });
+        self.sync_content_editing();
         true
     }
 
     /// Close the editor, keeping whatever was typed and recording it as the
-    /// one edit it was.
+    /// one edit it was — on the pane the note actually lives on, which is not
+    /// necessarily the one in front when it closes.
     fn end_inline_text_edit(&mut self) {
         let Some(edit) = self.inline_text_edit.take() else {
             return;
         };
-        self.drawing_pane_mut()
-            .drawings
-            .record_edit_of(edit.index, edit.before);
+        if let Some(tab) = self.tabs.iter_mut().find(|tab| tab.id == edit.tab) {
+            tab.pane_mut(edit.side)
+                .drawings
+                .record_edit_of(edit.index, edit.before);
+        }
+        self.sync_content_editing();
+    }
+
+    /// Tell every pane whether one of its objects is having its content typed
+    /// somewhere else on screen, so exactly one object anywhere stands down.
+    ///
+    /// Every pane, not just the one in front: the flag is what suppresses the
+    /// object's own painting, and a pane left holding a stale index would
+    /// keep a note invisible for the rest of the session with no way back.
+    fn sync_content_editing(&mut self) {
+        let editing = self
+            .inline_text_edit
+            .as_ref()
+            .map(|edit| (edit.tab, edit.side, edit.index));
+        for tab in &mut self.tabs {
+            let target = editing
+                .filter(|(id, _, _)| *id == tab.id)
+                .map(|(_, side, index)| (side, index));
+            tab.set_content_editing(target);
+        }
     }
 
     /// Which note is being typed on the chart right now — what a second
@@ -6309,14 +6357,22 @@ impl QuantickApp {
         {
             self.begin_inline_text_edit(index);
         }
-        let Some(index) = self.inline_text_editing() else {
+        let Some((tab, side, index)) = self
+            .inline_text_edit
+            .as_ref()
+            .map(|edit| (edit.tab, edit.side, edit.index))
+        else {
             return;
         };
         // The object can go away underneath the editor — undo, delete, a tab
-        // switch — and the selection can move to another one. Either way the
-        // editor is over, and it must not write into whatever now sits at
-        // that index.
-        if self.drawing_pane().drawings.selected() != Some(index) {
+        // switch, a click that moves the selection to the other pane. Any of
+        // those ends the editor, and it must not write into whatever now sits
+        // at that index: the note is only in front while its own tab and pane
+        // are the ones every drawing surface is reading.
+        if self.active_tab().id != tab
+            || self.active_tab().drawing_side() != side
+            || self.drawing_pane().drawings.selected() != Some(index)
+        {
             self.end_inline_text_edit();
             return;
         }
@@ -6354,10 +6410,30 @@ impl QuantickApp {
         // Anchored where the words are painted, so the field opens over the
         // object rather than beside it: the note is typed exactly where it
         // will be read.
+        // Where the words are painted — above the anchor — unless there is no
+        // room up there, in which case it opens below it instead. A field
+        // pinned upward against the top of the chart lands on the flow legend
+        // and covers the very key it is annotating; flipping keeps both
+        // readable, the way a popover does.
+        //
+        // Constrained to the chart either way, like every other floating
+        // drawing surface: the object stands down while the editor is up, so
+        // a field that ran off the window would leave the trader typing blind
+        // into a widget they cannot see.
+        let field_height = size_px * INLINE_TEXT_LINE_FACTOR + INLINE_TEXT_FRAME_PAD_PX;
+        let (position, pivot) = if bbox.bottom() - field_height < chart.top() {
+            (bbox.left_top(), egui::Align2::LEFT_TOP)
+        } else {
+            (
+                egui::pos2(bbox.left(), bbox.bottom()),
+                egui::Align2::LEFT_BOTTOM,
+            )
+        };
         let inner = egui::Area::new(egui::Id::new(INLINE_TEXT_AREA_ID))
             .order(egui::Order::Foreground)
-            .fixed_pos(egui::pos2(bbox.left(), bbox.bottom()))
-            .pivot(egui::Align2::LEFT_BOTTOM)
+            .fixed_pos(position)
+            .pivot(pivot)
+            .constrain_to(chart)
             .show(ctx, |ui| {
                 // A frame around it, in the accent: over a candle chart an
                 // unframed field is a rectangle of dark on dark, and the one
@@ -6392,7 +6468,11 @@ impl QuantickApp {
 
         if buffer != before {
             let text = buffer.clone();
-            if let Some(drawing) = self.drawing_pane_mut().drawings.items_mut().get_mut(index) {
+            // Through the selection, never `items_mut`: that hatch is
+            // documented for derived-state refresh only, and the words of a
+            // note take part in payload equality — writing them through it
+            // would let an unrelated in-flight gesture swallow this edit.
+            if let Some(drawing) = self.drawing_pane_mut().drawings.selected_mut() {
                 tool.set_inline_text(drawing.payload.as_mut(), text);
             }
         }
@@ -6420,8 +6500,8 @@ impl QuantickApp {
         else {
             return;
         };
-        let (point, ready) = {
-            let pane = &self.active_tab().flow_pane;
+        let point = {
+            let pane = self.drawing_pane();
             let slots = pane.slots();
             if pane.last_chart_area.is_none() || slots == 0 {
                 return;
@@ -6436,16 +6516,14 @@ impl QuantickApp {
                 .map_or(close, |(lo, hi)| (lo + hi) / 2.0);
             let visible = DEMO_VISIBLE_SLOTS.min(slots);
             let slot = (slots - visible / 2).min(slots.saturating_sub(1));
-            (
-                drawings::ChartPoint::at_time(slot as f32 + 0.5, centre, pane.slot_open_time(slot)),
-                true,
-            )
+            drawings::ChartPoint::at_time(slot as f32 + 0.5, centre, pane.slot_open_time(slot))
         };
-        debug_assert!(ready);
         self.pending_text_note = false;
-        // Through the same door the click path uses, saved defaults and all.
+        // Through the same door the click path uses, saved defaults and all —
+        // and on the same pane every drawing surface reads, so the index the
+        // editor opens on is the object this just placed.
         let fresh = drawings::new_drawing_from_defaults(&self.drawing_presets, tool);
-        let placed = self.active_tab_mut().flow_pane.drawings.place_with(
+        let placed = self.drawing_pane_mut().drawings.place_with(
             tool,
             &drawings::DrawingBand::Price,
             point,
@@ -8419,8 +8497,7 @@ impl QuantickApp {
         // Told before the canvas paints, not after: the object holding the
         // words the editor is showing must stand down on the *same* frame,
         // or the note flashes its placeholder under the field for one.
-        let editing = self.inline_text_editing();
-        self.drawing_pane_mut().content_editing = editing;
+        self.sync_content_editing();
         egui::CentralPanel::default()
             .frame(egui::Frame::none().fill(bg))
             .show(ctx, |ui| {
@@ -16701,6 +16778,174 @@ plot(close)
         assert!(
             painted.iter().any(|text| text == "Note"),
             "an empty note must stay findable once nothing is editing it: {painted:?}"
+        );
+    }
+
+    /// The frame the note is placed on is already the frame the field is on,
+    /// so the placeholder never appears under it — not even for one frame.
+    ///
+    /// The placement happens *inside* the canvas pass, so a host that waited
+    /// until the next frame to suppress the object would paint "Note" under
+    /// the field exactly once, on the click that made it.
+    #[test]
+    fn the_placeholder_never_flashes_under_the_field_it_is_replaced_by() {
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        run_frame(&mut app, &ctx);
+        arm_drawing_from_toolbox(&mut app, &ctx, "text");
+
+        let position = egui::pos2(700.0, 300.0);
+        run_frame_with_events(
+            &mut app,
+            &ctx,
+            vec![
+                egui::Event::PointerMoved(position),
+                pointer_button(position, true),
+            ],
+        );
+        // The release is the frame the object is born on.
+        let born = run_frame_with_events(&mut app, &ctx, vec![pointer_button(position, false)]);
+        assert!(
+            !painted_text(&born).iter().any(|text| text == "Note"),
+            "the object must stand down on the very frame it is placed"
+        );
+    }
+
+    /// A note against the top of the chart opens its field *below* the
+    /// anchor. Pinned upward it lands on the flow legend — chrome over the
+    /// key it is annotating — and the trader reads neither.
+    #[test]
+    fn the_field_opens_below_a_note_that_has_no_room_above_it() {
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        run_frame(&mut app, &ctx);
+        arm_drawing_from_toolbox(&mut app, &ctx, "text");
+        // As high in the chart as a note can be placed.
+        let chart = app
+            .active_tab()
+            .flow_pane
+            .last_chart_area
+            .expect("a drawn chart");
+        click_chart(&mut app, &ctx, egui::pos2(700.0, chart.top() + 2.0));
+        let output = run_frame(&mut app, &ctx);
+        assert!(app.inline_text_editing().is_some(), "the editor is open");
+
+        let hint = output
+            .shapes
+            .iter()
+            .filter_map(|clipped| match &clipped.shape {
+                egui::Shape::Text(text) if text.galley.text() == INLINE_TEXT_HINT => Some(text.pos),
+                _ => None,
+            })
+            .next()
+            .expect("the field is on screen with its hint");
+        assert!(
+            hint.y >= chart.top(),
+            "the field must stay inside the chart: {hint:?} against {chart:?}"
+        );
+        assert!(
+            hint.y > chart.top() + 2.0,
+            "with no room above the anchor the field opens below it: {hint:?}"
+        );
+    }
+
+    /// Fixing a typo has to be possible. Placing a note no longer opens the
+    /// panel, so the way back into its words is the object itself: pointing
+    /// at a note and double clicking asks to type in it, the same reading as
+    /// double clicking a curve to open its settings.
+    #[test]
+    fn a_double_click_on_a_note_opens_its_editor_again() {
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        run_frame(&mut app, &ctx);
+        arm_drawing_from_toolbox(&mut app, &ctx, "text");
+        let position = egui::pos2(700.0, 300.0);
+        click_chart(&mut app, &ctx, position);
+        run_frame(&mut app, &ctx);
+        run_frame_with_events(
+            &mut app,
+            &ctx,
+            vec![egui::Event::Text("swing high".to_owned())],
+        );
+        app.end_inline_text_edit();
+        run_frame(&mut app, &ctx);
+        assert_eq!(app.inline_text_editing(), None, "the editor is closed");
+
+        // The placement click has to age out of egui's click sequence first:
+        // it counts presses closer than `max_double_click_delay` as a double
+        // and twice that as a triple, so without the quiet stretch the pair
+        // below is reported as a *triple* click and `double_clicked()` never
+        // fires. Derived from egui's own default, not a magic frame count.
+        let quiet = ctx.options(|options| options.input_options.max_double_click_delay) * 2.0;
+        let frames = (quiet / f64::from(ctx.input(|input| input.predicted_dt))).ceil() as usize + 2;
+        for _ in 0..frames {
+            run_frame(&mut app, &ctx);
+        }
+
+        // Two clicks on the note the way a hand makes them.
+        click_chart(&mut app, &ctx, position);
+        click_chart(&mut app, &ctx, position);
+        run_frame(&mut app, &ctx);
+        let index = app
+            .inline_text_editing()
+            .expect("a double click on the note reopens its editor");
+        let drawing = &app.active_tab().flow_pane.drawings.items()[index];
+        assert_eq!(
+            drawing.tool.inline_text(drawing.payload.as_ref()),
+            Some("swing high"),
+            "and it opens on the words already there"
+        );
+    }
+
+    /// The editor belongs to one note on one pane of one tab. Switching tabs
+    /// with it open closes it and records the edit where the note actually
+    /// lives — never against whatever object sits at that index on the tab
+    /// now in front.
+    #[test]
+    fn switching_tabs_closes_the_editor_and_leaves_the_note_on_its_own_tab() {
+        let (mut app, _commands) = app_with_history(200);
+        let ctx = egui::Context::default();
+        run_frame(&mut app, &ctx);
+        arm_drawing_from_toolbox(&mut app, &ctx, "text");
+        click_chart(&mut app, &ctx, egui::pos2(700.0, 300.0));
+        run_frame(&mut app, &ctx);
+        run_frame_with_events(&mut app, &ctx, vec![egui::Event::Text("mine".to_owned())]);
+        assert!(app.inline_text_editing().is_some());
+        let home = app.active_tab().id;
+
+        app.open_tab("binance".to_owned(), "TESTUSDT".to_owned(), None);
+        run_frame(&mut app, &ctx);
+        assert_eq!(
+            app.inline_text_editing(),
+            None,
+            "the editor does not follow the trader to another tab"
+        );
+        assert!(
+            app.tabs
+                .iter()
+                .find(|tab| tab.id != home)
+                .expect("the new tab")
+                .flow_pane
+                .drawings
+                .items()
+                .is_empty(),
+            "and nothing of it is recorded against the new tab"
+        );
+
+        let owner = app
+            .tabs
+            .iter()
+            .find(|tab| tab.id == home)
+            .expect("home tab");
+        let drawing = &owner.flow_pane.drawings.items()[0];
+        assert_eq!(
+            drawing.tool.inline_text(drawing.payload.as_ref()),
+            Some("mine"),
+            "the words stayed with the note"
+        );
+        assert_eq!(
+            owner.flow_pane.content_editing, None,
+            "and the pane holding it stopped suppressing it, so it paints again"
         );
     }
 

--- a/crates/app/src/drawings/anchored_vwap.rs
+++ b/crates/app/src/drawings/anchored_vwap.rs
@@ -787,6 +787,7 @@ mod tests {
             style: DrawingStyle::default(),
             selected: false,
             halo: false,
+            content_editing: false,
         };
         let y = scale.y(100.0);
         // On the line at slot 10 and slot 12.

--- a/crates/app/src/drawings/brush.rs
+++ b/crates/app/src/drawings/brush.rs
@@ -30,6 +30,7 @@ pub(super) const BRUSH_FAMILY: ToolFamily = ToolFamily {
     title: "Freehand",
     icon: icons::SCRIBBLE,
     icon_strokes: &[],
+    icon_dots: &[],
 };
 
 impl DrawingToolImpl for Brush {

--- a/crates/app/src/drawings/fib.rs
+++ b/crates/app/src/drawings/fib.rs
@@ -28,32 +28,40 @@ use super::{
 /// looked like. Two dots against three is how the eye tells the two Fib
 /// tools apart in the flyout at a glance, which is exactly how every drawing
 /// platform draws them.
+/// The leg itself, named once: the strokes draw it and the dots mark its
+/// ends, so nudging the glyph cannot leave the anchors behind on the old line.
+const RETRACEMENT_LEG: &[(f32, f32)] = &[(0.06, 0.84), (0.60, 0.16)];
+
 pub(super) const FIB_RETRACEMENT_ICON: IconStrokes = &[
     &[(0.30, 0.16), (0.98, 0.16)],
     &[(0.30, 0.50), (0.98, 0.50)],
     &[(0.30, 0.84), (0.98, 0.84)],
-    &[(0.06, 0.84), (0.60, 0.16)],
+    RETRACEMENT_LEG,
 ];
 
 /// The two ends of the leg the retracement is dragged across. They sit on the
 /// outer levels because that is where they really are: the anchors *are* 0
 /// and 1, and every other line hangs between them.
-pub(super) const FIB_RETRACEMENT_DOTS: IconDots = &[(0.06, 0.84), (0.60, 0.16)];
+pub(super) const FIB_RETRACEMENT_DOTS: IconDots = RETRACEMENT_LEG;
 
 /// The extension icon: the same ladder under the *three*-anchor path —
 /// impulse, pullback, projection origin — because that is the gesture, and
 /// the third dot is what says so.
+/// The extension's three-anchor path, named once for the same reason as
+/// [`RETRACEMENT_LEG`].
+const EXTENSION_LEG: &[(f32, f32)] = &[(0.04, 0.84), (0.34, 0.16), (0.62, 0.56)];
+
 pub(super) const FIB_EXTENSION_ICON: IconStrokes = &[
     &[(0.30, 0.16), (0.98, 0.16)],
     &[(0.30, 0.50), (0.98, 0.50)],
     &[(0.30, 0.84), (0.98, 0.84)],
-    &[(0.04, 0.84), (0.34, 0.16), (0.62, 0.56)],
+    EXTENSION_LEG,
 ];
 
 /// The three anchors of the trend-based extension — impulse, pullback and the
 /// origin the projection hangs from. Three dots against two is what tells the
 /// two Fib rows apart in the flyout at icon size.
-pub(super) const FIB_EXTENSION_DOTS: IconDots = &[(0.04, 0.84), (0.34, 0.16), (0.62, 0.56)];
+pub(super) const FIB_EXTENSION_DOTS: IconDots = EXTENSION_LEG;
 
 /// The one rail family both Fib tools declare, shared here so the two
 /// members can never drift onto different family ids.
@@ -1122,7 +1130,11 @@ pub(super) fn draw_levels_tab(
         if super::has_saved_default(host, drawing.tool)
             && ui
                 .small_button("Reset to factory")
-                .on_hover_text("New objects go back to the built-in levels and colours")
+                .on_hover_text(concat!(
+                    "New objects go back to the built-in levels and ",
+                    "colours. Clears the default preset choice too; ",
+                    "saved presets are kept"
+                ))
                 .clicked()
         {
             super::reset_tool_default(host, drawing.tool);

--- a/crates/app/src/drawings/fib.rs
+++ b/crates/app/src/drawings/fib.rs
@@ -158,6 +158,8 @@ impl LabelPosition {
 /// How far the level lines run horizontally.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub enum Extend {
+    /// Between the anchors and nowhere else — what a fresh retracement opens
+    /// with, so the levels end where the trader stopped dragging.
     Anchors,
     /// Forward from the *last* anchor only — what a fresh extension opens
     /// with (see [`Extend::for_kind`], which is where a new object's span
@@ -174,9 +176,7 @@ pub enum Extend {
     /// on", which is what a target is.
     #[default]
     Forward,
-    /// The whole anchor span *and* the projection — what a fresh retracement
-    /// opens with, so the levels appear under the pointer during the drag
-    /// and still reach current price.
+    /// The whole anchor span *and* the projection onward.
     Right,
     Both,
 }
@@ -186,22 +186,25 @@ impl Extend {
 
     /// The span a fresh object of each kind opens with.
     ///
-    /// **Retracement starts at the first anchor.** A retracement is read
-    /// *across* the leg it measures: the trader drags from the swing low to
-    /// the swing high and watches the levels fill in under the pointer as
-    /// they go. Opening at the last anchor put every line on the far side of
-    /// the cursor, so the whole gesture happened with nothing under the hand
-    /// and the object only became legible after the release — reported from
-    /// the running build. It still runs to the right edge, so the levels
-    /// reach current price; only where they *begin* changes.
+    /// **A retracement lives between its own anchors.** It measures how much
+    /// of one move was given back, so its lines belong to that move: the
+    /// trader drags from the swing low to the swing high and the levels fill
+    /// in the leg under the pointer, ending where the pointer is. Reported
+    /// twice from the running build — first opening at the *last* anchor,
+    /// which put every line on the far side of the cursor during the very
+    /// drag that defines them, then running on to the right edge, which is
+    /// the trader's own words: "a linha deve ir até o ponto onde eu tô
+    /// traçando e não ir para o infinito". Extending it is a choice on the
+    /// Levels tab, and one that can now be saved as the default.
     ///
     /// **Extension keeps projecting from its last anchor.** Its levels are
-    /// where the next leg may reach, so drawing them back over the leg they
-    /// were measured from is backwards on its face.
+    /// where the next leg may reach — a target, ahead of the move — so
+    /// drawing them back over the leg they were measured from is backwards
+    /// on its face.
     #[must_use]
     pub fn for_kind(kind: FibKind) -> Self {
         match kind {
-            FibKind::Retracement => Self::Right,
+            FibKind::Retracement => Self::Anchors,
             FibKind::Extension => Self::Forward,
         }
     }
@@ -1359,10 +1362,11 @@ mod tests {
     /// The drag is the whole reading gesture: press on the swing low, pull up
     /// and to the right, watch the levels fill in the leg under the pointer.
     /// The draft preview completes the geometry with the hovered point, so
-    /// this is exactly the span a half-placed retracement paints — and it has
-    /// to start at the anchor that is already down, not at the cursor.
+    /// this is exactly the span a half-placed retracement paints — from the
+    /// anchor that is already down to where the pointer is now, and no
+    /// further. Both halves were reported from the running build.
     #[test]
-    fn a_retracement_being_dragged_draws_from_the_first_click() {
+    fn a_retracement_being_dragged_spans_the_first_click_to_the_pointer() {
         let chart = egui::Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(1000.0, 500.0));
         // Anchor down at x = 200, pointer at x = 620: what the preview holds
         // mid-drag, up and to the right.
@@ -1373,8 +1377,8 @@ mod tests {
             "the levels must begin at the first click, not at the pointer: {left}"
         );
         assert!(
-            (right - chart.right()).abs() < f32::EPSILON,
-            "and still reach current price on the right edge: {right}"
+            (right - 620.0).abs() < f32::EPSILON,
+            "and end under the pointer rather than running to the edge: {right}"
         );
     }
 

--- a/crates/app/src/drawings/fib.rs
+++ b/crates/app/src/drawings/fib.rs
@@ -29,29 +29,31 @@ use super::{
 /// tools apart in the flyout at a glance, which is exactly how every drawing
 /// platform draws them.
 pub(super) const FIB_RETRACEMENT_ICON: IconStrokes = &[
-    &[(0.08, 0.16), (0.92, 0.16)],
-    &[(0.08, 0.39), (0.92, 0.39)],
-    &[(0.08, 0.62), (0.92, 0.62)],
-    &[(0.08, 0.85), (0.92, 0.85)],
-    &[(0.22, 0.85), (0.78, 0.16)],
+    &[(0.30, 0.16), (0.98, 0.16)],
+    &[(0.30, 0.50), (0.98, 0.50)],
+    &[(0.30, 0.84), (0.98, 0.84)],
+    &[(0.06, 0.84), (0.60, 0.16)],
 ];
 
-/// The two ends of the leg the retracement is dragged across.
-pub(super) const FIB_RETRACEMENT_DOTS: IconDots = &[(0.22, 0.85), (0.78, 0.16)];
+/// The two ends of the leg the retracement is dragged across. They sit on the
+/// outer levels because that is where they really are: the anchors *are* 0
+/// and 1, and every other line hangs between them.
+pub(super) const FIB_RETRACEMENT_DOTS: IconDots = &[(0.06, 0.84), (0.60, 0.16)];
 
 /// The extension icon: the same ladder under the *three*-anchor path —
 /// impulse, pullback, projection origin — because that is the gesture, and
 /// the third dot is what says so.
 pub(super) const FIB_EXTENSION_ICON: IconStrokes = &[
-    &[(0.08, 0.14), (0.92, 0.14)],
-    &[(0.08, 0.38), (0.92, 0.38)],
-    &[(0.08, 0.62), (0.92, 0.62)],
-    &[(0.08, 0.86), (0.92, 0.86)],
-    &[(0.14, 0.80), (0.45, 0.20), (0.74, 0.58)],
+    &[(0.30, 0.16), (0.98, 0.16)],
+    &[(0.30, 0.50), (0.98, 0.50)],
+    &[(0.30, 0.84), (0.98, 0.84)],
+    &[(0.04, 0.84), (0.34, 0.16), (0.62, 0.56)],
 ];
 
-/// The three anchors of the trend-based extension.
-pub(super) const FIB_EXTENSION_DOTS: IconDots = &[(0.14, 0.80), (0.45, 0.20), (0.74, 0.58)];
+/// The three anchors of the trend-based extension — impulse, pullback and the
+/// origin the projection hangs from. Three dots against two is what tells the
+/// two Fib rows apart in the flyout at icon size.
+pub(super) const FIB_EXTENSION_DOTS: IconDots = &[(0.04, 0.84), (0.34, 0.16), (0.62, 0.56)];
 
 /// The one rail family both Fib tools declare, shared here so the two
 /// members can never drift onto different family ids.
@@ -1105,6 +1107,11 @@ pub(super) fn draw_levels_tab(
     // redone every single session.
     ui.separator();
     ui.horizontal(|ui| {
+        // Named, because "Set as default" sits four rows up and means the
+        // neighbouring thing: that one promotes a preset the trader *named*,
+        // this one takes the setup in front of them as it stands. Without the
+        // words in front, two buttons a thumb apart read as the same button.
+        ui.label(egui::RichText::new("New objects").small());
         if ui
             .small_button("Save as default")
             .on_hover_text("New objects of this tool open with these levels, colours and labels")

--- a/crates/app/src/drawings/fib.rs
+++ b/crates/app/src/drawings/fib.rs
@@ -16,28 +16,42 @@ use smallvec::SmallVec;
 
 use super::{
     DrawContext, Drawing, DrawingPayload, DrawingStyle, FIB_LABEL_OFFSET_PX, FIB_LABEL_SIZE_PX,
-    IconStrokes, PresetHost, ToolFamily, distance_to_segment, drawing_stroke,
+    IconDots, IconStrokes, PresetHost, ToolFamily, distance_to_segment, drawing_stroke,
 };
 
-/// The retracement icon the way TradingView draws it: the two-anchor trend
-/// diagonal with the horizontal levels it spans. The `ROWS` glyph it
-/// replaces read as a generic list, not as levels hung on a move.
+/// The retracement icon, drawn as the gesture it is: the ladder of levels
+/// with the two-anchor leg pulled across it, and the leg's two ends marked.
+///
+/// The marked ends are the part that carries the meaning. Without them the
+/// glyph is a stack of lines with a slash through it — which is also what an
+/// extension looks like, and what the `ROWS` glyph both tools used to share
+/// looked like. Two dots against three is how the eye tells the two Fib
+/// tools apart in the flyout at a glance, which is exactly how every drawing
+/// platform draws them.
 pub(super) const FIB_RETRACEMENT_ICON: IconStrokes = &[
-    &[(0.10, 0.18), (0.90, 0.18)],
-    &[(0.10, 0.52), (0.90, 0.52)],
-    &[(0.10, 0.86), (0.90, 0.86)],
-    &[(0.16, 0.86), (0.84, 0.18)],
+    &[(0.08, 0.16), (0.92, 0.16)],
+    &[(0.08, 0.39), (0.92, 0.39)],
+    &[(0.08, 0.62), (0.92, 0.62)],
+    &[(0.08, 0.85), (0.92, 0.85)],
+    &[(0.22, 0.85), (0.78, 0.16)],
 ];
 
-/// The extension icon: the retracement ladder plus the projected level past
-/// the move — shorter, because it hangs beyond the anchor leg.
+/// The two ends of the leg the retracement is dragged across.
+pub(super) const FIB_RETRACEMENT_DOTS: IconDots = &[(0.22, 0.85), (0.78, 0.16)];
+
+/// The extension icon: the same ladder under the *three*-anchor path —
+/// impulse, pullback, projection origin — because that is the gesture, and
+/// the third dot is what says so.
 pub(super) const FIB_EXTENSION_ICON: IconStrokes = &[
-    &[(0.34, 0.12), (0.90, 0.12)],
-    &[(0.10, 0.42), (0.90, 0.42)],
-    &[(0.10, 0.68), (0.90, 0.68)],
-    &[(0.10, 0.90), (0.90, 0.90)],
-    &[(0.16, 0.90), (0.84, 0.42)],
+    &[(0.08, 0.14), (0.92, 0.14)],
+    &[(0.08, 0.38), (0.92, 0.38)],
+    &[(0.08, 0.62), (0.92, 0.62)],
+    &[(0.08, 0.86), (0.92, 0.86)],
+    &[(0.14, 0.80), (0.45, 0.20), (0.74, 0.58)],
 ];
+
+/// The three anchors of the trend-based extension.
+pub(super) const FIB_EXTENSION_DOTS: IconDots = &[(0.14, 0.80), (0.45, 0.20), (0.74, 0.58)];
 
 /// The one rail family both Fib tools declare, shared here so the two
 /// members can never drift onto different family ids.
@@ -46,6 +60,7 @@ pub(super) const FIB_FAMILY: ToolFamily = ToolFamily {
     title: "Fibonacci",
     icon: egui_phosphor::regular::ROWS,
     icon_strokes: FIB_RETRACEMENT_ICON,
+    icon_dots: FIB_RETRACEMENT_DOTS,
 };
 
 /// Ratios closer than this are the same level; a duplicate is rejected.
@@ -134,7 +149,9 @@ impl LabelPosition {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub enum Extend {
     Anchors,
-    /// The default: forward from the *last* anchor only.
+    /// Forward from the *last* anchor only — what a fresh extension opens
+    /// with (see [`Extend::for_kind`], which is where a new object's span
+    /// is decided; this `Default` only answers for a value nobody set).
     ///
     /// A Fib level is something price is going to meet, so it has to be drawn
     /// where price is — to the right of the swing that defined it. Levels
@@ -147,13 +164,37 @@ pub enum Extend {
     /// on", which is what a target is.
     #[default]
     Forward,
-    /// The whole anchor span *and* the projection.
+    /// The whole anchor span *and* the projection — what a fresh retracement
+    /// opens with, so the levels appear under the pointer during the drag
+    /// and still reach current price.
     Right,
     Both,
 }
 
 impl Extend {
     const ALL: [Self; 4] = [Self::Anchors, Self::Forward, Self::Right, Self::Both];
+
+    /// The span a fresh object of each kind opens with.
+    ///
+    /// **Retracement starts at the first anchor.** A retracement is read
+    /// *across* the leg it measures: the trader drags from the swing low to
+    /// the swing high and watches the levels fill in under the pointer as
+    /// they go. Opening at the last anchor put every line on the far side of
+    /// the cursor, so the whole gesture happened with nothing under the hand
+    /// and the object only became legible after the release — reported from
+    /// the running build. It still runs to the right edge, so the levels
+    /// reach current price; only where they *begin* changes.
+    ///
+    /// **Extension keeps projecting from its last anchor.** Its levels are
+    /// where the next leg may reach, so drawing them back over the leg they
+    /// were measured from is backwards on its face.
+    #[must_use]
+    pub fn for_kind(kind: FibKind) -> Self {
+        match kind {
+            FibKind::Retracement => Self::Right,
+            FibKind::Extension => Self::Forward,
+        }
+    }
 
     #[must_use]
     fn describe(self) -> &'static str {
@@ -313,7 +354,7 @@ impl FibPayload {
             log_scale: false,
             label_mode: LabelMode::default(),
             label_position: LabelPosition::default(),
-            extend: Extend::default(),
+            extend: Extend::for_kind(kind),
             revision: 0,
             cache: RefCell::new(LabelCache::default()),
         }
@@ -1056,6 +1097,31 @@ pub(super) fn draw_levels_tab(
         drawing.points.swap(0, 1);
         edited = true;
     }
+
+    // The same two calls the Style tab makes, offered on the tab where the
+    // configuration is actually built. A trader who has just laid out their
+    // levels and colours is standing exactly where "and from now on" is worth
+    // asking; sending them to another tab for it is how this ended up being
+    // redone every single session.
+    ui.separator();
+    ui.horizontal(|ui| {
+        if ui
+            .small_button("Save as default")
+            .on_hover_text("New objects of this tool open with these levels, colours and labels")
+            .clicked()
+        {
+            super::save_tool_default(host, drawing);
+        }
+        if super::has_saved_default(host, drawing.tool)
+            && ui
+                .small_button("Reset to factory")
+                .on_hover_text("New objects go back to the built-in levels and colours")
+                .clicked()
+        {
+            super::reset_tool_default(host, drawing.tool);
+        }
+    });
+
     edited
 }
 
@@ -1269,5 +1335,45 @@ mod tests {
         payload.touch();
         let after = labels_for(&payload, 200.0, 100.0, 100.0, false);
         assert!(after.labels[0].starts_with("top"));
+    }
+
+    /// The drag is the whole reading gesture: press on the swing low, pull up
+    /// and to the right, watch the levels fill in the leg under the pointer.
+    /// The draft preview completes the geometry with the hovered point, so
+    /// this is exactly the span a half-placed retracement paints — and it has
+    /// to start at the anchor that is already down, not at the cursor.
+    #[test]
+    fn a_retracement_being_dragged_draws_from_the_first_click() {
+        let chart = egui::Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(1000.0, 500.0));
+        // Anchor down at x = 200, pointer at x = 620: what the preview holds
+        // mid-drag, up and to the right.
+        let dragging = [egui::pos2(200.0, 420.0), egui::pos2(620.0, 90.0)];
+        let (left, right) = level_span(&dragging, chart, Extend::for_kind(FibKind::Retracement));
+        assert!(
+            (left - 200.0).abs() < f32::EPSILON,
+            "the levels must begin at the first click, not at the pointer: {left}"
+        );
+        assert!(
+            (right - chart.right()).abs() < f32::EPSILON,
+            "and still reach current price on the right edge: {right}"
+        );
+    }
+
+    /// The other kind asks the other question: an extension's targets are
+    /// what comes after its last anchor, so they must not paint back over the
+    /// leg they were measured from.
+    #[test]
+    fn an_extension_still_projects_from_its_last_anchor() {
+        let chart = egui::Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(1000.0, 500.0));
+        let placed = [
+            egui::pos2(200.0, 420.0),
+            egui::pos2(400.0, 90.0),
+            egui::pos2(620.0, 260.0),
+        ];
+        let (left, _) = level_span(&placed, chart, Extend::for_kind(FibKind::Extension));
+        assert!(
+            (left - 620.0).abs() < f32::EPSILON,
+            "an extension starts where its projection origin is: {left}"
+        );
     }
 }

--- a/crates/app/src/drawings/fib_extension.rs
+++ b/crates/app/src/drawings/fib_extension.rs
@@ -24,6 +24,9 @@ impl DrawingToolImpl for FibExtension {
     fn icon_strokes(&self) -> super::IconStrokes {
         fib::FIB_EXTENSION_ICON
     }
+    fn icon_dots(&self) -> super::IconDots {
+        fib::FIB_EXTENSION_DOTS
+    }
     /// No key is named here, and that is deliberate: this tool gave up
     /// `Shift+F` because that key flattens the position (see
     /// [`Self::shortcut`]). The tooltip went on advertising it long after,

--- a/crates/app/src/drawings/fib_retracement.rs
+++ b/crates/app/src/drawings/fib_retracement.rs
@@ -82,8 +82,11 @@ impl DrawingToolImpl for FibRetracement {
     fn test_geometry(&self) -> (Vec<egui::Pos2>, egui::Pos2) {
         (
             vec![egui::pos2(100.0, 100.0), egui::pos2(250.0, 200.0)],
-            // Right of the last anchor: see `fib_extension`.
-            egui::pos2(300.0, 150.0),
+            // Between the anchors, on the 50 % line halfway down the leg:
+            // that is where a retracement's levels live now, so it is where
+            // one is grabbed. Right of the last anchor there is nothing to
+            // hit any more — see `Extend::for_kind`.
+            egui::pos2(175.0, 150.0),
         )
     }
 }

--- a/crates/app/src/drawings/fib_retracement.rs
+++ b/crates/app/src/drawings/fib_retracement.rs
@@ -24,6 +24,9 @@ impl DrawingToolImpl for FibRetracement {
     fn icon_strokes(&self) -> super::IconStrokes {
         fib::FIB_RETRACEMENT_ICON
     }
+    fn icon_dots(&self) -> super::IconDots {
+        fib::FIB_RETRACEMENT_DOTS
+    }
     fn hover_text(&self) -> &'static str {
         "Fib retracement - click two points or drag (F)"
     }

--- a/crates/app/src/drawings/fixed_range_profile.rs
+++ b/crates/app/src/drawings/fixed_range_profile.rs
@@ -1314,6 +1314,7 @@ mod tests {
             style: DrawingStyle::default(),
             selected: false,
             halo: false,
+            content_editing: false,
         };
         let (left, right) = range_edges(&payload, &points, &ctxt);
         assert_eq!(left, 100.0, "the drawn left edge is untouched");
@@ -1381,6 +1382,7 @@ mod tests {
             style: DrawingStyle::default(),
             selected: true,
             halo: false,
+            content_editing: false,
         };
 
         let handles = TOOL.handles(chart_rect, &points, &ctxt).expect("overridden");

--- a/crates/app/src/drawings/line_core.rs
+++ b/crates/app/src/drawings/line_core.rs
@@ -37,6 +37,7 @@ pub(super) const LINES_FAMILY: ToolFamily = ToolFamily {
     title: "Lines",
     icon: icons::LINE_SEGMENT,
     icon_strokes: &[],
+    icon_dots: &[],
 };
 
 /// How far a line runs past the anchors that define it.

--- a/crates/app/src/drawings/mark_core.rs
+++ b/crates/app/src/drawings/mark_core.rs
@@ -29,6 +29,7 @@ pub(super) const MARKS_FAMILY: ToolFamily = ToolFamily {
     title: "Marks",
     icon: egui_phosphor::regular::ARROW_FAT_UP,
     icon_strokes: &[],
+    icon_dots: &[],
 };
 
 /// Gap between the candle's extreme and the tip of the mark, in pixels, so

--- a/crates/app/src/drawings/measure_core.rs
+++ b/crates/app/src/drawings/measure_core.rs
@@ -22,6 +22,7 @@ pub(super) const MEASURE_FAMILY: ToolFamily = ToolFamily {
     title: "Measure",
     icon: icons::RULER,
     icon_strokes: &[],
+    icon_dots: &[],
 };
 
 /// Which axes a measurement reports. Price range suppresses time, date range

--- a/crates/app/src/drawings/mod.rs
+++ b/crates/app/src/drawings/mod.rs
@@ -285,6 +285,13 @@ pub struct DrawContext<'a> {
     /// True while the wrapper paints the selection halo pass: tools draw
     /// only their stroke geometry then — no fills, no labels.
     pub halo: bool,
+    /// True while this object's *content* is being edited somewhere else on
+    /// screen — the on-chart note editor holding the words while they are
+    /// typed. A tool whose content is words paints none of it then: the
+    /// field is showing the same thing, one line lower, and an empty note
+    /// showed its "Note" placeholder stacked over the field's "Add text",
+    /// which reads as two objects.
+    pub content_editing: bool,
 }
 
 /// What the trader is holding down while they shape an object.
@@ -868,6 +875,7 @@ impl DrawingTool {
             };
             let halo_ctxt = DrawContext {
                 halo: true,
+                content_editing: false,
                 ..*ctxt
             };
             self.0
@@ -2822,6 +2830,7 @@ mod tests {
             style: DrawingStyle::default(),
             selected: false,
             halo: false,
+            content_editing: false,
         };
         assert!(rectangle.hit_test(chart, &points, center, 5.0, &filled));
 
@@ -2911,6 +2920,7 @@ mod tests {
                 style,
                 selected: true,
                 halo: false,
+                content_editing: false,
             };
             line.paint(
                 &painter,
@@ -3212,6 +3222,7 @@ mod tests {
             style: DrawingStyle::default(),
             selected: false,
             halo: false,
+            content_editing: false,
         };
         assert!(line.hit_test(chart, &points, egui::pos2(450.0, 123.0), 5.0, &ctxt));
     }
@@ -3309,6 +3320,7 @@ mod tests {
             style: DrawingStyle::default(),
             selected: true,
             halo: false,
+            content_editing: false,
         };
         let handle = egui::pos2(50.0, 30.0);
         assert_eq!(tool.handles(chart, &points, &ctxt).as_slice(), &[handle]);
@@ -3429,6 +3441,7 @@ mod tests {
                 style: DrawingStyle::default(),
                 selected: true,
                 halo: false,
+                content_editing: false,
             };
             let handles = drawing_tool.handles(chart, &points, &ctxt);
             if drawing_tool.id() == "parallel-channel" {
@@ -3509,6 +3522,7 @@ mod tests {
                 style: DrawingStyle::default(),
                 selected: false,
                 halo: false,
+                content_editing: false,
             };
             assert!(
                 drawing_tool.hit_test(chart, &points, hit, 5.0, &ctxt),

--- a/crates/app/src/drawings/mod.rs
+++ b/crates/app/src/drawings/mod.rs
@@ -142,6 +142,11 @@ pub trait PresetHost {
     /// dialogs to answer "like this one, from now on".
     fn default_config(&self, tool_id: &str) -> Option<toml::Value>;
     fn set_default_config(&mut self, tool_id: &str, value: Option<toml::Value>);
+    /// Whether one is stored, without building it. The inspector asks this
+    /// every frame it is open, purely to decide whether a button exists —
+    /// answering it through [`Self::default_config`] would deep-clone a whole
+    /// level list per frame and drop it on the next line.
+    fn has_default_config(&self, tool_id: &str) -> bool;
 }
 
 /// What a new object of `tool` should open with, given everything the trader
@@ -200,7 +205,7 @@ pub fn reset_tool_default(host: &mut dyn PresetHost, tool: DrawingTool) {
 pub fn has_saved_default(host: &dyn PresetHost, tool: DrawingTool) -> bool {
     let tool_id = tool.id();
     host.default_style(tool_id).is_some()
-        || host.default_config(tool_id).is_some()
+        || host.has_default_config(tool_id)
         || host.default_preset(tool_id).is_some()
 }
 
@@ -240,6 +245,9 @@ impl PresetHost for NullPresetHost {
         None
     }
     fn set_default_config(&mut self, _tool_id: &str, _value: Option<toml::Value>) {}
+    fn has_default_config(&self, _tool_id: &str) -> bool {
+        false
+    }
 }
 
 /// What an anchor's second coordinate means in the band being painted.
@@ -485,6 +493,14 @@ trait DrawingToolImpl: Sync {
     /// Write the words back. Paired with [`Self::inline_text`]: a tool that
     /// answers one answers both, and the editor is the only caller.
     fn set_inline_text(&self, _payload: &mut dyn DrawingPayload, _text: String) {}
+    /// Whether this tool's content is words at all — asked of the *tool*,
+    /// with no object in hand, on the placement path. Answering it by
+    /// building a payload just to look at it would allocate a box to learn
+    /// something that is fixed at compile time. A test holds the two answers
+    /// together, so a tool cannot claim one and implement the other.
+    fn holds_text(&self) -> bool {
+        false
+    }
     /// Whether this tool is placed by a held drag instead of by N clicks.
     ///
     /// A freehand tool answers `0` from [`Self::required_points`], because
@@ -743,7 +759,7 @@ impl DrawingTool {
     /// freshly placed object to decide whether it needs the caret.
     #[must_use]
     pub fn holds_text(self) -> bool {
-        self.inline_text(self.default_payload().as_ref()).is_some()
+        self.0.holds_text()
     }
 
     /// The stock look of a fresh object of this tool, before the trader's
@@ -2064,6 +2080,9 @@ mod tests {
                 None => self.configs.remove(tool_id),
             };
         }
+        fn has_default_config(&self, tool_id: &str) -> bool {
+            self.configs.contains_key(tool_id)
+        }
     }
 
     /// The complaint this closes, in one flow: configure a Fib once, say
@@ -2263,6 +2282,34 @@ mod tests {
                 !tool(id).icon_strokes().is_empty(),
                 "{id} replaced its glyph and must keep vector strokes"
             );
+        }
+    }
+
+    /// The two halves of the note port answer together: `holds_text` is the
+    /// cheap question the placement path asks with no object in hand, and
+    /// `inline_text` is the borrow the editor reads. A tool that claimed one
+    /// and implemented the other would take the caret and then have nowhere
+    /// to put the words — or hold words nothing ever opens.
+    #[test]
+    fn a_tool_that_claims_words_can_actually_hand_them_over() {
+        for tool in DRAWING_TOOLS {
+            let payload = tool.default_payload();
+            assert_eq!(
+                tool.holds_text(),
+                tool.inline_text(payload.as_ref()).is_some(),
+                "{}: holds_text and inline_text disagree",
+                tool.id()
+            );
+            if tool.holds_text() {
+                let mut payload = tool.default_payload();
+                tool.set_inline_text(payload.as_mut(), "typed".to_owned());
+                assert_eq!(
+                    tool.inline_text(payload.as_ref()),
+                    Some("typed"),
+                    "{}: what is written must read back",
+                    tool.id()
+                );
+            }
         }
     }
 

--- a/crates/app/src/drawings/mod.rs
+++ b/crates/app/src/drawings/mod.rs
@@ -131,6 +131,77 @@ pub trait PresetHost {
     /// asking me for this look every single time".
     fn default_style(&self, tool_id: &str) -> Option<DrawingStyle>;
     fn set_default_style(&mut self, tool_id: &str, style: Option<DrawingStyle>);
+    /// Everything else a new object of this tool opens with — whatever the
+    /// tool's own payload exports, which for a Fib is the level list, the
+    /// per-level colours, the labels, the band and the span.
+    ///
+    /// The style pair above could not answer this: a Fib's colours are *per
+    /// level*, and they live in the payload, so "remember my look" was only
+    /// ever remembering the outline. Reaching for a named preset instead
+    /// meant inventing a name and then setting it as the default — two
+    /// dialogs to answer "like this one, from now on".
+    fn default_config(&self, tool_id: &str) -> Option<toml::Value>;
+    fn set_default_config(&mut self, tool_id: &str, value: Option<toml::Value>);
+}
+
+/// What a new object of `tool` should open with, given everything the trader
+/// has told the app to remember. The one place that answer is assembled, so
+/// the click path, the scripted hooks and the tests can never open different
+/// objects from the same saved defaults.
+///
+/// Order is precedence, weakest first: the built-in look, then the saved
+/// default configuration, then the explicitly *named* default preset — a
+/// name the trader chose beats one they saved by pressing a button.
+#[must_use]
+pub fn new_drawing_from_defaults(host: &dyn PresetHost, tool: DrawingTool) -> NewDrawing {
+    let style = host
+        .default_style(tool.id())
+        .unwrap_or_else(|| tool.default_style());
+    let mut payload = tool.default_payload();
+    if let Some(value) = host.default_config(tool.id()) {
+        payload.import_preset(&value);
+    }
+    if let Some(name) = host.default_preset(tool.id())
+        && let Some(value) = host.load_custom_preset(tool.id(), &name)
+    {
+        payload.import_preset(&value);
+    }
+    NewDrawing { style, payload }
+}
+
+/// Remember this object's whole configuration as what new objects of its tool
+/// open with — the named call behind the inspector's "save as default", so a
+/// script or the future assistant can do it without the button.
+///
+/// Objects already on the chart are never touched: a default is a statement
+/// about the *next* object, and repainting the marks a trader has placed is a
+/// bulk edit nobody asked for.
+pub fn save_tool_default(host: &mut dyn PresetHost, drawing: &Drawing) {
+    let tool_id = drawing.tool.id();
+    host.set_default_style(tool_id, Some(drawing.style));
+    host.set_default_config(tool_id, drawing.payload.export_preset());
+}
+
+/// Forget everything saved for this tool, so new objects open the way they
+/// did out of the box — style, configuration and the named default preset.
+///
+/// The named preset itself is kept: this restores the factory *start*, it
+/// does not delete work the trader saved under a name.
+pub fn reset_tool_default(host: &mut dyn PresetHost, tool: DrawingTool) {
+    let tool_id = tool.id();
+    host.set_default_style(tool_id, None);
+    host.set_default_config(tool_id, None);
+    host.set_default_preset(tool_id, None);
+}
+
+/// Whether this tool has anything saved to forget — what the reset control
+/// reads, so it is absent rather than inert when there is nothing to undo.
+#[must_use]
+pub fn has_saved_default(host: &dyn PresetHost, tool: DrawingTool) -> bool {
+    let tool_id = tool.id();
+    host.default_style(tool_id).is_some()
+        || host.default_config(tool_id).is_some()
+        || host.default_preset(tool_id).is_some()
 }
 
 /// A host with no storage: custom presets are absent, saving reports success
@@ -165,6 +236,10 @@ impl PresetHost for NullPresetHost {
         None
     }
     fn set_default_style(&mut self, _tool_id: &str, _style: Option<DrawingStyle>) {}
+    fn default_config(&self, _tool_id: &str) -> Option<toml::Value> {
+        None
+    }
+    fn set_default_config(&mut self, _tool_id: &str, _value: Option<toml::Value>) {}
 }
 
 /// What an anchor's second coordinate means in the band being painted.
@@ -287,6 +362,9 @@ pub struct ToolFamily {
     /// Vector icon for the slot, painted instead of `icon` when non-empty —
     /// same contract as [`DrawingTool::icon_strokes`].
     pub icon_strokes: IconStrokes,
+    /// Anchor dots for the slot icon — same contract as
+    /// [`DrawingTool::icon_dots`].
+    pub icon_dots: IconDots,
 }
 
 /// A vector icon: polylines in the unit square (x right, y down), scaled to
@@ -295,6 +373,17 @@ pub struct ToolFamily {
 /// channel, Fibonacci levels — so the icon is registry data, not a special
 /// case in the chrome.
 pub type IconStrokes = &'static [&'static [(f32, f32)]];
+
+/// The dots of a vector icon: points in the same unit square, painted as
+/// small filled circles over the strokes.
+///
+/// They exist because the icons that needed them are icons *of a gesture*.
+/// A Fib is not a stack of lines — it is a leg the trader dragged, with the
+/// levels hung off it, and the two ends of that drag are what tells it apart
+/// from the extension's three. Every drawing platform draws these tools with
+/// their anchors marked for that reason. Registry data like the strokes, so
+/// the chrome never learns which tool it is painting.
+pub type IconDots = &'static [(f32, f32)];
 
 /// The implementation port every drawing plugs into. Selection visuals (halo
 /// and anchor handles) are common chrome painted by the wrapper, so a tool
@@ -310,6 +399,11 @@ trait DrawingToolImpl: Sync {
     /// Vector strokes painted in place of [`Self::icon`] when non-empty —
     /// see [`IconStrokes`].
     fn icon_strokes(&self) -> IconStrokes {
+        &[]
+    }
+    /// Anchor dots painted over [`Self::icon_strokes`] — see [`IconDots`].
+    /// Only meaningful alongside strokes: a font glyph draws its own.
+    fn icon_dots(&self) -> IconDots {
         &[]
     }
     fn hover_text(&self) -> &'static str;
@@ -366,16 +460,24 @@ trait DrawingToolImpl: Sync {
     fn anchor_snap(&self) -> AnchorSnap {
         AnchorSnap::Pointer
     }
-    /// Whether a freshly placed object of this tool needs its settings panel
-    /// opened straight away.
+    /// The words this object holds, when its content is words rather than
+    /// geometry. `None` for every tool but the note.
     ///
-    /// `false` for every tool whose object is complete the moment it is
-    /// drawn — which is all of them but one. A text note is placed *empty*,
-    /// and the field that gives it words is in the panel: without this it
-    /// arrives as a grey placeholder with no visible way to write in it.
-    fn opens_settings_on_place(&self) -> bool {
-        false
+    /// Declaring it is what earns the on-chart editor: a tool that holds
+    /// text is placed *empty*, so the host puts the caret in the object
+    /// itself the moment it lands. That used to be answered by opening the
+    /// settings panel, which typed the note in one place and showed it in
+    /// another — the eye crossing the screen between keystrokes, and the
+    /// object under the pointer reading "Note" in grey the whole time.
+    ///
+    /// Borrowed, never cloned: this is read on the frame path while the
+    /// editor is open, and a note can be a paragraph.
+    fn inline_text<'a>(&self, _payload: &'a dyn DrawingPayload) -> Option<&'a str> {
+        None
     }
+    /// Write the words back. Paired with [`Self::inline_text`]: a tool that
+    /// answers one answers both, and the editor is the only caller.
+    fn set_inline_text(&self, _payload: &mut dyn DrawingPayload, _text: String) {}
     /// Whether this tool is placed by a held drag instead of by N clicks.
     ///
     /// A freehand tool answers `0` from [`Self::required_points`], because
@@ -577,6 +679,12 @@ impl DrawingTool {
         self.0.icon_strokes()
     }
 
+    /// Anchor dots of the vector icon, `&[]` when it has none.
+    #[must_use]
+    pub fn icon_dots(self) -> IconDots {
+        self.0.icon_dots()
+    }
+
     #[must_use]
     pub fn name(self) -> &'static str {
         self.0.name()
@@ -613,9 +721,22 @@ impl DrawingTool {
         self.0.painted_bounds(anchors, chart)
     }
 
+    /// See [`DrawingToolImpl::inline_text`].
     #[must_use]
-    pub fn opens_settings_on_place(self) -> bool {
-        self.0.opens_settings_on_place()
+    pub fn inline_text(self, payload: &dyn DrawingPayload) -> Option<&str> {
+        self.0.inline_text(payload)
+    }
+
+    /// See [`DrawingToolImpl::set_inline_text`].
+    pub fn set_inline_text(self, payload: &mut dyn DrawingPayload, text: String) {
+        self.0.set_inline_text(payload, text);
+    }
+
+    /// Whether this tool's content is words — the question the host asks a
+    /// freshly placed object to decide whether it needs the caret.
+    #[must_use]
+    pub fn holds_text(self) -> bool {
+        self.inline_text(self.default_payload().as_ref()).is_some()
     }
 
     /// The stock look of a fresh object of this tool, before the trader's
@@ -1866,6 +1987,200 @@ mod tests {
             .expect("registered test tool")
     }
 
+    /// A second implementation of the preset port, remembering everything in
+    /// memory. The store on disk is the first; this one proves the port is a
+    /// port — nothing above it knows a file is involved — and lets the
+    /// defaults flow be tested without touching a real preset file.
+    #[derive(Debug, Default)]
+    struct MemoryPresetHost {
+        presets: std::collections::BTreeMap<(String, String), toml::Value>,
+        default_preset: std::collections::BTreeMap<String, String>,
+        styles: std::collections::BTreeMap<String, DrawingStyle>,
+        configs: std::collections::BTreeMap<String, toml::Value>,
+    }
+
+    impl PresetHost for MemoryPresetHost {
+        fn custom_preset_names(&self, tool_id: &str) -> Vec<String> {
+            self.presets
+                .keys()
+                .filter(|(id, _)| id == tool_id)
+                .map(|(_, name)| name.clone())
+                .collect()
+        }
+        fn load_custom_preset(&self, tool_id: &str, name: &str) -> Option<toml::Value> {
+            self.presets
+                .get(&(tool_id.to_owned(), name.to_owned()))
+                .cloned()
+        }
+        fn save_custom_preset(
+            &mut self,
+            tool_id: &str,
+            name: &str,
+            value: toml::Value,
+            overwrite: bool,
+        ) -> bool {
+            let key = (tool_id.to_owned(), name.to_owned());
+            if self.presets.contains_key(&key) && !overwrite {
+                return false;
+            }
+            self.presets.insert(key, value);
+            true
+        }
+        fn delete_custom_preset(&mut self, tool_id: &str, name: &str) {
+            self.presets.remove(&(tool_id.to_owned(), name.to_owned()));
+        }
+        fn default_preset(&self, tool_id: &str) -> Option<String> {
+            self.default_preset.get(tool_id).cloned()
+        }
+        fn set_default_preset(&mut self, tool_id: &str, name: Option<String>) {
+            match name {
+                Some(name) => self.default_preset.insert(tool_id.to_owned(), name),
+                None => self.default_preset.remove(tool_id),
+            };
+        }
+        fn default_style(&self, tool_id: &str) -> Option<DrawingStyle> {
+            self.styles.get(tool_id).copied()
+        }
+        fn set_default_style(&mut self, tool_id: &str, style: Option<DrawingStyle>) {
+            match style {
+                Some(style) => self.styles.insert(tool_id.to_owned(), style),
+                None => self.styles.remove(tool_id),
+            };
+        }
+        fn default_config(&self, tool_id: &str) -> Option<toml::Value> {
+            self.configs.get(tool_id).cloned()
+        }
+        fn set_default_config(&mut self, tool_id: &str, value: Option<toml::Value>) {
+            match value {
+                Some(value) => self.configs.insert(tool_id.to_owned(), value),
+                None => self.configs.remove(tool_id),
+            };
+        }
+    }
+
+    /// The complaint this closes, in one flow: configure a Fib once, say
+    /// "like this from now on", and the next one opens that way — colours,
+    /// levels and all — while the ones already drawn stay exactly as they
+    /// are. Then reset, and the tool opens the way it did out of the box.
+    #[test]
+    fn a_saved_default_shapes_the_next_object_and_never_the_ones_already_drawn() {
+        use crate::drawings::fib::{FibPayload, LabelMode};
+
+        let mut host = MemoryPresetHost::default();
+        let fib = tool("fib-retracement");
+        let factory_levels = {
+            let payload = fib.default_payload();
+            payload
+                .as_any()
+                .downcast_ref::<FibPayload>()
+                .expect("fib payload")
+                .levels
+                .len()
+        };
+
+        // One object, configured by hand the way a trader would: fewer
+        // levels, one of them in its own colour, ratios read as ratios.
+        let mut drawings = Drawings::default();
+        assert!(!drawings.place(fib, ChartPoint::at(1.0, 100.0)));
+        assert!(drawings.place(fib, ChartPoint::at(9.0, 200.0)));
+        let mine = DrawingStyle {
+            color: egui::Color32::from_rgb(0x20, 0xC0, 0x80),
+            width_px: 2.5,
+            fill_alpha: 30,
+        };
+        {
+            let drawing = drawings.selected_mut().expect("placement selects");
+            drawing.style = mine;
+            let payload = drawing
+                .payload
+                .as_any_mut()
+                .downcast_mut::<FibPayload>()
+                .expect("fib payload");
+            payload.levels.truncate(3);
+            payload.levels[1].color = Some([0xFF, 0x00, 0x88]);
+            payload.label_mode = LabelMode::RatioPrice;
+        }
+        save_tool_default(&mut host, &drawings.items()[0].clone());
+
+        // The next one opens configured, with no name invented for it.
+        let fresh = new_drawing_from_defaults(&host, fib);
+        assert_eq!(fresh.style, mine, "the look travels with the configuration");
+        let fresh_fib = fresh
+            .payload
+            .as_any()
+            .downcast_ref::<FibPayload>()
+            .expect("fib payload");
+        assert_eq!(fresh_fib.levels.len(), 3);
+        assert_eq!(fresh_fib.levels[1].color, Some([0xFF, 0x00, 0x88]));
+        assert_eq!(fresh_fib.label_mode, LabelMode::RatioPrice);
+
+        // A tool that was never taught anything still opens factory-fresh.
+        let untouched = new_drawing_from_defaults(&host, tool("fib-extension"));
+        assert_eq!(untouched.style, tool("fib-extension").default_style());
+
+        // Reset puts the tool back the way it shipped...
+        reset_tool_default(&mut host, fib);
+        assert!(!has_saved_default(&host, fib));
+        let after_reset = new_drawing_from_defaults(&host, fib);
+        assert_eq!(
+            after_reset
+                .payload
+                .as_any()
+                .downcast_ref::<FibPayload>()
+                .expect("fib payload")
+                .levels
+                .len(),
+            factory_levels
+        );
+        assert_eq!(after_reset.style, fib.default_style());
+
+        // ...and the object on the chart never moved through any of it.
+        let on_chart = drawings.items()[0]
+            .payload
+            .as_any()
+            .downcast_ref::<FibPayload>()
+            .expect("fib payload");
+        assert_eq!(on_chart.levels.len(), 3);
+        assert_eq!(drawings.items()[0].style, mine);
+    }
+
+    /// Precedence, stated once: a preset the trader *named* and chose as the
+    /// default beats one they saved by pressing a button, because naming it
+    /// was the more deliberate act.
+    #[test]
+    fn a_named_default_preset_outranks_the_button_saved_configuration() {
+        use crate::drawings::fib::{FibKind, FibPayload};
+
+        let mut host = MemoryPresetHost::default();
+        let fib = tool("fib-retracement");
+        let mut by_button = FibPayload::new(FibKind::Retracement);
+        by_button.levels.truncate(2);
+        host.set_default_config(fib.id(), by_button.export_preset());
+
+        let mut named = FibPayload::new(FibKind::Retracement);
+        named.levels.truncate(5);
+        host.save_custom_preset(
+            fib.id(),
+            "mine",
+            named.export_preset().expect("export"),
+            false,
+        );
+        host.set_default_preset(fib.id(), Some("mine".to_owned()));
+
+        let fresh = new_drawing_from_defaults(&host, fib);
+        assert_eq!(
+            fresh
+                .payload
+                .as_any()
+                .downcast_ref::<FibPayload>()
+                .expect("fib payload")
+                .levels
+                .len(),
+            5,
+            "the named default preset wins"
+        );
+    }
+
     /// The rectangle a popup must keep clear of is what the tool *paints*,
     /// not where its anchors sit. A fixed-range profile carries two anchors at
     /// one price and covers the axis; placing against the anchors walks around
@@ -1939,6 +2254,45 @@ mod tests {
             assert!(
                 !tool(id).icon_strokes().is_empty(),
                 "{id} replaced its glyph and must keep vector strokes"
+            );
+        }
+    }
+
+    /// The dots half of the same port: they live in the same unit square,
+    /// and a tool only has them alongside strokes — a font glyph draws its
+    /// own anchors or none at all, and dots floating over one would land
+    /// wherever the typeface happened to put its ink.
+    ///
+    /// The two Fib tools are named because their anchor counts are the whole
+    /// difference between their icons: drop the dots and the flyout offers
+    /// two rows of the same picture.
+    #[test]
+    fn icon_dots_stay_in_the_unit_square_and_only_accompany_strokes() {
+        for tool in DRAWING_TOOLS {
+            let dots = tool.icon_dots();
+            assert!(
+                dots.is_empty() || !tool.icon_strokes().is_empty(),
+                "{}: anchor dots need strokes to sit on",
+                tool.id()
+            );
+            for (x, y) in dots {
+                assert!(
+                    (0.0..=1.0).contains(x) && (0.0..=1.0).contains(y),
+                    "{}: icon dot ({x}, {y}) leaves the unit square",
+                    tool.id()
+                );
+            }
+        }
+        for (id, anchors) in [("fib-retracement", 2), ("fib-extension", 3)] {
+            assert_eq!(
+                tool(id).icon_dots().len(),
+                anchors,
+                "{id}: the icon marks one dot per anchor of the gesture"
+            );
+            assert_eq!(
+                tool(id).icon_dots().len(),
+                tool(id).required_points(),
+                "{id}: the icon and the tool must agree on how many anchors it takes"
             );
         }
     }

--- a/crates/app/src/drawings/presets.rs
+++ b/crates/app/src/drawings/presets.rs
@@ -260,6 +260,12 @@ impl PresetHost for PresetStore {
         slot.config = value;
         self.persist();
     }
+
+    fn has_default_config(&self, tool_id: &str) -> bool {
+        self.tools
+            .get(tool_id)
+            .is_some_and(|slot| slot.config.is_some())
+    }
 }
 
 #[cfg(test)]

--- a/crates/app/src/drawings/presets.rs
+++ b/crates/app/src/drawings/presets.rs
@@ -74,6 +74,17 @@ struct ToolPresets {
     /// the version does not move.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     style: Option<StoredStyle>,
+    /// The tool's own configuration for new objects — a payload export,
+    /// exactly the shape a named preset holds. Added the same way and for
+    /// the same reason as `style`: absent in an older file, ignored by an
+    /// older build, so the format version stays put.
+    ///
+    /// Stored as the tool's opaque export rather than parsed here: this file
+    /// knows about tools, not about Fib levels, and the tool that wrote the
+    /// table is the one that reads it back through `import_preset` — which
+    /// already refuses a table it does not recognise.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    config: Option<toml::Value>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -239,6 +250,16 @@ impl PresetHost for PresetStore {
         slot.style = style.map(StoredStyle::from_style);
         self.persist();
     }
+
+    fn default_config(&self, tool_id: &str) -> Option<toml::Value> {
+        self.tools.get(tool_id)?.config.clone()
+    }
+
+    fn set_default_config(&mut self, tool_id: &str, value: Option<toml::Value>) {
+        let slot = self.tools.entry(tool_id.to_owned()).or_default();
+        slot.config = value;
+        self.persist();
+    }
 }
 
 #[cfg(test)]
@@ -315,6 +336,69 @@ mod tests {
         store.delete_custom_preset("fib-extension", "targets+");
         assert_eq!(store.default_preset("fib-extension"), None);
         assert!(store.custom_preset_names("fib-extension").is_empty());
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// The chore this removes is the one the trader actually complained
+    /// about: a Fib whose levels, per-level colours and labels had to be
+    /// rebuilt every session, because the only thing that survived a restart
+    /// was the outline colour.
+    #[test]
+    fn a_default_configuration_survives_a_restart() {
+        let path = scratch_path("default-config");
+        let mine = sample_value("my-levels");
+        {
+            let mut store = PresetStore::load_from(&path);
+            assert_eq!(store.default_config("fib-retracement"), None);
+            store.set_default_config("fib-retracement", Some(mine.clone()));
+        }
+        let store = PresetStore::load_from(&path);
+        assert_eq!(store.default_config("fib-retracement"), Some(mine));
+        assert_eq!(
+            store.default_config("fib-extension"),
+            None,
+            "one tool's configuration is not every tool's"
+        );
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// Clearing it is a real state, not an absence the next save has to fix:
+    /// the reset button writes `None` and the file must come back empty.
+    #[test]
+    fn resetting_the_configuration_writes_the_absence_through() {
+        let path = scratch_path("reset-config");
+        {
+            let mut store = PresetStore::load_from(&path);
+            store.set_default_config("rectangle", Some(sample_value("boxy")));
+            store.set_default_config("rectangle", None);
+        }
+        let store = PresetStore::load_from(&path);
+        assert_eq!(store.default_config("rectangle"), None);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// A file written before the configuration slot existed still reads —
+    /// the key is optional and the format version does not move for it.
+    #[test]
+    fn a_file_without_the_configuration_slot_still_loads() {
+        let path = scratch_path("older-file");
+        std::fs::write(
+            &path,
+            "version = 1
+
+[tools.\"trend-line\".style]
+color = \"#ff0000\"
+width_px = 2.0
+fill_alpha = 12
+",
+        )
+        .expect("the scratch file is writable");
+        let store = PresetStore::load_from(&path);
+        assert!(
+            store.default_style("trend-line").is_some(),
+            "the older file must still be read, not rejected"
+        );
+        assert_eq!(store.default_config("trend-line"), None);
         let _ = std::fs::remove_file(&path);
     }
 

--- a/crates/app/src/drawings/shape_core.rs
+++ b/crates/app/src/drawings/shape_core.rs
@@ -126,6 +126,7 @@ mod tests {
             style,
             selected: false,
             halo: false,
+            content_editing: false,
         };
         body(&ctxt)
     }

--- a/crates/app/src/drawings/shape_core.rs
+++ b/crates/app/src/drawings/shape_core.rs
@@ -19,6 +19,7 @@ pub(super) const SHAPES_FAMILY: ToolFamily = ToolFamily {
     title: "Shapes",
     icon: icons::SHAPES,
     icon_strokes: &[],
+    icon_dots: &[],
 };
 
 /// Segments in an ellipse outline. Fixed, not derived from the on-screen

--- a/crates/app/src/drawings/text.rs
+++ b/crates/app/src/drawings/text.rs
@@ -207,7 +207,10 @@ impl DrawingToolImpl for Text {
     ) {
         // The halo pass widens strokes; type has none, and a second draw of
         // the same glyphs would only smear them.
-        if ctxt.halo {
+        //
+        // The editor holding these words paints them itself, so the object
+        // stands down while it is open — see `DrawContext::content_editing`.
+        if ctxt.halo || ctxt.content_editing {
             return;
         }
         let Some(anchor) = points.first() else {

--- a/crates/app/src/drawings/text.rs
+++ b/crates/app/src/drawings/text.rs
@@ -143,6 +143,9 @@ impl DrawingToolImpl for Text {
             payload.text = text;
         }
     }
+    fn holds_text(&self) -> bool {
+        true
+    }
     /// …and what the width slot offers instead: the type size, so the size
     /// of a note is one click away from the note itself.
     fn glyph_size(&self, payload: &dyn DrawingPayload) -> Option<GlyphSize> {

--- a/crates/app/src/drawings/text.rs
+++ b/crates/app/src/drawings/text.rs
@@ -129,11 +129,19 @@ impl DrawingToolImpl for Text {
     fn supports_stroke_width(&self) -> bool {
         false
     }
-    /// The one tool placed empty: its words are its content, and the field
-    /// that takes them is in the panel. Placing a note and being shown only
-    /// style icons leaves the trader with a grey "Note" and no way in.
-    fn opens_settings_on_place(&self) -> bool {
-        true
+    /// The one tool placed empty: its words are its content, so it takes the
+    /// caret on the chart the moment it lands. Placing a note and being shown
+    /// only style icons left the trader with a grey "Note" and no way in.
+    fn inline_text<'a>(&self, payload: &'a dyn DrawingPayload) -> Option<&'a str> {
+        payload
+            .as_any()
+            .downcast_ref::<TextPayload>()
+            .map(|payload| payload.text.as_str())
+    }
+    fn set_inline_text(&self, payload: &mut dyn DrawingPayload, text: String) {
+        if let Some(payload) = payload.as_any_mut().downcast_mut::<TextPayload>() {
+            payload.text = text;
+        }
     }
     /// …and what the width slot offers instead: the type size, so the size
     /// of a note is one click away from the note itself.

--- a/crates/app/src/pane.rs
+++ b/crates/app/src/pane.rs
@@ -27,7 +27,7 @@ use crate::chart::{self, PriceScale};
 use crate::chart_layers::{ChartLayer, LayerActions};
 use crate::config::FeedCapabilities;
 use crate::drawings::{
-    self, ChartPoint, DrawContext, Drawing, DrawingBand, DrawingStyle, Drawings, PresetHost,
+    self, ChartPoint, DrawContext, Drawing, DrawingBand, DrawingStyle, Drawings,
 };
 use crate::indicator_render::{self, PlotX};
 use crate::indicator_worker::{
@@ -768,15 +768,15 @@ fn anchor_hit(points: &[egui::Pos2], pos: egui::Pos2) -> Option<usize> {
 pub struct PaneChrome<'a> {
     pub toolrail: &'a mut ToolRail,
     pub presets: &'a drawings::presets::PresetStore,
-    /// Raised when a tool that arrives empty was just placed, so the host
-    /// opens the settings panel for it.
+    /// Raised when a tool whose content is words was just placed, so the
+    /// host puts the caret in the object it just made.
     ///
-    /// Selecting a drawing raises the context bar, not the panel — but a
-    /// text note has no *content* until someone types it, and the field that
-    /// takes those words lives in the panel. Placing one and being shown a
-    /// row of style icons leaves the trader with an object that says "Note"
-    /// in grey and no way to make it say anything else.
-    pub open_settings: &'a mut bool,
+    /// Selecting a drawing raises the context bar, which is everything a
+    /// note needs *except* somewhere to type. This is that somewhere, and it
+    /// is on the chart: a note typed in a panel is read with the eye crossing
+    /// the screen between keystrokes, and until the first word lands the
+    /// object under the pointer just says "Note" in grey.
+    pub begin_text_edit: &'a mut bool,
     pub style: &'a ChartStyle,
     pub tz: TzOffset,
     /// The symbol to name while the series is still empty.
@@ -3404,20 +3404,13 @@ impl ChartPane {
         point: ChartPoint,
         chrome: &mut PaneChrome<'_>,
     ) {
-        // A new object starts from the user's explicit default preset when
-        // one is set; existing objects are never touched by that choice.
+        // A new object starts from whatever the trader told the app to
+        // remember for this tool — assembled in one place, so the click path
+        // and the scripted one open the same object. Existing objects are
+        // never touched by that choice.
         let presets = chrome.presets;
         let completed = self.drawings.place_with(tool, band, point, |tool| {
-            let style = presets
-                .default_style(tool.id())
-                .unwrap_or_else(|| tool.default_style());
-            let mut payload = tool.default_payload();
-            if let Some(name) = presets.default_preset(tool.id())
-                && let Some(value) = presets.load_custom_preset(tool.id(), &name)
-            {
-                payload.import_preset(&value);
-            }
-            drawings::NewDrawing { style, payload }
+            drawings::new_drawing_from_defaults(presets, tool)
         });
         if completed {
             // One-shot by default; the toolbox repeat pin keeps the tool
@@ -3425,8 +3418,10 @@ impl ChartPane {
             if !chrome.toolrail.repeat() {
                 chrome.toolrail.arm(Tool::Pointer);
             }
-            if tool.opens_settings_on_place() {
-                *chrome.open_settings = true;
+            // A tool whose content is words asks for the caret, not for a
+            // panel — see `PaneChrome::begin_text_edit`.
+            if tool.holds_text() {
+                *chrome.begin_text_edit = true;
             }
             self.drawing_hover = None;
         }
@@ -6880,7 +6875,7 @@ mod tests {
         let mut toolrail = crate::toolrail::ToolRail::new();
         let presets =
             drawings::presets::PresetStore::load_from(std::env::temp_dir().join("no-such.toml"));
-        let mut open_settings = false;
+        let mut begin_text_edit = false;
         let style = crate::style::ChartStyle::default();
         let mut paper = crate::paper_trading::PaperTrading::new();
         let footprint = crate::footprint_config::FootprintConfig::default();
@@ -6898,7 +6893,7 @@ mod tests {
                 let mut chrome = PaneChrome {
                     toolrail: &mut toolrail,
                     presets: &presets,
-                    open_settings: &mut open_settings,
+                    begin_text_edit: &mut begin_text_edit,
                     style: &style,
                     tz: crate::timezone::TzOffset::default(),
                     symbol: "TESTUSDT",

--- a/crates/app/src/pane.rs
+++ b/crates/app/src/pane.rs
@@ -1025,6 +1025,11 @@ pub struct ChartPane {
     // Drawing placement/movement state. Anchors are chart coordinates; only
     // the current hover and press position are transient pixels.
     pub drawing_hover: Option<ChartPoint>,
+    /// The object whose *content* is being edited off-canvas right now —
+    /// the on-chart note editor's subject. Told to the pane by the host each
+    /// frame, because the editor is chrome and lives above the canvas; the
+    /// object it holds the words for must not paint them twice.
+    pub content_editing: Option<usize>,
     /// The band the next anchor would land in, as the input pass resolved it.
     /// The draw pass puts the accent hairline on its top edge — one band at a
     /// time, and none at all when no tool is armed.
@@ -1194,6 +1199,7 @@ impl ChartPane {
             strategy_cleanup: Vec::new(),
             drawings: Drawings::default(),
             drawing_hover: None,
+            content_editing: None,
             drawing_band_hint: None,
             drawing_press_position: None,
             drawing_press_started_empty: false,
@@ -3471,6 +3477,7 @@ impl ChartPane {
                     style: drawing.style,
                     selected: self.drawings.selected() == Some(index),
                     halo: false,
+                    content_editing: false,
                 };
                 drawing
                     .tool
@@ -3507,6 +3514,7 @@ impl ChartPane {
                     style: drawing.style,
                     selected: self.drawings.selected() == Some(index),
                     halo: false,
+                    content_editing: false,
                 };
                 drawing
                     .tool
@@ -3555,6 +3563,7 @@ impl ChartPane {
             style: drawing.style,
             selected: self.drawings.selected() == Some(drawing_index),
             halo: false,
+            content_editing: false,
         };
         anchor_hit(&drawing.tool.handles(band.rect, &projected, &ctxt), pos)
     }
@@ -3607,6 +3616,7 @@ impl ChartPane {
                 style: drawing.style,
                 selected: true,
                 halo: false,
+                content_editing: false,
             };
             let to = self.drawing_screen_point(target, history_right, total, scale);
             drawing
@@ -5764,6 +5774,7 @@ impl ChartPane {
                 style: drawing.style,
                 selected: source.drawings.selected() == Some(index),
                 halo: false,
+                content_editing: false,
             };
             // Handle drags cross the pane boundary as "move anchor N", so a
             // tool whose handles are not its anchors — a channel's rail
@@ -5935,6 +5946,7 @@ impl ChartPane {
                     style,
                     selected,
                     halo: false,
+                    content_editing: false,
                 };
                 // Locked geometry shows no handles on either chart: they would
                 // advertise a drag that is refused.
@@ -6071,6 +6083,7 @@ impl ChartPane {
                 style,
                 selected,
                 halo: false,
+                content_editing: self.content_editing == Some(index),
             };
             // A locked object shows no resize handles: its geometry is not
             // editable, so the affordance would lie.
@@ -6132,6 +6145,7 @@ impl ChartPane {
                 style: draft.style,
                 selected: false,
                 halo: false,
+                content_editing: false,
             };
             draft
                 .tool

--- a/crates/app/src/pane.rs
+++ b/crates/app/src/pane.rs
@@ -3426,7 +3426,14 @@ impl ChartPane {
             }
             // A tool whose content is words asks for the caret, not for a
             // panel — see `PaneChrome::begin_text_edit`.
+            //
+            // The object stands down here rather than waiting for the host to
+            // notice next frame: the placement happens *inside* the canvas
+            // pass, so a note placed by click would otherwise paint its grey
+            // placeholder under the field that opens over it, for the one
+            // frame between the two.
             if tool.holds_text() {
+                self.content_editing = self.drawings.selected();
                 *chrome.begin_text_edit = true;
             }
             self.drawing_hover = None;
@@ -3996,6 +4003,26 @@ impl ChartPane {
                     })
                 };
                 self.drawings.select(selected);
+                // A note under the pointer takes a double click: its words
+                // *are* the object, so pointing at one and double clicking
+                // asks to type in it — the same reading as double clicking a
+                // curve to open its settings. It is read here rather than in
+                // the free-chart branch above because a click on an object
+                // starts a translate gesture, which is exactly what clears
+                // that branch's `primary_free`. Without this, fixing a typo
+                // meant hunting for a field in a panel that placing a note no
+                // longer opens.
+                if chart.double_clicked()
+                    && let Some(index) = selected
+                    && self
+                        .drawings
+                        .items()
+                        .get(index)
+                        .is_some_and(|drawing| drawing.tool.holds_text() && !drawing.locked)
+                {
+                    self.content_editing = Some(index);
+                    *chrome.begin_text_edit = true;
+                }
             }
             // Drag initiation reads the raw press (an `interact` per object
             // would be unbounded work), so it must honour the chrome gate
@@ -5946,7 +5973,12 @@ impl ChartPane {
                     style,
                     selected,
                     halo: false,
-                    content_editing: false,
+                    // The object lives on `source`, so that is the pane that knows
+                    // whether its words are in an editor right now. Left
+                    // hardcoded, a shared note being typed kept painting its
+                    // old words on the companion chart — the same double
+                    // render the editor stands the original down to avoid.
+                    content_editing: source.content_editing == Some(index),
                 };
                 // Locked geometry shows no handles on either chart: they would
                 // advertise a drag that is refused.

--- a/crates/app/src/tab.rs
+++ b/crates/app/src/tab.rs
@@ -104,8 +104,8 @@ impl From<CanvasLayout> for crate::config::DeclaredLayout {
 pub struct CanvasChrome<'a> {
     pub toolrail: &'a mut ToolRail,
     pub presets: &'a crate::drawings::presets::PresetStore,
-    /// See [`PaneChrome::open_settings`].
-    pub open_settings: &'a mut bool,
+    /// See [`PaneChrome::begin_text_edit`].
+    pub begin_text_edit: &'a mut bool,
     pub style: &'a ChartStyle,
     pub tz: TzOffset,
     /// What the running source can produce, for the layer menu's disabled
@@ -2088,7 +2088,7 @@ impl Tab {
             let mut chrome = PaneChrome {
                 toolrail: chrome.toolrail,
                 presets: chrome.presets,
-                open_settings: chrome.open_settings,
+                begin_text_edit: chrome.begin_text_edit,
                 style: chrome.style,
                 tz: chrome.tz,
                 symbol,

--- a/crates/app/src/tab.rs
+++ b/crates/app/src/tab.rs
@@ -829,6 +829,25 @@ impl Tab {
     }
 
     /// See [`Self::pane`].
+    /// Point exactly one of this tab's panes at the object whose content is
+    /// being typed off-canvas, and clear the other.
+    ///
+    /// Both are written every time on purpose: the flag suppresses an
+    /// object's own painting, so a pane left holding a stale index keeps a
+    /// note invisible for the rest of the session. The tab is what knows
+    /// whether a time pane exists at all, which is why the loop lives here
+    /// rather than in the host.
+    pub fn set_content_editing(&mut self, target: Option<(PaneSide, usize)>) {
+        self.flow_pane.content_editing = target
+            .filter(|(side, _)| *side == PaneSide::Flow)
+            .map(|(_, index)| index);
+        if let Some(time) = self.time_pane.as_mut() {
+            time.content_editing = target
+                .filter(|(side, _)| *side == PaneSide::Time)
+                .map(|(_, index)| index);
+        }
+    }
+
     pub fn pane_mut(&mut self, side: PaneSide) -> &mut ChartPane {
         match side {
             PaneSide::Time => self.time_pane.as_mut().unwrap_or(&mut self.flow_pane),

--- a/crates/app/src/toolrail.rs
+++ b/crates/app/src/toolrail.rs
@@ -10,9 +10,9 @@ use std::collections::BTreeMap;
 use eframe::egui;
 use egui_phosphor::regular as icons;
 
-use crate::drawings::{DRAWING_TOOLS, DrawingTool, Drawings, IconStrokes, ToolFamily};
+use crate::drawings::{DRAWING_TOOLS, DrawingTool, Drawings, IconDots, IconStrokes, ToolFamily};
 use crate::theme;
-use crate::widgets::{IconButton, MarkerEdge, TOOLRAIL_ICON, paint_icon_strokes};
+use crate::widgets::{IconButton, MarkerEdge, TOOLRAIL_ICON, paint_vector_icon};
 
 /// Rail cross axis, all four docks: `44 = 6 + 32 + 6`.
 const TOOLBOX_THICKNESS_PX: f32 = 44.0;
@@ -124,6 +124,14 @@ impl Tool {
         match self {
             Self::Pointer | Self::Crosshair => &[],
             Self::Drawing(tool) => tool.icon_strokes(),
+        }
+    }
+
+    #[must_use]
+    fn icon_dots(self) -> IconDots {
+        match self {
+            Self::Pointer | Self::Crosshair => &[],
+            Self::Drawing(tool) => tool.icon_dots(),
         }
     }
 
@@ -1196,7 +1204,7 @@ impl ToolRail {
 
     fn draw_button(&mut self, ui: &mut egui::Ui, tool: Tool, drawings: &Drawings) {
         let response = IconButton::new(tool.icon(), TOOLRAIL_ICON)
-            .strokes(tool.icon_strokes())
+            .vector_icon(tool.icon_strokes(), tool.icon_dots())
             .active(self.tool == tool)
             .active_marker(self.dock.marker_edge())
             .hover_text(tool.hover_text())
@@ -1268,7 +1276,7 @@ impl ToolRail {
             let tool = self.favorites[index];
             let armed = self.tool == Tool::Drawing(tool);
             let response = IconButton::new(tool.icon(), TOOLRAIL_ICON)
-                .strokes(tool.icon_strokes())
+                .vector_icon(tool.icon_strokes(), tool.icon_dots())
                 .active(armed)
                 .active_marker(self.dock.marker_edge())
                 .hover_text(tool.hover_text())
@@ -1531,9 +1539,10 @@ impl ToolRail {
             .is_some_and(|tool| members.contains(&tool));
         let icon = shown.map_or(family.icon, DrawingTool::icon);
         let strokes = shown.map_or(family.icon_strokes, DrawingTool::icon_strokes);
+        let dots = shown.map_or(family.icon_dots, DrawingTool::icon_dots);
         let hover = shown.map_or(family.title, DrawingTool::hover_text);
         let response = IconButton::new(icon, TOOLRAIL_ICON)
-            .strokes(strokes)
+            .vector_icon(strokes, dots)
             .active(armed)
             .active_marker(self.dock.marker_edge())
             .hover_text(hover)
@@ -1728,13 +1737,14 @@ impl ToolRail {
                     glyph_color,
                 );
             } else {
-                paint_icon_strokes(
+                paint_vector_icon(
                     ui.painter(),
                     egui::Rect::from_center_size(
                         glyph_center,
                         egui::Vec2::splat(FLYOUT_GLYPH_PX - 4.0),
                     ),
                     member.icon_strokes(),
+                    member.icon_dots(),
                     glyph_color,
                 );
             }

--- a/crates/app/src/widgets.rs
+++ b/crates/app/src/widgets.rs
@@ -303,7 +303,7 @@ const ICON_STROKE_WIDTH_PX: f32 = 1.4;
 
 /// Radius of an icon's anchor dot, in pixels at the rail's glyph size. Small
 /// enough to read as a handle on the leg rather than as a sixth level line.
-const ICON_DOT_RADIUS_PX: f32 = 1.5;
+const ICON_DOT_RADIUS_PX: f32 = 1.9;
 
 /// Paint a vector icon: each polyline's unit-square points scaled into
 /// `rect`, then the anchor dots over them. A handful of line segments and at

--- a/crates/app/src/widgets.rs
+++ b/crates/app/src/widgets.rs
@@ -324,6 +324,14 @@ pub fn paint_vector_icon(
     };
     let stroke = egui::Stroke::new(ICON_STROKE_WIDTH_PX, color);
     for polyline in strokes {
+        // `Shape::line` and its `Vec`, deliberately, even for the two-point
+        // strokes that make up most of an icon: `line_segment` would avoid
+        // the allocation, but a rail icon in the armed accent then counts as
+        // a drawing stroke everywhere the tests measure what a tool painted
+        // by filtering `Shape::LineSegment` on the drawing colour. Trading a
+        // handful of two-element `Vec`s per frame for that ambiguity is the
+        // wrong side of the bargain — this is chrome, painted a dozen times
+        // a frame, not the per-trade path.
         let points: Vec<egui::Pos2> = polyline.iter().copied().map(at).collect();
         painter.add(egui::Shape::line(points, stroke));
     }

--- a/crates/app/src/widgets.rs
+++ b/crates/app/src/widgets.rs
@@ -144,6 +144,7 @@ pub fn icon_paint(
 pub struct IconButton<'a> {
     glyph: &'a str,
     strokes: crate::drawings::IconStrokes,
+    dots: crate::drawings::IconDots,
     size: IconSize,
     active: bool,
     enabled: bool,
@@ -160,6 +161,7 @@ impl<'a> IconButton<'a> {
         Self {
             glyph,
             strokes: &[],
+            dots: &[],
             size,
             active: false,
             enabled: true,
@@ -170,12 +172,23 @@ impl<'a> IconButton<'a> {
         }
     }
 
-    /// Paint these vector strokes instead of the glyph when non-empty —
-    /// registry data from [`crate::drawings::IconStrokes`], so the button
-    /// stays one code path for every tool.
+    /// Paint this vector icon instead of the glyph when its strokes are
+    /// non-empty — registry data from [`crate::drawings::IconStrokes`] and
+    /// [`crate::drawings::IconDots`], so the button stays one code path for
+    /// every tool.
+    ///
+    /// Strokes and dots arrive together on purpose. They are two halves of
+    /// one drawing, and a caller that could ask for the lines alone would
+    /// paint a Fib retracement that reads exactly like the extension beside
+    /// it — the anchors are what tells them apart.
     #[must_use]
-    pub fn strokes(mut self, strokes: crate::drawings::IconStrokes) -> Self {
+    pub fn vector_icon(
+        mut self,
+        strokes: crate::drawings::IconStrokes,
+        dots: crate::drawings::IconDots,
+    ) -> Self {
         self.strokes = strokes;
+        self.dots = dots;
         self
     }
 
@@ -256,7 +269,7 @@ impl<'a> IconButton<'a> {
             } else {
                 let box_rect =
                     egui::Rect::from_center_size(rect.center(), egui::Vec2::splat(self.size.glyph));
-                paint_icon_strokes(painter, box_rect, self.strokes, paint.glyph);
+                paint_vector_icon(painter, box_rect, self.strokes, self.dots, paint.glyph);
             }
             if self.active
                 && let Some(edge) = self.marker_edge
@@ -288,27 +301,36 @@ impl<'a> IconButton<'a> {
 /// Phosphor regular glyph at the rail's glyph size.
 const ICON_STROKE_WIDTH_PX: f32 = 1.4;
 
+/// Radius of an icon's anchor dot, in pixels at the rail's glyph size. Small
+/// enough to read as a handle on the leg rather than as a sixth level line.
+const ICON_DOT_RADIUS_PX: f32 = 1.5;
+
 /// Paint a vector icon: each polyline's unit-square points scaled into
-/// `rect`. A handful of line segments — cheaper than tesselating a text
-/// glyph, so safe on the per-frame rail.
-pub fn paint_icon_strokes(
+/// `rect`, then the anchor dots over them. A handful of line segments and at
+/// most three tiny circles — cheaper than tesselating a text glyph, so safe
+/// on the per-frame rail.
+pub fn paint_vector_icon(
     painter: &egui::Painter,
     rect: egui::Rect,
     strokes: crate::drawings::IconStrokes,
+    dots: crate::drawings::IconDots,
     color: egui::Color32,
 ) {
+    let at = |(x, y): (f32, f32)| {
+        egui::pos2(
+            rect.left() + x * rect.width(),
+            rect.top() + y * rect.height(),
+        )
+    };
     let stroke = egui::Stroke::new(ICON_STROKE_WIDTH_PX, color);
     for polyline in strokes {
-        let points: Vec<egui::Pos2> = polyline
-            .iter()
-            .map(|(x, y)| {
-                egui::pos2(
-                    rect.left() + x * rect.width(),
-                    rect.top() + y * rect.height(),
-                )
-            })
-            .collect();
+        let points: Vec<egui::Pos2> = polyline.iter().copied().map(at).collect();
         painter.add(egui::Shape::line(points, stroke));
+    }
+    // Over the strokes: the leg passes through its own anchors, and a dot
+    // half-hidden under a level line stops reading as an anchor at all.
+    for &dot in dots {
+        painter.circle_filled(at(dot), ICON_DOT_RADIUS_PX, color);
     }
 }
 


### PR DESCRIPTION
Quatro incômodos das ferramentas de desenho, num passe só — todos reportados do app rodando, e as duas primeiras correções revalidadas em sessão de teste ao vivo com o autor do pedido.

## O que muda

**O ícone do Fibonacci lê como o gesto que ele é.** A escada de níveis com a perna atravessada e as pontas marcadas: duas âncoras na retração, três na extensão — que é o que separa as duas linhas do flyout num relance. Os pontos são a metade nova do port de ícone vetorial (`IconDots`), dado de registro como os traços, e viajam junto com eles por um único setter, então nada pinta meio ícone.

**A retração vive entre as próprias âncoras.** O primeiro passe corrigiu o span abrindo em `Anchors + right` — cobria a perna e ia até a borda direita. Testando ao vivo, ficou claro que não era isso: "a linha deve ir até o ponto onde eu tô traçando e não ir para o infinito." A retração agora abre em `Extend::Anchors`, exatamente entre os dois pontos, como o padrão do TradingView. `extend` continua na aba Levels para quem quiser estender — a opção não sumiu, só deixou de ser o padrão. A extensão continua projetando da última âncora, porque os alvos dela são o que vem *depois* do ponto C.

**"Save as default" passa a lembrar a configuração inteira.** Níveis, cor de cada nível, rótulos, banda, span e estilo — não só a cor do traço, que era tudo o que sobrevivia a um restart. E "Reset to factory" devolve o de fábrica. Objetos já na tela nunca são repintados. Os dois botões aparecem na aba Style (toda ferramenta) e na aba Levels, onde a configuração do Fib é realmente construída.

**A nota de texto recebe o cursor na própria nota.** Antes ela abria o painel de propriedades do outro lado da tela. Agora o campo abre onde as palavras vão ficar, com a barra de contexto ao lado. Duplo clique numa nota reabre o editor — é o caminho de volta para corrigir um erro de digitação.

**A popup de propriedades parou de tremer ao ser arrastada.** Bug relatado ao vivo: "quando eu mexo ela e movo ela para algum lugar ela treme." Cada frame do arrasto somava o deslocamento à posição em que a janela estava *desenhada*, que fica sempre um frame atrás da posição de referência — então cada frame descartava o movimento do anterior e a janela viajava na metade da velocidade da mão. Corrigido: o gesto adota a posição visível uma vez, no início, e acumula os deltas seguintes sobre a posição lembrada.

## Blast radius

Arquivos adicionados: 0. Editados: 12 (`app.rs`, `pane.rs`, `tab.rs`, `widgets.rs`, `toolrail.rs`, `drawings/{mod,fib,fib_retracement,fib_extension,text,presets}.rs`, mais os cinco registros de família que ganharam `icon_dots: &[]`).

Três ports ganharam metades novas, todas com default ou registro explícito: `IconDots` no port de ícone (default `&[]`), `default_config`/`set_default_config`/`has_default_config` no `PresetHost`, e `inline_text`/`set_inline_text`/`holds_text` no port de ferramenta. `DrawContext` ganhou `content_editing`, campo obrigatório como `halo` e `primary_band`.

## Performance

Caminhos tocados, classificados: **por frame** — pintura do Fib (mesma aritmética, só o span muda), pintura da nota, ícones do rail, e a guarda do inspector, que responde sem clonar a configuração salva. **Raro** — store de presets, chrome do inspector, arrasto da popup.

Medido com `APP_HEALTH_SUMMARY`, alternando A/B/A/B sob o mesmo cenário (`QUANTICK_BACKFILL=15000`, `QUANTICK_DRAWINGS_DEMO=1`, 22 objetos):

| corrida | frame_cpu_ms (mediana) | fps | trades/s |
| --- | --- | --- | --- |
| main | 2,747 | 59,1 | 1,31 |
| branch | 2,744 | 59,1 | 1,81 |
| main | 2,658 | 59,0 | 0,84 |
| branch | 2,769 | 59,0 | 3,05 |

Plano: o par melhor pareado empata, e a única corrida da branch acima do controle teve tape 3,6× mais denso.

## Revisão

`arch-review` com step 0 (`code-review` em `high`) sobre os três primeiros commits: 15 achados, 13 corrigidos, 1 deferido (persistência 2–3 gravações por clique do reset/save, caminho raro sobre um arquivo de poucos KB).

Os dois últimos commits (retração entre âncoras, popup sem tremor) vieram de uma sessão de teste ao vivo com quem pediu a feature: os dois bugs foram reproduzidos com o app rodando na tela do usuário, capturados passivamente (sem mover a janela nem tocar no mouse/teclado dele) para diagnosticar, e cada um ganhou um teste de regressão que falha sem a correção e passa com ela — confirmado revertendo a correção e rodando o teste antes de reaplicá-la.

`trader-ux-review` sem Blocker em aberto.

## Validação visual

Cinco superfícies capturadas via `ui-harness` no primeiro passe (fps 58–59). Depois, sessão de teste ao vivo no app real do usuário (não hooks de demo — sua própria configuração), onde surgiram os dois bugs corrigidos nos últimos dois commits, mais uma confusão de UX resolvida sem mudança de código: um preset salvo antes da correção do span (`extend = "Right"` gravado no `Save as default` do usuário) continuava sobrepondo o novo padrão do código — o sistema de "lembrar configuração" funcionando exatamente como desenhado, só que com dado velho. Resolvido limpando a configuração salva do usuário (preservando o preset nomeado) e reiniciando o app.

Hooks novos, registrados na tabela do `ui-harness`: `QUANTICK_TEXT_NOTE=1` e `QUANTICK_DRAWING_INSPECTOR_TAB=<style|extra|coordinates>`.

## Sem mouse

`save_tool_default`, `reset_tool_default`, `has_saved_default`, `begin_inline_text_edit` e `inline_text_editing` são chamadas nomeadas e públicas; as ferramentas já se anunciam em `DRAWING_TOOLS`, e o padrão salvo é dado legível no arquivo de presets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019EHoT4cKvasgzqBFQNiT2s
