### PR TITLE
feat(app): the two Fibonacci icons say which is which

### DIFF
--- a/.claude/GOAL-archive-fib-icon-letters.md
+++ b/.claude/GOAL-archive-fib-icon-letters.md
@@ -1,0 +1,44 @@
+# Mission
+
+Redraw the two Fibonacci tool icons to the trader's sketch: each names itself
+with one letter (`R` retracement, `P` projection) and hangs its levels where
+they say what the tool does — between the anchors for the retracement, beyond
+them for the projection — so the two are told apart at rail size without
+hovering for a tooltip.
+
+Source of the design: a sketch the trader drew and handed over in session —
+a leg with a marked anchor at each end, the level lines in the quadrant the
+leg leaves empty, and a large letter in the corner opposite them.
+
+## Acceptance criteria
+
+Mission-specific:
+
+1. Both Fib icons follow the sketch: marked anchors on the leg, level lines
+   placed where they distinguish the two tools, one large letter each.
+2. The letters differ (`R` / `P`) and are the same size in both icons, so
+   they read as a choice between two rows rather than two unrelated marks.
+3. The letter's corner is provably empty: a test holds every stroke and every
+   anchor of both icons clear of the region the letter is painted in.
+4. The icon stays registry data — a tool declares its letter, the chrome
+   paints what it is handed and never learns which tool it is drawing.
+5. Both icons are legible at both sizes they are painted: the 18 px rail
+   button and the 14 px flyout row.
+
+Injected by the kind of mission (code, user-visible, per-frame path):
+
+6. English throughout every artifact.
+7. Four checks green on the branch rebased on latest `main`
+   (`cargo fmt --all -- --check`, `clippy -D warnings`, `build`, `test`).
+8. Performance impact declared: the rail's icons are a **per-frame** path.
+   Evidence that frame cost is flat against a `main` control run
+   (`APP_HEALTH_SUMMARY` fps / frame_avg), numbers in the PR body.
+9. `ui-harness`: every surface the change touches is reachable by env hook
+   from a fresh launch — `QUANTICK_TOOL_FAVORITES` (rail buttons) and
+   `QUANTICK_TOOLBOX_FLYOUT=fib` (flyout rows). No new surface, so no new
+   hook; if that turns out false, the hook lands in this change.
+10. `visual-qa` pass over both surfaces, or defects explicitly accepted.
+11. `trader-ux-review` with no unresolved Blocker.
+12. `arch-review` run over `git diff main...HEAD`, every Blocker and
+    Should-fix resolved or deferred in the PR body.
+13. PR opened. Merging is not part of this mission.

--- a/crates/app/src/drawings/brush.rs
+++ b/crates/app/src/drawings/brush.rs
@@ -31,6 +31,7 @@ pub(super) const BRUSH_FAMILY: ToolFamily = ToolFamily {
     icon: icons::SCRIBBLE,
     icon_strokes: &[],
     icon_dots: &[],
+    icon_letter: None,
 };
 
 impl DrawingToolImpl for Brush {

--- a/crates/app/src/drawings/fib.rs
+++ b/crates/app/src/drawings/fib.rs
@@ -19,83 +19,104 @@ use super::{
     IconDots, IconLetter, IconStrokes, PresetHost, ToolFamily, distance_to_segment, drawing_stroke,
 };
 
-/// Left edge of the ladder in both Fib icons. The levels used to start at
-/// the glyph box's left margin; they were pulled right to leave the corner
-/// at [`FIB_LETTER_AT`] empty, because a letter painted over a level line is
+/// Left edge of the *drawing* in both Fib icons: every level line, every
+/// leg and every anchor stays right of this, so the column left of it
+/// belongs to the letter alone. A letter painted over a level line is
 /// neither a readable letter nor a readable level.
-const LEVELS_LEFT_X: f32 = 0.34;
-
-/// Where the letter sits in both Fib icons, and how tall it is.
 ///
-/// Named once and shared, because the letter is only useful as a
-/// *comparison*: `R` above `P` on the same baseline, at the same size, in
-/// the same corner, is a choice between two tools. Two letters that drift
-/// apart in size or position read as two unrelated marks instead.
-const FIB_LETTER_AT: (f32, f32) = (0.15, 0.26);
-/// Height of that letter as a fraction of the glyph box — as large as the
-/// corner left of the ladder and above the leg can hold.
-const FIB_LETTER_HEIGHT: f32 = 0.50;
+/// A bound rather than a coordinate — nothing is drawn *at* it — so it is
+/// the guard's constant and does not ship in the binary.
+#[cfg(test)]
+const DRAWING_LEFT_X: f32 = 0.34;
 
-/// The retracement icon, drawn as the gesture it is: the ladder of levels
-/// with the two-anchor leg pulled across it, and the leg's two ends marked.
+/// Centre-x of the letter in both icons — one column, so on two stacked rail
+/// buttons the eye finds the letter in the same place and only the letter
+/// changes.
+const FIB_LETTER_X: f32 = 0.15;
+/// Height of the letter in both icons, as a fraction of the glyph box.
+/// Shared for the same reason: an `R` and a `P` at one size are a choice
+/// between two tools, while two letters at two sizes read as two unrelated
+/// marks.
+const FIB_LETTER_HEIGHT: f32 = 0.46;
+/// Half the width of a capital in the proportional face, as a fraction of
+/// its font size, generously rounded up. It exists only so a test can prove
+/// the letter clears `DRAWING_LEFT_X`; egui measures the real glyph when it
+/// paints one, so this number never reaches the screen — or the binary.
+#[cfg(test)]
+const LETTER_HALF_WIDTH_RATIO: f32 = 0.4;
+
+/// The leg the retracement was dragged across, named once: the strokes draw
+/// it and the dots mark its ends, so nudging the glyph cannot leave the
+/// anchors behind on the old line.
 ///
-/// The marked ends are the part that carries the meaning. Without them the
-/// glyph is a stack of lines with a slash through it — which is also what an
-/// extension looks like, and what the `ROWS` glyph both tools used to share
-/// looked like. Two dots against three is how the eye tells the two Fib
-/// tools apart in the flyout at a glance, which is exactly how every drawing
-/// platform draws them.
-/// The leg itself, named once: the strokes draw it and the dots mark its
-/// ends, so nudging the glyph cannot leave the anchors behind on the old line.
-const RETRACEMENT_LEG: &[(f32, f32)] = &[(0.40, 0.84), (0.86, 0.16)];
+/// Its two ends are the 0 and the 1 of the level list — that is why they
+/// carry a dot and no line of their own.
+const RETRACEMENT_LEG: &[(f32, f32)] = &[(0.36, 0.88), (0.84, 0.22)];
 
+/// The retracement icon, drawn as the gesture is drawn on a chart: the leg
+/// across the move, its ends marked, and the levels hanging **between** those
+/// ends — inside the move, which is exactly what a retracement measures.
+///
+/// The levels' side of the leg is the whole difference from
+/// [`FIB_EXTENSION_ICON`], where the same lines sit *beyond* the move. Both
+/// then say in one picture what the tool does with the leg it was given, and
+/// the letter in the corner names it for the trader who would rather read
+/// than compare.
 pub(super) const FIB_RETRACEMENT_ICON: IconStrokes = &[
-    &[(LEVELS_LEFT_X, 0.16), (0.98, 0.16)],
-    &[(LEVELS_LEFT_X, 0.50), (0.98, 0.50)],
-    &[(LEVELS_LEFT_X, 0.84), (0.98, 0.84)],
+    &[(0.52, 0.42), (0.96, 0.42)],
+    &[(0.52, 0.58), (0.96, 0.58)],
+    &[(0.52, 0.74), (0.96, 0.74)],
     RETRACEMENT_LEG,
 ];
 
-/// The two ends of the leg the retracement is dragged across. They sit on the
-/// outer levels because that is where they really are: the anchors *are* 0
-/// and 1, and every other line hangs between them.
+/// The two ends of the leg the retracement is dragged across. They carry no
+/// line of their own because they *are* 0 and 1, and every level the icon
+/// draws hangs between them.
 pub(super) const FIB_RETRACEMENT_DOTS: IconDots = RETRACEMENT_LEG;
 
 /// `R` for retracement — the half of the pair that measures *back into* a
-/// move already made. Two dots against three is a true difference, but it is
-/// a difference the eye has to count; the letter is the one it reads.
+/// move already made. It takes the top-left corner because that is the one
+/// this icon's own drawing leaves empty.
 pub(super) const FIB_RETRACEMENT_LETTER: IconLetter = IconLetter {
     text: "R",
-    at: FIB_LETTER_AT,
+    at: (FIB_LETTER_X, 0.26),
     height: FIB_LETTER_HEIGHT,
 };
 
-/// The extension icon: the same ladder under the *three*-anchor path —
-/// impulse, pullback, projection origin — because that is the gesture, and
-/// the third dot is what says so.
 /// The extension's three-anchor path, named once for the same reason as
-/// [`RETRACEMENT_LEG`].
-const EXTENSION_LEG: &[(f32, f32)] = &[(0.40, 0.84), (0.70, 0.16), (0.92, 0.52)];
+/// [`RETRACEMENT_LEG`]: impulse up, pullback down, and the origin the
+/// projection hangs from.
+const EXTENSION_LEG: &[(f32, f32)] = &[(0.36, 0.92), (0.66, 0.64), (0.88, 0.80)];
 
+/// The extension icon: the same rungs as the retracement, moved **above** the
+/// leg — price the move has not reached yet, which is what a projection is.
+/// The three-anchor path under them is the gesture, and the third dot is
+/// what says so.
+///
+/// Neither icon reaches into the box's top-right corner: a pinned tool wears
+/// the favorites star there (`FAVORITE_BADGE_INSET_PX`), and an anchor under
+/// a star is an anchor the trader cannot see.
 pub(super) const FIB_EXTENSION_ICON: IconStrokes = &[
-    &[(LEVELS_LEFT_X, 0.16), (0.98, 0.16)],
-    &[(LEVELS_LEFT_X, 0.50), (0.98, 0.50)],
-    &[(LEVELS_LEFT_X, 0.84), (0.98, 0.84)],
+    &[(0.52, 0.20), (0.96, 0.20)],
+    &[(0.52, 0.33), (0.96, 0.33)],
+    &[(0.52, 0.46), (0.96, 0.46)],
     EXTENSION_LEG,
 ];
 
 /// The three anchors of the trend-based extension — impulse, pullback and the
-/// origin the projection hangs from. Three dots against two is what tells the
-/// two Fib rows apart in the flyout at icon size.
+/// origin the projection hangs from. Three dots against two is a true
+/// difference, but one the eye has to count.
 pub(super) const FIB_EXTENSION_DOTS: IconDots = EXTENSION_LEG;
 
 /// `P` for projection, not `E` for extension: the letter has to say what the
 /// tool does at a glance, and what this one does is throw the measured leg
 /// *forward*, past the move, onto price that has not traded yet. `E` beside
-/// `R` names the menu entry; `P` beside `R` names the difference.
+/// `R` names the menu entry; `P` beside `R` names the difference. It takes
+/// the bottom-left corner — the empty one here, since this icon's levels are
+/// at the top.
 pub(super) const FIB_EXTENSION_LETTER: IconLetter = IconLetter {
     text: "P",
-    at: FIB_LETTER_AT,
+    at: (FIB_LETTER_X, 0.72),
     height: FIB_LETTER_HEIGHT,
 };
 
@@ -1203,32 +1224,59 @@ mod tests {
 
     const EPS: f64 = 1e-9;
 
-    /// The letter's corner is only free because nothing else is drawn in it.
-    /// Both icons keep every stroke and every anchor right of
-    /// [`LEVELS_LEFT_X`]; since a segment between two such points can never
+    fn close(left: f64, right: f64) -> bool {
+        (left - right).abs() < EPS
+    }
+
+    /// The letters are only readable because nothing else is drawn in their
+    /// column. Both icons keep every stroke and every anchor right of
+    /// [`DRAWING_LEFT_X`]; since a segment between two such points can never
     /// wander left of them, that one bound is what proves the `R` and the
     /// `P` are painted on empty space rather than across a level line.
     #[test]
-    fn the_fib_icons_leave_their_letter_corner_empty() {
+    fn the_fib_icons_leave_their_letter_column_empty() {
         for (name, strokes, dots) in [
             ("retracement", FIB_RETRACEMENT_ICON, FIB_RETRACEMENT_DOTS),
             ("extension", FIB_EXTENSION_ICON, FIB_EXTENSION_DOTS),
         ] {
             for (x, y) in strokes.iter().copied().flatten().chain(dots) {
                 assert!(
-                    *x >= LEVELS_LEFT_X,
-                    "{name}: icon point ({x}, {y}) crosses into the letter's corner"
+                    *x >= DRAWING_LEFT_X,
+                    "{name}: icon point ({x}, {y}) crosses into the letter's column"
                 );
             }
         }
+        let letter_right = FIB_LETTER_X + FIB_LETTER_HEIGHT * LETTER_HALF_WIDTH_RATIO;
         assert!(
-            FIB_LETTER_AT.0 < LEVELS_LEFT_X,
-            "the letter sits in the corner the drawing leaves empty"
+            letter_right <= DRAWING_LEFT_X,
+            "the letter must fit in the column the drawing leaves empty"
         );
     }
 
-    fn close(left: f64, right: f64) -> bool {
-        (left - right).abs() < EPS
+    /// Each letter takes the corner its *own* drawing leaves empty, which is
+    /// why the retracement's sits high and the projection's low: the rungs
+    /// are what moved between the two icons, and the letter follows the free
+    /// space rather than a fixed corner. Both stay inside the box they are
+    /// painted in — a letter clipped by the glyph box is a letter the trader
+    /// reads as a different letter.
+    #[test]
+    fn the_two_fib_letters_take_opposite_corners() {
+        assert!(
+            FIB_RETRACEMENT_LETTER.at.1 < 0.5,
+            "the R sits high, above the rungs hanging inside the move"
+        );
+        assert!(
+            FIB_EXTENSION_LETTER.at.1 > 0.5,
+            "the P sits low, under the rungs projected past the move"
+        );
+        for letter in [FIB_RETRACEMENT_LETTER, FIB_EXTENSION_LETTER] {
+            let half = FIB_LETTER_HEIGHT / 2.0;
+            assert!(
+                letter.at.1 - half >= 0.0 && letter.at.1 + half <= 1.0,
+                "{}: the letter leaves the glyph box",
+                letter.text
+            );
+        }
     }
 
     /// A retracement runs *backwards* along the move: 0 % at the end of it,

--- a/crates/app/src/drawings/fib.rs
+++ b/crates/app/src/drawings/fib.rs
@@ -19,16 +19,6 @@ use super::{
     IconDots, IconLetter, IconStrokes, PresetHost, ToolFamily, distance_to_segment, drawing_stroke,
 };
 
-/// Left edge of the *drawing* in both Fib icons: every level line, every
-/// leg and every anchor stays right of this, so the column left of it
-/// belongs to the letter alone. A letter painted over a level line is
-/// neither a readable letter nor a readable level.
-///
-/// A bound rather than a coordinate — nothing is drawn *at* it — so it is
-/// the guard's constant and does not ship in the binary.
-#[cfg(test)]
-const DRAWING_LEFT_X: f32 = 0.34;
-
 /// Centre-x of the letter in both icons — one column, so on two stacked rail
 /// buttons the eye finds the letter in the same place and only the letter
 /// changes.
@@ -38,13 +28,6 @@ const FIB_LETTER_X: f32 = 0.15;
 /// between two tools, while two letters at two sizes read as two unrelated
 /// marks.
 const FIB_LETTER_HEIGHT: f32 = 0.46;
-/// Half the width of a capital in the proportional face, as a fraction of
-/// its font size, generously rounded up. It exists only so a test can prove
-/// the letter clears `DRAWING_LEFT_X`; egui measures the real glyph when it
-/// paints one, so this number never reaches the screen — or the binary.
-#[cfg(test)]
-const LETTER_HALF_WIDTH_RATIO: f32 = 0.4;
-
 /// The leg the retracement was dragged across, named once: the strokes draw
 /// it and the dots mark its ends, so nudging the glyph cannot leave the
 /// anchors behind on the old line.
@@ -86,7 +69,7 @@ pub(super) const FIB_RETRACEMENT_LETTER: IconLetter = IconLetter {
 /// The extension's three-anchor path, named once for the same reason as
 /// [`RETRACEMENT_LEG`]: impulse up, pullback down, and the origin the
 /// projection hangs from.
-const EXTENSION_LEG: &[(f32, f32)] = &[(0.36, 0.92), (0.66, 0.64), (0.88, 0.80)];
+const EXTENSION_LEG: &[(f32, f32)] = &[(0.44, 0.92), (0.68, 0.64), (0.88, 0.80)];
 
 /// The extension icon: the same rungs as the retracement, moved **above** the
 /// leg — price the move has not reached yet, which is what a projection is.
@@ -1228,37 +1211,132 @@ mod tests {
         (left - right).abs() < EPS
     }
 
-    /// The letters are only readable because nothing else is drawn in their
-    /// column. Both icons keep every stroke and every anchor right of
-    /// [`DRAWING_LEFT_X`]; since a segment between two such points can never
-    /// wander left of them, that one bound is what proves the `R` and the
-    /// `P` are painted on empty space rather than across a level line.
-    #[test]
-    fn the_fib_icons_leave_their_letter_column_empty() {
-        for (name, strokes, dots) in [
-            ("retracement", FIB_RETRACEMENT_ICON, FIB_RETRACEMENT_DOTS),
-            ("extension", FIB_EXTENSION_ICON, FIB_EXTENSION_DOTS),
+    /// Whether a stroke of `half_width` laid between `a` and `b` reaches
+    /// into `rect` — the separating-axis test for a capsule against a box,
+    /// conservative at the corners, which is the right side to be wrong on
+    /// for a guard.
+    fn stroke_touches(a: egui::Pos2, b: egui::Pos2, half_width: f32, rect: egui::Rect) -> bool {
+        let grown = rect.expand(half_width);
+        let outside_all = |pick: fn(egui::Pos2) -> f32, bound: f32, above: bool| {
+            let (pa, pb) = (pick(a), pick(b));
+            if above {
+                pa > bound && pb > bound
+            } else {
+                pa < bound && pb < bound
+            }
+        };
+        if outside_all(|p| p.x, grown.left(), false)
+            || outside_all(|p| p.x, grown.right(), true)
+            || outside_all(|p| p.y, grown.top(), false)
+            || outside_all(|p| p.y, grown.bottom(), true)
+        {
+            return false;
+        }
+        let along = b - a;
+        let normal = egui::vec2(-along.y, along.x);
+        if normal.length() <= f32::EPSILON {
+            return true;
+        }
+        let normal = normal.normalized();
+        let mut lowest = f32::MAX;
+        let mut highest = f32::MIN;
+        for corner in [
+            grown.left_top(),
+            grown.right_top(),
+            grown.left_bottom(),
+            grown.right_bottom(),
         ] {
-            for (x, y) in strokes.iter().copied().flatten().chain(dots) {
+            let side = (corner - a).dot(normal);
+            lowest = lowest.min(side);
+            highest = highest.max(side);
+        }
+        !(lowest > 0.0 || highest < 0.0)
+    }
+
+    /// The letter is readable only because nothing else is painted where it
+    /// lands — and *painted* is the word that matters. An earlier guard
+    /// compared the icon's stroke and anchor coordinates against a margin,
+    /// which is the geometry's centre line: a dot is drawn as a disc a tenth
+    /// of the box wide, so an anchor whose centre cleared the margin still
+    /// put ink a long way over it.
+    ///
+    /// This one measures what the painter measures: egui lays out the real
+    /// glyph at the size the icon asks for, the dots and strokes are grown
+    /// by the radius and width `paint_vector_icon` gives them, and the two
+    /// are held apart. Both sizes the icon is painted at are checked,
+    /// because the stroke width is in pixels and does not shrink with the
+    /// box — the flyout's smaller icon is the tighter fit, not the safer one.
+    #[test]
+    fn nothing_the_fib_icons_paint_reaches_the_letter_beside_it() {
+        let ctx = egui::Context::default();
+        // Fonts are built on the first frame; `layout_no_wrap` before one has
+        // nothing to measure with.
+        let _ = ctx.run(egui::RawInput::default(), |_| {});
+        for box_px in [
+            crate::widgets::TOOLRAIL_ICON.glyph,
+            crate::toolrail::FLYOUT_ICON_BOX_PX,
+        ] {
+            let at = |(x, y): (f32, f32)| egui::pos2(x * box_px, y * box_px);
+            let dot_radius = box_px * crate::widgets::ICON_DOT_RADIUS_RATIO;
+            let stroke_half = crate::widgets::ICON_STROKE_WIDTH_PX / 2.0;
+            for (name, strokes, dots, letter) in [
+                (
+                    "retracement",
+                    FIB_RETRACEMENT_ICON,
+                    FIB_RETRACEMENT_DOTS,
+                    FIB_RETRACEMENT_LETTER,
+                ),
+                (
+                    "extension",
+                    FIB_EXTENSION_ICON,
+                    FIB_EXTENSION_DOTS,
+                    FIB_EXTENSION_LETTER,
+                ),
+            ] {
+                let galley = ctx.fonts(|fonts| {
+                    fonts.layout_no_wrap(
+                        letter.text.to_owned(),
+                        egui::FontId::proportional(box_px * letter.height),
+                        egui::Color32::WHITE,
+                    )
+                });
+                let letter_rect = egui::Rect::from_center_size(at(letter.at), galley.size());
+                for polyline in strokes {
+                    for pair in polyline.windows(2) {
+                        assert!(
+                            !stroke_touches(at(pair[0]), at(pair[1]), stroke_half, letter_rect),
+                            "{name}: at {box_px} px the stroke {:?}-{:?} runs into the letter",
+                            pair[0],
+                            pair[1]
+                        );
+                    }
+                }
+                for dot in dots {
+                    assert!(
+                        !letter_rect.expand(dot_radius).contains(at(*dot)),
+                        "{name}: at {box_px} px the anchor {dot:?} lands on the letter"
+                    );
+                }
+                // The glyph box is not a clip rect — the button's hit target
+                // is what the neighbouring buttons leave free — so that is
+                // what the letter has to stay inside of.
+                let margin = (crate::widgets::TOOLRAIL_ICON.hit - box_px) / 2.0;
+                let button = egui::Rect::from_min_size(
+                    egui::pos2(-margin, -margin),
+                    egui::Vec2::splat(box_px + 2.0 * margin),
+                );
                 assert!(
-                    *x >= DRAWING_LEFT_X,
-                    "{name}: icon point ({x}, {y}) crosses into the letter's column"
+                    button.contains_rect(letter_rect),
+                    "{name}: at {box_px} px the letter spills out of its button"
                 );
             }
         }
-        let letter_right = FIB_LETTER_X + FIB_LETTER_HEIGHT * LETTER_HALF_WIDTH_RATIO;
-        assert!(
-            letter_right <= DRAWING_LEFT_X,
-            "the letter must fit in the column the drawing leaves empty"
-        );
     }
 
     /// Each letter takes the corner its *own* drawing leaves empty, which is
     /// why the retracement's sits high and the projection's low: the rungs
     /// are what moved between the two icons, and the letter follows the free
-    /// space rather than a fixed corner. Both stay inside the box they are
-    /// painted in — a letter clipped by the glyph box is a letter the trader
-    /// reads as a different letter.
+    /// space rather than a fixed corner.
     #[test]
     fn the_two_fib_letters_take_opposite_corners() {
         assert!(
@@ -1269,14 +1347,6 @@ mod tests {
             FIB_EXTENSION_LETTER.at.1 > 0.5,
             "the P sits low, under the rungs projected past the move"
         );
-        for letter in [FIB_RETRACEMENT_LETTER, FIB_EXTENSION_LETTER] {
-            let half = FIB_LETTER_HEIGHT / 2.0;
-            assert!(
-                letter.at.1 - half >= 0.0 && letter.at.1 + half <= 1.0,
-                "{}: the letter leaves the glyph box",
-                letter.text
-            );
-        }
     }
 
     /// A retracement runs *backwards* along the move: 0 % at the end of it,

--- a/crates/app/src/drawings/fib.rs
+++ b/crates/app/src/drawings/fib.rs
@@ -16,8 +16,25 @@ use smallvec::SmallVec;
 
 use super::{
     DrawContext, Drawing, DrawingPayload, DrawingStyle, FIB_LABEL_OFFSET_PX, FIB_LABEL_SIZE_PX,
-    IconDots, IconStrokes, PresetHost, ToolFamily, distance_to_segment, drawing_stroke,
+    IconDots, IconLetter, IconStrokes, PresetHost, ToolFamily, distance_to_segment, drawing_stroke,
 };
+
+/// Left edge of the ladder in both Fib icons. The levels used to start at
+/// the glyph box's left margin; they were pulled right to leave the corner
+/// at [`FIB_LETTER_AT`] empty, because a letter painted over a level line is
+/// neither a readable letter nor a readable level.
+const LEVELS_LEFT_X: f32 = 0.34;
+
+/// Where the letter sits in both Fib icons, and how tall it is.
+///
+/// Named once and shared, because the letter is only useful as a
+/// *comparison*: `R` above `P` on the same baseline, at the same size, in
+/// the same corner, is a choice between two tools. Two letters that drift
+/// apart in size or position read as two unrelated marks instead.
+const FIB_LETTER_AT: (f32, f32) = (0.15, 0.26);
+/// Height of that letter as a fraction of the glyph box — as large as the
+/// corner left of the ladder and above the leg can hold.
+const FIB_LETTER_HEIGHT: f32 = 0.50;
 
 /// The retracement icon, drawn as the gesture it is: the ladder of levels
 /// with the two-anchor leg pulled across it, and the leg's two ends marked.
@@ -30,12 +47,12 @@ use super::{
 /// platform draws them.
 /// The leg itself, named once: the strokes draw it and the dots mark its
 /// ends, so nudging the glyph cannot leave the anchors behind on the old line.
-const RETRACEMENT_LEG: &[(f32, f32)] = &[(0.06, 0.84), (0.60, 0.16)];
+const RETRACEMENT_LEG: &[(f32, f32)] = &[(0.40, 0.84), (0.86, 0.16)];
 
 pub(super) const FIB_RETRACEMENT_ICON: IconStrokes = &[
-    &[(0.30, 0.16), (0.98, 0.16)],
-    &[(0.30, 0.50), (0.98, 0.50)],
-    &[(0.30, 0.84), (0.98, 0.84)],
+    &[(LEVELS_LEFT_X, 0.16), (0.98, 0.16)],
+    &[(LEVELS_LEFT_X, 0.50), (0.98, 0.50)],
+    &[(LEVELS_LEFT_X, 0.84), (0.98, 0.84)],
     RETRACEMENT_LEG,
 ];
 
@@ -44,17 +61,26 @@ pub(super) const FIB_RETRACEMENT_ICON: IconStrokes = &[
 /// and 1, and every other line hangs between them.
 pub(super) const FIB_RETRACEMENT_DOTS: IconDots = RETRACEMENT_LEG;
 
+/// `R` for retracement — the half of the pair that measures *back into* a
+/// move already made. Two dots against three is a true difference, but it is
+/// a difference the eye has to count; the letter is the one it reads.
+pub(super) const FIB_RETRACEMENT_LETTER: IconLetter = IconLetter {
+    text: "R",
+    at: FIB_LETTER_AT,
+    height: FIB_LETTER_HEIGHT,
+};
+
 /// The extension icon: the same ladder under the *three*-anchor path —
 /// impulse, pullback, projection origin — because that is the gesture, and
 /// the third dot is what says so.
 /// The extension's three-anchor path, named once for the same reason as
 /// [`RETRACEMENT_LEG`].
-const EXTENSION_LEG: &[(f32, f32)] = &[(0.04, 0.84), (0.34, 0.16), (0.62, 0.56)];
+const EXTENSION_LEG: &[(f32, f32)] = &[(0.40, 0.84), (0.70, 0.16), (0.92, 0.52)];
 
 pub(super) const FIB_EXTENSION_ICON: IconStrokes = &[
-    &[(0.30, 0.16), (0.98, 0.16)],
-    &[(0.30, 0.50), (0.98, 0.50)],
-    &[(0.30, 0.84), (0.98, 0.84)],
+    &[(LEVELS_LEFT_X, 0.16), (0.98, 0.16)],
+    &[(LEVELS_LEFT_X, 0.50), (0.98, 0.50)],
+    &[(LEVELS_LEFT_X, 0.84), (0.98, 0.84)],
     EXTENSION_LEG,
 ];
 
@@ -62,6 +88,16 @@ pub(super) const FIB_EXTENSION_ICON: IconStrokes = &[
 /// origin the projection hangs from. Three dots against two is what tells the
 /// two Fib rows apart in the flyout at icon size.
 pub(super) const FIB_EXTENSION_DOTS: IconDots = EXTENSION_LEG;
+
+/// `P` for projection, not `E` for extension: the letter has to say what the
+/// tool does at a glance, and what this one does is throw the measured leg
+/// *forward*, past the move, onto price that has not traded yet. `E` beside
+/// `R` names the menu entry; `P` beside `R` names the difference.
+pub(super) const FIB_EXTENSION_LETTER: IconLetter = IconLetter {
+    text: "P",
+    at: FIB_LETTER_AT,
+    height: FIB_LETTER_HEIGHT,
+};
 
 /// The one rail family both Fib tools declare, shared here so the two
 /// members can never drift onto different family ids.
@@ -71,6 +107,7 @@ pub(super) const FIB_FAMILY: ToolFamily = ToolFamily {
     icon: egui_phosphor::regular::ROWS,
     icon_strokes: FIB_RETRACEMENT_ICON,
     icon_dots: FIB_RETRACEMENT_DOTS,
+    icon_letter: Some(FIB_RETRACEMENT_LETTER),
 };
 
 /// Ratios closer than this are the same level; a duplicate is rejected.
@@ -1165,6 +1202,30 @@ mod tests {
     use super::*;
 
     const EPS: f64 = 1e-9;
+
+    /// The letter's corner is only free because nothing else is drawn in it.
+    /// Both icons keep every stroke and every anchor right of
+    /// [`LEVELS_LEFT_X`]; since a segment between two such points can never
+    /// wander left of them, that one bound is what proves the `R` and the
+    /// `P` are painted on empty space rather than across a level line.
+    #[test]
+    fn the_fib_icons_leave_their_letter_corner_empty() {
+        for (name, strokes, dots) in [
+            ("retracement", FIB_RETRACEMENT_ICON, FIB_RETRACEMENT_DOTS),
+            ("extension", FIB_EXTENSION_ICON, FIB_EXTENSION_DOTS),
+        ] {
+            for (x, y) in strokes.iter().copied().flatten().chain(dots) {
+                assert!(
+                    *x >= LEVELS_LEFT_X,
+                    "{name}: icon point ({x}, {y}) crosses into the letter's corner"
+                );
+            }
+        }
+        assert!(
+            FIB_LETTER_AT.0 < LEVELS_LEFT_X,
+            "the letter sits in the corner the drawing leaves empty"
+        );
+    }
 
     fn close(left: f64, right: f64) -> bool {
         (left - right).abs() < EPS

--- a/crates/app/src/drawings/fib_extension.rs
+++ b/crates/app/src/drawings/fib_extension.rs
@@ -27,6 +27,9 @@ impl DrawingToolImpl for FibExtension {
     fn icon_dots(&self) -> super::IconDots {
         fib::FIB_EXTENSION_DOTS
     }
+    fn icon_letter(&self) -> Option<super::IconLetter> {
+        Some(fib::FIB_EXTENSION_LETTER)
+    }
     /// No key is named here, and that is deliberate: this tool gave up
     /// `Shift+F` because that key flattens the position (see
     /// [`Self::shortcut`]). The tooltip went on advertising it long after,

--- a/crates/app/src/drawings/fib_extension.rs
+++ b/crates/app/src/drawings/fib_extension.rs
@@ -35,8 +35,13 @@ impl DrawingToolImpl for FibExtension {
     /// [`Self::shortcut`]). The tooltip went on advertising it long after,
     /// which told the trader to press the one key that closes their position
     /// to reach a drawing tool.
+    ///
+    /// It does name the icon's letter. The registry calls this tool
+    /// *extension* and the icon says `P`, for the projection it draws; a
+    /// trader who has not met the pair yet meets them here, in the one place
+    /// they go to ask what a button is.
     fn hover_text(&self) -> &'static str {
-        "Fib extension - drag the first leg, then click the projection origin"
+        "Fib extension (P for projection) - drag the first leg, then click the projection origin"
     }
     fn placement_hint(&self, placed: usize) -> Option<&'static str> {
         match placed {

--- a/crates/app/src/drawings/fib_retracement.rs
+++ b/crates/app/src/drawings/fib_retracement.rs
@@ -27,6 +27,9 @@ impl DrawingToolImpl for FibRetracement {
     fn icon_dots(&self) -> super::IconDots {
         fib::FIB_RETRACEMENT_DOTS
     }
+    fn icon_letter(&self) -> Option<super::IconLetter> {
+        Some(fib::FIB_RETRACEMENT_LETTER)
+    }
     fn hover_text(&self) -> &'static str {
         "Fib retracement - click two points or drag (F)"
     }

--- a/crates/app/src/drawings/line_core.rs
+++ b/crates/app/src/drawings/line_core.rs
@@ -38,6 +38,7 @@ pub(super) const LINES_FAMILY: ToolFamily = ToolFamily {
     icon: icons::LINE_SEGMENT,
     icon_strokes: &[],
     icon_dots: &[],
+    icon_letter: None,
 };
 
 /// How far a line runs past the anchors that define it.

--- a/crates/app/src/drawings/mark_core.rs
+++ b/crates/app/src/drawings/mark_core.rs
@@ -30,6 +30,7 @@ pub(super) const MARKS_FAMILY: ToolFamily = ToolFamily {
     icon: egui_phosphor::regular::ARROW_FAT_UP,
     icon_strokes: &[],
     icon_dots: &[],
+    icon_letter: None,
 };
 
 /// Gap between the candle's extreme and the tip of the mark, in pixels, so

--- a/crates/app/src/drawings/measure_core.rs
+++ b/crates/app/src/drawings/measure_core.rs
@@ -23,6 +23,7 @@ pub(super) const MEASURE_FAMILY: ToolFamily = ToolFamily {
     icon: icons::RULER,
     icon_strokes: &[],
     icon_dots: &[],
+    icon_letter: None,
 };
 
 /// Which axes a measurement reports. Price range suppresses time, date range

--- a/crates/app/src/drawings/mod.rs
+++ b/crates/app/src/drawings/mod.rs
@@ -2478,10 +2478,10 @@ mod tests {
     /// typeface happened to leave a gap.
     ///
     /// The two Fib tools are named because the letters are the whole reason
-    /// the port exists: one ladder, one leg, two tools. The letters must
-    /// differ from each other, and must sit at the same place and size, or
-    /// they stop reading as a choice between two rows and start reading as
-    /// two unrelated marks.
+    /// the port exists: one leg, one set of rungs, two tools. The letters
+    /// must differ from each other and share a column and a size, or they
+    /// stop reading as a choice between two rows and start reading as two
+    /// unrelated marks.
     #[test]
     fn icon_letters_stay_in_the_unit_square_and_name_the_two_fib_tools() {
         for tool in DRAWING_TOOLS {
@@ -2522,9 +2522,13 @@ mod tests {
             "the two Fib icons must not answer with the same letter"
         );
         assert_eq!(
-            (retracement.at, retracement.height),
-            (extension.at, extension.height),
-            "the two Fib letters share one corner and one size, or they stop reading as a pair"
+            (retracement.at.0, retracement.height),
+            (extension.at.0, extension.height),
+            "the two Fib letters share one column and one size, or they stop reading as a pair"
+        );
+        assert_ne!(
+            retracement.at.1, extension.at.1,
+            "each letter takes the corner its own levels leave empty, so the two sit at              different heights"
         );
     }
 

--- a/crates/app/src/drawings/mod.rs
+++ b/crates/app/src/drawings/mod.rs
@@ -380,6 +380,11 @@ pub struct ToolFamily {
     /// Anchor dots for the slot icon — same contract as
     /// [`DrawingTool::icon_dots`].
     pub icon_dots: IconDots,
+    /// Letter set into the slot icon — same contract as
+    /// [`DrawingTool::icon_letter`]. A family whose slot borrows one
+    /// member's picture declares that member's letter, or the slot would be
+    /// the only place that drawing appears unnamed.
+    pub icon_letter: Option<IconLetter>,
 }
 
 /// A vector icon: polylines in the unit square (x right, y down), scaled to
@@ -399,6 +404,27 @@ pub type IconStrokes = &'static [&'static [(f32, f32)]];
 /// their anchors marked for that reason. Registry data like the strokes, so
 /// the chrome never learns which tool it is painting.
 pub type IconDots = &'static [(f32, f32)];
+
+/// A letter set into a vector icon: the character, where its centre sits in
+/// the same unit square as the strokes, and its size as a fraction of the
+/// glyph box.
+///
+/// It exists for the tools that draw the *same picture*. The two Fib tools
+/// are one ladder of levels hung off one leg, and only the number of anchors
+/// separates them — a difference that is two dots wide on a 32 px rail. `R`
+/// and `P` say retracement and projection outright, so a trader picks the
+/// one they meant without hovering for the tooltip first. Registry data like
+/// the strokes: the chrome paints the letter it is handed and never learns
+/// which tool it belongs to.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct IconLetter {
+    /// The letter itself, painted in the icon's own colour.
+    pub text: &'static str,
+    /// Centre of the letter in the unit square (x right, y down).
+    pub at: (f32, f32),
+    /// Font size as a fraction of the glyph box's height.
+    pub height: f32,
+}
 
 /// The implementation port every drawing plugs into. Selection visuals (halo
 /// and anchor handles) are common chrome painted by the wrapper, so a tool
@@ -420,6 +446,12 @@ trait DrawingToolImpl: Sync {
     /// Only meaningful alongside strokes: a font glyph draws its own.
     fn icon_dots(&self) -> IconDots {
         &[]
+    }
+    /// A letter set into the vector icon — see [`IconLetter`]. Only
+    /// meaningful alongside strokes: a font glyph is somebody else's
+    /// drawing, with no corner reserved to put a letter in.
+    fn icon_letter(&self) -> Option<IconLetter> {
+        None
     }
     fn hover_text(&self) -> &'static str;
     fn required_points(&self) -> usize;
@@ -727,6 +759,12 @@ impl DrawingTool {
     #[must_use]
     pub fn icon_dots(self) -> IconDots {
         self.0.icon_dots()
+    }
+
+    /// The letter set into the vector icon, `None` when it needs none.
+    #[must_use]
+    pub fn icon_letter(self) -> Option<IconLetter> {
+        self.0.icon_letter()
     }
 
     #[must_use]
@@ -2432,6 +2470,62 @@ mod tests {
                 "{id} replaced its glyph and must keep vector strokes"
             );
         }
+    }
+
+    /// The letter half of the same port: it lives in the same unit square,
+    /// is one character rather than a word, and only exists on a tool that
+    /// draws its own strokes — over a font glyph it would land wherever the
+    /// typeface happened to leave a gap.
+    ///
+    /// The two Fib tools are named because the letters are the whole reason
+    /// the port exists: one ladder, one leg, two tools. The letters must
+    /// differ from each other, and must sit at the same place and size, or
+    /// they stop reading as a choice between two rows and start reading as
+    /// two unrelated marks.
+    #[test]
+    fn icon_letters_stay_in_the_unit_square_and_name_the_two_fib_tools() {
+        for tool in DRAWING_TOOLS {
+            let Some(letter) = tool.icon_letter() else {
+                continue;
+            };
+            assert!(
+                !tool.icon_strokes().is_empty(),
+                "{}: a letter needs strokes to sit in",
+                tool.id()
+            );
+            let (x, y) = letter.at;
+            assert!(
+                (0.0..=1.0).contains(&x) && (0.0..=1.0).contains(&y),
+                "{}: icon letter at ({x}, {y}) leaves the unit square",
+                tool.id()
+            );
+            assert!(
+                letter.height > 0.0 && letter.height <= 1.0,
+                "{}: an icon letter is a fraction of the glyph box",
+                tool.id()
+            );
+            assert_eq!(
+                letter.text.chars().count(),
+                1,
+                "{}: the icon has room for a letter, not a word",
+                tool.id()
+            );
+        }
+        let retracement = tool("fib-retracement")
+            .icon_letter()
+            .expect("the retracement icon carries its letter");
+        let extension = tool("fib-extension")
+            .icon_letter()
+            .expect("the extension icon carries its letter");
+        assert_ne!(
+            retracement.text, extension.text,
+            "the two Fib icons must not answer with the same letter"
+        );
+        assert_eq!(
+            (retracement.at, retracement.height),
+            (extension.at, extension.height),
+            "the two Fib letters share one corner and one size, or they stop reading as a pair"
+        );
     }
 
     /// The two halves of the note port answer together: `holds_text` is the

--- a/crates/app/src/drawings/mod.rs
+++ b/crates/app/src/drawings/mod.rs
@@ -2511,6 +2511,25 @@ mod tests {
                 tool.id()
             );
         }
+        // A family slot borrows a member's picture, and the same rule holds
+        // there: `IconButton` only reaches the letter on the strokes branch,
+        // so a family that declared a letter over a font glyph would carry a
+        // letter nothing ever paints.
+        for family in DRAWING_TOOLS.into_iter().filter_map(DrawingTool::family) {
+            if let Some(letter) = family.icon_letter {
+                assert!(
+                    !family.icon_strokes.is_empty(),
+                    "{}: a family letter needs strokes to sit in",
+                    family.id
+                );
+                assert_eq!(
+                    letter.text.chars().count(),
+                    1,
+                    "{}: the slot has room for a letter, not a word",
+                    family.id
+                );
+            }
+        }
         let retracement = tool("fib-retracement")
             .icon_letter()
             .expect("the retracement icon carries its letter");
@@ -2528,7 +2547,7 @@ mod tests {
         );
         assert_ne!(
             retracement.at.1, extension.at.1,
-            "each letter takes the corner its own levels leave empty, so the two sit at              different heights"
+            "each letter takes the corner its own levels leave empty, so the two sit apart"
         );
     }
 

--- a/crates/app/src/drawings/shape_core.rs
+++ b/crates/app/src/drawings/shape_core.rs
@@ -20,6 +20,7 @@ pub(super) const SHAPES_FAMILY: ToolFamily = ToolFamily {
     icon: icons::SHAPES,
     icon_strokes: &[],
     icon_dots: &[],
+    icon_letter: None,
 };
 
 /// Segments in an ellipse outline. Fixed, not derived from the on-screen

--- a/crates/app/src/toolrail.rs
+++ b/crates/app/src/toolrail.rs
@@ -10,7 +10,9 @@ use std::collections::BTreeMap;
 use eframe::egui;
 use egui_phosphor::regular as icons;
 
-use crate::drawings::{DRAWING_TOOLS, DrawingTool, Drawings, IconDots, IconStrokes, ToolFamily};
+use crate::drawings::{
+    DRAWING_TOOLS, DrawingTool, Drawings, IconDots, IconLetter, IconStrokes, ToolFamily,
+};
 use crate::theme;
 use crate::widgets::{IconButton, MarkerEdge, TOOLRAIL_ICON, paint_vector_icon};
 
@@ -145,6 +147,14 @@ impl Tool {
         match self {
             Self::Pointer | Self::Crosshair => &[],
             Self::Drawing(tool) => tool.icon_dots(),
+        }
+    }
+
+    #[must_use]
+    fn icon_letter(self) -> Option<IconLetter> {
+        match self {
+            Self::Pointer | Self::Crosshair => None,
+            Self::Drawing(tool) => tool.icon_letter(),
         }
     }
 
@@ -1421,7 +1431,7 @@ impl ToolRail {
 
     fn draw_button(&mut self, ui: &mut egui::Ui, tool: Tool, drawings: &Drawings) {
         let response = IconButton::new(tool.icon(), TOOLRAIL_ICON)
-            .vector_icon(tool.icon_strokes(), tool.icon_dots())
+            .vector_icon(tool.icon_strokes(), tool.icon_dots(), tool.icon_letter())
             .active(self.tool == tool)
             .active_marker(self.dock.marker_edge())
             .hover_text(tool.hover_text())
@@ -1493,7 +1503,7 @@ impl ToolRail {
             let tool = self.favorites[index];
             let armed = self.tool == Tool::Drawing(tool);
             let response = IconButton::new(tool.icon(), TOOLRAIL_ICON)
-                .vector_icon(tool.icon_strokes(), tool.icon_dots())
+                .vector_icon(tool.icon_strokes(), tool.icon_dots(), tool.icon_letter())
                 .active(armed)
                 .active_marker(self.dock.marker_edge())
                 .hover_text(tool.hover_text())
@@ -1767,9 +1777,10 @@ impl ToolRail {
         let icon = shown.map_or(family.icon, DrawingTool::icon);
         let strokes = shown.map_or(family.icon_strokes, DrawingTool::icon_strokes);
         let dots = shown.map_or(family.icon_dots, DrawingTool::icon_dots);
+        let letter = shown.map_or(family.icon_letter, DrawingTool::icon_letter);
         let hover = shown.map_or(family.title, DrawingTool::hover_text);
         let response = IconButton::new(icon, TOOLRAIL_ICON)
-            .vector_icon(strokes, dots)
+            .vector_icon(strokes, dots, letter)
             .active(armed)
             .active_marker(self.dock.marker_edge())
             .hover_text(hover)
@@ -1972,6 +1983,7 @@ impl ToolRail {
                     ),
                     member.icon_strokes(),
                     member.icon_dots(),
+                    member.icon_letter(),
                     glyph_color,
                 );
             }

--- a/crates/app/src/toolrail.rs
+++ b/crates/app/src/toolrail.rs
@@ -54,6 +54,9 @@ const FLYOUT_HEADER_TEXT_PX: f32 = 11.0;
 /// left so the two never collide. The hit zone is bigger than the glyph —
 /// a 9 px star is no hit target — and stays clear of the icon and name, so
 /// an arming click can never silently star.
+/// Side of the icon box in a flyout row — the smallest box a vector icon is
+/// ever painted into, and therefore the size the icon guards measure against.
+pub(crate) const FLYOUT_ICON_BOX_PX: f32 = FLYOUT_GLYPH_PX - 4.0;
 const FLYOUT_STAR_PX: f32 = 9.0;
 const FLYOUT_STAR_RIGHT_INSET_PX: f32 = 10.0;
 const FLYOUT_STAR_HIT_PX: f32 = 14.0;
@@ -1979,7 +1982,7 @@ impl ToolRail {
                     ui.painter(),
                     egui::Rect::from_center_size(
                         glyph_center,
-                        egui::Vec2::splat(FLYOUT_GLYPH_PX - 4.0),
+                        egui::Vec2::splat(FLYOUT_ICON_BOX_PX),
                     ),
                     member.icon_strokes(),
                     member.icon_dots(),

--- a/crates/app/src/widgets.rs
+++ b/crates/app/src/widgets.rs
@@ -310,7 +310,7 @@ impl<'a> IconButton<'a> {
 
 /// Stroke width of a vector icon, chosen to sit near the visual weight of a
 /// Phosphor regular glyph at the rail's glyph size.
-const ICON_STROKE_WIDTH_PX: f32 = 1.4;
+pub(crate) const ICON_STROKE_WIDTH_PX: f32 = 1.4;
 
 /// Radius of an icon's anchor dot, as a fraction of the glyph box. Small
 /// enough to read as a handle on the leg rather than as a sixth level line —
@@ -319,7 +319,7 @@ const ICON_STROKE_WIDTH_PX: f32 = 1.4;
 /// A fraction rather than a pixel count because the same icon is painted at
 /// two sizes: the flyout's box is 14 px, and a dot fixed in pixels grew there
 /// from a handle into a blob that swallowed the level line under it.
-const ICON_DOT_RADIUS_RATIO: f32 = 1.9 / 18.0;
+pub(crate) const ICON_DOT_RADIUS_RATIO: f32 = 1.9 / 18.0;
 
 /// Paint a vector icon: each polyline's unit-square points scaled into
 /// `rect`, then the anchor dots over them. A handful of line segments and at
@@ -375,6 +375,66 @@ pub fn paint_vector_icon(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Every string one frame painted, so a test can ask what reached the
+    /// screen rather than what the builder was handed.
+    fn painted_text(output: &egui::FullOutput) -> Vec<String> {
+        fn walk(shape: &egui::Shape, found: &mut Vec<String>) {
+            match shape {
+                egui::Shape::Text(text) => found.push(text.galley.text().to_owned()),
+                egui::Shape::Vec(shapes) => {
+                    for shape in shapes {
+                        walk(shape, found);
+                    }
+                }
+                _ => {}
+            }
+        }
+        let mut found = Vec::new();
+        for clipped in &output.shapes {
+            walk(&clipped.shape, &mut found);
+        }
+        found
+    }
+
+    /// The letter has to reach the screen, not just the builder. A vector
+    /// icon takes the *strokes* branch of the paint, which is exactly the
+    /// branch that used to have no way to say a word — so a regression here
+    /// would be silent: the lines would still be there and the button would
+    /// still work, with the one mark that says which Fibonacci it is gone.
+    #[test]
+    fn a_vector_icon_paints_the_letter_it_was_given() {
+        let strokes: crate::drawings::IconStrokes = &[&[(0.4, 0.9), (0.9, 0.2)]];
+        let letter = crate::drawings::IconLetter {
+            text: "R",
+            at: (0.15, 0.26),
+            height: 0.46,
+        };
+        let ctx = egui::Context::default();
+        let draw = |with_letter: Option<crate::drawings::IconLetter>| {
+            ctx.run(egui::RawInput::default(), |ctx| {
+                egui::CentralPanel::default().show(ctx, |ui| {
+                    IconButton::new("", TOOLRAIL_ICON)
+                        .vector_icon(strokes, &[], with_letter)
+                        .show(ui);
+                });
+            })
+        };
+        // Twice: egui lays a frame out against the previous one, and the
+        // first frame of a fresh context has no sizes to paint into yet.
+        let _ = draw(Some(letter));
+        assert!(
+            painted_text(&draw(Some(letter)))
+                .iter()
+                .any(|text| text == "R"),
+            "a lettered vector icon must paint its letter"
+        );
+        let _ = draw(None);
+        assert!(
+            !painted_text(&draw(None)).iter().any(|text| text == "R"),
+            "an icon given no letter must paint none"
+        );
+    }
 
     #[test]
     fn idle_is_muted_on_bare_chrome() {

--- a/crates/app/src/widgets.rs
+++ b/crates/app/src/widgets.rs
@@ -145,6 +145,7 @@ pub struct IconButton<'a> {
     glyph: &'a str,
     strokes: crate::drawings::IconStrokes,
     dots: crate::drawings::IconDots,
+    letter: Option<crate::drawings::IconLetter>,
     size: IconSize,
     active: bool,
     enabled: bool,
@@ -162,6 +163,7 @@ impl<'a> IconButton<'a> {
             glyph,
             strokes: &[],
             dots: &[],
+            letter: None,
             size,
             active: false,
             enabled: true,
@@ -177,18 +179,20 @@ impl<'a> IconButton<'a> {
     /// [`crate::drawings::IconDots`], so the button stays one code path for
     /// every tool.
     ///
-    /// Strokes and dots arrive together on purpose. They are two halves of
-    /// one drawing, and a caller that could ask for the lines alone would
-    /// paint a Fib retracement that reads exactly like the extension beside
-    /// it — the anchors are what tells them apart.
+    /// Strokes, dots and letter arrive together on purpose. They are three
+    /// parts of one drawing, and a caller that could ask for the lines alone
+    /// would paint a Fib retracement that reads exactly like the extension
+    /// beside it — the anchors and the letter are what tell them apart.
     #[must_use]
     pub fn vector_icon(
         mut self,
         strokes: crate::drawings::IconStrokes,
         dots: crate::drawings::IconDots,
+        letter: Option<crate::drawings::IconLetter>,
     ) -> Self {
         self.strokes = strokes;
         self.dots = dots;
+        self.letter = letter;
         self
     }
 
@@ -269,7 +273,14 @@ impl<'a> IconButton<'a> {
             } else {
                 let box_rect =
                     egui::Rect::from_center_size(rect.center(), egui::Vec2::splat(self.size.glyph));
-                paint_vector_icon(painter, box_rect, self.strokes, self.dots, paint.glyph);
+                paint_vector_icon(
+                    painter,
+                    box_rect,
+                    self.strokes,
+                    self.dots,
+                    self.letter,
+                    paint.glyph,
+                );
             }
             if self.active
                 && let Some(edge) = self.marker_edge
@@ -301,9 +312,14 @@ impl<'a> IconButton<'a> {
 /// Phosphor regular glyph at the rail's glyph size.
 const ICON_STROKE_WIDTH_PX: f32 = 1.4;
 
-/// Radius of an icon's anchor dot, in pixels at the rail's glyph size. Small
-/// enough to read as a handle on the leg rather than as a sixth level line.
-const ICON_DOT_RADIUS_PX: f32 = 1.9;
+/// Radius of an icon's anchor dot, as a fraction of the glyph box. Small
+/// enough to read as a handle on the leg rather than as a sixth level line —
+/// 1.9 px at the rail's 18 px box, which is where it was chosen by eye.
+///
+/// A fraction rather than a pixel count because the same icon is painted at
+/// two sizes: the flyout's box is 14 px, and a dot fixed in pixels grew there
+/// from a handle into a blob that swallowed the level line under it.
+const ICON_DOT_RADIUS_RATIO: f32 = 1.9 / 18.0;
 
 /// Paint a vector icon: each polyline's unit-square points scaled into
 /// `rect`, then the anchor dots over them. A handful of line segments and at
@@ -314,6 +330,7 @@ pub fn paint_vector_icon(
     rect: egui::Rect,
     strokes: crate::drawings::IconStrokes,
     dots: crate::drawings::IconDots,
+    letter: Option<crate::drawings::IconLetter>,
     color: egui::Color32,
 ) {
     let at = |(x, y): (f32, f32)| {
@@ -338,7 +355,20 @@ pub fn paint_vector_icon(
     // Over the strokes: the leg passes through its own anchors, and a dot
     // half-hidden under a level line stops reading as an anchor at all.
     for &dot in dots {
-        painter.circle_filled(at(dot), ICON_DOT_RADIUS_PX, color);
+        painter.circle_filled(at(dot), rect.height() * ICON_DOT_RADIUS_RATIO, color);
+    }
+    // Last, in the icon's own colour: the letter that names which of two
+    // near-identical pictures this is. Same colour as the strokes on
+    // purpose — a letter in a colour of its own would be a second signal
+    // competing with the armed accent, when all it has to say is `R` or `P`.
+    if let Some(letter) = letter {
+        painter.text(
+            at(letter.at),
+            egui::Align2::CENTER_CENTER,
+            letter.text,
+            egui::FontId::proportional(rect.height() * letter.height),
+            color,
+        );
     }
 }
 


### PR DESCRIPTION

**CI note**: the first run went red on `app::tests::gateway_wait_for_change_sees_a_human_mark_and_does_not_delay_a_concurrent_read`, a control-plane timing test this branch does not touch. It is a pre-existing flake — the same test, the same assertion, failed on `main` in run 33119218734 (the #246 merge). The re-run of this job is green.
