### PR TITLE
feat(app): ship the chart's opening layers as config, and open the flow

### DIFF
--- a/.claude/skills/arch-review/SKILL.md
+++ b/.claude/skills/arch-review/SKILL.md
@@ -205,6 +205,15 @@ constant or in config — never inline at the point of use.
   never literals in code.
 - A magic number in a renderer or a threshold buried in a condition is a
   finding every time, including when it is "obviously" 2.0.
+- **Opening state is config, not a literal.** Which layers, panels and
+  surfaces a fresh launch draws is a product decision someone may want
+  different, so it belongs in the shipped TOML under `crates/app/config/`,
+  compiled in with `include_str!` the way `feeds.toml`, `bubbles.toml` and
+  `chart-layers.toml` are. A `Default` impl deciding what the first frame
+  shows, or a `set_*(false)` at startup, is a finding — it puts a product
+  decision where nobody can change it without a build, and it splits the
+  answer across a struct and a file the moment a state file exists. The test
+  is not "is it a number", it is "would a human ever want this different".
 - Config round-trips must survive a save: a writer that drops comments or
   re-emits `0.78` as `0.7799999713897705` destroys the reason the file is
   tracked in git. Check the write path, not just the read path.

--- a/crates/app/config/chart-layers.toml
+++ b/crates/app/config/chart-layers.toml
@@ -1,0 +1,60 @@
+# quantick — which chart layers a fresh launch opens with.
+#
+# This is the *shipped* answer, not the trader's. Resolution order at startup
+# (first hit wins):
+#   1. the file named by the QUANTICK_CHART_LAYERS environment variable
+#   2. `chart-layers.toml` in the durable cockpit home (Documents/Quantick),
+#      which the app writes back the moment a switch flips
+#   3. this file, compiled into the binary as the built-in default
+#
+# So a trader who switches a layer off keeps it off: their own file is written
+# on that click and takes precedence from the next launch on. This file only
+# decides what someone who has never touched a switch sees.
+#
+# Ids are `ChartLayer::id` (see `crates/app/src/chart_layers.rs`). An id this
+# build does not know is dropped rather than failing the launch, and an absent
+# id means "whatever the app decided" — the code default, a feed's preset or an
+# autostart env var. `lane_marks` is deliberately absent: it belongs to the
+# order-flow preset, which is its only home.
+
+version = 1
+
+[layers]
+# The flow layers. These are what the chart is *for* — a first launch that
+# draws none of them reads as a chart with no order flow in it, which is not
+# what this project is. They cost projection work, and the layer menu (or a
+# right-click on the canvas) is where a trader who wants that cost back gives
+# it back; the choice is then theirs and this file stops applying.
+heatmap = true
+bubbles = true
+footprint = true
+live_strip = true
+
+# The tape's own canvas: the band, and each of its two flow layers.
+tape_chart = true
+tape_heatmap = true
+tape_bubbles = true
+
+# The chart's own chrome. On, so the canvas explains itself: the key that names
+# the colours, the badge that says whether the book is live, the boundaries
+# around depth the venue never sent.
+flow_legend = true
+book_status = true
+depth_gaps = true
+grid = true
+last_price = true
+seam_divider = true
+crosshair = true
+
+# What the trader put on the chart. Never hidden by default — the two paper
+# layers are switched apart on purpose, because hiding trade history must never
+# hide the position you are in.
+paper_trading = true
+trade_paint = true
+drawings = true
+
+# The one layer that opens off: a full-height rule across the candles for a
+# boundary that matters once, when reading how far the live tape goes back.
+# Nothing is hidden about the data — the bars either side of it are exactly
+# what they were, and the mark is one click away in the layer menu.
+backfill_divider = false

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -9431,7 +9431,7 @@ mod tests {
         let pane = &app.active_tab().flow_pane;
         let areas = plot_split(
             pane.last_plot_area.expect("a frame has been drawn"),
-            pane.live_strip_width(),
+            pane.live_strip_width(app.active_tab().capabilities(&app.config)),
             pane.indicators.pane_sizing(
                 &mut [crate::indicators::PaneSizing::Auto; crate::indicators::MAX_PANES],
             ),
@@ -9445,7 +9445,7 @@ mod tests {
         let pane = &app.active_tab().flow_pane;
         let areas = plot_split(
             pane.last_plot_area.expect("a frame has been drawn"),
-            pane.live_strip_width(),
+            pane.live_strip_width(app.active_tab().capabilities(&app.config)),
             pane.indicators.pane_sizing(
                 &mut [crate::indicators::PaneSizing::Auto; crate::indicators::MAX_PANES],
             ),
@@ -9465,7 +9465,7 @@ mod tests {
         let pane = &app.active_tab().flow_pane;
         plot_split(
             pane.last_plot_area.expect("a frame has been drawn"),
-            pane.live_strip_width(),
+            pane.live_strip_width(app.active_tab().capabilities(&app.config)),
             pane.indicators.pane_sizing(
                 &mut [crate::indicators::PaneSizing::Auto; crate::indicators::MAX_PANES],
             ),
@@ -9856,7 +9856,7 @@ mod tests {
             let pane = &app.active_tab().flow_pane;
             plot_split(
                 pane.last_plot_area.expect("a frame has been drawn"),
-                pane.live_strip_width(),
+                pane.live_strip_width(app.active_tab().capabilities(&app.config)),
                 pane.indicators.pane_sizing(
                     &mut [crate::indicators::PaneSizing::Auto; crate::indicators::MAX_PANES],
                 ),
@@ -11506,6 +11506,36 @@ plot(close)
             pane.layer_states(&app.style).get(&ChartLayer::TapeHeatmap),
             Some(&true),
             "the tape's depth layer answers to the same rule"
+        );
+    }
+
+    /// A band nothing can fill never takes width from the candles.
+    ///
+    /// The strip draws resting depth and the aggressions landing into it. A
+    /// source with neither fills none of it, and the shipped default is what
+    /// made that reachable — the layer opened off until now, so the missing
+    /// capability gate never showed. Permanently narrowing the candles for a
+    /// blank rect is the one way this branch could make a chart worse.
+    #[test]
+    fn a_source_that_fills_neither_half_gets_no_live_strip() {
+        let (app, _commands) = app_without_depth();
+        let pane = &app.active_tab().flow_pane;
+        assert!(
+            pane.live_strip_visible,
+            "the shipped config switched it on, which is what makes the gate matter"
+        );
+        assert_eq!(
+            pane.live_strip_width(crate::config::FeedCapabilities::none()),
+            0.0,
+            "no book and no traded volume: the band would draw nothing"
+        );
+        assert!(
+            pane.layer_blocked(
+                ChartLayer::LiveStrip,
+                crate::config::FeedCapabilities::none()
+            )
+            .is_some(),
+            "and the menu says why instead of offering a switch that does nothing"
         );
     }
 
@@ -21795,7 +21825,7 @@ plot(close)
             "no tape means no book worker behind it"
         );
         assert_eq!(
-            time.live_strip_width(),
+            time.live_strip_width(app.active_tab().capabilities(&app.config)),
             0.0,
             "the strip is a flow layer and claims no pixels here"
         );

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -11480,6 +11480,35 @@ plot(close)
         (app, cmd_rx)
     }
 
+    /// A source with no book must never write the trader's answer for them.
+    ///
+    /// The saved file outranks the shipped default from the next launch on, so
+    /// a `heatmap = false` banked during a session on a book-less source — a
+    /// recording, a CFD bridge — would follow the trader onto every market
+    /// they open afterwards, including the ones that do have a book. Nobody
+    /// chose that: the source did. And the write is not hypothetical, because
+    /// `maintain_chart_layers` persists the whole map on any mask change, so
+    /// one unrelated click anywhere in the layer menu is enough to bank it.
+    #[test]
+    fn a_source_with_no_book_never_banks_the_heatmap_as_switched_off() {
+        let (app, _commands) = app_without_depth();
+        let pane = &app.active_tab().flow_pane;
+        assert!(
+            !pane.layer_visible(ChartLayer::Heatmap, &app.style),
+            "with no book there is nothing to draw, which is the renderer's answer"
+        );
+        assert_eq!(
+            pane.layer_states(&app.style).get(&ChartLayer::Heatmap),
+            Some(&true),
+            "but the file records the switch, which the shipped config left on"
+        );
+        assert_eq!(
+            pane.layer_states(&app.style).get(&ChartLayer::TapeHeatmap),
+            Some(&true),
+            "the tape's depth layer answers to the same rule"
+        );
+    }
+
     /// An app whose source quotes prices and nothing else: no book, no traded
     /// volume — what a live CFD bridge publishes.
     fn app_without_depth() -> (QuantickApp, mpsc::Receiver<FeedCommand>) {

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -1369,9 +1369,12 @@ impl QuantickApp {
         // Same for a declared opening layout: a feed the user reads by
         // timeframe can open straight on the timeframe chart.
         app.active_tab_mut().apply_feed_declared_layout(&config);
-        // The map itself stays hidden until asked for — a layer nobody
-        // requested must cost no projection. Capture is already running either
-        // way, so this is a display choice and nothing else.
+        // The code's own baseline, and nothing more: what a launch actually
+        // opens with is `config/chart-layers.toml`, applied by
+        // `restore_chart_layers` immediately below and shipping the map on.
+        // This line is what remains if that config is ever unreadable — a
+        // layer nobody requested costing no projection. Capture is already
+        // running either way, so it is a display choice and nothing else.
         app.active_tab_mut().tape_mut().set_depth_visible(false);
         // What the user last had on the canvas, applied over those defaults and
         // under the autostart hooks below: an env var is an explicit request
@@ -11458,6 +11461,15 @@ plot(close)
     /// bar per trade, the finest series a spec change can coarsen.
     fn app_with_history(count: u64) -> (QuantickApp, mpsc::Receiver<FeedCommand>) {
         let (mut app, evt_tx, cmd_rx, _book_tx) = test_app();
+        // A bare canvas, the one every caller here was written against: the
+        // strip stands beside the price axis and takes width from the candles,
+        // so leaving it on moves every hard-coded pointer coordinate in the
+        // drawing and inspector tests onto it — a collision about layout,
+        // never about what those tests assert. Which layers a launch opens
+        // with is a different question, and `test_app` keeps the shipped
+        // answer intact for the test that reads it
+        // (`each_layer_switch_moves_exactly_one_owner`).
+        app.active_tab_mut().flow_pane.live_strip_visible = false;
         app.active_tab_mut().flow_pane.tick_n = 1;
         app.active_tab_mut().apply_spec_changes();
         app.active_tab_mut().apply_spec_changes();
@@ -11570,15 +11582,15 @@ plot(close)
     #[test]
     fn each_layer_switch_moves_exactly_one_owner() {
         let (mut app, _events, _commands, _book) = test_app();
-        // What the chart opens with: the market layers are opt-in, the chart's
-        // own chrome is on. This is the state the file's absence must preserve.
+        // What the chart opens with, and where that is decided: with no file
+        // of the trader's own, `config/chart-layers.toml` is what reaches the
+        // panes. The flow layers are on there — they are what the chart is
+        // for — and only the backfill divider is held back.
         for (layer, expected) in [
-            (ChartLayer::Heatmap, false),
-            (ChartLayer::Bubbles, false),
-            // The footprint is opt-in like every market layer: the chart must
-            // open pixel-identical to the day before the layer existed.
-            (ChartLayer::Footprint, false),
-            (ChartLayer::LiveStrip, false),
+            (ChartLayer::Heatmap, true),
+            (ChartLayer::Bubbles, true),
+            (ChartLayer::Footprint, true),
+            (ChartLayer::LiveStrip, true),
             (ChartLayer::LaneMarks, true),
             (ChartLayer::DepthGaps, true),
             (ChartLayer::Grid, true),
@@ -19654,7 +19666,17 @@ plot(close)
     fn bubble_toggle_needs_no_feed_command_and_leaves_capture_alone() {
         let (mut app, _evt_tx, mut cmd_rx, _book_tx) = test_app();
         take_capture_start(&mut cmd_rx);
+        // The shipped config opens the layer, so the round trip is off and
+        // back on — both directions have to leave the feed alone, not just
+        // whichever one happens to be the opening state.
+        assert!(app.active_tab().tape().bubbles_enabled());
+
+        app.active_tab_mut().tape_mut().set_bubbles_enabled(false);
         assert!(!app.active_tab().tape().bubbles_enabled());
+        assert!(
+            cmd_rx.try_recv().is_err(),
+            "hiding the bubbles is a display choice; no feed command is needed"
+        );
 
         app.active_tab_mut().tape_mut().set_bubbles_enabled(true);
         assert!(app.active_tab().tape().bubbles_enabled());

--- a/crates/app/src/chart_layers.rs
+++ b/crates/app/src/chart_layers.rs
@@ -32,22 +32,35 @@
 //! the one field that already owns its layer.
 //!
 //! The file records each layer's *state*, not a list of hidden ones, because
-//! the layers do not share one default — the heatmap, the bubbles, the live
-//! strip and the backfill divider open off, everything else opens on. An
-//! absent entry therefore means
-//! "whatever the app decided", which is what keeps a fresh install, a feed's
-//! preset and the autostart env vars behaving exactly as they did before this
-//! file existed.
+//! the layers do not share one default. An absent entry means "whatever the
+//! app decided", which is what keeps a feed's preset and the autostart env
+//! vars behaving exactly as they did before this file existed.
+//!
+//! What a *fresh* install opens with is `config/chart-layers.toml`, compiled
+//! into the binary ([`EMBEDDED_DEFAULT`]) and read whenever the trader has no
+//! file of their own. Opening state is a product decision someone may want
+//! different, so it is shipped config like `feeds.toml` and `bubbles.toml`,
+//! never a `Default` impl or a `set_*(false)` at startup — those put it where
+//! it cannot be changed without a build. Today that file opens every flow
+//! layer and holds back only the backfill divider.
 //!
 //! Same store discipline as the indicator state: a versioned TOML next to the
 //! config (override with `QUANTICK_CHART_LAYERS`), read once at startup,
 //! written when a switch flips, temp-file-and-rename so a crash mid-write
-//! cannot leave half a file behind. Anything unreadable is ignored entirely.
+//! cannot leave half a file behind. Anything unreadable falls back to the
+//! shipped default rather than to a half-read file.
 
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
+
+/// What a launch opens with when the trader has no file of their own, shipped
+/// as config rather than decided by a field initialiser: which layers a fresh
+/// chart draws is a product decision someone may want different, and burying
+/// it in a `Default` impl puts it where no one can change it without a build.
+/// Same discipline as `feeds.toml` and `bubbles.toml`.
+const EMBEDDED_DEFAULT: &str = include_str!("../config/chart-layers.toml");
 
 /// Environment override for the layer-visibility file location.
 pub(crate) const LAYERS_ENV: &str = "QUANTICK_CHART_LAYERS";
@@ -396,7 +409,7 @@ pub(crate) fn validate(text: &str) -> Result<(), String> {
 #[must_use]
 pub(crate) fn load(path: &Path) -> BTreeMap<ChartLayer, bool> {
     let Ok(text) = std::fs::read_to_string(path) else {
-        return BTreeMap::new();
+        return shipped_default();
     };
     let stored = match toml::from_str::<LayersFile>(&text) {
         Ok(file) if file.version == FORMAT_VERSION => file.layers,
@@ -407,10 +420,10 @@ pub(crate) fn load(path: &Path) -> BTreeMap<ChartLayer, bool> {
                 event_code = "CHART_LAYERS_VERSION",
                 path = %path.display(),
                 version = file.version,
-                action = "keeping_default_visibility",
+                action = "keeping_shipped_visibility",
                 "chart layer file is from an unknown version"
             );
-            return BTreeMap::new();
+            return shipped_default();
         }
         Err(error) => {
             tracing::warn!(
@@ -419,12 +432,38 @@ pub(crate) fn load(path: &Path) -> BTreeMap<ChartLayer, bool> {
                 event_code = "CHART_LAYERS_UNREADABLE",
                 path = %path.display(),
                 %error,
-                action = "keeping_default_visibility",
+                action = "keeping_shipped_visibility",
                 "chart layer file is unreadable"
             );
-            return BTreeMap::new();
+            return shipped_default();
         }
     };
+    resolve(stored)
+}
+
+/// The built-in opening state, from the config compiled into the binary.
+///
+/// A launch with no file of the trader's own lands here, and so does one whose
+/// file this build cannot read: an unreadable file means "we do not know what
+/// they chose", which is the same question a first launch asks, and answering
+/// it from the shipped file keeps one answer instead of two.
+///
+/// The file is tracked, so a parse failure is a build-time mistake rather than
+/// anything a user did — `the_shipped_default_parses` is what catches it. At
+/// runtime an empty map is the honest fallback: it means "the code decides",
+/// exactly as it did before this file existed.
+fn shipped_default() -> BTreeMap<ChartLayer, bool> {
+    match toml::from_str::<LayersFile>(EMBEDDED_DEFAULT) {
+        Ok(file) if file.version == FORMAT_VERSION => resolve(file.layers),
+        _ => BTreeMap::new(),
+    }
+}
+
+/// Map stored ids onto the layers this build knows and this file owns.
+///
+/// An unknown id is dropped rather than failing the read, so a file written by
+/// a newer build still restores the layers this one has.
+fn resolve(stored: BTreeMap<String, bool>) -> BTreeMap<ChartLayer, bool> {
     stored
         .into_iter()
         .filter_map(|(id, visible)| {
@@ -496,10 +535,52 @@ mod tests {
     }
 
     #[test]
-    fn a_missing_file_changes_nothing() {
+    fn a_missing_file_opens_on_the_shipped_default() {
+        let fresh = load(&temp_dir().join("missing.toml"));
+        assert_eq!(
+            fresh,
+            shipped_default(),
+            "a fresh install opens on the config, not on whatever a struct              initialiser happened to say"
+        );
+        assert!(!fresh.is_empty(), "the shipped file has to reach the app");
+    }
+
+    /// The file is tracked and compiled in, so anything wrong with it is a
+    /// build-time mistake — and one that would otherwise degrade silently into
+    /// "the code decides", which is the state this file exists to end.
+    #[test]
+    fn the_shipped_default_parses_and_opens_the_flow_layers() {
+        let shipped = shipped_default();
+        for layer in [
+            ChartLayer::Heatmap,
+            ChartLayer::Bubbles,
+            ChartLayer::Footprint,
+            ChartLayer::LiveStrip,
+        ] {
+            assert_eq!(
+                shipped.get(&layer),
+                Some(&true),
+                "{} is what the chart is for; a first launch draws it",
+                layer.id()
+            );
+        }
+        assert_eq!(
+            shipped.get(&ChartLayer::BackfillDivider),
+            Some(&false),
+            "the one layer a fresh chart holds back"
+        );
+        // Every layer this file owns is stated, so no reader has to know which
+        // ones fall through to a struct initialiser.
+        for layer in ChartLayer::ALL.into_iter().filter(|l| l.persisted()) {
+            assert!(
+                shipped.contains_key(&layer),
+                "{} has no entry in config/chart-layers.toml",
+                layer.id()
+            );
+        }
         assert!(
-            load(&temp_dir().join("missing.toml")).is_empty(),
-            "a fresh install keeps every layer's own default"
+            !shipped.contains_key(&ChartLayer::LaneMarks),
+            "the preset is the lane marks' only home"
         );
     }
 
@@ -540,10 +621,21 @@ mod tests {
     #[test]
     fn unknown_versions_ids_and_garbage_degrade_instead_of_failing() {
         let path = temp_dir().join("bad-layers.toml");
+        // A file this build cannot read means "we do not know what they
+        // chose" — the same question a first launch asks, so it gets the same
+        // answer rather than a second one.
         std::fs::write(&path, "version = 99\n[layers]\ngrid = false\n").unwrap();
-        assert!(load(&path).is_empty(), "unknown version changes nothing");
+        assert_eq!(
+            load(&path),
+            shipped_default(),
+            "unknown version falls back to the shipped default"
+        );
         std::fs::write(&path, "not even toml [").unwrap();
-        assert!(load(&path).is_empty(), "garbage changes nothing");
+        assert_eq!(
+            load(&path),
+            shipped_default(),
+            "garbage falls back to the shipped default"
+        );
         std::fs::write(
             &path,
             "version = 1\n[layers]\ngrid = false\nfrom_the_future = true\n",

--- a/crates/app/src/chart_layers.rs
+++ b/crates/app/src/chart_layers.rs
@@ -545,6 +545,37 @@ mod tests {
         assert!(!fresh.is_empty(), "the shipped file has to reach the app");
     }
 
+    /// The promise the shipped default is only acceptable because of: it
+    /// decides for someone who has never touched a switch, and stops deciding
+    /// the moment they do. A trader who switched the heatmap off and found it
+    /// back on next launch would have lost the setting to a default, which is
+    /// worse than the bare chart this whole change is about.
+    #[test]
+    fn the_traders_own_choice_outranks_the_shipped_default() {
+        let path = temp_dir().join("trader-choice.toml");
+        assert_eq!(
+            shipped_default().get(&ChartLayer::Heatmap),
+            Some(&true),
+            "the layer has to be one the shipped file opens, or this proves nothing"
+        );
+        // A file with one switch in it, the way it lands after one click.
+        std::fs::write(&path, "version = 1\n[layers]\nheatmap = false\n").unwrap();
+        let loaded = load(&path);
+        assert_eq!(
+            loaded.get(&ChartLayer::Heatmap),
+            Some(&false),
+            "an explicit no stays a no"
+        );
+        // And the shipped answer does not leak in beside it: a layer the
+        // trader's file never mentions is the app's to decide, exactly as it
+        // was before this file existed.
+        assert!(
+            !loaded.contains_key(&ChartLayer::Bubbles),
+            "an absent layer keeps meaning \"whatever the app decided\""
+        );
+        std::fs::remove_file(&path).ok();
+    }
+
     /// The file is tracked and compiled in, so anything wrong with it is a
     /// build-time mistake — and one that would otherwise degrade silently into
     /// "the code decides", which is the state this file exists to end.

--- a/crates/app/src/chart_layers.rs
+++ b/crates/app/src/chart_layers.rs
@@ -403,9 +403,11 @@ pub(crate) fn validate(text: &str) -> Result<(), String> {
     }
 }
 
-/// Load the stored visibility; empty (change nothing) when the file is
-/// missing, unreadable or from an unknown version. Unknown ids are dropped one
-/// by one — a file from a newer build still restores the layers this one has.
+/// Load the stored visibility, falling back to [`shipped_default`] when the
+/// file is missing, unreadable or from an unknown version — all three mean
+/// "we do not know what this trader chose", which is the question a first
+/// launch asks. Unknown ids are dropped one by one, so a file from a newer
+/// build still restores the layers this one has.
 #[must_use]
 pub(crate) fn load(path: &Path) -> BTreeMap<ChartLayer, bool> {
     let Ok(text) = std::fs::read_to_string(path) else {
@@ -540,7 +542,7 @@ mod tests {
         assert_eq!(
             fresh,
             shipped_default(),
-            "a fresh install opens on the config, not on whatever a struct              initialiser happened to say"
+            "a fresh install opens on the config, not on a struct initialiser"
         );
         assert!(!fresh.is_empty(), "the shipped file has to reach the app");
     }

--- a/crates/app/src/orderflow_view.rs
+++ b/crates/app/src/orderflow_view.rs
@@ -315,6 +315,27 @@ impl OrderflowView {
         self.config.lane_depth_visible()
     }
 
+    /// The candles' depth switch alone, whatever capture lets through it.
+    ///
+    /// [`Self::depth_visible`] answers "is it drawn", which is what a renderer
+    /// needs; this answers "did anyone ask for it", which is what persistence
+    /// needs. On a source with no book the map is undrawn however the switch
+    /// stands, and writing that down as the trader's answer would turn a
+    /// capability into a choice they never made — and one that then outranks
+    /// the shipped default on every market, including the ones with a book.
+    /// The same rule [`Self::set_depth_visible`] already compares against.
+    #[must_use]
+    pub fn depth_switched_on(&self) -> bool {
+        self.config.show_depth
+    }
+
+    /// The tape's depth switch alone. Twin of [`Self::depth_switched_on`],
+    /// same rule and the same reason.
+    #[must_use]
+    pub fn lane_depth_switched_on(&self) -> bool {
+        self.config.live_lane.show_depth
+    }
+
     /// Show or hide the depth map on the tape alone. Capture is untouched, and
     /// so are the candles.
     pub fn set_lane_depth_visible(&mut self, visible: bool) {

--- a/crates/app/src/pane.rs
+++ b/crates/app/src/pane.rs
@@ -893,8 +893,10 @@ pub struct ChartPane {
     /// Whether the user wants the live strip shown. The pixels it actually
     /// gets are still capability-gated — see [`Self::live_strip_width`].
     pub live_strip_visible: bool,
-    /// Whether the candle footprint layer is on. Off by default: today's
-    /// rendering is pixel-identical until the user asks for the ladder.
+    /// Whether the candle footprint layer is on. What a fresh launch opens
+    /// with is `config/chart-layers.toml`, not this initialiser — see
+    /// [`crate::chart_layers`]; the ladder still follows the zoom's LOD, so it
+    /// draws nothing where the candle is too narrow to read.
     pub footprint_visible: bool,
     /// This chart's own footprint setup, once it has been configured here.
     ///
@@ -1552,7 +1554,27 @@ impl ChartPane {
         }
     }
 
-    /// Every layer this pane persists, and whether it is on.
+    /// The same layers as [`Self::layer_visible`], reporting the *switch*
+    /// rather than what the source lets through it.
+    ///
+    /// Only the two depth layers differ, and only because their "is it drawn"
+    /// answer folds in book capture: on a source with no book they read
+    /// undrawn however the switch stands. That is the right answer for a
+    /// renderer and the wrong one for a file — persisting it would record a
+    /// capability as the trader's choice, and their file outranks the shipped
+    /// default on every market from then on, including the ones that do have a
+    /// book. The setters already compare against the switch for this exact
+    /// reason (`OrderflowView::set_depth_visible`); this is the reading half.
+    pub fn layer_switched_on(&self, layer: ChartLayer, style: &ChartStyle) -> bool {
+        let tape = self.orderflow.as_ref();
+        match layer {
+            ChartLayer::Heatmap => tape.is_some_and(OrderflowView::depth_switched_on),
+            ChartLayer::TapeHeatmap => tape.is_some_and(OrderflowView::lane_depth_switched_on),
+            other => self.layer_visible(other, style),
+        }
+    }
+
+    /// Every layer this pane persists, and whether it is switched on.
     ///
     /// `style` comes from the window for the same reason it does in
     /// [`Self::layer_visible`].
@@ -1560,7 +1582,7 @@ impl ChartPane {
         ChartLayer::ALL
             .into_iter()
             .filter(|layer| layer.persisted())
-            .map(|layer| (layer, self.layer_visible(layer, style)))
+            .map(|layer| (layer, self.layer_switched_on(layer, style)))
             .collect()
     }
 
@@ -1576,7 +1598,7 @@ impl ChartPane {
         ChartLayer::ALL
             .into_iter()
             .enumerate()
-            .filter(|(_, layer)| layer.persisted() && self.layer_visible(*layer, style))
+            .filter(|(_, layer)| layer.persisted() && self.layer_switched_on(*layer, style))
             .fold(0_u32, |mask, (bit, _)| mask | (1 << bit))
     }
 

--- a/crates/app/src/pane.rs
+++ b/crates/app/src/pane.rs
@@ -1530,6 +1530,15 @@ impl ChartPane {
                 .then_some("this source quotes prices but prints no traded volume"),
             ChartLayer::Heatmap | ChartLayer::DepthGaps => (!capabilities.book_capture)
                 .then_some("order-book capture is not available for this source"),
+            // The strip draws the book and the aggressions landing into it, so
+            // it takes either one and is empty only without both. Disabled
+            // with the reason rather than offered as a switch that would
+            // reserve width for a blank band.
+            ChartLayer::LiveStrip => (!capabilities.book_capture && !capabilities.traded_volume)
+                .then_some(
+                    "this source publishes neither an order book nor traded volume, \
+                     so the strip would have nothing to draw",
+                ),
             // The badge reports on the book feed, so a source with no book has
             // nothing for it to say — and it is drawn with the map, so while
             // the map is hidden the switch would tick a box that draws
@@ -2511,8 +2520,20 @@ impl ChartPane {
     /// source provides (replay included), and without book data the strip
     /// honestly degrades to that histogram alone. A pane with no tape has no
     /// strip at all (§11).
-    pub fn live_strip_width(&self) -> f32 {
-        if self.live_strip_visible && self.orderflow.is_some() {
+    pub fn live_strip_width(&self, capabilities: FeedCapabilities) -> f32 {
+        // Both halves of the strip come from the source: resting depth and the
+        // aggressions landing into it. A source that produces neither fills
+        // none of it, so the band would be an empty rect permanently narrowing
+        // the candles — which is what the shipped default made reachable, the
+        // layer having opened off until now. The claim that these pixels were
+        // capability-gated predates the gate by some months; this is it.
+        //
+        // Passed in rather than cached on the pane for the reason
+        // `layer_blocked` states: the running feed is resolved once per frame
+        // by the caller, and a copy kept here would be one more thing to keep
+        // in step when MetaTrader narrows its capabilities mid-session.
+        let source_fills_it = capabilities.book_capture || capabilities.traded_volume;
+        if self.live_strip_visible && self.orderflow.is_some() && source_fills_it {
             crate::live_strip::LIVE_STRIP_WIDTH_PX
         } else {
             0.0
@@ -2521,11 +2542,11 @@ impl ChartPane {
 
     /// This pane's regions inside `area`, carved once so the input handler and
     /// the renderer can never disagree about a boundary.
-    fn plot_areas(&self, area: egui::Rect) -> PlotAreas {
+    fn plot_areas(&self, area: egui::Rect, capabilities: FeedCapabilities) -> PlotAreas {
         let mut sizing = [PaneSizing::Auto; crate::indicators::MAX_PANES];
         plot_split(
             area,
-            self.live_strip_width(),
+            self.live_strip_width(capabilities),
             self.indicators.pane_sizing(&mut sizing),
         )
     }
@@ -3835,7 +3856,7 @@ impl ChartPane {
         // Remembered for inspector placement and manager centring: the pane
         // where drawings live, already free of both axes and the live lane.
         self.last_plot_area = Some(area);
-        let areas = self.plot_areas(area);
+        let areas = self.plot_areas(area, chrome.capabilities);
         self.last_chart_area = Some(areas.chart);
         // One carve, consumed by placement, hit-testing, dragging and — after
         // the panes have drawn — painting.
@@ -4815,7 +4836,7 @@ impl ChartPane {
                 }
             }
         }
-        let areas = self.plot_areas(area);
+        let areas = self.plot_areas(area, chrome.capabilities);
         // Indicator panes claimed the bottom band inside `plot_split`, so the
         // rect the candles scale to is the same one the input handler uses.
         let chart_rect = areas.chart;
@@ -7537,7 +7558,7 @@ mod tests {
     }
 
     fn test_areas(pane: &ChartPane, rect: egui::Rect) -> PlotAreas {
-        pane.plot_areas(rect)
+        pane.plot_areas(rect, crate::config::FeedCapabilities::none())
     }
 
     const TEST_PLOT: egui::Rect = egui::Rect {


### PR DESCRIPTION
A fresh install drew bare candles. The L2 heatmap, the aggression bubbles, the footprint and the live strip all opened off, so the layers this chart exists for were invisible until someone found the right-click menu — a new user met an ordinary candlestick chart and had no reason to think otherwise.

Two things were wrong, and the second is the one that made this bigger than a flag flip.

**The layers opened off**, and **where that was decided**: a `set_depth_visible(false)` at startup, a `show_aggressions: false` in a `Default` impl, two `false` field initialisers in `ChartPane::new`. Opening state is a product decision someone may want different, and none of those four places can be changed without a build.

So it moves to `crates/app/config/chart-layers.toml`, compiled in with `include_str!` beside `feeds.toml` and `bubbles.toml`, read whenever the trader has no file of their own. Every flow layer opens on there; only the backfill divider is held back, and `lane_marks` stays absent because the order-flow preset is its only home.

The trader's own file still wins from the moment they touch a switch, so this changes nothing for anyone who has already made the choice.

## What the review turned up

`step 0: code-review at high, 9 findings, 6 confirmed`

The first two were confirmed against the code and fixed here — one of them defeated the branch outright.

**`layer_states` persisted the drawn state, not the switch** (`pane.rs`). `layer_visible(Heatmap)` is `enabled && show_depth`, so on a source with no book — a recording, a CFD bridge, an MT5 symbol with no depth — the map reads undrawn however the switch stands. `maintain_chart_layers` writes the whole map on any mask change, so one unrelated click during such a session banked `heatmap = false`. From the next launch that file outranks the shipped default **on every market**, including the ones that do have a book: the config that just turned the flow layers on would have quietly turned itself back off, for a choice nobody made. `layer_switched_on` is the reading half of a rule the setters already followed. It also stops the file materialising on its own when a tab's capabilities widen mid-session.

**The live strip reserved width nothing could fill** (`pane.rs`). `live_strip_width` never consulted `FeedCapabilities` and `layer_blocked` had no `LiveStrip` arm — harmless while the layer opened off, which is why two comments could claim the pixels were "capability-gated either way" with nothing backing them. The shipped default is what made it reachable.

### Deferred, with reasons

Both are pre-existing state-propagation bugs this branch makes visible rather than causes. Neither is on the path this PR changes, and folding either in would mix an unrelated subsystem into a review that is already three fixes deep.

- **A time pane never receives the `footprint = true` default** (`tab.rs`). `apply_pending_layout` copies `hidden_layers` but not `footprint_visible`, and `apply_layer_defaults` runs before any time pane exists. A split layout opens with the footprint on in the flow pane and off in the time pane, contradicting that function's own comment.
- **Workspace import now resets in-session layers** (`app.rs`). `reload_cockpit_stores` → `restore_chart_layers` → `load`; a bundle with no chart-layers section used to leave the session's layers alone via the empty-map early return, and now gets the shipped defaults instead.

One review finding is **not accepted**: that `app_with_history` pinning the strip off leaves the shipped geometry untested under pointer input. It is a real gap, but the alternative is 18 drawing and inspector tests asserting hard-coded pointer coordinates against a canvas whose width depends on a layer default — a collision about layout, not about what those tests assert. `each_layer_switch_moves_exactly_one_owner` reads the shipped answer; pointer-level coverage of the strip's hit-testing belongs to a test written for that, not to eighteen tests written for something else.

## Verification

Four checks green. `quantick-feed-mt5 --test bridge_paging` fails locally on Windows only: it tries `python3` first, which resolves to the Microsoft Store alias stub (exit 49), and the `INTERPRETERS` loop reads that as "found and failed" instead of falling through to `python`. The Python tests themselves pass (18 checks) when invoked directly, and CI's ubuntu image has a real `python3`. Untouched by this branch — worth its own fix.

Driven on a live Binance BTCUSDT session as a fresh install, every store pointed at scratch: `CHART_LAYERS_RESTORED hidden=1`, heatmap 1241 cells, 473 aggressions, fps 59-60, `frame_avg` 16.7 ms, heatmap projection 0.4-0.8 ms/frame.

**Performance.** The heatmap projection and the bubble pass now run on a fresh launch where they used to be skipped — a real cost at ~60 Hz, declared above and paid deliberately. Measured on Binance L2; a denser book would cost more, and a dense-book capture is the measurement that would settle the ceiling. The layer menu is where a trader gives the cost back.

**Proof.** `the_shipped_default_parses_and_opens_the_flow_layers`, `the_traders_own_choice_outranks_the_shipped_default`, `a_source_with_no_book_never_banks_the_heatmap_as_switched_off` (fails on the old reader with `left: Some(false), right: Some(true)`), `a_source_that_fills_neither_half_gets_no_live_strip`.

`arch-review` dimension 3 gains the rule that would have caught the original shape: opening state is config, not a field initialiser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R6Rfr3FrLvQgDTg21noZAL
