### PR TITLE
fix(app): the annotate tier takes back its own slot, not the trader's

### DIFF
--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -882,8 +882,11 @@ pub struct QuantickApp {
     /// first frame, through the panel button's own `enable`.
     pending_control_access_enable: bool,
     /// The indicator slots an operator other than the trader attached — the
-    /// only ones the annotate tier may take back off the chart.
-    operator_slots: std::collections::BTreeSet<u64>,
+    /// only ones the annotate tier may take back off the chart. Keyed by the
+    /// whole [`TabSlot`]: a slot number is allocated per pane and is reused
+    /// by every other pane, so the number alone would mark one tab's slot 0
+    /// as an operator's because another tab's slot 0 was.
+    operator_slots: std::collections::BTreeSet<TabSlot>,
     /// The `QUANTICK_CONTROL_ANNOTATE` hook: an agent-authored label on the
     /// first frame, so every attribution surface can be photographed.
     pending_control_annotation: Option<String>,
@@ -1200,7 +1203,7 @@ struct InspectorEdit {
 /// Slot ids are allocated per pane, so the id alone identifies nothing once
 /// there are two panes, let alone two tabs: without the rest, removing one
 /// tab's slot 0 would drop another's bookkeeping for its own.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 struct TabSlot {
     tab: u64,
     side: PaneSide,
@@ -2272,7 +2275,7 @@ impl QuantickApp {
         // Whose slot this is decides who may take it away again: the annotate
         // tier removes what it attached, never what the trader put there.
         if by_operator {
-            self.operator_slots.insert(slot.0);
+            self.operator_slots.insert(owner);
         }
         self.mark_indicator_state_dirty();
         (owner.tab, owner.side.into(), slot)
@@ -2285,19 +2288,29 @@ impl QuantickApp {
     /// takes back its own, and never removes work done by hand (plan §2.6).
     /// `Ok(false)` when there is no such slot at all.
     pub(crate) fn detach_script_indicator(&mut self, slot: u64) -> Result<bool, ()> {
-        let Some(target) = self
-            .slot_kinds
-            .iter()
-            .map(|(owner, _)| *owner)
-            .find(|owner| owner.slot.0 == slot)
-        else {
-            return Ok(false);
-        };
-        if !self.operator_slots.contains(&slot) {
-            return Err(());
+        // A slot number is allocated per pane, so several panes can carry the
+        // same one: the operator's own is the one to take, and matching on the
+        // number alone would remove whichever pane happened to be registered
+        // first — the trader's, as often as not.
+        let mut known = false;
+        let mut target = None;
+        for (owner, _) in &self.slot_kinds {
+            if owner.slot.0 != slot {
+                continue;
+            }
+            known = true;
+            if self.operator_slots.contains(owner) {
+                target = Some(*owner);
+                break;
+            }
         }
+        let Some(target) = target else {
+            // A slot that exists but belongs to the trader is refused; one
+            // that exists nowhere simply was not there.
+            return if known { Err(()) } else { Ok(false) };
+        };
         self.remove_indicator_at(target);
-        self.operator_slots.remove(&slot);
+        self.operator_slots.remove(&target);
         Ok(true)
     }
 
@@ -2743,6 +2756,7 @@ impl QuantickApp {
         // Its slots are gone with its panes; the bookkeeping must not outlive
         // them or a later tab reusing a slot number would inherit its kind.
         self.slot_kinds.retain(|(owner, _)| owner.tab != closed.id);
+        self.operator_slots.retain(|owner| owner.tab != closed.id);
         self.script_files
             .retain(|(owner, ..)| owner.tab != closed.id);
         if self.persisted_tab == Some(closed.id) {
@@ -3124,6 +3138,7 @@ impl QuantickApp {
         pane.indicator_worker
             .send(IndicatorCommand::Remove(target.slot));
         self.slot_kinds.retain(|(owner, _)| *owner != target);
+        self.operator_slots.remove(&target);
         self.script_files.retain(|(owner, ..)| *owner != target);
         self.mark_indicator_state_dirty();
     }
@@ -4700,6 +4715,7 @@ impl QuantickApp {
             }
         }
         self.slot_kinds.clear();
+        self.operator_slots.clear();
         self.script_files.clear();
         self.pending_hidden.clear();
         self.pending_styles.clear();
@@ -26884,6 +26900,104 @@ plot(close)
                 1,
                 crate::control::ActionOrigin::Human,
                 serde_json::json!({ "slot_id": mine.0.to_string() }),
+            )
+            .expect_err("the trader's own indicator is not this tier's to remove");
+        assert_eq!(refused.code.as_str(), codes::PERMISSION_DENIED);
+        assert_eq!(
+            indicator_kinds(&app).len(),
+            1,
+            "and it is still on the pane"
+        );
+    }
+
+    /// The regression the slot-identity fix exists for: slot numbers are
+    /// allocated per pane, so the trader's chart and an operator's second
+    /// chart both hold a slot 0. Keyed by the number alone, the operator's
+    /// detach walked `slot_kinds` and took whichever slot 0 was registered
+    /// first — the trader's.
+    #[test]
+    fn an_operator_detaching_its_own_slot_leaves_the_traders_slot_of_the_same_number() {
+        use quantick_control::error::codes;
+
+        const SCRIPT: &str = "//@version=5
+indicator(\"probe\")
+plot(close)
+";
+
+        let ctx = egui::Context::default();
+        let (mut app, _commands) = app_with_history(4);
+        run_frame(&mut app, &ctx);
+
+        // The trader's own, on the tab that is already open.
+        let (traders_tab, _, traders_slot) =
+            app.attach_script_indicator("the trader's".to_owned(), SCRIPT.to_owned(), false);
+        for _ in 0..200 {
+            run_frame(&mut app, &ctx);
+            if !indicator_kinds(&app).is_empty() {
+                break;
+            }
+        }
+
+        // A second chart, whose slot numbering starts over from zero.
+        app.open_tab("binance".to_owned(), "ETHUSDT".to_owned(), None);
+        run_frame(&mut app, &ctx);
+        let (operators_tab, _, operators_slot) =
+            app.attach_script_indicator("an assistant's".to_owned(), SCRIPT.to_owned(), true);
+        for _ in 0..200 {
+            run_frame(&mut app, &ctx);
+            if !indicator_kinds(&app).is_empty() {
+                break;
+            }
+        }
+        assert_ne!(traders_tab, operators_tab, "two charts, not one");
+        assert_eq!(
+            traders_slot.0, operators_slot.0,
+            "the numbering starts over per pane, which is what made the bug reachable"
+        );
+
+        // The operator takes back its own. The trader's, wearing the same
+        // number on another chart, must still be there afterwards.
+        assert!(
+            app.control_action(
+                "indicator.script.detach",
+                1,
+                crate::control::ActionOrigin::Human,
+                serde_json::json!({ "slot_id": operators_slot.0.to_string() }),
+            )
+            .is_ok(),
+            "an operator may take back what it attached"
+        );
+        run_frame(&mut app, &ctx);
+        assert!(
+            indicator_kinds(&app).is_empty(),
+            "the assistant's is off its own chart"
+        );
+
+        let traders_index = app
+            .control_tabs()
+            .iter()
+            .position(|tab| tab.id == traders_tab)
+            .expect("the trader's chart is still open");
+        assert_eq!(
+            app.control_tabs()[traders_index]
+                .focused_pane()
+                .indicators
+                .all()
+                .len(),
+            1,
+            "and the trader's, sharing only a number with it, was never touched"
+        );
+
+        // With its own claim spent, the same number now names only the
+        // trader's slot, and the tier refuses it rather than reaching across.
+        app.active_tab = traders_index;
+        run_frame(&mut app, &ctx);
+        let refused = app
+            .control_action(
+                "indicator.script.detach",
+                1,
+                crate::control::ActionOrigin::Human,
+                serde_json::json!({ "slot_id": traders_slot.0.to_string() }),
             )
             .expect_err("the trader's own indicator is not this tier's to remove");
         assert_eq!(refused.code.as_str(), codes::PERMISSION_DENIED);

--- a/crates/app/src/control/annotate.rs
+++ b/crates/app/src/control/annotate.rs
@@ -361,10 +361,10 @@ fn place(
     };
     // The look a fresh object opens with is read before the pane is borrowed
     // mutably, through the app's own door: an annotation looks like what the
-    // trader would have drawn.
-    let mut fresh: Vec<drawings::NewDrawing> = (0..required)
-        .map(|_| app.control_new_drawing(tool))
-        .collect();
+    // trader would have drawn. One is enough for the whole placement —
+    // `place_with` asks for the opening only when it installs the draft, so
+    // the second anchor of an arrow or a zone never calls for another.
+    let mut fresh = Some(app.control_new_drawing(tool));
     let pane = control_pane_mut(app, tab_id, pane_side)?;
     let pane_id = pane.id;
     // The trader is mid-gesture: `place_with` would push this call's anchor
@@ -399,10 +399,11 @@ fn place(
 
     let mut completed = false;
     for point in points {
-        let opening = fresh.pop().expect("one opening look per anchor");
         completed = pane
             .drawings
-            .place_with(tool, &DrawingBand::Price, point, |_| opening);
+            .place_with(tool, &DrawingBand::Price, point, |_| {
+                fresh.take().expect("one opening look per placement")
+            });
     }
     if !completed {
         // The anchors that did land are sitting in a draft nobody owns. Left

--- a/crates/app/src/control/gateway.rs
+++ b/crates/app/src/control/gateway.rs
@@ -1255,6 +1255,14 @@ impl ControlAccess {
         granted.insert(
             PermissionId::new(OBSERVE_PERMISSION_ID).expect("static permission ID is valid"),
         );
+        // The annotate tier's own floor, for the same reason: every annotate
+        // capability requires it, so `annotate.chart` on its own would raise
+        // the ceiling to `annotator` and then refuse every call made with it.
+        if granted.iter().any(is_annotate_scope) {
+            granted.insert(
+                PermissionId::new(ANNOTATE_PERMISSION_ID).expect("static permission ID is valid"),
+            );
+        }
         self.configured_scopes = granted;
         Ok(())
     }
@@ -1267,8 +1275,15 @@ impl ControlAccess {
     /// one question that decides whether a client may answer on the chart.
     pub(crate) fn grants_annotate(&self) -> bool {
         // The floor on its own opens nothing, so it never makes the status
-        // line claim the window can be answered on.
+        // line claim the window can be answered on — and a scope without the
+        // floor opens nothing either, because every annotate capability
+        // requires both. Claiming otherwise would put "answering on the
+        // chart" on the panel over a connection that is refused every time.
         self.configured_scopes.iter().any(is_annotate_scope)
+            && self
+                .configured_scopes
+                .iter()
+                .any(|permission| permission.as_str() == ANNOTATE_PERMISSION_ID)
     }
 
     /// The ceiling every connection of the next run is capped at. It follows
@@ -1592,10 +1607,12 @@ impl ControlAccess {
                     );
                     self.state = AccessState::Enabled(runtime);
                 }
-                LifecycleEvent::Started { runtime, .. } => {
-                    runtime.request_shutdown();
-                    self.state = AccessState::Disabling(Some(runtime));
-                }
+                // A gateway of a generation this run has moved past: shut it
+                // down and let it go. Overwriting the state here would throw
+                // away the runtime — or the pending enable — that replaced it,
+                // and an enable/disable/enable in quick succession would leave
+                // access off with no way back short of another enable.
+                LifecycleEvent::Started { runtime, .. } => runtime.request_shutdown(),
                 LifecycleEvent::Failed {
                     generation,
                     message,
@@ -1619,7 +1636,22 @@ impl ControlAccess {
                 LifecycleEvent::Failed { .. } => {}
                 LifecycleEvent::Stopped { generation } => {
                     let expected = matches!(self.state, AccessState::Disabling(_));
-                    if generation <= self.grant_generation {
+                    // Only the gateway this state actually holds may end it.
+                    // `request_disable` bumps the generation before the run it
+                    // is stopping reports back, so a `Disabling` state accepts
+                    // the stop it asked for; every other generation is an
+                    // older run finishing its own cleanup and must not turn
+                    // off the one that replaced it.
+                    let held = match &self.state {
+                        AccessState::Enabled(runtime) | AccessState::Disabling(Some(runtime)) => {
+                            Some(runtime.grant_generation)
+                        }
+                        AccessState::Disabled
+                        | AccessState::Enabling
+                        | AccessState::Disabling(None) => None,
+                    };
+                    let ours = held.map_or(expected, |held| held == generation);
+                    if ours {
                         self.active_cancellation = None;
                         self.connections.clear();
                         self.revoked_connections.clear();
@@ -2113,7 +2145,10 @@ fn waiter_manager(
             .unwrap_or(Duration::from_millis(WAITER_POLL_MS))
             .min(Duration::from_millis(WAITER_POLL_MS));
         crossbeam_channel::select! {
-            recv(ticks) -> _ => {}
+            // A disconnected receiver is *always* ready: without this the
+            // journal going away would spin this thread at full speed
+            // instead of ending it.
+            recv(ticks) -> tick => if tick.is_err() { break },
             recv(park) -> waiter => match waiter {
                 Ok(waiter) => waiters.push(waiter),
                 Err(_) => break,
@@ -2175,6 +2210,9 @@ fn accept_loop(
     let mut sockets = BTreeMap::<u64, TrackedSocket>::new();
     let mut next_socket_key = 1u64;
     let mut shutdown = false;
+    // Capacity rejections answer off this thread; this counts the ones still
+    // in flight so a reconnect loop cannot spawn threads without bound.
+    let rejecting = Arc::new(AtomicUsize::new(0));
     while !shutdown && !authority.cancellation.load(Ordering::Acquire) {
         loop {
             match commands.try_recv() {
@@ -2227,11 +2265,25 @@ fn accept_loop(
                     if sockets.len() >= authority.options.max_connections {
                         // Off the accept thread: the rejection reads the
                         // client's handshake first (see the function), which
-                        // may wait up to the handshake timeout.
+                        // may wait up to the handshake timeout. Bounded, for
+                        // the same reason the connections are: a peer that
+                        // reconnects in a loop would otherwise spawn a thread
+                        // per attempt, each living to the handshake timeout.
+                        if !try_reserve_in_flight(&rejecting, authority.options.max_connections) {
+                            let _ = stream.shutdown(Shutdown::Both);
+                            continue;
+                        }
                         let options = authority.options.clone();
-                        let _ = thread::Builder::new()
+                        let in_flight = Arc::clone(&rejecting);
+                        let spawned = thread::Builder::new()
                             .name("quantick-control-reject".to_owned())
-                            .spawn(move || reject_connection_capacity(stream, &options));
+                            .spawn(move || {
+                                reject_connection_capacity(stream, &options);
+                                in_flight.fetch_sub(1, Ordering::AcqRel);
+                            });
+                        if spawned.is_err() {
+                            rejecting.fetch_sub(1, Ordering::AcqRel);
+                        }
                         continue;
                     }
                     let Some(next_socket_key_value) = next_socket_key.checked_add(1) else {
@@ -3153,7 +3205,13 @@ fn send_response(
     let mut stream = writer
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
-    let _ = stream.write_all(&frame);
+    // A write that fails part-way has already put a truncated frame on the
+    // wire: every byte after it would be read as that frame's payload. The
+    // connection cannot be recovered, so it is closed rather than left
+    // writing garbage the client will parse as answers.
+    if stream.write_all(&frame).is_err() {
+        let _ = stream.shutdown(Shutdown::Both);
+    }
 }
 
 fn random_bytes<const N: usize>() -> Result<[u8; N], String> {
@@ -3173,6 +3231,43 @@ mod tests {
             std::process::id(),
             NEXT_DIRECTORY.fetch_add(1, Ordering::Relaxed)
         ))
+    }
+
+    /// The panel may not promise what the contract will refuse.
+    ///
+    /// Every annotate capability requires the `annotate` floor *and* its own
+    /// scope. Granting a scope alone used to raise the ceiling to `annotator`
+    /// and put "answering on the chart" on the status line over a connection
+    /// that was then denied every call it made.
+    #[test]
+    fn granting_an_annotate_scope_grants_the_floor_every_capability_also_needs() {
+        let mut access = ControlAccess::new();
+        access
+            .configure_scopes("all-reads,annotate.chart")
+            .expect("the test grants registered scopes");
+
+        assert!(
+            access.grants_annotate(),
+            "the panel says the window can be answered on"
+        );
+        assert!(
+            access
+                .configured_scopes
+                .iter()
+                .any(|permission| permission.as_str() == ANNOTATE_PERMISSION_ID),
+            "so the floor every annotate capability requires has to be there too"
+        );
+
+        // The contrast: the floor on its own opens nothing, so it must not
+        // make the status line claim the window can be answered on.
+        let mut floor_only = ControlAccess::new();
+        floor_only
+            .configure_scopes("all-reads,annotate")
+            .expect("the test grants registered scopes");
+        assert!(
+            !floor_only.grants_annotate(),
+            "a floor with no scope under it answers on nothing"
+        );
     }
 
     #[test]

--- a/crates/app/src/feed/replay.rs
+++ b/crates/app/src/feed/replay.rs
@@ -533,9 +533,14 @@ fn play(
                 if !apply(control, &mut playhead, trades, &tx, &session) {
                     return;
                 }
-                // A restart or a seek: readers that sample once per frame
-                // learn of it even when the rerun has already advanced past
-                // their last sample, and where it began.
+                // The new position first, the rewind count after it. A reader
+                // that samples between the two must never see the count move
+                // while the position is still the pre-seek one: it would
+                // rewind its walk and then replay everything up to where the
+                // playhead *used* to be, all in one frame. This order can
+                // only be seen the other way round, which the reader's own
+                // "the position went backwards" check already handles.
+                status.publish(&playhead);
                 status.note_rewind(playhead.position_ms());
             }
             reported_finished = false;

--- a/crates/app/src/pane.rs
+++ b/crates/app/src/pane.rs
@@ -160,7 +160,7 @@ fn draw_dashed_vertical(
 ///
 /// Named for where they sit in the split, because that is how the user picks
 /// one: the time pane is on the left, the flow pane on the right.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
 pub enum PaneSide {
     #[default]
     Flow,


### PR DESCRIPTION
## Summary

A `code-review` at `xhigh` over the merged control-plane stack (#233) returned 14 findings. **Eight are fixed here; six are reported below without a patch**, each with the reason it needs a decision rather than an edit.

The first one is why this is not a cleanup PR.

## The one that breaks a promise

`operator_slots` records which indicator slots an assistant attached — the only ones the annotate tier may take back. It was keyed by the **bare slot number**. Slot numbers are allocated *per pane*, so every chart has a slot 0.

```rust
// before
if !self.operator_slots.contains(&slot) { return Err(()); }
let target = self.slot_kinds.iter().find(|owner| owner.slot.0 == slot);
```

With the trader's script on one chart and an assistant's on another, the assistant taking back its own found the trader's `TabSlot` first and removed **that** — leaving its own on the chart. Plan §2.6's rule for the annotate tier is that nothing in it can discard work the trader did by hand; this discarded it.

`TabSlot` already carried the full identity, and its own doc comment already said so:

> Slot ids are allocated per pane, so the id alone identifies nothing once there are two panes, let alone two tabs.

The set is now keyed by `TabSlot`. A number that matches only the trader's slot is refused (`Err`); one that matches nothing is `Ok(false)`; the claim is dropped in `remove_indicator_at`, on tab close and in `clear_indicators`.

`an_operator_detaching_its_own_slot_leaves_the_traders_slot_of_the_same_number` opens two charts, attaches on each, and detaches the operator's. Reverting only the lookup makes it fail with `and the trader's, sharing only a number with it, was never touched: left 0, right 1` — the trader's indicator gone.

## The rest of the fixes

| Fix | What went wrong |
| --- | --- |
| `send_response` closes on a failed write | A failed `write_all` was swallowed, leaving a truncated frame on a connection that stayed open — every later response then read against the wrong offsets. Silent desynchronisation instead of a closed socket. |
| `poll_lifecycle` matches the runtime it holds | A superseded gateway generation reporting `Started` put a live one into `Disabling`; a superseded `Stopped` cleared connections and told the panel "stopped unexpectedly" while the current gateway was still bound and serving. |
| The `annotate` floor follows its scopes | Granting `annotate.chart` alone raised the ceiling to `annotator`, put "answering on the chart" on the panel and listed the tools — then the contract refused every call, because each capability requires the floor too. `configure_scopes` adds it; `grants_annotate` requires both. |
| Rejection threads are bounded | Once the connection cap was full, `accept_loop` spawned one thread per attempt, each parked for the handshake timeout — exhausting the resource the cap exists to protect. |
| `waiter_manager` stops instead of spinning | A disconnected tick channel is permanently ready with `Err`; the arm ignored it and spun a core. |
| Playhead published before the rewind count | A frame sampling between the two saw the new rewind count with the old position and could re-inject a whole control trace at once. |
| One `NewDrawing` per placement | `place` built one per anchor and dropped all but one on the application thread, inside the 250 µs control budget. |

## Reported, not fixed

Each of these needs a call rather than an edit; the finding is recorded so the next change in the area picks it up.

1. **Annotate, notify and script actions dock with `register`, not `register_resolved`.** Their inputs read live state at call time (`resolve_target` picks the active tab's drawing pane; `attach` uses `focused_pane_mut()`), so a control trace does not reproduce the session: replayed against a different active tab, a label lands on the wrong chart. This is the gap [roadmap §3](docs/control-plane/roadmap.md) recorded against #223 — PR 5b added the `resolve` step and gave it only to the mark. Fixing it means new `ActionResolver`s and a canonical input schema per action; it touches the determinism guarantee, so it belongs in a change of its own.
2. **The notification budget is keyed by `connection_id`,** which is minted fresh per handshake, so a client resets its rate limit by reconnecting. Needs a decision on what durable identity to key on — `client_name` is self-declared.
3. **`TraceReplay::load` returns `Err` on the first malformed line,** so a sidecar truncated by a kill loses `max_sequence` and the next run reuses sequence numbers. The fix trades against the deliberate "a malformed sidecar is not a fixture" semantics.
4. **`ChartBarPage` re-implements `quantick_control::cursor::Page<T>`** to attach a schemars length bound, duplicating `Page::new`'s invariants by hand.
5. **`actor_kind_name` hand-rolls `ActorKind`'s serde representation,** so the wire name and the plain-text name can drift; the mapping belongs on `ActorKind` beside its `Serialize` impl.
6. **`current_windows_token_owner_sid` duplicates ~50 lines of unsafe FFI** from `current_windows_user_sid`, differing only in the information class and the SID offset — a fix to one has to be made twice in security-critical code.

4–6 all reach into `quantick-control` or `control-local`, outside the lines this review changed.

## Rate class

Nothing here is per trade or per depth. The frame loop is touched in two places, both of which do *less* than before: `annotate::place` builds one draft instead of two (per gesture, not per frame), and `waiter_manager` stops instead of spinning a core. `detach_script_indicator` and the lifecycle poll are per action and per enable/disable. `send_response` is per response, on a gateway thread.

## Tests

| Finding | Test |
| --- | --- |
| Slot identity | `an_operator_detaching_its_own_slot_leaves_the_traders_slot_of_the_same_number` — verified to fail with the old lookup restored |
| Annotate floor | `granting_an_annotate_scope_grants_the_floor_every_capability_also_needs`, with the contrast that the floor alone still opens nothing |

**The other six fixes ship without a test, and that is a gap, not an omission I am hiding.** They live in thread lifecycle (a superseded generation reporting in), socket failure (a peer that stops reading mid-frame), thread-spawn bounds under connection pressure, and a publish-ordering race — each needs a harness that can drive a gateway thread to a chosen interleaving, which does not exist today. Building it is worth its own change; naming what is unproven is the minimum owed in the meantime.

## Verification

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo build --workspace`, `cargo test --workspace --no-fail-fast` — green.

`--no-fail-fast` matters here: `cargo test --workspace` stops at the first failing binary, and `the_bridge_paging_tests_pass` fails on this machine for an environmental reason (the Windows `python3` Store alias — it fails identically on `origin/main`, and the 18 bridge checks pass when `bridge/mt5/tests/test_paging.py` runs directly). Without the flag every crate after `quantick-feed-mt5` is silently skipped.

**Scope note.** This review was launched against the working tree and resolved its range to `git diff HEAD~1` — the #233 merge — rather than to any branch under development. The findings are therefore about code already on `main`, which is why this is a follow-up PR rather than a correction to an open one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G9uSzETFU69SRSgCkqu9Jk
