### PR TITLE
docs: complete the MCP control plane architecture contract

### DIFF
--- a/docs/control-plane/README.md
+++ b/docs/control-plane/README.md
@@ -1,0 +1,36 @@
+# Control plane architecture contract
+
+This directory contains the decisions required before implementation of the
+Quantick control plane can begin. The development plan describes the intended
+outcome and delivery sequence; the files here make the PR 0 decisions
+testable.
+
+## Documents
+
+- [Capability inventory](capability-inventory.md) records every production
+  `QUANTICK_*` surface currently present in `crates/app/src`, its owner, and
+  its migration target.
+- [Control contract](control-contract.md) fixes identifier, schema, revision,
+  authority, limit, tool-surface, determinism, and trade-annotation rules.
+- [ADR 0001](adr-0001-local-transport-and-instance-discovery.md) selects the
+  local transport and running-instance discovery mechanism.
+- [Observer threat model](observer-threat-model.md) defines the assets, trust
+  boundaries, threats, and required controls for the first profile.
+
+## Precedence
+
+The [development plan](../mcp-control-plane-development-plan.md) owns scope and
+ordering. The contract and ADRs in this directory own implementation details.
+If they disagree, implementation stops until the documents are reconciled in a
+reviewed change. Source code, generated schemas, and tests become authoritative
+only after their corresponding implementation pull request lands.
+
+## Change policy
+
+- Decisions are written in English and reviewed in pull requests.
+- A breaking wire-contract change requires a capability version change and a
+  schema snapshot diff.
+- A transport or trust-boundary change requires a new ADR and an updated
+  threat model.
+- A new action must appear in the capability registry. The inventory in this
+  directory is a migration baseline, not a second runtime registry.

--- a/docs/control-plane/adr-0001-local-transport-and-instance-discovery.md
+++ b/docs/control-plane/adr-0001-local-transport-and-instance-discovery.md
@@ -1,0 +1,294 @@
+# ADR 0001: Local transport and running-instance discovery
+
+**Status:** Accepted
+
+**Date:** 2026-08-19
+
+**Decision owners:** Quantick maintainers
+
+## Context
+
+An agent must inspect the Quantick instance the user already has open. The
+adapter cannot create a second application process and pretend it represents
+the visible session. The gateway must also remain independent of MCP so a CLI
+and later adapters can use the same contract.
+
+The first implementation must work on Windows, Linux, and macOS without
+placing network or serialization work on the render, trade-ingest, or depth
+paths. It must support more than one running instance and fail closed when an
+instance descriptor is stale or ambiguous.
+
+## Decision
+
+### 1. Process topology
+
+The running Quantick application hosts a local control gateway. A separate
+`quantick-mcp` process is launched by Codex, Claude Code, or another MCP client
+over STDIO. The adapter discovers the application gateway, authenticates, and
+translates MCP calls into the vendor-neutral Quantick control protocol.
+
+```text
+MCP client
+    |
+    | MCP over STDIO
+    v
+quantick-mcp
+    |
+    | authenticated Quantick control protocol
+    v
+gateway in the already-running Quantick app
+```
+
+Neither `quantick-mcp` nor the gateway may start Quantick. With no running
+instance, discovery returns an empty list and a next step telling the user to
+start the application.
+
+### 2. Gateway transport
+
+The first gateway transport is TCP bound to the literal IPv4 loopback address
+`127.0.0.1` on an operating-system-assigned port. It never binds to `0.0.0.0`,
+a LAN interface, a hostname, or IPv6 wildcard. Remote access is out of scope.
+
+The wire format is length-prefixed UTF-8 JSON:
+
+```text
+4-byte unsigned big-endian payload length
+exactly that many UTF-8 JSON bytes
+```
+
+The receiver validates the length against
+`CONTROL_PROTOCOL_MAX_FRAME_BYTES` before allocating or parsing the payload.
+Requests and responses carry IDs, so one connection may multiplex bounded
+in-flight work. The first frame must be a handshake. Any other first frame
+closes the connection without executing a capability.
+
+The handshake contains:
+
+```text
+protocol_min
+protocol_max
+instance_id
+bearer_token
+client_name
+client_version
+requested_profile
+requested_scopes
+```
+
+An accepted response contains:
+
+```text
+protocol_version
+instance_id
+process_nonce
+connection_id
+application_version
+application_commit
+effective_profile
+effective_scopes
+effective_limits
+```
+
+The response chooses the highest mutually supported protocol version. The app
+intersects the requested profile and scopes with the configured connection
+ceiling and the user's current grant. It never echoes the bearer token. Token
+comparison is constant-time, and an authentication failure returns only a safe
+code before closing the connection. Authentication and profile selection finish
+before the client can list or invoke capabilities.
+
+### 3. Instance identity and token
+
+Each application process creates at startup:
+
+- a cryptographically random 128-bit `instance_id`;
+- a cryptographically random 128-bit `process_nonce`;
+- a cryptographically random 256-bit bearer token.
+
+The token is encoded with unpadded base64url. It is valid only for that
+process, is rotated when local access is re-enabled, and is destroyed when
+access is disabled or the application exits. It is never accepted from a URL,
+command-line argument, log field, or MCP configuration file.
+
+### 4. Descriptor directory
+
+When the user enables local observer access, the app publishes one descriptor
+named `<instance_id>.json` in the current user's private Quantick runtime
+directory:
+
+| Platform | Directory |
+| --- | --- |
+| Windows | `%LOCALAPPDATA%\Quantick\control\instances` |
+| Linux | `$XDG_RUNTIME_DIR/quantick/control/instances` |
+| macOS | `~/Library/Application Support/Quantick/control/instances` |
+
+On Linux, gateway startup fails closed when `XDG_RUNTIME_DIR` is unavailable or
+not owned by the current user. A persistent or world-shared temporary directory
+is not a fallback for a bearer token.
+
+The directory and descriptor must be accessible only to the current user:
+
+- Unix creates the directory with mode `0700` and the file with mode `0600`.
+- Windows creates them under the user's Local AppData and verifies that the
+  effective ACL does not grant read access to broad principals such as
+  `Everyone` or `Users`.
+
+The descriptor is written to a new file, flushed, and atomically renamed after
+the socket is listening. Symlinks and reparse-point redirection are rejected.
+Its maximum encoded size is `CONTROL_DESCRIPTOR_MAX_BYTES`.
+
+The descriptor contains only:
+
+```text
+descriptor_version
+instance_id
+process_nonce
+process_id
+process_started_at_unix_ms
+application_version
+application_commit
+protocol_min
+protocol_max
+transport
+host
+port
+bearer_token
+published_at_unix_ms
+```
+
+For descriptor version 1, `transport` is exactly `tcp`, `host` is exactly
+`127.0.0.1`, and `port` is an integer from 1 through 65,535. The endpoint is not
+a URL or free-form command string.
+
+No workspace content, feed credential, account identifier, symbol, position,
+filesystem path outside the descriptor directory, or client permission is
+published there.
+
+### 5. Discovery and stale descriptors
+
+The adapter reads only regular `.json` files owned by the current user and
+smaller than `CONTROL_DESCRIPTOR_MAX_BYTES`. It validates every field before
+using an endpoint.
+
+For each candidate it:
+
+1. connects to the advertised loopback endpoint within the handshake timeout;
+2. authenticates with the descriptor token;
+3. verifies that the returned `instance_id` and `process_nonce` match;
+4. records the live instance and closes candidates that fail validation.
+
+The app removes its descriptor on clean disable and shutdown. A client may
+remove a stale descriptor only when it owns the file and can prove the process
+identity no longer exists or no longer matches its recorded start time. A
+connection failure alone is not permission to delete the file of a slow or
+suspended process.
+
+Live instances are returned in deterministic
+`(published_at_unix_ms, instance_id)` order. One live instance may be selected
+automatically. More than one returns
+`control.instance_ambiguous` until the user or client chooses an `instance_id`.
+The adapter never silently selects the newest window.
+
+### 6. Request execution
+
+Socket I/O, authentication, JSON parsing, serialization, compression, parked
+waiters, and client rate limiting run away from the UI thread. The gateway
+places only structurally validated, statically authorized, bounded envelopes in
+the UI request queue. The UI-thread dispatcher rechecks dynamic availability,
+current permission generation, preconditions, and expected revisions
+immediately before invoking a handler; queue time never turns an old check into
+authority.
+
+The UI thread drains work up to `CONTROL_UI_BUDGET_US` for one frame. It
+produces owned DTOs and never waits for a client. Full queues return
+`control.backpressure`. `wait_for_change` registers its cursor outside the UI
+queue and enters the queue only when it has a bounded event page to read.
+
+### 7. MCP transport
+
+STDIO is the required first transport for `quantick-mcp`. The client owns the
+adapter process lifecycle; the adapter owns no application lifecycle. MCP
+server instructions put the connection rule, read-before-act rule, instance
+selection rule, and authority boundary in their first 512 characters.
+
+Streamable HTTP for MCP may be added later. It does not replace or expose the
+in-app gateway, and it requires its own authentication review.
+
+## Why loopback TCP first
+
+Loopback TCP gives one implementation on all three target operating systems,
+supports concurrent local clients, and lets an independent CLI prove the port.
+The bearer token and private descriptor directory provide the authorization
+boundary that a port number does not.
+
+Named pipes and Unix domain sockets offer useful operating-system identity and
+ACL properties, but require two transports and platform-specific lifecycle
+code before the contract is proven. They remain a compatible future gateway
+transport because the contract and framing do not depend on TCP.
+
+## Alternatives considered
+
+### Embed MCP in the application
+
+Rejected. It couples the app to one client protocol, puts MCP lifecycle inside
+the UI process, and prevents a CLI from proving the control port.
+
+### Start a new Quantick process from the adapter
+
+Rejected. The user wants the already-open session. A new process has different
+state and creates a ghost platform the user is not looking at.
+
+### Use STDIO directly between the client and the app
+
+Rejected. STDIO belongs to a child process and cannot attach to an arbitrary
+running desktop process. It remains correct between the MCP client and
+`quantick-mcp`.
+
+### Expose HTTP directly from the app
+
+Rejected for the first release. It increases parsing and routing surface,
+encourages remote use before authentication exists, and conflates the control
+contract with a public API. A later HTTP adapter can use the same gateway.
+
+### Use named pipes on Windows and Unix domain sockets elsewhere
+
+Deferred. This may replace or supplement loopback TCP after the contract is
+proven and the threat model has platform-specific tests.
+
+### Inject mouse and keyboard input
+
+Rejected. Coordinates are not stable capabilities, do not provide structured
+results, cannot explain availability, and make evidence depend on pixels.
+
+## Consequences
+
+- The app gains a small cold-path gateway host but no MCP dependency.
+- `quantick-mcp` remains a leaf adapter and may restart independently.
+- A private descriptor contains a bearer secret, so permissions and stale-file
+  handling are security-critical and require platform tests.
+- Loopback traffic is plaintext. This is acceptable only under the local-user
+  threat boundary and must not be extended to non-loopback interfaces.
+- More than one open instance requires an explicit choice.
+- A future CLI can connect with the same descriptor, handshake, and framing.
+
+## Required tests
+
+PR 3 must cover:
+
+- bind only to `127.0.0.1`;
+- descriptor owner, permissions, maximum size, atomic publication, and clean
+  removal on each supported platform;
+- wrong token, wrong instance ID, wrong nonce, and non-overlapping versions;
+- stale descriptor, PID reuse, suspended process, and abrupt app exit;
+- zero, one, and multiple live instances;
+- oversized and truncated frames before JSON parsing;
+- full queues, request timeout, rate limit, and connection limit;
+- concurrent parked wait and ordinary read;
+- shutdown with connected and half-open clients;
+- proof that the adapter cannot start the application.
+
+## References
+
+- [Quantick control contract](control-contract.md)
+- [Observer threat model](observer-threat-model.md)
+- [OpenAI MCP documentation](https://developers.openai.com/codex/mcp)
+- [Claude Code MCP documentation](https://code.claude.com/docs/en/mcp)

--- a/docs/control-plane/capability-inventory.md
+++ b/docs/control-plane/capability-inventory.md
@@ -1,0 +1,259 @@
+# Control plane capability inventory
+
+**Status:** PR 0 migration baseline
+
+**Measured at commit:** `fcd2ac400ed5e6362595246120b93dfb08fdc7ab`
+
+**Date:** 2026-08-19
+
+This inventory starts from the control surfaces that already exist instead of
+guessing what Quantick can do. It is not the future runtime registry and must
+not become a hand-maintained second copy of one.
+
+## 1. Measurement
+
+`crates/app/src` contains 88 distinct `QUANTICK_*` string literals:
+
+- 86 production startup, configuration, validation, or action surfaces;
+- 2 test-only store variables.
+
+The earlier development-plan draft said 89. A source scan found 88, and the
+two test-only names explain why even that number is not a count of production
+capabilities. The corrected numbers are used below.
+
+The baseline can be reproduced with a literal scan over Rust source followed
+by unique sorting. Comments are not used to invent additional names; every
+inventory row has a quoted string literal in `crates/app/src`.
+
+## 2. Migration labels
+
+| Label | Meaning |
+| --- | --- |
+| `retain` | Startup or path override remains; effective state becomes readable |
+| `route` | Existing hook and UI must call one registered runtime handler |
+| `fixture` | Deterministic demo remains for tests but is composed from registered primitives |
+| `replace` | Structured snapshots or actions supersede the hook after harness migration |
+| `test-only` | Excluded from the public capability registry |
+
+Candidate IDs below follow the [control contract](control-contract.md). They
+name the intended owner and prevent two modules from implementing the same
+operation. PRs may refine an ID before it is released, but must update this
+inventory and the reviewed schema together.
+
+## 3. Bootstrap, configuration, and stores (22)
+
+Primary owners: `config.rs`, `main.rs`, store modules, feed configuration, and
+preset modules.
+
+| Existing surface | Current purpose | Candidate registry target | Remote effect | Migration |
+| --- | --- | --- | --- | --- |
+| `QUANTICK_CONFIG` | Select the startup feed configuration file | `system.config` snapshot scope | n/a | `retain` |
+| `QUANTICK_DEFAULT_FEED` | Override the initial feed | `workspace.market.select` | `cockpit` | `route` |
+| `QUANTICK_DEFAULT_SYMBOL` | Override the initial symbol | `workspace.market.select` | `cockpit` | `route` |
+| `QUANTICK_WINDOW_SIZE` | Set the opening window dimensions | `window.size.set` | `cockpit` | `route` |
+| `QUANTICK_LOG_FORMAT` | Select human or JSON startup logging | `system.logging` snapshot scope | n/a | `retain` |
+| `QUANTICK_BACKFILL` | Configure initial history depth | `feed.history.policy` snapshot scope | n/a | `retain` |
+| `QUANTICK_BOOK_DEPTH` | Configure Binance depth subscription size | `feed.orderbook.policy` snapshot scope | n/a | `retain` |
+| `QUANTICK_UI_STATE` | Relocate the persisted workspace state | `workspace.store` snapshot scope | n/a | `retain` |
+| `QUANTICK_REPLAY_DIR` | Select a replay folder for this run | `replay.library.folder.select` | `cockpit` | `route` |
+| `QUANTICK_TRADES_DIR` | Select the paper journal folder | `paper.journal.folder.select` | `cockpit` | `route` |
+| `QUANTICK_PAPER_STATE` | Relocate the paper settings sidecar | `paper.store` snapshot scope | n/a | `retain` |
+| `QUANTICK_INDICATORS_DIR` | Relocate the Pine script library | `indicator.library` snapshot scope | n/a | `retain` |
+| `QUANTICK_INDICATORS_STATE` | Relocate persisted active indicators | `indicator.store` snapshot scope | n/a | `retain` |
+| `QUANTICK_INDICATOR_PRESETS` | Relocate indicator presets | `indicator.preset_store` snapshot scope | n/a | `retain` |
+| `QUANTICK_DRAWING_PRESETS` | Relocate drawing presets | `drawing.preset_store` snapshot scope | n/a | `retain` |
+| `QUANTICK_FOOTPRINT` | Override the tracked footprint configuration | `orderflow.footprint.config` snapshot scope | n/a | `retain` |
+| `QUANTICK_FOOTPRINT_SETTINGS` | Relocate persisted footprint edits | `orderflow.footprint.store` snapshot scope | n/a | `retain` |
+| `QUANTICK_FOOTPRINT_PRESETS` | Relocate footprint presets | `orderflow.footprint.preset_store` snapshot scope | n/a | `retain` |
+| `QUANTICK_BUBBLES` | Override the bubble preset file | `orderflow.bubbles.config` snapshot scope | n/a | `retain` |
+| `QUANTICK_CHART_LAYERS` | Relocate persisted chart-layer visibility | `chart.layer_store` snapshot scope | n/a | `retain` |
+| `QUANTICK_STRATEGY_PRESETS` | Relocate the strategy preset bank | `strategy.preset_store` snapshot scope | n/a | `retain` |
+| `QUANTICK_SYMBOLS` | Relocate the user-added symbol catalog | `feed.symbol_store` snapshot scope | n/a | `retain` |
+
+Paths in these scopes are redacted by default. Retaining an environment
+override does not make arbitrary environment reads a capability.
+
+## 4. Workspace, chrome, and navigation (11)
+
+Primary owner: `app.rs`, with state persisted through `ui_state.rs` and
+`workspace_bundle.rs`.
+
+| Existing surface | Current purpose | Candidate registry target | Remote effect | Migration |
+| --- | --- | --- | --- | --- |
+| `QUANTICK_DOCK_TAB` | Activate a dock tab | `workspace.dock_tab.activate` | `cockpit` | `route` |
+| `QUANTICK_MENU` | Open the Workspace menu for validation | `ui.menu.open` | `cockpit` | `replace` |
+| `QUANTICK_LAYOUT` | Select flow, time, or split layout | `workspace.layout.set` | `cockpit` | `route` |
+| `QUANTICK_STYLE_PANEL` | Open chart appearance settings | `ui.dialog.open` with `chart.appearance` | `cockpit` | `replace` |
+| `QUANTICK_TOOL_FAVORITES` | Set drawing-tool favorites | `drawing.tool_favorites.set` | `cockpit` | `route` |
+| `QUANTICK_TOOLBOX_DOCK` | Move the drawing rail | `drawing.tool_rail.dock` | `cockpit` | `route` |
+| `QUANTICK_TOOLBAR_SCROLL` | Move the drawing-tool band | `drawing.tool_rail.scroll` | `cockpit` | `route` |
+| `QUANTICK_TOOLBOX_FLYOUT` | Open one tool family | `drawing.tool_family.open` | `cockpit` | `replace` |
+| `QUANTICK_WORKSPACE_SAVE` | Save the current workspace | `workspace.save` | `cockpit` | `route` |
+| `QUANTICK_WORKSPACE_EXPORT` | Export a workspace bundle to a supplied path | `workspace.export` | `cockpit` | `route` |
+| `QUANTICK_WORKSPACE_IMPORT` | Replace the cockpit from a bundle | `workspace.import` | `cockpit` | `route` |
+
+Import and export also declare `filesystem_read` or `filesystem_write` risk and
+are not part of the observer profile.
+
+## 5. Chart, viewport, and history (8)
+
+Primary owners: `app.rs`, `tab.rs`, `pane.rs`, `viewport.rs`, and feed history
+services.
+
+| Existing surface | Current purpose | Candidate registry target | Remote effect | Migration |
+| --- | --- | --- | --- | --- |
+| `QUANTICK_CANDLE_WIDTH` | Set pixels per bar through the zoom path | `chart.viewport.bar_width.set` | `cockpit` | `route` |
+| `QUANTICK_PAN_PX` | Pan through the same gesture path as the chart | `chart.viewport.pan` | `cockpit` | `route` |
+| `QUANTICK_INVERTED` | Invert the price axis on chart panes | `chart.price_axis.inverted.set` | `cockpit` | `route` |
+| `QUANTICK_LIVE_STRIP_AUTOSTART` | Enable the live order-flow strip | `chart.layer.visibility.set` | `cockpit` | `route` |
+| `QUANTICK_LOAD_OLDER` | Request older feed history by page | `feed.history.load_older` | `cockpit` | `route` |
+| `QUANTICK_PROGRESSIVE_HISTORY` | Set progressive history delivery | `feed.history.progressive.set` | `cockpit` | `route` |
+| `QUANTICK_VENUE_HISTORY_DEMO` | Inject deterministic complete or partial venue history | `feed.history.fixture.publish` | n/a | `fixture` |
+| `QUANTICK_CONTEXT_MENU` | Open chart, tape, or axis context menus | `ui.context_menu.open` | `cockpit` | `replace` |
+
+The observer equivalents are `chart.window.read`, viewport fields in the chart
+snapshot, feed capability state, and the semantic scene. Read operations never
+call the setters above.
+
+## 6. Order flow and L2 (8)
+
+Primary owners: `app.rs`, `footprint_config.rs`, `footprint_render.rs`,
+`orderflow`, and the chart-layer registry.
+
+| Existing surface | Current purpose | Candidate registry target | Remote effect | Migration |
+| --- | --- | --- | --- | --- |
+| `QUANTICK_BOOK_AUTOSTART` | Enable the chart heatmap | `chart.layer.visibility.set` | `cockpit` | `route` |
+| `QUANTICK_BUBBLES_AUTOSTART` | Enable aggression bubbles and live flow | `chart.layer.visibility.set` | `cockpit` | `route` |
+| `QUANTICK_FOOTPRINT_AUTOSTART` | Enable candle footprints | `chart.layer.visibility.set` | `cockpit` | `route` |
+| `QUANTICK_FOOTPRINT_DEBUG` | Append footprint decision inputs to the legend | `orderflow.footprint.diagnostics` snapshot scope | `observe` | `replace` |
+| `QUANTICK_FOOTPRINT_PANEL` | Open footprint settings | `ui.dialog.open` with `orderflow.footprint` | `cockpit` | `replace` |
+| `QUANTICK_TAPE` | Show or hide the tape pane | `orderflow.tape.visibility.set` | `cockpit` | `route` |
+| `QUANTICK_TAPE_LAYERS` | Set tape heatmap and bubble visibility | `orderflow.tape.layers.set` | `cockpit` | `route` |
+| `QUANTICK_TAPE_WINDOW` | Set the tape's visible market-time window | `orderflow.tape.window.set` | `cockpit` | `route` |
+
+## 7. Indicators and analytical drawings (7)
+
+Primary owners: `app.rs`, `app::indicators`, `IndicatorHost`, and drawing tools
+that compute AVWAP or fixed-range volume profiles.
+
+| Existing surface | Current purpose | Candidate registry target | Remote effect | Migration |
+| --- | --- | --- | --- | --- |
+| `QUANTICK_INDICATORS_AUTOSTART` | Attach deterministic built-in indicators | `indicator.attach` | `annotate` | `route` |
+| `QUANTICK_INDICATOR_SCRIPTS_AUTOSTART` | Attach named Pine library scripts | `indicator.script.attach` | `annotate` | `route` |
+| `QUANTICK_INDICATOR_SETTINGS` | Open an indicator inputs or style dialog | `ui.dialog.open` with `indicator.settings` | `cockpit` | `replace` |
+| `QUANTICK_LEGEND_COLLAPSED` | Collapse the focused pane legend | `indicator.legend.collapsed.set` | `cockpit` | `route` |
+| `QUANTICK_AVWAP_DEMO` | Place a deterministic anchored VWAP | `drawing.create` with `anchored-vwap` | n/a | `fixture` |
+| `QUANTICK_FRVP_DEMO` | Place deterministic fixed-range volume profiles | `drawing.create` with `fixed-range-volume-profile` | n/a | `fixture` |
+| `QUANTICK_FRVP_DEMO_SELECT` | Select the fixed-range profile fixture | `drawing.selection.set` | n/a | `fixture` |
+
+`indicator.script.compile` returns Pine diagnostics without attaching anything
+and has `observe` effect. `indicator.script.attach` is additive, reversible,
+and belongs to `annotate`.
+
+## 8. Drawings and attention surfaces (14)
+
+Primary owners: `app.rs`, `drawings`, `toolrail`, and `pane`.
+
+| Existing surface | Current purpose | Candidate registry target | Remote effect | Migration |
+| --- | --- | --- | --- | --- |
+| `QUANTICK_DRAWING_TOOL` | Arm a registered drawing tool | `drawing.tool.arm` | `cockpit` | `route` |
+| `QUANTICK_DRAWING_MAGNET` | Enable OHLC snapping | `drawing.magnet.set` | `cockpit` | `route` |
+| `QUANTICK_DRAWING_DRAFT` | Stage a partially placed drawing | `drawing.draft.begin` | n/a | `fixture` |
+| `QUANTICK_DRAWING_CONSTRAIN` | Hold the draft's constraint modifier | `drawing.draft.constraint.set` | n/a | `fixture` |
+| `QUANTICK_DRAWINGS_DEMO` | Place one fixture for every registered tool | `drawing.fixture.populate` | n/a | `fixture` |
+| `QUANTICK_DRAWINGS_DEMO_SHARED` | Make demo drawings visible across charts | `drawing.visibility_scope.set` | n/a | `fixture` |
+| `QUANTICK_DRAWINGS_DEMO_RECUT` | Re-cut bars under drawing fixtures | `chart.bar_spec.set` plus fixture data | n/a | `fixture` |
+| `QUANTICK_DRAWINGS_DEMO_SELECT` | Select and center a fixture by tool ID | `drawing.selection.set` | n/a | `fixture` |
+| `QUANTICK_DRAWINGS_MANAGER` | Open the object manager | `ui.dialog.open` with `drawing.manager` | `cockpit` | `replace` |
+| `QUANTICK_DRAWING_INSPECTOR` | Open the selected drawing's properties | `ui.dialog.open` with `drawing.inspector` | `cockpit` | `replace` |
+| `QUANTICK_DRAWING_INSPECTOR_TAB` | Select an inspector tab | `drawing.inspector.tab.set` | `cockpit` | `replace` |
+| `QUANTICK_DRAWING_INSPECTOR_POS` | Park the inspector window | `drawing.inspector.position.set` | `cockpit` | `route` |
+| `QUANTICK_CONTEXT_BAR_POS` | Park the selected object's context bar | `drawing.context_bar.position.set` | `cockpit` | `route` |
+| `QUANTICK_TEXT_NOTE` | Place a text drawing and enter inline edit | `drawing.create` with `text` | `annotate` | `route` |
+
+The new attention capabilities do not come from existing hooks:
+`attention.cursor`, `attention.selection`, and human-created mark events are
+read scopes. Remote `attention.mark.create` is a separate annotate action.
+
+## 9. Replay (5)
+
+Primary owners: `app.rs`, `replay_view.rs`, and the replay feed adapter.
+
+| Existing surface | Current purpose | Candidate registry target | Remote effect | Migration |
+| --- | --- | --- | --- | --- |
+| `QUANTICK_REPLAY_AUTOSTART` | Start the selected recorded session | `replay.start` | `cockpit` | `route` |
+| `QUANTICK_REPLAY_SPEED` | Set playback speed at startup | `replay.speed.set` | `cockpit` | `route` |
+| `QUANTICK_REPLAY_BROWSER` | Open the replay browser | `ui.dialog.open` with `replay.browser` | `cockpit` | `replace` |
+| `QUANTICK_REPLAY_GET_DATA` | Open and seed the Get data flow | `replay.data_request.open` | `cockpit` | `route` |
+| `QUANTICK_REPLAY_RESTART_AFTER` | Restart after a deterministic trade count | `replay.restart` | n/a | `fixture` |
+
+Non-observe agent actions during replay follow the durable control-trace rule in
+the [control contract](control-contract.md#11-replay-determinism-decision).
+
+## 10. Paper trading, reports, and strategies (11)
+
+Primary owners: `paper_trading.rs`, `app.rs`, `sim`, and `strategy`.
+
+| Existing surface | Current purpose | Candidate registry target | Remote effect | Migration |
+| --- | --- | --- | --- | --- |
+| `QUANTICK_PAPER_DEMO` | Run deterministic simulated trades | `paper.fixture.run` | n/a | `fixture` |
+| `QUANTICK_CMD_PREVIEW` | Paint a buy or sell command preview without placing | `paper.command.preview` | `annotate` | `route` |
+| `QUANTICK_PAPER_ORDER_HOVER` | Force resting-order tags into hover detail | `paper.order.scene` snapshot scope | n/a | `fixture` |
+| `QUANTICK_PAPER_ORDERS` | Rest deterministic orders around the mark | `paper.order.place` | `paper` | `fixture` |
+| `QUANTICK_PAPER_REPORT_AUTOSTART` | Open simulated performance | `ui.dialog.open` with `paper.performance` | `cockpit` | `replace` |
+| `QUANTICK_PAPER_CALENDAR` | Open and select report calendar periods | `paper.report.period.set` | `cockpit` | `route` |
+| `QUANTICK_PAPER_REPORT_LIST` | Collapse or expand the report trade list | `paper.report.trade_list.set` | `cockpit` | `route` |
+| `QUANTICK_LEDGER_SCOPE` | Select chart, all, or one symbol in the ledger | `paper.ledger.scope.set` | `cockpit` | `route` |
+| `QUANTICK_LEDGER_PAGES` | Reveal older ledger pages | `paper.ledger.load_older` | `cockpit` | `route` |
+| `QUANTICK_LEDGER_FOLD` | Fold every civil day in the ledger | `paper.ledger.days.collapse` | `cockpit` | `route` |
+| `QUANTICK_STRATEGY_DEMO` | Place a region and stage or arm a strategy | `strategy.arm` | `paper` | `fixture` |
+
+Fixtures that place orders or arm strategies are never exposed to an observer.
+They must reuse the same simulator and registry handlers as the corresponding
+human and future agent actions.
+
+## 11. Test-only variables (2)
+
+| Existing surface | Source | Disposition |
+| --- | --- | --- |
+| `QUANTICK_FAKE_STORE` | `workspace_bundle.rs` test fixture | `test-only`; never register |
+| `QUANTICK_TEST_STORE_HOME_ENV` | `store_home.rs` test fixture | `test-only`; never register |
+
+## 12. Capabilities missing from the current hooks
+
+The environment surfaces are mostly startup writes. They do not cover the
+observation side of the control plane. The initial registry must add at least:
+
+- system, build, instance, and effective-permission snapshots;
+- workspace, feed, chart, indicator, drawing, order-flow, replay, paper, and
+  health snapshots;
+- visible chart-window pagination;
+- semantic scene and stable control IDs;
+- cursor, selection, and human mark observation;
+- cursor-based semantic events and parked waits;
+- evidence capture and chunked resources;
+- capability search, availability, and structured errors;
+- compile-only Pine diagnostics;
+- connection and revocation state.
+
+## 13. Migration rule
+
+An existing production hook is not removed merely because a capability exists.
+Migration is complete only when:
+
+1. the UI and hook call the same named handler;
+2. the handler has a registry descriptor and structured result;
+3. the resulting state is readable through a snapshot or event;
+4. actor and authority rules are enforced;
+5. existing deterministic harness coverage passes through the handler;
+6. at least one harness scenario uses the live control plane;
+7. removal no longer reduces startup-only coverage.
+
+The inventory is retired when the runtime registry can generate an equivalent
+report and every retained hook is explicitly marked startup-only.
+
+## References
+
+- [UI harness catalog](../../.claude/skills/ui-harness/SKILL.md)
+- [Development plan](../mcp-control-plane-development-plan.md)
+- [Control contract](control-contract.md)

--- a/docs/control-plane/control-contract.md
+++ b/docs/control-plane/control-contract.md
@@ -1,0 +1,760 @@
+# Quantick control contract
+
+**Status:** Accepted for implementation
+
+**Date:** 2026-08-19
+
+This document fixes the contract decisions required by PR 0. It applies to
+`quantick-control`, the in-app gateway, MCP, and every later adapter.
+
+## 1. Scope
+
+The control contract describes a running Quantick instance without exposing
+`QuantickApp`, egui types, or domain internals. It defines:
+
+- stable identifiers and schemas;
+- request, response, error, revision, and actor semantics;
+- effect tiers and profile mapping;
+- the fixed MCP surface and the dynamic capability registry;
+- protocol, queue, pagination, timeout, and retention limits;
+- replay determinism for agent actions;
+- ownership of durable trade annotations;
+- local setup flows for Codex and Claude Code.
+
+MCP is one adapter. No rule in this document may require domain code to know
+that a request came from MCP.
+
+## 2. Identifiers and versions
+
+### 2.1 Identifier shape
+
+Capability IDs, module IDs, snapshot scope IDs, event kinds, permission IDs,
+effect IDs, profile IDs, risk-flag IDs, and error codes are validated strings
+stored in newtypes. They are not closed Rust enums.
+
+Every ID must match:
+
+```text
+^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)*$
+```
+
+Capability IDs, snapshot scope IDs, event kinds, and error codes are
+namespaced and therefore must contain at least one dot. Module, effect,
+profile, permission, and risk-flag IDs may be one segment or namespaced. This
+allows the initial `observe` effect and a future extension such as
+`filesystem.write` without converting extensible IDs into closed enums.
+Every ID also fits `CONTROL_ID_MAX_BYTES` and
+`CONTROL_ID_MAX_SEGMENTS`; validation occurs before registry lookup.
+
+Runtime identity values are a different type from registry IDs. Server-created
+instance, process nonce, connection, principal, evidence, and resource IDs use
+128 random bits encoded as unpadded base64url. A client-created `request_id` is
+1 through `CONTROL_REQUEST_ID_MAX_BYTES` printable ASCII bytes and is opaque to
+the server. None of these values is accepted where a registry ID is required.
+
+The first segment is the owning module. Later segments move from the resource
+to the operation or event:
+
+```text
+chart.snapshot
+chart.window.read
+chart.viewport.pan
+attention.cursor
+attention.mark.create
+indicator.script.attach
+paper.order.place
+control.auth_failed
+```
+
+An ID is permanent after release. A display label may change; an ID may not.
+Aliases are explicit registry entries with a deprecation marker and removal
+version, never silent rewrites.
+
+### 2.2 Versions
+
+Each capability has a positive `u32` version. The protocol has a supported
+inclusive version range. A handshake selects the highest mutually supported
+protocol version; failure to overlap returns `control.version_unsupported`.
+
+Capability and protocol versions are independent. Adding a capability does not
+bump the protocol. A breaking change to one capability bumps only that
+capability unless the envelope itself changed.
+
+## 3. Envelopes and wire values
+
+Every external request envelope carries:
+
+```text
+protocol_version
+request_id
+instance_id
+capability_id
+capability_version
+expected_revisions?
+idempotency_key?
+dry_run?
+reason?
+payload
+```
+
+After authentication and authorization, the gateway creates an internal
+authorized request by attaching the trusted actor context from section 6. That
+internal type, rather than the external DTO, is accepted by the registry
+executor.
+
+Every capability response carries:
+
+```text
+protocol_version
+request_id
+instance_id
+capture_revision?
+module_revisions
+result | error
+warnings
+```
+
+`capture_revision` is required for a coherent captured read and absent when no
+capture occurred. An action response includes the module revisions after the
+attempt. Handshake frames use their own schema and do not invent application
+revisions.
+
+Wire DTOs follow these rules:
+
+- Decimal values are canonical decimal strings matching
+  `^-?(0|[1-9][0-9]*)(\.[0-9]*[1-9])?$`; negative zero, leading plus signs,
+  exponents, leading integer zeros, and trailing fractional zeros are invalid.
+  A meaningful display scale travels in a separate field.
+- JSON numbers are integers. Non-integral values use canonical decimal strings.
+- Revisions, event sequences, and other full-range `u64` ordering tokens are
+  unsigned decimal strings on the wire, even though their Rust representation
+  is `u64`.
+- Absolute wall-clock fields include epoch and unit, normally `_at_unix_ms` or
+  `_time_unix_ms`; monotonic durations include `_elapsed_ms` or `_elapsed_us`.
+- Byte counts include `_bytes`; capacities include `_items` or `_entries`.
+- Optional, unavailable, inferred, and incomplete values remain distinct.
+- Collections whose order can reach a client have deterministic ordering.
+- Unknown additive fields are ignored by tolerant readers.
+- Private rendering types and filesystem paths never cross the wire by
+  accident.
+
+Canonical input, query, result, audit, and manifest digests use Quantick
+Canonical JSON version 1. It recursively sorts object keys by UTF-8 byte order,
+preserves array order, emits integers in minimal base-10 form, emits only
+required JSON string escapes, preserves exact UTF-8 without Unicode
+normalization, and forbids floating-point JSON numbers. The digest form is
+`sha256:<64 lowercase hexadecimal characters>`. Binary resource chunks are
+hashed as raw bytes; their ordered hashes are included in the canonical
+manifest. Golden cross-language vectors are part of the committed schemas, and
+changing these rules is a protocol break.
+
+## 4. Schema compatibility
+
+Every public input, result, event, error detail, and resource manifest has a
+JSON Schema committed under `schemas/control/` when its implementation lands.
+Tests generate the schema and compare it with the committed file.
+
+The compatibility rule is:
+
+- Adding an optional field, capability, scope, or event kind is additive.
+- Removing or renaming a field, making an optional field required, changing a
+  unit, narrowing a valid range, or changing the meaning of a value is
+  breaking.
+- A breaking capability change increments that capability's version and keeps
+  the previous version available for at least one minor release.
+- A protocol-envelope breaking change increments the protocol version.
+
+Examples included in capability descriptors are validated against the same
+schemas. Duplicate IDs, invalid descriptors, invalid examples, and undeclared
+permissions fail tests.
+
+## 5. Revisions and concurrency
+
+Each running instance owns a fresh random `instance_id`. Revisions are
+monotonic `u64` counters scoped to that instance:
+
+- each observable module has a revision;
+- a snapshot has one `capture_revision` assigned during its UI-thread capture;
+- the snapshot includes every module revision observed in that capture;
+- an event records the revision after the change it describes.
+
+Revisions are ordering tokens, not time. They reset when the application
+restarts and are meaningful only with their `instance_id`.
+
+A capability that can overwrite, remove, reorder, or financially affect state
+requires the relevant `expected_revisions`. A mismatch returns
+`control.revision_conflict` with the current revisions and changes nothing.
+Additive actions may omit an expected revision only when the descriptor states
+why stale input cannot damage existing state.
+
+Captures occur in one bounded UI-thread pass. Serialization and compression
+run after that pass on owned DTOs. A response must never mix module values from
+different UI-thread captures while claiming one capture revision.
+
+### 5.1 Event cursors
+
+An event cursor is a wire object, not an index into a current allocation:
+
+```text
+instance_id
+next_sequence
+```
+
+`next_sequence` is the next monotonic `u64` journal sequence the client expects
+to read. A first read omits the cursor and explicitly selects `oldest` or
+`latest`; there is no implicit start position. A response returns events in
+sequence order and a `next_cursor` one past the last returned event, or the
+input or resolved starting cursor when the page is empty.
+
+If retention has advanced past the requested sequence, the read begins at the
+oldest retained event and returns that position in `dropped_before`. A cursor
+from another instance, a sequence ahead of the journal tail, or an invalid
+start/cursor combination returns `control.cursor_invalid`. Cursors contain no
+pointer, token, secret, timestamp, or client-owned mutable state.
+
+### 5.2 Retries and dry runs
+
+`request_id` correlates one attempt and is never a retry key. A capability
+descriptor declares idempotency as `forbidden`, `optional`, or `required`, and
+separately declares whether it supports `dry_run`. Financial actions and any
+other non-idempotent action that is safe to retry require an idempotency key.
+A connection rejects duplicate request IDs while the first request is in
+flight.
+
+The gateway scopes an idempotency record by `instance_id`, trusted
+`principal_id`, capability ID and version, and the opaque key. It records the
+canonical digest of `expected_revisions` and `payload` before the handler can
+mutate state. Request ID, key, reason, and actor metadata are excluded; the
+trusted principal is already part of the store key. A retry with the same
+digest returns the original terminal result. Reusing the key with a different
+digest returns `control.idempotency_conflict`; retrying while the first attempt
+is still executing returns retryable `control.request_in_progress`. Raw keys
+are never logged.
+
+Records remain for the configured retention period or the life of the instance,
+whichever ends first. The store does not evict an unexpired record to accept a
+new request whose descriptor requires idempotency; it returns backpressure at
+capacity. Such capabilities return compact results that fit the record limit.
+They may reference a durable resource only when its lifetime is at least the
+idempotency retention; a temporary in-memory resource is invalid. A dry run
+never mutates state or reserves an idempotency key, and an unsupported dry run
+fails before dispatch.
+
+### 5.3 Pagination cursors
+
+A page cursor is server-produced structured data:
+
+```text
+instance_id
+scope_id
+query_digest
+consistency_mode
+consistency_revision
+high_water_position?
+next_position
+```
+
+The first request supplies the query and no cursor. The capability descriptor
+declares one pagination consistency mode:
+
+- `revision_locked`: any relevant module revision change makes the next page
+  stale;
+- `append_only`: the cursor fixes a high-water position and content-generation
+  revision; appends after that position are ignored, while a correction or
+  backfill at or before it makes the page stale;
+- `retained_resource`: every page reads one immutable retained resource and
+  returns `control.resource_gone` when that resource expires.
+
+Every later page must use the same scope, canonical query digest, and
+consistency values. A violation returns `control.page_stale` rather than
+combining incompatible states. Live chart history uses `append_only`; its
+in-progress bar is returned by the coherent snapshot, not mixed into a
+multi-page closed-bar series. `next_position` and `high_water_position` are
+bounded scope-specific values such as a slot, timestamp, or byte offset; they
+are never pointers, paths, commands, or credentials. A cursor from another
+instance or a cursor/query mismatch returns `control.cursor_invalid`. Every
+page reports `has_more`, its item count, and an optional next cursor.
+
+## 6. Actors and audit records
+
+Every action, including a human action routed through the registry, carries:
+
+```text
+actor_kind: human_ui | automation | agent
+principal_id
+client_name
+connection_id
+request_id
+reason
+requested_at_unix_ms
+```
+
+`principal_id`, `connection_id`, and `request_id` are opaque IDs. The gateway
+constructs the actor context after authentication and rejects reserved actor
+fields in the external envelope. Other additive fields follow the compatibility
+rule in section 3. A human UI action obtains the same context from an in-process
+dispatcher. The client cannot select `actor_kind`, `principal_id`, or
+`connection_id`.
+
+The gateway derives a local principal from the authenticated instance-token
+generation and assigns a connection ID. `client_name` comes from the handshake
+and is self-declared metadata, displayed as such and never treated as a
+cryptographically verified identity. The dispatcher stamps
+`requested_at_unix_ms`; a client-supplied clock is never used for audit order.
+
+An audit record includes a monotonic instance-scoped `audit_sequence`, the
+actor, capability ID and version, canonical input digest, revisions, result
+code, and `completed_at_unix_ms`. The sequence is authoritative for ordering;
+wall-clock time is informational. Authorship also lives on the resulting
+drawing, annotation, preset, script attachment, strategy, or order whenever
+that object is durable. A log entry alone is insufficient.
+
+Control audit records and request metrics use storage separate from the
+semantic `EventJournal`. Authentication failures, evidence captures, rate
+limits, and ordinary read telemetry cannot evict a user mark or domain event.
+Only a state transition that a semantic client may need, such as a connection
+becoming unavailable, enters the journal, and repetitive operational changes
+are coalesced.
+
+## 7. Effects, permissions, and profiles
+
+The effect attached to a capability describes what a remote invocation can do,
+not whether the UI happened to mutate internal bookkeeping while reporting a
+human action.
+
+| Effect ID | Remote effect | Minimum permission |
+| --- | --- | --- |
+| `observe` | Reads or derives data without changing user-visible state | `observe` |
+| `annotate` | Adds reversible state or emits a bounded notification; cannot remove existing work or affect a position | `annotate` |
+| `cockpit` | Can replace, hide, move, or discard work in the session | `cockpit` |
+| `paper` | Can change simulated orders, positions, or strategy state | `paper` |
+| `live` | Can affect a broker, venue, account, or real-money risk | `live` |
+
+Effects are registry strings so future modules can add a more specific effect
+without changing `quantick-control`. The host owns an `EffectPolicyRegistry`.
+An effect policy declares its permission floor, profile ceilings, confirmation
+class, MCP hint floor, and required risk flags. A module must register that
+policy before registering a capability that uses the effect. Duplicate or
+missing policies fail startup, so an unknown effect still fails closed without
+making `quantick-control` the extension gatekeeper. The app bootstrap registers
+the five initial policies above.
+
+Risk flags are separate from effects. Initial flags include
+`sensitive_data`, `filesystem_read`, `filesystem_write`, `state_loss`,
+`user_interrupt`, `audible_output`, `simulated_financial`, and
+`live_financial`.
+
+Registry validation rejects contradictory metadata. `observe` must be
+read-only and non-destructive. `annotate` must be non-destructive; a durable
+annotate result must be reversible, while an irreversible transient effect must
+declare `user_interrupt` and its stricter rate policy. Audible output also
+declares `audible_output`. Cockpit state loss, simulated finance, and live
+finance require their matching risk flags. These checks apply to extension
+capabilities as well as the initial registry.
+
+Profiles grant permissions:
+
+| Profile | Permissions |
+| --- | --- |
+| `observer` | `observe` plus the user-granted `observe.*` scopes; no write permission |
+| `annotator` | Observer permissions plus `annotate` |
+| `developer` | Annotator permissions plus `cockpit` |
+| `paper` | Developer permissions plus `paper` |
+
+There is no live-trading profile in the planned implementation.
+
+Profiles are app-registered policy presets, not a closed enum in the contract
+crate. Each descriptor expands to an explicit permission ceiling; inheritance
+is flattened and cycle-checked at startup. Unknown profiles fail the handshake.
+Adding a live profile still requires the separate threat model and policy even
+though the ID type itself is extensible.
+
+The profile is an authority ceiling. A capability also requires its declared
+scope, such as `observe.chart` or `observe.user_text`. Selecting `observer`
+does not silently grant every sensitive read scope.
+
+The host also owns a `PermissionRegistry`. Each permission descriptor supplies
+an ID, label, explanation of data or authority granted, sensitivity, default
+grant policy, and the profile ceilings under which it may appear. Snapshot and
+action modules register their permissions beside their scopes or capabilities.
+A capability that names an undeclared permission fails registration; a client
+that requests an undeclared permission fails closed. The in-app consent UI is
+generated from these descriptors rather than a hand-maintained MCP-only list.
+
+Write profiles are also ceilings, not blanket consent. The annotate tier opens
+with independent `annotate.attention`, `annotate.chart`,
+`annotate.notification`, `annotate.sound`, and `annotate.script` scopes.
+`annotate.sound` is off by default and is required in addition to
+`annotate.notification` for audible output. Later threat-model extensions must
+define cockpit and paper subscopes before those profiles ship.
+
+A `risk_reducing` descriptor flag may select a lighter confirmation policy, but
+does not lower the capability's effect. A paper or live safety action requires
+an explicit `paper.safety` or future `live.safety` grant. Observer, annotator,
+and developer profiles never receive financial authority through this flag.
+
+### 7.1 Marks and the observer boundary
+
+Cursor position, selection, and marks created by the human in the Quantick UI
+are observable state. An observer may read them and wait for their events.
+
+Creating a mark through a remote call changes session state. The capability is
+`attention.mark.create`, has the `annotate` effect, records its actor, and is
+unavailable to the `observer` profile. The UI hotkey, a deterministic test, and
+an authorized agent call the same handler. This distinction prevents a write
+from being mislabeled as observation.
+
+## 8. Capability registry and MCP tools
+
+The application registry is dynamic. MCP tools are deliberately small and
+stable.
+
+The first named read tools are:
+
+```text
+quantick_describe
+quantick_get_snapshot
+quantick_get_chart_window
+quantick_get_scene
+quantick_read_events
+quantick_wait_for_change
+quantick_get_diagnostics
+quantick_capture_evidence
+quantick_search_capabilities
+```
+
+The long tail uses:
+
+```text
+quantick_invoke
+```
+
+`quantick_invoke` accepts a capability ID, version, and declared input. It does
+not bypass availability, permission, confirmation, revision, idempotency, or
+audit checks. A capability unavailable to the current profile remains
+unavailable through `invoke`.
+
+High-frequency workflows may earn a named tool after usage evidence. The first
+planned write tools are `quantick_annotate`, `quantick_notify`, and
+`quantick_attach_script`; each still resolves to the same registry entry that
+`invoke` would use.
+
+MCP tool annotations are a client hint, not an authorization boundary. Named
+observer tools set `readOnlyHint: true`, `destructiveHint: false`, and
+`openWorldHint: false`. The configured profile is a ceiling known when the MCP
+server starts, so `quantick_invoke` uses conservative hints for that ceiling:
+
+| Profile ceiling | `readOnlyHint` | `destructiveHint` | `idempotentHint` | `openWorldHint` |
+| --- | --- | --- | --- | --- |
+| `observer` | `true` | `false` | `false` | `false` |
+| `annotator` | `false` | `false` | `false` | `false` |
+| `developer` or `paper` | `false` | `true` | `false` | `true` |
+
+The effective profile and scopes never exceed this ceiling. Increasing a grant
+requires a new authenticated connection before any tool hint can loosen;
+reducing or revoking a grant takes effect immediately. A named write tool
+derives its hints from the registry descriptor and fails startup if the fixed
+tool annotation contradicts that descriptor. The registry executor enforces
+the real effect, permission, confirmation, revision, and idempotency policy
+after lookup.
+
+Clients may cache the MCP tool list. They must not cache dynamic availability.
+`quantick_describe` and `quantick_search_capabilities` report availability and
+the blocking reason from the current application state.
+
+Every instance-bound MCP tool accepts an optional routing `instance_id` that
+the adapter removes before validating the capability payload. With exactly one
+live instance, omission selects it. With zero instances, the call returns
+`control.instance_gone`; with more than one, omission returns
+`control.instance_ambiguous` and the deterministically ordered choices. There
+is no hidden mutable "current instance." The adapter may also be launched with
+`--instance <id>` to pin every call and fail if that instance disappears.
+`quantick_describe` is the exception: without an ID it lists live instances;
+with an ID it describes that instance and its current grant and capabilities.
+
+For STDIO, `quantick-mcp` reserves standard output exclusively for MCP protocol
+frames. Redacted diagnostics go to standard error. A panic, tracing subscriber,
+or dependency must never print non-protocol text to standard output.
+
+## 9. Availability and errors
+
+Every descriptor reports one of:
+
+```text
+available
+unavailable
+confirmation_required
+permission_denied
+```
+
+An unavailable capability includes a stable reason code and a human-readable
+next step. Calling it returns the same reason instead of a generic failure.
+
+Errors use the shape defined in the development plan and stable dotted codes:
+
+```text
+code
+message
+retryable
+current_revisions?
+violated_precondition?
+details?
+next_steps?
+diagnostic_id?
+```
+
+`code`, `retryable`, revisions, precondition IDs, and typed details are
+machine-readable. The optional fields are bounded, redacted, and absent when
+they do not apply. Message and next-step text may improve without a protocol
+version change; clients must branch on `code`.
+The initial cross-module codes are:
+
+```text
+control.auth_failed
+control.backpressure
+control.capability_unknown
+control.capability_unavailable
+control.cursor_invalid
+control.idempotency_conflict
+control.instance_ambiguous
+control.instance_gone
+control.invalid_request
+control.page_stale
+control.payload_too_large
+control.permission_denied
+control.revision_conflict
+control.request_in_progress
+control.resource_gone
+control.scope_denied
+control.timeout
+control.version_unsupported
+```
+
+Internal error strings, panic payloads, tokens, paths, and credentials are not
+returned. An opaque diagnostic ID correlates a safe client error with local
+structured logs.
+
+## 10. Limits and retention
+
+These names become constants in `quantick-control::limits` and defaults in the
+app configuration. Values are initial safety and memory bounds, not measured
+performance claims. PR 2 and PR 3 may lower defaults after measurement. Raising
+a hard limit requires a reviewed contract change and threat-model check.
+
+| Name | Initial value | Kind | Purpose |
+| --- | ---: | --- | --- |
+| `CONTROL_TOKEN_BYTES` | 32 | hard | 256-bit instance bearer token |
+| `CONTROL_RUNTIME_ID_BYTES` | 16 | hard | 128-bit generated runtime identifiers |
+| `CONTROL_REQUEST_ID_MAX_BYTES` | 128 | hard | Bound client correlation identifiers |
+| `CONTROL_DESCRIPTOR_MAX_BYTES` | 16 KiB | hard | Bound descriptor reads before JSON parsing |
+| `CONTROL_PROTOCOL_MAX_FRAME_BYTES` | 16 MiB | hard | Reject a frame before allocation or JSON parsing |
+| `CONTROL_MAX_REQUEST_BYTES` | 1 MiB | hard | Bound schemas, scripts, and action inputs |
+| `CONTROL_MAX_RESPONSE_BYTES` | 8 MiB | hard | Force pagination or resource chunking |
+| `CONTROL_MAX_BUFFERED_RESPONSE_BYTES` | 64 MiB | hard | Bound responses waiting across all connections |
+| `CONTROL_MAX_JSON_DEPTH` | 64 | hard | Reject adversarial nesting |
+| `CONTROL_MAX_STRING_BYTES` | 256 KiB | hard | Bound any one wire string, including script source |
+| `CONTROL_ID_MAX_BYTES` | 128 | hard | Bound any registry or protocol identifier |
+| `CONTROL_ID_MAX_SEGMENTS` | 8 | hard | Bound dotted-identifier parsing and display |
+| `CONTROL_CLIENT_NAME_MAX_BYTES` | 128 | hard | Bound self-declared handshake metadata |
+| `CONTROL_REASON_MAX_BYTES` | 1 KiB | hard | Bound optional action rationale and audit data |
+| `CONTROL_IDEMPOTENCY_KEY_MAX_BYTES` | 128 | hard | Bound an opaque client retry key |
+| `CONTROL_IDEMPOTENCY_MAX_ENTRIES` | 1,024 | default | Bound retained retry records per instance |
+| `CONTROL_IDEMPOTENCY_RECORD_MAX_BYTES` | 64 KiB | hard | Keep cached action results compact |
+| `CONTROL_IDEMPOTENCY_RETENTION_MS` | 86,400,000 | default | Retain retry records for 24 hours or the instance lifetime |
+| `CONTROL_DEFAULT_PAGE_ITEMS` | 256 | default | Keep ordinary reads compact |
+| `CONTROL_MAX_PAGE_ITEMS` | 2,048 | hard | Bound chart and event pages |
+| `CONTROL_REQUEST_QUEUE_CAPACITY` | 64 | default | Bound pending UI-thread work |
+| `CONTROL_MAX_CONNECTIONS` | 8 | default | Bound local clients per instance |
+| `CONTROL_MAX_IN_FLIGHT_PER_CONNECTION` | 8 | hard | Prevent one client from owning the queue |
+| `CONTROL_MAX_PARKED_WAITERS` | 16 | hard | Bound `wait_for_change` registrations |
+| `CONTROL_HANDSHAKE_TIMEOUT_MS` | 2,000 | default | Drop unauthenticated sockets quickly |
+| `CONTROL_REQUEST_TIMEOUT_MS` | 5,000 | default | Bound ordinary calls |
+| `CONTROL_WAIT_TIMEOUT_MAX_MS` | 30,000 | hard | Bound one long poll |
+| `CONTROL_CLIENT_RATE_PER_SECOND` | 20 | default | Sustained per-client rate |
+| `CONTROL_CLIENT_BURST` | 40 | default | Short per-client burst |
+| `CONTROL_NOTIFICATION_RATE_PER_MINUTE` | 6 | default | Bound visible or audible interruptions per client |
+| `CONTROL_NOTIFICATION_BURST` | 2 | hard | Prevent notification floods within one moment |
+| `CONTROL_UI_BUDGET_US` | 1,000 | default | Maximum control work in one frame |
+| `CONTROL_EVENT_JOURNAL_CAPACITY` | 8,192 | default | Bound semantic event memory |
+| `CONTROL_EVENT_MAX_BYTES` | 64 KiB | hard | Force large event data into a resource |
+| `CONTROL_EVENT_JOURNAL_MAX_BYTES` | 32 MiB | hard | Bound the journal even when events vary in size |
+| `CONTROL_AUDIT_MAX_ENTRIES` | 4,096 | default | Bound the separate in-memory control audit view |
+| `CONTROL_AUDIT_RECORD_MAX_BYTES` | 16 KiB | hard | Keep one structured audit record compact |
+| `CONTROL_AUDIT_MAX_BYTES` | 16 MiB | hard | Bound the audit view independently of entry count |
+| `CONTROL_AUDIT_RETENTION_MS` | 86,400,000 | default | Retain control audit records for at most 24 hours |
+| `CONTROL_EVIDENCE_MAX_BUNDLES` | 8 | default | Bound retained captures |
+| `CONTROL_EVIDENCE_MAX_TOTAL_BYTES` | 64 MiB | hard | Bound total in-memory evidence |
+| `CONTROL_EVIDENCE_RETENTION_MS` | 900,000 | default | Retain evidence for 15 minutes |
+
+Evidence payloads are resources read in chunks no larger than
+`CONTROL_MAX_RESPONSE_BYTES`; `quantick_capture_evidence` returns a manifest
+and resource ID, not an unbounded inline bundle. Old evidence is evicted by the
+earlier of count, total bytes, or retention time.
+
+The event journal evicts by the earlier of entry capacity or total encoded
+bytes. A semantic event larger than `CONTROL_EVENT_MAX_BYTES` contains a
+bounded summary and resource ID instead of inline data. The gateway applies
+backpressure before queued and buffered responses exceed their global byte
+budget; a slow client cannot reserve one maximum response per allowed request.
+The separate audit view evicts by the earliest of entry count, encoded bytes,
+or retention time.
+
+`wait_for_change` parks outside the UI request queue and does not count as an
+in-flight UI request while it waits. When its cursor advances, only the bounded
+read that completes the call enters the queue.
+
+The executor checks `CONTROL_UI_BUDGET_US` between requests and independently
+bounded capture scopes. It never suspends one coherent capture across frames.
+Page and scope limits must keep each indivisible capture below the budget; an
+unexpected overrun is telemetry and a performance-test failure, not permission
+to return a mixed-revision response.
+
+## 11. Replay determinism decision
+
+**Decision:** Any accepted non-observe registry action during replay that can
+affect session output is a replay input, regardless of whether its actor is a
+human, automation, or agent. It must be recorded in a durable, versioned
+control trace. A replay with an unrecorded action is not eligible as a
+deterministic fixture.
+
+The market recording remains immutable. The control trace is a sidecar ordered
+by replay time and sequence number. Each entry stores:
+
+```text
+trace_version
+replay_elapsed_us
+sequence
+actor
+capability_id
+capability_version
+canonical_input
+expected_revisions
+result_code
+result_digest
+```
+
+Replaying the pair injects each accepted control action at the same logical
+replay position. Wall-clock time is never used. The dispatcher durably appends
+an intent before state changes and records its terminal result afterwards. An
+incomplete trace is not fixture-eligible. If a determinism-affecting action
+cannot append its intent, the action fails before state changes. Observe calls
+and reads of human attention do not enter the trace.
+
+The trace is required for annotate, cockpit, and paper actions that affect
+plots, layout, replay position, strategy state, or simulated trading. The PR
+that introduces the first such action must implement the trace port or keep the
+action unavailable during replay.
+
+## 12. Trade annotation ownership
+
+**Decision:** Durable notes about closed trades belong to an app-owned
+`trade_annotations` module, not to `quantick-sim` and not to MCP.
+
+The simulator remains a pure domain crate. The app stores annotations beside
+the selected paper journal so the history and its notes move together. A
+versioned sidecar records:
+
+- a stable `TradeReference` derived from the journal identity, canonical trade
+  fields, and duplicate occurrence index;
+- the note ID and exact UTF-8 text;
+- actor and timestamps;
+- optional source mark and evidence IDs;
+- edit revision and deletion state.
+
+The reference supports version-1 history rows whose aggregate IDs are unknown.
+No note field is added to `ClosedTrade`. Import and export either carry the
+annotation sidecar or state explicitly that annotations were not included.
+
+## 13. Codex and Claude Code setup flows
+
+The `quantick-mcp` binary is a local STDIO adapter. It discovers already
+running Quantick instances and never launches the application. Machine-specific
+binary paths and instance tokens are not committed to the repository.
+
+### 13.1 Codex
+
+1. Build or install `quantick-mcp`.
+2. Start Quantick manually and enable local observer access for this run.
+3. Register the adapter:
+
+   ```powershell
+   codex mcp add quantick -- "<absolute-path-to-quantick-mcp>" --profile observer
+   ```
+
+4. Verify configuration with `codex mcp list`.
+5. Start or restart the Codex client and use `/mcp` to verify the connection.
+6. Call `quantick_describe`. If more than one instance is running, select one
+   explicitly before reading it.
+
+Codex CLI, the Codex IDE extension, and the ChatGPT desktop app share the local
+Codex MCP configuration. A future setup helper may emit an equivalent
+`[mcp_servers.quantick]` table, but the CLI is the primary documented path.
+
+### 13.2 Claude Code
+
+1. Build or install `quantick-mcp`.
+2. Start Quantick manually and enable local observer access for this run.
+3. Register the adapter in local scope:
+
+   ```powershell
+   claude mcp add --transport stdio --scope local quantick -- "<absolute-path-to-quantick-mcp>" --profile observer
+   ```
+
+4. Verify it with `claude mcp get quantick` or `claude mcp list`.
+5. In Claude Code, use `/mcp` to inspect status and approve a project-scoped
+   configuration if that scope is used later.
+6. Call `quantick_describe` and select an instance explicitly when ambiguous.
+
+Open-source examples may include a `.mcp.json` template only after the binary
+has a portable installation command. It must contain no token, username, home
+path, or automatic application launch.
+
+## 14. Consequences for PR 1
+
+PR 1 must prove these decisions with tests:
+
+- string newtypes accept valid extension IDs and reject invalid IDs;
+- a fake second module registers without editing the contract crate;
+- that fake module can register an effect policy, while a capability whose
+  effect has no policy fails closed;
+- version negotiation succeeds only on an overlapping range;
+- an accepted handshake downscopes to the app grant, reports the selected
+  limits, and never echoes its bearer token;
+- descriptors, examples, and schemas validate;
+- canonical JSON and SHA-256 golden vectors produce identical digests for
+  reordered objects and distinct digests for distinct arrays or UTF-8 strings;
+- breaking schema fixtures require a version bump;
+- permissions fail closed for unknown effects;
+- contradictory effect, read-only, reversibility, destructive, and risk fields
+  fail descriptor validation;
+- oversized frames are rejected before payload allocation;
+- revision conflicts change no state in the fake host;
+- a second page cannot change its query; revision-locked pages reject a change,
+  while append-only pages accept a later append but reject a correction below
+  their high-water position;
+- retrying an idempotent fake action returns its first result, while reusing
+  the key with a different payload changes no state and returns a conflict;
+- the fake host and client use the same envelopes as later adapters.
+
+PR 1 does not implement sockets, MCP, app snapshots, persistence, or trading.
+
+## 15. Deferred decisions
+
+The following decisions need implementation evidence and are intentionally not
+fixed by PR 0:
+
+- the Rust MCP SDK, if any;
+- optional Streamable HTTP support;
+- named pipes or Unix domain sockets as an additional gateway transport;
+- the final measured value of the per-frame budget below its 1 ms opening cap;
+- compression format for evidence resources;
+- remote authentication and every live-trading policy.
+
+## References
+
+- [Development plan](../mcp-control-plane-development-plan.md)
+- [Capability inventory](capability-inventory.md)
+- [ADR 0001](adr-0001-local-transport-and-instance-discovery.md)
+- [Observer threat model](observer-threat-model.md)
+- [OpenAI MCP documentation](https://developers.openai.com/codex/mcp)
+- [Claude Code MCP documentation](https://code.claude.com/docs/en/mcp)

--- a/docs/control-plane/observer-threat-model.md
+++ b/docs/control-plane/observer-threat-model.md
@@ -1,0 +1,284 @@
+# Observer profile threat model
+
+**Status:** Accepted for implementation
+
+**Date:** 2026-08-19
+
+**Scope:** The local `observer` profile, the instance descriptor, the in-app
+gateway, `quantick-mcp`, semantic snapshots, events, attention state, and
+in-memory evidence resources.
+
+This threat model does not authorize cockpit, paper, or live actions. Each
+later authority tier must extend this document before it ships.
+
+## 1. Security objectives
+
+The observer implementation must:
+
+1. expose only an instance the user explicitly enabled;
+2. remain reachable only from the local machine and current OS user;
+3. authenticate every connection before disclosing instance state;
+4. prevent an observer from changing user-visible or financial state;
+5. minimize and label sensitive data leaving the application;
+6. bound memory, CPU, queue, connection, and retention costs;
+7. preserve snapshot consistency and report missing or stale data honestly;
+8. make connected clients and revocation visible in the application;
+9. fail closed on ambiguity, malformed input, unsupported versions, or
+   unknown permissions;
+10. leave no token, evidence bundle, or descriptor after its intended
+    lifetime.
+
+## 2. Assets
+
+| Asset | Sensitivity | Examples |
+| --- | --- | --- |
+| Instance authority | Critical | bearer token, effective profile, connection identity |
+| Trading state | High | paper positions, orders, P&L, strategy state |
+| User-created content | High | drawing text, typed marks, script source, trade notes |
+| Workspace state | Medium | tabs, symbols, layouts, active feed, viewport |
+| Market data | Medium | visible bars, order flow, depth, replay data |
+| Diagnostic data | Medium to high | logs, paths, endpoint errors, build and OS details |
+| Attention state | Medium | cursor target, selected object, recent human marks |
+| Evidence resources | Aggregate high | correlated state, events, logs, metrics, optional image |
+| Availability | High during trading | frame time, feed handling, UI responsiveness |
+
+Market data may have venue licensing restrictions even when it is public to the
+application. The control plane does not imply a right to redistribute it.
+
+## 3. Actors
+
+| Actor | Trust level | Notes |
+| --- | --- | --- |
+| Quantick user | Trusted authority | Enables access, chooses scopes, revokes clients |
+| Quantick app | Trusted computing base | Owns state, authorization, capture, and action dispatch |
+| `quantick-mcp` | Trusted local adapter | Translates MCP; has no domain authority of its own |
+| Configured MCP client | Conditionally trusted | Receives only granted scopes; may transmit data to a model provider |
+| Other local OS user | Untrusted | Must not read descriptor or connect successfully |
+| Untrusted local process under another user | Untrusted | May scan ports and race descriptor publication |
+| Same-user malicious process | Outside isolation guarantee | Can often read the user's files or process memory already |
+| Remote network peer | Untrusted | Must have no route to the gateway |
+| Market, feed, log, or imported text | Untrusted data | Must never become instructions or executable input |
+
+The same-user malware limitation is explicit: a bearer token in a file cannot
+protect a user from a process already running with that user's full filesystem
+rights. The design still prevents accidental discovery, cross-user access,
+network access, stale reuse, and unauthorized MCP clients.
+
+## 4. Trust boundaries
+
+```text
+remote model/provider
+        ^
+        | data chosen by the configured MCP client
+--------+---------------- client trust boundary ----------------
+Codex / Claude Code / other local MCP client
+        |
+        | MCP over STDIO
+        v
+quantick-mcp
+        |
+        | authenticated loopback protocol
+--------+---------------- app process boundary -----------------
+gateway I/O threads -> bounded UI request queue -> Quantick state
+        |
+        +-> bounded event journal and in-memory evidence store
+```
+
+The model provider is not part of the local trusted computing base. Once the
+configured client sends granted data to a provider, Quantick cannot enforce
+provider retention. The app must make this consequence clear when observer
+access is enabled.
+
+## 5. Consent and profile boundary
+
+Local control access is disabled at every application start. It is not restored
+from workspace state. Enabling it creates a new token and descriptor for that
+run. Disabling it:
+
+- stops accepting connections;
+- closes current connections;
+- rotates and destroys the token;
+- removes the descriptor;
+- clears retained evidence and parked waiters;
+- leaves a local audit event.
+
+The in-app access panel shows client name, connection time, requested and
+effective profile, granted read scopes, last request time, and a revoke action.
+The maximum effective profile and scope set are fixed at authentication.
+Increasing authority closes the old connection and requires a new handshake;
+removing a scope or revoking access applies immediately to in-flight and future
+requests.
+
+`observer` is a ceiling, not permission to return every field. The first
+implementation exposes these read scopes independently:
+
+```text
+observe.system
+observe.workspace
+observe.market
+observe.chart
+observe.indicators
+observe.drawings
+observe.orderflow
+observe.replay
+observe.paper
+observe.health
+observe.attention
+observe.events
+observe.evidence
+```
+
+The following sensitive or aggregate additions are off by default and require
+a visible scope grant:
+
+```text
+observe.paper
+observe.evidence
+observe.user_text
+observe.diagnostic_logs
+observe.screenshot
+```
+
+Raw filesystem paths, credentials, environment variables, arbitrary files,
+shell access, and process launch are not observer scopes.
+
+## 6. Allowed and denied behavior
+
+### Allowed
+
+- List live instances without disclosing their state.
+- Read granted semantic snapshots, chart pages, scene state, and diagnostics.
+- Read the resolved cursor, current selection, and marks created by the human.
+- Read bounded semantic events and wait for a cursor change.
+- Create a bounded, redacted evidence bundle in memory.
+- Read evidence resource chunks while the resource remains retained.
+
+### Denied
+
+- Create a mark, annotation, drawing, notification, script, preset, or note.
+- Change a tab, focus, viewport, layer, replay transport, or configuration.
+- Place, cancel, modify, close, flatten, arm, or disarm anything.
+- Export evidence or any other data to an arbitrary path.
+- Read an arbitrary file, directory, environment variable, clipboard, or shell
+  result.
+- Start Quantick, a terminal, a broker, or any other process.
+- Select one of several instances silently.
+
+A human-created mark is observable. `attention.mark.create` is an annotate
+capability and is not exposed to the observer profile.
+
+## 7. Data minimization and redaction
+
+- Snapshot callers name scopes; omitted scopes are not captured and are listed
+  as omitted.
+- Chart reads default to the visible window and require pagination beyond it.
+- User-authored text is replaced with a presence marker unless
+  `observe.user_text` is granted.
+- Attention and scene references do not bypass the target module's scope. For
+  example, a cursor over a paper order requires both `observe.attention` and
+  `observe.paper` to reveal order fields; otherwise it reports only a redacted
+  target kind and stable presence marker. Redacted reference IDs are scoped
+  opaque aliases and never embed a symbol, account, order, path, or note.
+- Diagnostics use an allowlist of structured fields. Raw log lines are not
+  returned unless `observe.diagnostic_logs` is granted, and are redacted even
+  then.
+- Tokens, credential-shaped values, authorization headers, account secrets,
+  environment values, and private keys are always removed.
+- Paths are reduced to logical store IDs or basenames unless a specific safe
+  path is required to explain a failure. Home directories and usernames are
+  removed.
+- Evidence manifests state every omitted, redacted, inferred, stale, or
+  unavailable field.
+- Evidence capture requires `observe.evidence` plus every source scope included
+  in the bundle; it cannot use aggregation to launder an ungranted scope.
+- Evidence resource IDs are random and unguessable but are not treated as
+  authorization. Every chunk read rechecks the current grant against the
+  manifest's source scopes.
+- Screenshots require `observe.screenshot`, an explicit capture request, and a
+  visible in-app indicator. They carry the same retention limits as the bundle.
+
+External strings such as symbol names, imported text, venue errors, script
+diagnostics, and note contents are data. They never contribute to MCP server
+instructions, capability descriptions, schema text, or executable commands.
+
+## 8. Threats and required controls
+
+| ID | Threat | Required controls | Verification |
+| --- | --- | --- | --- |
+| O-01 | Gateway exposed to LAN or internet | Bind literal `127.0.0.1`; reject configured host overrides; no port forwarding feature | Socket integration test checks bind address and remote-interface refusal |
+| O-02 | Another OS user reads the token | Private runtime directory, owner and ACL checks, `0700`/`0600`, no temp fallback | Platform permission tests |
+| O-03 | Descriptor symlink or replacement race | Reject symlinks/reparse points; exclusive create; atomic rename; owner validation | Adversarial filesystem tests |
+| O-04 | Stale descriptor reaches a new process after PID reuse | Match `instance_id`, random `process_nonce`, process start time, and authenticated handshake | PID-reuse and stale-file tests |
+| O-05 | Token appears in logs, URLs, crash text, or client config | Token only in private descriptor and handshake field; redacting logger; never command-line or URL | Secret canary scan over logs and errors |
+| O-06 | Client requests or later assumes a stronger profile | App computes an immutable connection grant below the configured ceiling; elevation requires reconnect; token carries no authority; unknown permission fails closed | Handshake and mid-connection escalation tests |
+| O-07 | `quantick_invoke` bypasses tool annotations | Authorization is enforced in the registry executor after lookup, not in the MCP wrapper | Invoke-vs-named-tool parity tests |
+| O-08 | Observer creates a mark or other state | Remote effect classification; observer grants only `observe`; mark creation is `annotate` | State digest unchanged after every observer tool test |
+| O-09 | Prompt injection arrives through feed, logs, notes, or symbols | Treat external strings as typed data; fixed server instructions; no command interpolation | Fixtures containing instruction-like strings remain payload data |
+| O-10 | Oversized or malformed frames exhaust memory | Length prefix checked before allocation; hard byte, depth, item, and string bounds; truncated-frame timeout | Fuzz and boundary tests |
+| O-11 | Long polls or slow clients starve the UI | Park waiters off the UI queue; bounded waiter count; write timeouts; no UI-thread socket work | Concurrent wait/read and slow-reader tests |
+| O-12 | Request flood consumes frames | Per-client rate and burst limits; bounded connections and queue; 1 ms opening frame budget | Flood test plus frame-budget instrumentation |
+| O-13 | Snapshot combines incompatible moments | One UI-thread capture revision; owned DTO; module revisions; explicit gaps | Mutation-between-modules test |
+| O-14 | Client acts on the wrong instance | Deterministic list; explicit selection on ambiguity; instance ID on every envelope | Two-instance test |
+| O-15 | Adapter launches a hidden app | No launch code or process capability; empty discovery returns a next step | Process-spawn guard and zero-instance integration test |
+| O-16 | Arbitrary file or shell access is smuggled through a generic tool | No generic path, command, eval, or shell capability; schema rejects extra fields | Capability inventory and schema tests |
+| O-17 | Evidence accumulates or launders sensitive data | Separate evidence and source scopes; count, byte, and time eviction; grant recheck on every chunk; clear on disable/exit; no default disk export | Cross-scope access, retention, revocation, and shutdown tests |
+| O-18 | Screenshot captures unrelated windows or secrets | Capture only Quantick-owned surface; explicit scope and request; visible indicator; revision correlation | Window ownership and consent tests |
+| O-19 | Diagnostics reveal secrets or private paths | Structured allowlist, mandatory redaction, opaque diagnostic IDs | Redaction fixtures with canary secrets and home paths |
+| O-20 | Protocol downgrade changes authorization meaning | Highest overlapping version; no overlap fails; effect and permission IDs validated | Version negotiation tests |
+| O-21 | Client keeps reading after revocation | Connection generation bound to token; close sockets; cancel waiters; clear resources | Mid-request and parked-wait revocation tests |
+| O-22 | Market-data volume or licensing is exceeded | Visible-window default, pagination, rate limits, no automatic full-history dump | Page-limit and rate tests |
+| O-23 | Client spoofs a human or another agent in audit records | Gateway constructs actor context after authentication; client controls only self-declared name and optional reason | Actor-field injection and cross-connection attribution tests |
+| O-24 | Observer telemetry or audit traffic evicts user marks and domain events | Separate bounded control audit storage; only semantic transitions enter the event journal; repetitive operational events are coalesced | Flood audit and reconnect telemetry, then prove a retained mark remains readable |
+| O-25 | Attention, selection, scene, or evidence references bypass a denied module scope | Intersect the reference scope with every target scope; return only a redacted presence marker when any required scope is absent | Cross-scope cursor, selection, scene, mark, and evidence fixtures |
+
+## 9. Security invariants
+
+The following properties are release blockers:
+
+1. The user and domain state digest is unchanged after any sequence of observer
+   calls. Observer calls may change only isolated control-plane operational
+   state: bounded caches, capture counters, connection telemetry, request
+   metrics, control audit records, client read cursors, and evidence resources.
+2. Those operational artifacts cannot alter rendering, market data, replay,
+   paper trading, persistence, later action availability, or the retention
+   budget of the semantic event journal.
+3. A token from one instance or token generation cannot authenticate to
+   another.
+4. Disabling access makes every existing and future request fail without an
+   application restart.
+5. Unknown scopes, effects, capability versions, and protocol versions fail
+   closed.
+6. No observer response contains a seeded canary secret or full seeded home
+   path in redaction tests.
+7. The gateway adds no per-trade or per-depth allocation, lock, or branch when
+   no semantic event is emitted.
+8. Every remotely initiated audit record uses gateway-assigned principal and
+   connection IDs; untrusted actor fields never reach the registry executor.
+
+## 10. Abuse and incident response
+
+The app records local structured events for enable, disable, connection,
+authentication failure, profile denial, rate limiting, revocation, evidence
+capture, and unexpected gateway shutdown. These events contain no token or raw
+payload.
+
+The access panel offers one action that disables the gateway and revokes every
+client immediately. Closing Quantick also revokes access. A suspected token
+leak is handled by disable and re-enable, which creates a new token and
+descriptor.
+
+## 11. Deferred threat-model extensions
+
+Before the corresponding tier ships, this document must be extended for:
+
+- annotate actions and replay control traces;
+- cockpit state loss, filesystem import/export, and confirmation;
+- paper orders, strategies, idempotency, and risk-reducing exceptions;
+- any Streamable HTTP or remote transport;
+- broker credentials, live orders, account data, and emergency controls.
+
+## References
+
+- [Control contract](control-contract.md)
+- [ADR 0001](adr-0001-local-transport-and-instance-discovery.md)
+- [Development plan](../mcp-control-plane-development-plan.md)

--- a/docs/mcp-control-plane-development-plan.md
+++ b/docs/mcp-control-plane-development-plan.md
@@ -1,21 +1,20 @@
 # Quantick control plane and MCP development plan
 
-**Status:** Proposal for review, revised after architecture review
+**Status:** Accepted for phased implementation; PR 0 contract in review
 
 **Date:** 2026-08-19
 
-**Authorship:** The first draft was written by Codex. This revision was made by
-Claude (Claude Code) on 2026-08-19, at the repository owner's request, as a
-review of that draft rather than a replacement for it.
+**History:** Codex produced the first draft. Claude Code reviewed and expanded
+it on 2026-08-19 at the repository owner's request. The PR 0 contract review
+then reconciled the plan with the measured source inventory, authority model,
+transport ADR, and observer threat model.
 
-**Why it was revised:** The draft's architecture was accepted as proposed and
-is unchanged. What the review changed is scope, schedule, and six technical
-details, because the draft did not yet satisfy the objective it was written for:
-the owner wants to point at something on a running chart and be understood, and
-to have the assistant answer on the chart rather than only in prose. A read-only
-snapshot API cannot do either. Section 0 lists every change with its reasoning,
-and section 3.1 gives the measurements each change rests on, so a reviewer can
-check the claims instead of trusting them.
+**Why it was revised:** The vendor-neutral control-plane spine was retained, but
+the first draft did not yet satisfy the workflow it was written for. The owner
+wants to point at something on a running chart and be understood, and to have
+the assistant answer on the chart rather than only in prose. A read-only
+snapshot API cannot do both. Section 0 summarizes the changes and section 3.1
+records the source measurements behind them.
 
 **Primary goal:** Let Codex, Claude, and other MCP-compatible clients observe a
 running Quantick instance, understand what the user is pointing at inside it,
@@ -27,10 +26,9 @@ public messages, and contributor-facing artifacts must be written in English.
 
 ## 0. What this revision changed
 
-The first draft's architecture is unchanged: a vendor-neutral control contract,
-MCP as one adapter, a single registry shared with the interface, and authority
-that starts small. The review kept that spine and changed the scope and the
-schedule.
+The retained architecture is a vendor-neutral control contract, MCP as one
+adapter, a single registry shared with the interface, and authority that starts
+small. The review expanded its scope, delivery order, and explicit contracts.
 
 Three gaps against the stated objective:
 
@@ -38,7 +36,8 @@ Three gaps against the stated objective:
   snapshots and a scene tree of controls, but no cursor, selection, or way to
   mark a target, so an agent could read the whole chart and still not know which
   bar the user meant. Section 6.5 adds a resolved cursor, a published selection,
-  and a mark, all inside the observe tier.
+  and human-created marks inside the observe tier. Creating a mark remotely is
+  an annotate action.
 - **Every write deferred, including the harmless ones.** The draft had one write
   cliff. Section 2.6 replaces it with tiers by effect, and PR 5b ships the tier
   that cannot lose the user's work inside the MVP, so the agent can answer on
@@ -49,17 +48,14 @@ Three gaps against the stated objective:
   settings actions. PR 5b makes it explicit, using compile diagnostics that
   already exist.
 
-Six technical corrections, each stated where it belongs: identifiers are
-registry strings rather than enumerations (5.5); schema compatibility is
-enforced by snapshot-tested files (5.6); the frame budget is milliseconds rather
-than a request count (10.2); `wait_for_change` parks off the UI thread and holds
-no request slot (6.4); the MCP tool list is not the capability registry (7.1);
-and the determinism consequence of an agent acting during a replay is a decision
-PR 0 must record (PR 0).
-
-Two smaller ones: a screenshot is correlated with the capture revision rather
-than treated as a bare fallback (section 8), and the adapter never starts the
-application (9.1).
+Contract corrections are stated where they belong: extensible validated IDs
+(5.5); snapshot-tested schema compatibility (5.6); gateway-assigned actor
+identity (5.2); explicit cursor, retry, and `dry_run` semantics (PR 0); MCP tool
+annotations that fail conservatively for generic invocation (7.1); byte and
+time budgets instead of request-count guesses (10.2); and a durable replay trace
+for determinism-affecting actions (PR 0). `wait_for_change` parks off the UI
+thread (6.4), screenshots correlate with semantic captures (section 8), and the
+adapter never starts the application (9.1).
 
 Section 3.1 records the measurements these changes rest on, so the next reviewer
 can check them rather than trust them.
@@ -80,11 +76,16 @@ At the end of the MVP, the workflow will be:
    feed, tabs, panes, visible bars, indicators, drawings, order flow, replay,
    paper trading, health, and recent errors, plus what the cursor is over, what
    is selected, and what the user just marked. It answers from structured data
-   instead of reading pixels.
-6. The agent answers on the chart as well as in prose. It can attach a label,
-   an arrow, a popup, a sound, or a compiled indicator, and then read the
-   result back through the same snapshot the user sees.
-7. When needed, the agent creates an evidence bundle with a stable ID that can
+   instead of reading pixels, subject to the scopes the user granted. Paper
+   state, evidence, user text, diagnostic log access, and screenshots are not
+   granted silently.
+6. If the user grants the `annotator` profile, the agent can also answer on the
+   chart. It can attach a label, an arrow, a popup, a sound, or a compiled
+   indicator, and then read the result back through the same snapshot the user
+   sees.
+7. Observer access remains read-only when the additional profile is not
+   granted.
+8. When needed, the agent creates an evidence bundle with a stable ID that can
    be attached to an investigation, issue, or pull request.
 
 The MVP stops there. It carries no cockpit write that can lose state the user
@@ -146,25 +147,29 @@ When the control plane is disabled or idle, it must introduce:
 ### 2.6 Effect tiers, not one write cliff
 
 "Read" and "write" is too coarse a split to schedule by. Sorting a capability
-by the damage it can do gives three tiers plus one asymmetry, and the tiers,
+by the damage it can do gives four tiers plus one asymmetry, and the tiers,
 not the calendar, decide what may ship together.
 
 | Tier | Examples | Property that sets the tier |
 | --- | --- | --- |
-| Observe | snapshot, chart window, scene, events, cursor, marks | Changes nothing |
-| Annotate and notify | label, arrow, popup, sound, attach a script | Additive, reversible, no money |
+| Observe | snapshot, chart window, scene, events, cursor, human-created marks | A remote call changes no user-visible state |
+| Annotate and notify | agent-created mark, label, arrow, popup, sound, attach a script | No state loss or money; durable additions are reversible |
 | Cockpit | tab, focus, viewport, bar spec, layers | Can discard work done by hand |
 | Financial | paper orders, strategies, then live trading | Moves money or its record |
 
-The observe tier needs no protection. The annotate tier needs attribution and a
-one-action undo. The cockpit tier needs `expected_revision` because the user can
-lose work. The financial tier needs everything in section 9.
+The observe tier needs authentication, explicit data scopes, redaction, and
+rate limits, but no mutation guard. Durable changes in the annotate tier need
+attribution and a one-action undo. Transient notifications need attribution,
+rate limits, and an explicit user grant because a sound cannot literally be
+undone. The cockpit tier needs `expected_revisions` because the user can lose
+work. The financial tier needs everything in section 9.
 
-The asymmetry: an operation that only ever *reduces* authority — lock entries,
-flatten, disarm a strategy, kill switch — cannot create exposure, and refusing
-it has a worse failure mode than allowing it. Such operations may ship with the
-annotate tier even though they touch trading, and section 9.4 states the rule
-that keeps that narrow.
+The asymmetry: an operation that only ever *reduces* authority, such as locking
+entries, flattening, disarming a strategy, or using a kill switch, cannot create
+exposure. Refusing it has a worse failure mode than allowing it. Such operations
+may use a lighter confirmation policy, but they keep their financial effect and
+require an explicit safety permission. They never inherit annotate authority.
+Section 9.4 states the rule that keeps this narrow.
 
 The annotate tier is what makes the loop bidirectional. Without it the control
 plane is a one-way mirror: the agent watches the user and has no way to show
@@ -193,10 +198,11 @@ impressions:
 
 - `ChartState` names egui only in comments, and already carries
   `timeline_revision`. A per-module revision is not new work.
-- The application defines 89 distinct `QUANTICK_*` hooks. Those hooks are
-  already a control plane with three defects: startup only, write only, and
-  unobservable. That list is the starting capability inventory for PR 0, not a
-  guess about scope.
+- The application contains 88 distinct `QUANTICK_*` string literals: 86
+  production surfaces and two test-only store variables. Many production
+  surfaces already resemble a control plane, but they are startup-only,
+  mostly write-only, and unobservable. The PR 0 inventory records each real
+  surface and its migration target.
 - `QuantickApp` has 107 fields and `crates/app/src/app.rs` is roughly 24k
   lines. This is the concrete reason section 12 forbids letting the control
   plane become a general refactor.
@@ -308,7 +314,7 @@ A leaf crate and adapter binary:
 - discovery of one or more running instances;
 - explicit instance selection when more than one is available;
 - mapping registered capabilities to MCP tools and resources;
-- `observer`, `developer`, and `paper` profiles;
+- `observer`, `annotator`, `developer`, and `paper` profiles;
 - guided local configuration for Codex and Claude.
 
 ## 5. Core contracts
@@ -329,7 +335,8 @@ examples
 effect
 risk
 read_only
-idempotent
+idempotency: forbidden | optional | required
+dry_run_supported
 reversible
 destructive
 required_permissions
@@ -355,8 +362,13 @@ client_name
 connection_id
 request_id
 reason
-requested_at_ms
+requested_at_unix_ms
 ```
+
+For remote calls, the gateway constructs the trusted actor fields after
+authentication. A client may supply its self-declared name and an optional
+reason, but it cannot select `actor_kind`, `principal_id`, or `connection_id`.
+Human UI actions receive the same context from the in-process dispatcher.
 
 Drawings, presets, strategies, and orders created by an agent must retain that
 authorship in application state, the interface, and the journal. Authorship
@@ -365,7 +377,7 @@ cannot exist only in an MCP log.
 ### 5.3 Revisions and concurrency
 
 Snapshots carry a monotonic revision for each module and one revision for the
-capture. Future writes accept `expected_revision`. If state changes after an
+capture. Future writes accept `expected_revisions`. If state changes after an
 agent observes it, the operation fails with a structured error instead of
 acting on a stale assumption.
 
@@ -377,10 +389,11 @@ Errors use a predictable shape:
 code
 message
 retryable
-current_revision
-violated_precondition
-details
-next_steps
+current_revisions?
+violated_precondition?
+details?
+next_steps?
+diagnostic_id?
 ```
 
 Error codes are stable and covered by tests, following the conventions already
@@ -407,10 +420,11 @@ expected to contain, not the definition of what it may contain.
 One rule, so that clients can be tolerant readers and the platform can still
 grow:
 
-- Adding a field, a scope, an event kind, or a capability is additive and does
-  not bump a version.
-- Removing a field, renaming one, changing its unit, or changing what a value
-  means is breaking and bumps the capability version.
+- Adding an optional field, a scope, an event kind, or a capability is additive
+  and does not bump a version.
+- Adding a required field, removing or renaming a field, changing its unit, or
+  changing what a value means is breaking. A capability payload change bumps
+  the capability version; an envelope change bumps the protocol version.
 
 Both halves are enforced mechanically. Declared schemas are written to files
 and snapshot-tested, so a breaking change appears as a reviewable diff instead
@@ -515,9 +529,10 @@ agent that has to infer the referent will confidently answer about the wrong
 bar.
 
 Section 3.2 records that no pointer model exists today. Three pieces are
-needed, and all three are observation, not authority: the application reports
-what the human did and changes nothing on the human's behalf. They belong to
-the `observer` profile.
+needed. Reading the resolved cursor, selection, and marks created by the human
+is observation: the application reports what the human did and changes nothing
+on the human's behalf. Those reads belong to the `observer` profile. Creating a
+mark through a remote call belongs to `annotator`.
 
 **A resolved cursor.** Not a coordinate pair. The application already knows how
 to turn a position into meaning during a frame, and the cursor scope publishes
@@ -526,7 +541,7 @@ that meaning:
 ```text
 pane, tab
 screen position
-slot index, bar timestamp_ms, price
+slot index, bar open_time_unix_ms, price
 the bar under the cursor: OHLCV, delta, trade count, progress
 the order-flow cell under the cursor, when a flow layer is on
 the drawing, anchor, or handle under the cursor
@@ -537,10 +552,10 @@ the control under the cursor, by the same stable ID the scene uses
 selected row in a trade history or event table. Drawings already carry a
 selected index internally; this exposes it, with its ID, through the contract.
 
-**A mark.** One hotkey that appends an event carrying the fully resolved target
-above, plus an optional note the user types. This is the primitive that makes
-the rest work. It converts "look at this" from a gesture the agent cannot see
-into a durable, structured referent the agent can quote back. Marks are
+**A human mark.** One hotkey that appends an event carrying the fully resolved
+target above, plus an optional note the user types. This is the primitive that
+makes the rest work. It converts "look at this" from a gesture the agent cannot
+see into a durable, structured referent the agent can quote back. Marks are
 timestamped, ordered, and readable through the same cursor as every other
 event, so an agent calling `wait_for_change` watches the user point in real time
 instead of polling and guessing.
@@ -673,16 +688,16 @@ font, GPU, clipping, and composition defects that neither half can show alone.
   list a thing the agent creates rather than observes.
 
 Profiles map onto the tiers of section 2.6 rather than onto a read and write
-split: `observer` covers the observe tier, including the cursor, selection, and
-marks of section 6.5, because none of it changes anything. `developer` adds the
-annotate tier and cockpit actions. `paper` adds simulated trading. Live trading
-has no profile in this plan.
+split: `observer` covers reads of the cursor, selection, and human-created marks
+from section 6.5. `annotator` adds reversible annotations, notifications,
+remote marks, and script attachment. `developer` adds cockpit actions. `paper`
+adds simulated trading. Live trading has no profile in this plan.
 
 ### 9.2 Future writes
 
 - Use `dry_run` whenever an operation can be validated first.
 - Require an `idempotency_key` for safe retries.
-- Use `expected_revision` to reject stale state.
+- Use `expected_revisions` to reject stale state.
 - Record an audit event for every attempt and result.
 - Match approval requirements to the declared effect.
 - Apply the same validation and confirmation rules as the user interface.
@@ -712,6 +727,9 @@ to stop and it argues instead.
 
 The rule that keeps this from becoming a loophole:
 
+- Risk reduction changes confirmation policy, not the capability's effect.
+  Paper and live operations still require an explicit `paper.safety` or future
+  `live.safety` grant; `observer`, `annotator`, and `developer` never inherit it.
 - An operation qualifies only if every reachable outcome leaves risk equal or
   lower. If any argument value, ordering, or failure path can increase
   exposure, it is not a risk-reducing operation and the exception does not
@@ -724,8 +742,9 @@ The rule that keeps this from becoming a loophole:
 - The audit trail is identical to any other action: actor, reason, timestamp,
   and result.
 
-This is what makes "block my entries" a capability the assistant can be trusted
-with early, while "let me trade again" stays a decision the user makes.
+This is what makes "block my entries" available under a narrow safety grant,
+while "let me trade again" stays under the full authority and confirmation of
+its financial tier.
 
 ## 10. Performance budget
 
@@ -744,15 +763,19 @@ pending or a semantic change needs to be recorded.
 - Aggregate market events before recording them.
 - Spend at most a fixed time budget on control-plane work per frame, stated in
   milliseconds and enforced in code, not as a count of requests.
-- Leave over-budget requests in the bounded queue or return backpressure.
+- Leave work that has not started in the bounded queue or return backpressure
+  when the remaining frame budget is insufficient.
 
 A request count is the wrong unit. One capture of a wide chart window with
 footprints and plot series can cost more than twenty small reads, so a cap of
 "N requests per frame" bounds the wrong quantity and still lets a single
 oversized capture blow a frame. The executor therefore checks a clock against a
-budget and stops, and any capture large enough to exceed the budget is either
-paginated by contract, as section 6.2 already requires, or resumed on the next
-frame.
+budget between requests and scopes. It never pauses one coherent capture and
+resumes it against a different frame. Every allowed capture shape has a measured
+upper bound below the budget; a request that could exceed it is paginated or
+rejected before capture, as section 6.2 requires. An unexpected single-capture
+overrun is recorded as a budget violation and fails the performance test rather
+than returning a mixed-revision result.
 
 The proposed opening budget is 1 ms at p99 with a hard stop well under a 16 ms
 frame. The number is calibrated in PR 2 against a measured baseline, but a
@@ -795,10 +818,10 @@ the work as parallel-safe.
 Deliverables:
 
 - Review and approve this document.
-- Create an initial capability inventory by module. Start from the 89
-  `QUANTICK_*` hooks of section 3.1: each one is an existing action with no
-  name, no result, and no discovery, so the inventory begins as a real list
-  with a migration target rather than as an estimate.
+- Create an initial capability inventory by module. Start from the 86
+  production `QUANTICK_*` surfaces of section 3.1 and identify the two
+  test-only variables separately, so the inventory begins as a measured list
+  with migration targets rather than as an estimate.
 - Add an ADR for local transport and instance discovery.
 - Add a threat model for the `observer` profile, covering the cursor and
   selection scopes of section 6.5. Publishing where the user is looking is
@@ -815,18 +838,11 @@ Deliverables:
 **Determinism.** `CLAUDE.md` makes "same trades in, same bars out" the first
 non-negotiable rule, and an agent acting during a session becomes part of that
 session's input. The event journal is a bounded ring buffer, so it is not a
-durable record of what happened. PR 0 picks one of two answers and writes it
-down:
-
-- agent-initiated actions are recorded into the replay session, so a run driven
-  by an agent stays reproducible; or
-- a session in which an agent acted is documented as not reproducible, and the
-  backtest harness refuses to treat it as a golden fixture.
-
-Either is defensible. Leaving it unstated is not, because the first agent action
-during a recorded replay would silently break the repository's primary
-invariant. Note that the observe tier, including marks, does not raise this
-question at all: it changes no input. Only the annotate tier and beyond do.
+durable record of what happened. PR 0 selects a durable, versioned control
+trace ordered by logical replay time for every determinism-affecting
+non-observe action, regardless of actor. A replay with an unrecorded action is
+ineligible as a deterministic fixture. The full decision is in the control
+contract.
 
 Acceptance criteria:
 
@@ -868,7 +884,7 @@ Acceptance criteria:
 - The crate has no dependency on `app` or domain crates.
 - All four repository checks pass.
 
-### PR 2: Snapshot registry in the application
+### PR 2: Snapshot registry and core application scopes
 
 **Branch:** `feat/control-observer`
 
@@ -878,7 +894,7 @@ Deliverables:
 
 - Add `crates/app/src/control/`.
 - Add a projection registry.
-- Add system, workspace, feed, chart, replay, paper, and health snapshots.
+- Add system, workspace, feed, chart, and health snapshots.
 - Add the cursor and selection scopes of section 6.5. This is where the
   application gains a pointer model it does not have today, so the work is a
   new concept rather than the exposure of an existing one: resolving a position
@@ -888,6 +904,20 @@ Deliverables:
 - Produce a consistent revision for each capture.
 - Measure the baseline and calibrate the per-frame budget of section 10.2.
 - Do not add a socket yet.
+
+After this registry merges, add the remaining snapshot modules in owner-focused
+pull requests that may run alongside PR 3:
+
+- `feat/control-snapshots-analysis`: indicators and drawings;
+- `feat/control-snapshots-orderflow`: tape, footprint, bubbles, heatmap, and L2;
+- `feat/control-snapshots-session`: replay and paper trading.
+- `feat/control-scene`: visible controls, stable IDs, state, bounds, ownership,
+  unavailable reasons, and related capability IDs.
+
+Each module registers through the projection port and touches the integration
+root only to dock itself. The semantic scene must merge before PR 4 exposes
+`quantick_get_scene`; the three domain snapshot branches must merge before the
+MVP evidence acceptance in PR 5c.
 
 Acceptance criteria:
 
@@ -899,9 +929,15 @@ Acceptance criteria:
   contract in silence.
 - A resolved cursor over a known bar reports that bar, verified headlessly
   against a fixture rather than by eye.
+- Chart pagination keeps its original high-water mark when a new live bar
+  appends, but rejects a page after a correction or backfill below that mark.
 - No request means no per-frame cost, measured as `frame_cpu_ms` against
   `origin/main` under the method in section 10.3.
 - No egui type appears in the wire schema.
+
+The same schema, consistency, no-egui, and performance criteria apply to every
+module snapshot pull request. Scene tests also prove stable control IDs across
+frames and explicit unavailable reasons without parsing rendered text.
 
 ### PR 3: Local gateway for the running instance
 
@@ -911,11 +947,12 @@ Acceptance criteria:
 
 Deliverables:
 
-- Implement the loopback or IPC endpoint selected by the ADR.
+- Implement the authenticated loopback TCP endpoint selected by the ADR.
 - Publish an instance descriptor.
 - Create an ephemeral token.
 - Add bounded queues.
-- Execute request and response work on the UI thread.
+- Dispatch only validated, authorized, bounded state access on the UI thread;
+  keep socket I/O, authentication, parsing, and serialization off-thread.
 - Wake or repaint the application when required.
 - Add timeouts, backpressure, and clean shutdown.
 - Support multiple instances in the protocol.
@@ -943,11 +980,14 @@ Deliverables:
 
 - Add the crate and binary.
 - Support STDIO.
-- Add optional Streamable HTTP if the selected SDK is mature enough.
+- Keep Streamable HTTP deferred until its separate transport and authentication
+  review; PR 4 ships STDIO only.
 - Implement the MVP tools except advanced event and evidence support.
 - Add instance selection.
 - Add short, self-contained server instructions.
 - Mark read-only tools correctly in their annotations.
+- Reserve standard output for MCP frames and send redacted diagnostics only to
+  standard error.
 - Add a local configuration generator or setup assistant.
 - Add MCP client smoke tests.
 
@@ -955,8 +995,11 @@ Acceptance criteria:
 
 - Codex and Claude run `describe`, `get_snapshot`, `get_chart_window`, and
   `get_diagnostics` against the same instance.
-- The observer profile exposes no write operation.
+- Under the observer ceiling, `quantick_invoke` is annotated read-only, no
+  registered write capability is available, and attempted write IDs are denied.
 - Disconnecting a client does not change application state.
+- A smoke test proves that startup, errors, and shutdown emit no non-MCP bytes
+  on standard output.
 - All four repository checks pass.
 
 The original plan combined events and evidence bundles in one pull request.
@@ -979,8 +1022,11 @@ Deliverables:
 - Emit selection-change events.
 - Add the mark hotkey of section 6.5: it appends an event carrying the fully
   resolved cursor target plus an optional typed note.
-- Register the hotkey as a named capability, so a mark can also be taken
-  without a keyboard.
+- Add the action-registry port and register `attention.mark.create`; the UI
+  hotkey and deterministic tests use that handler. The gateway keeps it
+  unavailable to remote observer clients.
+- Implement the durable control-trace port selected in PR 0, because the human
+  mark is the first registered non-observe action that can affect replay output.
 
 Acceptance criteria:
 
@@ -991,7 +1037,9 @@ Acceptance criteria:
 - An expired cursor reports `dropped_before`.
 - A parked waiter does not delay any other request, proved by a test that waits
   and reads concurrently.
-- Write requests remain impossible.
+- Remote write requests remain impossible under the observer profile.
+- Replaying a recorded human mark injects it at the same logical replay time;
+  an incomplete or missing trace makes the run fixture-ineligible.
 
 ### PR 5b: The annotate and notify tier
 
@@ -1005,11 +1053,16 @@ ships, the agent can see the chart and has no way to answer on it.
 
 Deliverables:
 
-- Implement the action registry port with the annotate tier as its first
-  consumer, then reuse the same registry in PR 6.
+- Extend the action registry introduced in PR 5a with remotely authorized
+  annotate handlers, then reuse the same registry in PR 6.
+- Expose `attention.mark.create` to the `annotator` profile through the same
+  handler the PR 5a UI hotkey already uses.
 - Add label, arrow, and zone annotations against a resolved chart target,
   attributed to the agent as author and removable in one action.
 - Add popup, toast, and sound notification capabilities.
+- Add independent annotate scopes for attention, chart state, notifications,
+  sound, and scripts. Sound is off by default and notifications have a stricter
+  rate limit than ordinary calls.
 - Add `attach_script`: compile a Quantick Pine source, return structured
   diagnostics on failure, attach the compiled indicator to a pane on success,
   and expose a matching detach.
@@ -1035,8 +1088,10 @@ Acceptance criteria:
   the prior state exactly.
 - No capability in this tier can discard user-created state or affect a
   position, verified by review against the tier table in section 2.6.
-- The determinism decision from PR 0 is honoured by every action here, since
-  this is the first pull request in which an agent changes session input.
+- Notification flood tests prove the per-client rate and burst limits, and a
+  client without the sound scope cannot produce audible output.
+- Every action uses the PR 5a control trace, since this is the first pull request
+  in which a remote agent changes session input.
 
 ### PR 5c: Evidence bundles
 
@@ -1048,15 +1103,17 @@ Deliverables:
 
 - Add consistent captures and a temporary resource.
 - Add redaction, an integrity hash, and a manifest.
-- Add the first semantic scene representation.
+- Consume the semantic scene through its existing projection port.
 - Correlate an optional screenshot with the capture revision, so pixel regions
   map to stable IDs (section 8).
-- Optionally add an explicit export operation.
-- Migrate the `ui-harness` and `visual-qa` skills onto the control plane. Both
-  drive the application through environment variables and read it through
-  window captures today; after PR 3 they can drive it live and read structured
-  state, which is what starts retiring the 89 hooks instead of adding a
-  parallel mechanism beside them.
+- Keep evidence in memory. Disk export is a later cockpit/filesystem action and
+  does not ship under observer or annotator authority.
+- Migrate the observation and evidence side of the `ui-harness` and `visual-qa`
+  skills onto the control plane. They may still use existing deterministic
+  hooks to establish a fixture until the corresponding cockpit handler lands in
+  PR 6, but assertions read structured live state instead of relying only on
+  window captures. Retirement of production hooks starts with the matching PR 6
+  and PR 7 actions, not with the observer gateway.
 
 MVP acceptance criteria:
 
@@ -1066,8 +1123,9 @@ MVP acceptance criteria:
 - The bundle reports omitted information and coverage gaps.
 - A bundle containing a screenshot maps every named control to a region of that
   image.
-- At least one existing validation skill runs against the control plane instead
-  of against environment variables.
+- At least one existing validation skill reads and asserts through the live
+  control plane; its fixture setup may still use an existing deterministic hook
+  until the matching action is available.
 
 ### PR 6: The cockpit tier
 
@@ -1075,10 +1133,13 @@ MVP acceptance criteria:
 
 **Rate class:** Human or agent actions, never trade or frame frequency.
 
-The action registry port itself lands in PR 5b with the annotate tier as its
-first consumer, so this pull request adds no port. It adds the tier that can
-discard work the user did by hand, which is why `expected_revision` and an undo
-path stop being optional here. Once the port has carried two tiers, independent
+The action registry port itself lands in PR 5a for the shared mark handler and
+gains remote annotate consumers in PR 5b, so this pull request adds no port. It
+adds the tier that can discard work the user did by hand, which is why
+`expected_revisions` and either an undo path or an explicit irreversible-change
+flow stop being optional here. Extend the threat model with cockpit subscopes,
+filesystem boundaries, and state-loss confirmation before enabling the
+`developer` profile. Once the port has carried multiple effects, independent
 modules can move into separate pull requests:
 
 1. workspace, tabs, and focus;
@@ -1095,7 +1156,10 @@ Acceptance criteria for every action:
 - The capability has a descriptor in the registry.
 - The actor is recorded.
 - Availability and blocking reasons match the user interface.
-- Undo or rollback is available when the human action already supports it.
+- Relevant `expected_revisions` are required.
+- Reversible actions expose undo or rollback. An irreversible action requires a
+  successful dry run, explicit confirmation, and a recoverable backup when the
+  underlying state can be backed up.
 - An existing hook, if any, calls the same handler.
 
 ### PR 7: Paper trading and strategies
@@ -1106,6 +1170,9 @@ Deliverables:
 
 - Add complete snapshots for orders, queued orders, positions, brackets, P&L,
   and the journal.
+- Extend the threat model with paper subscopes, confirmation, idempotency,
+  simulator failure modes, and the risk-reducing exception before enabling the
+  `paper` profile.
 - Add dry runs for commands.
 - Add strategy arm and disarm operations.
 - Route place, cancel, modify, close, and flatten through the same path as the
@@ -1151,11 +1218,18 @@ Recommended path to the MVP:
 
 ```text
 PR 0 -> PR 1 -> PR 2 -> PR 3 -> PR 4 -> PR 5a -> PR 5b -> PR 5c
+                    +-> semantic scene -> PR 4
+                    |                                      ^
+                    +-> analysis snapshots ----------------+
+                    +-> order-flow snapshots --------------+
+                    +-> replay/paper snapshots -------------+
 ```
 
-Keeping this sequence linear reduces protocol churn. Once the action registry
-is stable, indicator, drawing, replay, and workspace actions can be developed
-in parallel when they do not share files.
+Keeping the contract and registry spine linear reduces protocol churn. After PR
+2, owner-focused snapshot modules may run alongside PR 3. The semantic scene
+merges before PR 4; the remaining modules merge before PR 5c closes the evidence
+acceptance. Once the action registry is stable, indicator, drawing, replay, and
+workspace actions can be developed in parallel when they do not share files.
 
 The ordering inside PR 5 is the one change worth defending. 5a comes first
 because the event cursor is what the pointing channel is built on, and pointing
@@ -1254,8 +1328,8 @@ limitations for another agent to investigate without screenshots.
 ### Scenario E: Authority
 
 Under the observer profile, a write request is absent or rejected. Under a
-future developer profile, a stale action fails, while an accepted action records
-its actor and result.
+future annotator or developer profile, a stale action fails, while an accepted
+action records its actor and result.
 
 ### Scenario F: Multiple instances
 
@@ -1294,7 +1368,7 @@ error messages by hand.
 | Reading ships and answering never does | The annotate tier is inside the MVP (PR 5b) |
 | A cached tool list goes stale or grows unbounded | Named tools plus `invoke` (section 7.1) |
 | A closed enum blocks a future module | IDs are registry strings (section 5.5) |
-| An agent action breaks replay reproducibility | PR 0 records the decision either way |
+| A control action breaks replay reproducibility | Durable control trace ordered by logical replay time; an unrecorded action disqualifies the fixture |
 | Hand-mapped DTOs drift from the contract | Each snapshot validates against its schema |
 | One oversized capture blows a frame | A millisecond budget, not a request count |
 | A long poll starves other requests | Waiters park off the executor (section 6.4) |
@@ -1302,7 +1376,7 @@ error messages by hand.
 | Snapshots consume frame time | Build on demand, limit ranges, and serialize off-thread |
 | The tool list becomes too large | Use profiles, capability search, and module-based exposure |
 | Modules produce an inconsistent snapshot | Capture in one UI-thread pass and attach revisions |
-| A client acts on stale state | Require `expected_revision` |
+| A client acts on stale state | Require `expected_revisions` |
 | A retry duplicates an action | Require `idempotency_key` |
 | Local data leaks | Require opt-in, local endpoints, ephemeral tokens, and redaction |
 | An agent gets a trading shortcut | Reuse UI confirmation and use two phases for live trading |
@@ -1312,14 +1386,16 @@ error messages by hand.
 
 ## 16. Recommended starting decisions
 
-PR 0 should adopt these defaults unless the ADR or threat model finds a
-specific reason to change one:
+PR 0 adopts these defaults, with the details fixed by the control contract,
+ADR, and threat model:
 
 1. **Local first:** Use an authenticated loopback endpoint. Evaluate named
    pipes and Unix sockets in the ADR without blocking the MVP.
 2. **Local MCP over STDIO:** Prefer broad client compatibility and simple
    configuration.
-3. **Observer by default:** Expose no writes in the first release.
+3. **Observer by default:** Expose no writes unless the user grants a stronger
+   profile. Use `annotator` for reversible on-chart answers without cockpit
+   authority.
 4. **Model multiple instances immediately:** Keep this in the contract even if
    the first test runs only one instance.
 5. **Keep evidence in memory:** Make disk export explicit.
@@ -1330,8 +1406,9 @@ specific reason to change one:
 8. **Do not build a plugin VM yet:** The registry is the port. Add a plugin
    runtime only after a second concrete use case requires it.
 9. **Publish attention, not only state:** A resolved cursor, a published
-   selection, and a mark are part of the MVP. Pointing is what makes every
-   later exchange specific.
+   selection, and human-created marks are part of the observer MVP. Remote
+   mark creation is an annotate action. Pointing is what makes every later
+   exchange specific.
 10. **Ship the annotate tier inside the MVP:** Reading without answering leaves
     a one-way mirror. Annotate and notify cannot lose the user's work, so they
     are not the risk that justifies deferring them.
@@ -1346,18 +1423,16 @@ specific reason to change one:
 
 ## 17. Immediate next action
 
-After this plan is reviewed and accepted:
+PR 0 now contains the capability inventory, local transport ADR, observer
+threat model, contract conventions and limits, tool-surface decision, trade
+annotation owner, deterministic control-trace decision, and Codex and Claude
+setup flows.
 
-1. Complete PR 0 in the current worktree with the capability inventory seeded
-   from the 89 existing hooks, the local transport ADR, the observer threat
-   model including the cursor and selection scopes, the tool surface decision,
-   the owner of a trade annotation, and the determinism decision.
-2. Validate the documentation, complete the architecture review, and merge
-   PR 0.
-3. Create `feat/control-contract` in its own worktree.
-4. Implement only `quantick-control`, the fake host and client, and their tests.
-5. Run all four repository checks and the architecture review.
-6. Merge the contract before changing the application.
+1. Validate those documents, complete the architecture review, and merge PR 0.
+2. Create `feat/control-contract` in its own worktree.
+3. Implement only `quantick-control`, the fake host and client, and their tests.
+4. Run all four repository checks and the architecture review.
+5. Merge the contract before changing the application.
 
 This sequence establishes a small, testable boundary before touching the large
 `QuantickApp` state. It also keeps MCP SDK decisions out of domain code.
@@ -1388,6 +1463,8 @@ The MVP is complete when:
 
 ## 19. References
 
+- [PR 0 control-plane contract](control-plane/README.md): Normative decisions,
+  capability inventory, transport ADR, and observer threat model.
 - [`CLAUDE.md`](../CLAUDE.md): Architecture, determinism, dependency direction,
   and the "operable without a hand" rule.
 - [Local architecture review](../.claude/skills/arch-review/SKILL.md): The
@@ -1402,3 +1479,5 @@ The MVP is complete when:
   extensible registry.
 - [OpenAI Model Context Protocol documentation](https://learn.chatgpt.com/docs/extend/mcp?surface=cli):
   STDIO and Streamable HTTP transports, plus MCP configuration in Codex.
+- [Claude Code MCP documentation](https://code.claude.com/docs/en/mcp): Local
+  STDIO registration, scopes, and server verification.


### PR DESCRIPTION
## Summary

This follow-up completes PR 0 after #207 merged the reviewed development plan.

- inventory all 86 production `QUANTICK_*` surfaces and the two test-only names, with owners and migration targets;
- define the transport-neutral control contract, wire conventions, registries, authority model, bounded limits, cursors, pagination, idempotency, and canonical digests;
- select authenticated loopback TCP and private per-instance discovery in ADR 0001;
- define the observer threat model, consent flow, redaction, cross-scope rules, revocation, and required adversarial tests;
- reconcile the development sequence so each runtime module docks through a registry and unsafe or impossible ordering is removed.

## Key decisions

- `quantick-mcp` is a leaf STDIO adapter to an already-running app; it never starts Quantick.
- The in-app gateway binds only to `127.0.0.1`, uses a private descriptor and ephemeral token, and keeps I/O and serialization off the UI thread.
- Capability, effect, permission, profile, snapshot, and event identifiers are extensible validated strings backed by registries, not closed enums.
- `observer` is remotely read-only; `annotator` adds reversible annotations and bounded notifications without cockpit authority.
- Human-created marks are observable, while remote mark creation is an annotate action.
- Trusted actor fields are assigned by the gateway and cannot be supplied by a client.
- Replay-affecting actions use a durable control trace ordered by logical replay time.
- Durable trade notes belong to an app-owned `trade_annotations` sidecar, not `sim` or MCP.
- Payload, queue, event, audit, evidence, waiter, connection, timeout, and UI-frame budgets are named constants.

## Scope

Documentation and architecture contract only. This PR adds no runtime code and changes no existing application behavior.

## Validation

- strict UTF-8 / ASCII repository-language scan across all six documents;
- no trailing whitespace, balanced fences, and all local Markdown links resolve;
- literal source scan: 88/88 names match the inventory (86 production, 2 test-only);
- `git diff --check`;
- `cargo fmt --all -- --check`;
- `cargo clippy --workspace --all-targets -- -D warnings`;
- `cargo build --workspace`;
- `cargo test --workspace`.

## Architecture review

step 0: bundled `code-review` was unavailable in this environment; a manual high-effort correctness pass was completed, with all confirmed findings resolved before publication.

- **Correctness:** no open findings; authority, actor attribution, determinism, scope isolation, pagination consistency, and bounded-memory contradictions were reconciled.
- **Docking:** new modules register capabilities, effects, permissions, profiles, snapshots, and scene projections without extending closed enums; PR 1 must prove the port with a second fake module.
- **Performance:** docs-only, so runtime cost is unchanged; the contract prohibits disabled/idle hot-path work and fixes byte, queue, and per-frame budgets for implementation.
- **Operability:** no runtime surface is added here; the plan requires every later capability to satisfy Act, Read, and Discover through the shared registry.
- **Proof:** the document validators, exact source inventory comparison, four repository gates, and future per-PR acceptance tests are recorded above and in the contract.

## Next

After merge, PR 1 adds only `quantick-control`, its bounded codec, schemas, fake host/client, and contract tests before any application integration.