### PR TITLE
fix(app): size footprint rows from the tape's price as well as its tick

### DIFF
--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -5907,16 +5907,25 @@ impl QuantickApp {
             trades_per_s = rate,
             live_trades = self.active_tab().live_trades,
             bar_spec = self.active_tab().flow_pane.state.spec().summary(),
-            // What the tape says its own price grid is, and what the ladder
-            // ended up drawing rows at. A validation run reads the pair to
-            // tell "the chart has not been told a tick yet" from "the chart
-            // is drawing rows finer than the instrument can trade at".
+            // Both facts the tape states about its own prices — the grid they
+            // land on and the magnitude they land at — and the row width the
+            // ladder ended up drawing from them. A validation run reads all
+            // three: the first two are the sizing rule's whole input, so
+            // without them a run can see that rows are 1.00 and not why, and
+            // cannot tell "the chart has not been told a tick yet" from "the
+            // chart is drawing rows finer than the instrument can trade at".
             tape_price_step = self
                 .active_tab()
                 .flow_pane
                 .state
                 .tape_price_step()
                 .map_or_else(|| "unknown".to_owned(), |step| step.to_string()),
+            tape_reference_price = self
+                .active_tab()
+                .flow_pane
+                .state
+                .tape_reference_price()
+                .map_or_else(|| "unknown".to_owned(), |price| price.to_string()),
             footprint_rows = %self.active_tab().flow_pane.state.footprint_group(),
             canvas_layout = ?self.active_tab().layout,
             screen_pt_w = screen.x,

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -24650,6 +24650,33 @@ crosshair = false
         mpsc::Sender<FeedEvent>,
         mpsc::Receiver<FeedCommand>,
     ) {
+        app_backfilled_with(ctx, (0..200).map(minute_trade).collect())
+    }
+
+    /// [`history_app`] on a tape of a chosen magnitude and grid — the two
+    /// facts the row-sizing rule reads. Depth capture stays off, as it is
+    /// there: a chart no depth snapshot will ever hand a price to is the case
+    /// that sizing exists for.
+    fn tape_app(
+        ctx: &egui::Context,
+        first_price: Decimal,
+        step: Decimal,
+    ) -> (
+        QuantickApp,
+        mpsc::Sender<FeedEvent>,
+        mpsc::Receiver<FeedCommand>,
+    ) {
+        app_backfilled_with(ctx, grid_trades(first_price, step))
+    }
+
+    fn app_backfilled_with(
+        ctx: &egui::Context,
+        trades: Vec<quantick_engine::Trade>,
+    ) -> (
+        QuantickApp,
+        mpsc::Sender<FeedEvent>,
+        mpsc::Receiver<FeedCommand>,
+    ) {
         let (evt_tx, evt_rx) = mpsc::channel(64);
         let (book_tx, book_rx) = mpsc::channel(64);
         let (cmd_tx, cmd_rx) = mpsc::channel(16);
@@ -24675,7 +24702,6 @@ crosshair = false
             },
         );
         let _ = book_tx;
-        let trades: Vec<_> = (0..200).map(minute_trade).collect();
         evt_tx.try_send(FeedEvent::Backfilled(trades)).unwrap();
         app.drain_tabs();
         run_frame(&mut app, ctx);
@@ -24894,6 +24920,126 @@ crosshair = false
             time_group, market_bucket,
             "and it is the market's bucket, not either pane's default"
         );
+    }
+
+    /// Two hundred prints walking a `step`-wide grid from `first_price` — the
+    /// two facts the row-sizing rule reads off a tape. The prices move rather
+    /// than repeat because a grid is named from the *distances* between
+    /// prints, and the same price twice is no distance at all.
+    fn grid_trades(first_price: Decimal, step: Decimal) -> Vec<quantick_engine::Trade> {
+        (0..200)
+            .map(|i| quantick_engine::Trade {
+                agg_id: i + 1,
+                timestamp_ms: i as i64 * crate::feed::OHLCV_BASE_INTERVAL_MS + 1_000,
+                price: first_price + step * Decimal::from(i % 20),
+                quantity: Decimal::ONE,
+                side: if i.is_multiple_of(2) {
+                    quantick_engine::Side::Buy
+                } else {
+                    quantick_engine::Side::Sell
+                },
+            })
+            .collect()
+    }
+
+    /// A fixed-range profile placed on the flow pane with the footprint layer
+    /// switched off — the state the trader reported the jagged profile from,
+    /// and the one where nothing but the profile itself wants the ladders.
+    fn place_range_profile_with_the_layer_off(app: &mut QuantickApp) {
+        let frvp = crate::drawings::DRAWING_TOOLS
+            .into_iter()
+            .find(|tool| tool.id() == crate::frvp::TOOL_ID)
+            .expect("frvp is registered");
+        let pane = app.active_tab_mut().pane_mut(PaneSide::Flow);
+        pane.set_layer_visible(
+            ChartLayer::Footprint,
+            false,
+            &mut chart_layers::LayerActions::default(),
+        );
+        assert!(
+            !pane
+                .drawings
+                .place(frvp, crate::drawings::ChartPoint::at(1.0, 100.0))
+        );
+        assert!(
+            pane.drawings
+                .place(frvp, crate::drawings::ChartPoint::at(20.0, 105.0))
+        );
+    }
+
+    /// The grouping the flow pane's profile actually folded at, read off the
+    /// drawing rather than off the chart state — the ladder's row width and
+    /// the profile's are meant to be one number, and a test that read only the
+    /// state could not tell whether they had come apart.
+    fn folded_profile_group(app: &QuantickApp) -> Decimal {
+        app.active_tab().pane(PaneSide::Flow).drawings.items()[0]
+            .payload
+            .as_any()
+            .downcast_ref::<crate::drawings::FrvpPayload>()
+            .expect("frvp payload")
+            .cache
+            .as_ref()
+            .expect("a placed range over a live tape folded")
+            .profile
+            .as_ref()
+            .expect("the range covers bars that have tape")
+            .0
+            .group()
+    }
+
+    /// A fine-tick market at a high price: BTCUSDT quotes in cents and trades
+    /// near $80k, so its own tick is a true fact about the instrument and a
+    /// useless row — a few hundred dollars of range asks for tens of thousands
+    /// of them, and the profile paints as a jagged wash. The chart has no L2
+    /// here (`book_capture: false`), which is exactly why this used to fail:
+    /// the sizing rule only ever saw a price when a depth snapshot handed it
+    /// one.
+    #[test]
+    fn a_bitcoin_magnitude_tape_groups_the_profile_by_the_dollar() {
+        let ctx = egui::Context::default();
+        let (mut app, _events, _commands) =
+            tape_app(&ctx, Decimal::from(80_000), Decimal::new(1, 2));
+        place_range_profile_with_the_layer_off(&mut app);
+        run_frame(&mut app, &ctx);
+        run_frame(&mut app, &ctx);
+
+        assert_eq!(
+            app.active_tab()
+                .pane(PaneSide::Flow)
+                .state
+                .footprint_group(),
+            Decimal::from(1),
+            "an $80k market stayed on the cent-wide rows its tick names",
+        );
+        assert_eq!(
+            folded_profile_group(&app),
+            Decimal::from(1),
+            "the profile folded at a different width than the ladders under it",
+        );
+    }
+
+    /// The regression pin, on the market that already looked right. WIN trades
+    /// near 140k points on a five-point tick, and five points is the row a
+    /// trader expects to see; the price-derived width here is *two* points,
+    /// finer than the tick, and the instrument's own grid has to win.
+    #[test]
+    fn an_index_magnitude_tape_keeps_the_five_point_grouping_it_already_had() {
+        let ctx = egui::Context::default();
+        let (mut app, _events, _commands) =
+            tape_app(&ctx, Decimal::from(140_000), Decimal::from(5));
+        place_range_profile_with_the_layer_off(&mut app);
+        run_frame(&mut app, &ctx);
+        run_frame(&mut app, &ctx);
+
+        assert_eq!(
+            app.active_tab()
+                .pane(PaneSide::Flow)
+                .state
+                .footprint_group(),
+            Decimal::from(5),
+            "sizing from the tape's magnitude moved a grouping the tick had settled",
+        );
+        assert_eq!(folded_profile_group(&app), Decimal::from(5));
     }
 
     /// A short answer teaches nothing about where the record starts. A venue

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -25009,6 +25009,10 @@ crosshair = false
         let (mut app, _events, _commands) =
             tape_app(&ctx, Decimal::from(80_000), Decimal::new(1, 2));
         place_range_profile_with_the_layer_off(&mut app);
+        // The bucket these tests name an exact number for is decided on the
+        // book worker's own thread. Without this barrier they race it and read
+        // the fine default on a loaded runner.
+        app.active_tab_mut().tape_mut().flush_for_test();
         run_frame(&mut app, &ctx);
         run_frame(&mut app, &ctx);
 
@@ -25037,6 +25041,7 @@ crosshair = false
         let (mut app, _events, _commands) =
             tape_app(&ctx, Decimal::from(140_000), Decimal::from(5));
         place_range_profile_with_the_layer_off(&mut app);
+        app.active_tab_mut().tape_mut().flush_for_test();
         run_frame(&mut app, &ctx);
         run_frame(&mut app, &ctx);
 

--- a/crates/app/src/orderflow_engine.rs
+++ b/crates/app/src/orderflow_engine.rs
@@ -1189,6 +1189,17 @@ impl BookEngine {
     /// never hold a print. The tape knows the grid regardless, because every
     /// print lands on it.
     ///
+    /// `reference_price` is the same chart's own price magnitude, and it is
+    /// what a depth-less chart was missing. `capture_base` folds a tick up
+    /// toward the money a market moves in, but it can only do that when it is
+    /// told the price — and the only caller that ever told it read the mid off
+    /// a *book snapshot*. So BTCUSDT with the heatmap off, or on replay, came
+    /// through here with its true 0.01 tick and no price at all, and got
+    /// cent-wide rows: a fixed-range profile over a few hundred dollars asking
+    /// for tens of thousands of them, which is the jagged wash a trader sees.
+    /// `None` where the tape has not shown a price yet, which behaves exactly
+    /// as this did before.
+    ///
     /// A venue-stated step always wins: this is the fallback for a chart that
     /// was never told, never an override of one that was. It is also skipped
     /// once the trader sets the base resolution by hand, like every other
@@ -1196,7 +1207,7 @@ impl BookEngine {
     ///
     /// Goes through `capture_base`, so the ladder and the liquidity map are
     /// sized by one rule rather than by two that have to be kept in step.
-    pub fn size_from_tape(&mut self, step: Decimal) {
+    pub fn size_from_tape(&mut self, step: Decimal, reference_price: Option<Decimal>) {
         // `apply_auto_base` resizes by *discarding* history — the bucket width
         // is the grid every run and aggression was recorded against, and there
         // is no reindexing them. Its own doc says "while history is still empty
@@ -1213,11 +1224,18 @@ impl BookEngine {
         {
             return;
         }
+        // A book's mid outranks the tape's first print where both exist: one
+        // is the live spread, the other is wherever this chart happened to
+        // open. Where only the tape has spoken it is the whole answer, and
+        // that is the case this argument was added for.
+        let reference = self
+            .reference_price
+            .or_else(|| reference_price.and_then(|price| price.to_f64()));
         // `capture_base`'s own labels both name the instrument as the source.
         // That is true where a feed stated the tick and a lie here, where the
         // number was inferred from prints — and this log line is the only place
         // the provenance is recorded.
-        if let Some((base, _)) = capture_base(Some(step), self.reference_price) {
+        if let Some((base, _)) = capture_base(Some(step), reference) {
             self.apply_auto_base(base, "tape_price_grid");
         }
     }
@@ -1694,13 +1712,77 @@ mod tests {
         // on the fine default — rows most of which no print can land in.
         let mut engine = BookEngine::new("WINV26");
         let default_base = engine.config.price_grouping;
-        engine.size_from_tape(Decimal::from(5));
+        engine.size_from_tape(Decimal::from(5), None);
         assert_ne!(
             engine.published().base_price_grouping,
             default_base,
             "the tape said five and the bucket stayed on the default",
         );
         assert_eq!(engine.published().base_price_grouping, Decimal::from(5));
+    }
+
+    #[test]
+    fn a_coarse_tick_at_index_magnitude_keeps_the_tick_the_tape_named() {
+        // The regression pin. WIN trades near 140k points on a five-point
+        // tick, and five points is already the right row: a trader reading
+        // that ladder today sees the grouping they expect. Handing the sizing
+        // rule the tape's own magnitude must not move it — the price-derived
+        // base here is two points, *finer* than the tick, and the instrument's
+        // own grid wins whenever that happens.
+        let mut engine = BookEngine::new("WINV26");
+        engine.size_from_tape(Decimal::from(5), Some(Decimal::from(140_000)));
+        assert_eq!(
+            engine.published().base_price_grouping,
+            Decimal::from(5),
+            "the tape's magnitude moved a bucket the instrument's tick already settled",
+        );
+    }
+
+    #[test]
+    fn a_fine_tick_at_bitcoin_magnitude_sizes_the_bucket_from_the_tapes_own_price() {
+        // The defect. BTCUSDT prints on a 0.01 grid near $80k, so the tick is
+        // a true fact about the instrument and a useless row: a profile over a
+        // few hundred dollars of range asks for tens of thousands of them and
+        // paints as a jagged wash. `capture_base` has always known to fold that
+        // up to ~$1 — but only from a *snapshot's* mid, and a chart with no L2
+        // never gets one. The tape's own magnitude is the missing input.
+        let mut engine = BookEngine::new("BTCUSDT");
+        engine.size_from_tape(Decimal::new(1, 2), Some(Decimal::from(80_000)));
+        assert_eq!(
+            engine.published().base_price_grouping,
+            Decimal::from(1),
+            "an $80k instrument stayed on cent-wide rows",
+        );
+    }
+
+    #[test]
+    fn a_snapshots_mid_outranks_the_tapes_first_print() {
+        // Both are "the price this market is at", and where both exist the
+        // book's is the live spread while the tape's is wherever the chart
+        // happened to open. The snapshot path runs first and its answer stands.
+        let mut engine = BookEngine::new("BTCUSDT");
+        engine.set_enabled(true, 1);
+        engine.handle_depth_event(DepthEvent::Snapshot {
+            symbol: "BTCUSDT".to_owned(),
+            generation: 1,
+            observed_at_ms: 1_100,
+            effective_at_ms: 1_000,
+            price_step: None,
+            snapshot: BookSnapshot::new(
+                10,
+                vec![BookLevel::new(Decimal::from(64_999), Decimal::from(2)).unwrap()],
+                vec![BookLevel::new(Decimal::from(65_001), Decimal::from(3)).unwrap()],
+                BookCoverage::Limited {
+                    levels_per_side: 1_000,
+                },
+            ),
+        });
+        assert_eq!(engine.base_capture_grouping(), Decimal::from(1));
+        // A tape magnitude ten times larger arrives afterwards. History is no
+        // longer empty, so nothing is resized — and that gate is what keeps a
+        // live book from being reinterpreted underneath its own runs.
+        engine.size_from_tape(Decimal::new(1, 2), Some(Decimal::from(650_000)));
+        assert_eq!(engine.base_capture_grouping(), Decimal::from(1));
     }
 
     #[test]
@@ -1734,7 +1816,7 @@ mod tests {
         });
         assert_eq!(engine.published().base_price_grouping, Decimal::from(2));
 
-        engine.size_from_tape(Decimal::from(5));
+        engine.size_from_tape(Decimal::from(5), Some(Decimal::from(140_000)));
         assert_eq!(
             engine.published().base_price_grouping,
             Decimal::from(2),
@@ -1749,11 +1831,21 @@ mod tests {
         let mut engine = BookEngine::new("WINV26");
         engine.apply_grouping_now(Decimal::from(2));
         let chosen = engine.published().base_price_grouping;
-        engine.size_from_tape(Decimal::from(5));
+        engine.size_from_tape(Decimal::from(5), Some(Decimal::from(140_000)));
         assert_eq!(
             engine.published().base_price_grouping,
             chosen,
             "the tape overrode a bucket the trader picked by hand",
+        );
+        // And it keeps stepping aside as the tape keeps printing: the choice
+        // is not merely honoured on the print that follows it. A grid that
+        // narrows later — the only direction a GCD moves — must not become a
+        // second chance to resize.
+        engine.size_from_tape(Decimal::new(1, 2), Some(Decimal::from(140_000)));
+        assert_eq!(
+            engine.published().base_price_grouping,
+            chosen,
+            "a later, finer tape grid reopened a bucket the trader had closed",
         );
     }
 

--- a/crates/app/src/orderflow_engine.rs
+++ b/crates/app/src/orderflow_engine.rs
@@ -1224,10 +1224,16 @@ impl BookEngine {
         {
             return;
         }
-        // A book's mid outranks the tape's first print where both exist: one
-        // is the live spread, the other is wherever this chart happened to
-        // open. Where only the tape has spoken it is the whole answer, and
-        // that is the case this argument was added for.
+        // In practice the tape's own magnitude *is* the answer here, and the
+        // gate above is why: a book's mid would be the better number — it is
+        // the live spread rather than wherever this chart happened to open —
+        // but installing the snapshot that carries one is exactly what stops
+        // history being `Empty`, so a chart with a book has already returned.
+        // `self.reference_price` stays the first operand for the one state
+        // that falls between the two: a snapshot whose levels were read just
+        // before `install_snapshot` refused it. Written in that order because
+        // it is the right precedence when both are known, not because the
+        // first operand is the one usually taken.
         let reference = self
             .reference_price
             .or_else(|| reference_price.and_then(|price| price.to_f64()));
@@ -1542,6 +1548,10 @@ mod tests {
         assert!(engine.history.book().is_initialized());
     }
 
+    fn dec(text: &str) -> Decimal {
+        std::str::FromStr::from_str(text).expect("test literal is a decimal")
+    }
+
     fn snapshot_event(generation: u64) -> DepthEvent {
         DepthEvent::Snapshot {
             symbol: "BTCUSDT".to_owned(),
@@ -1756,10 +1766,58 @@ mod tests {
     }
 
     #[test]
-    fn a_snapshots_mid_outranks_the_tapes_first_print() {
-        // Both are "the price this market is at", and where both exist the
-        // book's is the live spread while the tape's is wherever the chart
-        // happened to open. The snapshot path runs first and its answer stands.
+    fn the_tapes_magnitude_only_moves_instruments_whose_tick_is_finer_than_their_scale() {
+        // The blast radius of sizing from the tape's own price, stated rather
+        // than discovered. A chart whose feed never declares a tick is every
+        // chart with the heatmap off, so this rule now reaches all of them —
+        // and it should, since a depth-less chart drawing different rows from
+        // the same instrument seen with depth is its own defect. What it must
+        // not do is move a market whose tick already suits its price.
+        //
+        // Moved: the tick is far finer than the money these markets travel in,
+        // which is the whole disease — cent rows on a four- or five-figure
+        // instrument, half-pip rows on a currency.
+        for (symbol, step, price, rows) in [
+            ("BTCUSDT", "0.01", "80000", "1"),
+            ("ETHUSDT", "0.01", "3000", "0.05"),
+            ("XAUUSD", "0.01", "2400", "0.05"),
+            ("EURUSD", "0.00001", "1.08", "0.00002"),
+        ] {
+            let mut engine = BookEngine::new(symbol);
+            engine.size_from_tape(dec(step), Some(dec(price)));
+            assert_eq!(
+                engine.published().base_price_grouping,
+                dec(rows),
+                "{symbol} sized its rows somewhere other than the documented width",
+            );
+        }
+
+        // Left alone: the instrument's own tick is already at least as coarse
+        // as the price-derived width, so the tick wins and nothing moves. The
+        // trader's own index and FX futures are both in this half, which is
+        // what makes the change safe to ship to the charts they watch daily.
+        for (symbol, step, price) in [
+            ("WINV26", "5", "177600"),
+            ("WDOU26", "0.5", "5500"),
+            ("US500", "0.1", "5800"),
+            ("PETR4", "0.01", "100"),
+        ] {
+            let mut engine = BookEngine::new(symbol);
+            engine.size_from_tape(dec(step), Some(dec(price)));
+            assert_eq!(
+                engine.published().base_price_grouping,
+                dec(step),
+                "{symbol} was regrouped away from the tick its own venue trades on",
+            );
+        }
+    }
+
+    #[test]
+    fn a_running_book_is_never_resized_by_a_later_tape_print() {
+        // The gate, not the precedence — and it is the gate that matters, since
+        // a resize here discards every run and aggression already recorded and
+        // leaves the map blank until the venue happens to resync. A tape whose
+        // magnitude disagrees with the book's must not be able to reach that.
         let mut engine = BookEngine::new("BTCUSDT");
         engine.set_enabled(true, 1);
         engine.handle_depth_event(DepthEvent::Snapshot {
@@ -1778,11 +1836,14 @@ mod tests {
             ),
         });
         assert_eq!(engine.base_capture_grouping(), Decimal::from(1));
-        // A tape magnitude ten times larger arrives afterwards. History is no
-        // longer empty, so nothing is resized — and that gate is what keeps a
-        // live book from being reinterpreted underneath its own runs.
+        // A tape magnitude ten times larger arrives afterwards, which on an
+        // empty history would size these rows at $10.
         engine.size_from_tape(Decimal::new(1, 2), Some(Decimal::from(650_000)));
-        assert_eq!(engine.base_capture_grouping(), Decimal::from(1));
+        assert_eq!(
+            engine.base_capture_grouping(),
+            Decimal::from(1),
+            "a tape print resized a book that was already recording against these rows",
+        );
     }
 
     #[test]

--- a/crates/app/src/orderflow_view.rs
+++ b/crates/app/src/orderflow_view.rs
@@ -123,7 +123,7 @@ pub struct OrderflowView {
     last_seen_base: Decimal,
     /// The tape grid last sent to the engine, so the per-trade path sends one
     /// command per change rather than one per print.
-    last_tape_price_step: Option<Decimal>,
+    last_tape_price_grid: Option<(Decimal, Option<Decimal>)>,
     capture_grouping_draft: f64,
     pending_capture_grouping_previous: Option<Decimal>,
     /// Named bubble looks, loaded from the versionable presets file.
@@ -183,7 +183,7 @@ impl OrderflowView {
             config,
             published: BookPublished::initial(),
             last_seen_base: base_grouping,
-            last_tape_price_step: None,
+            last_tape_price_grid: None,
             capture_grouping_draft: base_grouping.to_f64().unwrap_or(0.01),
             pending_capture_grouping_previous: None,
             presets,
@@ -807,7 +807,7 @@ impl OrderflowView {
         // whose tape prints on the same grid would be suppressed — and a grid
         // the engine refused while the trader had picked a bucket by hand
         // would never be re-offered once auto sizing is re-armed here.
-        self.last_tape_price_step = None;
+        self.last_tape_price_grid = None;
         self.published = BookPublished::initial();
         // The starvation clock is per market, like the history it starves.
         // Carrying the old symbol's zero across would open the new one on a
@@ -888,25 +888,36 @@ impl OrderflowView {
         self.worker.send(BookCommand::Trade(trade.clone()));
     }
 
-    /// Tell the engine the price grid the tape prints on.
+    /// Tell the engine the price grid the tape prints on, and the magnitude
+    /// it prints at.
+    ///
+    /// Both, because a tick alone does not size a row: BTCUSDT's real tick is
+    /// a cent and its rows are dollars. The engine folds the one toward the
+    /// other; it only ever had the price when a *book snapshot* carried one,
+    /// so a chart with no L2 fell back to raw cents.
     ///
     /// Sent only when the answer changes, which a running GCD makes rare: it
     /// starts as nothing, names a grid once the tape has shown one, and only
-    /// ever narrows from there. On the trader's own recordings it settles
-    /// within about thirty prints and never moves again, so a session pays for
-    /// one regroup rather than one per trade — which matters, because this is
-    /// called from the per-trade path.
+    /// ever narrows from there. The magnitude is frozen at the chart's first
+    /// print and never moves at all. On the trader's own recordings the pair
+    /// settles within about thirty prints and never moves again, so a session
+    /// pays for one regroup rather than one per trade — which matters, because
+    /// this is called from the per-trade path.
     ///
     /// Deliberately *not* gated on a layer being enabled, unlike
     /// [`record_trade`](Self::record_trade): the grid sizes the footprint
     /// ladder as well as the liquidity map, and a trader reading a ladder with
     /// the heatmap switched off needs its rows the right width just the same.
-    pub fn observe_tape_price_step(&mut self, step: Decimal) {
-        if self.last_tape_price_step == Some(step) {
+    pub fn observe_tape_price_grid(&mut self, step: Decimal, reference_price: Option<Decimal>) {
+        let grid = (step, reference_price);
+        if self.last_tape_price_grid == Some(grid) {
             return;
         }
-        self.last_tape_price_step = Some(step);
-        self.worker.send(BookCommand::TapePriceGrid(step));
+        self.last_tape_price_grid = Some(grid);
+        self.worker.send(BookCommand::TapePriceGrid {
+            step,
+            reference_price,
+        });
     }
 
     /// Whether the scripted starvation hook is holding this print back.
@@ -2491,7 +2502,7 @@ mod tests {
         // would write the mirror by itself and the test would pass either way.
         let mut view = OrderflowView::new("WINV26");
         let before = view.base_capture_grouping();
-        view.observe_tape_price_step(Decimal::from(5));
+        view.observe_tape_price_grid(Decimal::from(5), Some(Decimal::from(140_000)));
         view.worker.flush();
 
         let direct = view.capture_grouping_now();

--- a/crates/app/src/orderflow_view.rs
+++ b/crates/app/src/orderflow_view.rs
@@ -121,8 +121,12 @@ pub struct OrderflowView {
     published: BookPublished,
     /// Engine bucket last adopted into the mirror, to detect auto-base moves.
     last_seen_base: Decimal,
-    /// The tape grid last sent to the engine, so the per-trade path sends one
-    /// command per change rather than one per print.
+    /// The `(step, reference_price)` pair last sent to the engine, so the
+    /// per-trade path sends one command per change rather than one per print.
+    ///
+    /// Both halves are in the key: either one moving is a different answer,
+    /// and keying on the step alone would swallow the first magnitude a chart
+    /// ever learns whenever the grid happened to settle first.
     last_tape_price_grid: Option<(Decimal, Option<Decimal>)>,
     capture_grouping_draft: f64,
     pending_capture_grouping_previous: Option<Decimal>,

--- a/crates/app/src/orderflow_worker.rs
+++ b/crates/app/src/orderflow_worker.rs
@@ -39,10 +39,14 @@ pub(crate) enum BookCommand {
     },
     ApplyVisualConfig(HeatmapConfig),
     ApplyGroupingNow(Decimal),
-    /// The price grid the tape itself prints on, for a chart whose feed never
-    /// states an instrument tick. Loses to a venue-stated step; see
+    /// The price grid the tape itself prints on and the magnitude it prints
+    /// at, for a chart whose feed never states an instrument tick and whose
+    /// book never states a price. Loses to a venue-stated step; see
     /// [`BookEngine::size_from_tape`](crate::orderflow_engine::BookEngine::size_from_tape).
-    TapePriceGrid(Decimal),
+    TapePriceGrid {
+        step: Decimal,
+        reference_price: Option<Decimal>,
+    },
     AcceptGroupingRestart {
         grouping: Decimal,
         generation_floor: u64,
@@ -157,7 +161,10 @@ fn run(mut engine: BookEngine, rx: &Receiver<BookCommand>, shared: &Arc<Mutex<Bo
                 } => engine.prepare_restart(generation_floor, reason),
                 BookCommand::ApplyVisualConfig(config) => engine.apply_visual_config(config),
                 BookCommand::ApplyGroupingNow(grouping) => engine.apply_grouping_now(grouping),
-                BookCommand::TapePriceGrid(step) => engine.size_from_tape(step),
+                BookCommand::TapePriceGrid {
+                    step,
+                    reference_price,
+                } => engine.size_from_tape(step, reference_price),
                 BookCommand::AcceptGroupingRestart {
                     grouping,
                     generation_floor,

--- a/crates/app/src/pane.rs
+++ b/crates/app/src/pane.rs
@@ -2694,9 +2694,9 @@ impl ChartPane {
         }
     }
 
-    /// Hand the tape's own price grid to the order-flow engine, which sizes
-    /// the capture bucket — and through it the footprint ladder's rows — from
-    /// whichever tick it ends up trusting.
+    /// Hand the tape's own price grid — and the magnitude it prints at — to
+    /// the order-flow engine, which sizes the capture bucket, and through it
+    /// the footprint ladder's rows and the volume profile folded from them.
     ///
     /// Called after every ingest because the answer can only arrive after
     /// prints have. The view sends a command only when the answer changes, and
@@ -2709,7 +2709,7 @@ impl ChartPane {
             return;
         };
         if let Some(step) = self.state.tape_price_step() {
-            orderflow.observe_tape_price_step(step);
+            orderflow.observe_tape_price_grid(step, self.state.tape_reference_price());
         }
     }
 

--- a/crates/app/src/state.rs
+++ b/crates/app/src/state.rs
@@ -354,6 +354,17 @@ pub struct ChartState {
     /// whether a layer that draws it is switched on, and a consumer sizing
     /// rows needs it before anything is drawn.
     price_grid: PriceGrid,
+    /// The first price this chart ever saw, and never a later one.
+    ///
+    /// The row-sizing rule needs the magnitude a market trades at as well as
+    /// the grid it trades on, and this is the chart's own answer to the first
+    /// half. Deliberately frozen at the first print rather than tracking the
+    /// last: the sizing it feeds re-buckets and re-folds every retained ladder
+    /// when it changes, so a number that drifted with the tape would refold a
+    /// long session repeatedly to say almost the same thing. The heatmap's
+    /// snapshot path is frozen the same way, by only auto-sizing while its
+    /// history is still empty.
+    tape_reference_price: Option<Decimal>,
     /// Whether the ladders are being accumulated at all. Off (the default)
     /// costs nothing per trade and holds nothing per bar — a capability
     /// nobody asked for must not tax every ingest. Enabling refolds the
@@ -379,6 +390,7 @@ impl ChartState {
             backfill_boundary: None,
             footprints: FootprintSeries::new(footprint_series::default_group()),
             price_grid: PriceGrid::new(),
+            tape_reference_price: None,
             footprint_enabled: false,
         }
     }
@@ -388,7 +400,7 @@ impl ChartState {
     pub fn ingest_backfill(&mut self, trades: &[Trade]) {
         self.trades.extend_from_slice(trades);
         for trade in trades {
-            self.price_grid.observe(trade.price);
+            self.observe_price(trade.price);
         }
         self.backfill_trade_count = self.trades.len();
         self.backfill_done = true;
@@ -427,7 +439,7 @@ impl ChartState {
         // future live print able to correct it — and on a paused replay or a
         // closed market that print never comes.
         for trade in trades {
-            self.price_grid.observe(trade.price);
+            self.observe_price(trade.price);
         }
         let mut combined = Vec::with_capacity(trades.len() + self.trades.len());
         combined.extend_from_slice(trades);
@@ -441,7 +453,7 @@ impl ChartState {
     /// Ingest one live trade, incrementally (no full rebuild).
     pub fn ingest_live(&mut self, trade: &Trade) {
         self.trades.push(trade.clone());
-        self.price_grid.observe(trade.price);
+        self.observe_price(trade.price);
         let closed = self.builder.push(trade);
         if self.footprint_enabled {
             self.footprints.observe(trade, closed.as_ref());
@@ -469,6 +481,16 @@ impl ChartState {
 
     /// Replay every retained trade through a fresh builder for the current spec,
     /// recomputing the bars and the backfill/live boundary.
+    /// Fold one print into everything the chart learns from prices alone: the
+    /// grid the tape prints on, and the magnitude it prints at.
+    ///
+    /// Per-trade, and both halves are cheap — a modulo on the settled grid, and
+    /// an `Option` test that stores once per chart.
+    fn observe_price(&mut self, price: Decimal) {
+        self.price_grid.observe(price);
+        self.tape_reference_price.get_or_insert(price);
+    }
+
     fn rebuild(&mut self) {
         let mut builder = self.spec.build();
         let mut bars = Vec::new();
@@ -575,6 +597,20 @@ impl ChartState {
     #[must_use]
     pub fn partial_footprint(&self) -> Option<&BarFootprint> {
         self.footprints.partial()
+    }
+
+    /// The price magnitude this chart's tape trades at — the first price it
+    /// showed. See [the field](Self::tape_reference_price) for why the first
+    /// and not the latest.
+    ///
+    /// [`None`] only before the first print. Sizing rows needs this beside
+    /// [`tape_price_step`](Self::tape_price_step): a tick is a true fact about
+    /// an instrument and still a useless row on a market whose price dwarfs
+    /// it — BTCUSDT quotes in cents near $80k, and a profile at cent rows is
+    /// tens of thousands of them.
+    #[must_use]
+    pub fn tape_reference_price(&self) -> Option<Decimal> {
+        self.tape_reference_price
     }
 
     /// The price grid this chart's tape prints on, once enough prints have
@@ -881,6 +917,41 @@ mod tests {
             chart.ingest_live(&print_at(i as u64, price));
         }
         assert_eq!(chart.tape_price_step(), Some(dec("5")));
+    }
+
+    #[test]
+    fn a_chart_names_the_price_its_tape_trades_at_and_then_holds_still() {
+        // The other half of sizing a row. A tick is a true fact about an
+        // instrument and still a useless row where the price dwarfs it, so the
+        // rule needs the magnitude too — and it has to hold still, because
+        // every change to it re-buckets and re-folds every retained ladder.
+        let mut chart = ChartState::new(BarSpec::Tick(1000));
+        assert_eq!(chart.tape_reference_price(), None, "nothing has printed");
+
+        chart.ingest_live(&print_at(0, "80000"));
+        assert_eq!(chart.tape_reference_price(), Some(dec("80000")));
+
+        // A session that runs to a very different price is still the same
+        // market at the same magnitude, and re-grouping it mid-session would
+        // be a refold that says almost nothing new.
+        for (i, price) in ["81000", "84000", "88000"].iter().enumerate() {
+            chart.ingest_live(&print_at(i as u64 + 1, price));
+        }
+        assert_eq!(
+            chart.tape_reference_price(),
+            Some(dec("80000")),
+            "the magnitude drifted with the tape instead of holding at the first print",
+        );
+    }
+
+    #[test]
+    fn backfilled_history_names_the_price_as_well_as_the_grid() {
+        // History arrives as one batch before the first live print, and it is
+        // what a chart's very first screen is drawn from. A magnitude learned
+        // only from live prints would size that screen from nothing.
+        let mut chart = ChartState::new(BarSpec::Tick(1000));
+        chart.ingest_backfill(&[print_at(0, "140000"), print_at(1, "140005")]);
+        assert_eq!(chart.tape_reference_price(), Some(dec("140000")));
     }
 
     #[test]

--- a/crates/app/src/state.rs
+++ b/crates/app/src/state.rs
@@ -364,6 +364,12 @@ pub struct ChartState {
     /// long session repeatedly to say almost the same thing. The heatmap's
     /// snapshot path is frozen the same way, by only auto-sizing while its
     /// history is still empty.
+    ///
+    /// First *seen*, which is not first in time: paging older history in
+    /// through [`prepend_history`](Self::prepend_history) feeds prints that
+    /// predate this one and deliberately leaves it standing. A market's
+    /// magnitude is the same an hour earlier, and re-grouping a chart because
+    /// the trader scrolled left would be a refold with nothing to show for it.
     tape_reference_price: Option<Decimal>,
     /// Whether the ladders are being accumulated at all. Off (the default)
     /// costs nothing per trade and holds nothing per bar — a capability
@@ -479,10 +485,11 @@ impl ChartState {
         self.rebuild();
     }
 
-    /// Replay every retained trade through a fresh builder for the current spec,
-    /// recomputing the bars and the backfill/live boundary.
     /// Fold one print into everything the chart learns from prices alone: the
     /// grid the tape prints on, and the magnitude it prints at.
+    ///
+    /// One function rather than two calls at each ingest site, so a fourth
+    /// ingest path cannot pick up the grid and quietly forget the magnitude.
     ///
     /// Per-trade, and both halves are cheap — a modulo on the settled grid, and
     /// an `Option` test that stores once per chart.
@@ -491,6 +498,8 @@ impl ChartState {
         self.tape_reference_price.get_or_insert(price);
     }
 
+    /// Replay every retained trade through a fresh builder for the current spec,
+    /// recomputing the bars and the backfill/live boundary.
     fn rebuild(&mut self) {
         let mut builder = self.spec.build();
         let mut bars = Vec::new();


### PR DESCRIPTION
Size the footprint ladder's rows — and the fixed-range volume profile folded from them — from the instrument's own price magnitude as well as its tick, so a fine-tick market at a high price stops rendering as a jagged wash.

## Where the defect actually was

Not in `footprint_series::default_group()`. That `0.01` is only the fallback *before any data*; it is not what a live chart settles on. The plumbing was already there and already shared:

`Pane::draw_chart` → `OrderflowView::capture_grouping_now` → `BookEngine`'s capture bucket → `ChartState::set_footprint_group` → `footprint_group()`, read by both the footprint layer and `frvp.rs`.

What starved it was one line, `orderflow_engine.rs:1220`:

```rust
if let Some((base, _)) = capture_base(Some(step), self.reference_price) {
```

`self.reference_price` is set **only** from a depth snapshot (`orderflow_engine.rs:860`). `capture_base` has always known to fold a fine tick up toward the money a market moves in — it turns a ~65k book's `0.01` into `$1` — but only when it is told the price. A chart with no L2 (a market replay, or any feed with heatmap capture off) therefore arrived with BTCUSDT's true `0.01` tick and no price at all, and got cent-wide rows: a few hundred dollars of range asking for tens of thousands of them.

So this feeds that same rule the magnitude the chart already knows from its own tape. One rule, not two.

## What changed

- `ChartState` names its tape's **magnitude** as well as its grid: `tape_reference_price()`, frozen at the chart's first print. Frozen deliberately — every change to it re-buckets and re-folds every retained ladder, so a number that drifted with the tape would refold a long session repeatedly to say almost the same thing. The heatmap's snapshot path is frozen the same way, by only auto-sizing while its history is empty.
- `size_from_tape` takes it and passes it to the unchanged `capture_base`. A book's own mid still wins where both exist.
- `APP_HEALTH_SUMMARY` now logs `tape_reference_price` beside `tape_price_step` and `footprint_rows`, so all three inputs to the rule are legible to a script rather than two of three.

## Blast radius — stated, not discovered

Charts whose feed never declares a tick are every chart with the heatmap off, so this rule now reaches all of them. `the_tapes_magnitude_only_moves_instruments_whose_tick_is_finer_than_their_scale` pins both halves:

| Moves | tick → rows | | Unchanged | tick |
| --- | --- | --- | --- | --- |
| BTCUSDT (~$80k) | `0.01` → `1` | | WINV26 (~177.6k) | `5` |
| ETHUSDT (~$3k) | `0.01` → `0.05` | | WDOU26 (~5.5k) | `0.5` |
| XAUUSD (~$2.4k) | `0.01` → `0.05` | | US500 (~5.8k) | `0.1` |
| EURUSD (~1.08) | `0.00001` → `0.00002` | | a ~100 stock | `0.01` |

The moved set is exactly the disease: a tick far finer than the money the market travels in. The unchanged set includes both instruments the trader watches daily. A depth-less chart drawing different rows from the same instrument seen *with* depth would be its own defect, so the coarsening is the point — but it is on the record now rather than emergent.

A hand-picked capture grouping still beats all of it, and keeps beating it as the tape goes on printing (`a_hand_picked_bucket_is_not_resized_by_the_tape`).

## Proof

Test-first. Both BTC tests confirmed red before the fix (`left: 0.01, right: 1`); both WIN pins stayed green either way, which is what a regression pin should do.

- `a_fine_tick_at_bitcoin_magnitude_sizes_the_bucket_from_the_tapes_own_price`
- `a_coarse_tick_at_index_magnitude_keeps_the_tick_the_tape_named`
- `the_tapes_magnitude_only_moves_instruments_whose_tick_is_finer_than_their_scale` (8 instruments)
- `a_bitcoin_magnitude_tape_groups_the_profile_by_the_dollar` — end to end through a real pane and a placed FRVP, asserting on the **folded profile's own group**, not just the chart state
- `an_index_magnitude_tape_keeps_the_five_point_grouping_it_already_had`
- `a_chart_names_the_price_its_tape_trades_at_and_then_holds_still`, `backfilled_history_names_the_price_as_well_as_the_grid`

Four checks green on this branch rebased on `main`: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo build --workspace`, `cargo test --workspace` (2 234 passing).

## Performance

Per-trade path touched (`ChartState::observe_price`, `ChartPane::publish_tape_price_step`): one extra `Option` test per print that stores once per chart, one `Decimal` copy, and the send-once dedupe key widened from a `Decimal` to a pair. Everything downstream is rare — `size_from_tape` fires a handful of times a session.

Measured better, not flat, under a dense replayed tape vs. a `main` control build on the identical recording:

| Scene | build | fps | `frame_avg_ms` | `frame_cpu_ms` | `footprint_rows` |
| --- | --- | --- | --- | --- | --- |
| BTC, 3 000 prints | `main` | 59–60 | 16.67 | 3.10–3.32 | `0.01` |
| BTC, 3 000 prints | branch | 59–60 | 16.67 | **2.13–2.31** | `1.00` |
| WIN, real recording | `main` | 59–60 | 16.67 | 2.70–2.83 | `5` |
| WIN, real recording | branch | 59–60 | 16.67 | 2.70–2.79 | `5` |

BTC frame CPU falls ~30% because the profile and the ladders fold and draw ~100× fewer rows. WIN is inside its own noise band.

## Visual QA

`visual-qa` via `ui-harness` hooks, four captures at 2572×1558, every store pointed at scratch. BTC is a synthetic recording at $80k on the real 0.01 grid (no BTC recording exists on this machine and a live venue is not a deterministic fixture); WIN is the trader's own `WINV26 2026-08-26` recording, first 3 000 prints.

- **BTC before** — the profile is a hair-fine comb of sub-pixel rows with no readable structure, **no POC line drawn at all**, and the VAH label colliding with its neighbour. Status line: `rows 0.01`; ladder legend `[w20 row0.017 g0.01 …]`.
- **BTC after** — a shaped histogram with POC 80027.00, VAH 80184.00 and VAL 80000.00 on three clean lines. Status line: `rows 1.00`; ladder legend `[w20 row1.678 g1.00 …]`.
- **WIN before/after** — **pixel-identical across the entire chart canvas.** A 16×10 grid diff puts every differing pixel in the title/menu strip (sub-pixel font antialiasing); rows 1–9, the whole canvas, profile, ladders, axes and status bar, differ in zero sampled pixels.

`trader-ux-review`: no Blocker, no Should-fix. Rafa never sees it (WIN identical, frame time flat); Marina gets her bug fixed and keeps her manual override; Duda gets a readable profile without learning the word "grouping". One *Consider*, accepted: a BTC chart now regroups once shortly after open when the tape names its grid — the same settle WIN has always had, and once per session only, because the reference is frozen at the first print.

## Review

`arch-review` run over `git diff origin/main...HEAD`. **step 0: `code-review` at `high`, 3 findings, 3 confirmed** — all fixed in `6b92b87`, none deferred:

1. *(Medium)* The rule reaches more instruments than BTC and only the two ends were pinned → the eight-instrument table above.
2. *(Low)* The two app-level tests raced the book worker's thread and could read the default on a loaded runner → they now take `flush_for_test()`, the barrier the repo already uses.
3. *(Low)* `a_snapshots_mid_outranks_the_tapes_first_print` could not reach the precedence its name claimed — installing the snapshot is exactly what stops history being `Empty`, so `size_from_tape` returns at the gate three statements earlier → renamed to the property it does pin, and the comment beside the `or_else` now says which operand is actually taken.

Three further findings I raised against my own diff are fixed in `56e4528`: `rebuild`'s doc comment had been stranded over the new `observe_price`; the health summary logged two of the rule's three inputs; and the doc now says what paging older history does to the reference price (nothing, on purpose).

No shape findings survive. Docking: no new port — the change removes a starvation, it does not add a second rule. Language: `language_guard` passes, and I read the prose, the branch name and the commit messages myself.

## Unrelated, seen while verifying

`cargo test --workspace` intermittently fails three `paper_trading` tests (`an_in_session_rerun_opens_its_own_file`, `the_ledger_never_lists_this_sessions_trades_twice_after_a_retarget`, `a_close_refreshes_an_open_report_by_itself`) and always fails `quantick-feed-mt5::bridge_paging` on this machine. Neither is this branch:

- `paper_trading::test_scratch_dir` keys its temp folder on `std::process::id()` and never cleans up. Windows reuses PIDs, so a later run inherits an earlier one's files and the directory-content assertions see 4 entries where they expect 2. There are **1 650** leftover `quantick-paper-host-*` directories in `%TEMP%` right now, several PIDs with 6–8 each.
- `bridge_paging` tries `python3` first, which on this machine is the Microsoft Store alias stub. The stub *spawns* successfully and then fails, so the `python` fallback never runs. Both Python suites pass when invoked directly: 21 bridge checks and the exporter tests.

Happy to file either as its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016c3JGym3oLu5XWGpvU5ihu
