### PR TITLE
fix(app): let the shipped layers reach the trader

### DIFF
--- a/.claude/GOAL-archive-first-run-cockpit.md
+++ b/.claude/GOAL-archive-first-run-cockpit.md
@@ -1,0 +1,96 @@
+# Mission: the first launch opens the cockpit the chart is for
+
+**Objective:** on a machine with no saved cockpit, quantick's first launch opens
+on Binance **BTCUSDT** in the **timeframe + flow** split with all four flow-layer
+switches — bubbles, L2 heatmap, footprint, live strip — **on**; every later
+launch keeps them on unless the trader switched one off; and the window the
+trader actually works in shows them at all.
+
+Branch: `fix/first-run-cockpit` · Worktree: `../quantick-worktrees/fix-first-run-cockpit`
+
+## What the reproduction changed about this mission
+
+The three settings asked for were **already the shipped answer** — `feeds.toml`
+has `default_symbol = "BTCUSDT"` and `default_layout = "time+flow"`, and PR #229
+put all four flow layers in `config/chart-layers.toml`. A launch on `main` with
+every store pointed at a non-existent scratch path proved it: `feed=binance
+symbol=BTCUSDT`, `canvas_layout=TimeAndFlow`, `CHART_LAYERS_RESTORED hidden=1`,
+and all four lamps lit in the capture.
+
+So the mission was never to change a default. It was to find why the shipped
+answer does not reach the trader, and two independent causes were found.
+
+**Bug A — the trader's file replaced the shipped default instead of covering
+it.** `chart_layers::load` returned only the keys in the trader's file. A layer
+absent from it fell through to the code baseline, which for all four flow layers
+is *off*. Any cockpit written before PR #229 therefore answered "off" to a
+question it had never been asked, on every launch — and `maintain_chart_layers`
+rewrites the whole map on the first switch of a session, freezing that silence
+into an explicit `false`. That is precisely why PR #229 changed nothing for the
+trader who reported it.
+
+**Bug B — a maximised window lays out larger than its own surface.** Measured:
+client `2560x1369 px`, egui told `2560x1369 pt` at `scale=1.5`, painting
+`3840x2054 px` into it. The right and bottom third fall outside the window —
+exactly where the four lamps, the price axis, the live strip and the dock rail
+live.
+
+**Not fixed, and the reason is the deliverable.** Three corrections were built
+and measured. Against `monitor_size`: that field is in *points*
+(`egui-winit-0.29.1/src/lib.rs:970`), so the check would have shrunk every
+honest window on a 150% display to 933x600 — caught by `arch-review` as a
+Blocker. Against `inner_rect`: wrong together with `screen_rect`. Against the
+platform's own `GetClientRect`: returns 3840x2052 *from inside the process*
+where the same call from outside returns 2560x1369, because Windows virtualises
+coordinates into the caller's DPI context. Every observable inside the process
+is self-consistently wrong, because what is wrong is the process's coordinate
+space. Upstream has it open and unfixed (`emilk/egui#7648` at 0.33.1); the
+upgrade from 0.29 was priced at 262 compile errors for a release that still has
+it. What ships is the measurement — `client_px` beside `screen_pt` and `scale`
+in the health summary — plus `QUANTICK_WINDOW_MAXIMIZED=1` to reach the state,
+and `window_scale`'s module doc recording all three dead ends for whoever picks
+it up.
+
+## Acceptance criteria
+
+1. Reproduced on `main` before any code was written — capture plus log. **met**
+2. BTCUSDT on a virgin launch, no env override. **met**
+3. The time+flow split on a virgin launch. **met**
+4. All four lamps lit on a virgin launch, in both focus states. **met**
+5. The cause named and regression-tested — a test that fails on `main` with the
+   observed wrong value and passes here. **met**
+6. The trader's own choice still outranks the shipped default; the two #229
+   tests still pass. **met**
+7. A capability-blocked layer explains itself rather than reading as a switch
+   the trader turned off. **met** — the lamp reads the switch, the button keeps
+   its `disabled_explanation`.
+8. The maximised window lays out inside its own surface. **not met** — three
+   corrections built, measured and withdrawn; the diagnosis, the reproduction
+   hook and the three dead ends ship instead. Taken to a follow-up issue.
+
+### Standard gates
+
+- [x] four checks green (`fmt`, `clippy -D warnings`, `build`, `test`)
+- [x] performance declared: every touched path classified below
+- [x] `ui-harness`: `QUANTICK_WINDOW_MAXIMIZED=1` added and registered
+- [ ] `arch-review` with every Blocker/Should-fix resolved or deferred
+- [ ] PR opened
+
+## Performance, by rate
+
+| Path | Rate | Cost |
+| --- | --- | --- |
+| `chart_layers::load` merge | rare (startup) | one `BTreeMap` extend |
+| `apply_pending_layout` layer copy | rare (a layout change) | ~18 switch writes |
+| `open_tab` inherited layers | rare (a new tab) | one map build |
+| `CHART_LAYER_SWITCHED` log | rare | gated behind the mask compare that already existed |
+| `SurfaceProbe::client_size_px` | rare (the 2 s health summary) | one `GetClientRect` |
+| the four layers being on | per-frame | unchanged from PR #229, which declared and measured it |
+
+## Out of scope
+
+- Changing *which* layers ship on — PR #229's decision, and the trader is asking
+  for it to hold rather than to change.
+- The eframe upgrade: priced, proved not to fix the bug, reverted.
+- `open_tab`'s pre-existing habit of resurrecting layers is fixed only where
+  this branch's own change would otherwise have widened it.

--- a/.claude/skills/ui-harness/SKILL.md
+++ b/.claude/skills/ui-harness/SKILL.md
@@ -25,6 +25,7 @@ is the source of truth, this table is the index):
 | --- | --- |
 | `QUANTICK_CONFIG=<toml>` | full feed/symbol config override (use a scratchpad toml; **never** edit the user's root `quantick.toml`) |
 | `QUANTICK_DEFAULT_FEED` / `QUANTICK_DEFAULT_SYMBOL` | startup feed/symbol |
+| `QUANTICK_WINDOW_MAXIMIZED=1` | the window **maximised** on the first frame. Not a larger `QUANTICK_WINDOW_SIZE`: maximising is what the window manager does, and on Windows at a scale factor other than 1 it is the state where the platform hands the client size in physical pixels where points were due — the chart then lays out a third wider than its own surface and the toolbar's layer group, the price axis, the live strip and the dock rail are painted off the edge (`crates/app/src/window_scale.rs`). No size can reach that state, so without this hook the whole class of defect is invisible to anything but a human clicking the title bar. Pair with `QUANTICK_WINDOW_SIZE` to control what the window restores *down* to |
 | `QUANTICK_WINDOW_SIZE=WxH` | the size the window opens at, floored at the app's own 900x560 minimum. Window size decides whether the indicator band has room for its panes and the time axis for its labels, so without this that whole class of defect is invisible to anything but a human dragging a corner. With it plus `QUANTICK_INDICATORS_AUTOSTART`, the collapsed-pane strip is reachable from a fresh launch. |
 | `QUANTICK_BOOK_AUTOSTART=1` | L2 heatmap layer |
 | `QUANTICK_LIVE_STRIP_AUTOSTART=1` | live strip |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2752,6 +2752,7 @@ dependencies = [
  "quantick-replay",
  "quantick-sim",
  "quantick-strategy",
+ "raw-window-handle",
  "rfd",
  "rust_decimal",
  "schemars",

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -50,12 +50,17 @@ eframe = { version = "0.29", default-features = false, features = [
     "default_fonts",
 ] }
 egui-phosphor = "0.7"
+# The window handle eframe hands out at startup, so `window_scale` can ask the
+# platform for the client area it actually has. Already in the tree as eframe's
+# own dependency; named here because this crate calls it directly.
+raw-window-handle = "0.6"
 
 [target.'cfg(windows)'.dependencies]
 # The platform's own attention sound, for the annotate tier's audible alert.
 # No audio engine: `MessageBeep` is the sound Windows itself uses, and a
 # platform without one reports that instead of pretending (see `audio.rs`).
 windows-sys = { version = "0.61", features = [
+    "Win32_Foundation",
     "Win32_System_Diagnostics_Debug",
     "Win32_UI_WindowsAndMessaging",
 ] }

--- a/crates/app/config/chart-layers.toml
+++ b/crates/app/config/chart-layers.toml
@@ -7,15 +7,18 @@
 #      which the app writes back the moment a switch flips
 #   3. this file, compiled into the binary as the built-in default
 #
-# So a trader who switches a layer off keeps it off: their own file is written
-# on that click and takes precedence from the next launch on. This file only
-# decides what someone who has never touched a switch sees.
+# The trader's file is laid *over* this one, never instead of it: an answer they
+# gave wins, and a layer they never touched opens on the answer here. So
+# switching a layer off keeps it off from the next launch on, while a file
+# written before a layer had a shipped answer does not silently pin it off — the
+# reading that made this file unreachable for everyone who already had a cockpit
+# (see `load` in `crates/app/src/chart_layers.rs`).
 #
-# Ids are `ChartLayer::id` (see `crates/app/src/chart_layers.rs`). An id this
-# build does not know is dropped rather than failing the launch, and an absent
-# id means "whatever the app decided" — the code default, a feed's preset or an
-# autostart env var. `lane_marks` is deliberately absent: it belongs to the
-# order-flow preset, which is its only home.
+# Ids are `ChartLayer::id` (same file). An id this build does not know is dropped
+# rather than failing the launch. An id absent from *both* files means "whatever
+# the app decided" — the code default, a feed's preset or an autostart env var —
+# and `lane_marks` is deliberately the only one: it belongs to the order-flow
+# preset, which is its only home.
 
 version = 1
 

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -51,6 +51,7 @@ use crate::toolbar::{self, ToolbarAction};
 use crate::toolrail::{Tool, ToolRail, ToolboxDock};
 use crate::ui_state;
 use crate::widgets::{IconButton, TOOLBAR_ICON};
+use crate::window_scale;
 
 /// Width of the right-hand price-axis gutter, in pixels (§5 zone 9).
 const AXIS_GUTTER: f32 = 64.0;
@@ -1006,8 +1007,14 @@ pub struct QuantickApp {
     /// panel. A dozen bool reads and an integer compare: cheaper than teaching
     /// four call sites to remember.
     saved_layer_mask: u32,
-    /// What the file said at startup, applied to every pane opened since.
-    layer_defaults: std::collections::BTreeMap<ChartLayer, bool>,
+    /// The last size [`Self::correct_window_scale`] had to put back into
+    /// points, so the correction is announced when it starts rather than on
+    /// every frame it holds for. `None` while the platform is reporting
+    /// honestly.
+    corrected_window_size: Option<egui::Vec2>,
+    /// Whether `QUANTICK_WINDOW_MAXIMIZED=1` still owes the window a maximise.
+    /// Drained on the first frame — see [`Self::apply_maximize_hook`].
+    pending_maximize: bool,
     /// Where a pane's layer menu leaves the grid switch and the "an indicator
     /// was hidden" flag; drained right after the canvas is drawn.
     layer_actions: chart_layers::LayerActions,
@@ -1356,7 +1363,9 @@ impl QuantickApp {
             manager_action_rects: Vec::new(),
             chart_layers_path: chart_layers::default_path(),
             saved_layer_mask: 0,
-            layer_defaults: std::collections::BTreeMap::new(),
+            corrected_window_size: None,
+            pending_maximize: std::env::var("QUANTICK_WINDOW_MAXIMIZED")
+                .is_ok_and(|value| value == "1"),
             layer_actions: chart_layers::LayerActions::default(),
             footprint_config: crate::footprint_config::load(&footprint_settings_path),
             footprint_settings_path,
@@ -2671,6 +2680,15 @@ impl QuantickApp {
         // a market opened to compare against the active one is only
         // comparable the same way up. Per pane; a pane the source tab does
         // not have follows its flow chart.
+        // The layers the active tab is *actually showing*, read before the new
+        // tab is pushed. This used to be `self.layer_defaults` — the map read
+        // off the file at startup — which was only harmless while that map was
+        // whatever partial thing the trader's file happened to hold. Now that a
+        // file's silence resolves to the shipped answer (`chart_layers::load`),
+        // that map speaks for every layer, and applying it here would undo the
+        // switches of the session mid-flight. Reading the live state is also
+        // what the comment below has always promised.
+        let inherited_layers = self.active_tab().flow_pane.layer_states(&self.style);
         let flow_inverted = self.active_tab().flow_pane.price_view.is_inverted();
         let time_inverted = self
             .active_tab()
@@ -2689,10 +2707,9 @@ impl QuantickApp {
         // The new tab opens on the layers the user left showing, over the
         // preset it just put on: opening a second market is not a request to
         // bring back the chrome they switched off.
-        let defaults = self.layer_defaults.clone();
         self.active_tab_mut()
             .flow_pane
-            .apply_layer_states(&defaults);
+            .apply_layer_states(&inherited_layers);
         // The scripted footprint/zoom hooks reach tabs opened later too: the
         // replay tab a validation run autostarts is the tab the run means,
         // and it does not exist yet when the boot hooks fire.
@@ -2822,7 +2839,16 @@ impl QuantickApp {
             });
         let capabilities = self.active_tab().capabilities(&self.config);
         let feed_display_name = self.active_tab().feed_display_name(&self.config).to_owned();
-        let heatmap_on = self.active_tab().tape().depth_visible();
+        // The *switch*, not what capture lets through it — the same reading
+        // the layer file was taught in 848cba0, and for a sibling reason. A
+        // lamp lit from `depth_visible()` (`enabled && show_depth`) reports
+        // the heatmap off for as long as book capture is starting, or forever
+        // on a source with no book: the trader sees an unlit button, presses
+        // it, and switches the layer they wanted *off*. The button already has
+        // an honest way to say a source cannot fill it — `.enabled(...)` with
+        // its `disabled_explanation` — so the lamp beside it answers the only
+        // other question: is this layer switched on.
+        let heatmap_on = self.active_tab().tape().depth_switched_on();
         let bubbles_on = self.active_tab().tape().bubbles_enabled();
         // The focused pane's slots (§11): the menu lists what a command from
         // it would act on, and never the pane beside it.
@@ -4071,6 +4097,35 @@ impl QuantickApp {
         if mask == self.saved_layer_mask {
             return;
         }
+        // Name every switch that moved, before writing it down.
+        //
+        // This file is the trader's own answer, and it outranks the shipped
+        // default from the next launch on — so a layer that goes off without a
+        // click is not a display glitch, it is a choice attributed to someone
+        // who never made it, and it lasts. The bug that motivated this line was
+        // exactly that shape and cost a day to chase, because the only record
+        // was the file itself: a trio of `false`s with no timestamp, no
+        // sequence and nothing to say whether a hand had been near them.
+        //
+        // Off the frame path in every sense that matters: the mask compare
+        // above already gates it, so this runs on the frames a switch actually
+        // moves — a handful in a session — and not one of the other 60 a
+        // second.
+        let flipped = mask ^ self.saved_layer_mask;
+        for (bit, layer) in ChartLayer::ALL.into_iter().enumerate() {
+            if flipped & (1 << bit) == 0 {
+                continue;
+            }
+            tracing::info!(
+                target: "quantick::app",
+                schema_version = 1_u8,
+                event_code = "CHART_LAYER_SWITCHED",
+                layer = layer.id(),
+                on = mask & (1 << bit) != 0,
+                action = "persist_switch",
+                "a chart layer switch moved; recording it as the trader's choice"
+            );
+        }
         chart_layers::save(
             &self.chart_layers_path,
             &self.active_tab().flow_pane.layer_states(&self.style),
@@ -4084,17 +4139,16 @@ impl QuantickApp {
     /// still wins for the run it was set on: a validation session asks for the
     /// heatmap on the command line and gets it, whatever the file remembers.
     fn restore_chart_layers(&mut self) {
-        self.layer_defaults = chart_layers::load(&self.chart_layers_path);
+        let defaults = chart_layers::load(&self.chart_layers_path);
         // Whatever the file said (including nothing at all) is now on screen;
         // only a change from here is worth another write.
-        if self.layer_defaults.is_empty() {
+        if defaults.is_empty() {
             self.saved_layer_mask = self.layer_mask();
             return;
         }
-        if let Some(grid) = self.layer_defaults.get(&ChartLayer::Grid) {
+        if let Some(grid) = defaults.get(&ChartLayer::Grid) {
             self.style.canvas.grid_enabled = *grid;
         }
-        let defaults = self.layer_defaults.clone();
         self.apply_layer_defaults(&defaults);
         self.saved_layer_mask = self.layer_mask();
         tracing::info!(
@@ -5289,6 +5343,85 @@ impl QuantickApp {
     /// viewport has already been asked to close: what a workspace should
     /// remember is the window the trader was working in, not whatever the
     /// platform reports on the way out.
+    /// Take the window manager's own maximise, once, on the first frame.
+    ///
+    /// Through [`egui::ViewportCommand::Maximized`] rather than the viewport
+    /// builder's `with_maximized`: eframe 0.29 does not honour that flag beside
+    /// an `inner_size`, and a hook that silently opens a 1100×650 window while
+    /// reporting success is worse than no hook — a validation run would
+    /// photograph the wrong state and call it a pass. The command is the one
+    /// the platform runs when a hand hits the title bar, which is the state
+    /// this hook exists to reach.
+    fn apply_maximize_hook(&mut self, ctx: &egui::Context) {
+        if !self.pending_maximize {
+            return;
+        }
+        self.pending_maximize = false;
+        ctx.send_viewport_cmd(egui::ViewportCommand::Maximized(true));
+        tracing::info!(
+            target: "quantick::app",
+            schema_version = 1_u8,
+            event_code = "WINDOW_MAXIMIZE_AUTOSTART",
+            action = "maximize",
+            "QUANTICK_WINDOW_MAXIMIZED asked for the maximised layout"
+        );
+    }
+
+    /// Put a wrongly-scaled window size back into points, and say so once.
+    ///
+    /// Both the screen rect and the viewport's inner rect are corrected, and
+    /// they have to move together: the first is what the chart lays out in, and
+    /// the second is what [`Self::maintain_workspace`] writes into the saved
+    /// workspace. Leaving the second alone would bank the pixel count as a
+    /// point count, so the *next* launch would open a window 1.5× too large
+    /// with no scale bug in sight — the defect outliving its cause, which is
+    /// the shape of bug this codebase already learned to distrust in the layer
+    /// file.
+    ///
+    /// Logged once per corrected size rather than once per frame: the numbers
+    /// are worth having when this is diagnosed again, and sixty identical lines
+    /// a second are not.
+    fn correct_window_scale(&mut self, raw_input: &mut egui::RawInput) {
+        let viewport = raw_input.viewport();
+        let (Some(scale), Some(monitor)) =
+            (viewport.native_pixels_per_point, viewport.monitor_size)
+        else {
+            return;
+        };
+        let Some(screen) = raw_input.screen_rect else {
+            return;
+        };
+        let Some(size) = window_scale::corrected_size(screen.size(), scale, monitor) else {
+            self.corrected_window_size = None;
+            return;
+        };
+        if self.corrected_window_size != Some(size) {
+            self.corrected_window_size = Some(size);
+            tracing::warn!(
+                target: "quantick::app",
+                schema_version = 1_u8,
+                event_code = "WINDOW_SCALE_CORRECTED",
+                reported_w = screen.width(),
+                reported_h = screen.height(),
+                scale,
+                monitor_px_w = monitor.x,
+                monitor_px_h = monitor.y,
+                corrected_w = size.x,
+                corrected_h = size.y,
+                action = "lay_out_in_points",
+                "the platform reported the window in pixels where points were due; corrected"
+            );
+        }
+        raw_input.screen_rect = Some(egui::Rect::from_min_size(screen.min, size));
+        let viewport = raw_input
+            .viewports
+            .entry(raw_input.viewport_id)
+            .or_default();
+        if let Some(inner) = viewport.inner_rect {
+            viewport.inner_rect = Some(egui::Rect::from_min_size(inner.min, size));
+        }
+    }
+
     fn maintain_workspace(&mut self, ctx: &egui::Context) {
         let (size, closing) = ctx.input(|input| {
             let viewport = input.viewport();
@@ -5344,11 +5477,28 @@ impl QuantickApp {
     }
 
     /// Periodically log a perf summary and warn on threshold breaches.
-    fn maybe_emit_summary(&mut self, now: Instant) {
+    fn maybe_emit_summary(&mut self, now: Instant, ctx: &egui::Context) {
         let elapsed = now - self.last_summary;
         if elapsed < SUMMARY_INTERVAL {
             return;
         }
+        // The window's own geometry, because a chart that lays out wider than
+        // the surface it is painted on loses its right edge — the toolbar's
+        // layer group, the price axis, the live strip and the dock all live
+        // there — and nothing else in this line would say so. `screen` is what
+        // egui laid out in, `surface` what the platform gave it, and `scale`
+        // the number between them; when `screen * scale` and `surface`
+        // disagree, the difference is the strip of chart nobody can see.
+        // Read outside the `input` closure: egui holds one lock for the whole
+        // of it, and reaching back into the context from inside deadlocks.
+        let zoom = ctx.zoom_factor();
+        let (screen, scale, native_scale) = ctx.input(|input| {
+            (
+                input.screen_rect.size(),
+                input.pixels_per_point(),
+                input.viewport().native_pixels_per_point,
+            )
+        });
         let rate = self.trades_since_summary as f64 / elapsed.as_secs_f64();
         let lag = self.active_tab().trade_arrival_ms();
         let avg = self.frames.avg_ms().unwrap_or(0.0);
@@ -5379,6 +5529,13 @@ impl QuantickApp {
             live_trades = self.active_tab().live_trades,
             bar_spec = self.active_tab().flow_pane.state.spec().summary(),
             canvas_layout = ?self.active_tab().layout,
+            screen_pt_w = screen.x,
+            screen_pt_h = screen.y,
+            surface_px_w = screen.x * scale,
+            surface_px_h = screen.y * scale,
+            scale = scale,
+            native_scale = native_scale,
+            zoom_factor = zoom,
             time_pane_spec = self.active_tab().time_pane.as_ref().map(|pane| pane.state.spec().summary()),
             // Drawings are a per-frame, O(objects) paint cost, and the shared
             // ones are additionally reprojected on every other pane of the
@@ -8103,6 +8260,12 @@ impl eframe::App for QuantickApp {
     /// the first. So the hook supplies the click itself, on the pane it names,
     /// and every line after that is the code a trader's own click runs.
     fn raw_input_hook(&mut self, _ctx: &egui::Context, raw_input: &mut egui::RawInput) {
+        // Before anything reads it: a window size the platform reported in the
+        // wrong unit. First in the hook, and above every early return below,
+        // because a frame that skips this lays the whole chart out at the wrong
+        // size — see `crate::window_scale` for the invariant and its one known
+        // limit.
+        self.correct_window_scale(raw_input);
         // Second frame: the button comes up where it went down, and the menu
         // that opened on the press stays open.
         if let Some(position) = self.scripted_context_menu_release.take() {
@@ -9329,7 +9492,8 @@ impl QuantickApp {
         self.apply_avwap_demo();
         self.apply_strategy_demo();
         self.apply_replay_restart();
-        self.maybe_emit_summary(now);
+        self.apply_maximize_hook(ctx);
+        self.maybe_emit_summary(now, ctx);
         self.maintain_workspace(ctx);
 
         let bg = pane::background_color(&self.style);
@@ -9531,9 +9695,14 @@ impl QuantickApp {
         tab.maybe_switch_feed(config);
         // Both deferrals settle here, a frame after the click that armed
         // them, so the frame carrying the change paints its overlay first.
-        let Self { tabs, config, .. } = self;
+        let Self {
+            tabs,
+            config,
+            style,
+            ..
+        } = self;
         for tab in tabs.iter_mut() {
-            tab.apply_pending_layout(config);
+            tab.apply_pending_layout(config, style);
         }
         self.active_tab_mut().apply_spec_changes();
         self.draw_style_panel(ctx, now);

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -1007,11 +1007,14 @@ pub struct QuantickApp {
     /// panel. A dozen bool reads and an integer compare: cheaper than teaching
     /// four call sites to remember.
     saved_layer_mask: u32,
-    /// The last size [`Self::correct_window_scale`] had to put back into
-    /// points, so the correction is announced when it starts rather than on
-    /// every frame it holds for. `None` while the platform is reporting
-    /// honestly.
-    corrected_window_size: Option<egui::Vec2>,
+    /// Which tab [`Self::saved_layer_mask`] was taken from, so a tab *switch*
+    /// is never mistaken for a switch the trader flipped.
+    saved_layer_tab: u64,
+    /// The window this app is drawing into, kept so the health summary can
+    /// report the client area the platform believes it has — see
+    /// [`crate::window_scale`] for why that number is worth logging, and for
+    /// the defect it was measured chasing.
+    surface: Option<window_scale::SurfaceProbe>,
     /// Whether `QUANTICK_WINDOW_MAXIMIZED=1` still owes the window a maximise.
     /// Drained on the first frame — see [`Self::apply_maximize_hook`].
     pending_maximize: bool,
@@ -1363,7 +1366,8 @@ impl QuantickApp {
             manager_action_rects: Vec::new(),
             chart_layers_path: chart_layers::default_path(),
             saved_layer_mask: 0,
-            corrected_window_size: None,
+            saved_layer_tab: 0,
+            surface: None,
             pending_maximize: std::env::var("QUANTICK_WINDOW_MAXIMIZED")
                 .is_ok_and(|value| value == "1"),
             layer_actions: chart_layers::LayerActions::default(),
@@ -2791,6 +2795,26 @@ impl QuantickApp {
         self.active_tab = next as usize;
     }
 
+    /// Whether the toolbar's heatmap lamp is lit.
+    ///
+    /// The *switch*, not what capture lets through it — the same reading the
+    /// layer file was taught in 848cba0, and for a sibling reason. A lamp lit
+    /// from `depth_visible()` (`enabled && show_depth`) reports the heatmap off
+    /// for as long as book capture is starting, and forever on a source with no
+    /// book: the trader sees an unlit button, presses it, and switches the
+    /// layer they wanted *off*. The button already has an honest way to say a
+    /// source cannot fill it — `.enabled(...)` carrying its
+    /// `disabled_explanation` — so the lamp beside it answers the only other
+    /// question there is.
+    ///
+    /// A named reading rather than an expression inside the toolbar's own
+    /// frame, so the rule can be asserted without painting a toolbar and read
+    /// back by something that is not looking at the screen.
+    #[must_use]
+    fn heatmap_lamp_on(&self) -> bool {
+        self.active_tab().tape().depth_switched_on()
+    }
+
     /// Build the toolbar's model from the app's state, draw it, and carry
     /// out whatever it asked (§6 — the toolbar module owns grouping and the
     /// overflow rule; this method owns the side effects).
@@ -2839,16 +2863,7 @@ impl QuantickApp {
             });
         let capabilities = self.active_tab().capabilities(&self.config);
         let feed_display_name = self.active_tab().feed_display_name(&self.config).to_owned();
-        // The *switch*, not what capture lets through it — the same reading
-        // the layer file was taught in 848cba0, and for a sibling reason. A
-        // lamp lit from `depth_visible()` (`enabled && show_depth`) reports
-        // the heatmap off for as long as book capture is starting, or forever
-        // on a source with no book: the trader sees an unlit button, presses
-        // it, and switches the layer they wanted *off*. The button already has
-        // an honest way to say a source cannot fill it — `.enabled(...)` with
-        // its `disabled_explanation` — so the lamp beside it answers the only
-        // other question: is this layer switched on.
-        let heatmap_on = self.active_tab().tape().depth_switched_on();
+        let heatmap_on = self.heatmap_lamp_on();
         let bubbles_on = self.active_tab().tape().bubbles_enabled();
         // The focused pane's slots (§11): the menu lists what a command from
         // it would act on, and never the pane beside it.
@@ -4094,6 +4109,19 @@ impl QuantickApp {
     /// chances to forget one.
     fn maintain_chart_layers(&mut self) {
         let mask = self.layer_mask();
+        // Layer state is per-pane, and this reads the *active* tab's flow pane
+        // — so activating a tab whose chart is set up differently changes the
+        // mask with nobody having touched a switch. Left alone, Ctrl+Tab
+        // records the other tab's opinion as the trader's choice, thrashes the
+        // file between two of them, and fills the log below with switches no
+        // hand moved. A different chart answering is a re-baseline, not an
+        // edit; the file keeps whatever the last real switch put there.
+        let tab = self.active_tab().id;
+        if tab != self.saved_layer_tab {
+            self.saved_layer_tab = tab;
+            self.saved_layer_mask = mask;
+            return;
+        }
         if mask == self.saved_layer_mask {
             return;
         }
@@ -4143,7 +4171,21 @@ impl QuantickApp {
         // Whatever the file said (including nothing at all) is now on screen;
         // only a change from here is worth another write.
         if defaults.is_empty() {
+            // Only reachable when the *shipped* config failed to parse, since
+            // every other path in `load` falls back to it — a build-time
+            // mistake, and the one launch where saying nothing would be worst:
+            // the chart opens on whatever the code decided and no one is told
+            // the product's own answer never arrived.
+            tracing::error!(
+                target: "quantick::app",
+                schema_version = 1_u8,
+                event_code = "CHART_LAYERS_UNAVAILABLE",
+                path = %self.chart_layers_path.display(),
+                action = "keep_code_defaults",
+                "no layer visibility to apply; the shipped config did not parse"
+            );
             self.saved_layer_mask = self.layer_mask();
+            self.saved_layer_tab = self.active_tab().id;
             return;
         }
         if let Some(grid) = defaults.get(&ChartLayer::Grid) {
@@ -4151,19 +4193,31 @@ impl QuantickApp {
         }
         self.apply_layer_defaults(&defaults);
         self.saved_layer_mask = self.layer_mask();
+        self.saved_layer_tab = self.active_tab().id;
         tracing::info!(
             target: "quantick::app",
             schema_version = 1_u8,
             event_code = "CHART_LAYERS_RESTORED",
             path = %self.chart_layers_path.display(),
-            hidden = defaults.values().filter(|visible| !**visible).count(),
+            // `off`, not `hidden`: the map now always speaks for every layer,
+            // the shipped-off `backfill_divider` included, so a count over it
+            // is no longer "how many the trader switched off". Renamed rather
+            // than quietly redefined — a field that keeps its name and changes
+            // its meaning misleads every dashboard already reading it.
+            off = defaults.values().filter(|visible| !**visible).count(),
+            layers = defaults.len(),
             "chart layer visibility restored"
         );
     }
 
-    /// Put every open pane on the saved visibility. Also run when a tab is
-    /// opened later, so a new tab looks like the one beside it rather than
-    /// bringing back layers the user switched off.
+    /// Put every open pane on the saved visibility, once, at startup.
+    ///
+    /// A tab opened later does *not* come through here: it inherits the layers
+    /// the active tab is showing at that moment (`inherited_layers` in
+    /// [`Self::adopt_tab`]), which is the live state rather than the map read
+    /// off disk during boot. The two policies differ on purpose — see the note
+    /// there — so a reader arriving here for new-tab behaviour is in the wrong
+    /// function.
     fn apply_layer_defaults(&mut self, states: &std::collections::BTreeMap<ChartLayer, bool>) {
         for tab in &mut self.tabs {
             tab.flow_pane.apply_layer_states(states);
@@ -5330,19 +5384,17 @@ impl QuantickApp {
         });
     }
 
-    /// Keep the window size the workspace would record, flush a popup the
-    /// trader just re-parked, and take the exit save when the window is
-    /// closing.
+    /// Hand the app the window it is drawing into.
     ///
-    /// **Per-frame cost**: two reads off the frame's own input state, a float
-    /// compare and a `bool` test. No save is on this path — each of the three
-    /// happens on one frame: the frame a drag ends, and the frame the close is
-    /// requested, when the window is going away anyway.
-    ///
-    /// The size is tracked here rather than read at exit because by then the
-    /// viewport has already been asked to close: what a workspace should
-    /// remember is the window the trader was working in, not whatever the
-    /// platform reports on the way out.
+    /// Called once from `main`, which is where eframe offers the handle: the
+    /// hook that needs it (`raw_input_hook`) is given only the input. One
+    /// registration line rather than a constructor argument, because every
+    /// other construction path — every test — wants the `None` this defaults
+    /// to, which is also what every non-Windows target gets.
+    pub fn attach_surface(&mut self, handle: &impl raw_window_handle::HasWindowHandle) {
+        self.surface = window_scale::SurfaceProbe::new(handle);
+    }
+
     /// Take the window manager's own maximise, once, on the first frame.
     ///
     /// Through [`egui::ViewportCommand::Maximized`] rather than the viewport
@@ -5367,61 +5419,19 @@ impl QuantickApp {
         );
     }
 
-    /// Put a wrongly-scaled window size back into points, and say so once.
+    /// Keep the window size the workspace would record, flush a popup the
+    /// trader just re-parked, and take the exit save when the window is
+    /// closing.
     ///
-    /// Both the screen rect and the viewport's inner rect are corrected, and
-    /// they have to move together: the first is what the chart lays out in, and
-    /// the second is what [`Self::maintain_workspace`] writes into the saved
-    /// workspace. Leaving the second alone would bank the pixel count as a
-    /// point count, so the *next* launch would open a window 1.5× too large
-    /// with no scale bug in sight — the defect outliving its cause, which is
-    /// the shape of bug this codebase already learned to distrust in the layer
-    /// file.
+    /// **Per-frame cost**: two reads off the frame's own input state, a float
+    /// compare and a `bool` test. No save is on this path — each of the three
+    /// happens on one frame: the frame a drag ends, and the frame the close is
+    /// requested, when the window is going away anyway.
     ///
-    /// Logged once per corrected size rather than once per frame: the numbers
-    /// are worth having when this is diagnosed again, and sixty identical lines
-    /// a second are not.
-    fn correct_window_scale(&mut self, raw_input: &mut egui::RawInput) {
-        let viewport = raw_input.viewport();
-        let (Some(scale), Some(monitor)) =
-            (viewport.native_pixels_per_point, viewport.monitor_size)
-        else {
-            return;
-        };
-        let Some(screen) = raw_input.screen_rect else {
-            return;
-        };
-        let Some(size) = window_scale::corrected_size(screen.size(), scale, monitor) else {
-            self.corrected_window_size = None;
-            return;
-        };
-        if self.corrected_window_size != Some(size) {
-            self.corrected_window_size = Some(size);
-            tracing::warn!(
-                target: "quantick::app",
-                schema_version = 1_u8,
-                event_code = "WINDOW_SCALE_CORRECTED",
-                reported_w = screen.width(),
-                reported_h = screen.height(),
-                scale,
-                monitor_px_w = monitor.x,
-                monitor_px_h = monitor.y,
-                corrected_w = size.x,
-                corrected_h = size.y,
-                action = "lay_out_in_points",
-                "the platform reported the window in pixels where points were due; corrected"
-            );
-        }
-        raw_input.screen_rect = Some(egui::Rect::from_min_size(screen.min, size));
-        let viewport = raw_input
-            .viewports
-            .entry(raw_input.viewport_id)
-            .or_default();
-        if let Some(inner) = viewport.inner_rect {
-            viewport.inner_rect = Some(egui::Rect::from_min_size(inner.min, size));
-        }
-    }
-
+    /// The size is tracked here rather than read at exit because by then the
+    /// viewport has already been asked to close: what a workspace should
+    /// remember is the window the trader was working in, not whatever the
+    /// platform reports on the way out.
     fn maintain_workspace(&mut self, ctx: &egui::Context) {
         let (size, closing) = ctx.input(|input| {
             let viewport = input.viewport();
@@ -5485,13 +5495,22 @@ impl QuantickApp {
         // The window's own geometry, because a chart that lays out wider than
         // the surface it is painted on loses its right edge — the toolbar's
         // layer group, the price axis, the live strip and the dock all live
-        // there — and nothing else in this line would say so. `screen` is what
-        // egui laid out in, `surface` what the platform gave it, and `scale`
-        // the number between them; when `screen * scale` and `surface`
-        // disagree, the difference is the strip of chart nobody can see.
+        // there — and nothing else in this line would say so.
+        //
+        // `client_px` is the platform's *own* answer, not `screen * scale`:
+        // that product is algebraically the same number as `screen_pt` beside
+        // it and could never contradict anything, which would make the whole
+        // block decoration. Two independent readings, so the line can be read
+        // for whether they agree — and by the time it is written a correction
+        // may already have restored that agreement, which `WINDOW_SCALE_CORRECTED`
+        // is the record of.
         // Read outside the `input` closure: egui holds one lock for the whole
         // of it, and reaching back into the context from inside deadlocks.
         let zoom = ctx.zoom_factor();
+        let client = self
+            .surface
+            .as_ref()
+            .and_then(window_scale::SurfaceProbe::client_size_px);
         let (screen, scale, native_scale) = ctx.input(|input| {
             (
                 input.screen_rect.size(),
@@ -5531,8 +5550,8 @@ impl QuantickApp {
             canvas_layout = ?self.active_tab().layout,
             screen_pt_w = screen.x,
             screen_pt_h = screen.y,
-            surface_px_w = screen.x * scale,
-            surface_px_h = screen.y * scale,
+            client_px_w = client.map(|size| size.x),
+            client_px_h = client.map(|size| size.y),
             scale = scale,
             native_scale = native_scale,
             zoom_factor = zoom,
@@ -8260,12 +8279,6 @@ impl eframe::App for QuantickApp {
     /// the first. So the hook supplies the click itself, on the pane it names,
     /// and every line after that is the code a trader's own click runs.
     fn raw_input_hook(&mut self, _ctx: &egui::Context, raw_input: &mut egui::RawInput) {
-        // Before anything reads it: a window size the platform reported in the
-        // wrong unit. First in the hook, and above every early return below,
-        // because a frame that skips this lays the whole chart out at the wrong
-        // size — see `crate::window_scale` for the invariant and its one known
-        // limit.
-        self.correct_window_scale(raw_input);
         // Second frame: the button comes up where it went down, and the menu
         // that opened on the press stays open.
         if let Some(position) = self.scripted_context_menu_release.take() {
@@ -12636,6 +12649,122 @@ plot(close)
             "the new tab brought back a layer the user had switched off"
         );
         std::fs::remove_file(&path).ok();
+    }
+
+    /// The split's second pane opens wearing the same layers as the first.
+    ///
+    /// `apply_pending_layout` used to copy `hidden_layers` and stop, which left
+    /// out every per-pane layer that does not live in that set — the footprint
+    /// being the one that has one. So the shipped `footprint = true` reached
+    /// the flow pane and never the time pane, and the toolbar's footprint lamp
+    /// went dark the moment the trader clicked into the left chart. The
+    /// deferred finding from PR #229, closed here.
+    #[test]
+    fn the_time_pane_opens_on_the_same_layers_as_the_flow_pane() {
+        let ctx = egui::Context::default();
+        let (mut app, _commands) = app_with_history(120);
+        // The state a shipped default leaves behind: the ladder on, before the
+        // second pane exists at all.
+        app.active_tab_mut().flow_pane.footprint_visible = true;
+        app.active_tab_mut().set_layout(CanvasLayout::TimeAndFlow);
+        // One frame builds the time pane; that is the frame under test.
+        run_frame(&mut app, &ctx);
+        let time = app
+            .active_tab()
+            .time_pane
+            .as_ref()
+            .expect("the split is what this proof is about");
+        assert!(
+            time.footprint_visible,
+            "the time pane opened without the ladder the flow pane beside it is drawing"
+        );
+    }
+
+    /// A tab opened mid-session inherits what is on screen *now*, not what the
+    /// file said at startup.
+    ///
+    /// `open_tab` used to apply the map read off disk during boot. That was
+    /// harmless only while the map was whatever partial thing the trader's file
+    /// held; now that a file's silence resolves to the shipped answer, it
+    /// speaks for every layer, and applying it here would undo the session's
+    /// own switches on the way past.
+    #[test]
+    fn a_new_tab_inherits_the_live_layers_not_the_startup_file() {
+        let dir = std::env::temp_dir().join(format!("quantick-app-live-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("scratch dir");
+        let path = dir.join("chart-layers.toml");
+        let _ = std::fs::remove_file(&path);
+
+        let (mut app, _events, _commands, _book) = test_app();
+        app.chart_layers_path = path.clone();
+        // Boot on a file that says the crosshair is off...
+        std::fs::write(
+            &path,
+            "version = 1
+[layers]
+crosshair = false
+",
+        )
+        .unwrap();
+        app.restore_chart_layers();
+        assert!(!layer_on(&app, ChartLayer::Crosshair), "the file was read");
+        // ...then the trader switches it back on, and opens a second market.
+        switch_layer(&mut app, ChartLayer::Crosshair, true);
+        let (_evt_tx, evt_rx) = mpsc::channel(4);
+        let (_book_tx, book_rx) = mpsc::channel(4);
+        let (cmd_tx, _cmd_rx) = mpsc::channel(4);
+        app.adopt_tab(
+            "binance".to_owned(),
+            "OTHERUSDT".to_owned(),
+            FeedHandle {
+                events: evt_rx,
+                book_events: book_rx,
+                notices: feed::silent_notices(),
+                capabilities: feed::fixed_capabilities(ProviderKind::Binance.capabilities()),
+                commands: cmd_tx,
+                replay: None,
+            },
+            None,
+        );
+        assert!(
+            layer_on(&app, ChartLayer::Crosshair),
+            "the new tab reached past the session and brought back the startup file's answer"
+        );
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// The toolbar's heatmap lamp answers "is this switched on", not "is the
+    /// book capture up yet".
+    ///
+    /// `depth_visible()` is `enabled && show_depth`, so a lamp lit from it
+    /// reads dark while capture is starting — and a trader who presses a dark
+    /// button switches *off* the layer they were reaching for. The button
+    /// states a source's inability separately, through `disabled_explanation`.
+    #[test]
+    fn the_heatmap_lamp_reads_the_switch_not_the_capture() {
+        let (mut app, _events, _commands, _book) = test_app();
+        {
+            let tape = app.active_tab_mut().tape_mut();
+            tape.set_depth_visible(true);
+            // Capture not up: exactly the first seconds of every launch, and
+            // permanently on a source with no book.
+            tape.set_enabled(false, 0);
+            assert!(
+                !tape.depth_visible(),
+                "the renderer is right to draw nothing; this test is about the lamp"
+            );
+            assert!(tape.depth_switched_on(), "the switch itself is on");
+        }
+        assert!(
+            app.heatmap_lamp_on(),
+            "the lamp reads the switch, so it stays lit while capture catches up"
+        );
+        // And it goes dark for the one reason it should: the switch itself.
+        app.active_tab_mut().tape_mut().set_depth_visible(false);
+        assert!(
+            !app.heatmap_lamp_on(),
+            "switched off is the only way it darkens"
+        );
     }
 
     /// The menu itself: every layer gets a switch, a layer the feed cannot

--- a/crates/app/src/chart_layers.rs
+++ b/crates/app/src/chart_layers.rs
@@ -403,11 +403,36 @@ pub(crate) fn validate(text: &str) -> Result<(), String> {
     }
 }
 
-/// Load the stored visibility, falling back to [`shipped_default`] when the
-/// file is missing, unreadable or from an unknown version — all three mean
-/// "we do not know what this trader chose", which is the question a first
-/// launch asks. Unknown ids are dropped one by one, so a file from a newer
-/// build still restores the layers this one has.
+/// Load the stored visibility **over** [`shipped_default`], falling back to the
+/// shipped answer alone when the file is missing, unreadable or from an unknown
+/// version — all three mean "we do not know what this trader chose", which is
+/// the question a first launch asks. Unknown ids are dropped one by one, so a
+/// file from a newer build still restores the layers this one has.
+///
+/// The trader's file is laid *on top of* the shipped one rather than replacing
+/// it, and that is the whole difference between this reader and the one that
+/// shipped the defaults. A layer the file does not mention has no answer in it,
+/// and the two candidate readings of that silence are not equal:
+///
+/// - "whatever the code decides" — which for all four flow layers is *off*
+///   ([`crate::pane::ChartPane`]'s field initialisers, and the
+///   `set_depth_visible(false)` at startup), so an older file pins them off
+///   forever;
+/// - "whatever this build ships" — the answer in `config/chart-layers.toml`.
+///
+/// The first reading is why shipping the defaults changed nothing for anyone
+/// who already had a cockpit: their file predated the flow-layer keys, so it
+/// answered "off" to a question it had never been asked. Worse, it then froze:
+/// [`crate::app::QuantickApp::maintain_chart_layers`] rewrites the *whole* map
+/// on the first switch of the session, so one unrelated click turns a silent
+/// file into an explicit `heatmap = false`. A default nobody can receive is not
+/// a default, so silence now means the shipped answer.
+///
+/// What that costs is precise and small: a layer absent from **both** files is
+/// still the app's to decide — `lane_marks` is the one, deliberately, because
+/// the order-flow preset is its home. And an explicit `false` in the trader's
+/// file still outranks everything, which is the promise that makes a shipped
+/// default acceptable at all (`the_traders_own_choice_outranks_the_shipped_default`).
 #[must_use]
 pub(crate) fn load(path: &Path) -> BTreeMap<ChartLayer, bool> {
     let Ok(text) = std::fs::read_to_string(path) else {
@@ -440,7 +465,10 @@ pub(crate) fn load(path: &Path) -> BTreeMap<ChartLayer, bool> {
             return shipped_default();
         }
     };
-    resolve(stored)
+    // The trader's answers over the shipped ones, never instead of them.
+    let mut states = shipped_default();
+    states.extend(resolve(stored));
+    states
 }
 
 /// The built-in opening state, from the config compiled into the binary.
@@ -568,12 +596,67 @@ mod tests {
             Some(&false),
             "an explicit no stays a no"
         );
-        // And the shipped answer does not leak in beside it: a layer the
-        // trader's file never mentions is the app's to decide, exactly as it
-        // was before this file existed.
+        // And the answer they did not give is the shipped one, not the code's
+        // off baseline — see `load`. Switching the heatmap off must not take
+        // the bubbles down with it.
+        assert_eq!(
+            loaded.get(&ChartLayer::Bubbles),
+            Some(&true),
+            "a layer the trader never touched opens on the shipped answer"
+        );
+        // A layer absent from *both* files is still the app's to decide, which
+        // is what keeps the order-flow preset the only home of `lane_marks`.
         assert!(
-            !loaded.contains_key(&ChartLayer::Bubbles),
-            "an absent layer keeps meaning \"whatever the app decided\""
+            !loaded.contains_key(&ChartLayer::LaneMarks),
+            "a layer the shipped file holds no opinion on stays the app's"
+        );
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// The bug that made shipping the defaults change nothing for the trader
+    /// who reported the bare chart in the first place.
+    ///
+    /// Their `chart-layers.toml` was written by a build from before the flow
+    /// layers had shipped defaults, so it names the chrome and says nothing
+    /// about the four layers the chart is for. Read as "whatever the code
+    /// decides", that silence is *off* on all four — a file that has never
+    /// been asked the question answering it anyway, on every launch, forever.
+    ///
+    /// This is the file, key for key, that `chart-layers.toml.bak` on the
+    /// reporter's machine turned out to hold.
+    #[test]
+    fn a_file_from_before_the_defaults_still_opens_the_flow_layers() {
+        let path = temp_dir().join("pre-defaults.toml");
+        std::fs::write(
+            &path,
+            "version = 1
+[layers]
+             grid = true
+             crosshair = true
+             last_price = true
+             backfill_divider = false
+",
+        )
+        .unwrap();
+        let loaded = load(&path);
+        for layer in [
+            ChartLayer::Heatmap,
+            ChartLayer::Bubbles,
+            ChartLayer::Footprint,
+            ChartLayer::LiveStrip,
+        ] {
+            assert_eq!(
+                loaded.get(&layer),
+                Some(&true),
+                "{} is unanswered in this file, so it opens on the shipped answer",
+                layer.id()
+            );
+        }
+        // What the file *does* say still wins, including its one no.
+        assert_eq!(
+            loaded.get(&ChartLayer::BackfillDivider),
+            Some(&false),
+            "the file's own answers are untouched"
         );
         std::fs::remove_file(&path).ok();
     }
@@ -617,6 +700,16 @@ mod tests {
         );
     }
 
+    /// What `load` must return for a file holding exactly `states`: the
+    /// trader's answers over the shipped ones. Written once because three
+    /// tests need it and a fourth copy of `shipped_default().extend(...)` is
+    /// three chances to encode the *old* contract by accident.
+    fn shipped_with(states: &BTreeMap<ChartLayer, bool>) -> BTreeMap<ChartLayer, bool> {
+        let mut expected = shipped_default();
+        expected.extend(states.iter().filter(|(layer, _)| layer.persisted()));
+        expected
+    }
+
     #[test]
     fn visibility_round_trips_through_disk() {
         let path = temp_dir().join("round-trip.toml");
@@ -627,7 +720,10 @@ mod tests {
             (ChartLayer::Drawings, true),
         ]);
         save(&path, &states);
-        assert_eq!(load(&path), states);
+        // Every answer written comes back, and the layers this file says
+        // nothing about come back as the shipped answer rather than as the
+        // code's off baseline — see `load`.
+        assert_eq!(load(&path), shipped_with(&states));
         std::fs::remove_file(&path).ok();
     }
 
@@ -645,8 +741,12 @@ mod tests {
         );
         assert_eq!(
             load(&path),
-            BTreeMap::from([(ChartLayer::Grid, false)]),
-            "everything else still round-trips"
+            shipped_with(&BTreeMap::from([(ChartLayer::Grid, false)])),
+            "everything else still round-trips, over the shipped answer"
+        );
+        assert!(
+            !load(&path).contains_key(&ChartLayer::LaneMarks),
+            "and the lane marks are in neither file, so they stay the app's"
         );
         std::fs::remove_file(&path).ok();
     }
@@ -676,7 +776,7 @@ mod tests {
         .unwrap();
         assert_eq!(
             load(&path),
-            BTreeMap::from([(ChartLayer::Grid, false)]),
+            shipped_with(&BTreeMap::from([(ChartLayer::Grid, false)])),
             "an id this build does not know is dropped, the rest still restores"
         );
         std::fs::remove_file(&path).ok();

--- a/crates/app/src/drawings/mod.rs
+++ b/crates/app/src/drawings/mod.rs
@@ -1956,6 +1956,17 @@ impl Drawings {
         self.record(before);
     }
 
+    /// The *opening* hidden state, seeded as a pane is built.
+    ///
+    /// Deliberately not [`Self::set_all_hidden`]: that one records an undo
+    /// entry, which is right for a click and wrong for a pane that has just
+    /// come into existence. A time pane seeded through the recording setter
+    /// opens with a non-empty history on a store holding zero objects, so the
+    /// trader's first Ctrl+Z there un-hides drawings instead of doing nothing.
+    pub fn open_all_hidden(&mut self, hidden: bool) {
+        self.all_hidden = hidden;
+    }
+
     pub fn set_all_hidden(&mut self, hidden: bool) {
         let before = self.snapshot();
         self.all_hidden = hidden;

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -231,9 +231,14 @@ fn main() -> eframe::Result {
             egui_phosphor::add_to_fonts(&mut fonts, egui_phosphor::Variant::Regular);
             cc.egui_ctx.set_fonts(fonts);
             theme::apply(&cc.egui_ctx);
-            Ok(Box::new(app::QuantickApp::new_with_workspace(
+            let mut app = app::QuantickApp::new_with_workspace(
                 config, feed_id, symbol, spec, feed, workspace,
-            )))
+            );
+            // The window itself, which only this closure is handed: the app
+            // measures its real client area through it (see
+            // `crate::window_scale`).
+            app.attach_surface(cc);
+            Ok(Box::new(app))
         }),
     )
 }

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -76,6 +76,7 @@ mod trade_paint;
 mod ui_state;
 mod viewport;
 mod widgets;
+mod window_scale;
 mod workspace_bundle;
 
 /// The bar type the chart opens on. The type and its parameter are tunable live

--- a/crates/app/src/tab.rs
+++ b/crates/app/src/tab.rs
@@ -17,6 +17,7 @@ use tokio::sync::{mpsc, watch};
 
 use quantick_feed_binance::depth::DepthEvent;
 
+use crate::chart_layers::ChartLayer;
 use crate::config::{AppConfig, FeedCapabilities};
 use crate::feed::{
     self, FeedCommand, FeedConnectionState, FeedEvent, FeedHandle, FeedNotice, ReplayLink,
@@ -1020,17 +1021,26 @@ impl Tab {
         // an upside-down market does not turn back over by being given a
         // second view, and the boot's QUANTICK_INVERTED hook fires before
         // this pane exists at all.
-        pane.hidden_layers = self.flow_pane.hidden_layers.clone();
-        // ...and the same is true of every layer that does not live in that
-        // set. `hidden_layers` alone left the footprint behind — a per-pane
-        // field of its own — so the split opened with the ladder on in the
-        // flow pane and off in the time pane, contradicting the paragraph
-        // above and reporting the toolbar's footprint lamp off the moment the
-        // trader clicked into the left chart. Copying the *switches* rather
-        // than a list of field names is what keeps the next per-pane layer
-        // from being forgotten here: `apply_layer_states` drops whatever this
-        // pane does not draw, which is the whole of what §11 asks for.
-        pane.apply_layer_states(&self.flow_pane.layer_states(style));
+        // Copying the *switches* rather than a list of field names: an earlier
+        // version cloned `hidden_layers` alone, which left the footprint
+        // behind — a per-pane field of its own — so the split opened with the
+        // ladder on in the flow pane and off in the time pane, contradicting
+        // the paragraph above and darkening the toolbar's footprint lamp the
+        // moment the trader clicked into the left chart. `apply_layer_states`
+        // drops whatever this pane does not draw, which is the whole of what
+        // §11 asks for, and it covers `hidden_layers` in passing.
+        //
+        // Every layer but one. `Drawings` resolves to `DrawingStore`, whose
+        // setter records an undo entry — right for a click, wrong for a pane
+        // being born: seeded through it, a time pane holding zero objects
+        // opens with a non-empty history, and the trader's first Ctrl+Z there
+        // un-hides drawings rather than doing nothing. It is seeded through
+        // the store's own opening setter instead.
+        let mut states = self.flow_pane.layer_states(style);
+        states.remove(&ChartLayer::Drawings);
+        pane.apply_layer_states(&states);
+        pane.drawings
+            .open_all_hidden(self.flow_pane.drawings.all_hidden());
         pane.price_view
             .set_inverted(self.flow_pane.price_view.is_inverted());
         self.time_pane = Some(pane);

--- a/crates/app/src/tab.rs
+++ b/crates/app/src/tab.rs
@@ -1003,7 +1003,7 @@ impl Tab {
     ///
     /// Runs at the top of the frame after the click, so the overlay armed by
     /// [`Self::set_layout`] has already been painted once.
-    pub fn apply_pending_layout(&mut self, config: &AppConfig) {
+    pub fn apply_pending_layout(&mut self, config: &AppConfig, style: &ChartStyle) {
         if !self.pending_time_pane {
             return;
         }
@@ -1021,6 +1021,16 @@ impl Tab {
         // second view, and the boot's QUANTICK_INVERTED hook fires before
         // this pane exists at all.
         pane.hidden_layers = self.flow_pane.hidden_layers.clone();
+        // ...and the same is true of every layer that does not live in that
+        // set. `hidden_layers` alone left the footprint behind — a per-pane
+        // field of its own — so the split opened with the ladder on in the
+        // flow pane and off in the time pane, contradicting the paragraph
+        // above and reporting the toolbar's footprint lamp off the moment the
+        // trader clicked into the left chart. Copying the *switches* rather
+        // than a list of field names is what keeps the next per-pane layer
+        // from being forgotten here: `apply_layer_states` drops whatever this
+        // pane does not draw, which is the whole of what §11 asks for.
+        pane.apply_layer_states(&self.flow_pane.layer_states(style));
         pane.price_view
             .set_inverted(self.flow_pane.price_view.is_inverted());
         self.time_pane = Some(pane);

--- a/crates/app/src/window_scale.rs
+++ b/crates/app/src/window_scale.rs
@@ -1,147 +1,152 @@
-//! Correcting a window size the platform reported in the wrong unit.
+//! Reading the window's client area straight from the platform.
 //!
-//! egui is told the window's size in *points* and paints at
-//! `pixels_per_point`; the two multiply out to the surface the platform
-//! actually gave us. On Windows, at a scale factor other than 1, maximising
-//! breaks that identity: the client size arrives in **physical pixels** while
-//! the scale factor stays put, so egui lays out a screen 1.5× too large and
-//! paints a third of the chart outside the window. What falls off is the right
-//! and bottom edge — which on this chart is the toolbar's layer group, the
-//! price axis, the live strip and the dock rail.
+//! This module exists because of a defect it deliberately does **not** try to
+//! correct, and the reason for that restraint is the whole point of the file.
 //!
-//! This is an upstream bug, not ours: `emilk/egui#7648` (still open at 0.33.1)
-//! and `emilk/egui#7095` are the same family, and the jump from the 0.29 we
-//! build against to the current release is 262 compile errors for a version
-//! that still has it. So the size is corrected here, on the way in, and the
-//! rule is written as one pure function with the arithmetic on show.
+//! On Windows, a process whose DPI context has gone stale — the display's
+//! scaling changed without a sign-out, so the session's system DPI is 144 while
+//! the monitor reports 96 — lays the chart out 1.5x too large and paints a
+//! third of it outside the window. What falls off is the right and bottom edge,
+//! which on this chart is the toolbar's layer group, the price axis, the live
+//! strip and the dock rail. Measured: `screen_rect` 2560x1369 points at
+//! `native_pixels_per_point = 1.5`, painting 3840x2054 pixels into a surface
+//! that is really 2560x1369.
 //!
-//! **The invariant.** A window's client area cannot be larger than the screen
-//! it is on: `size_in_points × scale ≤ monitor_in_pixels`. When that fails, the
-//! size we were handed is already in pixels, and dividing by the scale recovers
-//! the points exactly — 2560 px ÷ 1.5 = 1706.7 pt, which paints back to 2560 px.
+//! Three candidate corrections were built and measured, and each failed for its
+//! own reason. They are written down here because the next person to try will
+//! reach for them in this order:
 //!
-//! **The limit, stated rather than hidden.** A window stretched across two
-//! side-by-side monitors is legitimately wider than the monitor egui reports,
-//! so width alone must never trigger a correction. Requiring *both* axes to
-//! overflow is what separates the two: a spanning window is wider without being
-//! taller, and a wrongly-scaled one overflows both by the same factor. A window
-//! spanning monitors stacked vertically *and* horizontally would fool this, and
-//! is left uncorrected on purpose — a rare arrangement, and drawing it small is
-//! worse than drawing it as the platform asked.
+//! 1. **Against `ViewportInfo::monitor_size`** — "a window cannot be bigger
+//!    than its screen". `egui-winit-0.29.1/src/lib.rs:970` builds that field as
+//!    `monitor.size().to_logical(pixels_per_point)`, so it is in **points**.
+//!    Comparing `points * scale` against it condemns every honest window on a
+//!    150% display: 1400x900 points evaluates `2100 > 1707` and `1350 > 961`
+//!    and gets shrunk to 933x600 — a correction far worse than the defect.
+//!    Reading it as points removes the danger and the detection with it, since
+//!    a maximised window legitimately *equals* its monitor in points.
+//! 2. **Against `screen_rect` vs `inner_rect`** — they are wrong together.
+//! 3. **Against the platform's own `GetClientRect`** — the reading this module
+//!    still provides. It comes back **3840x2052** from inside the process, not
+//!    the 2560x1369 the same call returns from a process with a correct DPI
+//!    context: Windows virtualises coordinates into the caller's context, so
+//!    this "independent" reading is wrong in exactly the same way and agrees
+//!    with egui to the pixel.
+//!
+//! The conclusion is the finding: every observable available *inside* the
+//! process is self-consistently wrong, because the thing that is wrong is the
+//! process's own coordinate space. A correction would have to key off something
+//! outside it — the GL framebuffer's real size, or a DPI comparison made in a
+//! different awareness context — and that is a change to how the app declares
+//! its DPI awareness, not a fix-up on the way into a frame.
+//!
+//! Upstream has the same family open and unfixed: `emilk/egui#7648` (0.33.1)
+//! and `emilk/egui#7095`. The jump from the 0.29 we build against is 262
+//! compile errors for a release that still has it.
+//!
+//! So what ships here is the *reading*, wired into the health summary beside
+//! `screen_pt` and `scale`. Those three numbers together are what turned this
+//! from "the buttons are gone" into a measurement, and they are what the next
+//! diagnosis will start from.
 
 use eframe::egui;
 
-/// How far past the monitor a size may sit before we call it wrong. Guards the
-/// float compare against a window that is legitimately flush with the screen
-/// edge, where the two sides land a rounding error apart.
-const OVERFLOW_SLACK_PX: f32 = 1.0;
-
-/// The size egui should lay out in, when the one we were handed cannot be
-/// points. `None` means the size is already right and nothing should change.
+/// A handle to the window, kept so the client area can be read back from the
+/// platform on any frame.
 ///
-/// `size` is what the platform reported, `scale` the pixels-per-point it
-/// reported alongside, and `monitor` the screen size — which eframe gives in
-/// physical pixels, the unit inconsistency this whole module is downstream of.
-#[must_use]
-pub(crate) fn corrected_size(
-    size: egui::Vec2,
-    scale: f32,
-    monitor: egui::Vec2,
-) -> Option<egui::Vec2> {
-    // At scale 1 the two units are the same number and there is nothing to get
-    // wrong. A non-finite or non-positive scale is not something to divide by.
-    if !(scale.is_finite() && scale > 1.0) {
-        return None;
+/// Taken once at startup from the [`eframe::CreationContext`], because that is
+/// where eframe hands out the window handle; `App::raw_input_hook`, where the
+/// correction is applied, has no window of its own.
+pub(crate) struct SurfaceProbe {
+    #[cfg(windows)]
+    hwnd: isize,
+}
+
+impl SurfaceProbe {
+    /// Take the platform handle, or `None` on a platform (or a windowing
+    /// backend) that does not offer the one this reads.
+    #[must_use]
+    pub(crate) fn new(_handle: &impl raw_window_handle::HasWindowHandle) -> Option<Self> {
+        #[cfg(windows)]
+        {
+            let handle = _handle.window_handle().ok()?;
+            match handle.as_raw() {
+                raw_window_handle::RawWindowHandle::Win32(win32) => Some(Self {
+                    hwnd: win32.hwnd.get(),
+                }),
+                _ => None,
+            }
+        }
+        #[cfg(not(windows))]
+        {
+            None
+        }
     }
-    if !(size.x > 0.0 && size.y > 0.0 && monitor.x > 0.0 && monitor.y > 0.0) {
-        return None;
+
+    /// The window's client area in physical pixels, straight from the platform.
+    ///
+    /// This is the reading the whole module exists for: the one number egui's
+    /// own input cannot be wrong about, because it never passes through the
+    /// scale factor that is in doubt.
+    #[must_use]
+    pub(crate) fn client_size_px(&self) -> Option<egui::Vec2> {
+        #[cfg(windows)]
+        {
+            use windows_sys::Win32::Foundation::{HWND, RECT};
+            use windows_sys::Win32::UI::WindowsAndMessaging::GetClientRect;
+
+            let mut rect = RECT {
+                left: 0,
+                top: 0,
+                right: 0,
+                bottom: 0,
+            };
+            // SAFETY: `hwnd` came from the windowing backend for this process's
+            // own window, and is only read while that window is alive — the app
+            // owns it for the whole of its run. `GetClientRect` writes the
+            // `RECT` it is handed and touches nothing else.
+            let ok = unsafe { GetClientRect(self.hwnd as HWND, &raw mut rect) };
+            if ok == 0 {
+                return None;
+            }
+            let width = (rect.right - rect.left) as f32;
+            let height = (rect.bottom - rect.top) as f32;
+            (width > 0.0 && height > 0.0).then_some(egui::vec2(width, height))
+        }
+        #[cfg(not(windows))]
+        {
+            None
+        }
     }
-    let overflows = |points: f32, monitor_px: f32| points * scale > monitor_px + OVERFLOW_SLACK_PX;
-    // Both axes, never one — see the module's note on spanning windows.
-    if !(overflows(size.x, monitor.x) && overflows(size.y, monitor.y)) {
-        return None;
-    }
-    Some(size / scale)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    /// The reported bug, in the numbers it was measured with: a 2560×1369
-    /// client on a 2560×1440 screen at scale 1.5, which egui was laying out as
-    /// 2560×1369 *points* and painting as 3840×2054 pixels.
+    /// Off Windows there is no handle of the kind this reads, and the probe
+    /// says so rather than inventing a size — the health summary then reports
+    /// the client area as absent, which is the honest answer.
+    #[cfg(not(windows))]
     #[test]
-    fn a_maximised_window_reported_in_pixels_is_corrected_back_to_points() {
-        let corrected =
-            corrected_size(egui::vec2(2560.0, 1369.33), 1.5, egui::vec2(2560.0, 1440.0))
-                .expect("3840x2054 px of content cannot fit a 2560x1440 screen");
-        // Divided by the scale, and back to exactly the surface we have.
-        assert!((corrected.x - 1706.67).abs() < 0.01, "{corrected:?}");
+    fn a_platform_without_this_handle_reports_no_client_size() {
+        // Nothing to construct: `new` is the only constructor and it returns
+        // `None` on every non-Windows target, so no probe can exist to ask.
         assert!(
-            (corrected.x * 1.5 - 2560.0).abs() < 0.01,
-            "paints back to px"
+            size_of::<SurfaceProbe>() == 0,
+            "the probe carries no handle here"
         );
     }
 
-    /// The same window before it was maximised, which was never wrong.
+    /// On Windows the probe is a plain handle, and reading through a window
+    /// that does not exist fails rather than returning a made-up size.
+    #[cfg(windows)]
     #[test]
-    fn a_window_that_fits_its_screen_is_left_alone() {
+    fn a_dead_window_reports_no_client_size() {
+        let probe = SurfaceProbe { hwnd: 0 };
         assert_eq!(
-            corrected_size(egui::vec2(1400.0, 900.0), 1.5, egui::vec2(2560.0, 1440.0)),
+            probe.client_size_px(),
             None,
-            "1400x1.5 = 2100 px fits a 2560 px screen; nothing to correct"
+            "a handle that names no window has no client area to report"
         );
-    }
-
-    /// Scale 1 is every machine that never sees this bug, and the arithmetic
-    /// there is a no-op — so the rule must not fire on it whatever the sizes.
-    #[test]
-    fn scale_one_is_never_corrected() {
-        assert_eq!(
-            corrected_size(egui::vec2(2560.0, 1369.0), 1.0, egui::vec2(2560.0, 1440.0)),
-            None
-        );
-    }
-
-    /// The false positive this rule is shaped around: a window dragged wide
-    /// across two side-by-side monitors is genuinely wider than the monitor
-    /// egui names, and shrinking it would be the bug rather than the fix.
-    #[test]
-    fn a_window_spanning_two_monitors_is_not_mistaken_for_a_bad_scale() {
-        assert_eq!(
-            corrected_size(egui::vec2(3000.0, 800.0), 1.5, egui::vec2(2560.0, 1440.0)),
-            None,
-            "wider than one screen but not taller: a spanning window, not a unit mix-up"
-        );
-    }
-
-    /// A window flush with the screen edge must not be shaved by a rounding
-    /// error — the reason the compare carries slack at all.
-    #[test]
-    fn a_window_exactly_filling_the_screen_survives_the_float_compare() {
-        assert_eq!(
-            corrected_size(
-                egui::vec2(2560.0 / 1.5, 1440.0 / 1.5),
-                1.5,
-                egui::vec2(2560.0, 1440.0)
-            ),
-            None,
-            "a correctly-reported full-screen window is not an overflow"
-        );
-    }
-
-    /// Nonsense in, nothing out: a zero monitor or a garbage scale must not
-    /// produce a zero-sized or infinite screen for the chart to lay out in.
-    #[test]
-    fn degenerate_input_changes_nothing() {
-        let screen = egui::vec2(2560.0, 1369.0);
-        let monitor = egui::vec2(2560.0, 1440.0);
-        assert_eq!(corrected_size(screen, f32::NAN, monitor), None);
-        assert_eq!(corrected_size(screen, f32::INFINITY, monitor), None);
-        assert_eq!(corrected_size(screen, 0.0, monitor), None);
-        assert_eq!(corrected_size(screen, -1.5, monitor), None);
-        assert_eq!(corrected_size(screen, 1.5, egui::Vec2::ZERO), None);
-        assert_eq!(corrected_size(egui::Vec2::ZERO, 1.5, monitor), None);
     }
 }

--- a/crates/app/src/window_scale.rs
+++ b/crates/app/src/window_scale.rs
@@ -1,0 +1,147 @@
+//! Correcting a window size the platform reported in the wrong unit.
+//!
+//! egui is told the window's size in *points* and paints at
+//! `pixels_per_point`; the two multiply out to the surface the platform
+//! actually gave us. On Windows, at a scale factor other than 1, maximising
+//! breaks that identity: the client size arrives in **physical pixels** while
+//! the scale factor stays put, so egui lays out a screen 1.5× too large and
+//! paints a third of the chart outside the window. What falls off is the right
+//! and bottom edge — which on this chart is the toolbar's layer group, the
+//! price axis, the live strip and the dock rail.
+//!
+//! This is an upstream bug, not ours: `emilk/egui#7648` (still open at 0.33.1)
+//! and `emilk/egui#7095` are the same family, and the jump from the 0.29 we
+//! build against to the current release is 262 compile errors for a version
+//! that still has it. So the size is corrected here, on the way in, and the
+//! rule is written as one pure function with the arithmetic on show.
+//!
+//! **The invariant.** A window's client area cannot be larger than the screen
+//! it is on: `size_in_points × scale ≤ monitor_in_pixels`. When that fails, the
+//! size we were handed is already in pixels, and dividing by the scale recovers
+//! the points exactly — 2560 px ÷ 1.5 = 1706.7 pt, which paints back to 2560 px.
+//!
+//! **The limit, stated rather than hidden.** A window stretched across two
+//! side-by-side monitors is legitimately wider than the monitor egui reports,
+//! so width alone must never trigger a correction. Requiring *both* axes to
+//! overflow is what separates the two: a spanning window is wider without being
+//! taller, and a wrongly-scaled one overflows both by the same factor. A window
+//! spanning monitors stacked vertically *and* horizontally would fool this, and
+//! is left uncorrected on purpose — a rare arrangement, and drawing it small is
+//! worse than drawing it as the platform asked.
+
+use eframe::egui;
+
+/// How far past the monitor a size may sit before we call it wrong. Guards the
+/// float compare against a window that is legitimately flush with the screen
+/// edge, where the two sides land a rounding error apart.
+const OVERFLOW_SLACK_PX: f32 = 1.0;
+
+/// The size egui should lay out in, when the one we were handed cannot be
+/// points. `None` means the size is already right and nothing should change.
+///
+/// `size` is what the platform reported, `scale` the pixels-per-point it
+/// reported alongside, and `monitor` the screen size — which eframe gives in
+/// physical pixels, the unit inconsistency this whole module is downstream of.
+#[must_use]
+pub(crate) fn corrected_size(
+    size: egui::Vec2,
+    scale: f32,
+    monitor: egui::Vec2,
+) -> Option<egui::Vec2> {
+    // At scale 1 the two units are the same number and there is nothing to get
+    // wrong. A non-finite or non-positive scale is not something to divide by.
+    if !(scale.is_finite() && scale > 1.0) {
+        return None;
+    }
+    if !(size.x > 0.0 && size.y > 0.0 && monitor.x > 0.0 && monitor.y > 0.0) {
+        return None;
+    }
+    let overflows = |points: f32, monitor_px: f32| points * scale > monitor_px + OVERFLOW_SLACK_PX;
+    // Both axes, never one — see the module's note on spanning windows.
+    if !(overflows(size.x, monitor.x) && overflows(size.y, monitor.y)) {
+        return None;
+    }
+    Some(size / scale)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The reported bug, in the numbers it was measured with: a 2560×1369
+    /// client on a 2560×1440 screen at scale 1.5, which egui was laying out as
+    /// 2560×1369 *points* and painting as 3840×2054 pixels.
+    #[test]
+    fn a_maximised_window_reported_in_pixels_is_corrected_back_to_points() {
+        let corrected =
+            corrected_size(egui::vec2(2560.0, 1369.33), 1.5, egui::vec2(2560.0, 1440.0))
+                .expect("3840x2054 px of content cannot fit a 2560x1440 screen");
+        // Divided by the scale, and back to exactly the surface we have.
+        assert!((corrected.x - 1706.67).abs() < 0.01, "{corrected:?}");
+        assert!(
+            (corrected.x * 1.5 - 2560.0).abs() < 0.01,
+            "paints back to px"
+        );
+    }
+
+    /// The same window before it was maximised, which was never wrong.
+    #[test]
+    fn a_window_that_fits_its_screen_is_left_alone() {
+        assert_eq!(
+            corrected_size(egui::vec2(1400.0, 900.0), 1.5, egui::vec2(2560.0, 1440.0)),
+            None,
+            "1400x1.5 = 2100 px fits a 2560 px screen; nothing to correct"
+        );
+    }
+
+    /// Scale 1 is every machine that never sees this bug, and the arithmetic
+    /// there is a no-op — so the rule must not fire on it whatever the sizes.
+    #[test]
+    fn scale_one_is_never_corrected() {
+        assert_eq!(
+            corrected_size(egui::vec2(2560.0, 1369.0), 1.0, egui::vec2(2560.0, 1440.0)),
+            None
+        );
+    }
+
+    /// The false positive this rule is shaped around: a window dragged wide
+    /// across two side-by-side monitors is genuinely wider than the monitor
+    /// egui names, and shrinking it would be the bug rather than the fix.
+    #[test]
+    fn a_window_spanning_two_monitors_is_not_mistaken_for_a_bad_scale() {
+        assert_eq!(
+            corrected_size(egui::vec2(3000.0, 800.0), 1.5, egui::vec2(2560.0, 1440.0)),
+            None,
+            "wider than one screen but not taller: a spanning window, not a unit mix-up"
+        );
+    }
+
+    /// A window flush with the screen edge must not be shaved by a rounding
+    /// error — the reason the compare carries slack at all.
+    #[test]
+    fn a_window_exactly_filling_the_screen_survives_the_float_compare() {
+        assert_eq!(
+            corrected_size(
+                egui::vec2(2560.0 / 1.5, 1440.0 / 1.5),
+                1.5,
+                egui::vec2(2560.0, 1440.0)
+            ),
+            None,
+            "a correctly-reported full-screen window is not an overflow"
+        );
+    }
+
+    /// Nonsense in, nothing out: a zero monitor or a garbage scale must not
+    /// produce a zero-sized or infinite screen for the chart to lay out in.
+    #[test]
+    fn degenerate_input_changes_nothing() {
+        let screen = egui::vec2(2560.0, 1369.0);
+        let monitor = egui::vec2(2560.0, 1440.0);
+        assert_eq!(corrected_size(screen, f32::NAN, monitor), None);
+        assert_eq!(corrected_size(screen, f32::INFINITY, monitor), None);
+        assert_eq!(corrected_size(screen, 0.0, monitor), None);
+        assert_eq!(corrected_size(screen, -1.5, monitor), None);
+        assert_eq!(corrected_size(screen, 1.5, egui::Vec2::ZERO), None);
+        assert_eq!(corrected_size(egui::Vec2::ZERO, 1.5, monitor), None);
+    }
+}


### PR DESCRIPTION
A trader reported that the four flow layers in the toolbar's top-right group —
bubbles, L2 heatmap, footprint, live strip — open **off** every launch, and that
the PR which shipped them on (#229) had changed nothing.

Both halves were true, and the first thing the reproduction settled is that the
defaults were never the problem. A launch with every cockpit store pointed at a
non-existent scratch path — a virgin machine — already opens Binance BTCUSDT in
the time+flow split with all four lamps lit:

```
APP_STARTING   feed=binance symbol=BTCUSDT
CANVAS_LAYOUT  layout=TimeAndFlow
CHART_LAYERS_RESTORED  hidden=1
```

So this is not a change of default. It is why the shipped answer never reached
anyone who already had a cockpit.

## The cause

`chart_layers::load` returned **only** the keys in the trader's file. A layer
absent from it fell through to the code baseline, which for all four flow layers
is *off*. Any `chart-layers.toml` written before #229 therefore answered "off"
to a question it had never been asked, on every launch. And it froze there:
`maintain_chart_layers` rewrites the whole map on the first switch of a session,
so one unrelated click turned that silence into an explicit `false` nobody
chose. A default that cannot reach anyone who already has a cockpit is not a
default.

Silence now resolves to the shipped answer. An explicit `false` still wins — the
promise that makes a shipped default acceptable — and a layer absent from *both*
files is still the app's to decide, which keeps the order-flow preset the only
home of `lane_marks`.

Three smaller ones travel with it, each a different way the same answer failed to
arrive:

- **The time pane never received the layer switches.** `apply_pending_layout`
  copied `hidden_layers` and stopped, leaving out every per-pane layer that does
  not live in that set — the footprint being the one that has one. This is the
  finding #229 deferred by name.
- **The heatmap lamp reported capture, not the switch.** `depth_visible()` is
  `enabled && show_depth`, so the button read unlit while book capture was
  starting; a trader pressing a dark button switched *off* the layer they were
  reaching for.
- **A new tab applied the startup map** rather than the live state its own
  comment promised — harmless only while that map was partial, and not once
  silence resolves.

And because this file is the trader's own answer and outranks the shipped
default from the next launch on, **every switch that moves is now named in the
log before it is written down** (`CHART_LAYER_SWITCHED`). The bug above cost a
day to chase because the only record was the file itself: a trio of `false`s
with no timestamp and nothing to say whether a hand had been near them.

## What is *not* fixed, and why that is the deliverable

A second, independent defect was found and could not be closed honestly.

On this machine a **maximised** window lays out larger than its own surface:
client `2560x1369 px`, egui told `2560x1369 pt` at `scale=1.5`, painting
`3840x2054 px` into it. The right and bottom third fall outside the window —
exactly where the four lamps, the price axis, the live strip and the dock rail
live. So the switches this PR turns on were not merely off for that trader; they
were off-screen.

Three corrections were built and measured, and each failed:

1. **Against `ViewportInfo::monitor_size`.** That field is in *points*
   (`egui-winit-0.29.1/src/lib.rs:970` builds it as
   `monitor.size().to_logical(pixels_per_point)`), so the check condemned every
   honest window on a 150% display: 1400x900 points evaluates `2100 > 1707` and
   `1350 > 961` and would have been shrunk to 933x600, then banked into the
   workspace file. **`arch-review` step 0 caught this as a Blocker** against an
   earlier commit on this branch; it is withdrawn.
2. **Against `inner_rect`.** Wrong together with `screen_rect`.
3. **Against the platform's own `GetClientRect`.** Returns **3840x2052** from
   inside the process where the same call from outside returns 2560x1369 —
   Windows virtualises coordinates into the caller's DPI context, so the
   "independent" reading agrees with egui to the pixel and never fires.

That is the finding: every observable available *inside* the process is
self-consistently wrong, because what is wrong is the process's own coordinate
space. A real fix has to key off something outside it — the GL framebuffer's
size, or a DPI comparison made in another awareness context — which is a change
to how the app declares DPI awareness, not a fix-up on the way into a frame.

Upstream has the same family open and unfixed: `emilk/egui#7648` (reproduces at
0.33.1, no PR) and `emilk/egui#7095`. The upgrade from the 0.29 we build against
was priced: **262 compile errors**, and `egui-phosphor` lags behind besides.

So what ships for it is the measurement, not a guess: `client_px` beside
`screen_pt` and `scale` in `APP_HEALTH_SUMMARY`, `QUANTICK_WINDOW_MAXIMIZED=1`
to reach the state from a cold launch, and `window_scale`'s module doc recording
all three dead ends. Those three numbers are what turned "the buttons are gone"
into a measurement. **Follow-up issue to come**; nothing here pretends it is
handled.

## Review

`step 0: code-review at xhigh, 11 findings, 11 confirmed` — all resolved, none
deferred. The first is the withdrawal above. The rest, resolved in `ae0be9d`:
a tautological perf-summary field; a doc comment stolen from `draw_toolbar` (the
same misplacement the branch had already fixed once for `maintain_workspace`); a
tab *switch* banking the other tab's layers as a choice and filling the new log
with switches no hand moved; seeding the time pane pushing an undo entry into an
empty drawing store; a `hidden_layers` clone overwritten one line later;
`CHART_LAYERS_RESTORED hidden=` no longer meaning what it said (renamed to `off`
with a `layers` total rather than quietly redefined); an unreachable branch that
returned before its own log on the one launch where an operator most needs it;
and a doc naming a caller this branch removed.

The shape pass found three behaviour changes with no test between them. All
three now have one, and the two that assert new behaviour were run against
`main`'s to confirm they fail without their fix:

```
the_time_pane_opens_on_the_same_layers_as_the_flow_pane        fails on main
a_new_tab_inherits_the_live_layers_not_the_startup_file        fails on main
  "the new tab reached past the session and brought back the startup file's answer"
a_file_from_before_the_defaults_still_opens_the_flow_layers    fails on main
  left: None  right: Some(true)   "heatmap is unanswered in this file"
```

Reaching the heatmap lamp needed it lifted out of the toolbar's frame into a
named reading — worth having anyway, and dimension 7's *read* half: the lamp is
now assertable without painting a toolbar.

## Verification

Four checks green. `cargo test --workspace`: **1660 passed, 0 failed** in the app
crate; `language_guard` passes and the prose, branch name and commit messages
were read. `the_bridge_paging_tests_pass` fails locally on Windows only — it
tries `python3`, which resolves to the Microsoft Store alias stub; the Python
tests themselves pass (18 checks) run directly, and CI's ubuntu image has a real
`python3`. Untouched by this branch.

**Performance.** Measured on Binance BTCUSDT at 1600x1000, eight health
summaries each:

| | fps | frame_avg | frame_cpu |
| --- | --- | --- | --- |
| `main` | 59-60 | 16.66-16.67 ms | 2.27-3.44 ms |
| this branch | 59-60 | 16.66-16.68 ms | 2.42-3.02 ms |

Every path touched is rare — startup, a layout change, a new tab, a layer switch
— and the one new per-frame cost from the withdrawn correction went with it.
`client_size_px` runs on the 2 s summary, not per frame.

**Visual QA.** Virgin launch and cold maximised launch captured and read: the
four lamps lit, both price axes, the live strip, the dock rail and the status bar
all present in the windowed case. The maximised case remains cut by the defect
above, which is stated rather than accepted as fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017nQssV6ZTFWqKXCr91Lgm4
