### PR TITLE
feat(app): give the force bar a floor, a body ruler, and a colour

### DIFF
--- a/crates/app/scripts/exhaustion_reversal.pine
+++ b/crates/app/scripts/exhaustion_reversal.pine
@@ -179,7 +179,7 @@ coverage = input.float(0.7, "2 Run: min give-back of the force bar", minval=0.05
 // immediate response, and five bars later it is a different bar reacting to
 // a different thing.
 use_cover = input.bool(true, "3 Cover: mark a give-back by one opposite candle")
-cover_window = input.int(3, "3 Cover: window after the force bar (bars)", minval=1, maxval=100)
+cover_window = input.int(5, "3 Cover: window after the force bar (bars)", minval=1, maxval=100)
 cover_fraction = input.float(0.7, "3 Cover: min overlap with the force bar", minval=0.05, maxval=1.0, step=0.05)
 
 // 4 — display: which side to mark. These gate the two TRIANGLES only. The
@@ -224,9 +224,26 @@ show_bottom = input.bool(true, "4 Display: mark bottom reversals (buy side)")
 // the number is typed instead. A script cannot ask what a tick is worth here,
 // so one of the two has to be the dragged case.
 min_body_points = input.float(0.0, "5 Calibration: min force-bar body (points, 0 = off)", minval=0.0, step=1.0)
-run_body_only = input.bool(false, "5 Calibration: run measures the body, not the range")
-cover_body_only = input.bool(false, "5 Calibration: cover measures the body, not the range")
+run_body_only = input.bool(true, "5 Calibration: run measures the body, not the range")
+cover_body_only = input.bool(true, "5 Calibration: cover measures the body, not the range")
 paint_force = input.bool(false, "5 Calibration: paint the bars that arm a push")
+
+// 6 — invalidation: when the give-back went too far to be a give-back.
+//
+// A candle that closes BEYOND the far end of the force bar — below its low on
+// a top, above its high on a bottom — has not faded the push, it has replaced
+// it. That candle is itself a force bar candidate in the other direction, and
+// what comes next is the exhaustion of the exhaustion. The trade this
+// indicator is about is fading the green bar, not chasing the red one that
+// buried it.
+//
+// It kills the setup on the spot, whichever shape was about to mark and
+// whenever inside the window it happens: a candle that covers 70% AND closes
+// past the far end is not a mark, and the push does not get a second chance
+// from a later bar either. The far end is the force bar's own extreme, wick
+// included — what the eye reads off the chart — not the body, even when the
+// two shapes above are measuring against the body.
+invalidate_beyond = input.bool(true, "6 Invalidation: a close past the force bar's far end kills the setup")
 
 // ---------------------------------------------------------------- measures
 
@@ -302,6 +319,7 @@ var float top_run_range = na
 var float top_cover_high = na
 var float top_cover_low = na
 var float top_cover_range = na
+var float top_bar_low = na
 var bool bottom_armed = false
 var int bottom_age = 0
 var float bottom_run_high = na
@@ -310,6 +328,7 @@ var float bottom_run_range = na
 var float bottom_cover_high = na
 var float bottom_cover_low = na
 var float bottom_cover_range = na
+var float bottom_bar_high = na
 
 // Age first, test second, arm last. Ageing before the test is what makes the
 // bar `run_len` bars after the force bar read as age `run_len`; arming after
@@ -324,6 +343,13 @@ if bottom_armed
         bottom_armed := false
 
 // ----------------------------------------------------------------- signals
+
+// Invalidation first, because it outranks both shapes: a bar that closes past
+// the force bar's far end kills the setup even when that same bar would have
+// marked. `top_armed` short-circuits it away on the bars where nothing is
+// armed, which is most of them.
+top_killed = invalidate_beyond and top_armed and close < top_bar_low
+bottom_killed = invalidate_beyond and bottom_armed and close > bottom_bar_high
 
 // Every ruler below was resolved when its push armed, and it KEEPS that value
 // after the push is spent — nothing writes `na` back on disarm or expiry. So
@@ -349,13 +375,15 @@ buy_run = use_run and bottom_armed and bottom_age >= run_len and bottom_age <= r
 sell_cover = use_cover and top_armed and top_age <= cover_window and bear_bar and top_cover_range > 0 and (math.min(open, top_cover_high) - math.max(close, top_cover_low)) / top_cover_range >= cover_fraction
 buy_cover = use_cover and bottom_armed and bottom_age <= cover_window and bull_bar and bottom_cover_range > 0 and (math.min(close, bottom_cover_high) - math.max(open, bottom_cover_low)) / bottom_cover_range >= cover_fraction
 
-// Either shape marks, and the first one to fire spends the push.
-sell_signal = sell_run or sell_cover
-buy_signal = buy_run or buy_cover
+// Either shape marks, unless the setup was killed on this very bar.
+sell_signal = (sell_run or sell_cover) and not top_killed
+buy_signal = (buy_run or buy_cover) and not bottom_killed
 
-if sell_signal
+// A push is spent by the signal it produced OR by the close that invalidated
+// it — a killed push gets no second chance from a later bar in the window.
+if sell_signal or top_killed
     top_armed := false
-if buy_signal
+if buy_signal or bottom_killed
     bottom_armed := false
 
 // Arming is also where each shape's ruler is measured out, once, from the
@@ -370,6 +398,7 @@ if top_anchor
     top_cover_high := cover_body_only ? math.max(open, close) : high
     top_cover_low := cover_body_only ? math.min(open, close) : low
     top_cover_range := top_cover_high - top_cover_low
+    top_bar_low := low
 if bottom_anchor
     bottom_armed := true
     bottom_age := 0
@@ -379,6 +408,7 @@ if bottom_anchor
     bottom_cover_high := cover_body_only ? math.max(open, close) : high
     bottom_cover_low := cover_body_only ? math.min(open, close) : low
     bottom_cover_range := bottom_cover_high - bottom_cover_low
+    bottom_bar_high := high
 
 // ------------------------------------------------------------------- marks
 

--- a/crates/app/scripts/exhaustion_reversal.pine
+++ b/crates/app/scripts/exhaustion_reversal.pine
@@ -75,6 +75,18 @@
 // that erases most of a large one is exactly the exhaustion this is looking
 // for, whether or not it pokes out the ends.
 //
+// BODY-ONLY REFERENCE: both fractions above are measured, by default, against
+// the force bar's full RANGE (high to low). Each has its own switch in
+// section 5 — "run measures the body, not the range" and its cover
+// counterpart — to measure against the force bar's BODY (open to close)
+// instead, ignoring its wicks. This is the fix for a specific misreading: a
+// force bar with a long wick makes the range wider than the body, so a candle
+// that visibly erases most of the BODY can still fall short of a threshold
+// judged against the whole wick-to-wick range. Switch it on and that same
+// candle is judged only against what it actually erased. The two references
+// can disagree in either direction — body-only is not simply "easier" — the
+// wick shrinks both the numerator and the denominator, not one alone.
+//
 // The force bar's body is judged against the average of the bars BEFORE it
 // (same discipline as force_bar.pine): a huge bar must not be allowed to
 // inflate the very average that is deciding whether it is huge.
@@ -98,6 +110,51 @@
 // finally completes. A mark that jumps when you flip a switch is those two
 // shapes disagreeing about when the push ended, not an inconsistency.
 //
+// AN ELEPHANT HAS A SIZE, NOT ONLY A RATIO. The body test above is a
+// RATIO — this body against the average of the recent ones — and a ratio
+// alone is honest on time candles and promiscuous on activity-cut bars. When
+// the tape goes quiet the average it multiplies collapses, so an unremarkable
+// bar clears 1.5× of almost nothing and arms a push that nobody watching the
+// chart would call one. This is measured, not suspected: on a live WINV26
+// session the same bare band marked 247 of 1 355 volume bars as force bars;
+// an absolute floor of 100 points left 7 (see docs/ux/strategy-anchors.md,
+// which is why the strategy kernel's force ruler carries `min_body`).
+//
+// So section 5 adds a floor in POINTS, `and`ed with the ratio above: a
+// bar must be big relative to its neighbours AND big in the instrument's own
+// units. It ships at 0 — disabled, the ratio alone, exactly what this script
+// did before the floor existed — because the right number is a property of
+// the instrument and nothing else: ~100 points on WIN mini index, a different
+// order of magnitude on BTC. Turn the paint below on and raise the floor
+// until only bars you would call pushes stay coloured.
+//
+// SEEING WHICH BARS ARMED: section 5 carries a diagnostic switch — "paint
+// the bars that arm a push". Off by default. Switch it on and every bar this
+// script accepted as a force bar is painted: ORANGE for a top (sell-side)
+// push, BLUE for a bottom (buy-side) one. Nothing else changes; the paint
+// reports what the state machine already decided, it does not decide it.
+//
+// It is there because the arrows alone cannot answer "is it reading the
+// right bars?". An arrow needs a push that was BOTH armed AND given back, so
+// a force bar nothing faded leaves no trace at all — and neither does a bar
+// that armed when it should not have. Paint them and calibration becomes a
+// visual question: if bars you would never call a push come out coloured,
+// `min body (×average)` is too low for this instrument, the points floor is
+// still at 0, or the extreme window is too short. Worth knowing while you
+// read it: the default 1.5× is the same multiple force_bar.pine calls the
+// FLOOR of its force band, not its exhaustion threshold (2.5×). This section
+// deliberately sets the lower bar, because the give-back is the other half of
+// the test — but on a quiet tape the average it multiplies is small, and 1.5×
+// of small is small.
+//
+// A bar that anchors both sides at once — possible only with the direction
+// filter off — is painted for the top. One bar, one colour, priority fixed
+// rather than left to evaluation order.
+//
+// HONEST ABOUT THE FORMING BAR: paint is drawn from the preview, so the bar
+// being built can take a colour and lose it again before it closes (the same
+// rule force_bar.pine states). A closed bar's colour never changes.
+//
 // Every threshold below is an input: this is a shape, and where the shape
 // begins and ends is a judgement about the instrument in front of you.
 // Defaults are a starting point measured on nothing in particular —
@@ -115,7 +172,7 @@ need_direction = input.bool(true, "1 Force bar: must close in the direction of t
 use_run = input.bool(true, "2 Run: mark a give-back by consecutive candles")
 run_len = input.int(3, "2 Run: opposite candles in a row", minval=1, maxval=20)
 window_len = input.int(5, "2 Run: window after the force bar (bars)", minval=1, maxval=100)
-coverage = input.float(0.7, "2 Run: min give-back of the force bar (fraction of range)", minval=0.05, maxval=3.0, step=0.05)
+coverage = input.float(0.7, "2 Run: min give-back of the force bar", minval=0.05, maxval=3.0, step=0.05)
 
 // 3 — the cover: one opposite candle sitting on top of the force bar.
 // Shorter window than the run by default: a single bar answering a push is an
@@ -123,11 +180,16 @@ coverage = input.float(0.7, "2 Run: min give-back of the force bar (fraction of 
 // a different thing.
 use_cover = input.bool(true, "3 Cover: mark a give-back by one opposite candle")
 cover_window = input.int(3, "3 Cover: window after the force bar (bars)", minval=1, maxval=100)
-cover_fraction = input.float(0.7, "3 Cover: min overlap with the force bar (fraction of range)", minval=0.05, maxval=1.0, step=0.05)
+cover_fraction = input.float(0.7, "3 Cover: min overlap with the force bar", minval=0.05, maxval=1.0, step=0.05)
 
-// 4 — display: which side to mark. These gate the drawing sites only. The
+// 4 — display: which side to mark. These gate the two TRIANGLES only. The
 // state machine below runs whatever they say, so flipping a side back on
 // never changes what the indicator concluded while it was off.
+//
+// They deliberately do NOT gate section 5's paint. The triangles are the
+// reading; the paint is the ruler being checked, and a trader who silenced
+// one side and then went looking for why nothing arms there would be misled
+// by a diagnostic that had silenced itself along with the marks.
 //
 // Colour and width are deliberately NOT inputs: they live on the dialog's
 // Style tab, per plot, which is what the chart actually reads. An
@@ -135,6 +197,31 @@ cover_fraction = input.float(0.7, "3 Cover: min overlap with the force bar (frac
 // silently comes out amber — so a colour slider here would be a dead control.
 show_top = input.bool(true, "4 Display: mark top reversals (sell side)")
 show_bottom = input.bool(true, "4 Display: mark bottom reversals (buy side)")
+
+// 5 — calibration: the rulers this shape is measured with, and the paint that
+// shows what they accepted. Every one of them ships OFF (or at 0), so a fresh
+// load behaves exactly like the first version of this script.
+//
+// THIS SECTION IS LAST FOR A REASON, and new inputs belong at the end of it.
+// A saved preset is a list of values matched to inputs BY POSITION: the app
+// walks the declared inputs and takes the saved value at the same index when
+// its type matches. Insert an input in the middle and every preset saved
+// before it silently shifts — the value a trader stored for "opposite candles
+// in a row" lands on whatever now sits at that index, and a bool switch can
+// be turned ON by a preset that never knew it existed. Appending keeps every
+// older index pointing at the input it was saved for; the new ones simply
+// find nothing and take their defaults. A test pins this order.
+// No `maxval`/`step` on purpose. Every other float here is a scale-free
+// multiple over a tight range, and the panel renders a bounded float as a
+// slider quantised to its step — which on this input would mean a WIN floor
+// of ~100 living in the first 0.1% of the track, and a step of 1 that no
+// instrument priced under a unit could ever get below. Bounded on one side
+// only, it is a typed field with a floor of zero, which is what an absolute
+// quantity in the instrument's own units wants to be.
+min_body_points = input.float(0.0, "5 Calibration: min force-bar body (points, 0 = off)", minval=0.0)
+run_body_only = input.bool(false, "5 Calibration: run measures the body, not the range")
+cover_body_only = input.bool(false, "5 Calibration: cover measures the body, not the range")
+paint_force = input.bool(false, "5 Calibration: paint the bars that arm a push")
 
 // ---------------------------------------------------------------- measures
 
@@ -161,7 +248,11 @@ arm_window = math.max(run_window, cover_window)
 
 // A zero average is warm-up or a dead tape, not a bar that beats it. The
 // `not na` guards are what keep the opening stretch unmarked.
-big_body = not na(avg_body_before) and avg_body_before > 0 and body >= body_factor * avg_body_before
+// The ratio and the floor, in that order: the ratio rejects most bars on its
+// own, so the floor is a comparison the short-circuit rarely reaches. A floor
+// of 0 is `body >= 0`, true for every bar including a doji — the ratio is
+// what still decides, exactly as it did before this input existed.
+big_body = not na(avg_body_before) and avg_body_before > 0 and body >= body_factor * avg_body_before and body >= min_body_points
 new_high = not na(high_before) and high >= high_before
 new_low = not na(low_before) and low <= low_before
 
@@ -179,17 +270,35 @@ bottom_anchor = big_body and new_low and (not need_direction or bear_bar)
 
 // ------------------------------------------------------------------- state
 
-// One armed force bar per side, with its own age and its own range. The two
+// One armed force bar per side, with its own age and its own rulers. The two
 // sides are independent: the bar that gives back a buying push may itself be
 // the selling push that arms the other side.
+//
+// The rulers are RESOLVED WHEN THE BAR ARMS, not read per bar: the two
+// body-only switches pick between the force bar's wick-to-wick extremes and
+// its body, and that choice cannot change while a push is armed — editing any
+// input rebuilds the indicator and replays the whole history, so there is no
+// live tape on which a stored ruler could go stale. Resolving it here keeps
+// eight ternaries and four subtractions off every bar, armed or not, and puts
+// them on the rare bar that actually arms. Each shape stores its own pair
+// because the run and the cover choose independently: a wide-wick push can be
+// judged by its body for one and by its range for the other.
 var bool top_armed = false
 var int top_age = 0
-var float top_high = na
-var float top_low = na
+var float top_run_high = na
+var float top_run_low = na
+var float top_run_range = na
+var float top_cover_high = na
+var float top_cover_low = na
+var float top_cover_range = na
 var bool bottom_armed = false
 var int bottom_age = 0
-var float bottom_high = na
-var float bottom_low = na
+var float bottom_run_high = na
+var float bottom_run_low = na
+var float bottom_run_range = na
+var float bottom_cover_high = na
+var float bottom_cover_low = na
+var float bottom_cover_range = na
 
 // Age first, test second, arm last. Ageing before the test is what makes the
 // bar `run_len` bars after the force bar read as age `run_len`; arming after
@@ -205,27 +314,29 @@ if bottom_armed
 
 // ----------------------------------------------------------------- signals
 
-// Two subtractions, cheap enough to keep in the open for readability; `na`
-// when no push is armed, which makes every `> 0` below false.
-top_range = top_high - top_low
-bottom_range = bottom_high - bottom_low
-
+// Every ruler below was resolved when its push armed, and it KEEPS that value
+// after the push is spent — nothing writes `na` back on disarm or expiry. So
+// `top_armed` / `bottom_armed` is the only thing standing between a stale
+// ruler and this arithmetic, and it is deliberately first in every chain
+// below. The `> 0` tests guard against a zero denominator, not a stale one;
+// reordering the chain so one of them runs first would read a spent push.
+//
 // The divisions and the overlap arithmetic sit BEHIND the guards on purpose.
 // `and` short-circuits, and on the large majority of bars no push is armed —
 // so on those bars this line stops at `top_armed` and the maths never runs.
 // (Measured: ~17% of the script's commit cost, and this runs again for every
 // preview of the forming bar.) Nothing here is a `ta.*` kernel, so unlike the
 // measures above there is no warm-up to protect by hoisting it.
-sell_run = use_run and top_armed and top_age >= run_len and top_age <= run_window and bear_run >= run_len and top_range > 0 and (top_high - close) / top_range >= coverage
-buy_run = use_run and bottom_armed and bottom_age >= run_len and bottom_age <= run_window and bull_run >= run_len and bottom_range > 0 and (close - bottom_low) / bottom_range >= coverage
+sell_run = use_run and top_armed and top_age >= run_len and top_age <= run_window and bear_run >= run_len and top_run_range > 0 and (top_run_high - close) / top_run_range >= coverage
+buy_run = use_run and bottom_armed and bottom_age >= run_len and bottom_age <= run_window and bull_run >= run_len and bottom_run_range > 0 and (close - bottom_run_low) / bottom_run_range >= coverage
 
 // The cover: the overlap of two intervals — this candle's body against the
-// force bar's range — so it is bounded by the force bar and cannot be
-// inflated by a candle that is merely enormous somewhere else. A body that
+// force bar's range (or body) — so it is bounded by the force bar and cannot
+// be inflated by a candle that is merely enormous somewhere else. A body that
 // does not reach the force bar at all makes the overlap negative, which
 // fails on its own.
-sell_cover = use_cover and top_armed and top_age <= cover_window and bear_bar and top_range > 0 and (math.min(open, top_high) - math.max(close, top_low)) / top_range >= cover_fraction
-buy_cover = use_cover and bottom_armed and bottom_age <= cover_window and bull_bar and bottom_range > 0 and (math.min(close, bottom_high) - math.max(open, bottom_low)) / bottom_range >= cover_fraction
+sell_cover = use_cover and top_armed and top_age <= cover_window and bear_bar and top_cover_range > 0 and (math.min(open, top_cover_high) - math.max(close, top_cover_low)) / top_cover_range >= cover_fraction
+buy_cover = use_cover and bottom_armed and bottom_age <= cover_window and bull_bar and bottom_cover_range > 0 and (math.min(close, bottom_cover_high) - math.max(open, bottom_cover_low)) / bottom_cover_range >= cover_fraction
 
 // Either shape marks, and the first one to fire spends the push.
 sell_signal = sell_run or sell_cover
@@ -236,16 +347,27 @@ if sell_signal
 if buy_signal
     bottom_armed := false
 
+// Arming is also where each shape's ruler is measured out, once, from the
+// force bar that is being armed — see the state block above for why storing
+// it is safe and what it saves.
 if top_anchor
     top_armed := true
     top_age := 0
-    top_high := high
-    top_low := low
+    top_run_high := run_body_only ? math.max(open, close) : high
+    top_run_low := run_body_only ? math.min(open, close) : low
+    top_run_range := top_run_high - top_run_low
+    top_cover_high := cover_body_only ? math.max(open, close) : high
+    top_cover_low := cover_body_only ? math.min(open, close) : low
+    top_cover_range := top_cover_high - top_cover_low
 if bottom_anchor
     bottom_armed := true
     bottom_age := 0
-    bottom_high := high
-    bottom_low := low
+    bottom_run_high := run_body_only ? math.max(open, close) : high
+    bottom_run_low := run_body_only ? math.min(open, close) : low
+    bottom_run_range := bottom_run_high - bottom_run_low
+    bottom_cover_high := cover_body_only ? math.max(open, close) : high
+    bottom_cover_low := cover_body_only ? math.min(open, close) : low
+    bottom_cover_range := bottom_cover_high - bottom_cover_low
 
 // ------------------------------------------------------------------- marks
 
@@ -256,3 +378,17 @@ buy_mark = buy_signal and barstate.isconfirmed
 
 plotshape(show_top and sell_mark, "Exhaustion reversal: sell", style=shape.triangledown, location=location.abovebar, color=color.red)
 plotshape(show_bottom and buy_mark, "Exhaustion reversal: buy", style=shape.triangleup, location=location.belowbar, color=color.teal)
+
+// ------------------------------------------------------------------- paint
+
+// The diagnostic, and the only thing in this script that draws on a bar that
+// produced no signal. `na` on every other bar leaves the chart's own candle
+// colours alone — an unpainted bar is this script saying "not a push", which
+// is the answer on the large majority of them.
+paint = na
+if paint_force and top_anchor
+    paint := color.orange
+else if paint_force and bottom_anchor
+    paint := color.blue
+
+barcolor(paint)

--- a/crates/app/scripts/exhaustion_reversal.pine
+++ b/crates/app/scripts/exhaustion_reversal.pine
@@ -218,7 +218,11 @@ show_bottom = input.bool(true, "4 Display: mark bottom reversals (buy side)")
 // typed field with a floor of zero, which is what an absolute quantity in the
 // instrument's own units wants to be. `step` is then no longer a quantiser at
 // all, only the drag speed, and 1 point per pixel beats the 0.1 default:
-// dragging to 100 should not take a thousand pixels.
+// dragging to 100 should not take a thousand pixels. That speed is chosen for
+// an index future, where a point is the unit the floor is thought in; on an
+// instrument priced in fractions a drag of 1 per pixel is far too coarse and
+// the number is typed instead. A script cannot ask what a tick is worth here,
+// so one of the two has to be the dragged case.
 min_body_points = input.float(0.0, "5 Calibration: min force-bar body (points, 0 = off)", minval=0.0, step=1.0)
 run_body_only = input.bool(false, "5 Calibration: run measures the body, not the range")
 cover_body_only = input.bool(false, "5 Calibration: cover measures the body, not the range")
@@ -281,7 +285,13 @@ bottom_anchor = big_body and new_low and (not need_direction or bear_bar)
 // input rebuilds the indicator and replays the whole history, so there is no
 // live tape on which a stored ruler could go stale. Resolving it here keeps
 // eight ternaries and four subtractions off every bar, armed or not, and puts
-// them on the rare bar that actually arms. Each shape stores its own pair
+// them on the rare bar that actually arms. Measured on the commit path (the
+// 100k-bar interpreter bench): the version that read the switches per bar
+// cost about 20% more per bar, this one about 5%. What that bench does NOT
+// cover is the preview path, which runs per print rather than per bar and
+// clones every global slot — and this shape holds six more of them than the
+// per-bar one did. The trade is a win on the measured path and unmeasured on
+// the other; that is the honest statement of it. Each shape stores its own pair
 // because the run and the cover choose independently: a wide-wick push can be
 // judged by its body for one and by its range for the other.
 var bool top_armed = false

--- a/crates/app/scripts/exhaustion_reversal.pine
+++ b/crates/app/scripts/exhaustion_reversal.pine
@@ -211,14 +211,15 @@ show_bottom = input.bool(true, "4 Display: mark bottom reversals (buy side)")
 // be turned ON by a preset that never knew it existed. Appending keeps every
 // older index pointing at the input it was saved for; the new ones simply
 // find nothing and take their defaults. A test pins this order.
-// No `maxval`/`step` on purpose. Every other float here is a scale-free
-// multiple over a tight range, and the panel renders a bounded float as a
-// slider quantised to its step — which on this input would mean a WIN floor
-// of ~100 living in the first 0.1% of the track, and a step of 1 that no
-// instrument priced under a unit could ever get below. Bounded on one side
-// only, it is a typed field with a floor of zero, which is what an absolute
-// quantity in the instrument's own units wants to be.
-min_body_points = input.float(0.0, "5 Calibration: min force-bar body (points, 0 = off)", minval=0.0)
+// No `maxval` on purpose. Every other float here is a scale-free multiple
+// over a tight range, and the panel renders a float with BOTH bounds as a
+// slider quantised to its step — which on this input would put the ~100 a WIN
+// contract wants in the first 0.1% of the track. Bounded below only, it is a
+// typed field with a floor of zero, which is what an absolute quantity in the
+// instrument's own units wants to be. `step` is then no longer a quantiser at
+// all, only the drag speed, and 1 point per pixel beats the 0.1 default:
+// dragging to 100 should not take a thousand pixels.
+min_body_points = input.float(0.0, "5 Calibration: min force-bar body (points, 0 = off)", minval=0.0, step=1.0)
 run_body_only = input.bool(false, "5 Calibration: run measures the body, not the range")
 cover_body_only = input.bool(false, "5 Calibration: cover measures the body, not the range")
 paint_force = input.bool(false, "5 Calibration: paint the bars that arm a push")
@@ -385,10 +386,20 @@ plotshape(show_bottom and buy_mark, "Exhaustion reversal: buy", style=shape.tria
 // produced no signal. `na` on every other bar leaves the chart's own candle
 // colours alone — an unpainted bar is this script saying "not a push", which
 // is the answer on the large majority of them.
+//
+// ONE PAINTER WINS PER BAR, AND IT IS THE LAST ONE ADDED. The chart resolves
+// the bar paint channel by walking the indicator stack backwards and taking
+// the first colour it finds (`resolve_bar_paint`), so a script added AFTER
+// this one hides it wherever both paint. force_bar.pine paints every body at
+// or above 1.5x its average — which is nearly every bar this diagnostic is
+// about — so run this one alone while calibrating, or add it last. The two
+// colours here being ones force_bar.pine does not use settles which script a
+// colour came from; it does not make both visible on one bar.
 paint = na
-if paint_force and top_anchor
-    paint := color.orange
-else if paint_force and bottom_anchor
-    paint := color.blue
+if paint_force
+    if top_anchor
+        paint := color.orange
+    else if bottom_anchor
+        paint := color.blue
 
 barcolor(paint)

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -2877,9 +2877,25 @@ impl QuantickApp {
         let Some(saved) = saved else {
             return;
         };
-        // The same binder the state-file path uses: one rule for what a saved
-        // value means, in one place.
-        let draft = quantick_indicators::bind_by_position(&specs, &saved).values;
+        // The same binder the worker binds a saved state file with: one rule
+        // for what a saved value means, in one place.
+        let bound = quantick_indicators::bind_by_position(&specs, &saved);
+        if bound.kept < saved.len() {
+            // The preset on screen is not the preset that was saved. Silence
+            // here would show a chart that does not match the name above it.
+            tracing::warn!(
+                target: "quantick::app",
+                schema_version = 1_u8,
+                event_code = "INDICATOR_PRESET_REBOUND",
+                preset = %name.as_deref().unwrap_or(indicator_panel::DEFAULT_PRESET),
+                saved = saved.len(),
+                declared = specs.len(),
+                kept = bound.kept,
+                action = "bound_by_position",
+                "some of this preset's values no longer bind; those inputs took their defaults"
+            );
+        }
+        let draft = bound.values;
         let label = name.unwrap_or_else(|| indicator_panel::DEFAULT_PRESET.to_owned());
         if let Some(dialog) = self.indicator_settings.as_mut() {
             dialog.draft = draft;

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -2852,7 +2852,7 @@ impl QuantickApp {
         else {
             return;
         };
-        let saved: Option<Vec<quantick_indicators::InputValue>> = match &name {
+        let saved: Option<Vec<Option<quantick_indicators::InputValue>>> = match &name {
             None => Some(Vec::new()),
             Some(name) => {
                 let Some(kind) = self
@@ -2865,27 +2865,21 @@ impl QuantickApp {
                 };
                 self.indicator_presets
                     .get(kind, name)
-                    .map(|inputs| inputs.iter().filter_map(SavedInput::to_value).collect())
+                    // `map`, not `filter_map`: a stored cell that no longer
+                    // reads (a source whose name the dialect dropped, say)
+                    // still has to hold its index. Dropping it from the list
+                    // would slide every value after it one input to the left,
+                    // and same-typed neighbours would take each other's
+                    // settings without a word.
+                    .map(|inputs| inputs.iter().map(SavedInput::to_value).collect())
             }
         };
         let Some(saved) = saved else {
             return;
         };
-        let draft: Vec<quantick_indicators::InputValue> = specs
-            .iter()
-            .enumerate()
-            .map(|(index, spec)| {
-                let default = spec.default_value();
-                match saved.get(index) {
-                    Some(value)
-                        if std::mem::discriminant(value) == std::mem::discriminant(&default) =>
-                    {
-                        value.clone()
-                    }
-                    _ => default,
-                }
-            })
-            .collect();
+        // The same binder the state-file path uses: one rule for what a saved
+        // value means, in one place.
+        let draft = quantick_indicators::bind_by_position(&specs, &saved).values;
         let label = name.unwrap_or_else(|| indicator_panel::DEFAULT_PRESET.to_owned());
         if let Some(dialog) = self.indicator_settings.as_mut() {
             dialog.draft = draft;

--- a/crates/app/src/indicator_worker.rs
+++ b/crates/app/src/indicator_worker.rs
@@ -91,6 +91,15 @@ pub(crate) enum IndicatorSource {
     Script { name: String, text: String },
 }
 
+/// Saved values that were all readable, in the cell form
+/// [`quantick_indicators::bind_by_position`] takes. The preset file can yield
+/// a `None` — a stored cell that no longer parses, which must still hold its
+/// index — while these came from a live indicator and cannot. Widening, not a
+/// loss.
+fn to_cells(values: &[InputValue]) -> Vec<Option<InputValue>> {
+    values.iter().cloned().map(Some).collect()
+}
+
 impl IndicatorSource {
     /// Build the indicator, or explain why the script does not load. The
     /// error string is the full human rendering — every problem, each with
@@ -118,72 +127,46 @@ impl IndicatorSource {
             IndicatorSource::NativeCvd => Ok(Box::new(Cvd::new())),
             IndicatorSource::Script { name, text } => match quantick_pine::compile(text, name) {
                 Ok(compiled) => Ok(Box::new(match values {
-                    Some(values) if values.len() == compiled.inputs.len() => {
+                    // A slot whose first compile failed carries no values at
+                    // all (`values: Vec::new()`), and `Reload` builds with
+                    // exactly those. Nothing was ever saved there, so there is
+                    // nothing to bind and nothing to report.
+                    Some(values) if !values.is_empty() => {
+                        // Cell by cell, type-checked, through the one binder
+                        // both persistence paths use — an edited or upgraded
+                        // script keeps every setting whose input is still
+                        // there, at its type, and only the rest fall back.
+                        // Binding the whole vector on an exact count match
+                        // instead would take a stale value whenever a script
+                        // changed an input's TYPE without changing how many it
+                        // has; refusing the whole vector on a count mismatch
+                        // (which this did) meant one added knob reset every
+                        // other one — "I reopened the app and my settings were
+                        // gone".
+                        let bound = quantick_indicators::bind_by_position(
+                            &compiled.inputs,
+                            &to_cells(values),
+                        );
+                        if bound.kept < values.len() {
+                            // A setting the trader chose is not the setting
+                            // that will run. That is theirs to know.
+                            tracing::warn!(
+                                target: "quantick::app",
+                                schema_version = 1_u8,
+                                event_code = "INDICATOR_INPUTS_COUNT_CHANGED",
+                                script = %name,
+                                saved = values.len(),
+                                declared = compiled.inputs.len(),
+                                kept = bound.kept,
+                                action = "kept_what_still_lines_up",
+                                "the script's input list changed since these settings were saved"
+                            );
+                        }
                         quantick_pine::ScriptIndicator::with_inputs(
                             compiled,
                             text.clone(),
-                            values.to_vec(),
+                            bound.values,
                         )
-                    }
-                    // A slot whose first compile failed carries no values
-                    // at all (`values: Vec::new()`), and `Reload` builds with
-                    // exactly those. Nothing was ever saved there, so it is
-                    // not a parameter set being dropped — warning about it
-                    // would fire on every typo-then-fix cycle.
-                    Some(values) if !values.is_empty() => {
-                        // The script declares a different number of inputs
-                        // than these values were saved against — an edited or
-                        // upgraded script. Keep what still lines up instead of
-                        // dropping the lot: a saved value is taken when the
-                        // input now at its index still has its type, and every
-                        // other input takes its declared default. Discarding
-                        // all of them would mean that adding one knob to a
-                        // script came back as a chart with every OTHER knob
-                        // reset — which is exactly how "I reopened the app and
-                        // my settings were gone" happens.
-                        //
-                        // This is the per-cell read the preset path already
-                        // does (`App::load_indicator_preset`), and one rule
-                        // makes both safe: new inputs are APPENDED. An input
-                        // inserted in the middle shifts every later value onto
-                        // the wrong knob, which is why a script's input order
-                        // is pinned by a test.
-                        let bound: Vec<InputValue> = compiled
-                            .inputs
-                            .iter()
-                            .enumerate()
-                            .map(|(index, spec)| {
-                                let default = spec.default_value();
-                                match values.get(index) {
-                                    Some(saved)
-                                        if std::mem::discriminant(saved)
-                                            == std::mem::discriminant(&default) =>
-                                    {
-                                        saved.clone()
-                                    }
-                                    _ => default,
-                                }
-                            })
-                            .collect();
-                        // Which values survived is the one thing the trader
-                        // cannot read off the dialog afterwards.
-                        let kept = bound
-                            .iter()
-                            .zip(values)
-                            .filter(|(bound, saved)| bound == saved)
-                            .count();
-                        tracing::warn!(
-                            target: "quantick::app",
-                            schema_version = 1_u8,
-                            event_code = "INDICATOR_INPUTS_COUNT_CHANGED",
-                            script = %name,
-                            saved = values.len(),
-                            declared = compiled.inputs.len(),
-                            kept,
-                            action = "kept_what_still_lines_up",
-                            "the script's input list changed since these settings were saved"
-                        );
-                        quantick_pine::ScriptIndicator::with_inputs(compiled, text.clone(), bound)
                     }
                     _ => quantick_pine::ScriptIndicator::new(compiled, text.clone()),
                 })),

--- a/crates/app/src/indicator_worker.rs
+++ b/crates/app/src/indicator_worker.rs
@@ -125,6 +125,66 @@ impl IndicatorSource {
                             values.to_vec(),
                         )
                     }
+                    // A slot whose first compile failed carries no values
+                    // at all (`values: Vec::new()`), and `Reload` builds with
+                    // exactly those. Nothing was ever saved there, so it is
+                    // not a parameter set being dropped — warning about it
+                    // would fire on every typo-then-fix cycle.
+                    Some(values) if !values.is_empty() => {
+                        // The script declares a different number of inputs
+                        // than these values were saved against — an edited or
+                        // upgraded script. Keep what still lines up instead of
+                        // dropping the lot: a saved value is taken when the
+                        // input now at its index still has its type, and every
+                        // other input takes its declared default. Discarding
+                        // all of them would mean that adding one knob to a
+                        // script came back as a chart with every OTHER knob
+                        // reset — which is exactly how "I reopened the app and
+                        // my settings were gone" happens.
+                        //
+                        // This is the per-cell read the preset path already
+                        // does (`App::load_indicator_preset`), and one rule
+                        // makes both safe: new inputs are APPENDED. An input
+                        // inserted in the middle shifts every later value onto
+                        // the wrong knob, which is why a script's input order
+                        // is pinned by a test.
+                        let bound: Vec<InputValue> = compiled
+                            .inputs
+                            .iter()
+                            .enumerate()
+                            .map(|(index, spec)| {
+                                let default = spec.default_value();
+                                match values.get(index) {
+                                    Some(saved)
+                                        if std::mem::discriminant(saved)
+                                            == std::mem::discriminant(&default) =>
+                                    {
+                                        saved.clone()
+                                    }
+                                    _ => default,
+                                }
+                            })
+                            .collect();
+                        // Which values survived is the one thing the trader
+                        // cannot read off the dialog afterwards.
+                        let kept = bound
+                            .iter()
+                            .zip(values)
+                            .filter(|(bound, saved)| bound == saved)
+                            .count();
+                        tracing::warn!(
+                            target: "quantick::app",
+                            schema_version = 1_u8,
+                            event_code = "INDICATOR_INPUTS_COUNT_CHANGED",
+                            script = %name,
+                            saved = values.len(),
+                            declared = compiled.inputs.len(),
+                            kept,
+                            action = "kept_what_still_lines_up",
+                            "the script's input list changed since these settings were saved"
+                        );
+                        quantick_pine::ScriptIndicator::with_inputs(compiled, text.clone(), bound)
+                    }
                     _ => quantick_pine::ScriptIndicator::new(compiled, text.clone()),
                 })),
                 Err(errors) => Err(errors
@@ -862,6 +922,73 @@ mod tests {
         (bars, builder.partial().cloned())
     }
 
+    /// A script with three inputs, the third of which is imagined to have
+    /// been added after the trader saved their settings for the first two.
+    fn grown_script() -> IndicatorSource {
+        IndicatorSource::Script {
+            name: "grown.pine".to_owned(),
+            text: concat!(
+                "//@version=5\n",
+                "indicator(\"Grown\", overlay=true)\n",
+                "len = input.int(20, \"len\")\n",
+                "factor = input.float(1.5, \"factor\")\n",
+                "added = input.bool(false, \"added\")\n",
+                "plot(close)\n"
+            )
+            .to_owned(),
+        }
+    }
+
+    /// Saved indicator settings are stored positionally, so a script that
+    /// gained an input arrives with fewer saved values than declared inputs.
+    /// Binding only on an exact count match meant the trader lost the
+    /// settings for every input that WAS still there — one added knob, and a
+    /// whole tuned indicator came back at its defaults.
+    #[test]
+    fn a_script_that_gained_an_input_keeps_the_values_saved_for_the_older_ones() {
+        let saved = vec![InputValue::Int(50), InputValue::Float(2.5)];
+        let built = grown_script()
+            .build_with(Some(&saved))
+            .expect("the script compiles");
+        assert_eq!(
+            built.input_values(),
+            vec![
+                InputValue::Int(50),
+                InputValue::Float(2.5),
+                InputValue::Bool(false),
+            ],
+            "the two saved values survive at their own indices and the input added since takes its declared default"
+        );
+    }
+
+    /// The type check is what keeps the per-cell bind honest: a value that no
+    /// longer matches the input at its index is not carried over, it is
+    /// dropped for that input's default — and its neighbours are unaffected.
+    ///
+    /// (Only this path checks types. When the counts DO match, the values go
+    /// through untouched — `with_inputs` guards the count and nothing else —
+    /// so a script that changed an input's type without changing how many it
+    /// has still binds the old value. Pre-existing, and its own fix.)
+    #[test]
+    fn a_saved_value_whose_input_changed_type_falls_back_alone() {
+        let saved = vec![
+            InputValue::Int(50),
+            InputValue::Bool(true), // a float lives at this index now
+        ];
+        let built = grown_script()
+            .build_with(Some(&saved))
+            .expect("the script compiles");
+        assert_eq!(
+            built.input_values(),
+            vec![
+                InputValue::Int(50),
+                InputValue::Float(1.5),
+                InputValue::Bool(false),
+            ],
+            "the mistyped cell falls back alone; the value before it survives"
+        );
+    }
+
     /// A slider drag enqueues one `SetInputs` per UI frame; only the newest
     /// per slot may run, and other slots' requests must survive untouched.
     #[test]
@@ -1394,7 +1521,7 @@ plot(close * k)
         assert_eq!(
             view.input_values[1],
             InputValue::Source(SourceId::Hl2),
-            "the source cell is bound too — applying `Close` to an instance              that already had it proved nothing"
+            "the source cell is bound too — applying `Close` to an instance that already had it proved nothing"
         );
         assert_eq!(
             format!("{:?}", view.columns[0]),

--- a/crates/app/src/indicator_worker.rs
+++ b/crates/app/src/indicator_worker.rs
@@ -127,10 +127,12 @@ impl IndicatorSource {
             IndicatorSource::NativeCvd => Ok(Box::new(Cvd::new())),
             IndicatorSource::Script { name, text } => match quantick_pine::compile(text, name) {
                 Ok(compiled) => Ok(Box::new(match values {
-                    // A slot whose first compile failed carries no values at
-                    // all (`values: Vec::new()`), and `Reload` builds with
-                    // exactly those. Nothing was ever saved there, so there is
-                    // nothing to bind and nothing to report.
+                    // An empty set is a slot that has never been given one:
+                    // a brand-new indicator, or one whose first compile failed
+                    // before any `SetInputs` reached it. Nothing to bind and
+                    // nothing to report — and note this is now genuinely rare,
+                    // because `SetInputs` keeps the values even when it has no
+                    // instance to apply them to.
                     Some(values) if !values.is_empty() => {
                         // Cell by cell, type-checked, through the one binder
                         // both persistence paths use — an edited or upgraded
@@ -147,19 +149,27 @@ impl IndicatorSource {
                             &compiled.inputs,
                             &to_cells(values),
                         );
-                        if bound.kept < values.len() {
-                            // A setting the trader chose is not the setting
-                            // that will run. That is theirs to know.
+                        // Two reasons to speak, and the count is only one of
+                        // them: a cell can be refused at an unchanged count
+                        // when an input changed type. The other is louder than
+                        // it looks — when the list grew or shrank, EVERY value
+                        // after the edit may now sit on a different knob, and
+                        // that binds silently whenever the types happen to
+                        // line up. A count change is therefore worth a line
+                        // even when nothing was refused.
+                        let count_changed = values.len() != compiled.inputs.len();
+                        if count_changed || bound.kept < values.len() {
                             tracing::warn!(
                                 target: "quantick::app",
                                 schema_version = 1_u8,
-                                event_code = "INDICATOR_INPUTS_COUNT_CHANGED",
+                                event_code = "INDICATOR_INPUTS_REBOUND",
                                 script = %name,
                                 saved = values.len(),
                                 declared = compiled.inputs.len(),
                                 kept = bound.kept,
-                                action = "kept_what_still_lines_up",
-                                "the script's input list changed since these settings were saved"
+                                count_changed,
+                                action = "bound_by_position",
+                                "saved settings were rebound to a changed input list"
                             );
                         }
                         quantick_pine::ScriptIndicator::with_inputs(
@@ -630,9 +640,20 @@ fn run(rx: &Receiver<IndicatorCommand>, events: &Sender<IndicatorEvent>) {
                     if last_set_inputs.get(&slot) != Some(&index) {
                         continue;
                     }
-                    if let Some(mirror) = slots.get_mut(&slot)
-                        && let Some(host_id) = mirror.host_id
-                    {
+                    if let Some(mirror) = slots.get_mut(&slot) {
+                        let Some(host_id) = mirror.host_id else {
+                            // No instance to rebuild: this slot's first
+                            // compile failed. The values are still the
+                            // trader's, though, and `Reload` builds from this
+                            // mirror — so keep them. Dropping them here is
+                            // what made repairing a broken script cost every
+                            // setting it had: the fixed script loaded at its
+                            // declared defaults, the slot's error cleared,
+                            // and the next state save wrote those defaults
+                            // over the tuned ones on disk.
+                            mirror.values = values;
+                            continue;
+                        };
                         match mirror.source.build_with(Some(&values)) {
                             Ok(indicator) => {
                                 // Mirror what the instance bound, not what
@@ -948,10 +969,10 @@ mod tests {
     /// longer matches the input at its index is not carried over, it is
     /// dropped for that input's default — and its neighbours are unaffected.
     ///
-    /// (Only this path checks types. When the counts DO match, the values go
-    /// through untouched — `with_inputs` guards the count and nothing else —
-    /// so a script that changed an input's type without changing how many it
-    /// has still binds the old value. Pre-existing, and its own fix.)
+    /// It applies at every count, including a matching one: there is no
+    /// longer a fast path that hands the vector over unchecked, so a script
+    /// that changed an input's TYPE without changing how many it has no
+    /// longer binds the stale value.
     #[test]
     fn a_saved_value_whose_input_changed_type_falls_back_alone() {
         let saved = vec![
@@ -969,6 +990,30 @@ mod tests {
                 InputValue::Bool(false),
             ],
             "the mistyped cell falls back alone; the value before it survives"
+        );
+    }
+
+    /// The count-matched case, which used to skip type checks entirely: a
+    /// script that swapped an input's type while keeping the same number of
+    /// them bound the stale value straight through.
+    #[test]
+    fn a_type_change_at_an_unchanged_count_no_longer_binds_the_stale_value() {
+        let saved = vec![
+            InputValue::Int(50),
+            InputValue::Bool(true), // the float's index
+            InputValue::Bool(true),
+        ];
+        let built = grown_script()
+            .build_with(Some(&saved))
+            .expect("the script compiles");
+        assert_eq!(
+            built.input_values(),
+            vec![
+                InputValue::Int(50),
+                InputValue::Float(1.5),
+                InputValue::Bool(true),
+            ],
+            "three saved, three declared, and the mistyped one still falls back alone"
         );
     }
 

--- a/crates/indicators/src/input.rs
+++ b/crates/indicators/src/input.rs
@@ -265,6 +265,59 @@ pub enum InputValue {
     Source(SourceId),
 }
 
+/// What [`bind_by_position`] made of a saved value set.
+#[derive(Debug, Clone, PartialEq)]
+pub struct BoundInputs {
+    /// One value per declared input, in declaration order — ready to hand to
+    /// an indicator.
+    pub values: Vec<InputValue>,
+    /// How many saved cells were taken as they stood. Anything less than the
+    /// number of saved cells means the rest fell back to a default, which is
+    /// a trader's setting quietly changing under them: say so.
+    pub kept: usize,
+}
+
+/// Bind saved values to declared inputs **by position**, cell by cell.
+///
+/// Saved input sets carry no names — neither the state file nor a preset
+/// stores one — so position is the only key there is, and a value is taken
+/// only when the input now at its index still has its type. Everything else
+/// takes its declared default: an input added since (there is no saved cell
+/// at its index), an input removed (the saved tail is ignored), an input
+/// whose type changed, and a cell that could not be read at all, which is why
+/// `saved` holds `Option`s — a dropped cell must hold its place or every
+/// value after it binds to the wrong input.
+///
+/// This is only safe under one rule, and the rule is on the script author:
+/// **new inputs are appended**. An input inserted in the middle shifts every
+/// value saved before it onto its neighbour, silently, because a `bool`
+/// matches a `bool`. Scripts pin their input order in a test.
+///
+/// One function rather than one copy per persistence path: the state file and
+/// the preset file are two ways of storing the same thing, and a binding rule
+/// that lives twice diverges on the third change.
+#[must_use]
+pub fn bind_by_position(specs: &[InputSpec], saved: &[Option<InputValue>]) -> BoundInputs {
+    let mut kept = 0;
+    let values = specs
+        .iter()
+        .enumerate()
+        .map(|(index, spec)| {
+            let default = spec.default_value();
+            match saved.get(index).and_then(Option::as_ref) {
+                Some(value)
+                    if std::mem::discriminant(value) == std::mem::discriminant(&default) =>
+                {
+                    kept += 1;
+                    value.clone()
+                }
+                _ => default,
+            }
+        })
+        .collect();
+    BoundInputs { values, kept }
+}
+
 #[cfg(test)]
 mod tests {
     /// A fifteenth series would vanish from every settings dropdown without
@@ -353,6 +406,112 @@ mod tests {
         assert_eq!(SourceId::SellVolume.value(&b, 0.0), 1.0);
         assert_eq!(SourceId::TradeCount.value(&b, 0.0), 4.0);
         assert_eq!(SourceId::Cvd.value(&b, -7.5), -7.5);
+    }
+
+    fn specs() -> Vec<InputSpec> {
+        vec![
+            InputSpec::Int {
+                name: "len".into(),
+                title: "Length".into(),
+                default: 20,
+                min: None,
+                max: None,
+                step: None,
+                options: Vec::new(),
+            },
+            InputSpec::Float {
+                name: "factor".into(),
+                title: "Factor".into(),
+                default: 1.5,
+                min: None,
+                max: None,
+                step: None,
+                options: Vec::new(),
+            },
+            InputSpec::Bool {
+                name: "added".into(),
+                title: "Added since".into(),
+                default: false,
+            },
+        ]
+    }
+
+    /// The upgrade case: a script (or a native) gained an input, so the saved
+    /// set is shorter than the declared one. Refusing the whole set here is
+    /// how "I reopened the app and every setting was back to default" used to
+    /// happen — one added knob costing the trader all the others.
+    #[test]
+    fn values_saved_before_an_input_existed_still_bind() {
+        let saved = vec![Some(InputValue::Int(50)), Some(InputValue::Float(2.5))];
+        let bound = bind_by_position(&specs(), &saved);
+        assert_eq!(
+            bound.values,
+            vec![
+                InputValue::Int(50),
+                InputValue::Float(2.5),
+                InputValue::Bool(false),
+            ]
+        );
+        assert_eq!(bound.kept, 2, "both saved cells were taken as they stood");
+    }
+
+    /// An unreadable cell must hold its place. Dropping it from the list
+    /// instead would slide every later value one input to the left, and
+    /// same-typed neighbours would take each other's settings in silence.
+    #[test]
+    fn an_unreadable_cell_holds_its_place_instead_of_shifting_the_rest() {
+        let saved = vec![
+            Some(InputValue::Int(50)),
+            None,
+            Some(InputValue::Bool(true)),
+        ];
+        let bound = bind_by_position(&specs(), &saved);
+        assert_eq!(
+            bound.values,
+            vec![
+                InputValue::Int(50),
+                InputValue::Float(1.5),
+                InputValue::Bool(true),
+            ],
+            "the float falls back alone; the bool after it is not pulled forward"
+        );
+        assert_eq!(bound.kept, 2);
+    }
+
+    /// The type check is the whole guard: a value is a bare number in the
+    /// file, so an input that changed type would otherwise bind a stale one.
+    #[test]
+    fn a_value_whose_input_changed_type_falls_back_alone() {
+        let saved = vec![
+            Some(InputValue::Int(50)),
+            Some(InputValue::Bool(true)),
+            Some(InputValue::Bool(true)),
+        ];
+        let bound = bind_by_position(&specs(), &saved);
+        assert_eq!(
+            bound.values,
+            vec![
+                InputValue::Int(50),
+                InputValue::Float(1.5),
+                InputValue::Bool(true),
+            ]
+        );
+        assert_eq!(bound.kept, 2, "the mistyped cell is not counted as kept");
+    }
+
+    /// A saved tail that no longer has inputs to bind to is ignored, not an
+    /// error: removing an input is a script edit, not a corrupt file.
+    #[test]
+    fn a_saved_set_longer_than_the_declared_one_binds_what_fits() {
+        let saved = vec![
+            Some(InputValue::Int(50)),
+            Some(InputValue::Float(2.5)),
+            Some(InputValue::Bool(true)),
+            Some(InputValue::Int(9)),
+        ];
+        let bound = bind_by_position(&specs(), &saved);
+        assert_eq!(bound.values.len(), 3);
+        assert_eq!(bound.kept, 3);
     }
 
     #[test]

--- a/crates/indicators/src/lib.rs
+++ b/crates/indicators/src/lib.rs
@@ -59,7 +59,7 @@ mod output;
 pub use bar::IndicatorBar;
 pub use host::{IndicatorHost, InstanceId, PreviewsAt};
 pub use indicator::{Ctx, EvalError, Indicator, IndicatorDescriptor};
-pub use input::{InputSpec, InputValue, SourceId};
+pub use input::{BoundInputs, InputSpec, InputValue, SourceId, bind_by_position};
 pub use objects::{
     BoxObj, LabelObj, LabelStyle, LineObj, MAX_OBJECTS_PER_KIND, OFF_CHART_BAR, ObjectId,
     ObjectSnapshot, ObjectStore,

--- a/crates/pine/tests/corpus/ok/exhaustion_reversal.pine
+++ b/crates/pine/tests/corpus/ok/exhaustion_reversal.pine
@@ -179,7 +179,7 @@ coverage = input.float(0.7, "2 Run: min give-back of the force bar", minval=0.05
 // immediate response, and five bars later it is a different bar reacting to
 // a different thing.
 use_cover = input.bool(true, "3 Cover: mark a give-back by one opposite candle")
-cover_window = input.int(3, "3 Cover: window after the force bar (bars)", minval=1, maxval=100)
+cover_window = input.int(5, "3 Cover: window after the force bar (bars)", minval=1, maxval=100)
 cover_fraction = input.float(0.7, "3 Cover: min overlap with the force bar", minval=0.05, maxval=1.0, step=0.05)
 
 // 4 — display: which side to mark. These gate the two TRIANGLES only. The
@@ -224,9 +224,26 @@ show_bottom = input.bool(true, "4 Display: mark bottom reversals (buy side)")
 // the number is typed instead. A script cannot ask what a tick is worth here,
 // so one of the two has to be the dragged case.
 min_body_points = input.float(0.0, "5 Calibration: min force-bar body (points, 0 = off)", minval=0.0, step=1.0)
-run_body_only = input.bool(false, "5 Calibration: run measures the body, not the range")
-cover_body_only = input.bool(false, "5 Calibration: cover measures the body, not the range")
+run_body_only = input.bool(true, "5 Calibration: run measures the body, not the range")
+cover_body_only = input.bool(true, "5 Calibration: cover measures the body, not the range")
 paint_force = input.bool(false, "5 Calibration: paint the bars that arm a push")
+
+// 6 — invalidation: when the give-back went too far to be a give-back.
+//
+// A candle that closes BEYOND the far end of the force bar — below its low on
+// a top, above its high on a bottom — has not faded the push, it has replaced
+// it. That candle is itself a force bar candidate in the other direction, and
+// what comes next is the exhaustion of the exhaustion. The trade this
+// indicator is about is fading the green bar, not chasing the red one that
+// buried it.
+//
+// It kills the setup on the spot, whichever shape was about to mark and
+// whenever inside the window it happens: a candle that covers 70% AND closes
+// past the far end is not a mark, and the push does not get a second chance
+// from a later bar either. The far end is the force bar's own extreme, wick
+// included — what the eye reads off the chart — not the body, even when the
+// two shapes above are measuring against the body.
+invalidate_beyond = input.bool(true, "6 Invalidation: a close past the force bar's far end kills the setup")
 
 // ---------------------------------------------------------------- measures
 
@@ -302,6 +319,7 @@ var float top_run_range = na
 var float top_cover_high = na
 var float top_cover_low = na
 var float top_cover_range = na
+var float top_bar_low = na
 var bool bottom_armed = false
 var int bottom_age = 0
 var float bottom_run_high = na
@@ -310,6 +328,7 @@ var float bottom_run_range = na
 var float bottom_cover_high = na
 var float bottom_cover_low = na
 var float bottom_cover_range = na
+var float bottom_bar_high = na
 
 // Age first, test second, arm last. Ageing before the test is what makes the
 // bar `run_len` bars after the force bar read as age `run_len`; arming after
@@ -324,6 +343,13 @@ if bottom_armed
         bottom_armed := false
 
 // ----------------------------------------------------------------- signals
+
+// Invalidation first, because it outranks both shapes: a bar that closes past
+// the force bar's far end kills the setup even when that same bar would have
+// marked. `top_armed` short-circuits it away on the bars where nothing is
+// armed, which is most of them.
+top_killed = invalidate_beyond and top_armed and close < top_bar_low
+bottom_killed = invalidate_beyond and bottom_armed and close > bottom_bar_high
 
 // Every ruler below was resolved when its push armed, and it KEEPS that value
 // after the push is spent — nothing writes `na` back on disarm or expiry. So
@@ -349,13 +375,15 @@ buy_run = use_run and bottom_armed and bottom_age >= run_len and bottom_age <= r
 sell_cover = use_cover and top_armed and top_age <= cover_window and bear_bar and top_cover_range > 0 and (math.min(open, top_cover_high) - math.max(close, top_cover_low)) / top_cover_range >= cover_fraction
 buy_cover = use_cover and bottom_armed and bottom_age <= cover_window and bull_bar and bottom_cover_range > 0 and (math.min(close, bottom_cover_high) - math.max(open, bottom_cover_low)) / bottom_cover_range >= cover_fraction
 
-// Either shape marks, and the first one to fire spends the push.
-sell_signal = sell_run or sell_cover
-buy_signal = buy_run or buy_cover
+// Either shape marks, unless the setup was killed on this very bar.
+sell_signal = (sell_run or sell_cover) and not top_killed
+buy_signal = (buy_run or buy_cover) and not bottom_killed
 
-if sell_signal
+// A push is spent by the signal it produced OR by the close that invalidated
+// it — a killed push gets no second chance from a later bar in the window.
+if sell_signal or top_killed
     top_armed := false
-if buy_signal
+if buy_signal or bottom_killed
     bottom_armed := false
 
 // Arming is also where each shape's ruler is measured out, once, from the
@@ -370,6 +398,7 @@ if top_anchor
     top_cover_high := cover_body_only ? math.max(open, close) : high
     top_cover_low := cover_body_only ? math.min(open, close) : low
     top_cover_range := top_cover_high - top_cover_low
+    top_bar_low := low
 if bottom_anchor
     bottom_armed := true
     bottom_age := 0
@@ -379,6 +408,7 @@ if bottom_anchor
     bottom_cover_high := cover_body_only ? math.max(open, close) : high
     bottom_cover_low := cover_body_only ? math.min(open, close) : low
     bottom_cover_range := bottom_cover_high - bottom_cover_low
+    bottom_bar_high := high
 
 // ------------------------------------------------------------------- marks
 

--- a/crates/pine/tests/corpus/ok/exhaustion_reversal.pine
+++ b/crates/pine/tests/corpus/ok/exhaustion_reversal.pine
@@ -75,6 +75,18 @@
 // that erases most of a large one is exactly the exhaustion this is looking
 // for, whether or not it pokes out the ends.
 //
+// BODY-ONLY REFERENCE: both fractions above are measured, by default, against
+// the force bar's full RANGE (high to low). Each has its own switch in
+// section 5 — "run measures the body, not the range" and its cover
+// counterpart — to measure against the force bar's BODY (open to close)
+// instead, ignoring its wicks. This is the fix for a specific misreading: a
+// force bar with a long wick makes the range wider than the body, so a candle
+// that visibly erases most of the BODY can still fall short of a threshold
+// judged against the whole wick-to-wick range. Switch it on and that same
+// candle is judged only against what it actually erased. The two references
+// can disagree in either direction — body-only is not simply "easier" — the
+// wick shrinks both the numerator and the denominator, not one alone.
+//
 // The force bar's body is judged against the average of the bars BEFORE it
 // (same discipline as force_bar.pine): a huge bar must not be allowed to
 // inflate the very average that is deciding whether it is huge.
@@ -98,6 +110,51 @@
 // finally completes. A mark that jumps when you flip a switch is those two
 // shapes disagreeing about when the push ended, not an inconsistency.
 //
+// AN ELEPHANT HAS A SIZE, NOT ONLY A RATIO. The body test above is a
+// RATIO — this body against the average of the recent ones — and a ratio
+// alone is honest on time candles and promiscuous on activity-cut bars. When
+// the tape goes quiet the average it multiplies collapses, so an unremarkable
+// bar clears 1.5× of almost nothing and arms a push that nobody watching the
+// chart would call one. This is measured, not suspected: on a live WINV26
+// session the same bare band marked 247 of 1 355 volume bars as force bars;
+// an absolute floor of 100 points left 7 (see docs/ux/strategy-anchors.md,
+// which is why the strategy kernel's force ruler carries `min_body`).
+//
+// So section 5 adds a floor in POINTS, `and`ed with the ratio above: a
+// bar must be big relative to its neighbours AND big in the instrument's own
+// units. It ships at 0 — disabled, the ratio alone, exactly what this script
+// did before the floor existed — because the right number is a property of
+// the instrument and nothing else: ~100 points on WIN mini index, a different
+// order of magnitude on BTC. Turn the paint below on and raise the floor
+// until only bars you would call pushes stay coloured.
+//
+// SEEING WHICH BARS ARMED: section 5 carries a diagnostic switch — "paint
+// the bars that arm a push". Off by default. Switch it on and every bar this
+// script accepted as a force bar is painted: ORANGE for a top (sell-side)
+// push, BLUE for a bottom (buy-side) one. Nothing else changes; the paint
+// reports what the state machine already decided, it does not decide it.
+//
+// It is there because the arrows alone cannot answer "is it reading the
+// right bars?". An arrow needs a push that was BOTH armed AND given back, so
+// a force bar nothing faded leaves no trace at all — and neither does a bar
+// that armed when it should not have. Paint them and calibration becomes a
+// visual question: if bars you would never call a push come out coloured,
+// `min body (×average)` is too low for this instrument, the points floor is
+// still at 0, or the extreme window is too short. Worth knowing while you
+// read it: the default 1.5× is the same multiple force_bar.pine calls the
+// FLOOR of its force band, not its exhaustion threshold (2.5×). This section
+// deliberately sets the lower bar, because the give-back is the other half of
+// the test — but on a quiet tape the average it multiplies is small, and 1.5×
+// of small is small.
+//
+// A bar that anchors both sides at once — possible only with the direction
+// filter off — is painted for the top. One bar, one colour, priority fixed
+// rather than left to evaluation order.
+//
+// HONEST ABOUT THE FORMING BAR: paint is drawn from the preview, so the bar
+// being built can take a colour and lose it again before it closes (the same
+// rule force_bar.pine states). A closed bar's colour never changes.
+//
 // Every threshold below is an input: this is a shape, and where the shape
 // begins and ends is a judgement about the instrument in front of you.
 // Defaults are a starting point measured on nothing in particular —
@@ -115,7 +172,7 @@ need_direction = input.bool(true, "1 Force bar: must close in the direction of t
 use_run = input.bool(true, "2 Run: mark a give-back by consecutive candles")
 run_len = input.int(3, "2 Run: opposite candles in a row", minval=1, maxval=20)
 window_len = input.int(5, "2 Run: window after the force bar (bars)", minval=1, maxval=100)
-coverage = input.float(0.7, "2 Run: min give-back of the force bar (fraction of range)", minval=0.05, maxval=3.0, step=0.05)
+coverage = input.float(0.7, "2 Run: min give-back of the force bar", minval=0.05, maxval=3.0, step=0.05)
 
 // 3 — the cover: one opposite candle sitting on top of the force bar.
 // Shorter window than the run by default: a single bar answering a push is an
@@ -123,11 +180,16 @@ coverage = input.float(0.7, "2 Run: min give-back of the force bar (fraction of 
 // a different thing.
 use_cover = input.bool(true, "3 Cover: mark a give-back by one opposite candle")
 cover_window = input.int(3, "3 Cover: window after the force bar (bars)", minval=1, maxval=100)
-cover_fraction = input.float(0.7, "3 Cover: min overlap with the force bar (fraction of range)", minval=0.05, maxval=1.0, step=0.05)
+cover_fraction = input.float(0.7, "3 Cover: min overlap with the force bar", minval=0.05, maxval=1.0, step=0.05)
 
-// 4 — display: which side to mark. These gate the drawing sites only. The
+// 4 — display: which side to mark. These gate the two TRIANGLES only. The
 // state machine below runs whatever they say, so flipping a side back on
 // never changes what the indicator concluded while it was off.
+//
+// They deliberately do NOT gate section 5's paint. The triangles are the
+// reading; the paint is the ruler being checked, and a trader who silenced
+// one side and then went looking for why nothing arms there would be misled
+// by a diagnostic that had silenced itself along with the marks.
 //
 // Colour and width are deliberately NOT inputs: they live on the dialog's
 // Style tab, per plot, which is what the chart actually reads. An
@@ -135,6 +197,31 @@ cover_fraction = input.float(0.7, "3 Cover: min overlap with the force bar (frac
 // silently comes out amber — so a colour slider here would be a dead control.
 show_top = input.bool(true, "4 Display: mark top reversals (sell side)")
 show_bottom = input.bool(true, "4 Display: mark bottom reversals (buy side)")
+
+// 5 — calibration: the rulers this shape is measured with, and the paint that
+// shows what they accepted. Every one of them ships OFF (or at 0), so a fresh
+// load behaves exactly like the first version of this script.
+//
+// THIS SECTION IS LAST FOR A REASON, and new inputs belong at the end of it.
+// A saved preset is a list of values matched to inputs BY POSITION: the app
+// walks the declared inputs and takes the saved value at the same index when
+// its type matches. Insert an input in the middle and every preset saved
+// before it silently shifts — the value a trader stored for "opposite candles
+// in a row" lands on whatever now sits at that index, and a bool switch can
+// be turned ON by a preset that never knew it existed. Appending keeps every
+// older index pointing at the input it was saved for; the new ones simply
+// find nothing and take their defaults. A test pins this order.
+// No `maxval`/`step` on purpose. Every other float here is a scale-free
+// multiple over a tight range, and the panel renders a bounded float as a
+// slider quantised to its step — which on this input would mean a WIN floor
+// of ~100 living in the first 0.1% of the track, and a step of 1 that no
+// instrument priced under a unit could ever get below. Bounded on one side
+// only, it is a typed field with a floor of zero, which is what an absolute
+// quantity in the instrument's own units wants to be.
+min_body_points = input.float(0.0, "5 Calibration: min force-bar body (points, 0 = off)", minval=0.0)
+run_body_only = input.bool(false, "5 Calibration: run measures the body, not the range")
+cover_body_only = input.bool(false, "5 Calibration: cover measures the body, not the range")
+paint_force = input.bool(false, "5 Calibration: paint the bars that arm a push")
 
 // ---------------------------------------------------------------- measures
 
@@ -161,7 +248,11 @@ arm_window = math.max(run_window, cover_window)
 
 // A zero average is warm-up or a dead tape, not a bar that beats it. The
 // `not na` guards are what keep the opening stretch unmarked.
-big_body = not na(avg_body_before) and avg_body_before > 0 and body >= body_factor * avg_body_before
+// The ratio and the floor, in that order: the ratio rejects most bars on its
+// own, so the floor is a comparison the short-circuit rarely reaches. A floor
+// of 0 is `body >= 0`, true for every bar including a doji — the ratio is
+// what still decides, exactly as it did before this input existed.
+big_body = not na(avg_body_before) and avg_body_before > 0 and body >= body_factor * avg_body_before and body >= min_body_points
 new_high = not na(high_before) and high >= high_before
 new_low = not na(low_before) and low <= low_before
 
@@ -179,17 +270,35 @@ bottom_anchor = big_body and new_low and (not need_direction or bear_bar)
 
 // ------------------------------------------------------------------- state
 
-// One armed force bar per side, with its own age and its own range. The two
+// One armed force bar per side, with its own age and its own rulers. The two
 // sides are independent: the bar that gives back a buying push may itself be
 // the selling push that arms the other side.
+//
+// The rulers are RESOLVED WHEN THE BAR ARMS, not read per bar: the two
+// body-only switches pick between the force bar's wick-to-wick extremes and
+// its body, and that choice cannot change while a push is armed — editing any
+// input rebuilds the indicator and replays the whole history, so there is no
+// live tape on which a stored ruler could go stale. Resolving it here keeps
+// eight ternaries and four subtractions off every bar, armed or not, and puts
+// them on the rare bar that actually arms. Each shape stores its own pair
+// because the run and the cover choose independently: a wide-wick push can be
+// judged by its body for one and by its range for the other.
 var bool top_armed = false
 var int top_age = 0
-var float top_high = na
-var float top_low = na
+var float top_run_high = na
+var float top_run_low = na
+var float top_run_range = na
+var float top_cover_high = na
+var float top_cover_low = na
+var float top_cover_range = na
 var bool bottom_armed = false
 var int bottom_age = 0
-var float bottom_high = na
-var float bottom_low = na
+var float bottom_run_high = na
+var float bottom_run_low = na
+var float bottom_run_range = na
+var float bottom_cover_high = na
+var float bottom_cover_low = na
+var float bottom_cover_range = na
 
 // Age first, test second, arm last. Ageing before the test is what makes the
 // bar `run_len` bars after the force bar read as age `run_len`; arming after
@@ -205,27 +314,29 @@ if bottom_armed
 
 // ----------------------------------------------------------------- signals
 
-// Two subtractions, cheap enough to keep in the open for readability; `na`
-// when no push is armed, which makes every `> 0` below false.
-top_range = top_high - top_low
-bottom_range = bottom_high - bottom_low
-
+// Every ruler below was resolved when its push armed, and it KEEPS that value
+// after the push is spent — nothing writes `na` back on disarm or expiry. So
+// `top_armed` / `bottom_armed` is the only thing standing between a stale
+// ruler and this arithmetic, and it is deliberately first in every chain
+// below. The `> 0` tests guard against a zero denominator, not a stale one;
+// reordering the chain so one of them runs first would read a spent push.
+//
 // The divisions and the overlap arithmetic sit BEHIND the guards on purpose.
 // `and` short-circuits, and on the large majority of bars no push is armed —
 // so on those bars this line stops at `top_armed` and the maths never runs.
 // (Measured: ~17% of the script's commit cost, and this runs again for every
 // preview of the forming bar.) Nothing here is a `ta.*` kernel, so unlike the
 // measures above there is no warm-up to protect by hoisting it.
-sell_run = use_run and top_armed and top_age >= run_len and top_age <= run_window and bear_run >= run_len and top_range > 0 and (top_high - close) / top_range >= coverage
-buy_run = use_run and bottom_armed and bottom_age >= run_len and bottom_age <= run_window and bull_run >= run_len and bottom_range > 0 and (close - bottom_low) / bottom_range >= coverage
+sell_run = use_run and top_armed and top_age >= run_len and top_age <= run_window and bear_run >= run_len and top_run_range > 0 and (top_run_high - close) / top_run_range >= coverage
+buy_run = use_run and bottom_armed and bottom_age >= run_len and bottom_age <= run_window and bull_run >= run_len and bottom_run_range > 0 and (close - bottom_run_low) / bottom_run_range >= coverage
 
 // The cover: the overlap of two intervals — this candle's body against the
-// force bar's range — so it is bounded by the force bar and cannot be
-// inflated by a candle that is merely enormous somewhere else. A body that
+// force bar's range (or body) — so it is bounded by the force bar and cannot
+// be inflated by a candle that is merely enormous somewhere else. A body that
 // does not reach the force bar at all makes the overlap negative, which
 // fails on its own.
-sell_cover = use_cover and top_armed and top_age <= cover_window and bear_bar and top_range > 0 and (math.min(open, top_high) - math.max(close, top_low)) / top_range >= cover_fraction
-buy_cover = use_cover and bottom_armed and bottom_age <= cover_window and bull_bar and bottom_range > 0 and (math.min(close, bottom_high) - math.max(open, bottom_low)) / bottom_range >= cover_fraction
+sell_cover = use_cover and top_armed and top_age <= cover_window and bear_bar and top_cover_range > 0 and (math.min(open, top_cover_high) - math.max(close, top_cover_low)) / top_cover_range >= cover_fraction
+buy_cover = use_cover and bottom_armed and bottom_age <= cover_window and bull_bar and bottom_cover_range > 0 and (math.min(close, bottom_cover_high) - math.max(open, bottom_cover_low)) / bottom_cover_range >= cover_fraction
 
 // Either shape marks, and the first one to fire spends the push.
 sell_signal = sell_run or sell_cover
@@ -236,16 +347,27 @@ if sell_signal
 if buy_signal
     bottom_armed := false
 
+// Arming is also where each shape's ruler is measured out, once, from the
+// force bar that is being armed — see the state block above for why storing
+// it is safe and what it saves.
 if top_anchor
     top_armed := true
     top_age := 0
-    top_high := high
-    top_low := low
+    top_run_high := run_body_only ? math.max(open, close) : high
+    top_run_low := run_body_only ? math.min(open, close) : low
+    top_run_range := top_run_high - top_run_low
+    top_cover_high := cover_body_only ? math.max(open, close) : high
+    top_cover_low := cover_body_only ? math.min(open, close) : low
+    top_cover_range := top_cover_high - top_cover_low
 if bottom_anchor
     bottom_armed := true
     bottom_age := 0
-    bottom_high := high
-    bottom_low := low
+    bottom_run_high := run_body_only ? math.max(open, close) : high
+    bottom_run_low := run_body_only ? math.min(open, close) : low
+    bottom_run_range := bottom_run_high - bottom_run_low
+    bottom_cover_high := cover_body_only ? math.max(open, close) : high
+    bottom_cover_low := cover_body_only ? math.min(open, close) : low
+    bottom_cover_range := bottom_cover_high - bottom_cover_low
 
 // ------------------------------------------------------------------- marks
 
@@ -256,3 +378,17 @@ buy_mark = buy_signal and barstate.isconfirmed
 
 plotshape(show_top and sell_mark, "Exhaustion reversal: sell", style=shape.triangledown, location=location.abovebar, color=color.red)
 plotshape(show_bottom and buy_mark, "Exhaustion reversal: buy", style=shape.triangleup, location=location.belowbar, color=color.teal)
+
+// ------------------------------------------------------------------- paint
+
+// The diagnostic, and the only thing in this script that draws on a bar that
+// produced no signal. `na` on every other bar leaves the chart's own candle
+// colours alone — an unpainted bar is this script saying "not a push", which
+// is the answer on the large majority of them.
+paint = na
+if paint_force and top_anchor
+    paint := color.orange
+else if paint_force and bottom_anchor
+    paint := color.blue
+
+barcolor(paint)

--- a/crates/pine/tests/corpus/ok/exhaustion_reversal.pine
+++ b/crates/pine/tests/corpus/ok/exhaustion_reversal.pine
@@ -218,7 +218,11 @@ show_bottom = input.bool(true, "4 Display: mark bottom reversals (buy side)")
 // typed field with a floor of zero, which is what an absolute quantity in the
 // instrument's own units wants to be. `step` is then no longer a quantiser at
 // all, only the drag speed, and 1 point per pixel beats the 0.1 default:
-// dragging to 100 should not take a thousand pixels.
+// dragging to 100 should not take a thousand pixels. That speed is chosen for
+// an index future, where a point is the unit the floor is thought in; on an
+// instrument priced in fractions a drag of 1 per pixel is far too coarse and
+// the number is typed instead. A script cannot ask what a tick is worth here,
+// so one of the two has to be the dragged case.
 min_body_points = input.float(0.0, "5 Calibration: min force-bar body (points, 0 = off)", minval=0.0, step=1.0)
 run_body_only = input.bool(false, "5 Calibration: run measures the body, not the range")
 cover_body_only = input.bool(false, "5 Calibration: cover measures the body, not the range")
@@ -281,7 +285,13 @@ bottom_anchor = big_body and new_low and (not need_direction or bear_bar)
 // input rebuilds the indicator and replays the whole history, so there is no
 // live tape on which a stored ruler could go stale. Resolving it here keeps
 // eight ternaries and four subtractions off every bar, armed or not, and puts
-// them on the rare bar that actually arms. Each shape stores its own pair
+// them on the rare bar that actually arms. Measured on the commit path (the
+// 100k-bar interpreter bench): the version that read the switches per bar
+// cost about 20% more per bar, this one about 5%. What that bench does NOT
+// cover is the preview path, which runs per print rather than per bar and
+// clones every global slot — and this shape holds six more of them than the
+// per-bar one did. The trade is a win on the measured path and unmeasured on
+// the other; that is the honest statement of it. Each shape stores its own pair
 // because the run and the cover choose independently: a wide-wick push can be
 // judged by its body for one and by its range for the other.
 var bool top_armed = false

--- a/crates/pine/tests/corpus/ok/exhaustion_reversal.pine
+++ b/crates/pine/tests/corpus/ok/exhaustion_reversal.pine
@@ -211,14 +211,15 @@ show_bottom = input.bool(true, "4 Display: mark bottom reversals (buy side)")
 // be turned ON by a preset that never knew it existed. Appending keeps every
 // older index pointing at the input it was saved for; the new ones simply
 // find nothing and take their defaults. A test pins this order.
-// No `maxval`/`step` on purpose. Every other float here is a scale-free
-// multiple over a tight range, and the panel renders a bounded float as a
-// slider quantised to its step — which on this input would mean a WIN floor
-// of ~100 living in the first 0.1% of the track, and a step of 1 that no
-// instrument priced under a unit could ever get below. Bounded on one side
-// only, it is a typed field with a floor of zero, which is what an absolute
-// quantity in the instrument's own units wants to be.
-min_body_points = input.float(0.0, "5 Calibration: min force-bar body (points, 0 = off)", minval=0.0)
+// No `maxval` on purpose. Every other float here is a scale-free multiple
+// over a tight range, and the panel renders a float with BOTH bounds as a
+// slider quantised to its step — which on this input would put the ~100 a WIN
+// contract wants in the first 0.1% of the track. Bounded below only, it is a
+// typed field with a floor of zero, which is what an absolute quantity in the
+// instrument's own units wants to be. `step` is then no longer a quantiser at
+// all, only the drag speed, and 1 point per pixel beats the 0.1 default:
+// dragging to 100 should not take a thousand pixels.
+min_body_points = input.float(0.0, "5 Calibration: min force-bar body (points, 0 = off)", minval=0.0, step=1.0)
 run_body_only = input.bool(false, "5 Calibration: run measures the body, not the range")
 cover_body_only = input.bool(false, "5 Calibration: cover measures the body, not the range")
 paint_force = input.bool(false, "5 Calibration: paint the bars that arm a push")
@@ -385,10 +386,20 @@ plotshape(show_bottom and buy_mark, "Exhaustion reversal: buy", style=shape.tria
 // produced no signal. `na` on every other bar leaves the chart's own candle
 // colours alone — an unpainted bar is this script saying "not a push", which
 // is the answer on the large majority of them.
+//
+// ONE PAINTER WINS PER BAR, AND IT IS THE LAST ONE ADDED. The chart resolves
+// the bar paint channel by walking the indicator stack backwards and taking
+// the first colour it finds (`resolve_bar_paint`), so a script added AFTER
+// this one hides it wherever both paint. force_bar.pine paints every body at
+// or above 1.5x its average — which is nearly every bar this diagnostic is
+// about — so run this one alone while calibrating, or add it last. The two
+// colours here being ones force_bar.pine does not use settles which script a
+// colour came from; it does not make both visible on one bar.
 paint = na
-if paint_force and top_anchor
-    paint := color.orange
-else if paint_force and bottom_anchor
-    paint := color.blue
+if paint_force
+    if top_anchor
+        paint := color.orange
+    else if bottom_anchor
+        paint := color.blue
 
 barcolor(paint)

--- a/crates/pine/tests/exhaustion_reversal_semantics.rs
+++ b/crates/pine/tests/exhaustion_reversal_semantics.rs
@@ -270,11 +270,15 @@ fn the_declared_marks_are_the_ones_the_renderer_draws() {
     );
 }
 
-/// The thirteen inputs the indicator shipped with in #212, in order. This is
-/// not documentation — it is the binding contract for every preset a trader
-/// has already saved. Titles rather than the derived `name()`, because they
-/// are what a reader can check against the script in one glance; `name()` is
-/// a slug of the title, so pinning one pins the other.
+/// The thirteen inputs the indicator shipped with in #212, at the indices it
+/// shipped them. This is not documentation — it is the binding contract for
+/// every value a trader has already saved, which is matched by POSITION.
+///
+/// The titles are the current ones, not #212's: two of them lost "(fraction
+/// of range)" when the fraction became readable against the body. What is
+/// pinned here is the ORDER; the titles are how a reader checks it against
+/// the script in one glance, and a rename trips the test on purpose because
+/// `name()` is a slug of the title and is documented as a persistence key.
 const SHIPPED_ORDER: [&str; 13] = [
     "1 Force bar: body average window (bars)",
     "1 Force bar: min body (×average)",
@@ -768,6 +772,47 @@ fn the_cover_reads_the_body_on_the_buy_side_too() {
         buys(&run(&body_only, &wicked)),
         vec![6],
         "the identical candle marks once the overlap is judged against the body"
+    );
+}
+
+#[test]
+fn the_display_toggles_silence_the_triangle_and_leave_the_paint_alone() {
+    // The script states this as a contract, and it is the reason the
+    // diagnostic is trustworthy: a trader who silenced one side and then went
+    // looking for why nothing arms there must not be answered by a diagnostic
+    // that silenced itself along with the marks.
+    let mut top_off = inputs();
+    top_off[SHOW_TOP] = InputValue::Bool(false);
+    top_off[PAINT_FORCE] = InputValue::Bool(true);
+
+    let tape = sell_tape();
+    let hit = run(&top_off, &tape);
+    assert_eq!(sells(&hit), none(), "the triangle is silenced");
+    assert_eq!(
+        paints(&hit, tape.len())[5],
+        Some(PAINT_TOP),
+        "the force bar is still painted: the toggle governs the marks, not the ruler"
+    );
+}
+
+#[test]
+fn a_bar_that_anchors_both_sides_is_painted_for_the_top() {
+    // Reachable only with the direction filter off, which is exactly why it
+    // is worth pinning: an outside bar with a body big enough to arm makes a
+    // new high AND a new low, both anchors fire on the same bar, and the
+    // script promises a fixed priority rather than whatever the evaluation
+    // order happens to be.
+    let mut both = inputs();
+    both[NEED_DIRECTION] = InputValue::Bool(false);
+    both[PAINT_FORCE] = InputValue::Bool(true);
+
+    let mut tape = context_up();
+    tape.push((100.0, 115.0, 90.0, 110.0)); // 5  outside bar: new high and new low
+
+    assert_eq!(
+        paints(&run(&both, &tape), tape.len())[5],
+        Some(PAINT_TOP),
+        "one bar, one colour, and the top wins by rule"
     );
 }
 

--- a/crates/pine/tests/exhaustion_reversal_semantics.rs
+++ b/crates/pine/tests/exhaustion_reversal_semantics.rs
@@ -48,6 +48,7 @@ fn inputs() -> Vec<InputValue> {
         InputValue::Bool(false), // 14 5 Calibration: run reads the body
         InputValue::Bool(false), // 15 5 Calibration: cover reads the body
         InputValue::Bool(false), // 16 5 Calibration: paint what armed
+        InputValue::Bool(true),  // 17 6 Invalidation: a close past the far end
     ]
 }
 
@@ -66,6 +67,7 @@ const MIN_BODY_POINTS: usize = 13;
 const RUN_BODY_ONLY: usize = 14;
 const COVER_BODY_ONLY: usize = 15;
 const PAINT_FORCE: usize = 16;
+const INVALIDATE_BEYOND: usize = 17;
 
 fn make(index: usize, row: Ohlc) -> IndicatorBar {
     let (open, high, low, close) = row;
@@ -227,6 +229,175 @@ fn paints(indicator: &ScriptIndicator, rows: usize) -> Vec<Option<Rgba8>> {
         .collect()
 }
 
+/// Twenty-two flat bars: body 1.0, high 101.0. Long enough to fill the
+/// SHIPPED windows (20-bar body average, 10-bar extreme), which the fixtures
+/// above shrink to keep themselves readable. The scenarios below deliberately
+/// shrink nothing — the question they answer is whether the defaults a trader
+/// gets on adding the indicator read the chart the way they drew it.
+fn quiet_context() -> Vec<Ohlc> {
+    vec![(100.0, 101.0, 100.0, 101.0); 22]
+}
+
+/// The buying push those defaults are measured against: body 100..110 against
+/// an average of 1.0, high 112 over an extreme of 101. Its range is 99..112,
+/// so the body is 10 wide and the whole bar 13 — the two rulers disagree,
+/// which is the point of every scenario that follows.
+const PUSH: Ohlc = (100.0, 112.0, 99.0, 110.0);
+
+/// Index of the force bar in a `quiet_context()` tape.
+const PUSH_BAR: usize = 22;
+
+/// The declared defaults, read off the script rather than restated here, so
+/// a scenario cannot quietly test a configuration nobody ships.
+fn defaults() -> Vec<InputValue> {
+    load().input_values()
+}
+
+/// Run a tape against those defaults — no input vector at all, exactly what
+/// the settings dialog opens with.
+fn run_defaults(rows: &[Ohlc]) -> ScriptIndicator {
+    let mut indicator = load();
+    let mut cvd = Vec::new();
+    let mut sum = 0.0;
+    for (index, row) in rows.iter().enumerate() {
+        let bar = make(index, *row);
+        sum += bar.delta();
+        cvd.push(sum);
+        let mut ctx = Ctx {
+            bar_index: index,
+            cvd: &cvd,
+        };
+        indicator.on_close(&bar, &mut ctx).expect("commit run");
+    }
+    indicator
+}
+
+#[test]
+fn the_defaults_mark_one_candle_that_covers_the_bodys_seventy_percent() {
+    // Scenario 1: the force bar, then one opposite candle whose BODY covers
+    // 70% of the force bar's body. Against the full range that same candle
+    // covers 54% and says nothing — which is why body-to-body is the shipped
+    // default rather than an option to go and find.
+    let mut tape = quiet_context();
+    tape.push(PUSH); //                         22  force bar
+    tape.push((110.0, 110.0, 103.0, 103.0)); // 23  body 110->103 = 70% of 100..110
+
+    assert_eq!(
+        sells(&run_defaults(&tape)),
+        vec![PUSH_BAR + 1],
+        "the cover marks on the candle that erased the body"
+    );
+}
+
+#[test]
+fn the_defaults_mark_three_candles_that_hand_back_the_body() {
+    // Scenario 2: three consecutive down candles, price back to 103 — 70% of
+    // the body handed back by the close of the third. No single one of them
+    // covers enough to be a cover, so this is the run and nothing else.
+    let mut tape = quiet_context();
+    tape.push(PUSH); //                         22  force bar
+    tape.push((110.0, 110.0, 107.0, 107.0)); // 23  1 of 3
+    tape.push((107.0, 107.0, 105.0, 105.0)); // 24  2 of 3
+    tape.push((105.0, 105.0, 103.0, 103.0)); // 25  3 of 3 -> 70%
+
+    assert_eq!(
+        sells(&run_defaults(&tape)),
+        vec![PUSH_BAR + 3],
+        "the mark lands on the close of the third candle, not at the extreme"
+    );
+}
+
+#[test]
+fn the_defaults_still_mark_a_run_that_completes_on_the_fifth_bar() {
+    // Scenario 3: a green candle interrupts, so the three-in-a-row only
+    // completes on the fifth bar after the push — the last bar the window
+    // allows.
+    let mut tape = quiet_context();
+    tape.push(PUSH); //                         22  force bar
+    tape.push((110.0, 110.0, 108.0, 108.0)); // 23  down
+    tape.push((108.0, 109.0, 108.0, 109.0)); // 24  up — the streak restarts
+    tape.push((109.0, 109.0, 106.0, 106.0)); // 25  1 of 3
+    tape.push((106.0, 106.0, 104.0, 104.0)); // 26  2 of 3
+    tape.push((104.0, 104.0, 102.0, 102.0)); // 27  3 of 3 -> 80%, age 5
+
+    assert_eq!(
+        sells(&run_defaults(&tape)),
+        vec![PUSH_BAR + 5],
+        "five bars after the push is inside the window, and the run is what marks"
+    );
+}
+
+#[test]
+fn the_defaults_mark_a_cover_four_bars_after_the_push() {
+    // Scenario 4: nothing for three bars, then one big opposite candle that
+    // covers the body. The cover's window ships at 5 for exactly this: at the
+    // old 3, the identical candle arrived too late and the setup said nothing.
+    let mut tape = quiet_context();
+    tape.push(PUSH); //                         22  force bar
+    tape.push((110.0, 110.0, 108.0, 108.0)); // 23  small down
+    tape.push((108.0, 110.0, 108.0, 110.0)); // 24  up
+    tape.push((109.0, 111.0, 109.0, 110.0)); // 25  up
+    tape.push((110.0, 110.0, 103.0, 103.0)); // 26  covers 70% of the body, age 4
+
+    assert_eq!(
+        sells(&run_defaults(&tape)),
+        vec![PUSH_BAR + 4],
+        "a cover on the fourth bar is inside the shipped window"
+    );
+}
+
+#[test]
+fn a_cover_that_closes_past_the_force_bars_low_is_not_a_reversal() {
+    // Scenario 5: the candle covers the body outright, but closes BELOW the
+    // force bar's low. That is not the push being faded, it is the push being
+    // replaced — the candle is a selling force bar in its own right, and
+    // marking it would be fading the exhaustion of the exhaustion.
+    let mut tape = quiet_context();
+    tape.push(PUSH); //                         22  force bar, low 99
+    tape.push((110.0, 110.0, 97.0, 98.0)); //   23  closes at 98, under the low
+
+    assert_eq!(
+        sells(&run_defaults(&tape)),
+        none(),
+        "the setup is killed by that close, not marked"
+    );
+
+    // And the switch is real: off, the same tape is an ordinary cover.
+    let mut off = defaults();
+    off[INVALIDATE_BEYOND] = InputValue::Bool(false);
+    assert_eq!(
+        sells(&run(&off, &tape)),
+        vec![PUSH_BAR + 1],
+        "with invalidation off the identical candle marks"
+    );
+}
+
+#[test]
+fn a_run_whose_last_candle_closes_past_the_low_is_not_a_reversal() {
+    // Scenario 6: the same rule reached by the other shape. Three candles
+    // down, the third closing under the force bar's low — 120% handed back,
+    // which is not a deeper give-back but a new push the other way.
+    let mut tape = quiet_context();
+    tape.push(PUSH); //                         22  force bar, low 99
+    tape.push((110.0, 110.0, 106.0, 106.0)); // 23  1 of 3
+    tape.push((106.0, 106.0, 102.0, 102.0)); // 24  2 of 3
+    tape.push((102.0, 102.0, 97.0, 98.0)); //   25  3 of 3, closes at 98
+
+    assert_eq!(
+        sells(&run_defaults(&tape)),
+        none(),
+        "a run that runs past the force bar is the reversal of the reversal"
+    );
+
+    let mut off = defaults();
+    off[INVALIDATE_BEYOND] = InputValue::Bool(false);
+    assert_eq!(
+        sells(&run(&off, &tape)),
+        vec![PUSH_BAR + 3],
+        "with invalidation off the identical run marks"
+    );
+}
+
 #[test]
 fn the_declared_marks_are_the_ones_the_renderer_draws() {
     // Shape, location and colour all fold at load time and all fall back
@@ -350,8 +521,8 @@ fn no_declared_input_is_a_control_that_does_nothing() {
     let inputs = &indicator.descriptor().inputs;
     assert_eq!(
         inputs.len(),
-        17,
-        "four force-bar knobs, four run, three cover, two display, four calibration"
+        18,
+        "four force-bar knobs, four run, three cover, two display, four calibration, one invalidation"
     );
     for spec in inputs {
         assert!(
@@ -559,13 +730,19 @@ fn the_direction_rule_decides_whether_a_reversal_bar_can_anchor() {
     wick.push((100.0, 100.0, 99.0, 99.0)); //   7  bearish
     wick.push((99.0, 99.0, 98.0, 98.0)); //     8  bearish, 127% given back
 
+    // This tape hands back 127%: it closes past the force bar's low, which
+    // section 6 kills on sight. Invalidation is off for both halves here —
+    // the clause under test is the direction rule, and the kill has its own
+    // scenarios.
+    let mut base = inputs();
+    base[INVALIDATE_BEYOND] = InputValue::Bool(false);
     assert_eq!(
-        sells(&run(&inputs(), &wick)),
+        sells(&run(&base, &wick)),
         none(),
         "with the direction rule on, only a bar closing up can be a buying push"
     );
 
-    let mut loose = inputs();
+    let mut loose = base.clone();
     loose[NEED_DIRECTION] = InputValue::Bool(false);
     assert_eq!(
         sells(&run(&loose, &wick)),

--- a/crates/pine/tests/exhaustion_reversal_semantics.rs
+++ b/crates/pine/tests/exhaustion_reversal_semantics.rs
@@ -211,7 +211,7 @@ fn none() -> Vec<usize> {
 }
 
 /// `color.orange` and `color.blue` as this dialect folds them: the two paints
-/// the section-1 diagnostic uses. Constants in the script, constants here —
+/// the section-5 diagnostic uses. Constants in the script, constants here —
 /// asserting on the exact colour is what catches the two sides being wired to
 /// the same one, which is a bug the arrows already shipped once.
 const PAINT_TOP: Rgba8 = Rgba8::opaque(0xFF, 0x98, 0x00);
@@ -325,7 +325,7 @@ fn the_inputs_this_script_shipped_with_keep_their_positions() {
     assert_eq!(
         &declared[..SHIPPED_ORDER.len()],
         &SHIPPED_ORDER[..],
-        "the inputs this script shipped with must keep their indices —          append new ones instead of inserting them"
+        "the inputs this script shipped with must keep their indices — append new ones instead of inserting them"
     );
 }
 
@@ -699,6 +699,12 @@ fn the_two_sides_of_the_diagnostic_wear_different_colours() {
     on[PAINT_FORCE] = InputValue::Bool(true);
 
     let tape = buy_tape();
+    assert_eq!(
+        paints(&run(&inputs(), &tape), tape.len()),
+        vec![None; tape.len()],
+        "off is off on this side too — the bottom branch needs its own guard, and a sell tape can never prove it has one"
+    );
+
     let painted = paints(&run(&on, &tape), tape.len());
     assert_eq!(
         painted[5],
@@ -707,6 +713,62 @@ fn the_two_sides_of_the_diagnostic_wear_different_colours() {
     );
     assert_ne!(PAINT_TOP, PAINT_BOTTOM);
     assert_eq!(painted.iter().filter(|p| p.is_some()).count(), 1);
+}
+
+#[test]
+fn the_run_reads_the_body_on_the_buy_side_too() {
+    // The mirror of the test above, and not a formality: the buy side reads
+    // `bottom_run_low` where the sell side reads `top_run_high`, so a min/max
+    // slip in the arming block would leave the sell side correct and this one
+    // measuring the give-back from the wrong end of the force bar.
+    //
+    // Selling push with wicks on both sides: body 94..100 (width 6), full
+    // range 90..104 (width 14). The three-candle run closes at 99 — 64% of
+    // the RANGE handed back (short of 70%) but 83% of the BODY (past it).
+    let mut wicked = context_down();
+    wicked.push((100.0, 104.0, 90.0, 94.0)); // 5  force bar, body 94..100
+    wicked.push((94.0, 96.0, 94.0, 96.0)); //   6  give-back 1 of 3
+    wicked.push((96.0, 98.0, 96.0, 98.0)); //   7  give-back 2 of 3
+    wicked.push((98.0, 99.0, 98.0, 99.0)); //   8  give-back 3 of 3
+
+    assert_eq!(
+        buys(&run(&inputs(), &wicked)),
+        none(),
+        "against the full range this run gives back only 64% of it"
+    );
+
+    let mut body_only = inputs();
+    body_only[RUN_BODY_ONLY] = InputValue::Bool(true);
+    assert_eq!(
+        buys(&run(&body_only, &wicked)),
+        vec![8],
+        "the identical tape marks once the give-back is judged against the body alone"
+    );
+}
+
+#[test]
+fn the_cover_reads_the_body_on_the_buy_side_too() {
+    // Same mirror for the cover, which reads `bottom_cover_high`/`_low`: a
+    // selling push with a 4-wide wick BELOW its body, body 100..110 (width
+    // 10) inside a 96..110 range (width 14). The answering candle's body
+    // covers exactly 70% of the body and only 50% of the range.
+    let mut wicked = context_down();
+    wicked.push((110.0, 110.0, 96.0, 100.0)); // 5  force bar, body 100..110
+    wicked.push((100.0, 107.0, 100.0, 107.0)); // 6  body 100->107
+
+    assert_eq!(
+        buys(&run(&inputs(), &wicked)),
+        none(),
+        "against the full range the overlap is 50%, short of the threshold"
+    );
+
+    let mut body_only = inputs();
+    body_only[COVER_BODY_ONLY] = InputValue::Bool(true);
+    assert_eq!(
+        buys(&run(&body_only, &wicked)),
+        vec![6],
+        "the identical candle marks once the overlap is judged against the body"
+    );
 }
 
 #[test]

--- a/crates/pine/tests/exhaustion_reversal_semantics.rs
+++ b/crates/pine/tests/exhaustion_reversal_semantics.rs
@@ -31,24 +31,28 @@ type Ohlc = (f64, f64, f64, f64);
 /// identical at any length. Positional — the script's `input.*` order.
 fn inputs() -> Vec<InputValue> {
     vec![
-        InputValue::Int(4),     // 0  1 Force bar: body average window
-        InputValue::Float(1.5), // 1  1 Force bar: min body (×average)
-        InputValue::Int(4),     // 2  1 Force bar: reaches the extreme of
-        InputValue::Bool(true), // 3  1 Force bar: must close with the push
-        InputValue::Bool(true), // 4  2 Run: on
-        InputValue::Int(3),     // 5  2 Run: opposite candles in a row
-        InputValue::Int(5),     // 6  2 Run: window after the force bar
-        InputValue::Float(0.7), // 7  2 Run: min give-back
-        InputValue::Bool(true), // 8  3 Cover: on
-        InputValue::Int(3),     // 9  3 Cover: window after the force bar
-        InputValue::Float(0.7), // 10 3 Cover: min overlap
-        InputValue::Bool(true), // 11 4 Display: mark top reversals
-        InputValue::Bool(true), // 12 4 Display: mark bottom reversals
+        InputValue::Int(4),      // 0  1 Force bar: body average window
+        InputValue::Float(1.5),  // 1  1 Force bar: min body (×average)
+        InputValue::Int(4),      // 2  1 Force bar: reaches the extreme of
+        InputValue::Bool(true),  // 3  1 Force bar: must close with the push
+        InputValue::Bool(true),  // 4  2 Run: on
+        InputValue::Int(3),      // 5  2 Run: opposite candles in a row
+        InputValue::Int(5),      // 6  2 Run: window after the force bar
+        InputValue::Float(0.7),  // 7  2 Run: min give-back
+        InputValue::Bool(true),  // 8  3 Cover: on
+        InputValue::Int(3),      // 9  3 Cover: window after the force bar
+        InputValue::Float(0.7),  // 10 3 Cover: min overlap
+        InputValue::Bool(true),  // 11 4 Display: mark top reversals
+        InputValue::Bool(true),  // 12 4 Display: mark bottom reversals
+        InputValue::Float(0.0),  // 13 5 Calibration: points floor, off
+        InputValue::Bool(false), // 14 5 Calibration: run reads the body
+        InputValue::Bool(false), // 15 5 Calibration: cover reads the body
+        InputValue::Bool(false), // 16 5 Calibration: paint what armed
     ]
 }
 
 // Positions into the hand-ordered `Vec` above. Naming them keeps a test from
-// reading as `off[8] = false` — but note this is legibility only: the bind
+// reading as `off[10] = false` — but note this is legibility only: the bind
 // path checks the input *count*, never a name, so reordering two same-typed
 // inputs would leave these pointing at the wrong knob with the suite green.
 // There is no by-name input API to reach for; the behavioural assertions are
@@ -58,6 +62,10 @@ const USE_RUN: usize = 4;
 const RUN_WINDOW: usize = 6;
 const USE_COVER: usize = 8;
 const SHOW_TOP: usize = 11;
+const MIN_BODY_POINTS: usize = 13;
+const RUN_BODY_ONLY: usize = 14;
+const COVER_BODY_ONLY: usize = 15;
+const PAINT_FORCE: usize = 16;
 
 fn make(index: usize, row: Ohlc) -> IndicatorBar {
     let (open, high, low, close) = row;
@@ -202,6 +210,23 @@ fn none() -> Vec<usize> {
     Vec::new()
 }
 
+/// `color.orange` and `color.blue` as this dialect folds them: the two paints
+/// the section-1 diagnostic uses. Constants in the script, constants here —
+/// asserting on the exact colour is what catches the two sides being wired to
+/// the same one, which is a bug the arrows already shipped once.
+const PAINT_TOP: Rgba8 = Rgba8::opaque(0xFF, 0x98, 0x00);
+const PAINT_BOTTOM: Rgba8 = Rgba8::opaque(0x29, 0x62, 0xFF);
+
+/// The bar paint of each row, `None` where the script asked for none. The row
+/// count is passed in rather than read off the channel: the channel is kept
+/// only as far as the last painted bar, so its length would silently shorten
+/// the assertion to exactly the rows that happen to be painted.
+fn paints(indicator: &ScriptIndicator, rows: usize) -> Vec<Option<Rgba8>> {
+    (0..rows)
+        .map(|row| indicator.plots().bar_paint(row))
+        .collect()
+}
+
 #[test]
 fn the_declared_marks_are_the_ones_the_renderer_draws() {
     // Shape, location and colour all fold at load time and all fall back
@@ -245,6 +270,65 @@ fn the_declared_marks_are_the_ones_the_renderer_draws() {
     );
 }
 
+/// The thirteen inputs the indicator shipped with in #212, in order. This is
+/// not documentation — it is the binding contract for every preset a trader
+/// has already saved. Titles rather than the derived `name()`, because they
+/// are what a reader can check against the script in one glance; `name()` is
+/// a slug of the title, so pinning one pins the other.
+const SHIPPED_ORDER: [&str; 13] = [
+    "1 Force bar: body average window (bars)",
+    "1 Force bar: min body (×average)",
+    "1 Force bar: reaches the extreme of (bars)",
+    "1 Force bar: must close in the direction of the push",
+    "2 Run: mark a give-back by consecutive candles",
+    "2 Run: opposite candles in a row",
+    "2 Run: window after the force bar (bars)",
+    "2 Run: min give-back of the force bar",
+    "3 Cover: mark a give-back by one opposite candle",
+    "3 Cover: window after the force bar (bars)",
+    "3 Cover: min overlap with the force bar",
+    "4 Display: mark top reversals (sell side)",
+    "4 Display: mark bottom reversals (buy side)",
+];
+
+#[test]
+fn the_inputs_this_script_shipped_with_keep_their_positions() {
+    // A saved preset is a list of values matched to inputs BY POSITION, with
+    // only a type check to object (`App::load_indicator_preset`): the loader
+    // walks the declared inputs and takes the saved value at the same index
+    // when the discriminant matches. Insert an input in the middle and every
+    // preset saved before it shifts one place — silently, because a `bool`
+    // matches a `bool`. That is not hypothetical: dropping "paint the bars
+    // that arm a push" at index 4 would have handed it the value saved for
+    // "2 Run: on" — `true` by default — and a trader's candles would have
+    // started repainting themselves from a preset written before the switch
+    // existed. So new inputs go at the END, in section 5, and this test is
+    // what says so out loud.
+    //
+    // Two titles here lost "(fraction of range)" in this same change, because
+    // the fraction can now be read against the body instead; that is a
+    // rename, not a reorder, and the loader never reads a title. The test
+    // still catches it, deliberately: `InputSpec::name()` is documented as a
+    // persistence key, and the day something starts persisting by it, a
+    // rename becomes a silent data loss.
+    let indicator = load();
+    let declared: Vec<&str> = indicator
+        .descriptor()
+        .inputs
+        .iter()
+        .map(|spec| spec.title())
+        .collect();
+    assert!(
+        declared.len() >= SHIPPED_ORDER.len(),
+        "an input was removed: presets bind by position, so removing one shifts every value saved after it"
+    );
+    assert_eq!(
+        &declared[..SHIPPED_ORDER.len()],
+        &SHIPPED_ORDER[..],
+        "the inputs this script shipped with must keep their indices —          append new ones instead of inserting them"
+    );
+}
+
 #[test]
 fn no_declared_input_is_a_control_that_does_nothing() {
     // `input.color` does not fold in this dialect, so a colour handed to a
@@ -254,12 +338,16 @@ fn no_declared_input_is_a_control_that_does_nothing() {
     // nothing, which the repo treats as worse than an absent one. This
     // script therefore declares no colour input at all and takes its colours
     // from the Style tab; the assertion is here so nobody adds one back.
+    //
+    // `barcolor` is the one site an `input.color` *would* fold through
+    // (force_bar.pine proves it), so this is a ban on the picker, not on
+    // paint: the diagnostic below paints with folded constants instead.
     let indicator = load();
     let inputs = &indicator.descriptor().inputs;
     assert_eq!(
         inputs.len(),
-        13,
-        "four force-bar knobs, four run, three cover, two display"
+        17,
+        "four force-bar knobs, four run, three cover, two display, four calibration"
     );
     for spec in inputs {
         assert!(
@@ -373,6 +461,52 @@ fn an_ordinary_bar_at_a_new_high_is_not_a_force_bar() {
         sells(&run(&inputs(), &weak)),
         none(),
         "a breakout the tape did not have to work for is not exhaustion"
+    );
+}
+
+#[test]
+fn a_ratio_without_a_size_is_not_an_elephant() {
+    // The force bar's body is 10 points against an average of 1.0, so the
+    // ratio says force at any factor this fixture could carry. The floor is
+    // the other half of the question, and it is the half a quiet tape needs:
+    // a collapsed average makes 1.5× of almost nothing arm a push nobody
+    // would call one (measured on WINV26: 247 of 1 355 bars by ratio alone,
+    // 7 with a 100-point floor — docs/ux/strategy-anchors.md).
+    let mut floored = inputs();
+    floored[MIN_BODY_POINTS] = InputValue::Float(11.0);
+    assert_eq!(
+        sells(&run(&floored, &sell_tape())),
+        none(),
+        "a 10-point body under an 11-point floor never arms, so nothing the bars after it do can mark"
+    );
+
+    // And the floor is a floor, not a filter on the mark: one point lower and
+    // the identical tape marks where it always did.
+    let mut cleared = inputs();
+    cleared[MIN_BODY_POINTS] = InputValue::Float(10.0);
+    assert_eq!(
+        sells(&run(&cleared, &sell_tape())),
+        vec![8],
+        "the floor is `>=`: a body exactly at it still counts"
+    );
+
+    // Off is off — the shipped default changes nothing about the old ruler.
+    assert_eq!(sells(&run(&inputs(), &sell_tape())), vec![8]);
+}
+
+#[test]
+fn the_floor_and_the_paint_agree_about_what_armed() {
+    // The diagnostic is only useful if it reports the same decision the
+    // signal path made. A floor that silenced the arrow while leaving the bar
+    // painted would send the trader hunting a bug that is not there.
+    let mut floored = inputs();
+    floored[MIN_BODY_POINTS] = InputValue::Float(11.0);
+    floored[PAINT_FORCE] = InputValue::Bool(true);
+    let tape = sell_tape();
+    assert_eq!(
+        paints(&run(&floored, &tape), tape.len()),
+        vec![None; tape.len()],
+        "no bar armed, so no bar is painted"
     );
 }
 
@@ -492,6 +626,87 @@ fn a_window_shorter_than_the_run_still_means_the_run() {
         vec![8],
         "an input that cannot fire is a trap, not a setting"
     );
+}
+
+#[test]
+fn the_run_can_measure_give_back_against_the_force_bars_body_instead_of_its_range() {
+    // A force bar with wicks on both sides: body 105..111 (width 6), full
+    // range 101..115 (width 14, a 4-wide wick on each end). The three-candle
+    // run below closes at 106 — 64% of the RANGE given back (short of 70%)
+    // but 83% of the BODY (past it).
+    let mut wicked = context_up();
+    wicked.push((105.0, 115.0, 101.0, 111.0)); // 5  force bar, body 105..111
+    wicked.push((111.0, 111.0, 109.0, 109.0)); // 6  give-back 1 of 3
+    wicked.push((109.0, 109.0, 107.0, 107.0)); // 7  give-back 2 of 3
+    wicked.push((107.0, 107.0, 106.0, 106.0)); // 8  give-back 3 of 3
+
+    assert_eq!(
+        sells(&run(&inputs(), &wicked)),
+        none(),
+        "measured against the full range this run gives back only 64% of \
+         it — short of the 70% threshold"
+    );
+
+    let mut body_only = inputs();
+    body_only[RUN_BODY_ONLY] = InputValue::Bool(true);
+    assert_eq!(
+        sells(&run(&body_only, &wicked)),
+        vec![8],
+        "the identical tape marks once the switch says to ignore the wicks \
+         and judge the give-back against the body alone"
+    );
+}
+
+#[test]
+fn the_force_bar_diagnostic_paints_the_push_and_leaves_every_other_bar_alone() {
+    // Silent unless asked. An indicator that painted candles the moment it
+    // was added would repaint the chart of everyone who already runs it.
+    let tape = sell_tape();
+    assert_eq!(
+        paints(&run(&inputs(), &tape), tape.len()),
+        vec![None; tape.len()],
+        "with the switch off the script asks for no paint at all"
+    );
+
+    let mut on = inputs();
+    on[PAINT_FORCE] = InputValue::Bool(true);
+    let painted = paints(&run(&on, &tape), tape.len());
+    assert_eq!(
+        painted[5],
+        Some(PAINT_TOP),
+        "bar 5 is the force bar — the whole point of the switch is that it becomes visible whether or not anything fades it"
+    );
+    assert_eq!(
+        painted[8], None,
+        "bar 8 carries the arrow, and the give-back is not a push: painting it would answer a question nobody asked"
+    );
+    assert_eq!(
+        painted.iter().filter(|p| p.is_some()).count(),
+        1,
+        "one push in this tape, one painted bar"
+    );
+
+    // The switch is a diagnostic, not a filter: the arrow is unchanged.
+    assert_eq!(sells(&run(&on, &tape)), vec![8]);
+}
+
+#[test]
+fn the_two_sides_of_the_diagnostic_wear_different_colours() {
+    // A single colour for both would make the paint useless exactly where a
+    // trader needs it — a bar painted at the bottom of a slide is either the
+    // selling push it should be, or a buying push read upside down.
+    let mut on = inputs();
+    on[PAINT_FORCE] = InputValue::Bool(true);
+
+    let tape = buy_tape();
+    let painted = paints(&run(&on, &tape), tape.len());
+    assert_eq!(
+        painted[5],
+        Some(PAINT_BOTTOM),
+        "the selling push at a new low is the other colour"
+    );
+    assert_ne!(PAINT_TOP, PAINT_BOTTOM);
+    assert_eq!(painted.iter().filter(|p| p.is_some()).count(), 1);
 }
 
 #[test]
@@ -667,6 +882,34 @@ fn the_cover_marks_the_buy_side_too() {
     let hit = run(&inputs(), &t);
     assert_eq!(buys(&hit), vec![6]);
     assert_eq!(sells(&hit), none());
+}
+
+#[test]
+fn the_cover_can_measure_overlap_against_the_force_bars_body_instead_of_its_range() {
+    // A force bar with a wick above its body: body 101..111 (width 10), full
+    // range 101..115 (width 14, a 4-wide upper wick). The next candle's body
+    // overlaps the force bar's body by exactly 70%, but only 50% of its full
+    // range — the trader's exact complaint: a candle that visibly erases the
+    // body still fails a threshold judged against the whole wick-to-wick range.
+    let mut wicked = context_up();
+    wicked.push((101.0, 115.0, 101.0, 111.0)); // 5  force bar, body 101..111
+    wicked.push((111.0, 111.0, 104.0, 104.0)); // 6  body 111->104: 50% of range, 70% of body
+
+    assert_eq!(
+        sells(&run(&inputs(), &wicked)),
+        none(),
+        "measured against the full range the overlap is only 50%, short of \
+         the 70% threshold"
+    );
+
+    let mut body_only = inputs();
+    body_only[COVER_BODY_ONLY] = InputValue::Bool(true);
+    assert_eq!(
+        sells(&run(&body_only, &wicked)),
+        vec![6],
+        "the identical candle marks once the switch says to judge the \
+         overlap against the body alone"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## What this is

Three answers to the same complaint about **Exhaustion reversal** (#212, merged
yesterday): a candle could visibly erase most of a force bar's **body** and get
no arrow; bars nobody would call a push were arming; and there was no way to
see which bars the script had accepted in the first place.

Everything here ships **off** (or at `0`). A fresh load behaves exactly like
the merged version.

### 1. An absolute body floor — `5 Calibration: min force-bar body (points)`

The body test was a pure **ratio**: this body against the average of the recent
ones. That is honest on time candles and promiscuous on activity-cut bars —
when the tape goes quiet the average collapses, and an unremarkable bar clears
1.5× of almost nothing.

Measured, not suspected: `docs/ux/strategy-anchors.md` records the same ruler
marking **247 of 1 355 volume bars** on a live WINV26 session, and **7** once a
100-point floor was added — which is why the strategy kernel's force trigger
already carries `min_body` (`crates/strategy/src/force.rs`). The script now
takes the same floor, `and`ed with the ratio. It ships at `0` because the right
number is a property of the instrument: ~100 points on WIN, a different order
of magnitude on BTC.

It declares a **lower bound only**. The panel renders a two-sided float as a
slider quantised to its step (`indicator_panel.rs:622`), which for an absolute
quantity would put the WIN target of ~100 in the first 0.1% of a 0..100000
track and set a floor of 1 that no instrument priced under a unit could get
below. One-sided, it is a typed field.

### 2. Body-only reference — `5 Calibration: run/cover measures the body`

Both give-back fractions were measured against the force bar's full **range**,
so a long wick widens the denominator and a candle that erases the body still
falls short of 70%. Each shape now has its own switch to measure against the
**body** instead. They choose independently, and body-only is not simply the
easier test — the wick shrinks numerator and denominator alike, so the two
references disagree in either direction.

### 3. The diagnostic — `5 Calibration: paint the bars that arm a push`

Every bar accepted as a force bar is painted **orange** (top / sell side) or
**blue** (bottom / buy side), through the same bar paint channel
`force_bar.pine` uses.

The arrows alone cannot answer *"is it reading the right bars?"*: an arrow
needs a push that was **both** armed **and** given back, so a force bar nothing
faded leaves no trace — and neither does a bar that armed when it should not
have. This paints the state machine's own decision without changing it. Colours
are folded constants (not a picker) and ones `force_bar.pine` does not use, so
both scripts can be on at once and still be told apart.

It deliberately ignores section 4's side toggles, and section 4 now says so:
those silence the **triangles**, and a diagnostic that silenced itself along
with them would answer "nothing arms on this side" — wrongly.

## Why section 5 sits at the end, and what that alone did not fix

Saved values — state file and presets alike — are matched to inputs **by
position**. An input inserted in the middle shifts every value saved before it,
silently, because a `bool` matches a `bool`. The first cut of this PR did
exactly that: at index 4, "paint the bars that arm a push" would have inherited
the value saved for "2 Run: on" (`true` by default) and started **repainting a
trader's candles from a preset written before the switch existed**. All four
new inputs are therefore appended, and
`the_inputs_this_script_shipped_with_keep_their_positions` pins the thirteen
shipped inputs to their indices.

Appending was only half of it. The **state-file** path
(`IndicatorSource::build_with`) bound values only on an exact count match and
fell back to declared defaults otherwise — so one added input meant every
*other* knob a trader had tuned came back at its default on the next launch. It
now keeps what still lines up, per cell, type-checked, exactly as
`App::load_indicator_preset` already did, and reports what survived with
`INDICATOR_INPUTS_COUNT_CHANGED`. A slot whose first compile failed carries no
values at all and is excluded — nothing was saved there to keep.

## Performance

100k-bar interpreter bench (`cargo bench -p quantick-pine`), normalised against
unmodified `force_bar.pine` in the same run — the machine drifted up to 20%
between runs, so the raw column alone would be noise:

| tape | main | this branch | Δ raw | Δ normalised |
| --- | --- | --- | --- | --- |
| quiet | 6373 ns/bar | 6817 ns/bar | +7.0% | +8.4% |
| arming | 6526 ns/bar | 6930 ns/bar | +6.2% | +10.1% |

~14% of the bench's declared 50 µs/commit budget. Branch runs varied ~1.5%
between repeats; the table is the last of four.

The first cut cost **+20%**: it read the two body-only switches per bar, which
put eight ternaries and four subtractions on every commit and every preview.
Each shape's ruler is now resolved once, on the bar that arms, and stored with
the armed state — safe because editing any input rebuilds the indicator and
replays the whole history, so a stored ruler can never be read against a switch
that has since moved.

## Tests

- the floor: the tape that arms without it and stays silent with it, `>=` at
  the boundary, off-is-off, and the paint agreeing with the arrow about what
  armed;
- each body-only reference: the tape that fails against the range and passes
  against the body;
- the paint: silent by default, landing on the force bar and **not** on the bar
  that carries the arrow, one painted bar per push, the two sides in different
  colours;
- the input order pinned against the positional binding described above;
- the per-cell rebind: older values kept, and only the cell whose type no
  longer matches falling back.

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -D
warnings`, `cargo build --workspace`, `cargo test --workspace` — green (74
suites, 0 failures).

## Review

**step 0: code-review at high, run twice** (the branch changed substantially
after the first pass, so it was re-run against the final code). First pass: 6
findings, of which the input-insertion one above was the serious one. Second
pass: 6 findings — 4 confirmed and fixed here, 1 answered by documentation, 1
refuted.

| # | finding | outcome |
| --- | --- | --- |
| 1 | state file reset every saved value on an input count change | **fixed** — per-cell rebind + 2 tests |
| 2 | absolute floor rendered as a step-quantised 0..100000 slider | **fixed** — lower bound only |
| 3 | collapsed spaces inside log and assertion messages | **fixed** — `rustfmt` joins a `\` continuation and keeps the indentation as literal spaces, so 6 messages were rewritten on one line (one of them pre-existing, in the same file) |
| 4 | comment claimed the rulers return to `na` on disarm | **fixed** — they do not; `top_armed` is the guard, and the comment now says the `> 0` tests are not a second line of defence |
| 5 | the paint ignores the display toggles | **documented** — deliberate, see above |
| 6 | assertion message calls a bottom anchor a "selling push" | **refuted** — a bottom anchor *is* a selling push (a bearish bar at a new low); the buy arrow appears when it is given back |

Not validated visually: no app instance was launched (agents do not open one
here without being asked). Switching the paint on against a live or replayed
tape is the check that remains.

## Deferred findings

- `App::load_indicator_preset` (`app.rs:2869`) builds its value list with
  `.filter_map(SavedInput::to_value)`, which **drops** an unreadable cell
  instead of holding its place, shifting every later value by one. Pre-existing
  and not triggered here (appending keeps indices aligned).
- When the counts *do* match, no types are checked at all —
  `ScriptIndicator::with_inputs` guards the count and nothing else — so a
  script that changed an input's type without changing how many it has still
  binds the old value. Pre-existing; the new per-cell path type-checks, the
  exact-count path does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TRW3HYmyY7RRTWzZdjtkMv

---

## Second review pass (`/code-review xhigh`) — 14 findings

**8 fixed, 2 refuted, 2 deferred, 2 folded into the fixes above.**

| # | finding | outcome |
| --- | --- | --- |
| 1 | nothing proved the buy-side paint is gated on `paint_force` | **fixed** — off-is-off now runs a tape that arms the bottom side; the mutation the reviewer demonstrated (dropping the guard) now fails |
| 2 | the buy-side body-only rulers had no test at all | **fixed** — `the_run_reads_the_body_on_the_buy_side_too` and its cover twin; the `bottom_run_low` min→max mutation now fails |
| 3 | bar paint is last-indicator-wins, so `force_bar.pine` hides the diagnostic | **fixed (documentation)** — the claim was wrong; the script now states the resolution rule and says to run this alone while calibrating, or add it last |
| 4 | `NativeEma` still drops saved values on a count change | **refuted** — `Ema::rebind` reads `values.first()` / `values.get(1)` with a per-cell fallback; it never refuses |
| 5 | `kept` re-derived by comparing floats, wrong for `NaN` | **fixed** — counted inside the binder where the decision is made |
| 6 | the per-cell bind loop is a second copy of the preset path's | **fixed** — extracted as `quantick_indicators::bind_by_position`, with its own tests; both paths call it |
| 7 | altitude: `SavedInput` carries no input name, so position is the only key | **deferred** — a persistence-format change; noted below |
| 8 | partial loss of settings is logged but not marked on screen | **deferred** — `IndicatorView.stale` exists, but it means "the running version is stale after a failed reload"; reusing it needs its own decision |
| 9 | the stated reason for omitting `step` was wrong | **fixed** — quantisation needs both bounds; `step=1.0` restored, purely as drag speed, and the comment corrected |
| 10 | ruler assignments repeat; `paint_force` tested in both branches | **partly fixed** — one outer `if paint_force`; the four ruler blocks stay explicit, now covered by the buy-side tests above |
| 11 | one new assertion message still carries the collapsed-space artifact | **fixed** — and the whole diff is now checked for it after `cargo fmt`, which is what produces it |
| 12 | doc comment says "section-1 diagnostic" | **fixed** — it is section 5 |
| 13 | preset path drops an unreadable cell and shifts the rest | **fixed** — `map` instead of `filter_map`, and the binder holds the index |
| 14 | the exact-count path binds with no type check | **fixed** — that path is gone; everything goes through the binder |

### Still deferred

- `SavedInput` (`state_file.rs:47`) stores a bare typed value with no name,
  while `InputSpec::name()` is documented as the persistence key. Adding an
  optional name and preferring a name match over the index would protect every
  script at once instead of one order-pinning test per script. Its own PR.
- A partial rebind is reported only in the log. `IndicatorView.stale` is the
  obvious channel, but it currently means "a hot reload failed and you are
  looking at the previous version" — a different statement, rendered
  differently. Worth doing, not worth overloading.
