### PR TITLE
fix(strategy): make a force bar cut the region with its body, not its wick

### DIFF
--- a/.claude/GOAL-archive-force-bar-cuts-the-region.md
+++ b/.claude/GOAL-archive-force-bar-cuts-the-region.md
@@ -1,0 +1,65 @@
+# Mission
+
+Fix the rectangle strategy so a force bar trades a drawn region only when its
+**body** — open and close, never the wicks — actually cuts that region.
+
+## The bug, in the trader's words
+
+> A barra de força precisa cruzar, e não só cruzar as sombras. Cruzar é
+> abertura e fechamento dela.
+
+(Quoted verbatim, per the English rule's attributed-quotation exemption. In
+English: the force bar has to cross, and the wicks crossing is not crossing —
+crossing is its open and its close.)
+
+Today `ArmedStrategy::on_closed_bar` decides the entry from the trigger bar's
+**close alone**. For a sell instance any force bar closing below the region's
+low rests a retest limit at that low — including a bar that opened below the
+low too and therefore never touched the region. That is the reported symptom:
+a force bar that never cut the region still leaves a limit order sitting in
+it.
+
+## The rule this mission installs
+
+For a **sell** instance on a region `[low, high]`, judged on the trigger bar's
+open `o` and close `c`:
+
+| Geometry | Action |
+| --- | --- |
+| `c` inside `[low, high]` (whatever `o` did) | market sell |
+| `c < low` and `o >= low` — the body cut the lower edge | retest limit at `low` (under `BreakPolicy::RetestLimit`) |
+| `c < low` and `o < low` — the body never crossed the edge | nothing, gate named on the badge |
+| `c > high` — closed away, above the region | nothing |
+
+A **buy** instance is the mirror image around `high`.
+
+## Acceptance criteria
+
+1. The region/cut test judges the trigger bar's body (open **and** close). A
+   close inside fires at market whatever the open did; a close beyond the near
+   edge rests the retest limit only when the open sat on the region's side of
+   that edge; every other geometry holds fire.
+2. A force bar whose body lies wholly beyond the near edge places **no**
+   order, and names its own gate on the badge (no bare "armed" over a bar
+   that did nothing).
+3. A close beyond the *opposite* edge still never fires — kept under test.
+4. The rule has exactly one home in the kernel, consumed identically by the
+   chart and the backtest. No second copy in `app`.
+5. Test-first, as a pure domain crate demands: fixture bars and expected
+   commands written before the code, covering all four geometries on both
+   sides.
+6. Performance impact declared: the strategy kernel runs **per closed bar**
+   (rare), not per trade, per depth update or per frame. The change adds two
+   `Decimal` comparisons to a path that already does several.
+7. Every artifact in English.
+8. Four checks green after rebasing on latest `main`; `arch-review` run with
+   every Blocker/Should-fix resolved or deferred in the PR body; PR opened.
+
+## Explicitly not in scope
+
+- The retest bracket is projected off the trigger bar's close, not off the
+  edge the order actually rests at. That is a separate design question and is
+  reported in the PR body, not changed here.
+- No new UI surface and no layout change: the only user-visible delta is one
+  more status-line note in a badge that already renders arbitrary notes, so
+  `visual-qa` / `ui-harness` add nothing to grade.

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -9124,13 +9124,14 @@ impl QuantickApp {
                         "on a cut: rest a limit at the region edge until the target",
                     )
                     .on_hover_text(
-                        "a trigger bar whose body cuts the region \
-                         — open on the region's side of the edge, close beyond it, \
-                         wicks ignored — rests a limit at the edge it cut, the \
-                         retest entry, bracketed off the bar; the order removes \
-                         itself if the bar's projected target trades first. A bar \
-                         that closed past an edge it never crossed rests nothing. \
-                         Off = a cut holds fire, as before.",
+                        "a trigger bar whose body cuts the region in the trade's direction \
+                         — it opened on the region's side of that edge and closed beyond it, \
+                         wicks ignored — rests a limit at the edge it cut, the retest entry, \
+                         bracketed off the bar; the order removes itself if the bar's \
+                         projected target trades first. A bar that closed past an edge its \
+                         body never crossed, or closed away on the far side of the region, \
+                         cut nothing and rests nothing either way. Off = a cut holds fire, \
+                         as before.",
                     )
                     .changed()
                 {
@@ -13734,10 +13735,14 @@ crosshair = false
     }
 
     /// The bug the trader reported, walked through the real chart path: a
-    /// sell region drawn above the market, and a force bar that opens below
-    /// its lower edge and closes lower still. The bar never crossed into
-    /// the band, so nothing may rest on it — before the body rule this left
-    /// a limit order sitting inside a region the bar had not touched.
+    /// sell region drawn above the market, and a force bar whose *shadow*
+    /// reaches into the band while its body stays entirely below it. The
+    /// body never crossed the edge, so nothing may rest on it.
+    ///
+    /// The numbers make the test bite: range 10 puts the projected SL at
+    /// 106 and the TP at 86, both clear of the 105 edge, so the old
+    /// close-only rule really did rest a sell limit at 105 — an order
+    /// inside a band the bar's body never entered.
     #[test]
     fn a_force_bar_that_never_crossed_the_region_leaves_no_order_in_it() {
         fn print(app: &mut QuantickApp, id: &mut u64, price: &str) {
@@ -13756,6 +13761,15 @@ crosshair = false
             for _ in 0..49 {
                 print(app, id, open);
             }
+            print(app, id, close);
+        }
+        /// Fifty prints again, but one of them reaches `wick` — so the bar
+        /// carries a shadow its body never covers.
+        fn bar_with_wick(app: &mut QuantickApp, id: &mut u64, open: &str, wick: &str, close: &str) {
+            for _ in 0..48 {
+                print(app, id, open);
+            }
+            print(app, id, wick);
             print(app, id, close);
         }
 
@@ -13784,14 +13798,15 @@ crosshair = false
         bar(&mut app, &mut id, "102", "101");
         bar(&mut app, &mut id, "101", "100");
         // Body 4 over average (1+1+4)/3 = 2: a genuine force bar. It opens
-        // at 100, already below the region's 105 edge, and closes at 96 —
-        // the whole body sits under a band it never entered.
-        bar(&mut app, &mut id, "100", "96");
+        // at 100, already below the region's 105 edge, prints once at 106
+        // inside the band, and closes at 96. The shadow visited the region;
+        // the body never did.
+        bar_with_wick(&mut app, &mut id, "100", "106", "96");
 
         let tab = app.active_tab();
         assert!(
             tab.paper.working_orders().is_empty(),
-            "a bar that never cut the region rests no order in it: {:?}",
+            "a bar whose body never cut the region rests no order in it: {:?}",
             tab.paper.working_orders()
         );
         assert!(tab.paper.is_flat(), "and takes no position either");
@@ -13807,7 +13822,7 @@ crosshair = false
         assert_eq!(
             instance.armed.status_line(),
             "armed · trigger held: the body never cut the region",
-            "the badge names the gate rather than showing a bare armed"
+            "the instance names the gate it held on rather than reporting a bare armed"
         );
     }
 

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -9124,10 +9124,13 @@ impl QuantickApp {
                         "on a cut: rest a limit at the region edge until the target",
                     )
                     .on_hover_text(
-                        "a trigger bar closing beyond the region in the trade's direction \
-                         rests a limit at the edge it cut — the retest entry — bracketed \
-                         off the bar; the order removes itself if the bar's projected \
-                         target trades first. Off = a cut holds fire, as before.",
+                        "a trigger bar whose body cuts the region \
+                         — open on the region's side of the edge, close beyond it, \
+                         wicks ignored — rests a limit at the edge it cut, the \
+                         retest entry, bracketed off the bar; the order removes \
+                         itself if the bar's projected target trades first. A bar \
+                         that closed past an edge it never crossed rests nothing. \
+                         Off = a cut holds fire, as before.",
                     )
                     .changed()
                 {

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -9119,18 +9119,17 @@ impl QuantickApp {
                 }
                 let mut retest = popup.form.on_break == "retest_limit";
                 if ui
-                    .checkbox(
-                        &mut retest,
-                        "on a cut: rest a limit at the region edge until the target",
-                    )
+                    .checkbox(&mut retest, "on a cut: rest a limit at the region edge")
                     .on_hover_text(
                         "a trigger bar whose body cuts the region in the trade's direction \
                          — it opened on the region's side of that edge and closed beyond it, \
                          wicks ignored — rests a limit at the edge it cut, the retest entry, \
-                         bracketed off the bar; the order removes itself if the bar's \
-                         projected target trades first. A bar that closed past an edge its \
-                         body never crossed, or closed away on the far side of the region, \
-                         cut nothing and rests nothing either way. Off = a cut holds fire, \
+                         bracketed off the bar. The order removes itself if the bar's \
+                         projected target trades first; with the TP multiplier at 0 there is \
+                         no such level, so it rests until it fills or you disarm it — the \
+                         badge says which. A bar that closed past an edge its body never \
+                         crossed, one that closed away on the far side, and a cut whose legs \
+                         would not clear the edge all rest nothing. Off = a cut holds fire, \
                          as before.",
                     )
                     .changed()
@@ -13804,6 +13803,25 @@ crosshair = false
         bar_with_wick(&mut app, &mut id, "100", "106", "96");
 
         let tab = app.active_tab();
+        // The premise, pinned: if the bar spec or the print counts ever
+        // drift, the 106 print lands in a neighbouring bar and this test
+        // silently stops testing wick-versus-body — the only thing it is
+        // here for.
+        assert_eq!(
+            tab.flow_pane.closed_slots(),
+            3,
+            "the three fixture bars closed as three bars"
+        );
+        let trigger = tab.flow_pane.closed_bar(2).expect("the trigger bar closed");
+        assert_eq!(
+            (trigger.open, trigger.high, trigger.close),
+            (
+                rust_decimal::Decimal::from(100),
+                rust_decimal::Decimal::from(106),
+                rust_decimal::Decimal::from(96)
+            ),
+            "the shadow reaches into the 105-115 band while the body stays below it"
+        );
         assert!(
             tab.paper.working_orders().is_empty(),
             "a bar whose body never cut the region rests no order in it: {:?}",

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -13733,6 +13733,84 @@ crosshair = false
         assert!(app.active_tab().flow_pane.strategies.is_empty());
     }
 
+    /// The bug the trader reported, walked through the real chart path: a
+    /// sell region drawn above the market, and a force bar that opens below
+    /// its lower edge and closes lower still. The bar never crossed into
+    /// the band, so nothing may rest on it — before the body rule this left
+    /// a limit order sitting inside a region the bar had not touched.
+    #[test]
+    fn a_force_bar_that_never_crossed_the_region_leaves_no_order_in_it() {
+        fn print(app: &mut QuantickApp, id: &mut u64, price: &str) {
+            *id += 1;
+            let trade = quantick_engine::Trade {
+                agg_id: *id,
+                timestamp_ms: 1_700_000_000_000 + *id as i64 * 100,
+                price: rust_decimal::Decimal::from_str_exact(price).unwrap(),
+                quantity: rust_decimal::Decimal::ONE,
+                side: quantick_engine::Side::Buy,
+            };
+            app.active_tab_mut()
+                .ingest_live_trade_at(&trade, trade.timestamp_ms);
+        }
+        fn bar(app: &mut QuantickApp, id: &mut u64, open: &str, close: &str) {
+            for _ in 0..49 {
+                print(app, id, open);
+            }
+            print(app, id, close);
+        }
+
+        let (mut app, _events, _commands, _book) = test_app();
+        let rectangle = drawings::DRAWING_TOOLS
+            .into_iter()
+            .find(|tool| tool.id() == "rectangle")
+            .expect("the rectangle tool is registered");
+        {
+            let pane = &mut app.active_tab_mut().flow_pane;
+            pane.drawings
+                .place(rectangle, drawings::ChartPoint::at(0.0, 105.0));
+            pane.drawings
+                .place(rectangle, drawings::ChartPoint::at(30.0, 115.0));
+        }
+        let drawing = app.active_tab().flow_pane.drawings.items()[0].id;
+        let mut form =
+            crate::strategy_presets::StoredPreset::starting_point(quantick_engine::Side::Sell);
+        form.window = 3;
+        form.min_body = "0".to_owned();
+        form.on_break = "retest_limit".to_owned();
+        app.arm_strategy_instance(pane::PaneSide::Flow, drawing, &form, "BF no cut".to_owned())
+            .expect("the retest form compiles");
+
+        let mut id = 0u64;
+        bar(&mut app, &mut id, "102", "101");
+        bar(&mut app, &mut id, "101", "100");
+        // Body 4 over average (1+1+4)/3 = 2: a genuine force bar. It opens
+        // at 100, already below the region's 105 edge, and closes at 96 —
+        // the whole body sits under a band it never entered.
+        bar(&mut app, &mut id, "100", "96");
+
+        let tab = app.active_tab();
+        assert!(
+            tab.paper.working_orders().is_empty(),
+            "a bar that never cut the region rests no order in it: {:?}",
+            tab.paper.working_orders()
+        );
+        assert!(tab.paper.is_flat(), "and takes no position either");
+        let instance = tab
+            .flow_pane
+            .strategies
+            .for_drawing(drawing)
+            .expect("instance");
+        assert_eq!(
+            instance.armed.state(),
+            &quantick_strategy::ArmedState::Armed
+        );
+        assert_eq!(
+            instance.armed.status_line(),
+            "armed · trigger held: the body never cut the region",
+            "the badge names the gate rather than showing a bare armed"
+        );
+    }
+
     /// The user's retest flow end to end in the app: a sell preset with the
     /// retest option armed on a region, a force bar cutting below it, the
     /// limit resting at the cut edge — then the tape reaching the target

--- a/crates/app/src/strategy_presets.rs
+++ b/crates/app/src/strategy_presets.rs
@@ -68,8 +68,11 @@ pub struct StoredPreset {
     /// What a trigger bar cutting through the region does: `ignore`
     /// (default — hold fire, the behaviour before the option existed) or
     /// `retest_limit` (rest a limit at the cut edge, cancelled at the
-    /// bar's projected target). Optional for the same vintage reason as
-    /// `min_body`, which is why the version does not move.
+    /// bar's projected target). A cut is read off the bar's body — open on
+    /// the region's side of the edge, close beyond it, wicks ignored — so
+    /// a bar that never crossed the edge rests nothing under either value.
+    /// Optional for the same vintage reason as `min_body`, which is why
+    /// the version does not move.
     #[serde(default = "ignore_break")]
     pub on_break: String,
 }

--- a/crates/app/src/strategy_presets.rs
+++ b/crates/app/src/strategy_presets.rs
@@ -70,7 +70,9 @@ pub struct StoredPreset {
     /// `retest_limit` (rest a limit at the cut edge, cancelled at the
     /// bar's projected target). A cut is read off the bar's body — open on
     /// the region's side of the edge, close beyond it, wicks ignored — so
-    /// a bar that never crossed the edge rests nothing under either value.
+    /// a bar that never crossed the edge rests nothing under either value,
+    /// and neither does a cut whose projected legs would not clear the
+    /// edge — an entry is never armed unprotected.
     /// Optional for the same vintage reason as `min_body`, which is why
     /// the version does not move.
     #[serde(default = "ignore_break")]

--- a/crates/backtest/src/main.rs
+++ b/crates/backtest/src/main.rs
@@ -155,6 +155,11 @@ struct Args {
     /// Force-region only: on a bar cutting through the region, rest a limit
     /// at the cut edge (cancelled at the bar's target) instead of holding
     /// fire — the chart's "retest limit" option, measured headless.
+    ///
+    /// "Cutting through" is read off the bar's **body**: it opened on the
+    /// region's side of the edge the trade leaves by and closed beyond it.
+    /// A bar that merely finished past an edge its body never crossed cut
+    /// nothing and rests nothing, however far its wick reached.
     retest_limit: bool,
     quantity: Decimal,
     protection: Protection,
@@ -209,9 +214,11 @@ fn usage() -> String {
   --region <low:high:side> the force-region strategy's price band and the
                            side it hunts (buy|sell); auto re-arms so every
                            qualifying bar in the recording is measured
-  --retest-limit           force-region: a bar cutting through the region
-                           rests a limit at the cut edge, cancelled if the
-                           bar's projected target trades first
+  --retest-limit           force-region: a bar whose body cuts through the
+                           region — open on the region's side of the edge,
+                           close beyond it, wicks ignored — rests a limit at
+                           the cut edge, cancelled if the bar's projected
+                           target trades first
   --quantity <n>           contracts per entry (default {DEFAULT_QUANTITY})
   --stop <points>          protective stop distance from the entry mark
   --target <points>        protective target distance from the entry mark

--- a/crates/backtest/src/main.rs
+++ b/crates/backtest/src/main.rs
@@ -159,7 +159,10 @@ struct Args {
     /// "Cutting through" is read off the bar's **body**: it opened on the
     /// region's side of the edge the trade leaves by and closed beyond it.
     /// A bar that merely finished past an edge its body never crossed cut
-    /// nothing and rests nothing, however far its wick reached.
+    /// nothing and rests nothing, however far its wick reached. A cut whose
+    /// projected legs would not clear the edge is refused too — an entry is
+    /// never armed unprotected — so a run can report fewer entries than the
+    /// cuts on the chart suggest.
     retest_limit: bool,
     quantity: Decimal,
     protection: Protection,
@@ -218,7 +221,8 @@ fn usage() -> String {
                            region — open on the region's side of the edge,
                            close beyond it, wicks ignored — rests a limit at
                            the cut edge, cancelled if the bar's projected
-                           target trades first
+                           target trades first; a cut whose legs would not
+                           clear that edge is refused, never armed bare
   --quantity <n>           contracts per entry (default {DEFAULT_QUANTITY})
   --stop <points>          protective stop distance from the entry mark
   --target <points>        protective target distance from the entry mark

--- a/crates/backtest/tests/harness.rs
+++ b/crates/backtest/tests/harness.rs
@@ -149,6 +149,59 @@ fn tape_of(prices: &[&str]) -> String {
 /// consumers. The tape mirrors the strategy crate's own golden walk
 /// (`crates/strategy/tests/full_operation.rs`), so any divergence between
 /// the live chart and this harness has nowhere to hide.
+/// The body rule reaches the *second* consumer, proved through the fill
+/// path rather than asserted. A sell region sits at 105–115 and the force
+/// bar's shadow reaches 106, inside the band, while its body runs 100 → 96
+/// entirely below it. Under the old close-only rule this rested a retest
+/// limit at 105 and the later print at 105 filled it; under the body rule
+/// nothing rests, so nothing fills.
+///
+/// The chart proves the same walk in `crates/app/src/app.rs`. One kernel,
+/// two consumers, one geometry — this is the test that would catch them
+/// drifting apart.
+#[test]
+fn a_body_that_never_cut_the_region_rests_nothing_under_the_harness() {
+    use quantick_strategy::{ForceParams, Rearm, Region, StrategyParams};
+
+    // Tick(3) bars: two body-1 warmup bars, the force bar with its shadow
+    // in the band and its body under it, then a bar printing back at 105 —
+    // the price a wrongly rested limit would have filled at.
+    let session = synthetic(&tape_of(&[
+        "102", "102", "101", //
+        "101", "101", "100", //
+        "100", "106", "96", //
+        "100", "105", "100",
+    ]));
+    let mut strategy = ForceRegion::new(
+        Region::new(Decimal::from(105), Decimal::from(115)),
+        StrategyParams {
+            side: Side::Sell,
+            quantity: Decimal::ONE,
+            tp_mult: Decimal::ONE,
+            sl_mult: Decimal::ONE,
+            rearm: Rearm::OneShot,
+            on_break: quantick_strategy::BreakPolicy::RetestLimit,
+        },
+        ForceParams {
+            window: 3,
+            min_factor: "1.5".parse().expect("fixture factor"),
+            max_factor: "2.5".parse().expect("fixture factor"),
+            min_body: Decimal::ZERO,
+        },
+    );
+    let run = run_session(&session, BarSpec::Tick(3), &mut strategy);
+
+    assert!(
+        run.trades.is_empty(),
+        "a body that never cut the region rests no limit, so the print back          at the edge fills nothing: {:?}",
+        run.trades
+    );
+    assert_eq!(
+        run.open_at_end, None,
+        "and the recording ends flat, with nothing resting"
+    );
+}
+
 #[test]
 fn the_force_region_kernel_walks_a_full_operation_under_the_harness() {
     use quantick_strategy::{ForceParams, Rearm, Region, StrategyParams};

--- a/crates/backtest/tests/harness.rs
+++ b/crates/backtest/tests/harness.rs
@@ -149,59 +149,6 @@ fn tape_of(prices: &[&str]) -> String {
 /// consumers. The tape mirrors the strategy crate's own golden walk
 /// (`crates/strategy/tests/full_operation.rs`), so any divergence between
 /// the live chart and this harness has nowhere to hide.
-/// The body rule reaches the *second* consumer, proved through the fill
-/// path rather than asserted. A sell region sits at 105–115 and the force
-/// bar's shadow reaches 106, inside the band, while its body runs 100 → 96
-/// entirely below it. Under the old close-only rule this rested a retest
-/// limit at 105 and the later print at 105 filled it; under the body rule
-/// nothing rests, so nothing fills.
-///
-/// The chart proves the same walk in `crates/app/src/app.rs`. One kernel,
-/// two consumers, one geometry — this is the test that would catch them
-/// drifting apart.
-#[test]
-fn a_body_that_never_cut_the_region_rests_nothing_under_the_harness() {
-    use quantick_strategy::{ForceParams, Rearm, Region, StrategyParams};
-
-    // Tick(3) bars: two body-1 warmup bars, the force bar with its shadow
-    // in the band and its body under it, then a bar printing back at 105 —
-    // the price a wrongly rested limit would have filled at.
-    let session = synthetic(&tape_of(&[
-        "102", "102", "101", //
-        "101", "101", "100", //
-        "100", "106", "96", //
-        "100", "105", "100",
-    ]));
-    let mut strategy = ForceRegion::new(
-        Region::new(Decimal::from(105), Decimal::from(115)),
-        StrategyParams {
-            side: Side::Sell,
-            quantity: Decimal::ONE,
-            tp_mult: Decimal::ONE,
-            sl_mult: Decimal::ONE,
-            rearm: Rearm::OneShot,
-            on_break: quantick_strategy::BreakPolicy::RetestLimit,
-        },
-        ForceParams {
-            window: 3,
-            min_factor: "1.5".parse().expect("fixture factor"),
-            max_factor: "2.5".parse().expect("fixture factor"),
-            min_body: Decimal::ZERO,
-        },
-    );
-    let run = run_session(&session, BarSpec::Tick(3), &mut strategy);
-
-    assert!(
-        run.trades.is_empty(),
-        "a body that never cut the region rests no limit, so the print back          at the edge fills nothing: {:?}",
-        run.trades
-    );
-    assert_eq!(
-        run.open_at_end, None,
-        "and the recording ends flat, with nothing resting"
-    );
-}
-
 #[test]
 fn the_force_region_kernel_walks_a_full_operation_under_the_harness() {
     use quantick_strategy::{ForceParams, Rearm, Region, StrategyParams};
@@ -247,6 +194,115 @@ fn the_force_region_kernel_walks_a_full_operation_under_the_harness() {
     assert_eq!(
         run.open_at_end, None,
         "the take profit closed it before the recording ended"
+    );
+}
+
+/// The body rule reaches the *second* consumer, and a genuine cut still
+/// trades there. Sell region 105–115; the force bar opens at 108 inside
+/// the band and closes at 104 below it — a body cut — so a limit rests at
+/// the 105 edge, the tape comes back to it, and the projected target
+/// closes the operation.
+///
+/// This is the positive half the negative test below cannot supply: invert
+/// the open comparison in `Region::body_cut` and this test goes red, which
+/// is what makes the pair a guard against the chart and the harness
+/// drifting apart rather than a pair of assertions that nothing happened.
+#[test]
+fn a_body_cut_rests_a_limit_under_the_harness_and_the_retest_fills() {
+    use quantick_strategy::{BreakPolicy, ForceParams, Rearm, Region, StrategyParams};
+
+    // Tick(3) bars: two body-1 warmup bars, the body-4 cut, the return to
+    // the 105 edge that fills the limit, then the walk down to the target.
+    let session = synthetic(&tape_of(&[
+        "110", "110", "109", //
+        "109", "109", "108", //
+        "108", "108", "104", //
+        "104", "105", "105", //
+        "105", "102", "100",
+    ]));
+    let mut strategy = ForceRegion::new(
+        Region::new(Decimal::from(105), Decimal::from(115)),
+        StrategyParams {
+            side: Side::Sell,
+            quantity: Decimal::ONE,
+            tp_mult: Decimal::ONE,
+            sl_mult: Decimal::ONE,
+            rearm: Rearm::OneShot,
+            on_break: BreakPolicy::RetestLimit,
+        },
+        ForceParams {
+            window: 3,
+            min_factor: "1.5".parse().expect("fixture factor"),
+            max_factor: "2.5".parse().expect("fixture factor"),
+            min_body: Decimal::ZERO,
+        },
+    );
+    let run = run_session(&session, BarSpec::Tick(3), &mut strategy);
+
+    assert_eq!(run.trades.len(), 1, "the retest round-tripped: {:?}", run);
+    let trade = &run.trades[0];
+    assert_eq!(
+        trade.entry_price,
+        Decimal::from(105),
+        "the limit filled at the edge the body cut, not at the bar's close"
+    );
+    assert_eq!(trade.exit_price, Decimal::from(100));
+    assert_eq!(trade.exit_reason, ExitReason::TakeProfit);
+    assert_eq!(run.resting_at_end, 0, "nothing left waiting");
+}
+
+/// The mirror, and the one that pins the reported bug: the force bar's
+/// *shadow* reaches 106 inside the 105–115 band while its body runs
+/// 100 → 96 entirely below it, so nothing may rest. The tape then prints
+/// back at 105 — the price a wrongly rested limit would have filled at.
+///
+/// `resting_at_end` is the assertion that carries the bug, not
+/// `trades.is_empty()`: under the pre-fix geometry the limit rested, the
+/// 105 print filled it, and the position was still open when the recording
+/// ended — so no *closed* trade existed and an `is_empty()` check on
+/// `trades` passed against the very bug it names. `SessionRun` separates
+/// the two for exactly this reason.
+#[test]
+fn a_body_that_never_cut_the_region_rests_nothing_under_the_harness() {
+    use quantick_strategy::{BreakPolicy, ForceParams, Rearm, Region, StrategyParams};
+
+    let session = synthetic(&tape_of(&[
+        "102", "102", "101", //
+        "101", "101", "100", //
+        "100", "106", "96", //
+        "100", "105", "100",
+    ]));
+    let mut strategy = ForceRegion::new(
+        Region::new(Decimal::from(105), Decimal::from(115)),
+        StrategyParams {
+            side: Side::Sell,
+            quantity: Decimal::ONE,
+            tp_mult: Decimal::ONE,
+            sl_mult: Decimal::ONE,
+            rearm: Rearm::OneShot,
+            on_break: BreakPolicy::RetestLimit,
+        },
+        ForceParams {
+            window: 3,
+            min_factor: "1.5".parse().expect("fixture factor"),
+            max_factor: "2.5".parse().expect("fixture factor"),
+            min_body: Decimal::ZERO,
+        },
+    );
+    let run = run_session(&session, BarSpec::Tick(3), &mut strategy);
+
+    assert_eq!(
+        run.resting_at_end, 0,
+        "a body that never cut the region rests no limit at the edge"
+    );
+    assert_eq!(
+        run.open_at_end, None,
+        "so the print back at 105 had nothing to fill"
+    );
+    assert!(
+        run.trades.is_empty(),
+        "and no operation ran: {:?}",
+        run.trades
     );
 }
 

--- a/crates/strategy/src/armed.rs
+++ b/crates/strategy/src/armed.rs
@@ -273,7 +273,14 @@ impl ArmedStrategy {
         // ignored — because that is what "the force bar cut the region"
         // means to the trader reading the chart. `signal.reference` keeps
         // its separate job: the price the bracket projects from.
-        let edge = match region.body_cut(self.params.side, bar.open, bar.close) {
+        //
+        // Each arm below is complete on its own, policy included, so that a
+        // fifth `BodyCut` or a third `BreakPolicy` cannot fall through into
+        // a neighbour's outcome and rest a real order by accident. Every
+        // hold names the gate that actually decided it — the geometry when
+        // the bar could never have traded, the policy when the option was
+        // simply off.
+        let edge = match region.body_cut(self.params.side, bar) {
             BodyCut::ClosedInside => {
                 self.note = None;
                 self.state = ArmedState::Fired {
@@ -286,14 +293,23 @@ impl ArmedStrategy {
                     bracket,
                 }];
             }
-            // The body crossed the edge and finished beyond it. Under the
-            // retest policy that edge is where the limit rests.
-            BodyCut::CutThrough { edge } => edge,
+            // The body crossed the edge and finished beyond it — the one
+            // geometry the retest option exists for. With the option off,
+            // the policy is what held fire, and the badge says so rather
+            // than blaming a bar that did its part.
+            BodyCut::CutThrough { edge } => match self.params.on_break {
+                BreakPolicy::RetestLimit => edge,
+                BreakPolicy::Ignore => {
+                    self.note = Some("trigger held: cut the region, retest option off");
+                    return Vec::new();
+                }
+            },
             BodyCut::NoCut => {
                 // The bar closed past the edge but opened past it too: it
                 // travelled beyond a region it never crossed into. Resting
                 // a limit on that edge would put an order in a band this
-                // bar has no claim on.
+                // bar has no claim on. True whatever the policy says, so
+                // the geometry is the honest reason.
                 self.note = Some("trigger held: the body never cut the region");
                 return Vec::new();
             }
@@ -301,10 +317,6 @@ impl ArmedStrategy {
                 self.note = Some("trigger held: closed outside region");
                 return Vec::new();
             }
-        };
-        let BreakPolicy::RetestLimit = self.params.on_break else {
-            self.note = Some("trigger held: closed outside region");
-            return Vec::new();
         };
         // The projected legs anchor on the trigger bar, but the entry now
         // prices at the edge: a leg that does not clear the edge would be
@@ -616,6 +628,23 @@ mod tests {
         }
     }
 
+    /// A bar whose shadows reach past its body, so a fixture can put the
+    /// wick inside the region and the body outside it — the shape the whole
+    /// rule turns on.
+    fn wicked(open: &str, close: &str, high: &str, low: &str) -> Bar {
+        Bar {
+            open_time: 0,
+            close_time: 0,
+            open: dec(open),
+            high: dec(high),
+            low: dec(low),
+            close: dec(close),
+            buy_volume: Decimal::ONE,
+            sell_volume: Decimal::ONE,
+            trade_count: 2,
+        }
+    }
+
     fn params(side: Side) -> StrategyParams {
         StrategyParams {
             side,
@@ -710,10 +739,27 @@ mod tests {
         assert!(warm_then_force(&mut instance, &region).is_empty());
         assert_eq!(instance.state(), &ArmedState::Armed);
 
-        // Close outside the region.
+        // Closed away from the region: the buy force bar closes at 106,
+        // below a band sitting at 110–120, so it never reached it.
+        let above_region = Region::new(dec("110"), dec("120"));
+        let mut instance = force_instance(Side::Buy);
+        assert!(warm_then_force(&mut instance, &above_region).is_empty());
+        assert_eq!(
+            instance.status_line(),
+            "armed · trigger held: closed outside region"
+        );
+
+        // Past the edge without crossing it: the same bar opens at 102,
+        // already above a band sitting at 90–100. Two different holds, two
+        // different sentences — asserted here so neither can drift into
+        // the other's wording unnoticed.
         let low_region = Region::new(dec("90"), dec("100"));
         let mut instance = force_instance(Side::Buy);
         assert!(warm_then_force(&mut instance, &low_region).is_empty());
+        assert_eq!(
+            instance.status_line(),
+            "armed · trigger held: the body never cut the region"
+        );
 
         // Region no longer active in time.
         let mut instance = force_instance(Side::Buy);
@@ -1165,12 +1211,15 @@ mod tests {
         assert_eq!(instance.state(), &ArmedState::Armed);
         assert_eq!(
             instance.status_line(),
-            "armed · trigger held: closed outside region"
+            "armed · trigger held: cut the region, retest option off",
+            "the bar did its part; the option is what held fire, and the              badge blames the option rather than the bar"
         );
     }
 
     /// A close beyond the *opposite* edge is a miss, never a retest: a sell
-    /// bar closing above the region has not cut anything downward.
+    /// bar closing above the region has not cut anything downward. Its note
+    /// is pinned here so it cannot silently become the same sentence a real
+    /// cut produces — the two mean opposite things to a trader.
     #[test]
     fn a_cut_beyond_the_opposite_edge_never_arms_a_retest() {
         let region = Region::new(dec("90"), dec("100"));
@@ -1181,22 +1230,31 @@ mod tests {
         let commands = instance.on_closed_bar(&bar("108", "104"), &region, true, true);
         assert!(commands.is_empty());
         assert_eq!(instance.state(), &ArmedState::Armed);
+        assert_eq!(
+            instance.status_line(),
+            "armed · trigger held: closed outside region"
+        );
     }
 
-    /// The reported bug. A sell force bar whose whole body sits below the
-    /// region — it opened under the low and closed lower still — never cut
-    /// anything: the region is above it, untouched. Resting a limit on the
-    /// low there puts an order in a band the bar never crossed, which is
-    /// exactly what the trader saw on the chart.
+    /// The reported bug, in the shape that proves it. A sell region sits at
+    /// 105–115 and the force bar's *shadow* reaches 106, right into the
+    /// band — but its body opened at 100 and closed at 96, entirely below
+    /// the region, so it cut nothing. The old close-only rule rested a
+    /// limit at 105: an order inside a band the bar's body never entered,
+    /// which is what the trader saw on the chart.
+    ///
+    /// The numbers are chosen so the pre-fix code really did place that
+    /// order — range 10 puts SL at 106 and TP at 86, both clear of the 105
+    /// edge — otherwise this test would pass against the bug it names.
     #[test]
-    fn a_body_wholly_below_the_region_is_no_cut_and_rests_nothing() {
+    fn a_body_below_the_region_rests_nothing_however_far_its_wick_reaches() {
         let region = Region::new(dec("105"), dec("115"));
         let mut instance = retest_instance(Side::Sell);
         instance.on_closed_bar(&bar("102", "101"), &region, true, true);
         instance.on_closed_bar(&bar("101", "100"), &region, true, true);
-        // Body 4, ratio 2 — a genuine force bar, opening at 100 (below the
-        // 105 edge) and closing at 96. It cut nothing.
-        let commands = instance.on_closed_bar(&bar("100", "96"), &region, true, true);
+        // Body 4 over average (1+1+4)/3 = 2: a genuine force bar.
+        let commands =
+            instance.on_closed_bar(&wicked("100", "96", "106", "96"), &region, true, true);
         assert!(
             commands.is_empty(),
             "a body that never crossed the edge rests no limit: {commands:?}"
@@ -1208,14 +1266,18 @@ mod tests {
         );
     }
 
-    /// The buy mirror: a body wholly above a buy region cut nothing either.
+    /// The buy mirror, built the same way: the shadow dips to 99 inside the
+    /// 90–100 band while the body runs 101 → 105 above it. Range 6 puts SL
+    /// at 99 and TP at 111 around the 100 edge, so the pre-fix code rested
+    /// a buy limit at 100 here.
     #[test]
-    fn a_body_wholly_above_the_region_is_no_cut_and_rests_nothing() {
+    fn a_body_above_the_region_rests_nothing_however_far_its_wick_reaches() {
         let region = Region::new(dec("90"), dec("100"));
         let mut instance = retest_instance(Side::Buy);
         instance.on_closed_bar(&bar("101", "102"), &region, true, true);
         instance.on_closed_bar(&bar("102", "103"), &region, true, true);
-        let commands = instance.on_closed_bar(&bar("103", "107"), &region, true, true);
+        let commands =
+            instance.on_closed_bar(&wicked("101", "105", "105", "99"), &region, true, true);
         assert!(
             commands.is_empty(),
             "a body that never crossed the edge rests no limit: {commands:?}"

--- a/crates/strategy/src/armed.rs
+++ b/crates/strategy/src/armed.rs
@@ -13,7 +13,7 @@ use quantick_engine::{Bar, Side};
 use quantick_sim::{Bracket, Command, OrderId, RejectReason, SimEvent};
 use rust_decimal::Decimal;
 
-use crate::region::Region;
+use crate::region::{BodyCut, Region};
 use crate::trigger::Trigger;
 
 /// What the instance does after its operation closes.
@@ -28,9 +28,10 @@ pub enum Rearm {
 }
 
 /// What the instance does when the trigger bar cuts *through* the region —
-/// same side, region active, but the close beyond the region's edge in the
-/// trade's direction. Closing inside still fires at market; closing beyond
-/// the *opposite* edge never fires at all.
+/// same side, region active, and a body ([`Region::body_cut`]) that opened
+/// on the region's side of the edge the trade leaves by and closed beyond
+/// it. Closing inside still fires at market; closing beyond the *opposite*
+/// edge, or beyond an edge the body never crossed, never fires at all.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum BreakPolicy {
     /// Hold fire, exactly as before this option existed. The default.
@@ -268,27 +269,40 @@ impl ArmedStrategy {
             self.note = Some("projection invalid — held fire");
             return Vec::new();
         };
-        if region.contains(signal.reference) {
-            self.note = None;
-            self.state = ArmedState::Fired {
-                order_id: None,
-                retest: false,
-            };
-            return vec![Command::PlaceMarket {
-                side: self.params.side,
-                quantity: self.params.quantity,
-                bracket,
-            }];
-        }
-        // The close sits outside the region. A cut — beyond the edge in the
-        // trade's own direction — may still become a retest limit at that
-        // edge; beyond the opposite edge it is just a miss.
-        let edge = match self.params.side {
-            Side::Sell if signal.reference < region.low() => Some(region.low()),
-            Side::Buy if signal.reference > region.high() => Some(region.high()),
-            _ => None,
+        // The geometry is the bar's own body — open to close, wicks
+        // ignored — because that is what "the force bar cut the region"
+        // means to the trader reading the chart. `signal.reference` keeps
+        // its separate job: the price the bracket projects from.
+        let edge = match region.body_cut(self.params.side, bar.open, bar.close) {
+            BodyCut::ClosedInside => {
+                self.note = None;
+                self.state = ArmedState::Fired {
+                    order_id: None,
+                    retest: false,
+                };
+                return vec![Command::PlaceMarket {
+                    side: self.params.side,
+                    quantity: self.params.quantity,
+                    bracket,
+                }];
+            }
+            // The body crossed the edge and finished beyond it. Under the
+            // retest policy that edge is where the limit rests.
+            BodyCut::CutThrough { edge } => edge,
+            BodyCut::NoCut => {
+                // The bar closed past the edge but opened past it too: it
+                // travelled beyond a region it never crossed into. Resting
+                // a limit on that edge would put an order in a band this
+                // bar has no claim on.
+                self.note = Some("trigger held: the body never cut the region");
+                return Vec::new();
+            }
+            BodyCut::ClosedAway => {
+                self.note = Some("trigger held: closed outside region");
+                return Vec::new();
+            }
         };
-        let (BreakPolicy::RetestLimit, Some(edge)) = (self.params.on_break, edge) else {
+        let BreakPolicy::RetestLimit = self.params.on_break else {
             self.note = Some("trigger held: closed outside region");
             return Vec::new();
         };
@@ -1167,6 +1181,68 @@ mod tests {
         let commands = instance.on_closed_bar(&bar("108", "104"), &region, true, true);
         assert!(commands.is_empty());
         assert_eq!(instance.state(), &ArmedState::Armed);
+    }
+
+    /// The reported bug. A sell force bar whose whole body sits below the
+    /// region — it opened under the low and closed lower still — never cut
+    /// anything: the region is above it, untouched. Resting a limit on the
+    /// low there puts an order in a band the bar never crossed, which is
+    /// exactly what the trader saw on the chart.
+    #[test]
+    fn a_body_wholly_below_the_region_is_no_cut_and_rests_nothing() {
+        let region = Region::new(dec("105"), dec("115"));
+        let mut instance = retest_instance(Side::Sell);
+        instance.on_closed_bar(&bar("102", "101"), &region, true, true);
+        instance.on_closed_bar(&bar("101", "100"), &region, true, true);
+        // Body 4, ratio 2 — a genuine force bar, opening at 100 (below the
+        // 105 edge) and closing at 96. It cut nothing.
+        let commands = instance.on_closed_bar(&bar("100", "96"), &region, true, true);
+        assert!(
+            commands.is_empty(),
+            "a body that never crossed the edge rests no limit: {commands:?}"
+        );
+        assert_eq!(instance.state(), &ArmedState::Armed);
+        assert_eq!(
+            instance.status_line(),
+            "armed · trigger held: the body never cut the region"
+        );
+    }
+
+    /// The buy mirror: a body wholly above a buy region cut nothing either.
+    #[test]
+    fn a_body_wholly_above_the_region_is_no_cut_and_rests_nothing() {
+        let region = Region::new(dec("90"), dec("100"));
+        let mut instance = retest_instance(Side::Buy);
+        instance.on_closed_bar(&bar("101", "102"), &region, true, true);
+        instance.on_closed_bar(&bar("102", "103"), &region, true, true);
+        let commands = instance.on_closed_bar(&bar("103", "107"), &region, true, true);
+        assert!(
+            commands.is_empty(),
+            "a body that never crossed the edge rests no limit: {commands:?}"
+        );
+        assert_eq!(
+            instance.status_line(),
+            "armed · trigger held: the body never cut the region"
+        );
+    }
+
+    /// The open is read for the *cut*, never for the market entry: a bar
+    /// that opened clear above a sell region and closed inside it sells at
+    /// market, because where it opened does not matter once it finished in
+    /// the band.
+    #[test]
+    fn an_open_outside_the_region_never_blocks_a_close_inside_it() {
+        let region = Region::new(dec("100"), dec("110"));
+        let mut instance = retest_instance(Side::Sell);
+        instance.on_closed_bar(&bar("120", "119"), &region, true, true);
+        instance.on_closed_bar(&bar("119", "118"), &region, true, true);
+        // Body 4, ratio 2: opens at 112 above the 110 edge, closes at 108
+        // inside the band.
+        let commands = instance.on_closed_bar(&bar("112", "108"), &region, true, true);
+        assert!(
+            matches!(commands.as_slice(), [Command::PlaceMarket { .. }]),
+            "a close inside fires at market whatever the open did: {commands:?}"
+        );
     }
 
     /// The option only changes what a *cut* does: a close inside the region

--- a/crates/strategy/src/armed.rs
+++ b/crates/strategy/src/armed.rs
@@ -14,7 +14,7 @@ use quantick_sim::{Bracket, Command, OrderId, RejectReason, SimEvent};
 use rust_decimal::Decimal;
 
 use crate::region::{BodyCut, Region};
-use crate::trigger::Trigger;
+use crate::trigger::{Signal, Trigger};
 
 /// What the instance does after its operation closes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -257,18 +257,11 @@ impl ArmedStrategy {
             self.note = Some("trigger held: account not flat");
             return Vec::new();
         }
-        let Some(bracket) = project_bracket(
-            self.params.side,
-            signal.reference,
-            signal.projection,
-            self.params.tp_mult,
-            self.params.sl_mult,
-        ) else {
-            // A promised protective leg that cannot be priced is a reason
-            // not to fire, never a reason to fire unprotected.
-            self.note = Some("projection invalid — held fire");
-            return Vec::new();
-        };
+        // The geometry is judged before the projection: a bar whose body
+        // never came near the region could not have traded under any
+        // multiplier, and blaming an unpriceable leg there sends the
+        // trader tuning numbers that were never the reason.
+        //
         // The geometry is the bar's own body — open to close, wicks
         // ignored — because that is what "the force bar cut the region"
         // means to the trader reading the chart. `signal.reference` keeps
@@ -282,6 +275,9 @@ impl ArmedStrategy {
         // simply off.
         let edge = match region.body_cut(self.params.side, bar) {
             BodyCut::ClosedInside => {
+                let Some(bracket) = self.project(&signal) else {
+                    return Vec::new();
+                };
                 self.note = None;
                 self.state = ArmedState::Fired {
                     order_id: None,
@@ -317,6 +313,9 @@ impl ArmedStrategy {
                 self.note = Some("trigger held: closed outside region");
                 return Vec::new();
             }
+        };
+        let Some(bracket) = self.project(&signal) else {
+            return Vec::new();
         };
         // The projected legs anchor on the trigger bar, but the entry now
         // prices at the edge: a leg that does not clear the edge would be
@@ -357,6 +356,25 @@ impl ArmedStrategy {
             // resting window, not just the trigger bar.
             flat_only: true,
         }]
+    }
+
+    /// The protective bracket for this signal, or `None` with the reason
+    /// already on the badge. A promised leg that cannot be priced is a
+    /// reason not to fire, never a reason to fire unprotected — and one
+    /// definition of that refusal serves both the market entry and the
+    /// retest limit.
+    fn project(&mut self, signal: &Signal) -> Option<Bracket> {
+        let bracket = project_bracket(
+            self.params.side,
+            signal.reference,
+            signal.projection,
+            self.params.tp_mult,
+            self.params.sl_mult,
+        );
+        if bracket.is_none() {
+            self.note = Some("projection invalid — held fire");
+        }
+        bracket
     }
 
     /// Feed simulator events back in, and apply whatever the instance
@@ -1212,7 +1230,8 @@ mod tests {
         assert_eq!(
             instance.status_line(),
             "armed · trigger held: cut the region, retest option off",
-            "the bar did its part; the option is what held fire, and the              badge blames the option rather than the bar"
+            "the bar did its part; the option is what held fire, and the \
+             badge blames the option rather than the bar"
         );
     }
 
@@ -1220,6 +1239,10 @@ mod tests {
     /// bar closing above the region has not cut anything downward. Its note
     /// is pinned here so it cannot silently become the same sentence a real
     /// cut produces — the two mean opposite things to a trader.
+    ///
+    /// Like the market-path test above, this holds on both sides of the
+    /// fix: it guards against over-correction and against the note drifting,
+    /// not against the reported bug.
     #[test]
     fn a_cut_beyond_the_opposite_edge_never_arms_a_retest() {
         let region = Region::new(dec("90"), dec("100"));
@@ -1233,6 +1256,29 @@ mod tests {
         assert_eq!(
             instance.status_line(),
             "armed · trigger held: closed outside region"
+        );
+    }
+
+    /// The geometry outranks the projection. A crash bar whose body never
+    /// came near the region also prices an impossible take profit; before
+    /// the gates were reordered the badge blamed the projection, sending
+    /// the trader to tune multipliers that were never the reason this bar
+    /// did not trade.
+    #[test]
+    fn a_bar_that_cut_nothing_blames_the_geometry_not_the_projection() {
+        // Region far above the tape: nothing here could ever have traded.
+        let region = Region::new(dec("300"), dec("320"));
+        let mut instance = retest_instance(Side::Sell);
+        instance.on_closed_bar(&bar("102", "101"), &region, true, true);
+        instance.on_closed_bar(&bar("101", "100"), &region, true, true);
+        // Close 90 with range 110 prices the take profit at -20: invalid.
+        let commands =
+            instance.on_closed_bar(&wicked("100", "96", "200", "90"), &region, true, true);
+        assert!(commands.is_empty());
+        assert_eq!(
+            instance.status_line(),
+            "armed · trigger held: the body never cut the region",
+            "the bar's geometry is the honest reason, not a leg it would never have used"
         );
     }
 
@@ -1292,6 +1338,11 @@ mod tests {
     /// that opened clear above a sell region and closed inside it sells at
     /// market, because where it opened does not matter once it finished in
     /// the band.
+    ///
+    /// This one passes against the old rule too, deliberately — it does not
+    /// guard the reported bug, it guards the *over-correction*: a fix that
+    /// started demanding something of the open on the market path would
+    /// turn this green test red, which is the point of keeping it.
     #[test]
     fn an_open_outside_the_region_never_blocks_a_close_inside_it() {
         let region = Region::new(dec("100"), dec("110"));

--- a/crates/strategy/src/lib.rs
+++ b/crates/strategy/src/lib.rs
@@ -24,12 +24,16 @@
 //! the expected next tenant — dock beside it without surgery on the state
 //! machine.
 //!
-//! A trigger bar that closes *inside* the region fires a market entry. One
-//! that cuts **through** the region — closing beyond its edge in the
-//! trade's own direction — follows [`BreakPolicy`]: hold fire (the
-//! default), or rest a limit at the cut edge, bracketed off the trigger
-//! bar and cancelled if the tape reaches the bar's projected target before
-//! returning for the retest.
+//! The geometry is read off the trigger bar's **body** — open to close, its
+//! wicks ignored ([`BodyCut`]) — because a shadow poking into the band is
+//! the level being probed and refused, not cut. A bar that closes *inside*
+//! the region fires a market entry, whatever its open did. One that cut
+//! **through** the region — opening on the region's side of the edge the
+//! trade leaves by and closing beyond it — follows [`BreakPolicy`]: hold
+//! fire (the default), or rest a limit at the cut edge, bracketed off the
+//! trigger bar and cancelled if the tape reaches the bar's projected target
+//! before returning for the retest. A body that finished beyond an edge it
+//! never crossed cut nothing, and rests nothing.
 
 mod armed;
 mod force;
@@ -38,5 +42,5 @@ mod trigger;
 
 pub use armed::{ArmedState, ArmedStrategy, BreakPolicy, DisarmReason, Rearm, StrategyParams};
 pub use force::{BarVerdict, ForceBar, ForceParams, ForceWindow};
-pub use region::Region;
+pub use region::{BodyCut, Region};
 pub use trigger::{ForceTrigger, Signal, Trigger};

--- a/crates/strategy/src/lib.rs
+++ b/crates/strategy/src/lib.rs
@@ -24,16 +24,23 @@
 //! the expected next tenant — dock beside it without surgery on the state
 //! machine.
 //!
-//! The geometry is read off the trigger bar's **body** — open to close, its
-//! wicks ignored ([`BodyCut`]) — because a shadow poking into the band is
-//! the level being probed and refused, not cut. A bar that closes *inside*
-//! the region fires a market entry, whatever its open did. One that cut
-//! **through** the region — opening on the region's side of the edge the
-//! trade leaves by and closing beyond it — follows [`BreakPolicy`]: hold
-//! fire (the default), or rest a limit at the cut edge, bracketed off the
-//! trigger bar and cancelled if the tape reaches the bar's projected target
-//! before returning for the retest. A body that finished beyond an edge it
-//! never crossed cut nothing, and rests nothing.
+//! The *region test* is read off the trigger bar's **body** — open to
+//! close, its wicks ignored ([`BodyCut`]) — because a shadow poking into
+//! the band is the level being probed and refused, not cut. That scope is
+//! deliberate and it is only the region test: the **projection** that
+//! prices both protective legs is still the bar's full range, wicks
+//! included, so a long-shadowed force bar brackets wide while its body
+//! decides whether to trade at all. The body says *whether*, the range
+//! says *how wide*.
+//!
+//! A bar that closes *inside* the region fires a market entry, whatever
+//! its open did. One that cut **through** the region — opening on the
+//! region's side of the edge the trade leaves by and closing beyond it —
+//! follows [`BreakPolicy`]: hold fire (the default), or rest a limit at
+//! the cut edge, bracketed off the trigger bar and cancelled if the tape
+//! reaches the bar's projected target before returning for the retest. A
+//! body that finished beyond an edge it never crossed cut nothing, and
+//! rests nothing.
 
 mod armed;
 mod force;

--- a/crates/strategy/src/lib.rs
+++ b/crates/strategy/src/lib.rs
@@ -29,18 +29,21 @@
 //! the band is the level being probed and refused, not cut. That scope is
 //! deliberate and it is only the region test: the **projection** that
 //! prices both protective legs is still the bar's full range, wicks
-//! included, so a long-shadowed force bar brackets wide while its body
-//! decides whether to trade at all. The body says *whether*, the range
-//! says *how wide*.
+//! included, so a long-shadowed force bar brackets wide. The body decides
+//! whether the bar *reached* the region; the range then decides how wide
+//! the bracket sits — and because a retest limit whose legs do not clear
+//! the edge is refused rather than fired bare, the range has a say in
+//! whether that entry happens at all. Two gates, not one.
 //!
 //! A bar that closes *inside* the region fires a market entry, whatever
 //! its open did. One that cut **through** the region — opening on the
 //! region's side of the edge the trade leaves by and closing beyond it —
 //! follows [`BreakPolicy`]: hold fire (the default), or rest a limit at
 //! the cut edge, bracketed off the trigger bar and cancelled if the tape
-//! reaches the bar's projected target before returning for the retest. A
-//! body that finished beyond an edge it never crossed cut nothing, and
-//! rests nothing.
+//! reaches the bar's projected target before returning for the retest —
+//! or refused outright when those legs would not clear the edge, since a
+//! resting entry is never armed unprotected. A body that finished beyond
+//! an edge it never crossed cut nothing, and rests nothing.
 
 mod armed;
 mod force;

--- a/crates/strategy/src/region.rs
+++ b/crates/strategy/src/region.rs
@@ -1,5 +1,6 @@
 //! The human half of the setup: a price region the machine never invents.
 
+use quantick_engine::Side;
 use rust_decimal::Decimal;
 
 /// A price band, drawn by a human on the chart (or fixed by a backtest
@@ -14,6 +15,36 @@ use rust_decimal::Decimal;
 pub struct Region {
     low: Decimal,
     high: Decimal,
+}
+
+/// How a trigger bar's *body* met the region, read from the point of view
+/// of a trade on one side.
+///
+/// The bar's wicks are deliberately not consulted. A shadow poking into the
+/// band is the market probing the level and being refused; the trader's
+/// rule is that crossing means **open to close**, so that is what this
+/// answers. The state machine turns the answer into an order (or into a
+/// named reason not to place one); the geometry lives here, once, for the
+/// chart and the backtest both.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BodyCut {
+    /// The close landed inside the band. Whatever the open did — above it,
+    /// below it, inside it — the bar finished in the zone the human drew,
+    /// and that is the market entry.
+    ClosedInside,
+    /// The body crossed the edge the trade pushes towards and finished
+    /// past it: the open sat on the region's side of `edge`, the close
+    /// beyond it. `edge` is the price the tape must come back to for the
+    /// retest.
+    CutThrough { edge: Decimal },
+    /// The close sits past that same edge — but so did the open. The body
+    /// travelled entirely beyond the region without ever crossing into it,
+    /// so there is no cut and no edge to rest an order on.
+    NoCut,
+    /// The close sits past the *opposite* edge, the side the trade would be
+    /// pushing away from. A sell bar closing above a sell zone cut nothing
+    /// downward.
+    ClosedAway,
 }
 
 impl Region {
@@ -43,6 +74,34 @@ impl Region {
     pub fn contains(&self, price: Decimal) -> bool {
         price >= self.low && price <= self.high
     }
+
+    /// Judge one trigger bar's body against the band, for a trade on
+    /// `side`. See [`BodyCut`] for what each answer means.
+    ///
+    /// The edge is inclusive on both tests, exactly as [`Self::contains`]
+    /// reads it: a price resting on the drawn line is inside the region the
+    /// human drew. So a bar opening *on* the low and closing below it did
+    /// leave the band, and cuts.
+    #[must_use]
+    pub fn body_cut(&self, side: Side, open: Decimal, close: Decimal) -> BodyCut {
+        if self.contains(close) {
+            return BodyCut::ClosedInside;
+        }
+        // The edge a trade leaves through: a sell exits the band downward
+        // at the low, a buy upward at the high.
+        let (edge, closed_beyond, opened_inside) = match side {
+            Side::Sell => (self.low, close < self.low, open >= self.low),
+            Side::Buy => (self.high, close > self.high, open <= self.high),
+        };
+        if !closed_beyond {
+            return BodyCut::ClosedAway;
+        }
+        if opened_inside {
+            BodyCut::CutThrough { edge }
+        } else {
+            BodyCut::NoCut
+        }
+    }
 }
 
 #[cfg(test)]
@@ -51,6 +110,95 @@ mod tests {
 
     fn dec(v: i64) -> Decimal {
         Decimal::from(v)
+    }
+
+    /// The trader's rule, walked on a sell zone: crossing is open-to-close,
+    /// and a body that never crossed the edge is not a cut however far
+    /// beyond it the bar finished.
+    #[test]
+    fn a_sell_only_cuts_the_low_when_the_body_crossed_it() {
+        let region = Region::new(dec(100), dec(110));
+        // Closed inside — the open is irrelevant, from above or below.
+        assert_eq!(
+            region.body_cut(Side::Sell, dec(115), dec(105)),
+            BodyCut::ClosedInside
+        );
+        assert_eq!(
+            region.body_cut(Side::Sell, dec(95), dec(105)),
+            BodyCut::ClosedInside
+        );
+        // Opened above the low (inside the band or over it) and closed
+        // below: the body cut the lower edge.
+        assert_eq!(
+            region.body_cut(Side::Sell, dec(115), dec(95)),
+            BodyCut::CutThrough { edge: dec(100) }
+        );
+        assert_eq!(
+            region.body_cut(Side::Sell, dec(105), dec(95)),
+            BodyCut::CutThrough { edge: dec(100) }
+        );
+        // The whole body below the low: nothing was cut. This is the bug
+        // that put a resting limit under a bar that never touched the band.
+        assert_eq!(
+            region.body_cut(Side::Sell, dec(99), dec(95)),
+            BodyCut::NoCut
+        );
+        // Closed above the band: the far side, nothing to sell into.
+        assert_eq!(
+            region.body_cut(Side::Sell, dec(105), dec(115)),
+            BodyCut::ClosedAway
+        );
+        assert_eq!(
+            region.body_cut(Side::Sell, dec(120), dec(115)),
+            BodyCut::ClosedAway
+        );
+    }
+
+    /// A buy zone is the same rule mirrored around the high.
+    #[test]
+    fn a_buy_only_cuts_the_high_when_the_body_crossed_it() {
+        let region = Region::new(dec(100), dec(110));
+        assert_eq!(
+            region.body_cut(Side::Buy, dec(95), dec(105)),
+            BodyCut::ClosedInside
+        );
+        assert_eq!(
+            region.body_cut(Side::Buy, dec(95), dec(115)),
+            BodyCut::CutThrough { edge: dec(110) }
+        );
+        assert_eq!(
+            region.body_cut(Side::Buy, dec(105), dec(115)),
+            BodyCut::CutThrough { edge: dec(110) }
+        );
+        assert_eq!(
+            region.body_cut(Side::Buy, dec(111), dec(115)),
+            BodyCut::NoCut
+        );
+        assert_eq!(
+            region.body_cut(Side::Buy, dec(105), dec(95)),
+            BodyCut::ClosedAway
+        );
+    }
+
+    /// The drawn edge belongs to the region on both tests, exactly as
+    /// [`Region::contains`] reads it: an open resting on the line opened
+    /// inside the band the human drew, so the bar that leaves it cuts.
+    #[test]
+    fn the_drawn_edge_counts_as_inside_for_the_open_too() {
+        let region = Region::new(dec(100), dec(110));
+        assert_eq!(
+            region.body_cut(Side::Sell, dec(100), dec(95)),
+            BodyCut::CutThrough { edge: dec(100) }
+        );
+        assert_eq!(
+            region.body_cut(Side::Buy, dec(110), dec(115)),
+            BodyCut::CutThrough { edge: dec(110) }
+        );
+        // A close on the line is inside, so it is a market entry, not a cut.
+        assert_eq!(
+            region.body_cut(Side::Sell, dec(115), dec(100)),
+            BodyCut::ClosedInside
+        );
     }
 
     #[test]

--- a/crates/strategy/src/region.rs
+++ b/crates/strategy/src/region.rs
@@ -1,6 +1,6 @@
 //! The human half of the setup: a price region the machine never invents.
 
-use quantick_engine::Side;
+use quantick_engine::{Bar, Side};
 use rust_decimal::Decimal;
 
 /// A price band, drawn by a human on the chart (or fixed by a backtest
@@ -78,25 +78,36 @@ impl Region {
     /// Judge one trigger bar's body against the band, for a trade on
     /// `side`. See [`BodyCut`] for what each answer means.
     ///
+    /// The whole bar is taken rather than two prices because the argument
+    /// order would otherwise carry the entire meaning of the verdict:
+    /// transposing open and close turns a bar that cut nothing into one
+    /// that rests a limit order, and two adjacent `Decimal`s cannot be
+    /// transposed wrongly if they are never passed apart. The bar's `high`
+    /// and `low` are deliberately not read — that is the whole point of
+    /// the rule.
+    ///
     /// The edge is inclusive on both tests, exactly as [`Self::contains`]
     /// reads it: a price resting on the drawn line is inside the region the
     /// human drew. So a bar opening *on* the low and closing below it did
     /// leave the band, and cuts.
     #[must_use]
-    pub fn body_cut(&self, side: Side, open: Decimal, close: Decimal) -> BodyCut {
-        if self.contains(close) {
+    pub fn body_cut(&self, side: Side, bar: &Bar) -> BodyCut {
+        if self.contains(bar.close) {
             return BodyCut::ClosedInside;
         }
         // The edge a trade leaves through: a sell exits the band downward
-        // at the low, a buy upward at the high.
-        let (edge, closed_beyond, opened_inside) = match side {
-            Side::Sell => (self.low, close < self.low, open >= self.low),
-            Side::Buy => (self.high, close > self.high, open <= self.high),
+        // at the low, a buy upward at the high. `open_on_region_side` is
+        // not "the open was inside the band" — an open far above a sell
+        // region is outside it and still on the region's side of the low,
+        // which is exactly what makes the bar's travel a crossing.
+        let (edge, closed_beyond, open_on_region_side) = match side {
+            Side::Sell => (self.low, bar.close < self.low, bar.open >= self.low),
+            Side::Buy => (self.high, bar.close > self.high, bar.open <= self.high),
         };
         if !closed_beyond {
             return BodyCut::ClosedAway;
         }
-        if opened_inside {
+        if open_on_region_side {
             BodyCut::CutThrough { edge }
         } else {
             BodyCut::NoCut
@@ -112,6 +123,27 @@ mod tests {
         Decimal::from(v)
     }
 
+    /// A bar with no shadow beyond its body: open, close, and nothing else.
+    fn body(open: i64, close: i64) -> Bar {
+        wicked(open, close, open.max(close), open.min(close))
+    }
+
+    /// A bar whose shadows reach past its body — the case the whole rule
+    /// exists for.
+    fn wicked(open: i64, close: i64, high: i64, low: i64) -> Bar {
+        Bar {
+            open_time: 0,
+            close_time: 0,
+            open: dec(open),
+            high: dec(high),
+            low: dec(low),
+            close: dec(close),
+            buy_volume: Decimal::ONE,
+            sell_volume: Decimal::ONE,
+            trade_count: 2,
+        }
+    }
+
     /// The trader's rule, walked on a sell zone: crossing is open-to-close,
     /// and a body that never crossed the edge is not a cut however far
     /// beyond it the bar finished.
@@ -120,36 +152,33 @@ mod tests {
         let region = Region::new(dec(100), dec(110));
         // Closed inside — the open is irrelevant, from above or below.
         assert_eq!(
-            region.body_cut(Side::Sell, dec(115), dec(105)),
+            region.body_cut(Side::Sell, &body(115, 105)),
             BodyCut::ClosedInside
         );
         assert_eq!(
-            region.body_cut(Side::Sell, dec(95), dec(105)),
+            region.body_cut(Side::Sell, &body(95, 105)),
             BodyCut::ClosedInside
         );
-        // Opened above the low (inside the band or over it) and closed
+        // Opened above the low (over the band or inside it) and closed
         // below: the body cut the lower edge.
         assert_eq!(
-            region.body_cut(Side::Sell, dec(115), dec(95)),
+            region.body_cut(Side::Sell, &body(115, 95)),
             BodyCut::CutThrough { edge: dec(100) }
         );
         assert_eq!(
-            region.body_cut(Side::Sell, dec(105), dec(95)),
+            region.body_cut(Side::Sell, &body(105, 95)),
             BodyCut::CutThrough { edge: dec(100) }
         );
         // The whole body below the low: nothing was cut. This is the bug
         // that put a resting limit under a bar that never touched the band.
-        assert_eq!(
-            region.body_cut(Side::Sell, dec(99), dec(95)),
-            BodyCut::NoCut
-        );
+        assert_eq!(region.body_cut(Side::Sell, &body(99, 95)), BodyCut::NoCut);
         // Closed above the band: the far side, nothing to sell into.
         assert_eq!(
-            region.body_cut(Side::Sell, dec(105), dec(115)),
+            region.body_cut(Side::Sell, &body(105, 115)),
             BodyCut::ClosedAway
         );
         assert_eq!(
-            region.body_cut(Side::Sell, dec(120), dec(115)),
+            region.body_cut(Side::Sell, &body(120, 115)),
             BodyCut::ClosedAway
         );
     }
@@ -159,24 +188,54 @@ mod tests {
     fn a_buy_only_cuts_the_high_when_the_body_crossed_it() {
         let region = Region::new(dec(100), dec(110));
         assert_eq!(
-            region.body_cut(Side::Buy, dec(95), dec(105)),
+            region.body_cut(Side::Buy, &body(95, 105)),
             BodyCut::ClosedInside
         );
         assert_eq!(
-            region.body_cut(Side::Buy, dec(95), dec(115)),
+            region.body_cut(Side::Buy, &body(115, 105)),
+            BodyCut::ClosedInside
+        );
+        assert_eq!(
+            region.body_cut(Side::Buy, &body(95, 115)),
             BodyCut::CutThrough { edge: dec(110) }
         );
         assert_eq!(
-            region.body_cut(Side::Buy, dec(105), dec(115)),
+            region.body_cut(Side::Buy, &body(105, 115)),
             BodyCut::CutThrough { edge: dec(110) }
         );
+        assert_eq!(region.body_cut(Side::Buy, &body(111, 115)), BodyCut::NoCut);
         assert_eq!(
-            region.body_cut(Side::Buy, dec(111), dec(115)),
+            region.body_cut(Side::Buy, &body(105, 95)),
+            BodyCut::ClosedAway
+        );
+        assert_eq!(
+            region.body_cut(Side::Buy, &body(90, 95)),
+            BodyCut::ClosedAway
+        );
+    }
+
+    /// The sentence the whole rule was written for: a shadow reaching deep
+    /// into the band is the level being probed and refused, not cut. The
+    /// verdict must not move when only the wicks do.
+    #[test]
+    fn wicks_never_change_the_verdict() {
+        let region = Region::new(dec(100), dec(110));
+        // Sell: body wholly under the band, upper shadow well inside it.
+        assert_eq!(
+            region.body_cut(Side::Sell, &wicked(99, 95, 108, 94)),
             BodyCut::NoCut
         );
+        // The same body with no shadow at all answers the same.
+        assert_eq!(region.body_cut(Side::Sell, &body(99, 95)), BodyCut::NoCut);
+        // Buy: body wholly above the band, lower shadow inside it.
         assert_eq!(
-            region.body_cut(Side::Buy, dec(105), dec(95)),
-            BodyCut::ClosedAway
+            region.body_cut(Side::Buy, &wicked(111, 115, 116, 102)),
+            BodyCut::NoCut
+        );
+        // And a genuine cut keeps its edge however far the shadows run.
+        assert_eq!(
+            region.body_cut(Side::Sell, &wicked(105, 95, 130, 70)),
+            BodyCut::CutThrough { edge: dec(100) }
         );
     }
 
@@ -187,16 +246,16 @@ mod tests {
     fn the_drawn_edge_counts_as_inside_for_the_open_too() {
         let region = Region::new(dec(100), dec(110));
         assert_eq!(
-            region.body_cut(Side::Sell, dec(100), dec(95)),
+            region.body_cut(Side::Sell, &body(100, 95)),
             BodyCut::CutThrough { edge: dec(100) }
         );
         assert_eq!(
-            region.body_cut(Side::Buy, dec(110), dec(115)),
+            region.body_cut(Side::Buy, &body(110, 115)),
             BodyCut::CutThrough { edge: dec(110) }
         );
         // A close on the line is inside, so it is a market entry, not a cut.
         assert_eq!(
-            region.body_cut(Side::Sell, dec(115), dec(100)),
+            region.body_cut(Side::Sell, &body(115, 100)),
             BodyCut::ClosedInside
         );
     }

--- a/crates/strategy/src/trigger.rs
+++ b/crates/strategy/src/trigger.rs
@@ -17,9 +17,18 @@ use crate::force::{BarVerdict, ForceParams, ForceWindow};
 pub struct Signal {
     /// Direction the bar pushed.
     pub side: Side,
-    /// The entry reference price (the trigger bar's close — a market order
-    /// meets the tape at the next print, but the *projection* anchors on
-    /// the fact the trigger measured).
+    /// The entry reference price, and **only** the price the bracket
+    /// projects from: a market order meets the tape at the next print,
+    /// while the projection anchors on the fact the trigger measured.
+    ///
+    /// The region test does not read this — it reads the bar's own open
+    /// and close ([`Region::body_cut`]), because "the force bar cut the
+    /// region" is a statement about the bar, not about a ruler's anchor.
+    /// An implementation whose reference is *not* the judged bar's close
+    /// therefore brackets around a price the entry will not fill near, and
+    /// owes its consumers a word about that in its own documentation.
+    ///
+    /// [`Region::body_cut`]: crate::Region::body_cut
     pub reference: Decimal,
     /// The projection ruler: for the force bar, its full range.
     pub projection: Decimal,

--- a/docs/ux/strategy-anchors.md
+++ b/docs/ux/strategy-anchors.md
@@ -27,7 +27,10 @@ headless over recorded sessions. Never fork strategy logic per consumer.
 4. On every **closed** bar: is it a force bar of the armed side, closing
    inside the region, with the account flat? Then a market order with its
    projected bracket goes to the simulator, filling on the next print —
-   like the hand would, minus the seconds the hand needs.
+   like the hand would, minus the seconds the hand needs. A bar that
+   instead **cut clean through** the region may rest a limit at the edge
+   it cut, if the instance was armed with that option — see **Region**
+   below for what counts as a cut.
 5. The operation runs to its bracket (or to a manual close — the human
    always outranks the bot). One-shot instances are then `done`; auto
    instances re-arm and hunt the next qualifying bar.
@@ -46,11 +49,36 @@ headless over recorded sessions. Never fork strategy logic per consumer.
   is **exhaustion and does not fire** — too big to chase, by design.
   Dojis have no side. The window must be full; warmup is a badge state,
   not a silent zero.
-- **Region**: the rectangle's price band, inclusive of its edges; the
-  bar's *close* must sit inside it, and the bar's slot inside the
-  rectangle's span of the tape. A rectangle that ended in the past is an
-  expired region — stretch it to re-live it.
-- **Projection**: TP = close + `tp_mult` × range(trigger bar) in the
+- **Region**: the rectangle's price band, inclusive of its edges, with
+  the bar's slot inside the rectangle's span of the tape. A rectangle
+  that ended in the past is an expired region — stretch it to re-live it.
+
+  The band is judged against the trigger bar's **body — its open and its
+  close. The wicks are not consulted**: a shadow poking into the band is
+  the level being probed and refused, not cut. Reading the bar's open `o`
+  and close `c` against a band `[low, high]`, for a **sell** instance:
+
+  | Geometry | What happens |
+  | --- | --- |
+  | `c` inside `[low, high]`, whatever `o` did | market sell |
+  | `c < low` and `o >= low` — the body cut the lower edge | a limit rests at `low` if **on-break** is `retest_limit`; otherwise the bar is reported as a cut the option declined |
+  | `c < low` and `o < low` — the body finished past an edge it never crossed | nothing |
+  | `c > high` — closed away, above the band | nothing |
+
+  A **buy** instance is the same rule mirrored around `high`. The kernel
+  answers this as `Region::body_cut` (`crates/strategy/src/region.rs`),
+  one definition for the chart and the backtest both.
+
+- **On break** (`on_break`, default `ignore`): what a bar that *cut* the
+  region does. `retest_limit` rests a limit at the edge the body cut —
+  the price the tape must revisit for the retest — bracketed off the
+  trigger bar and cancelling itself if the bar's projected target trades
+  before the return. The order also stands down at its own fill moment if
+  a position is open by then: a bot never trades against a hand. `ignore`
+  holds fire and says so on the instance's status line.
+- **Projection**: measured on the trigger bar's **full range, wicks
+  included** — the body decides *whether* to trade, the range decides
+  *how wide*. TP = close + `tp_mult` × range(trigger bar) in the
   trade's favour; SL = close − `sl_mult` × range against it (defaults
   1.0 / 1.0; `0` = no leg). A promised leg that cannot be priced holds
   fire — never fires unprotected.

--- a/docs/ux/strategy-anchors.md
+++ b/docs/ux/strategy-anchors.md
@@ -61,7 +61,7 @@ headless over recorded sessions. Never fork strategy logic per consumer.
   | Geometry | What happens |
   | --- | --- |
   | `c` inside `[low, high]`, whatever `o` did | market sell |
-  | `c < low` and `o >= low` — the body cut the lower edge | a limit rests at `low` if **on-break** is `retest_limit`; otherwise the bar is reported as a cut the option declined |
+  | `c < low` and `o >= low` — the body cut the lower edge | a limit rests at `low` if **on-break** is `retest_limit` *and* the projected legs clear that edge; otherwise the bar is reported as a cut the option declined |
   | `c < low` and `o < low` — the body finished past an edge it never crossed | nothing |
   | `c > high` — closed away, above the band | nothing |
 
@@ -76,6 +76,22 @@ headless over recorded sessions. Never fork strategy logic per consumer.
   before the return. The order also stands down at its own fill moment if
   a position is open by then: a bot never trades against a hand. `ignore`
   holds fire and says so on the instance's status line.
+
+  Two cases the option cannot deliver, both narrated on the status line
+  rather than silently:
+
+  - **The legs do not clear the edge.** The bracket is projected off the
+    trigger bar's close, but the entry prices at the *edge*. A leg landing
+    on the wrong side of that edge would be dropped at fill time, and an
+    entry is never armed unprotected — so the instance refuses the cut
+    instead ("retest bracket does not clear the edge — held fire"). A
+    tight `sl_mult` on a bar that closed just past the edge is the usual
+    way to meet this.
+  - **No take-profit leg means no expiry.** The cancel-at level *is* the
+    projected target, so with `tp_mult` at `0` the order carries none and
+    rests until it fills or the instance is disarmed. The status line says
+    "until filled or disarmed" rather than "cancels at target" — believe
+    the badge over the checkbox.
 - **Projection**: measured on the trigger bar's **full range, wicks
   included** — the body decides *whether* to trade, the range decides
   *how wide*. TP = close + `tp_mult` × range(trigger bar) in the


### PR DESCRIPTION
Fix the rectangle strategy so a force bar trades a drawn region only when its **body** — open and close, never the wicks — actually cuts that region.

## The bug

`ArmedStrategy::on_closed_bar` decided the entry from the trigger bar's **close alone**. For a sell instance, any force bar closing below the region's low rested a retest limit at that low — including a bar that opened below the low too, and therefore never touched the region. The trader reported the symptom: a limit order sitting in a band the bar never crossed.

In the trader's words: *"A barra de força precisa cruzar, e não só cruzar as sombras. Cruzar é abertura e fechamento dela."* — the force bar has to cross, and the wicks crossing is not crossing; crossing is its open and its close.

## The rule

For a **sell** instance on `[low, high]`, reading the trigger bar's open `o` and close `c`:

| Geometry | Action |
| --- | --- |
| `c` inside `[low, high]`, whatever `o` did | market sell |
| `c < low` and `o >= low` — the body cut the lower edge | retest limit at `low` (under `BreakPolicy::RetestLimit`, if the projected legs clear that edge) |
| `c < low` and `o < low` — finished past an edge it never crossed | nothing, gate named on the status line |
| `c > high` — closed away | nothing |

A **buy** instance is the mirror around `high`. The rule lands in `Region::body_cut`, beside `contains` and reading the same inclusive edges, so the chart and the backtest keep consuming one definition. `Signal::reference` keeps its separate job as the bracket's projection anchor.

## Evidence

**The tests bite.** Replayed against the reverted close-only geometry, each new test fails reproducing the reported symptom:

| Surface | Pre-fix result |
| --- | --- |
| kernel (`armed.rs`) | `PlaceLimit { side: Sell, price: 105, ... }` |
| chart (`app.rs`) | `Order { side: Sell, kind: Limit, price: Some(105), ... }` |
| backtest (`harness.rs`) | limit rested, filled at 105, `resting_at_end`/`open_at_end` non-zero |

The fixtures use the shape the rule exists for: a bar whose **shadow** reaches into the band while its body stays outside.

**Four checks, clean tree:**

- `cargo fmt --all -- --check` → exit 0
- `cargo clippy --workspace --all-targets -- -D warnings` → exit 0
- `cargo build --workspace` → exit 0
- `cargo test --workspace` → **2127 passing across 36 suites**

The one failure, `the_bridge_paging_tests_pass`, is the known Windows `python3` Store-alias issue and is unrelated to this diff — `python bridge/mt5/tests/test_paging.py` passes 21/21 directly. The two CI-only Python checks also pass locally: `ruff check --select F tools/mt5/ bridge/mt5/` → "All checks passed!", and `tools/mt5/test_export_session.py` → ok.

**Performance:** the strategy kernel runs **per closed bar** (rare — not per trade, per depth update or per frame). `body_cut` adds at most two `Decimal` comparisons and no allocation. Moving the projection below the geometry makes the cold path slightly cheaper, not dearer.

## Review

**step 0: `code-review` at `max`, run twice — 15 findings then 15 findings.** Both passes are reflected in the commits; the second was run because the first's findings changed the diff by ~350 lines.

The first pass caught the finding that mattered most: the three original regression tests were **vacuous** — their numbers put the projected stop on the wrong side of the edge, so `legs_clear_edge` had already held fire on the pre-fix code, and the assertion encoding the bug could not fail. The second pass caught the same class of error in the backtest test, where `trades.is_empty()` passed against the bug because the wrongly rested limit filled and left the position *open* rather than closed. Both are fixed and re-verified by replay.

### Resolved

Geometry reads the bar's body; `body_cut` takes the `Bar` so the open/close arguments cannot be transposed; every `BodyCut` arm is complete on its own so a future `BreakPolicy` variant cannot fall through; `opened_inside` renamed (it was false as a name — for a sell it is `open >= low`, true for an open far above the band); the projection gate moved below the geometry so a bar that cut nothing is not blamed on an unpriceable leg; the `Ignore` policy names itself instead of borrowing the closed-away sentence; the `legs_clear_edge` refusal and the `tp_mult = 0` no-expiry case added to all five trader-facing surfaces; `docs/ux/strategy-anchors.md` — the page that calls itself the kernel's contract — updated; the crate doc's "the body says whether, the range says how wide" scoped, since a range-derived bracket also gates the entry; positive `RetestLimit` coverage added to the backtest, which had none.

### Deferred

- **The hold reason does not reach the on-chart badge.** `badge_text` renders `ArmedState::Armed` as a bare `⚡ {preset}`; the note only appears in the drawing's right-click menu. Both reviews raised it, and it is real — the chart shows nothing over a force bar that did nothing. Deferred because it is a visible chart change that pulls in `visual-qa` and `trader-ux-review` with a scope of its own.
- **A gap past the edge can never arm the retest**, and neither can any later bar, since bars are print-contiguous and all subsequent ones open beyond the edge. This is what the specified rule implies — *"se fechar abaixo da zona inferior e não abriu dentro da zona ou acima da borda superior, não faça nada"* — and is flagged for the trader's confirmation rather than changed unilaterally.
- **The region edge arrives as an unsnapped f64.** Rectangles use `AnchorSnap::Pointer` and reach the kernel through `dec_from_f64`, so the new inclusive open test sits on a sub-tick threshold the trader cannot see. Pre-existing, but the body rule makes it matter more than a close-only test did.
- **`Signal::reference` is held to the judged bar's close by documentation only** — no assert, no trait method. The contract is now stated on the field; enforcing it belongs with the next trigger implementation.
- **`CutThrough` accepts an open arbitrarily far beyond the region**, so a long approach sizes a wide bracket for an entry pinned at the edge. This is the specified rule (*"abertura acima da zona inferior, qualquer nível"*), kept deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NktxU5o7kCaDZ2fRAJKzAU
