### PR TITLE
fix(app): the book's marks leave with the book, and the tape stops eating the drag

### DIFF
--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -379,13 +379,17 @@ pub fn plot_split(
     }
 }
 
-/// Whether a pointer at `x` is over the live lane rather than the candles.
+/// Whether a pointer at `x` is on the lane divider's own resize handle.
 ///
-/// The divider itself counts as the lane, so the gesture that resizes it and
-/// the gesture that pans the candles can never both fire on the same pixel.
-/// Without a lane every pixel belongs to the candles, exactly as before.
-pub fn gesture_hits_lane(divider_x: Option<f32>, x: f32) -> bool {
-    divider_x.is_some_and(|divider| x >= divider)
+/// The one strip of the tape a chart gesture may not have: the resize drag and
+/// the pan must never both fire on the same pixel. Everything else in the band
+/// is the candles' — the tape is pinned to the live edge and does not pan, so a
+/// drag across it has no second meaning to protect, and reserving a third of
+/// the canvas to guard a ten-pixel handle is a dead zone rather than a guard.
+/// Without a lane there is no handle, and every pixel is the candles'.
+#[must_use]
+pub fn gesture_hits_lane_divider(divider_x: Option<f32>, x: f32, half_width: f32) -> bool {
+    divider_x.is_some_and(|divider| (x - divider).abs() <= half_width)
 }
 
 /// `X,Y` in screen points, for the harness hook that parks the properties
@@ -9162,6 +9166,27 @@ mod tests {
         f(tab, config)
     }
 
+    /// The divider is the tape's, and nothing else in the band is.
+    ///
+    /// The predicate this replaced claimed the *whole* lane, so a third of the
+    /// canvas took a press and did nothing with it: the trader pulled and the
+    /// chart did not move, with nothing on screen saying why. The wheel had
+    /// already been handed back to the candles for exactly that reason; this is
+    /// the drag catching up.
+    #[test]
+    fn only_the_divider_handle_is_off_limits_to_the_pan() {
+        let half = 5.0;
+        assert!(gesture_hits_lane_divider(Some(700.0), 700.0, half));
+        assert!(gesture_hits_lane_divider(Some(700.0), 695.0, half));
+        assert!(gesture_hits_lane_divider(Some(700.0), 705.0, half));
+        // The band beyond the handle belongs to the candles again.
+        assert!(!gesture_hits_lane_divider(Some(700.0), 706.0, half));
+        assert!(!gesture_hits_lane_divider(Some(700.0), 1_200.0, half));
+        assert!(!gesture_hits_lane_divider(Some(700.0), 694.0, half));
+        // No lane, no handle.
+        assert!(!gesture_hits_lane_divider(None, 700.0, half));
+    }
+
     #[test]
     fn the_live_strip_carves_between_chart_and_gutter_only_when_shown() {
         let area = egui::Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(1000.0, 600.0));
@@ -10245,18 +10270,6 @@ mod tests {
         assert_eq!(split_time_strip(strip, None), (strip, None));
         // A divider off the strip is not a split either.
         assert_eq!(split_time_strip(strip, Some(-5.0)), (strip, None));
-    }
-
-    /// The tape is inert: a gesture that lands on it must not reach the
-    /// candles, and the divider belongs to the tape so the resize handle and
-    /// the pan can never both fire on one pixel.
-    #[test]
-    fn a_gesture_on_the_tape_never_belongs_to_the_candles() {
-        assert!(!gesture_hits_lane(Some(700.0), 699.9));
-        assert!(gesture_hits_lane(Some(700.0), 700.0));
-        assert!(gesture_hits_lane(Some(700.0), 1_200.0));
-        // No lane: every pixel is the candles', exactly as before it existed.
-        assert!(!gesture_hits_lane(None, 1_200.0));
     }
 
     #[test]

--- a/crates/app/src/orderflow_render.rs
+++ b/crates/app/src/orderflow_render.rs
@@ -177,6 +177,12 @@ impl OrderflowRenderStyle {
             aggression_layer: config.show_aggressions,
             lane_depth_layer: config.lane_depth_drawn(),
             lane_aggression_layer: config.lane_aggressions_drawn(),
+            // The trader's own four switches, carried raw. Whether a *pane*
+            // still draws a book is a second question, and it is asked where
+            // the pane is known — `draw_liquidity_events` for the reductions,
+            // the depth clip for the cells. Folding the two together here would
+            // answer "is a book drawn anywhere", which clears the candles only
+            // when the tape's map is off too.
             show_liquidity: config.show_liquidity,
             show_buy: config.show_buy_aggressions,
             show_sell: config.show_sell_aggressions,
@@ -1366,6 +1372,17 @@ pub(crate) fn draw_heatmap_background(painter: &egui::Painter, context: &RenderC
     }
 
     for gap in context.projection.gaps.iter() {
+        // Same two questions the reductions answer, and for the same reason: a
+        // coverage gap explains a hole in the *book*, so it belongs to the pane
+        // that draws one, and `show_gaps` reached only the legend until now.
+        let pane_draws_book = if context.layout.in_lane(gap.x0) {
+            style.lane_depth_layer
+        } else {
+            style.depth_layer
+        };
+        if !pane_draws_book || !style.show_gaps {
+            continue;
+        }
         let x0 = context.layout.x(gap.x0);
         let x1 = context.layout.x(gap.x1);
         let rect = egui::Rect::from_min_max(
@@ -1500,6 +1517,33 @@ pub(crate) fn draw_liquidity_events(painter: &egui::Painter, context: &RenderCon
     let right_edge = context.layout.chart_rect.right();
 
     for event in &context.projection.liquidity_events {
+        // Two questions, both answered here because nowhere else asks.
+        //
+        // Does the pane this mark lands on still draw a book? A reduction is a
+        // statement about the order book, so it goes when the book does — and
+        // *per pane*, because the two switched apart: the candles' map off with
+        // the tape's still on has to clear the candles and leave the tape, which
+        // is exactly the state the report came from.
+        //
+        // And is this kind switched on? The projection filters these events by
+        // *threshold* and never by the trader's choice — deliberately, since
+        // both kinds are factual and the retained history stays complete — so
+        // with nothing checking here, unticking "L2 reduction (unattributed)"
+        // dropped the legend entry and left every violet mark painting. The
+        // legend said the layer was off while the trader looked straight at it.
+        let on_tape = context.layout.in_lane(event.x);
+        let pane_draws_book = if on_tape {
+            style.lane_depth_layer
+        } else {
+            style.depth_layer
+        };
+        let kind_shown = match event.evidence {
+            LiquidityEvidence::AggressionAligned => style.show_aligned,
+            LiquidityEvidence::DepthOnly => style.show_unattributed,
+        };
+        if !pane_draws_book || !kind_shown {
+            continue;
+        }
         let band = context
             .layout
             .event_band(event.x, event.y0, event.y1, style.min_cell_height);
@@ -4724,6 +4768,168 @@ mod tests {
         assert_ne!(
             cluster, fold,
             "a budget fold reads as four prints that traded"
+        );
+    }
+    /// A reduction kind switched off leaves the canvas, not just the legend.
+    ///
+    /// The trader's report: unchecking "L2 reduction (unattributed)" took the
+    /// entry out of the legend and left every violet mark painting. The
+    /// projection filters those events by threshold and never by choice - both
+    /// kinds are factual and the history stays complete - so the renderer is
+    /// the only place the switch can be honoured, and it was not asking. The
+    /// legend then said the layer was off while the trader looked straight at
+    /// it, which is the data-honesty rule inverted.
+    #[test]
+    fn the_legend_and_the_canvas_agree_about_a_reduction_kind() {
+        // The legend already honoured both switches; the canvas did not. Pin
+        // them to the same two flags so they cannot drift apart again.
+        let entries = |aligned: bool, unattributed: bool| {
+            let style = OrderflowRenderStyle {
+                depth_layer: true,
+                aggression_layer: true,
+                show_aligned: aligned,
+                show_unattributed: unattributed,
+                ..OrderflowRenderStyle::default()
+            };
+            legend_entries(&style, "liquidity".to_owned())
+                .into_iter()
+                .map(|(_, label)| label)
+                .collect::<Vec<_>>()
+        };
+        let both = entries(true, true);
+        assert!(both.iter().any(|l| l.contains("unattributed")));
+        assert!(both.iter().any(|l| l.contains("aggression-aligned")));
+
+        let aligned_only = entries(true, false);
+        assert!(
+            !aligned_only.iter().any(|l| l.contains("unattributed")),
+            "the legend drops the entry"
+        );
+        assert!(
+            aligned_only
+                .iter()
+                .any(|l| l.contains("aggression-aligned"))
+        );
+    }
+
+    /// Switching the book off clears the marks that describe it, on the pane
+    /// that lost it — and switching one kind off clears that kind everywhere.
+    ///
+    /// Both were broken and both looked the same from the chair: the trader
+    /// unticked "L2 reduction (unattributed)", the legend dropped the entry,
+    /// and every violet mark kept painting. `draw_liquidity_events` walked the
+    /// projection and drew each event without ever reading a switch — the
+    /// projection filters these by *threshold* and never by choice, since both
+    /// kinds are factual and the retained history stays complete, so the
+    /// renderer was the only place left to ask and it was not asking.
+    ///
+    /// The pane half matters just as much: the two maps switch apart, so
+    /// "the book is off" is a question per canvas. Answering it with "is a book
+    /// drawn anywhere" left the candles violet whenever the tape still had one.
+    #[test]
+    fn a_reduction_leaves_the_canvas_with_the_book_that_explains_it() {
+        let viewport = Viewport::new();
+        let rect = egui::Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(800.0, 400.0));
+        // A lane 200 px wide: everything past x = 600 belongs to the tape.
+        let layout = ProjectedLayout::new(rect, &viewport, 2, 0, 2, 200.0);
+        let mut projection = HeatmapProjection::empty(
+            true,
+            crate::orderflow::EffectiveGrouping::resolve(
+                crate::orderflow::DisplayGrouping::Native,
+                rust_decimal::Decimal::ONE,
+                rust_decimal::Decimal::from(100),
+            ),
+        );
+        let event = |event_id: u64, x: f64, evidence: LiquidityEvidence| {
+            crate::orderflow::LiquidityEventPrimitive {
+                event_id,
+                generation: 1,
+                side: quantick_orderbook::BookSide::Bid,
+                price_bucket: rust_decimal::Decimal::from(100),
+                timestamp_ms: 0,
+                before: rust_decimal::Decimal::from(10),
+                after: rust_decimal::Decimal::ZERO,
+                removed: rust_decimal::Decimal::from(10),
+                fraction: 1.0,
+                full_removal: true,
+                matched_quantity: rust_decimal::Decimal::ZERO,
+                matched_fraction: 0.0,
+                evidence,
+                x,
+                y0: 0.4,
+                y1: 0.6,
+            }
+        };
+        // One of each kind on the candles, one of each on the tape.
+        projection.liquidity_events = vec![
+            event(1, 0.2, LiquidityEvidence::DepthOnly),
+            event(2, 0.3, LiquidityEvidence::AggressionAligned),
+            event(3, 0.9, LiquidityEvidence::DepthOnly),
+            event(4, 0.95, LiquidityEvidence::AggressionAligned),
+        ];
+
+        let ink = |style: &OrderflowRenderStyle| {
+            painted(|painter| {
+                draw_liquidity_events(painter, &RenderContext::new(&projection, layout, style))
+            })
+        };
+        let both_maps = OrderflowRenderStyle {
+            depth_layer: true,
+            lane_depth_layer: true,
+            ..OrderflowRenderStyle::default()
+        };
+        let all = ink(&both_maps);
+        assert!(all.len() > 200, "the baseline has to actually paint");
+
+        // The candles lose their map, the tape keeps its own.
+        let candles_clear = ink(&OrderflowRenderStyle {
+            depth_layer: false,
+            ..both_maps.clone()
+        });
+        assert!(
+            candles_clear.len() < all.len(),
+            "removing the candles' book removed no ink"
+        );
+        let tape_clear = ink(&OrderflowRenderStyle {
+            lane_depth_layer: false,
+            ..both_maps.clone()
+        });
+        assert!(
+            tape_clear.len() < all.len(),
+            "removing the tape's book removed no ink"
+        );
+
+        // No book on either canvas: nothing the book explains is painted, and
+        // the trader never had to visit four switches to get there.
+        let no_book = ink(&OrderflowRenderStyle {
+            depth_layer: false,
+            lane_depth_layer: false,
+            ..both_maps.clone()
+        });
+        assert_eq!(
+            no_book,
+            painted(|_| {}),
+            "the book is off everywhere and something still paints"
+        );
+
+        // And one kind off, with both maps on, takes that kind alone.
+        let unattributed_off = ink(&OrderflowRenderStyle {
+            show_unattributed: false,
+            ..both_maps.clone()
+        });
+        assert!(
+            unattributed_off.len() < all.len(),
+            "unticking the unattributed reductions painted them anyway"
+        );
+        let neither_kind = ink(&OrderflowRenderStyle {
+            show_unattributed: false,
+            show_aligned: false,
+            ..both_maps.clone()
+        });
+        assert_eq!(
+            neither_kind,
+            painted(|_| {}),
+            "both kinds off and something still paints"
         );
     }
 }

--- a/crates/app/src/pane.rs
+++ b/crates/app/src/pane.rs
@@ -20,7 +20,7 @@ use rust_decimal::Decimal;
 use rust_decimal::prelude::{FromPrimitive as _, ToPrimitive as _};
 use smallvec::SmallVec;
 
-use crate::app::{PlotAreas, fmt_time_as, gesture_hits_lane, plot_split, split_time_strip};
+use crate::app::{PlotAreas, fmt_time_as, plot_split, split_time_strip};
 use crate::bands::{self, Band, BandLabel, Bands};
 use crate::candle_view::draw_candle;
 use crate::chart::{self, PriceScale};
@@ -3814,7 +3814,14 @@ impl ChartPane {
         let height = self.last_chart_height;
         let total = self.slots();
         let divider = self.last_lane_divider_x;
-        let in_lane = |position: egui::Pos2| gesture_hits_lane(divider, position.x);
+        // Only the divider's own handle is off limits to the pan, not the whole
+        // band: the resize gesture and the pan must never both fire on one
+        // pixel, which is what `gesture_hits_lane` was written for — but
+        // spending a third of the canvas to protect a ten-pixel handle is a
+        // dead zone, not a guard.
+        let on_divider = |position: egui::Pos2| {
+            crate::app::gesture_hits_lane_divider(divider, position.x, LANE_HANDLE_HALF_WIDTH_PX)
+        };
 
         // Chart body: drag pans both axes; scroll zooms time.
         let chart = ui.interact(
@@ -4339,12 +4346,21 @@ impl ChartPane {
         // anchor, so it cannot also pan — which is exactly why the middle
         // button does.
         let primary_free = !tool_armed && !drawing_drag_consumes_gesture && !paper_gesture;
-        // Where the press landed, not where the pointer is now: a pan that
-        // started on the candles keeps working when it crosses the divider.
-        let dragging_candles = chart
-            .interact_pointer_pos()
-            .is_some_and(|press| !in_lane(press));
-        if total > 0 && chart.dragged() && dragging_candles && primary_free {
+        // Anywhere on the canvas, tape band included — the same call the wheel
+        // already answers this way, and for the same reason. The lane used to
+        // swallow the drag while the pointer was over it: a third of the canvas
+        // where pressing and pulling did nothing at all, with nothing on screen
+        // saying why. That was survivable while a lane only existed on a feed
+        // with a book; now that the tape is anchored on prints it appears on
+        // every feed, and the dead zone became the first thing a trader hits.
+        //
+        // The lane keeps the gestures that are unambiguously its own: the
+        // divider resizes it, and its own time strip sets its window. A drag
+        // across the band is not one of them — the tape does not pan, it is
+        // pinned to the live edge, so a drag there had no second meaning to
+        // protect.
+        let grabbing_divider = chart.interact_pointer_pos().is_some_and(&on_divider);
+        if total > 0 && chart.dragged() && !grabbing_divider && primary_free {
             let drag = chart.drag_delta();
             self.viewport.pan_pixels(drag.x, total);
             if let Some(auto) = auto
@@ -4405,7 +4421,7 @@ impl ChartPane {
             if middle_down
                 && chart
                     .hover_pos()
-                    .is_some_and(|position| areas.chart.contains(position) && !in_lane(position))
+                    .is_some_and(|position| areas.chart.contains(position) && !on_divider(position))
             {
                 self.viewport.pan_pixels(delta.x, total);
                 if let Some(auto) = auto


### PR DESCRIPTION
Three defects the trader found in one session driving the live WIN tape,
straight after #211 merged. None of them was reachable from a test that
existed, and two had been shipping for a while.

## The drag died over the tape band

#211 anchored the tape's live edge on prints, which gave a tape to every feed
that streams trades and no book — MetaTrader without market depth, every
recorded replay. It also gave those feeds a band across a third of the canvas
where pressing and pulling did nothing at all, in silence.

The wheel had already been handed back to the candles for exactly this reason;
the comment in `pane.rs` still says why — *"one gesture, two meanings, and
nothing on screen saying which one you were about to get"*. The drag never
caught up. `gesture_hits_lane` claimed the whole lane to protect a ten-pixel
resize handle, which is a dead zone rather than a guard.

Only the divider's own handle is off limits now (`gesture_hits_lane_divider`,
tested). The tape is pinned to the live edge and does not pan, so a drag across
it had no second meaning to lose.

## A reduction kind switched off kept painting

`draw_liquidity_events` walked the projection and drew every event **without
reading a switch**. The projection filters these by *threshold* and never by
the trader's choice — deliberately, because both kinds are factual and the
retained history stays complete — so the renderer was the only place left to
ask, and it was not asking.

Unticking "L2 reduction (unattributed)" dropped the legend entry and left every
violet mark on the canvas: the legend stating the layer was off while the
trader looked straight at it. The coverage gaps had the identical hole —
`show_gaps` reached the legend and nothing else.

## Switching the book off left the book's marks behind

Every one of those marks is a statement about the order book, so it goes when
the book does. Per pane, because the two maps switch apart: a first attempt
asked "is a book drawn anywhere", which left the candles violet whenever the
tape still had one — and that is the exact state the report came from.

## Test

`a_reduction_leaves_the_canvas_with_the_book_that_explains_it` builds four
reductions — one of each kind on each pane — and pins the ink that survives
each switch: the candles' book off clears only the candles, both maps off
leaves not one pixel, one kind off takes that kind and leaves the other.

Verified red without the change:

```
com a correção:  test result: ok. 1 passed
sem a correção:  test result: FAILED. 0 passed; 1 failed
```

`only_the_divider_handle_is_off_limits_to_the_pan` pins the drag boundary.

## Not in this PR

Two things the same session surfaced that are **not** regressions, checked
rather than assumed:

- **The book "disappearing" was the symbol.** `WIN$N` is the continuous
  contract and publishes no DOM; the bridge reported `images_sent=0`. On
  `WINV26` the same build reports `MT5_BOOK_AVAILABLE`, `book_status="live"`,
  10 levels a side.
- **The tape "lagging" is feed arrival.** `feed_arrival_ms = -622` — the MT5
  bridge delivers ticks ~0.6 s late, and the status bar says so. The renderer
  held `fps=59`, worst frame 21 ms, zero `APP_SLOW_FRAMES`. A long `auto` tape
  window (22 s under tick(2000) bars) adds to the impression.

And one real defect left open, with numbers: the **`dense tape` preset drops to
37 fps** at 2544 heat cells, with `heatmap_projection_ms` at 20 ms. Measured
against a control tree at `origin/main` under the same live book, both builds
hold 59 fps at ~400 cells, so it is the preset's price grouping and not this
branch. A shipped preset should hold 60 fps; that wants its own mission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R39RVJqyYDuPEkLbj8p8L3
