### PR TITLE
feat(app): Exhaustion reversal — mark where a push was handed back

### DIFF
--- a/crates/app/scripts/exhaustion_reversal.pine
+++ b/crates/app/scripts/exhaustion_reversal.pine
@@ -1,0 +1,237 @@
+//@version=5
+// Exhaustion reversal — the small arrow where a push ran out of buyers.
+//
+// The shape it looks for is one move in two acts. First a FORCE BAR: a bar
+// whose body dwarfs the recent average AND which takes out the extreme of
+// the last N bars. That is a push spending itself at the edge of the move,
+// not a bar that merely happens to be large in the middle of one. Then the
+// GIVE-BACK, which arrives in one of two shapes — either is enough, and each
+// has its own switch and its own settings:
+//
+//   THE RUN (section 2)      within a short window, several consecutive
+//                            opposite candles that together hand back most
+//                            of what the force bar took.
+//   THE ENGULF (section 3)   within a shorter window, ONE opposite candle
+//                            whose body covers most of the force bar on its
+//                            own.
+//
+// They are not the same test with different numbers, which is why they are
+// two sections instead of one. The run measures GIVE-BACK: how far price has
+// travelled back from the extreme, read at the close of the last candle in
+// the run. The engulf measures OVERLAP: how much of the force bar's range
+// the single candle's body actually sits on top of. A drift back over three
+// bars gives ground without covering anything; a wide bar that opens away
+// from the force bar covers nothing while closing far past it. Each shape
+// catches what the other misses.
+//
+// HOW TO READ THE CHART:
+//
+//   red triangle above a bar    a buying push at a new high was given back.
+//                               Exhaustion of the up move may be at hand.
+//   teal triangle below a bar   the mirror: a selling push at a new low was
+//                               given back.
+//   no triangle                 no completed give-back. Most bars have no
+//                               triangle, and that is the point — a chart
+//                               where every bar is marked has told you
+//                               nothing.
+//
+// The triangle sits above/below the bar and never covers it.
+//
+// HONEST ABOUT THE DELAY: the mark cannot appear at the extreme. It appears
+// on the bar that CLOSES the opposite run — at the earliest `run` bars after
+// the force bar, at the latest `window` bars after it. You are being shown a
+// reversal that has already partly happened, which is the only kind that can
+// be proven from closed bars. Nothing here is drawn on a forming bar, so no
+// mark ever appears and then disappears: what you see has committed.
+//
+// WHY THE WINDOW: without a ceiling, "three opposite candles eventually
+// showed up" is true of almost every force bar if you wait long enough — the
+// give-back would just be the tape drifting sideways in a micro range. The
+// window is what makes the give-back a REACTION to the push rather than a
+// coincidence that followed it. Widen it and you buy more signals with less
+// meaning; that trade is yours to make, not the indicator's.
+//
+// HOW THE RUN IS MEASURED: from the force bar's extreme to the CLOSE of the
+// bar completing the run, as a fraction of the force bar's whole range
+// (high - low). Closes, never wicks — a spike that pokes back through and
+// closes away from it has not given anything back. Above 1.0 the run has
+// gone past the far side of the force bar entirely, which is why that slider
+// goes beyond 100%.
+//
+// HOW THE ENGULF IS MEASURED: the overlap between the opposite candle's BODY
+// (open to close) and the force bar's range, as a fraction of that range. A
+// full 1.0 means the single body covers the force bar end to end. Because it
+// is an overlap it cannot exceed 100%, which is why that slider stops there
+// while the run's does not.
+//
+// The force bar's body is judged against the average of the bars BEFORE it
+// (same discipline as force_bar.pine): a huge bar must not be allowed to
+// inflate the very average that is deciding whether it is huge.
+//
+// A "new extreme" is strict: equalling the last N highs is not taking them
+// out. On a flat stretch where bars share a high, a >= test would call every
+// one of them a breakout — the strict test says nothing there, correctly.
+//
+// ONE MARK PER PUSH: a force bar arms once and is spent by the first signal
+// it produces, whichever shape produced it. Without that, a run of four
+// opposite candles inside the window would mark the second, third and fourth
+// as separate reversals of the same push — and with both shapes switched on,
+// an engulf would be marked again a bar later as a run. Both shapes draw the
+// same triangle: turn one off to see which one is speaking. A newer force
+// bar re-arms the side.
+//
+// Every threshold below is an input: this is a shape, and where the shape
+// begins and ends is a judgement about the instrument in front of you.
+// Defaults are a starting point measured on nothing in particular —
+// calibrate on recorded sessions. Information, not advice: the last decision
+// belongs to the trader.
+indicator("Exhaustion reversal", overlay=true)
+
+// 1 — the force bar: what counts as a push worth fading?
+body_len = input.int(20, "1 Force bar: body average window (bars)", minval=1, maxval=500)
+body_factor = input.float(1.5, "1 Force bar: min body (×average)", minval=0.1, maxval=20.0, step=0.1)
+extreme_len = input.int(10, "1 Force bar: new extreme over (bars)", minval=1, maxval=500)
+need_direction = input.bool(true, "1 Force bar: must close in the direction of the push")
+
+// 2 — the run: several opposite candles handing the push back together.
+use_run = input.bool(true, "2 Run: mark a give-back by consecutive candles")
+run_len = input.int(3, "2 Run: opposite candles in a row", minval=1, maxval=20)
+window_len = input.int(5, "2 Run: window after the force bar (bars)", minval=1, maxval=100)
+coverage = input.float(0.7, "2 Run: min give-back of the force bar (fraction of range)", minval=0.05, maxval=3.0, step=0.05)
+
+// 3 — the engulf: one opposite candle covering the force bar by itself.
+// Shorter window than the run by default: a single bar answering a push is
+// an immediate response, and three bars later it is a different bar reacting
+// to a different thing.
+use_engulf = input.bool(true, "3 Engulf: mark a give-back by one opposite candle")
+engulf_window = input.int(3, "3 Engulf: window after the force bar (bars)", minval=1, maxval=100)
+engulf_coverage = input.float(0.7, "3 Engulf: min overlap with the force bar (fraction of range)", minval=0.05, maxval=1.0, step=0.05)
+
+// 4 — display: which side to mark, and in what colour. These gate the
+// drawing sites only. The state machine below runs whatever they say, so
+// flipping a side back on never changes what the indicator concluded while
+// it was off.
+show_top = input.bool(true, "4 Display: mark top reversals (sell side)")
+show_bottom = input.bool(true, "4 Display: mark bottom reversals (buy side)")
+top_colour = input.color(color.red, "4 Display: top mark colour")
+bottom_colour = input.color(color.teal, "4 Display: bottom mark colour")
+
+// ---------------------------------------------------------------- measures
+
+// Every stateful ta.* call is hoisted to the top level and fed on every bar:
+// kernels have call-site identity and `and` short-circuits, so a kernel
+// behind a condition would warm up late and read a gapped series.
+body = math.abs(close - open)
+avg_body_before = ta.sma(body[1], body_len)
+high_before = ta.highest(high[1], extreme_len)
+low_before = ta.lowest(low[1], extreme_len)
+
+// A window shorter than the run it must contain would mean "never" — an
+// input that silently cannot fire is a trap, so the window is at least the
+// run. (Same spirit as force_bar.pine reordering its min/max multiples.)
+run_window = math.max(window_len, run_len)
+
+// How long a force bar stays armed: the longer of the two shapes' windows,
+// and deliberately NOT conditional on their switches. If the state machine
+// forgot the push sooner with one shape switched off, the other shape would
+// answer differently depending on a checkbox it has nothing to do with.
+arm_window = math.max(run_window, engulf_window)
+
+// A zero average is warm-up or a dead tape, not a bar that beats it.
+big_body = not na(avg_body_before) and avg_body_before > 0 and body >= body_factor * avg_body_before
+new_high = not na(high_before) and high > high_before
+new_low = not na(low_before) and low < low_before
+
+bull_bar = close > open
+bear_bar = close < open
+
+// A doji closes neither way and breaks a run: it is a pause, not a give-back.
+var int bear_run = 0
+var int bull_run = 0
+bear_run := bear_bar ? bear_run + 1 : 0
+bull_run := bull_bar ? bull_run + 1 : 0
+
+top_anchor = big_body and new_high and (not need_direction or bull_bar)
+bottom_anchor = big_body and new_low and (not need_direction or bear_bar)
+
+// ------------------------------------------------------------------- state
+
+// One armed force bar per side, with its own age and its own range. The two
+// sides are independent: the bar that gives back a buying push may itself be
+// the selling push that arms the other side.
+var bool top_armed = false
+var int top_age = 0
+var float top_high = na
+var float top_low = na
+var bool bottom_armed = false
+var int bottom_age = 0
+var float bottom_high = na
+var float bottom_low = na
+
+// Age first, test second, arm last. Ageing before the test is what makes the
+// bar `run_len` bars after the force bar read as age `run_len`; arming after
+// it is what stops a force bar from being faded by the very bar that made it.
+if top_armed
+    top_age := top_age + 1
+    if top_age > arm_window
+        top_armed := false
+if bottom_armed
+    bottom_age := bottom_age + 1
+    if bottom_age > arm_window
+        bottom_armed := false
+
+// ----------------------------------------------------------------- signals
+
+// Division by zero yields na in this dialect, and the na guard below is what
+// keeps a zero-range force bar from being "covered" by anything at all.
+top_range = top_high - top_low
+bottom_range = bottom_high - bottom_low
+top_given_back = top_range > 0 ? (top_high - close) / top_range : na
+bottom_given_back = bottom_range > 0 ? (close - bottom_low) / bottom_range : na
+
+sell_run = use_run and top_armed and top_age >= run_len and top_age <= run_window and bear_run >= run_len and not na(top_given_back) and top_given_back >= coverage
+buy_run = use_run and bottom_armed and bottom_age >= run_len and bottom_age <= run_window and bull_run >= run_len and not na(bottom_given_back) and bottom_given_back >= coverage
+
+// The engulf: how much of the force bar's range this one body sits on top
+// of. Overlap of two intervals — the candle's body against the force bar's
+// range — so it is bounded by the force bar and cannot be inflated by a
+// candle that is merely enormous somewhere else. A body that does not reach
+// the force bar at all makes this negative, which fails the test on its own.
+top_overlap = math.min(open, top_high) - math.max(close, top_low)
+bottom_overlap = math.min(close, bottom_high) - math.max(open, bottom_low)
+top_engulfed = top_range > 0 ? top_overlap / top_range : na
+bottom_engulfed = bottom_range > 0 ? bottom_overlap / bottom_range : na
+
+sell_engulf = use_engulf and top_armed and top_age <= engulf_window and bear_bar and not na(top_engulfed) and top_engulfed >= engulf_coverage
+buy_engulf = use_engulf and bottom_armed and bottom_age <= engulf_window and bull_bar and not na(bottom_engulfed) and bottom_engulfed >= engulf_coverage
+
+// Either shape marks, and the first one to fire spends the push.
+sell_signal = sell_run or sell_engulf
+buy_signal = buy_run or buy_engulf
+
+// Spent by its own signal, re-armed only by a newer force bar.
+if sell_signal
+    top_armed := false
+if buy_signal
+    bottom_armed := false
+
+if top_anchor
+    top_armed := true
+    top_age := 0
+    top_high := high
+    top_low := low
+if bottom_anchor
+    bottom_armed := true
+    bottom_age := 0
+    bottom_high := high
+    bottom_low := low
+
+// ------------------------------------------------------------------- marks
+
+// Closed bars only. The forming bar's preview is rolled back, so a mark that
+// appeared there would be a promise the tape had not yet made.
+sell_mark = sell_signal and barstate.isconfirmed
+buy_mark = buy_signal and barstate.isconfirmed
+
+plotshape(show_top and sell_mark, "Exhaustion reversal: sell", style=shape.triangledown, location=location.abovebar, color=top_colour)
+plotshape(show_bottom and buy_mark, "Exhaustion reversal: buy", style=shape.triangleup, location=location.belowbar, color=bottom_colour)

--- a/crates/app/scripts/exhaustion_reversal.pine
+++ b/crates/app/scripts/exhaustion_reversal.pine
@@ -2,27 +2,24 @@
 // Exhaustion reversal — the small arrow where a push ran out of buyers.
 //
 // The shape it looks for is one move in two acts. First a FORCE BAR: a bar
-// whose body dwarfs the recent average AND which takes out the extreme of
-// the last N bars. That is a push spending itself at the edge of the move,
-// not a bar that merely happens to be large in the middle of one. Then the
+// whose body dwarfs the recent average AND which reaches the extreme of the
+// last N bars. That is a push spending itself at the edge of the move, not a
+// bar that merely happens to be large in the middle of one. Then the
 // GIVE-BACK, which arrives in one of two shapes — either is enough, and each
 // has its own switch and its own settings:
 //
-//   THE RUN (section 2)      within a short window, several consecutive
-//                            opposite candles that together hand back most
-//                            of what the force bar took.
-//   THE ENGULF (section 3)   within a shorter window, ONE opposite candle
-//                            whose body covers most of the force bar on its
-//                            own.
+//   THE RUN (section 2)     several consecutive opposite candles, with price
+//                           back below (or above) a set fraction of the force
+//                           bar by the close of the last of them.
+//   THE COVER (section 3)   ONE opposite candle whose body sits on top of
+//                           most of the force bar's range.
 //
 // They are not the same test with different numbers, which is why they are
-// two sections instead of one. The run measures GIVE-BACK: how far price has
-// travelled back from the extreme, read at the close of the last candle in
-// the run. The engulf measures OVERLAP: how much of the force bar's range
-// the single candle's body actually sits on top of. A drift back over three
-// bars gives ground without covering anything; a wide bar that opens away
-// from the force bar covers nothing while closing far past it. Each shape
-// catches what the other misses.
+// two sections instead of one. The run is about TRAVEL: where price ended up,
+// relative to the extreme. The cover is about OVERLAP: how much of the force
+// bar a single body actually covers, wherever price ends up. A slow drift
+// travels without covering; a wide bar can cover the force bar and close only
+// just past it. Each shape catches what the other misses.
 //
 // HOW TO READ THE CHART:
 //
@@ -33,52 +30,73 @@
 //   no triangle                 no completed give-back. Most bars have no
 //                               triangle, and that is the point — a chart
 //                               where every bar is marked has told you
-//                               nothing.
+//                               nothing. (Measured: ~3% of bars at these
+//                               defaults on a 2 000-bar random walk.)
 //
-// The triangle sits above/below the bar and never covers it.
+// The triangle sits above/below the bar and never covers it. Its colour and
+// width are on the indicator dialog's STYLE tab, per plot, where every other
+// indicator's colours live — not in the inputs below.
 //
-// HONEST ABOUT THE DELAY: the mark cannot appear at the extreme. It appears
-// on the bar that CLOSES the opposite run — at the earliest `run` bars after
-// the force bar, at the latest `window` bars after it. You are being shown a
+// HONEST ABOUT THE DELAY: the mark cannot appear at the extreme, and how late
+// it is depends on which shape fired. A cover can mark the very next bar
+// after the force bar; a run needs at least its own length. The latest either
+// can be is that shape's own window. So with the defaults a triangle is
+// between 1 and 5 bars behind the extreme it is about. You are being shown a
 // reversal that has already partly happened, which is the only kind that can
-// be proven from closed bars. Nothing here is drawn on a forming bar, so no
-// mark ever appears and then disappears: what you see has committed.
+// be proven from closed bars. Nothing is drawn on a forming bar, so no mark
+// ever appears and then disappears: what you see has committed.
 //
-// WHY THE WINDOW: without a ceiling, "three opposite candles eventually
-// showed up" is true of almost every force bar if you wait long enough — the
-// give-back would just be the tape drifting sideways in a micro range. The
-// window is what makes the give-back a REACTION to the push rather than a
-// coincidence that followed it. Widen it and you buy more signals with less
-// meaning; that trade is yours to make, not the indicator's.
+// WHY THE WINDOWS: without a ceiling, "opposite candles eventually showed up"
+// is true of almost every force bar if you wait long enough — the give-back
+// would just be the tape drifting sideways in a micro range. The window is
+// what makes the give-back a REACTION to the push rather than a coincidence
+// that followed it. Widen it and you buy more signals with less meaning; that
+// trade is yours to make, not the indicator's.
 //
-// HOW THE RUN IS MEASURED: from the force bar's extreme to the CLOSE of the
-// bar completing the run, as a fraction of the force bar's whole range
-// (high - low). Closes, never wicks — a spike that pokes back through and
-// closes away from it has not given anything back. Above 1.0 the run has
-// gone past the far side of the force bar entirely, which is why that slider
-// goes beyond 100%.
+// HOW THE RUN IS MEASURED — two conditions, deliberately independent:
+//   (a) the last `run` candles all closed against the push, and
+//   (b) at this bar's CLOSE, price has given back `give-back` of the force
+//       bar's range, measured from the force bar's extreme.
+// It does NOT check that the run itself did the travelling. A gap that hands
+// back the whole force bar in one bar, followed by three tiny down-closes,
+// satisfies both and marks. That is intentional — the question being asked is
+// "is price back, and is the tape still leaning that way?", not "which bar
+// carried it" — but it is worth knowing, because the streak can be cosmetic.
 //
-// HOW THE ENGULF IS MEASURED: the overlap between the opposite candle's BODY
+// HOW THE COVER IS MEASURED: the overlap between the opposite candle's BODY
 // (open to close) and the force bar's range, as a fraction of that range. A
-// full 1.0 means the single body covers the force bar end to end. Because it
-// is an overlap it cannot exceed 100%, which is why that slider stops there
-// while the run's does not.
+// full 1.0 means one body covers the force bar end to end. Because it is an
+// overlap it cannot exceed 100%, which is why that slider stops there while
+// the run's does not (a run can travel past the far side entirely).
+//
+// Note what "overlap" allows: a candle whose whole range sits INSIDE the
+// force bar counts, if its body still covers enough of it. That is not a
+// classical engulfing candle, and it is not called one here — a small bar
+// that erases most of a large one is exactly the exhaustion this is looking
+// for, whether or not it pokes out the ends.
 //
 // The force bar's body is judged against the average of the bars BEFORE it
 // (same discipline as force_bar.pine): a huge bar must not be allowed to
 // inflate the very average that is deciding whether it is huge.
 //
-// A "new extreme" is strict: equalling the last N highs is not taking them
-// out. On a flat stretch where bars share a high, a >= test would call every
-// one of them a breakout — the strict test says nothing there, correctly.
+// Reaching the extreme is `>=`, not `>`: on futures the offer parks at a
+// price and highs tie constantly, and a push that shoves into a level the
+// tape touched N bars ago is the same event as one that clears it by a tick.
+// The body test is what keeps a flat, quiet stretch from anchoring — a run of
+// tied highs has no body behind it and never becomes a force bar.
 //
 // ONE MARK PER PUSH: a force bar arms once and is spent by the first signal
 // it produces, whichever shape produced it. Without that, a run of four
 // opposite candles inside the window would mark the second, third and fourth
-// as separate reversals of the same push — and with both shapes switched on,
-// an engulf would be marked again a bar later as a run. Both shapes draw the
-// same triangle: turn one off to see which one is speaking. A newer force
-// bar re-arms the side.
+// as separate reversals of the same push. A newer force bar re-arms the side.
+//
+// Both shapes draw the same triangle, so switching one off is how you find
+// out which one is speaking — but read the result carefully: the switches do
+// not only silence marks, they can MOVE one. If a cover spends a push on the
+// bar after the force bar, the run never sees that push at all; switch the
+// cover off and the same tape may mark three bars later, where the run
+// finally completes. A mark that jumps when you flip a switch is those two
+// shapes disagreeing about when the push ended, not an inconsistency.
 //
 // Every threshold below is an input: this is a shape, and where the shape
 // begins and ends is a judgement about the instrument in front of you.
@@ -90,37 +108,41 @@ indicator("Exhaustion reversal", overlay=true)
 // 1 — the force bar: what counts as a push worth fading?
 body_len = input.int(20, "1 Force bar: body average window (bars)", minval=1, maxval=500)
 body_factor = input.float(1.5, "1 Force bar: min body (×average)", minval=0.1, maxval=20.0, step=0.1)
-extreme_len = input.int(10, "1 Force bar: new extreme over (bars)", minval=1, maxval=500)
+extreme_len = input.int(10, "1 Force bar: reaches the extreme of (bars)", minval=1, maxval=500)
 need_direction = input.bool(true, "1 Force bar: must close in the direction of the push")
 
-// 2 — the run: several opposite candles handing the push back together.
+// 2 — the run: several opposite candles, and price back off the extreme.
 use_run = input.bool(true, "2 Run: mark a give-back by consecutive candles")
 run_len = input.int(3, "2 Run: opposite candles in a row", minval=1, maxval=20)
 window_len = input.int(5, "2 Run: window after the force bar (bars)", minval=1, maxval=100)
 coverage = input.float(0.7, "2 Run: min give-back of the force bar (fraction of range)", minval=0.05, maxval=3.0, step=0.05)
 
-// 3 — the engulf: one opposite candle covering the force bar by itself.
-// Shorter window than the run by default: a single bar answering a push is
-// an immediate response, and three bars later it is a different bar reacting
-// to a different thing.
-use_engulf = input.bool(true, "3 Engulf: mark a give-back by one opposite candle")
-engulf_window = input.int(3, "3 Engulf: window after the force bar (bars)", minval=1, maxval=100)
-engulf_coverage = input.float(0.7, "3 Engulf: min overlap with the force bar (fraction of range)", minval=0.05, maxval=1.0, step=0.05)
+// 3 — the cover: one opposite candle sitting on top of the force bar.
+// Shorter window than the run by default: a single bar answering a push is an
+// immediate response, and five bars later it is a different bar reacting to
+// a different thing.
+use_cover = input.bool(true, "3 Cover: mark a give-back by one opposite candle")
+cover_window = input.int(3, "3 Cover: window after the force bar (bars)", minval=1, maxval=100)
+cover_fraction = input.float(0.7, "3 Cover: min overlap with the force bar (fraction of range)", minval=0.05, maxval=1.0, step=0.05)
 
-// 4 — display: which side to mark, and in what colour. These gate the
-// drawing sites only. The state machine below runs whatever they say, so
-// flipping a side back on never changes what the indicator concluded while
-// it was off.
+// 4 — display: which side to mark. These gate the drawing sites only. The
+// state machine below runs whatever they say, so flipping a side back on
+// never changes what the indicator concluded while it was off.
+//
+// Colour and width are deliberately NOT inputs: they live on the dialog's
+// Style tab, per plot, which is what the chart actually reads. An
+// `input.color` handed to a plot in this dialect does not fold, and the mark
+// silently comes out amber — so a colour slider here would be a dead control.
 show_top = input.bool(true, "4 Display: mark top reversals (sell side)")
 show_bottom = input.bool(true, "4 Display: mark bottom reversals (buy side)")
-top_colour = input.color(color.red, "4 Display: top mark colour")
-bottom_colour = input.color(color.teal, "4 Display: bottom mark colour")
 
 // ---------------------------------------------------------------- measures
 
 // Every stateful ta.* call is hoisted to the top level and fed on every bar:
 // kernels have call-site identity and `and` short-circuits, so a kernel
-// behind a condition would warm up late and read a gapped series.
+// behind a condition would warm up late and read a gapped series. This
+// applies to the four below and to nothing else — the arithmetic further
+// down is current-bar only, and is deliberately left behind its guards.
 body = math.abs(close - open)
 avg_body_before = ta.sma(body[1], body_len)
 high_before = ta.highest(high[1], extreme_len)
@@ -135,12 +157,13 @@ run_window = math.max(window_len, run_len)
 // and deliberately NOT conditional on their switches. If the state machine
 // forgot the push sooner with one shape switched off, the other shape would
 // answer differently depending on a checkbox it has nothing to do with.
-arm_window = math.max(run_window, engulf_window)
+arm_window = math.max(run_window, cover_window)
 
-// A zero average is warm-up or a dead tape, not a bar that beats it.
+// A zero average is warm-up or a dead tape, not a bar that beats it. The
+// `not na` guards are what keep the opening stretch unmarked.
 big_body = not na(avg_body_before) and avg_body_before > 0 and body >= body_factor * avg_body_before
-new_high = not na(high_before) and high > high_before
-new_low = not na(low_before) and low < low_before
+new_high = not na(high_before) and high >= high_before
+new_low = not na(low_before) and low <= low_before
 
 bull_bar = close > open
 bear_bar = close < open
@@ -182,34 +205,32 @@ if bottom_armed
 
 // ----------------------------------------------------------------- signals
 
-// Division by zero yields na in this dialect, and the na guard below is what
-// keeps a zero-range force bar from being "covered" by anything at all.
+// Two subtractions, cheap enough to keep in the open for readability; `na`
+// when no push is armed, which makes every `> 0` below false.
 top_range = top_high - top_low
 bottom_range = bottom_high - bottom_low
-top_given_back = top_range > 0 ? (top_high - close) / top_range : na
-bottom_given_back = bottom_range > 0 ? (close - bottom_low) / bottom_range : na
 
-sell_run = use_run and top_armed and top_age >= run_len and top_age <= run_window and bear_run >= run_len and not na(top_given_back) and top_given_back >= coverage
-buy_run = use_run and bottom_armed and bottom_age >= run_len and bottom_age <= run_window and bull_run >= run_len and not na(bottom_given_back) and bottom_given_back >= coverage
+// The divisions and the overlap arithmetic sit BEHIND the guards on purpose.
+// `and` short-circuits, and on the large majority of bars no push is armed —
+// so on those bars this line stops at `top_armed` and the maths never runs.
+// (Measured: ~17% of the script's commit cost, and this runs again for every
+// preview of the forming bar.) Nothing here is a `ta.*` kernel, so unlike the
+// measures above there is no warm-up to protect by hoisting it.
+sell_run = use_run and top_armed and top_age >= run_len and top_age <= run_window and bear_run >= run_len and top_range > 0 and (top_high - close) / top_range >= coverage
+buy_run = use_run and bottom_armed and bottom_age >= run_len and bottom_age <= run_window and bull_run >= run_len and bottom_range > 0 and (close - bottom_low) / bottom_range >= coverage
 
-// The engulf: how much of the force bar's range this one body sits on top
-// of. Overlap of two intervals — the candle's body against the force bar's
-// range — so it is bounded by the force bar and cannot be inflated by a
-// candle that is merely enormous somewhere else. A body that does not reach
-// the force bar at all makes this negative, which fails the test on its own.
-top_overlap = math.min(open, top_high) - math.max(close, top_low)
-bottom_overlap = math.min(close, bottom_high) - math.max(open, bottom_low)
-top_engulfed = top_range > 0 ? top_overlap / top_range : na
-bottom_engulfed = bottom_range > 0 ? bottom_overlap / bottom_range : na
-
-sell_engulf = use_engulf and top_armed and top_age <= engulf_window and bear_bar and not na(top_engulfed) and top_engulfed >= engulf_coverage
-buy_engulf = use_engulf and bottom_armed and bottom_age <= engulf_window and bull_bar and not na(bottom_engulfed) and bottom_engulfed >= engulf_coverage
+// The cover: the overlap of two intervals — this candle's body against the
+// force bar's range — so it is bounded by the force bar and cannot be
+// inflated by a candle that is merely enormous somewhere else. A body that
+// does not reach the force bar at all makes the overlap negative, which
+// fails on its own.
+sell_cover = use_cover and top_armed and top_age <= cover_window and bear_bar and top_range > 0 and (math.min(open, top_high) - math.max(close, top_low)) / top_range >= cover_fraction
+buy_cover = use_cover and bottom_armed and bottom_age <= cover_window and bull_bar and bottom_range > 0 and (math.min(close, bottom_high) - math.max(open, bottom_low)) / bottom_range >= cover_fraction
 
 // Either shape marks, and the first one to fire spends the push.
-sell_signal = sell_run or sell_engulf
-buy_signal = buy_run or buy_engulf
+sell_signal = sell_run or sell_cover
+buy_signal = buy_run or buy_cover
 
-// Spent by its own signal, re-armed only by a newer force bar.
 if sell_signal
     top_armed := false
 if buy_signal
@@ -233,5 +254,5 @@ if bottom_anchor
 sell_mark = sell_signal and barstate.isconfirmed
 buy_mark = buy_signal and barstate.isconfirmed
 
-plotshape(show_top and sell_mark, "Exhaustion reversal: sell", style=shape.triangledown, location=location.abovebar, color=top_colour)
-plotshape(show_bottom and buy_mark, "Exhaustion reversal: buy", style=shape.triangleup, location=location.belowbar, color=bottom_colour)
+plotshape(show_top and sell_mark, "Exhaustion reversal: sell", style=shape.triangledown, location=location.abovebar, color=color.red)
+plotshape(show_bottom and buy_mark, "Exhaustion reversal: buy", style=shape.triangleup, location=location.belowbar, color=color.teal)

--- a/crates/app/src/indicator_worker.rs
+++ b/crates/app/src/indicator_worker.rs
@@ -1760,15 +1760,24 @@ mod exhaustion_reversal_chain_tests {
         }
     }
 
-    /// 24 tick(2) bars sized for the script's *defaults*: twenty quiet
-    /// bullish bars (body 1) to warm a 20-bar body average and a 10-bar
-    /// extreme, then a body-10 bar taking out the high, then three bearish
-    /// bars handing 80% of it back.
+    /// Quiet bars before the force bar. The 20-bar body average this script
+    /// defaults to first exists on bar 20 (`body[1]` is `na` on bar 0 and
+    /// that NaN sits in the window until it slides out), so a fixture with
+    /// exactly 20 would put the force bar on the very first bar that can be
+    /// judged at all — and any edit that shifts warm-up by one would fail
+    /// this test with an empty marker column, which reads as a broken
+    /// channel rather than as a fixture one bar short.
+    const WARMUP_BARS: usize = 25;
+
+    /// 29 tick(2) bars sized for the script's *defaults*: the quiet bullish
+    /// run above (body 1) to warm a 20-bar body average and a 10-bar extreme,
+    /// then a body-10 bar taking out the high, then three bearish bars
+    /// handing 80% of it back.
     fn tape() -> Vec<Bar> {
         // Two prints per bar, so each pair below *is* one bar's open and
         // close (and, with no third print, its low and high).
         let mut prices: Vec<i64> = Vec::new();
-        for _ in 0..20 {
+        for _ in 0..WARMUP_BARS {
             prices.extend([100, 101]);
         }
         // 20: the force bar — body 10 against an average of 1, high 111
@@ -1808,7 +1817,7 @@ mod exhaustion_reversal_chain_tests {
     #[test]
     fn the_embedded_exhaustion_reversal_marks_through_the_whole_chain() {
         let bars = tape();
-        assert_eq!(bars.len(), 24, "fixture shape");
+        assert_eq!(bars.len(), WARMUP_BARS + 4, "fixture shape");
 
         let source = EMBEDDED_SCRIPTS
             .iter()
@@ -1836,7 +1845,7 @@ mod exhaustion_reversal_chain_tests {
         assert_eq!(views.all()[0].rows, bars.len());
         assert_eq!(
             marks(&views, "Exhaustion reversal: sell"),
-            vec![23],
+            vec![WARMUP_BARS + 3],
             "the triangle lands on the bar closing the give-back, with the \
              defaults a trader gets from the menu — no test-only inputs"
         );

--- a/crates/app/src/indicator_worker.rs
+++ b/crates/app/src/indicator_worker.rs
@@ -1733,3 +1733,117 @@ mod paint_tests {
         );
     }
 }
+
+/// The marker channel end to end, for `exhaustion_reversal.pine`.
+///
+/// `exhaustion_reversal_semantics.rs` proves the rules against the corpus
+/// copy with shrunken windows. This proves the other half: that the script
+/// the menu actually offers, run with **its own declared defaults** through
+/// the real worker and the real delta events, puts a triangle in the column
+/// the renderer reads. A script can be semantically perfect and still reach
+/// the chart with nothing on it.
+#[cfg(test)]
+mod exhaustion_reversal_chain_tests {
+    use super::*;
+    use crate::indicators::IndicatorViews;
+    use crate::indicators::library::EMBEDDED_SCRIPTS;
+    use quantick_engine::{Side, TickBarBuilder, Trade, golden as engine_golden};
+    use rust_decimal::Decimal;
+
+    fn print(id: u64, price: i64) -> Trade {
+        Trade {
+            agg_id: id,
+            timestamp_ms: 1_000 + id as i64 * 100,
+            price: Decimal::from(price),
+            quantity: Decimal::ONE,
+            side: Side::Buy,
+        }
+    }
+
+    /// 24 tick(2) bars sized for the script's *defaults*: twenty quiet
+    /// bullish bars (body 1) to warm a 20-bar body average and a 10-bar
+    /// extreme, then a body-10 bar taking out the high, then three bearish
+    /// bars handing 80% of it back.
+    fn tape() -> Vec<Bar> {
+        // Two prints per bar, so each pair below *is* one bar's open and
+        // close (and, with no third print, its low and high).
+        let mut prices: Vec<i64> = Vec::new();
+        for _ in 0..20 {
+            prices.extend([100, 101]);
+        }
+        // 20: the force bar — body 10 against an average of 1, high 111
+        // against a 10-bar extreme of 101.
+        prices.extend([101, 111]);
+        // 21..23: three bearish bars, the last closing at 103 — 80% of the
+        // force bar's range given back, on the third bar of the run.
+        prices.extend([111, 109]);
+        prices.extend([109, 107]);
+        prices.extend([107, 103]);
+
+        let trades: Vec<Trade> = prices
+            .iter()
+            .enumerate()
+            .map(|(index, price)| print(index as u64 + 1, *price))
+            .collect();
+        engine_golden::replay(&mut TickBarBuilder::new(2), &trades)
+    }
+
+    /// Rows of `title` carrying a mark, read the way the renderer reads them.
+    fn marks(views: &IndicatorViews, title: &str) -> Vec<usize> {
+        let view = &views.all()[0];
+        let index = view
+            .descriptor
+            .plots
+            .iter()
+            .position(|plot| plot.title == title)
+            .unwrap_or_else(|| panic!("plot {title:?} is declared"));
+        view.columns[index]
+            .iter()
+            .enumerate()
+            .filter(|(_, value)| !value.is_nan())
+            .map(|(row, _)| row)
+            .collect()
+    }
+
+    #[test]
+    fn the_embedded_exhaustion_reversal_marks_through_the_whole_chain() {
+        let bars = tape();
+        assert_eq!(bars.len(), 24, "fixture shape");
+
+        let source = EMBEDDED_SCRIPTS
+            .iter()
+            .find(|(name, _)| *name == "exhaustion_reversal.pine")
+            .expect("exhaustion_reversal.pine is embedded")
+            .1;
+
+        let worker = IndicatorWorker::spawn();
+        let mut views = IndicatorViews::new();
+        let slot = views.allocate_slot("script.exhaustion_reversal");
+        worker.send(IndicatorCommand::Add {
+            slot,
+            source: IndicatorSource::Script {
+                name: "exhaustion_reversal.pine".to_owned(),
+                text: source.to_owned(),
+            },
+        });
+        worker.send(IndicatorCommand::Backfilled(bars.clone()));
+        worker.flush();
+        for event in worker.drain_events() {
+            views.apply(event);
+        }
+
+        assert!(views.all()[0].error.is_none(), "the script loaded");
+        assert_eq!(views.all()[0].rows, bars.len());
+        assert_eq!(
+            marks(&views, "Exhaustion reversal: sell"),
+            vec![23],
+            "the triangle lands on the bar closing the give-back, with the \
+             defaults a trader gets from the menu — no test-only inputs"
+        );
+        assert_eq!(
+            marks(&views, "Exhaustion reversal: buy"),
+            Vec::<usize>::new(),
+            "and the other side stays empty on a tape that only fades a rally"
+        );
+    }
+}

--- a/crates/app/src/indicators/library.rs
+++ b/crates/app/src/indicators/library.rs
@@ -236,7 +236,7 @@ mod tests {
 
     /// Same pin, same reason: `exhaustion_reversal_semantics.rs` proves the
     /// force-bar / give-back pairs against the corpus copy, and a drift would
-    /// leave twelve passing tests describing a script nobody ships.
+    /// leave a suite of passing tests describing a script nobody ships.
     #[test]
     fn the_embedded_exhaustion_reversal_matches_its_semantics_fixture() {
         assert_eq!(

--- a/crates/app/src/indicators/library.rs
+++ b/crates/app/src/indicators/library.rs
@@ -42,6 +42,10 @@ pub(crate) const EMBEDDED_SCRIPTS: &[(&str, &str)] = &[
         "force_bar.pine",
         include_str!("../../scripts/force_bar.pine"),
     ),
+    (
+        "exhaustion_reversal.pine",
+        include_str!("../../scripts/exhaustion_reversal.pine"),
+    ),
 ];
 
 /// One loadable script.
@@ -227,6 +231,19 @@ mod tests {
             embedded("force_bar.pine"),
             include_str!("../../../pine/tests/corpus/ok/force_bar.pine"),
             "sync crates/pine/tests/corpus/ok/force_bar.pine with crates/app/scripts/force_bar.pine"
+        );
+    }
+
+    /// Same pin, same reason: `exhaustion_reversal_semantics.rs` proves the
+    /// force-bar / give-back pairs against the corpus copy, and a drift would
+    /// leave twelve passing tests describing a script nobody ships.
+    #[test]
+    fn the_embedded_exhaustion_reversal_matches_its_semantics_fixture() {
+        assert_eq!(
+            embedded("exhaustion_reversal.pine"),
+            include_str!("../../../pine/tests/corpus/ok/exhaustion_reversal.pine"),
+            "sync crates/pine/tests/corpus/ok/exhaustion_reversal.pine with \
+             crates/app/scripts/exhaustion_reversal.pine"
         );
     }
 

--- a/crates/app/tests/source_encoding_guard.rs
+++ b/crates/app/tests/source_encoding_guard.rs
@@ -20,6 +20,15 @@ use std::path::Path;
 /// mangled multi-byte character.
 const MOJIBAKE: &[&str] = &["Â", "Ã", "â€", "âœ", "â†", "Ð"];
 
+/// Extensions worth scanning. `.pine` is here for the same reason `.rs` is,
+/// and arguably more: `crates/app/scripts/*.pine` hold the repo's densest
+/// non-ASCII prose — trader-facing headers full of `—`, plus input titles
+/// like `min body (×average)` that the settings dialog renders verbatim. A
+/// folder-wide rewrite mangles a script and its byte-identical corpus copy
+/// together, so the pin test that compares the two stays green while the
+/// dialog fills with `Ã—`.
+const SCANNED: &[&str] = &["rs", "pine"];
+
 /// The UTF-8 byte-order mark. Legal UTF-8, but nothing in this repo carries
 /// one, and a tool that adds one has usually changed the encoding too.
 const BOM: &[u8] = &[0xEF, 0xBB, 0xBF];
@@ -31,7 +40,10 @@ fn scan(dir: &Path, violations: &mut Vec<String>) {
             scan(&path, violations);
             continue;
         }
-        if path.extension().is_none_or(|e| e != "rs") {
+        if path
+            .extension()
+            .is_none_or(|e| !SCANNED.iter().any(|ext| e == *ext))
+        {
             continue;
         }
         let bytes = fs::read(&path).expect("source file is readable");
@@ -59,9 +71,10 @@ fn scan(dir: &Path, violations: &mut Vec<String>) {
 
 #[test]
 fn sources_are_utf8_without_a_bom_or_mojibake() {
-    let src = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let crate_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
     let mut violations = Vec::new();
-    scan(&src, &mut violations);
+    scan(&crate_dir.join("src"), &mut violations);
+    scan(&crate_dir.join("scripts"), &mut violations);
     assert!(
         violations.is_empty(),
         "source files were rewritten in the wrong encoding (write them as UTF-8 without a \

--- a/crates/pine/benches/interp.rs
+++ b/crates/pine/benches/interp.rs
@@ -21,6 +21,12 @@ const FLOW_SCRIPT: &str = "//@version=5\nindicator(\"flow\")\nfast = ta.ema(clos
 /// rather than on a sketch of it.
 const FORCE_BAR: &str = include_str!("../tests/corpus/ok/force_bar.pine");
 
+/// The embedded `exhaustion_reversal.pine`, byte for byte. Its per-bar work
+/// is a state machine plus three hoisted kernels — no loops, no dynamic
+/// history offsets — so this number says what the arm-and-fade shape costs
+/// when written that way instead of as a scan back over the window.
+const EXHAUSTION_REVERSAL: &str = include_str!("../tests/corpus/ok/exhaustion_reversal.pine");
+
 fn make_bars(n: usize) -> Vec<IndicatorBar> {
     (0..n)
         .map(|i| {
@@ -75,4 +81,5 @@ fn main() {
     bench("ema.pine", EMA_SCRIPT, &bars);
     bench("flow.pine", FLOW_SCRIPT, &bars);
     bench("force_bar", FORCE_BAR, &bars);
+    bench("exh_reversal", EXHAUSTION_REVERSAL, &bars);
 }

--- a/crates/pine/benches/interp.rs
+++ b/crates/pine/benches/interp.rs
@@ -8,7 +8,7 @@
 use std::hint::black_box;
 use std::time::Instant;
 
-use quantick_indicators::{Ctx, Indicator, IndicatorBar};
+use quantick_indicators::{Ctx, Indicator, IndicatorBar, PlotId};
 use quantick_pine::{ScriptIndicator, compile};
 
 const EMA_SCRIPT: &str =
@@ -25,6 +25,11 @@ const FORCE_BAR: &str = include_str!("../tests/corpus/ok/force_bar.pine");
 /// is a state machine plus three hoisted kernels — no loops, no dynamic
 /// history offsets — so this number says what the arm-and-fade shape costs
 /// when written that way instead of as a scan back over the window.
+///
+/// Measured on **both** tapes below, and the pair is the point: this script
+/// keeps most of its arithmetic behind `and` guards that only open once a
+/// force bar is armed, so the quiet tape measures the cheap path and the
+/// active one measures the path that actually does the work.
 const EXHAUSTION_REVERSAL: &str = include_str!("../tests/corpus/ok/exhaustion_reversal.pine");
 
 fn make_bars(n: usize) -> Vec<IndicatorBar> {
@@ -47,6 +52,54 @@ fn make_bars(n: usize) -> Vec<IndicatorBar> {
         .collect()
 }
 
+/// A tape whose bars are not all the same size, so a script that asks "is
+/// this bar unusually large?" can answer yes.
+///
+/// `make_bars` cannot: its body is a constant 0.3 on every one of its bars,
+/// so every ×average test is false forever and a conditional script is timed
+/// entirely on its untaken branches. Here every `CYCLE`th bar carries a body
+/// ten times the ordinary one and reaches a new high, and the three bars
+/// after it hand most of it back — the shape `exhaustion_reversal.pine` arms
+/// on, delivered often enough to be measured and rarely enough to stay
+/// realistic.
+fn make_active_bars(n: usize) -> Vec<IndicatorBar> {
+    /// Bars between one force bar and the next.
+    const CYCLE: usize = 37;
+    /// Body of the force bar, in price units.
+    const PUSH: f64 = 3.0;
+    /// Body of each of the three bars that hand it back.
+    const GIVE_BACK: f64 = 0.9;
+    /// Body of an ordinary bar.
+    const CHOP: f64 = 0.3;
+    /// Wick beyond the body, each side.
+    const WICK: f64 = 0.1;
+
+    let mut bars = Vec::with_capacity(n);
+    let mut open = 36_000.0;
+    for i in 0..n {
+        let close = match i % CYCLE {
+            0 => open + PUSH,
+            1..=3 => open - GIVE_BACK,
+            phase if phase % 2 == 0 => open + CHOP,
+            _ => open - CHOP,
+        };
+        let t = 1_700_000_000_000 + i as i64 * 250;
+        bars.push(IndicatorBar {
+            open_time: t,
+            close_time: t + 249,
+            open,
+            high: open.max(close) + WICK,
+            low: open.min(close) - WICK,
+            close,
+            buy_volume: ((i % 900) + 1) as f64 / 1000.0,
+            sell_volume: ((i % 700) + 1) as f64 / 1000.0,
+            trade_count: (i % 50 + 1) as f64,
+        });
+        open = close;
+    }
+    bars
+}
+
 fn bench(name: &str, source: &str, bars: &[IndicatorBar]) {
     let compiled = compile(source, name).expect("bench script compiles");
     let nodes = compiled.ast.len();
@@ -67,8 +120,22 @@ fn bench(name: &str, source: &str, bars: &[IndicatorBar]) {
     }
     let elapsed = start.elapsed();
     let ns_per = elapsed.as_secs_f64() * 1e9 / bars.len() as f64;
+    // Cells the script actually drew. A conditional script on the wrong tape
+    // draws nothing and times only its untaken branches, which reads as a
+    // flattering number rather than as the mistake it is — so the count goes
+    // beside the timing instead of being left to be assumed.
+    let drawn: usize = (0..indicator.descriptor().plots.len())
+        .map(|plot| {
+            indicator
+                .plots()
+                .column(PlotId::new(plot))
+                .iter()
+                .filter(|value| !value.is_nan())
+                .count()
+        })
+        .sum();
     println!(
-        "{name:12} {nodes:>4} AST nodes  {n:>7} bars in {elapsed:>9.2?}  =>  {ns_per:8.1} ns/bar",
+        "{name:16} {nodes:>4} AST nodes  {n:>7} bars in {elapsed:>9.2?}  =>  {ns_per:8.1} ns/bar  ({drawn} cells drawn)",
         n = bars.len(),
     );
     black_box(indicator.plots().len());
@@ -82,4 +149,12 @@ fn main() {
     bench("flow.pine", FLOW_SCRIPT, &bars);
     bench("force_bar", FORCE_BAR, &bars);
     bench("exh_reversal", EXHAUSTION_REVERSAL, &bars);
+
+    // The same script on a tape that arms it. Everything above runs on bars
+    // of one constant body, where every "unusually large?" test is false and
+    // the conditional half of a script is never entered.
+    println!("\non a tape that actually arms the conditional paths:\n");
+    let active = make_active_bars(n);
+    bench("force_bar", FORCE_BAR, &active);
+    bench("exh_reversal", EXHAUSTION_REVERSAL, &active);
 }

--- a/crates/pine/tests/corpus/ok/exhaustion_reversal.pine
+++ b/crates/pine/tests/corpus/ok/exhaustion_reversal.pine
@@ -1,0 +1,237 @@
+//@version=5
+// Exhaustion reversal — the small arrow where a push ran out of buyers.
+//
+// The shape it looks for is one move in two acts. First a FORCE BAR: a bar
+// whose body dwarfs the recent average AND which takes out the extreme of
+// the last N bars. That is a push spending itself at the edge of the move,
+// not a bar that merely happens to be large in the middle of one. Then the
+// GIVE-BACK, which arrives in one of two shapes — either is enough, and each
+// has its own switch and its own settings:
+//
+//   THE RUN (section 2)      within a short window, several consecutive
+//                            opposite candles that together hand back most
+//                            of what the force bar took.
+//   THE ENGULF (section 3)   within a shorter window, ONE opposite candle
+//                            whose body covers most of the force bar on its
+//                            own.
+//
+// They are not the same test with different numbers, which is why they are
+// two sections instead of one. The run measures GIVE-BACK: how far price has
+// travelled back from the extreme, read at the close of the last candle in
+// the run. The engulf measures OVERLAP: how much of the force bar's range
+// the single candle's body actually sits on top of. A drift back over three
+// bars gives ground without covering anything; a wide bar that opens away
+// from the force bar covers nothing while closing far past it. Each shape
+// catches what the other misses.
+//
+// HOW TO READ THE CHART:
+//
+//   red triangle above a bar    a buying push at a new high was given back.
+//                               Exhaustion of the up move may be at hand.
+//   teal triangle below a bar   the mirror: a selling push at a new low was
+//                               given back.
+//   no triangle                 no completed give-back. Most bars have no
+//                               triangle, and that is the point — a chart
+//                               where every bar is marked has told you
+//                               nothing.
+//
+// The triangle sits above/below the bar and never covers it.
+//
+// HONEST ABOUT THE DELAY: the mark cannot appear at the extreme. It appears
+// on the bar that CLOSES the opposite run — at the earliest `run` bars after
+// the force bar, at the latest `window` bars after it. You are being shown a
+// reversal that has already partly happened, which is the only kind that can
+// be proven from closed bars. Nothing here is drawn on a forming bar, so no
+// mark ever appears and then disappears: what you see has committed.
+//
+// WHY THE WINDOW: without a ceiling, "three opposite candles eventually
+// showed up" is true of almost every force bar if you wait long enough — the
+// give-back would just be the tape drifting sideways in a micro range. The
+// window is what makes the give-back a REACTION to the push rather than a
+// coincidence that followed it. Widen it and you buy more signals with less
+// meaning; that trade is yours to make, not the indicator's.
+//
+// HOW THE RUN IS MEASURED: from the force bar's extreme to the CLOSE of the
+// bar completing the run, as a fraction of the force bar's whole range
+// (high - low). Closes, never wicks — a spike that pokes back through and
+// closes away from it has not given anything back. Above 1.0 the run has
+// gone past the far side of the force bar entirely, which is why that slider
+// goes beyond 100%.
+//
+// HOW THE ENGULF IS MEASURED: the overlap between the opposite candle's BODY
+// (open to close) and the force bar's range, as a fraction of that range. A
+// full 1.0 means the single body covers the force bar end to end. Because it
+// is an overlap it cannot exceed 100%, which is why that slider stops there
+// while the run's does not.
+//
+// The force bar's body is judged against the average of the bars BEFORE it
+// (same discipline as force_bar.pine): a huge bar must not be allowed to
+// inflate the very average that is deciding whether it is huge.
+//
+// A "new extreme" is strict: equalling the last N highs is not taking them
+// out. On a flat stretch where bars share a high, a >= test would call every
+// one of them a breakout — the strict test says nothing there, correctly.
+//
+// ONE MARK PER PUSH: a force bar arms once and is spent by the first signal
+// it produces, whichever shape produced it. Without that, a run of four
+// opposite candles inside the window would mark the second, third and fourth
+// as separate reversals of the same push — and with both shapes switched on,
+// an engulf would be marked again a bar later as a run. Both shapes draw the
+// same triangle: turn one off to see which one is speaking. A newer force
+// bar re-arms the side.
+//
+// Every threshold below is an input: this is a shape, and where the shape
+// begins and ends is a judgement about the instrument in front of you.
+// Defaults are a starting point measured on nothing in particular —
+// calibrate on recorded sessions. Information, not advice: the last decision
+// belongs to the trader.
+indicator("Exhaustion reversal", overlay=true)
+
+// 1 — the force bar: what counts as a push worth fading?
+body_len = input.int(20, "1 Force bar: body average window (bars)", minval=1, maxval=500)
+body_factor = input.float(1.5, "1 Force bar: min body (×average)", minval=0.1, maxval=20.0, step=0.1)
+extreme_len = input.int(10, "1 Force bar: new extreme over (bars)", minval=1, maxval=500)
+need_direction = input.bool(true, "1 Force bar: must close in the direction of the push")
+
+// 2 — the run: several opposite candles handing the push back together.
+use_run = input.bool(true, "2 Run: mark a give-back by consecutive candles")
+run_len = input.int(3, "2 Run: opposite candles in a row", minval=1, maxval=20)
+window_len = input.int(5, "2 Run: window after the force bar (bars)", minval=1, maxval=100)
+coverage = input.float(0.7, "2 Run: min give-back of the force bar (fraction of range)", minval=0.05, maxval=3.0, step=0.05)
+
+// 3 — the engulf: one opposite candle covering the force bar by itself.
+// Shorter window than the run by default: a single bar answering a push is
+// an immediate response, and three bars later it is a different bar reacting
+// to a different thing.
+use_engulf = input.bool(true, "3 Engulf: mark a give-back by one opposite candle")
+engulf_window = input.int(3, "3 Engulf: window after the force bar (bars)", minval=1, maxval=100)
+engulf_coverage = input.float(0.7, "3 Engulf: min overlap with the force bar (fraction of range)", minval=0.05, maxval=1.0, step=0.05)
+
+// 4 — display: which side to mark, and in what colour. These gate the
+// drawing sites only. The state machine below runs whatever they say, so
+// flipping a side back on never changes what the indicator concluded while
+// it was off.
+show_top = input.bool(true, "4 Display: mark top reversals (sell side)")
+show_bottom = input.bool(true, "4 Display: mark bottom reversals (buy side)")
+top_colour = input.color(color.red, "4 Display: top mark colour")
+bottom_colour = input.color(color.teal, "4 Display: bottom mark colour")
+
+// ---------------------------------------------------------------- measures
+
+// Every stateful ta.* call is hoisted to the top level and fed on every bar:
+// kernels have call-site identity and `and` short-circuits, so a kernel
+// behind a condition would warm up late and read a gapped series.
+body = math.abs(close - open)
+avg_body_before = ta.sma(body[1], body_len)
+high_before = ta.highest(high[1], extreme_len)
+low_before = ta.lowest(low[1], extreme_len)
+
+// A window shorter than the run it must contain would mean "never" — an
+// input that silently cannot fire is a trap, so the window is at least the
+// run. (Same spirit as force_bar.pine reordering its min/max multiples.)
+run_window = math.max(window_len, run_len)
+
+// How long a force bar stays armed: the longer of the two shapes' windows,
+// and deliberately NOT conditional on their switches. If the state machine
+// forgot the push sooner with one shape switched off, the other shape would
+// answer differently depending on a checkbox it has nothing to do with.
+arm_window = math.max(run_window, engulf_window)
+
+// A zero average is warm-up or a dead tape, not a bar that beats it.
+big_body = not na(avg_body_before) and avg_body_before > 0 and body >= body_factor * avg_body_before
+new_high = not na(high_before) and high > high_before
+new_low = not na(low_before) and low < low_before
+
+bull_bar = close > open
+bear_bar = close < open
+
+// A doji closes neither way and breaks a run: it is a pause, not a give-back.
+var int bear_run = 0
+var int bull_run = 0
+bear_run := bear_bar ? bear_run + 1 : 0
+bull_run := bull_bar ? bull_run + 1 : 0
+
+top_anchor = big_body and new_high and (not need_direction or bull_bar)
+bottom_anchor = big_body and new_low and (not need_direction or bear_bar)
+
+// ------------------------------------------------------------------- state
+
+// One armed force bar per side, with its own age and its own range. The two
+// sides are independent: the bar that gives back a buying push may itself be
+// the selling push that arms the other side.
+var bool top_armed = false
+var int top_age = 0
+var float top_high = na
+var float top_low = na
+var bool bottom_armed = false
+var int bottom_age = 0
+var float bottom_high = na
+var float bottom_low = na
+
+// Age first, test second, arm last. Ageing before the test is what makes the
+// bar `run_len` bars after the force bar read as age `run_len`; arming after
+// it is what stops a force bar from being faded by the very bar that made it.
+if top_armed
+    top_age := top_age + 1
+    if top_age > arm_window
+        top_armed := false
+if bottom_armed
+    bottom_age := bottom_age + 1
+    if bottom_age > arm_window
+        bottom_armed := false
+
+// ----------------------------------------------------------------- signals
+
+// Division by zero yields na in this dialect, and the na guard below is what
+// keeps a zero-range force bar from being "covered" by anything at all.
+top_range = top_high - top_low
+bottom_range = bottom_high - bottom_low
+top_given_back = top_range > 0 ? (top_high - close) / top_range : na
+bottom_given_back = bottom_range > 0 ? (close - bottom_low) / bottom_range : na
+
+sell_run = use_run and top_armed and top_age >= run_len and top_age <= run_window and bear_run >= run_len and not na(top_given_back) and top_given_back >= coverage
+buy_run = use_run and bottom_armed and bottom_age >= run_len and bottom_age <= run_window and bull_run >= run_len and not na(bottom_given_back) and bottom_given_back >= coverage
+
+// The engulf: how much of the force bar's range this one body sits on top
+// of. Overlap of two intervals — the candle's body against the force bar's
+// range — so it is bounded by the force bar and cannot be inflated by a
+// candle that is merely enormous somewhere else. A body that does not reach
+// the force bar at all makes this negative, which fails the test on its own.
+top_overlap = math.min(open, top_high) - math.max(close, top_low)
+bottom_overlap = math.min(close, bottom_high) - math.max(open, bottom_low)
+top_engulfed = top_range > 0 ? top_overlap / top_range : na
+bottom_engulfed = bottom_range > 0 ? bottom_overlap / bottom_range : na
+
+sell_engulf = use_engulf and top_armed and top_age <= engulf_window and bear_bar and not na(top_engulfed) and top_engulfed >= engulf_coverage
+buy_engulf = use_engulf and bottom_armed and bottom_age <= engulf_window and bull_bar and not na(bottom_engulfed) and bottom_engulfed >= engulf_coverage
+
+// Either shape marks, and the first one to fire spends the push.
+sell_signal = sell_run or sell_engulf
+buy_signal = buy_run or buy_engulf
+
+// Spent by its own signal, re-armed only by a newer force bar.
+if sell_signal
+    top_armed := false
+if buy_signal
+    bottom_armed := false
+
+if top_anchor
+    top_armed := true
+    top_age := 0
+    top_high := high
+    top_low := low
+if bottom_anchor
+    bottom_armed := true
+    bottom_age := 0
+    bottom_high := high
+    bottom_low := low
+
+// ------------------------------------------------------------------- marks
+
+// Closed bars only. The forming bar's preview is rolled back, so a mark that
+// appeared there would be a promise the tape had not yet made.
+sell_mark = sell_signal and barstate.isconfirmed
+buy_mark = buy_signal and barstate.isconfirmed
+
+plotshape(show_top and sell_mark, "Exhaustion reversal: sell", style=shape.triangledown, location=location.abovebar, color=top_colour)
+plotshape(show_bottom and buy_mark, "Exhaustion reversal: buy", style=shape.triangleup, location=location.belowbar, color=bottom_colour)

--- a/crates/pine/tests/corpus/ok/exhaustion_reversal.pine
+++ b/crates/pine/tests/corpus/ok/exhaustion_reversal.pine
@@ -2,27 +2,24 @@
 // Exhaustion reversal — the small arrow where a push ran out of buyers.
 //
 // The shape it looks for is one move in two acts. First a FORCE BAR: a bar
-// whose body dwarfs the recent average AND which takes out the extreme of
-// the last N bars. That is a push spending itself at the edge of the move,
-// not a bar that merely happens to be large in the middle of one. Then the
+// whose body dwarfs the recent average AND which reaches the extreme of the
+// last N bars. That is a push spending itself at the edge of the move, not a
+// bar that merely happens to be large in the middle of one. Then the
 // GIVE-BACK, which arrives in one of two shapes — either is enough, and each
 // has its own switch and its own settings:
 //
-//   THE RUN (section 2)      within a short window, several consecutive
-//                            opposite candles that together hand back most
-//                            of what the force bar took.
-//   THE ENGULF (section 3)   within a shorter window, ONE opposite candle
-//                            whose body covers most of the force bar on its
-//                            own.
+//   THE RUN (section 2)     several consecutive opposite candles, with price
+//                           back below (or above) a set fraction of the force
+//                           bar by the close of the last of them.
+//   THE COVER (section 3)   ONE opposite candle whose body sits on top of
+//                           most of the force bar's range.
 //
 // They are not the same test with different numbers, which is why they are
-// two sections instead of one. The run measures GIVE-BACK: how far price has
-// travelled back from the extreme, read at the close of the last candle in
-// the run. The engulf measures OVERLAP: how much of the force bar's range
-// the single candle's body actually sits on top of. A drift back over three
-// bars gives ground without covering anything; a wide bar that opens away
-// from the force bar covers nothing while closing far past it. Each shape
-// catches what the other misses.
+// two sections instead of one. The run is about TRAVEL: where price ended up,
+// relative to the extreme. The cover is about OVERLAP: how much of the force
+// bar a single body actually covers, wherever price ends up. A slow drift
+// travels without covering; a wide bar can cover the force bar and close only
+// just past it. Each shape catches what the other misses.
 //
 // HOW TO READ THE CHART:
 //
@@ -33,52 +30,73 @@
 //   no triangle                 no completed give-back. Most bars have no
 //                               triangle, and that is the point — a chart
 //                               where every bar is marked has told you
-//                               nothing.
+//                               nothing. (Measured: ~3% of bars at these
+//                               defaults on a 2 000-bar random walk.)
 //
-// The triangle sits above/below the bar and never covers it.
+// The triangle sits above/below the bar and never covers it. Its colour and
+// width are on the indicator dialog's STYLE tab, per plot, where every other
+// indicator's colours live — not in the inputs below.
 //
-// HONEST ABOUT THE DELAY: the mark cannot appear at the extreme. It appears
-// on the bar that CLOSES the opposite run — at the earliest `run` bars after
-// the force bar, at the latest `window` bars after it. You are being shown a
+// HONEST ABOUT THE DELAY: the mark cannot appear at the extreme, and how late
+// it is depends on which shape fired. A cover can mark the very next bar
+// after the force bar; a run needs at least its own length. The latest either
+// can be is that shape's own window. So with the defaults a triangle is
+// between 1 and 5 bars behind the extreme it is about. You are being shown a
 // reversal that has already partly happened, which is the only kind that can
-// be proven from closed bars. Nothing here is drawn on a forming bar, so no
-// mark ever appears and then disappears: what you see has committed.
+// be proven from closed bars. Nothing is drawn on a forming bar, so no mark
+// ever appears and then disappears: what you see has committed.
 //
-// WHY THE WINDOW: without a ceiling, "three opposite candles eventually
-// showed up" is true of almost every force bar if you wait long enough — the
-// give-back would just be the tape drifting sideways in a micro range. The
-// window is what makes the give-back a REACTION to the push rather than a
-// coincidence that followed it. Widen it and you buy more signals with less
-// meaning; that trade is yours to make, not the indicator's.
+// WHY THE WINDOWS: without a ceiling, "opposite candles eventually showed up"
+// is true of almost every force bar if you wait long enough — the give-back
+// would just be the tape drifting sideways in a micro range. The window is
+// what makes the give-back a REACTION to the push rather than a coincidence
+// that followed it. Widen it and you buy more signals with less meaning; that
+// trade is yours to make, not the indicator's.
 //
-// HOW THE RUN IS MEASURED: from the force bar's extreme to the CLOSE of the
-// bar completing the run, as a fraction of the force bar's whole range
-// (high - low). Closes, never wicks — a spike that pokes back through and
-// closes away from it has not given anything back. Above 1.0 the run has
-// gone past the far side of the force bar entirely, which is why that slider
-// goes beyond 100%.
+// HOW THE RUN IS MEASURED — two conditions, deliberately independent:
+//   (a) the last `run` candles all closed against the push, and
+//   (b) at this bar's CLOSE, price has given back `give-back` of the force
+//       bar's range, measured from the force bar's extreme.
+// It does NOT check that the run itself did the travelling. A gap that hands
+// back the whole force bar in one bar, followed by three tiny down-closes,
+// satisfies both and marks. That is intentional — the question being asked is
+// "is price back, and is the tape still leaning that way?", not "which bar
+// carried it" — but it is worth knowing, because the streak can be cosmetic.
 //
-// HOW THE ENGULF IS MEASURED: the overlap between the opposite candle's BODY
+// HOW THE COVER IS MEASURED: the overlap between the opposite candle's BODY
 // (open to close) and the force bar's range, as a fraction of that range. A
-// full 1.0 means the single body covers the force bar end to end. Because it
-// is an overlap it cannot exceed 100%, which is why that slider stops there
-// while the run's does not.
+// full 1.0 means one body covers the force bar end to end. Because it is an
+// overlap it cannot exceed 100%, which is why that slider stops there while
+// the run's does not (a run can travel past the far side entirely).
+//
+// Note what "overlap" allows: a candle whose whole range sits INSIDE the
+// force bar counts, if its body still covers enough of it. That is not a
+// classical engulfing candle, and it is not called one here — a small bar
+// that erases most of a large one is exactly the exhaustion this is looking
+// for, whether or not it pokes out the ends.
 //
 // The force bar's body is judged against the average of the bars BEFORE it
 // (same discipline as force_bar.pine): a huge bar must not be allowed to
 // inflate the very average that is deciding whether it is huge.
 //
-// A "new extreme" is strict: equalling the last N highs is not taking them
-// out. On a flat stretch where bars share a high, a >= test would call every
-// one of them a breakout — the strict test says nothing there, correctly.
+// Reaching the extreme is `>=`, not `>`: on futures the offer parks at a
+// price and highs tie constantly, and a push that shoves into a level the
+// tape touched N bars ago is the same event as one that clears it by a tick.
+// The body test is what keeps a flat, quiet stretch from anchoring — a run of
+// tied highs has no body behind it and never becomes a force bar.
 //
 // ONE MARK PER PUSH: a force bar arms once and is spent by the first signal
 // it produces, whichever shape produced it. Without that, a run of four
 // opposite candles inside the window would mark the second, third and fourth
-// as separate reversals of the same push — and with both shapes switched on,
-// an engulf would be marked again a bar later as a run. Both shapes draw the
-// same triangle: turn one off to see which one is speaking. A newer force
-// bar re-arms the side.
+// as separate reversals of the same push. A newer force bar re-arms the side.
+//
+// Both shapes draw the same triangle, so switching one off is how you find
+// out which one is speaking — but read the result carefully: the switches do
+// not only silence marks, they can MOVE one. If a cover spends a push on the
+// bar after the force bar, the run never sees that push at all; switch the
+// cover off and the same tape may mark three bars later, where the run
+// finally completes. A mark that jumps when you flip a switch is those two
+// shapes disagreeing about when the push ended, not an inconsistency.
 //
 // Every threshold below is an input: this is a shape, and where the shape
 // begins and ends is a judgement about the instrument in front of you.
@@ -90,37 +108,41 @@ indicator("Exhaustion reversal", overlay=true)
 // 1 — the force bar: what counts as a push worth fading?
 body_len = input.int(20, "1 Force bar: body average window (bars)", minval=1, maxval=500)
 body_factor = input.float(1.5, "1 Force bar: min body (×average)", minval=0.1, maxval=20.0, step=0.1)
-extreme_len = input.int(10, "1 Force bar: new extreme over (bars)", minval=1, maxval=500)
+extreme_len = input.int(10, "1 Force bar: reaches the extreme of (bars)", minval=1, maxval=500)
 need_direction = input.bool(true, "1 Force bar: must close in the direction of the push")
 
-// 2 — the run: several opposite candles handing the push back together.
+// 2 — the run: several opposite candles, and price back off the extreme.
 use_run = input.bool(true, "2 Run: mark a give-back by consecutive candles")
 run_len = input.int(3, "2 Run: opposite candles in a row", minval=1, maxval=20)
 window_len = input.int(5, "2 Run: window after the force bar (bars)", minval=1, maxval=100)
 coverage = input.float(0.7, "2 Run: min give-back of the force bar (fraction of range)", minval=0.05, maxval=3.0, step=0.05)
 
-// 3 — the engulf: one opposite candle covering the force bar by itself.
-// Shorter window than the run by default: a single bar answering a push is
-// an immediate response, and three bars later it is a different bar reacting
-// to a different thing.
-use_engulf = input.bool(true, "3 Engulf: mark a give-back by one opposite candle")
-engulf_window = input.int(3, "3 Engulf: window after the force bar (bars)", minval=1, maxval=100)
-engulf_coverage = input.float(0.7, "3 Engulf: min overlap with the force bar (fraction of range)", minval=0.05, maxval=1.0, step=0.05)
+// 3 — the cover: one opposite candle sitting on top of the force bar.
+// Shorter window than the run by default: a single bar answering a push is an
+// immediate response, and five bars later it is a different bar reacting to
+// a different thing.
+use_cover = input.bool(true, "3 Cover: mark a give-back by one opposite candle")
+cover_window = input.int(3, "3 Cover: window after the force bar (bars)", minval=1, maxval=100)
+cover_fraction = input.float(0.7, "3 Cover: min overlap with the force bar (fraction of range)", minval=0.05, maxval=1.0, step=0.05)
 
-// 4 — display: which side to mark, and in what colour. These gate the
-// drawing sites only. The state machine below runs whatever they say, so
-// flipping a side back on never changes what the indicator concluded while
-// it was off.
+// 4 — display: which side to mark. These gate the drawing sites only. The
+// state machine below runs whatever they say, so flipping a side back on
+// never changes what the indicator concluded while it was off.
+//
+// Colour and width are deliberately NOT inputs: they live on the dialog's
+// Style tab, per plot, which is what the chart actually reads. An
+// `input.color` handed to a plot in this dialect does not fold, and the mark
+// silently comes out amber — so a colour slider here would be a dead control.
 show_top = input.bool(true, "4 Display: mark top reversals (sell side)")
 show_bottom = input.bool(true, "4 Display: mark bottom reversals (buy side)")
-top_colour = input.color(color.red, "4 Display: top mark colour")
-bottom_colour = input.color(color.teal, "4 Display: bottom mark colour")
 
 // ---------------------------------------------------------------- measures
 
 // Every stateful ta.* call is hoisted to the top level and fed on every bar:
 // kernels have call-site identity and `and` short-circuits, so a kernel
-// behind a condition would warm up late and read a gapped series.
+// behind a condition would warm up late and read a gapped series. This
+// applies to the four below and to nothing else — the arithmetic further
+// down is current-bar only, and is deliberately left behind its guards.
 body = math.abs(close - open)
 avg_body_before = ta.sma(body[1], body_len)
 high_before = ta.highest(high[1], extreme_len)
@@ -135,12 +157,13 @@ run_window = math.max(window_len, run_len)
 // and deliberately NOT conditional on their switches. If the state machine
 // forgot the push sooner with one shape switched off, the other shape would
 // answer differently depending on a checkbox it has nothing to do with.
-arm_window = math.max(run_window, engulf_window)
+arm_window = math.max(run_window, cover_window)
 
-// A zero average is warm-up or a dead tape, not a bar that beats it.
+// A zero average is warm-up or a dead tape, not a bar that beats it. The
+// `not na` guards are what keep the opening stretch unmarked.
 big_body = not na(avg_body_before) and avg_body_before > 0 and body >= body_factor * avg_body_before
-new_high = not na(high_before) and high > high_before
-new_low = not na(low_before) and low < low_before
+new_high = not na(high_before) and high >= high_before
+new_low = not na(low_before) and low <= low_before
 
 bull_bar = close > open
 bear_bar = close < open
@@ -182,34 +205,32 @@ if bottom_armed
 
 // ----------------------------------------------------------------- signals
 
-// Division by zero yields na in this dialect, and the na guard below is what
-// keeps a zero-range force bar from being "covered" by anything at all.
+// Two subtractions, cheap enough to keep in the open for readability; `na`
+// when no push is armed, which makes every `> 0` below false.
 top_range = top_high - top_low
 bottom_range = bottom_high - bottom_low
-top_given_back = top_range > 0 ? (top_high - close) / top_range : na
-bottom_given_back = bottom_range > 0 ? (close - bottom_low) / bottom_range : na
 
-sell_run = use_run and top_armed and top_age >= run_len and top_age <= run_window and bear_run >= run_len and not na(top_given_back) and top_given_back >= coverage
-buy_run = use_run and bottom_armed and bottom_age >= run_len and bottom_age <= run_window and bull_run >= run_len and not na(bottom_given_back) and bottom_given_back >= coverage
+// The divisions and the overlap arithmetic sit BEHIND the guards on purpose.
+// `and` short-circuits, and on the large majority of bars no push is armed —
+// so on those bars this line stops at `top_armed` and the maths never runs.
+// (Measured: ~17% of the script's commit cost, and this runs again for every
+// preview of the forming bar.) Nothing here is a `ta.*` kernel, so unlike the
+// measures above there is no warm-up to protect by hoisting it.
+sell_run = use_run and top_armed and top_age >= run_len and top_age <= run_window and bear_run >= run_len and top_range > 0 and (top_high - close) / top_range >= coverage
+buy_run = use_run and bottom_armed and bottom_age >= run_len and bottom_age <= run_window and bull_run >= run_len and bottom_range > 0 and (close - bottom_low) / bottom_range >= coverage
 
-// The engulf: how much of the force bar's range this one body sits on top
-// of. Overlap of two intervals — the candle's body against the force bar's
-// range — so it is bounded by the force bar and cannot be inflated by a
-// candle that is merely enormous somewhere else. A body that does not reach
-// the force bar at all makes this negative, which fails the test on its own.
-top_overlap = math.min(open, top_high) - math.max(close, top_low)
-bottom_overlap = math.min(close, bottom_high) - math.max(open, bottom_low)
-top_engulfed = top_range > 0 ? top_overlap / top_range : na
-bottom_engulfed = bottom_range > 0 ? bottom_overlap / bottom_range : na
-
-sell_engulf = use_engulf and top_armed and top_age <= engulf_window and bear_bar and not na(top_engulfed) and top_engulfed >= engulf_coverage
-buy_engulf = use_engulf and bottom_armed and bottom_age <= engulf_window and bull_bar and not na(bottom_engulfed) and bottom_engulfed >= engulf_coverage
+// The cover: the overlap of two intervals — this candle's body against the
+// force bar's range — so it is bounded by the force bar and cannot be
+// inflated by a candle that is merely enormous somewhere else. A body that
+// does not reach the force bar at all makes the overlap negative, which
+// fails on its own.
+sell_cover = use_cover and top_armed and top_age <= cover_window and bear_bar and top_range > 0 and (math.min(open, top_high) - math.max(close, top_low)) / top_range >= cover_fraction
+buy_cover = use_cover and bottom_armed and bottom_age <= cover_window and bull_bar and bottom_range > 0 and (math.min(close, bottom_high) - math.max(open, bottom_low)) / bottom_range >= cover_fraction
 
 // Either shape marks, and the first one to fire spends the push.
-sell_signal = sell_run or sell_engulf
-buy_signal = buy_run or buy_engulf
+sell_signal = sell_run or sell_cover
+buy_signal = buy_run or buy_cover
 
-// Spent by its own signal, re-armed only by a newer force bar.
 if sell_signal
     top_armed := false
 if buy_signal
@@ -233,5 +254,5 @@ if bottom_anchor
 sell_mark = sell_signal and barstate.isconfirmed
 buy_mark = buy_signal and barstate.isconfirmed
 
-plotshape(show_top and sell_mark, "Exhaustion reversal: sell", style=shape.triangledown, location=location.abovebar, color=top_colour)
-plotshape(show_bottom and buy_mark, "Exhaustion reversal: buy", style=shape.triangleup, location=location.belowbar, color=bottom_colour)
+plotshape(show_top and sell_mark, "Exhaustion reversal: sell", style=shape.triangledown, location=location.abovebar, color=color.red)
+plotshape(show_bottom and buy_mark, "Exhaustion reversal: buy", style=shape.triangleup, location=location.belowbar, color=color.teal)

--- a/crates/pine/tests/exhaustion_reversal_semantics.rs
+++ b/crates/pine/tests/exhaustion_reversal_semantics.rs
@@ -1,0 +1,554 @@
+//! Semantic proof for the embedded `exhaustion_reversal.pine`.
+//!
+//! Every clause of the signal is tested as a **pair**: a tape that must mark
+//! and a near-identical one that must not. A test that only proves the
+//! triangle appears would pass on a script that marks every bar, and the
+//! whole value of this indicator is the bars it stays silent on.
+//!
+//! The tapes are written as raw `(open, high, low, close)` rows because those
+//! four numbers are the entire input surface of this script — no volume, no
+//! delta, no CVD. What each row is for is stated beside it.
+
+use quantick_indicators::{Ctx, Indicator, IndicatorBar, InputValue, PlotId, Rgba8};
+use quantick_pine::{ScriptIndicator, compile};
+
+const SCRIPT: &str = include_str!("corpus/ok/exhaustion_reversal.pine");
+
+const SELL_PLOT: &str = "Exhaustion reversal: sell";
+const BUY_PLOT: &str = "Exhaustion reversal: buy";
+
+const TOP_COLOUR: Rgba8 = Rgba8::opaque(1, 0, 0);
+const BOTTOM_COLOUR: Rgba8 = Rgba8::opaque(2, 0, 0);
+
+/// (open, high, low, close).
+type Ohlc = (f64, f64, f64, f64);
+
+/// Windows shrunk to 4 bars so a fixture stays readable; the rules are
+/// identical at any length. Positional — the script's `input.*` order.
+fn inputs() -> Vec<InputValue> {
+    vec![
+        InputValue::Int(4),               // 0  1 Force bar: body average window
+        InputValue::Float(1.5),           // 1  1 Force bar: min body (×average)
+        InputValue::Int(4),               // 2  1 Force bar: new extreme over (bars)
+        InputValue::Bool(true),           // 3  1 Force bar: must close with the push
+        InputValue::Bool(true),           // 4  2 Run: on
+        InputValue::Int(3),               // 5  2 Run: opposite candles in a row
+        InputValue::Int(5),               // 6  2 Run: window after the force bar
+        InputValue::Float(0.7),           // 7  2 Run: min give-back
+        InputValue::Bool(true),           // 8  3 Engulf: on
+        InputValue::Int(3),               // 9  3 Engulf: window after the force bar
+        InputValue::Float(0.7),           // 10 3 Engulf: min overlap
+        InputValue::Bool(true),           // 11 4 Display: mark top reversals
+        InputValue::Bool(true),           // 12 4 Display: mark bottom reversals
+        InputValue::Color(TOP_COLOUR),    // 13
+        InputValue::Color(BOTTOM_COLOUR), // 14
+    ]
+}
+
+/// Input slots the tests reach for by name, so a reordering of the script's
+/// inputs breaks compilation here instead of silently testing the wrong knob.
+const NEED_DIRECTION: usize = 3;
+const USE_RUN: usize = 4;
+const RUN_WINDOW: usize = 6;
+const USE_ENGULF: usize = 8;
+const SHOW_TOP: usize = 11;
+
+fn make(index: usize, row: Ohlc) -> IndicatorBar {
+    let (open, high, low, close) = row;
+    let t = 1_700_000_000_000 + index as i64 * 1_000;
+    IndicatorBar {
+        open_time: t,
+        close_time: t + 999,
+        open,
+        high,
+        low,
+        close,
+        buy_volume: 2.0,
+        sell_volume: 1.0,
+        trade_count: 3.0,
+    }
+}
+
+/// Five flat bullish bars: body 1.0, range 1.0, every high identical. The
+/// averages the force bar is judged against are therefore exactly 1.0, and
+/// the extreme it must clear is exactly 101.0.
+fn context_up() -> Vec<Ohlc> {
+    vec![(100.0, 101.0, 100.0, 101.0); 5]
+}
+
+/// The mirror: flat bearish bars, extreme to clear exactly 100.0.
+fn context_down() -> Vec<Ohlc> {
+    vec![(101.0, 101.0, 100.0, 100.0); 5]
+}
+
+/// Body 10 against an average of 1.0, high 111 against an extreme of 101,
+/// closing up: a buying push at a new high. Range 10, so a close at or below
+/// 104.0 gives back the required 70%.
+const FORCE_UP: Ohlc = (101.0, 111.0, 101.0, 111.0);
+
+/// The canonical tape: force bar, then three bearish candles closing at 103
+/// — 80% of the force bar handed back on the third.
+fn sell_tape() -> Vec<Ohlc> {
+    let mut t = context_up();
+    t.push(FORCE_UP); //                      5  force bar
+    t.push((111.0, 111.0, 109.0, 109.0)); //  6  give-back 1 of 3 (age 1)
+    t.push((109.0, 109.0, 107.0, 107.0)); //  7  give-back 2 of 3 (age 2)
+    t.push((107.0, 107.0, 103.0, 103.0)); //  8  give-back 3 of 3 -> 80%, marks
+    t
+}
+
+fn run(inputs: Vec<InputValue>, rows: &[Ohlc]) -> ScriptIndicator {
+    let compiled = match compile(SCRIPT, "exhaustion_reversal.pine") {
+        Ok(c) => c,
+        Err(errors) => panic!(
+            "exhaustion_reversal.pine must compile:\n{}",
+            errors
+                .iter()
+                .map(|e| e.render("exhaustion_reversal.pine", SCRIPT))
+                .collect::<Vec<_>>()
+                .join("\n")
+        ),
+    };
+    let mut indicator = ScriptIndicator::with_inputs(compiled, SCRIPT, inputs);
+
+    let mut cvd = Vec::new();
+    let mut sum = 0.0;
+    for (index, row) in rows.iter().enumerate() {
+        let bar = make(index, *row);
+        sum += bar.delta();
+        cvd.push(sum);
+        let mut ctx = Ctx {
+            bar_index: index,
+            cvd: &cvd,
+        };
+        indicator.on_close(&bar, &mut ctx).expect("commit run");
+    }
+    indicator
+}
+
+/// The bar indices carrying a mark on the named plot.
+fn marker_rows(indicator: &dyn Indicator, title: &str) -> Vec<usize> {
+    let spec = indicator
+        .descriptor()
+        .plots
+        .iter()
+        .find(|p| p.title == title)
+        .unwrap_or_else(|| panic!("plot {title:?} exists"));
+    indicator
+        .plots()
+        .column(PlotId::new(spec.id.index()))
+        .iter()
+        .enumerate()
+        .filter(|(_, v)| !v.is_nan())
+        .map(|(i, _)| i)
+        .collect()
+}
+
+fn sells(indicator: &ScriptIndicator) -> Vec<usize> {
+    marker_rows(indicator, SELL_PLOT)
+}
+
+fn buys(indicator: &ScriptIndicator) -> Vec<usize> {
+    marker_rows(indicator, BUY_PLOT)
+}
+
+fn none() -> Vec<usize> {
+    Vec::new()
+}
+
+#[test]
+fn three_bearish_candles_give_back_the_push_and_a_shallower_run_does_not() {
+    let hit = run(inputs(), &sell_tape());
+    assert_eq!(
+        sells(&hit),
+        vec![8],
+        "the mark lands on the bar that closes the run, not at the extreme"
+    );
+    assert_eq!(buys(&hit), none(), "a faded buying push marks no long");
+
+    // Same tape, third candle closing at 105: 60% given back, short of 70%.
+    let mut shallow = sell_tape();
+    shallow[8] = (107.0, 107.0, 105.0, 105.0);
+    assert_eq!(
+        sells(&run(inputs(), &shallow)),
+        none(),
+        "60% is not 70% — the threshold is real, not decorative"
+    );
+}
+
+#[test]
+fn two_pause_bars_still_count_and_three_pause_bars_are_too_late() {
+    // The trader's second example: force bar, two bars of pause, then the
+    // three-candle give-back landing exactly on the window's last bar.
+    let mut paused = context_up();
+    paused.push(FORCE_UP); //                      5  force bar
+    paused.push((111.0, 111.6, 110.9, 111.5)); //  6  pause (body 0.5)
+    paused.push((111.5, 112.1, 111.4, 112.0)); //  7  pause (body 0.5)
+    paused.push((112.0, 112.0, 110.0, 110.0)); //  8  give-back 1 of 3
+    paused.push((110.0, 110.0, 107.0, 107.0)); //  9  give-back 2 of 3
+    paused.push((107.0, 107.0, 103.0, 103.0)); // 10  give-back 3 of 3, age 5
+    assert_eq!(
+        sells(&run(inputs(), &paused)),
+        vec![10],
+        "age 5 is the last bar the window covers, and it still marks"
+    );
+
+    // One more bar of pause pushes the same give-back to age 6.
+    let mut late = context_up();
+    late.push(FORCE_UP); //                      5  force bar
+    late.push((111.0, 111.6, 110.9, 111.5)); //  6  pause
+    late.push((111.5, 112.1, 111.4, 112.0)); //  7  pause
+    late.push((112.0, 112.6, 111.9, 112.5)); //  8  pause
+    late.push((112.5, 112.5, 110.0, 110.0)); //  9  give-back 1 of 3
+    late.push((110.0, 110.0, 107.0, 107.0)); // 10  give-back 2 of 3
+    late.push((107.0, 107.0, 103.0, 103.0)); // 11  give-back 3 of 3, age 6
+    assert_eq!(
+        sells(&run(inputs(), &late)),
+        none(),
+        "the same give-back one bar later is a micro range, not a reversal — \
+         this pair is the entire reason the window exists"
+    );
+}
+
+#[test]
+fn the_run_must_be_consecutive() {
+    // Four bearish closes, but a bullish bar in the middle: the run restarts,
+    // and the last two bars are only two in a row.
+    let mut broken = context_up();
+    broken.push(FORCE_UP); //                      5  force bar
+    broken.push((111.0, 111.0, 109.0, 109.0)); //  6  bearish
+    broken.push((109.0, 109.0, 107.0, 107.0)); //  7  bearish
+    broken.push((107.0, 108.5, 107.0, 108.0)); //  8  bullish — breaks the run
+    broken.push((108.0, 108.0, 105.0, 105.0)); //  9  bearish (1 of a new run)
+    broken.push((105.0, 105.0, 103.0, 103.0)); // 10  bearish (2), 80% given back
+    assert_eq!(
+        sells(&run(inputs(), &broken)),
+        none(),
+        "the push was given back, but not by a run — two in a row is not three"
+    );
+}
+
+#[test]
+fn an_ordinary_bar_at_a_new_high_is_not_a_force_bar() {
+    let mut weak = context_up();
+    weak.push((101.0, 102.0, 101.0, 102.0)); // 5  new high, body 1.0 = average
+    weak.push((102.0, 102.0, 101.5, 101.5)); // 6
+    weak.push((101.5, 101.5, 101.0, 101.0)); // 7
+    weak.push((101.0, 101.0, 100.5, 100.5)); // 8  gives back far more than 70%
+    assert_eq!(
+        sells(&run(inputs(), &weak)),
+        none(),
+        "a breakout the tape did not have to work for is not exhaustion"
+    );
+}
+
+#[test]
+fn a_force_bar_that_takes_out_no_extreme_is_not_a_force_bar() {
+    // Identical to the canonical tape except bar 3, which leaves a 120 high
+    // standing above everything the force bar can reach.
+    let mut buried = sell_tape();
+    buried[3] = (100.0, 120.0, 100.0, 101.0); // tall wick, body still 1.0
+    assert_eq!(
+        sells(&run(inputs(), &buried)),
+        none(),
+        "a big body in the middle of a move is not a move ending"
+    );
+    // The pair: the same tape without that overhead high does mark.
+    assert_eq!(sells(&run(inputs(), &sell_tape())), vec![8]);
+}
+
+#[test]
+fn the_direction_rule_decides_whether_a_reversal_bar_can_anchor() {
+    // Body 10, high 112 clears the extreme, but the bar closes DOWN: a
+    // rejection bar, not a buying push.
+    let mut wick = context_up();
+    wick.push((111.0, 112.0, 101.0, 101.0)); // 5  big bearish bar at a new high
+    wick.push((101.0, 101.0, 100.0, 100.0)); // 6  bearish
+    wick.push((100.0, 100.0, 99.0, 99.0)); //   7  bearish
+    wick.push((99.0, 99.0, 98.0, 98.0)); //     8  bearish, 127% given back
+
+    assert_eq!(
+        sells(&run(inputs(), &wick)),
+        none(),
+        "with the direction rule on, only a bar closing up can be a buying push"
+    );
+
+    let mut loose = inputs();
+    loose[NEED_DIRECTION] = InputValue::Bool(false);
+    assert_eq!(
+        sells(&run(loose, &wick)),
+        vec![8],
+        "with it off, any big bar at a new extreme anchors — the input is \
+         wired to the clause it names"
+    );
+}
+
+#[test]
+fn the_buy_side_is_the_exact_mirror() {
+    let mut t = context_down();
+    t.push((100.0, 100.0, 90.0, 90.0)); //  5  selling push at a new low
+    t.push((90.0, 92.0, 90.0, 92.0)); //    6  give-back 1 of 3
+    t.push((92.0, 94.0, 92.0, 94.0)); //    7  give-back 2 of 3
+    t.push((94.0, 98.0, 94.0, 98.0)); //    8  give-back 3 of 3 -> 80%
+
+    let hit = run(inputs(), &t);
+    assert_eq!(buys(&hit), vec![8]);
+    assert_eq!(sells(&hit), none(), "a faded selling push marks no short");
+}
+
+#[test]
+fn a_push_is_spent_by_its_own_signal() {
+    // A fourth bearish candle, still inside the window, giving back even more.
+    let mut long_run = sell_tape();
+    long_run.push((103.0, 103.0, 101.0, 101.0)); // 9  age 4, run 4, 100% back
+    assert_eq!(
+        run(inputs(), &long_run)
+            .plots()
+            .column(PlotId::new(0))
+            .len(),
+        10,
+        "the tape really is ten bars long"
+    );
+    assert_eq!(
+        sells(&run(inputs(), &long_run)),
+        vec![8],
+        "one arrow per push: the same reversal must not be marked twice"
+    );
+}
+
+#[test]
+fn nothing_is_marked_while_the_averages_are_warming_up() {
+    let warm = run(inputs(), &context_up());
+    assert_eq!(sells(&warm), none());
+    assert_eq!(buys(&warm), none());
+}
+
+#[test]
+fn a_window_shorter_than_the_run_still_means_the_run() {
+    // window 1 with a run of 3 would be "never" read literally. The script
+    // lifts the window to the run instead of silently never firing.
+    let mut impossible = inputs();
+    impossible[RUN_WINDOW] = InputValue::Int(1);
+    assert_eq!(
+        sells(&run(impossible, &sell_tape())),
+        vec![8],
+        "an input that cannot fire is a trap, not a setting"
+    );
+}
+
+#[test]
+fn a_display_toggle_silences_its_own_side_and_nothing_else() {
+    let mut top_off = inputs();
+    top_off[SHOW_TOP] = InputValue::Bool(false);
+    assert_eq!(
+        sells(&run(top_off, &sell_tape())),
+        none(),
+        "the sell side goes quiet"
+    );
+
+    let mut t = context_down();
+    t.push((100.0, 100.0, 90.0, 90.0));
+    t.push((90.0, 92.0, 90.0, 92.0));
+    t.push((92.0, 94.0, 92.0, 94.0));
+    t.push((94.0, 98.0, 94.0, 98.0));
+    let mut top_off_again = inputs();
+    top_off_again[SHOW_TOP] = InputValue::Bool(false);
+    assert_eq!(
+        buys(&run(top_off_again, &t)),
+        vec![8],
+        "…while the other side keeps marking: the toggle gates one draw site"
+    );
+}
+
+#[test]
+fn a_forming_bar_never_shows_the_mark_and_never_consumes_the_push() {
+    let compiled = compile(SCRIPT, "exhaustion_reversal.pine").expect("compiles");
+    let mut indicator = ScriptIndicator::with_inputs(compiled, SCRIPT, inputs());
+
+    let rows = sell_tape();
+    let mut cvd = Vec::new();
+    let mut sum = 0.0;
+    // Commit every bar up to, but not including, the one that signals.
+    for (index, row) in rows.iter().enumerate().take(8) {
+        let bar = make(index, *row);
+        sum += bar.delta();
+        cvd.push(sum);
+        let mut ctx = Ctx {
+            bar_index: index,
+            cvd: &cvd,
+        };
+        indicator.on_close(&bar, &mut ctx).expect("commit run");
+    }
+
+    // Now preview the signalling bar, twice, as a live tape would.
+    let forming = make(8, rows[8]);
+    for _ in 0..2 {
+        cvd.push(sum + forming.delta());
+        let mut ctx = Ctx {
+            bar_index: 8,
+            cvd: &cvd,
+        };
+        let frame = indicator.preview(&forming, &mut ctx).expect("preview run");
+        cvd.pop();
+        assert!(
+            frame.values.iter().all(|v| v.is_nan()),
+            "a forming bar carries no mark: {:?}",
+            frame.values
+        );
+    }
+
+    // The previews must not have spent the armed force bar.
+    sum += forming.delta();
+    cvd.push(sum);
+    let mut ctx = Ctx {
+        bar_index: 8,
+        cvd: &cvd,
+    };
+    indicator.on_close(&forming, &mut ctx).expect("commit run");
+    assert_eq!(
+        sells(&indicator),
+        vec![8],
+        "the mark appears when the bar closes — previews rolled back cleanly"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The engulf: one opposite candle covering the force bar by itself.
+//
+// Measured as OVERLAP, not as give-back: the two shapes answer different
+// questions, and these tapes are chosen so that each is invisible to the
+// other. `engulf_tape` has no run (one candle is not three); `sell_tape` has
+// no engulf (its deepest single body overlaps 40%). Anything that mixed the
+// two measures up would light both tapes.
+// ---------------------------------------------------------------------------
+
+/// Force bar, then one bearish candle whose body covers 80% of its range.
+fn engulf_tape() -> Vec<Ohlc> {
+    let mut t = context_up();
+    t.push(FORCE_UP); //                      5  force bar, range 101..111
+    t.push((111.0, 111.0, 103.0, 103.0)); //  6  body 111->103 = 80% overlap
+    t
+}
+
+#[test]
+fn one_opposite_candle_covering_the_force_bar_marks_on_its_own() {
+    assert_eq!(
+        sells(&run(inputs(), &engulf_tape())),
+        vec![6],
+        "the engulf answers the push the bar after it, long before three \
+         candles could line up"
+    );
+
+    let mut run_only = inputs();
+    run_only[USE_ENGULF] = InputValue::Bool(false);
+    assert_eq!(
+        sells(&run(run_only, &engulf_tape())),
+        none(),
+        "with the engulf switched off the same tape goes quiet: the checkbox \
+         is wired to the shape it names"
+    );
+}
+
+#[test]
+fn an_engulf_short_of_the_overlap_threshold_does_not_mark() {
+    let mut shallow = engulf_tape();
+    shallow[6] = (111.0, 111.0, 105.0, 105.0); // covers 60%, not 70%
+    assert_eq!(
+        sells(&run(inputs(), &shallow)),
+        none(),
+        "60% of the force bar is not enough, and nothing else on this tape \
+         can mark it"
+    );
+}
+
+#[test]
+fn the_engulf_has_its_own_shorter_window() {
+    // Two pause bars: the covering candle lands at age 3, the last bar the
+    // engulf window covers.
+    let mut in_time = context_up();
+    in_time.push(FORCE_UP); //                      5  force bar
+    in_time.push((111.0, 111.6, 110.9, 111.5)); //  6  pause
+    in_time.push((111.5, 112.1, 111.4, 112.0)); //  7  pause
+    in_time.push((112.0, 112.0, 103.0, 103.0)); //  8  covers 80%, age 3
+    assert_eq!(sells(&run(inputs(), &in_time)), vec![8]);
+
+    // One more pause and the identical candle is a bar too late — even though
+    // the run's own window (5) would still have the force bar armed.
+    let mut late = context_up();
+    late.push(FORCE_UP); //                      5  force bar
+    late.push((111.0, 111.6, 110.9, 111.5)); //  6  pause
+    late.push((111.5, 112.1, 111.4, 112.0)); //  7  pause
+    late.push((112.0, 112.6, 111.9, 112.5)); //  8  pause
+    late.push((112.5, 112.5, 103.0, 103.0)); //  9  covers 80%, age 4
+    assert_eq!(
+        sells(&run(inputs(), &late)),
+        none(),
+        "a bar reacting four bars later is reacting to something else"
+    );
+}
+
+#[test]
+fn a_candle_closing_with_the_push_never_engulfs_it() {
+    let mut wrong_way = context_up();
+    wrong_way.push(FORCE_UP); //                     5  force bar
+    wrong_way.push((103.0, 111.5, 102.5, 111.0)); // 6  wide, but BULLISH
+    assert_eq!(
+        sells(&run(inputs(), &wrong_way)),
+        none(),
+        "a body spanning the force bar in the push's own direction is the \
+         push continuing, not a reversal of it"
+    );
+}
+
+#[test]
+fn the_engulf_marks_the_buy_side_too() {
+    let mut t = context_down();
+    t.push((100.0, 100.0, 90.0, 90.0)); // 5  selling push at a new low
+    t.push((90.0, 98.0, 90.0, 98.0)); //   6  bullish body covering 80%
+    let hit = run(inputs(), &t);
+    assert_eq!(buys(&hit), vec![6]);
+    assert_eq!(sells(&hit), none());
+}
+
+#[test]
+fn the_two_shapes_share_one_arrow_per_push() {
+    // The engulf fires at bar 6; bars 7 and 8 then complete a three-candle
+    // run that gives back 100% and would fire on its own.
+    let mut both = engulf_tape();
+    both.push((103.0, 103.0, 102.0, 102.0)); // 7  bearish
+    both.push((102.0, 102.0, 101.0, 101.0)); // 8  bearish — run of 3, 100% back
+    assert_eq!(
+        sells(&run(inputs(), &both)),
+        vec![6],
+        "the push was spent by the engulf; the run must not mark it again"
+    );
+}
+
+#[test]
+fn switching_the_run_off_leaves_the_engulf_alone_and_vice_versa() {
+    let mut engulf_only = inputs();
+    engulf_only[USE_RUN] = InputValue::Bool(false);
+    assert_eq!(
+        sells(&run(engulf_only, &sell_tape())),
+        none(),
+        "the canonical run tape has no single candle covering 70% — its \
+         deepest body overlaps 40%"
+    );
+
+    let mut engulf_only_again = inputs();
+    engulf_only_again[USE_RUN] = InputValue::Bool(false);
+    assert_eq!(
+        sells(&run(engulf_only_again, &engulf_tape())),
+        vec![6],
+        "…while the engulf tape still marks with the run switched off"
+    );
+
+    let mut neither = inputs();
+    neither[USE_RUN] = InputValue::Bool(false);
+    neither[USE_ENGULF] = InputValue::Bool(false);
+    assert_eq!(
+        sells(&run(neither, &engulf_tape())),
+        none(),
+        "both shapes off is an indicator that marks nothing at all"
+    );
+}

--- a/crates/pine/tests/exhaustion_reversal_semantics.rs
+++ b/crates/pine/tests/exhaustion_reversal_semantics.rs
@@ -5,20 +5,24 @@
 //! triangle appears would pass on a script that marks every bar, and the
 //! whole value of this indicator is the bars it stays silent on.
 //!
+//! One test does not read rows at all: `the_declared_marks_are_the_ones_the_
+//! renderer_draws` pins shape, location and colour. Those three fold at load
+//! time with silent fallbacks, so a swapped `location.abovebar` — the sell
+//! triangle drawn under the low — is invisible to every row assertion here.
+//!
 //! The tapes are written as raw `(open, high, low, close)` rows because those
 //! four numbers are the entire input surface of this script — no volume, no
 //! delta, no CVD. What each row is for is stated beside it.
 
-use quantick_indicators::{Ctx, Indicator, IndicatorBar, InputValue, PlotId, Rgba8};
+use quantick_indicators::{
+    Ctx, Indicator, IndicatorBar, InputSpec, InputValue, MarkerLocation, MarkerShape, PlotId, Rgba8,
+};
 use quantick_pine::{ScriptIndicator, compile};
 
 const SCRIPT: &str = include_str!("corpus/ok/exhaustion_reversal.pine");
 
 const SELL_PLOT: &str = "Exhaustion reversal: sell";
 const BUY_PLOT: &str = "Exhaustion reversal: buy";
-
-const TOP_COLOUR: Rgba8 = Rgba8::opaque(1, 0, 0);
-const BOTTOM_COLOUR: Rgba8 = Rgba8::opaque(2, 0, 0);
 
 /// (open, high, low, close).
 type Ohlc = (f64, f64, f64, f64);
@@ -27,30 +31,32 @@ type Ohlc = (f64, f64, f64, f64);
 /// identical at any length. Positional — the script's `input.*` order.
 fn inputs() -> Vec<InputValue> {
     vec![
-        InputValue::Int(4),               // 0  1 Force bar: body average window
-        InputValue::Float(1.5),           // 1  1 Force bar: min body (×average)
-        InputValue::Int(4),               // 2  1 Force bar: new extreme over (bars)
-        InputValue::Bool(true),           // 3  1 Force bar: must close with the push
-        InputValue::Bool(true),           // 4  2 Run: on
-        InputValue::Int(3),               // 5  2 Run: opposite candles in a row
-        InputValue::Int(5),               // 6  2 Run: window after the force bar
-        InputValue::Float(0.7),           // 7  2 Run: min give-back
-        InputValue::Bool(true),           // 8  3 Engulf: on
-        InputValue::Int(3),               // 9  3 Engulf: window after the force bar
-        InputValue::Float(0.7),           // 10 3 Engulf: min overlap
-        InputValue::Bool(true),           // 11 4 Display: mark top reversals
-        InputValue::Bool(true),           // 12 4 Display: mark bottom reversals
-        InputValue::Color(TOP_COLOUR),    // 13
-        InputValue::Color(BOTTOM_COLOUR), // 14
+        InputValue::Int(4),     // 0  1 Force bar: body average window
+        InputValue::Float(1.5), // 1  1 Force bar: min body (×average)
+        InputValue::Int(4),     // 2  1 Force bar: reaches the extreme of
+        InputValue::Bool(true), // 3  1 Force bar: must close with the push
+        InputValue::Bool(true), // 4  2 Run: on
+        InputValue::Int(3),     // 5  2 Run: opposite candles in a row
+        InputValue::Int(5),     // 6  2 Run: window after the force bar
+        InputValue::Float(0.7), // 7  2 Run: min give-back
+        InputValue::Bool(true), // 8  3 Cover: on
+        InputValue::Int(3),     // 9  3 Cover: window after the force bar
+        InputValue::Float(0.7), // 10 3 Cover: min overlap
+        InputValue::Bool(true), // 11 4 Display: mark top reversals
+        InputValue::Bool(true), // 12 4 Display: mark bottom reversals
     ]
 }
 
-/// Input slots the tests reach for by name, so a reordering of the script's
-/// inputs breaks compilation here instead of silently testing the wrong knob.
+// Positions into the hand-ordered `Vec` above. Naming them keeps a test from
+// reading as `off[8] = false` — but note this is legibility only: the bind
+// path checks the input *count*, never a name, so reordering two same-typed
+// inputs would leave these pointing at the wrong knob with the suite green.
+// There is no by-name input API to reach for; the behavioural assertions are
+// what actually catch a reorder.
 const NEED_DIRECTION: usize = 3;
 const USE_RUN: usize = 4;
 const RUN_WINDOW: usize = 6;
-const USE_ENGULF: usize = 8;
+const USE_COVER: usize = 8;
 const SHOW_TOP: usize = 11;
 
 fn make(index: usize, row: Ohlc) -> IndicatorBar {
@@ -71,12 +77,12 @@ fn make(index: usize, row: Ohlc) -> IndicatorBar {
 
 /// Five flat bullish bars: body 1.0, range 1.0, every high identical. The
 /// averages the force bar is judged against are therefore exactly 1.0, and
-/// the extreme it must clear is exactly 101.0.
+/// the extreme it must reach is exactly 101.0.
 fn context_up() -> Vec<Ohlc> {
     vec![(100.0, 101.0, 100.0, 101.0); 5]
 }
 
-/// The mirror: flat bearish bars, extreme to clear exactly 100.0.
+/// The mirror: flat bearish bars, extreme to reach exactly 100.0.
 fn context_down() -> Vec<Ohlc> {
     vec![(101.0, 101.0, 100.0, 100.0); 5]
 }
@@ -86,8 +92,12 @@ fn context_down() -> Vec<Ohlc> {
 /// 104.0 gives back the required 70%.
 const FORCE_UP: Ohlc = (101.0, 111.0, 101.0, 111.0);
 
-/// The canonical tape: force bar, then three bearish candles closing at 103
-/// — 80% of the force bar handed back on the third.
+/// The mirror: a selling push at a new low, range 90..100.
+const FORCE_DOWN: Ohlc = (100.0, 100.0, 90.0, 90.0);
+
+/// The canonical run tape: force bar, then three bearish candles closing at
+/// 103 — 80% of the force bar handed back on the third. Its deepest single
+/// body overlaps only 40%, so the cover shape cannot see this tape.
 fn sell_tape() -> Vec<Ohlc> {
     let mut t = context_up();
     t.push(FORCE_UP); //                      5  force bar
@@ -97,7 +107,26 @@ fn sell_tape() -> Vec<Ohlc> {
     t
 }
 
-fn run(inputs: Vec<InputValue>, rows: &[Ohlc]) -> ScriptIndicator {
+/// The mirror of `sell_tape`.
+fn buy_tape() -> Vec<Ohlc> {
+    let mut t = context_down();
+    t.push(FORCE_DOWN); //                5  selling push at a new low
+    t.push((90.0, 92.0, 90.0, 92.0)); //  6  give-back 1 of 3
+    t.push((92.0, 94.0, 92.0, 94.0)); //  7  give-back 2 of 3
+    t.push((94.0, 98.0, 94.0, 98.0)); //  8  give-back 3 of 3 -> 80%, marks
+    t
+}
+
+/// Force bar, then one bearish candle whose body covers 80% of its range —
+/// the shape the run cannot see, because one candle is not three.
+fn cover_tape() -> Vec<Ohlc> {
+    let mut t = context_up();
+    t.push(FORCE_UP); //                      5  force bar, range 101..111
+    t.push((111.0, 111.0, 103.0, 103.0)); //  6  body 111->103 = 80% overlap
+    t
+}
+
+fn load() -> ScriptIndicator {
     let compiled = match compile(SCRIPT, "exhaustion_reversal.pine") {
         Ok(c) => c,
         Err(errors) => panic!(
@@ -109,7 +138,24 @@ fn run(inputs: Vec<InputValue>, rows: &[Ohlc]) -> ScriptIndicator {
                 .join("\n")
         ),
     };
-    let mut indicator = ScriptIndicator::with_inputs(compiled, SCRIPT, inputs);
+    ScriptIndicator::new(compiled, SCRIPT)
+}
+
+/// Borrowed inputs on purpose: a test that flips two switches would otherwise
+/// have to build the vector twice, and the second copy silently drifts.
+fn run(inputs: &[InputValue], rows: &[Ohlc]) -> ScriptIndicator {
+    let compiled = match compile(SCRIPT, "exhaustion_reversal.pine") {
+        Ok(c) => c,
+        Err(errors) => panic!(
+            "exhaustion_reversal.pine must compile:\n{}",
+            errors
+                .iter()
+                .map(|e| e.render("exhaustion_reversal.pine", SCRIPT))
+                .collect::<Vec<_>>()
+                .join("\n")
+        ),
+    };
+    let mut indicator = ScriptIndicator::with_inputs(compiled, SCRIPT, inputs.to_vec());
 
     let mut cvd = Vec::new();
     let mut sum = 0.0;
@@ -157,8 +203,75 @@ fn none() -> Vec<usize> {
 }
 
 #[test]
+fn the_declared_marks_are_the_ones_the_renderer_draws() {
+    // Shape, location and colour all fold at load time and all fall back
+    // SILENTLY when they do not fold — `plotshape` has no unfoldable-argument
+    // warning. So every row assertion in this file would survive a sell
+    // triangle pointing up, drawn under the bar, in the wrong colour.
+    let indicator = load();
+    let plots = &indicator.descriptor().plots;
+    assert_eq!(plots.len(), 2, "one plot per side, and nothing else");
+
+    let sell = plots
+        .iter()
+        .find(|p| p.title == SELL_PLOT)
+        .expect("sell plot");
+    let sell_marker = sell.marker.as_ref().expect("the sell plot is a marker");
+    assert_eq!(sell_marker.shape, MarkerShape::TriangleDown);
+    assert_eq!(
+        sell_marker.location,
+        MarkerLocation::AboveBar,
+        "a sell mark sits above the bar; below it would point at the wrong \
+         price and cover the candle it is about"
+    );
+    assert_eq!(
+        sell.base_color,
+        Rgba8::new(0xF2, 0x36, 0x45, 0xFF),
+        "color.red — an unfoldable colour argument lands as amber instead, \
+         which is how both sides once shipped the same colour"
+    );
+
+    let buy = plots
+        .iter()
+        .find(|p| p.title == BUY_PLOT)
+        .expect("buy plot");
+    let buy_marker = buy.marker.as_ref().expect("the buy plot is a marker");
+    assert_eq!(buy_marker.shape, MarkerShape::TriangleUp);
+    assert_eq!(buy_marker.location, MarkerLocation::BelowBar);
+    assert_eq!(
+        buy.base_color,
+        Rgba8::new(0x00, 0x89, 0x7B, 0xFF),
+        "color.teal, and distinct from the sell colour"
+    );
+}
+
+#[test]
+fn no_declared_input_is_a_control_that_does_nothing() {
+    // `input.color` does not fold in this dialect, so a colour handed to a
+    // `plotshape` is dropped for the default amber — silently, because
+    // `plotshape` has no unfoldable-argument warning. The settings dialog
+    // still renders the picker, so the trader gets a control that moves
+    // nothing, which the repo treats as worse than an absent one. This
+    // script therefore declares no colour input at all and takes its colours
+    // from the Style tab; the assertion is here so nobody adds one back.
+    let indicator = load();
+    let inputs = &indicator.descriptor().inputs;
+    assert_eq!(
+        inputs.len(),
+        13,
+        "four force-bar knobs, four run, three cover, two display"
+    );
+    for spec in inputs {
+        assert!(
+            !matches!(spec, InputSpec::Color { .. }),
+            "colour inputs cannot reach a plot in this dialect: {spec:?}"
+        );
+    }
+}
+
+#[test]
 fn three_bearish_candles_give_back_the_push_and_a_shallower_run_does_not() {
-    let hit = run(inputs(), &sell_tape());
+    let hit = run(&inputs(), &sell_tape());
     assert_eq!(
         sells(&hit),
         vec![8],
@@ -170,7 +283,7 @@ fn three_bearish_candles_give_back_the_push_and_a_shallower_run_does_not() {
     let mut shallow = sell_tape();
     shallow[8] = (107.0, 107.0, 105.0, 105.0);
     assert_eq!(
-        sells(&run(inputs(), &shallow)),
+        sells(&run(&inputs(), &shallow)),
         none(),
         "60% is not 70% — the threshold is real, not decorative"
     );
@@ -188,7 +301,7 @@ fn two_pause_bars_still_count_and_three_pause_bars_are_too_late() {
     paused.push((110.0, 110.0, 107.0, 107.0)); //  9  give-back 2 of 3
     paused.push((107.0, 107.0, 103.0, 103.0)); // 10  give-back 3 of 3, age 5
     assert_eq!(
-        sells(&run(inputs(), &paused)),
+        sells(&run(&inputs(), &paused)),
         vec![10],
         "age 5 is the last bar the window covers, and it still marks"
     );
@@ -203,7 +316,7 @@ fn two_pause_bars_still_count_and_three_pause_bars_are_too_late() {
     late.push((110.0, 110.0, 107.0, 107.0)); // 10  give-back 2 of 3
     late.push((107.0, 107.0, 103.0, 103.0)); // 11  give-back 3 of 3, age 6
     assert_eq!(
-        sells(&run(inputs(), &late)),
+        sells(&run(&inputs(), &late)),
         none(),
         "the same give-back one bar later is a micro range, not a reversal — \
          this pair is the entire reason the window exists"
@@ -222,9 +335,30 @@ fn the_run_must_be_consecutive() {
     broken.push((108.0, 108.0, 105.0, 105.0)); //  9  bearish (1 of a new run)
     broken.push((105.0, 105.0, 103.0, 103.0)); // 10  bearish (2), 80% given back
     assert_eq!(
-        sells(&run(inputs(), &broken)),
+        sells(&run(&inputs(), &broken)),
         none(),
         "the push was given back, but not by a run — two in a row is not three"
+    );
+}
+
+#[test]
+fn the_streak_and_the_give_back_are_independent_tests() {
+    // Documented behaviour, pinned so nobody "fixes" it by accident: the run
+    // asks (a) did the last three candles close against the push, and (b) is
+    // price now back off the extreme. It does NOT ask that the three candles
+    // did the travelling. Here a single bullish gap hands back 80% and the
+    // three bearish candles that follow move 1% between them.
+    let mut cosmetic = context_up();
+    cosmetic.push(FORCE_UP); //                        5  force bar, range 10
+    cosmetic.push((102.0, 103.2, 101.8, 103.0)); //    6  bullish gap — gives back 80%
+    cosmetic.push((103.0, 103.0, 102.9, 102.9)); //    7  bearish by 0.1
+    cosmetic.push((102.9, 102.9, 102.8, 102.8)); //    8  bearish by 0.1
+    cosmetic.push((102.8, 102.8, 102.7, 102.7)); //    9  bearish by 0.1 -> marks
+    assert_eq!(
+        sells(&run(&inputs(), &cosmetic)),
+        vec![9],
+        "price is back and the tape is still leaning down, which is what the \
+         two conditions actually say — the header says so too"
     );
 }
 
@@ -236,25 +370,45 @@ fn an_ordinary_bar_at_a_new_high_is_not_a_force_bar() {
     weak.push((101.5, 101.5, 101.0, 101.0)); // 7
     weak.push((101.0, 101.0, 100.5, 100.5)); // 8  gives back far more than 70%
     assert_eq!(
-        sells(&run(inputs(), &weak)),
+        sells(&run(&inputs(), &weak)),
         none(),
         "a breakout the tape did not have to work for is not exhaustion"
     );
 }
 
 #[test]
-fn a_force_bar_that_takes_out_no_extreme_is_not_a_force_bar() {
+fn a_force_bar_that_reaches_no_extreme_is_not_a_force_bar() {
     // Identical to the canonical tape except bar 3, which leaves a 120 high
     // standing above everything the force bar can reach.
     let mut buried = sell_tape();
     buried[3] = (100.0, 120.0, 100.0, 101.0); // tall wick, body still 1.0
     assert_eq!(
-        sells(&run(inputs(), &buried)),
+        sells(&run(&inputs(), &buried)),
         none(),
         "a big body in the middle of a move is not a move ending"
     );
     // The pair: the same tape without that overhead high does mark.
-    assert_eq!(sells(&run(inputs(), &sell_tape())), vec![8]);
+    assert_eq!(sells(&run(&inputs(), &sell_tape())), vec![8]);
+}
+
+#[test]
+fn touching_the_extreme_is_enough_to_anchor() {
+    // Equalling the last N highs anchors: on futures the offer parks at a
+    // price and highs tie constantly, and a push that shoves into a level the
+    // tape touched N bars ago is the same event as one that clears it.
+    let mut tie = context_up();
+    // A bullish body of 10 whose high is exactly the window's high of 101 —
+    // it ties the extreme rather than clearing it.
+    tie.push((91.0, 101.0, 91.0, 101.0)); //  5  force bar, high ties 101
+    tie.push((101.0, 101.0, 99.0, 99.0)); //  6  give-back 1 of 3
+    tie.push((99.0, 99.0, 97.0, 97.0)); //    7  give-back 2 of 3
+    tie.push((97.0, 97.0, 93.0, 93.0)); //    8  give-back 3 of 3 -> 80%
+    assert_eq!(
+        sells(&run(&inputs(), &tie)),
+        vec![8],
+        "a tied high still anchors; the body test is what keeps a flat, quiet \
+         stretch of tied highs from ever getting here"
+    );
 }
 
 #[test]
@@ -268,7 +422,7 @@ fn the_direction_rule_decides_whether_a_reversal_bar_can_anchor() {
     wick.push((99.0, 99.0, 98.0, 98.0)); //     8  bearish, 127% given back
 
     assert_eq!(
-        sells(&run(inputs(), &wick)),
+        sells(&run(&inputs(), &wick)),
         none(),
         "with the direction rule on, only a bar closing up can be a buying push"
     );
@@ -276,7 +430,7 @@ fn the_direction_rule_decides_whether_a_reversal_bar_can_anchor() {
     let mut loose = inputs();
     loose[NEED_DIRECTION] = InputValue::Bool(false);
     assert_eq!(
-        sells(&run(loose, &wick)),
+        sells(&run(&loose, &wick)),
         vec![8],
         "with it off, any big bar at a new extreme anchors — the input is \
          wired to the clause it names"
@@ -285,13 +439,7 @@ fn the_direction_rule_decides_whether_a_reversal_bar_can_anchor() {
 
 #[test]
 fn the_buy_side_is_the_exact_mirror() {
-    let mut t = context_down();
-    t.push((100.0, 100.0, 90.0, 90.0)); //  5  selling push at a new low
-    t.push((90.0, 92.0, 90.0, 92.0)); //    6  give-back 1 of 3
-    t.push((92.0, 94.0, 92.0, 94.0)); //    7  give-back 2 of 3
-    t.push((94.0, 98.0, 94.0, 98.0)); //    8  give-back 3 of 3 -> 80%
-
-    let hit = run(inputs(), &t);
+    let hit = run(&inputs(), &buy_tape());
     assert_eq!(buys(&hit), vec![8]);
     assert_eq!(sells(&hit), none(), "a faded selling push marks no short");
 }
@@ -301,26 +449,36 @@ fn a_push_is_spent_by_its_own_signal() {
     // A fourth bearish candle, still inside the window, giving back even more.
     let mut long_run = sell_tape();
     long_run.push((103.0, 103.0, 101.0, 101.0)); // 9  age 4, run 4, 100% back
+    assert_eq!(long_run.len(), 10, "the tape really is ten bars long");
     assert_eq!(
-        run(inputs(), &long_run)
-            .plots()
-            .column(PlotId::new(0))
-            .len(),
-        10,
-        "the tape really is ten bars long"
-    );
-    assert_eq!(
-        sells(&run(inputs(), &long_run)),
+        sells(&run(&inputs(), &long_run)),
         vec![8],
         "one arrow per push: the same reversal must not be marked twice"
     );
 }
 
 #[test]
-fn nothing_is_marked_while_the_averages_are_warming_up() {
-    let warm = run(inputs(), &context_up());
-    assert_eq!(sells(&warm), none());
-    assert_eq!(buys(&warm), none());
+fn the_warm_up_guards_keep_the_opening_stretch_clean() {
+    // `ta.sma(body[1], 4)` carries a NaN until bar 4, so a textbook shape one
+    // bar earlier must not mark. The two tapes are the same shape, one bar
+    // apart — without the `not na` guards the first would mark too.
+    let mut too_early = vec![(100.0, 101.0, 100.0, 101.0); 3];
+    too_early.push(FORCE_UP); //                      3  force shape, still warming
+    too_early.push((111.0, 111.0, 103.0, 103.0)); //  4  would cover 80%
+    assert_eq!(
+        sells(&run(&inputs(), &too_early)),
+        none(),
+        "the body average does not exist yet, so nothing can beat it"
+    );
+
+    let mut warm = vec![(100.0, 101.0, 100.0, 101.0); 4];
+    warm.push(FORCE_UP); //                      4  the same force shape, warm
+    warm.push((111.0, 111.0, 103.0, 103.0)); //  5  covers 80% -> marks
+    assert_eq!(
+        sells(&run(&inputs(), &warm)),
+        vec![5],
+        "one bar later the average exists and the identical shape marks"
+    );
 }
 
 #[test]
@@ -330,7 +488,7 @@ fn a_window_shorter_than_the_run_still_means_the_run() {
     let mut impossible = inputs();
     impossible[RUN_WINDOW] = InputValue::Int(1);
     assert_eq!(
-        sells(&run(impossible, &sell_tape())),
+        sells(&run(&impossible, &sell_tape())),
         vec![8],
         "an input that cannot fire is a trap, not a setting"
     );
@@ -341,20 +499,12 @@ fn a_display_toggle_silences_its_own_side_and_nothing_else() {
     let mut top_off = inputs();
     top_off[SHOW_TOP] = InputValue::Bool(false);
     assert_eq!(
-        sells(&run(top_off, &sell_tape())),
+        sells(&run(&top_off, &sell_tape())),
         none(),
         "the sell side goes quiet"
     );
-
-    let mut t = context_down();
-    t.push((100.0, 100.0, 90.0, 90.0));
-    t.push((90.0, 92.0, 90.0, 92.0));
-    t.push((92.0, 94.0, 92.0, 94.0));
-    t.push((94.0, 98.0, 94.0, 98.0));
-    let mut top_off_again = inputs();
-    top_off_again[SHOW_TOP] = InputValue::Bool(false);
     assert_eq!(
-        buys(&run(top_off_again, &t)),
+        buys(&run(&top_off, &buy_tape())),
         vec![8],
         "…while the other side keeps marking: the toggle gates one draw site"
     );
@@ -413,48 +563,40 @@ fn a_forming_bar_never_shows_the_mark_and_never_consumes_the_push() {
 }
 
 // ---------------------------------------------------------------------------
-// The engulf: one opposite candle covering the force bar by itself.
+// The cover: one opposite candle sitting on top of the force bar.
 //
-// Measured as OVERLAP, not as give-back: the two shapes answer different
-// questions, and these tapes are chosen so that each is invisible to the
-// other. `engulf_tape` has no run (one candle is not three); `sell_tape` has
-// no engulf (its deepest single body overlaps 40%). Anything that mixed the
-// two measures up would light both tapes.
+// Measured as OVERLAP, not as travel: the two shapes answer different
+// questions, and these tapes are chosen so each is invisible to the other.
+// `cover_tape` has no run (one candle is not three); `sell_tape` has no cover
+// (its deepest single body overlaps 40%). Anything that mixed the two
+// measures up would light both tapes.
 // ---------------------------------------------------------------------------
-
-/// Force bar, then one bearish candle whose body covers 80% of its range.
-fn engulf_tape() -> Vec<Ohlc> {
-    let mut t = context_up();
-    t.push(FORCE_UP); //                      5  force bar, range 101..111
-    t.push((111.0, 111.0, 103.0, 103.0)); //  6  body 111->103 = 80% overlap
-    t
-}
 
 #[test]
 fn one_opposite_candle_covering_the_force_bar_marks_on_its_own() {
     assert_eq!(
-        sells(&run(inputs(), &engulf_tape())),
+        sells(&run(&inputs(), &cover_tape())),
         vec![6],
-        "the engulf answers the push the bar after it, long before three \
+        "the cover answers the push the bar after it, long before three \
          candles could line up"
     );
 
     let mut run_only = inputs();
-    run_only[USE_ENGULF] = InputValue::Bool(false);
+    run_only[USE_COVER] = InputValue::Bool(false);
     assert_eq!(
-        sells(&run(run_only, &engulf_tape())),
+        sells(&run(&run_only, &cover_tape())),
         none(),
-        "with the engulf switched off the same tape goes quiet: the checkbox \
+        "with the cover switched off the same tape goes quiet: the checkbox \
          is wired to the shape it names"
     );
 }
 
 #[test]
-fn an_engulf_short_of_the_overlap_threshold_does_not_mark() {
-    let mut shallow = engulf_tape();
+fn a_cover_short_of_the_overlap_threshold_does_not_mark() {
+    let mut shallow = cover_tape();
     shallow[6] = (111.0, 111.0, 105.0, 105.0); // covers 60%, not 70%
     assert_eq!(
-        sells(&run(inputs(), &shallow)),
+        sells(&run(&inputs(), &shallow)),
         none(),
         "60% of the force bar is not enough, and nothing else on this tape \
          can mark it"
@@ -462,15 +604,32 @@ fn an_engulf_short_of_the_overlap_threshold_does_not_mark() {
 }
 
 #[test]
-fn the_engulf_has_its_own_shorter_window() {
+fn a_candle_inside_the_force_bar_still_covers_it() {
+    // High below the force bar's high, low above its low — the opposite of a
+    // classical engulfing candle, and it marks, because its body still erases
+    // 80% of the push. Pinned because the name "cover" was chosen over
+    // "engulf" precisely to stop this reading as a bug.
+    let mut inside = context_up();
+    inside.push(FORCE_UP); //                        5  force bar, range 101..111
+    inside.push((110.0, 110.5, 101.5, 102.0)); //    6  strictly inside, covers 80%
+    assert_eq!(
+        sells(&run(&inputs(), &inside)),
+        vec![6],
+        "a small bar that erases most of a large one is the exhaustion this \
+         is looking for, whether or not it pokes out the ends"
+    );
+}
+
+#[test]
+fn the_cover_has_its_own_shorter_window() {
     // Two pause bars: the covering candle lands at age 3, the last bar the
-    // engulf window covers.
+    // cover window covers.
     let mut in_time = context_up();
     in_time.push(FORCE_UP); //                      5  force bar
     in_time.push((111.0, 111.6, 110.9, 111.5)); //  6  pause
     in_time.push((111.5, 112.1, 111.4, 112.0)); //  7  pause
     in_time.push((112.0, 112.0, 103.0, 103.0)); //  8  covers 80%, age 3
-    assert_eq!(sells(&run(inputs(), &in_time)), vec![8]);
+    assert_eq!(sells(&run(&inputs(), &in_time)), vec![8]);
 
     // One more pause and the identical candle is a bar too late — even though
     // the run's own window (5) would still have the force bar armed.
@@ -481,19 +640,19 @@ fn the_engulf_has_its_own_shorter_window() {
     late.push((112.0, 112.6, 111.9, 112.5)); //  8  pause
     late.push((112.5, 112.5, 103.0, 103.0)); //  9  covers 80%, age 4
     assert_eq!(
-        sells(&run(inputs(), &late)),
+        sells(&run(&inputs(), &late)),
         none(),
         "a bar reacting four bars later is reacting to something else"
     );
 }
 
 #[test]
-fn a_candle_closing_with_the_push_never_engulfs_it() {
+fn a_candle_closing_with_the_push_never_covers_it() {
     let mut wrong_way = context_up();
     wrong_way.push(FORCE_UP); //                     5  force bar
     wrong_way.push((103.0, 111.5, 102.5, 111.0)); // 6  wide, but BULLISH
     assert_eq!(
-        sells(&run(inputs(), &wrong_way)),
+        sells(&run(&inputs(), &wrong_way)),
         none(),
         "a body spanning the force bar in the push's own direction is the \
          push continuing, not a reversal of it"
@@ -501,53 +660,62 @@ fn a_candle_closing_with_the_push_never_engulfs_it() {
 }
 
 #[test]
-fn the_engulf_marks_the_buy_side_too() {
+fn the_cover_marks_the_buy_side_too() {
     let mut t = context_down();
-    t.push((100.0, 100.0, 90.0, 90.0)); // 5  selling push at a new low
-    t.push((90.0, 98.0, 90.0, 98.0)); //   6  bullish body covering 80%
-    let hit = run(inputs(), &t);
+    t.push(FORCE_DOWN); //                5  selling push at a new low
+    t.push((90.0, 98.0, 90.0, 98.0)); //  6  bullish body covering 80%
+    let hit = run(&inputs(), &t);
     assert_eq!(buys(&hit), vec![6]);
     assert_eq!(sells(&hit), none());
 }
 
 #[test]
 fn the_two_shapes_share_one_arrow_per_push() {
-    // The engulf fires at bar 6; bars 7 and 8 then complete a three-candle
-    // run that gives back 100% and would fire on its own.
-    let mut both = engulf_tape();
+    // The cover fires at bar 6; bars 7 and 8 then complete a three-candle run
+    // that gives back 100% and would fire on its own.
+    let mut both = cover_tape();
     both.push((103.0, 103.0, 102.0, 102.0)); // 7  bearish
     both.push((102.0, 102.0, 101.0, 101.0)); // 8  bearish — run of 3, 100% back
     assert_eq!(
-        sells(&run(inputs(), &both)),
+        sells(&run(&inputs(), &both)),
         vec![6],
-        "the push was spent by the engulf; the run must not mark it again"
+        "the push was spent by the cover; the run must not mark it again"
+    );
+
+    // Switching a shape off does not only remove marks — it can move one,
+    // because a push the cover never spent is still there for the run to
+    // find. The script header says so; this is the tape that proves it.
+    let mut run_only = inputs();
+    run_only[USE_COVER] = InputValue::Bool(false);
+    assert_eq!(
+        sells(&run(&run_only, &both)),
+        vec![8],
+        "with the cover off the same push is marked three bars later, where \
+         the run completes — a jump, not an inconsistency"
     );
 }
 
 #[test]
-fn switching_the_run_off_leaves_the_engulf_alone_and_vice_versa() {
-    let mut engulf_only = inputs();
-    engulf_only[USE_RUN] = InputValue::Bool(false);
+fn switching_the_run_off_leaves_the_cover_alone_and_vice_versa() {
+    let mut cover_only = inputs();
+    cover_only[USE_RUN] = InputValue::Bool(false);
     assert_eq!(
-        sells(&run(engulf_only, &sell_tape())),
+        sells(&run(&cover_only, &sell_tape())),
         none(),
         "the canonical run tape has no single candle covering 70% — its \
          deepest body overlaps 40%"
     );
-
-    let mut engulf_only_again = inputs();
-    engulf_only_again[USE_RUN] = InputValue::Bool(false);
     assert_eq!(
-        sells(&run(engulf_only_again, &engulf_tape())),
+        sells(&run(&cover_only, &cover_tape())),
         vec![6],
-        "…while the engulf tape still marks with the run switched off"
+        "…while the cover tape still marks with the run switched off"
     );
 
     let mut neither = inputs();
     neither[USE_RUN] = InputValue::Bool(false);
-    neither[USE_ENGULF] = InputValue::Bool(false);
+    neither[USE_COVER] = InputValue::Bool(false);
     assert_eq!(
-        sells(&run(neither, &engulf_tape())),
+        sells(&run(&neither, &cover_tape())),
         none(),
         "both shapes off is an indicator that marks nothing at all"
     );


### PR DESCRIPTION
A new embedded script: a small triangle on the bar where a force bar was
given back. Additive — one new script, one line in `EMBEDDED_SCRIPTS`, new
tests. No existing script, plot or code path changes behaviour.

## The signal

A **force bar** is a bar whose body clears `factor × sma(body, len)` of the
bars *before* it **and** which reaches the extreme of the last `N` bars
(`>=`, not `>`: highs tie constantly on futures, and the body test is what
keeps a flat stretch from anchoring). Then the give-back, in either of two
shapes, each with its own switch and settings:

| | measures | sell side |
| --- | --- | --- |
| **Run** | travel — where price ended up | `(fb_high - close) / fb_range >= 0.70`, with `K` opposite closes in a row, inside `W` bars |
| **Cover** | overlap — how much of the force bar one body sits on | `(min(open, fb_high) - max(close, fb_low)) / fb_range >= 0.70`, inside its own shorter window |

They are not one test with two settings. A slow drift travels without
covering; a wide bar can cover the force bar and close just past it. The
trader asked for both; the second arrived mid-session with a chart example.

**One arrow per push**: a force bar arms once and is spent by the first
signal, whichever shape produced it. Marks are drawn on closed bars only.

Everything is an `input` with a range — averages, extreme window, both
windows, both thresholds, run length, the direction rule and the two
sides. Colour and width are on the Style tab, per plot, deliberately (see
below).

## Verification

| Gate | Result |
| --- | --- |
| `cargo fmt --all -- --check` | pass |
| `cargo clippy --workspace --all-targets -- -D warnings` | pass, 0 warnings |
| `cargo build --workspace` | pass |
| `cargo test --workspace` | **2298 passed, 0 failed** |

Not run: `ruff` and `test_export_session.py` — this branch touches no
Python.

### Performance

The script runs on the commit path and again on every preview of the
forming bar, so it is a hot path. `cargo bench -p quantick-pine`:

```
exh_reversal  475 nodes  100k bars =>   6272 ns/bar  (0 cells drawn)      idle
exh_reversal  475 nodes  100k bars =>  12114 ns/bar  (2702 cells drawn)   armed
```

**12.1 µs/bar armed against the 50 µs budget** (200 µs is the hard fail).
The two numbers are the point: the script keeps its arithmetic behind `and`
guards that only open once a push is armed.

The idle/armed split exists because the review found the bench was measuring
the dead path — `make_bars` has a constant 0.3 body, so `body >= 1.5 ×
average` was false on all 100 000 bars and the state machine never armed.
A second tape now injects a force bar every 37th bar, and every bench line
reports how many cells it drew, so a zero cannot pass as a fast script.

### Blast radius

Added: `scripts/exhaustion_reversal.pine`, its corpus copy,
`exhaustion_reversal_semantics.rs`. Edited: one line in `EMBEDDED_SCRIPTS`
(appended — index 0 is positional), a chain test, the bench, and the
encoding guard.

### Proof

24 semantics tests, every clause as an **acende/não-acende pair**, plus a
chain test driving the real worker with the script's own defaults. Four
mutations were run against the suite to confirm it discriminates: weakening
the run, the window, the give-back and the overlap each break exactly the
test that owns that clause.

`ui-harness`: reachable with the existing hook,
`QUANTICK_INDICATOR_SCRIPTS_AUTOSTART=exhaustion_reversal.pine`. No new
hook needed.

`visual-qa`: PASS. Driven on a recorded WINQ26 session (copied to scratch,
the archive untouched) at fps 51–71. Sell marks are red triangles above the
bar, buy marks teal triangles below it, neither covering a candle. The
settings dialog renders its grouped inputs, `×` included, with no mojibake.

`trader-ux-review`: no Blocker, no Should-fix. Four Consider, listed below.

## What the reviews caught

The visual capture and the bug pass independently found the same **blocker**:
`input.color` does not fold in this dialect — `fold()` has no
`Builtin::InputColor` arm — so `plotshape(color=…)` fed from an input was
silently dropped for the default amber. Both sides shipped the same colour
and the dialog showed two pickers that moved nothing. Fixed by using
literals (which fold) and leaving per-plot colour to the Style tab, where
every other indicator's colour lives. A test now pins both colours, both
shapes and both locations: all six fall back silently, so a sell triangle
drawn under the low was invisible to every row assertion.

Also fixed from the review: the warm-up test could not have failed (its
tape cannot make a force bar, warm or cold); the chain fixture had zero
warm-up margin; the delay paragraph claimed a floor that stopped being true
when the cover shape landed; "engulf" was renamed "cover" because the
formula measures overlap and an inside bar counts; and the encoding guard
scanned only `src/**/*.rs` while the densest non-ASCII file in the crate is
a `.pine` under `scripts/`.

## Deferred

- **One arrow for both shapes.** Run and cover draw the same triangle, so
  which one spoke is only visible by switching one off — and doing that can
  *move* a mark rather than remove it (a push the cover never spent is still
  there for the run to find). Documented in the header and pinned by a test.
  Four separate plots were offered and the trader chose one mark.
- **Chain-test duplication** (`indicator_worker.rs`): the new module repeats
  `print`, the tape shape and the worker-drive block from `paint_tests`
  100 lines above. Extracting a shared `chain_support` module touches an
  existing test that is not this branch's; worth its own PR when the third
  script arrives.
- **Preview is not benched.** Measured at ~1.3× the commit cost and it runs
  far more often; `preview_cost.rs` is the right home and covers only the
  copilot today.
- **Header invisible in the app.** "No triangle" and "information, not
  advice" live in the script header, which the app never shows — a newcomer
  reading a quiet chart has no way to know silence is the normal state.
  Applies to every embedded script, not just this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BcFSZcZUABAiAYVn2AFZ9v
