### PR TITLE
feat(app): carve the Surface port, and a ratchet that keeps the trunk shut

### DIFF
--- a/.claude/GOAL-archive-surface-port-and-size-ratchet.md
+++ b/.claude/GOAL-archive-surface-port-and-size-ratchet.md
@@ -1,0 +1,64 @@
+# Mission
+
+Stop the `app` crate's trunk from absorbing every new capability: add a
+mechanical size ratchet and an `arch-review` accumulation dimension, then
+carve the `Surface` port and move exemplary surfaces onto it.
+
+## Why (the diagnosis this mission answers)
+
+`arch-review` dimension 1 asks whether a new capability can dock as a new file
+plus one registration line. Every recent feature answered yes honestly — and
+`app.rs` still grew from 108 lines to 34,030 in 37 days, monotonically. The
+review measures the leaf and never the trunk: nobody asks *where the
+registration lines accumulate*. They accumulate in `QuantickApp` (130 fields)
+and `new_with_workspace` (1,022 lines), because there is no port for "being a
+surface of the app" — so each of the 68 modules is wired by hand in four
+places: a field, an init, a draw call, a hotkey.
+
+Measured coupling says the underlying design is sound, not rotten: 9 of 21
+`draw_*` surfaces touch 1-2 fields of `QuantickApp`; only `draw_frame` (14)
+and `draw_menu_bar` (17) are genuinely tangled. This is wiring debt, not
+architecture debt, which is why it is mechanical to repay.
+
+`grep` for "line count | file size | god object | monolith" in
+`arch-review/SKILL.md` returns zero hits. The repo already knows how to turn a
+rule into a test (`language_guard.rs`, `source_encoding_guard.rs`); size has no
+such guard. A rule enforced only by a skill's judgement drifts.
+
+## Classification
+
+Code change + hot path (per-frame draw dispatch) + user-visible + adds a
+capability (the port). All four gate sets apply.
+
+## Acceptance criteria
+
+1. `crates/app/tests/size_guard.rs` fails when any tracked file grows past a
+   versioned baseline, and passes at today's baseline.
+2. `arch-review` gains an accumulation dimension: it judges where registration
+   lines pile up, not only whether a new file was added.
+3. `new-extension` states that a UI surface docks through the `Surface` port,
+   never through a new `QuantickApp` field.
+4. A `Surface` port and registry exist in the `app` crate, with a fake second
+   implementation covered by a test (`new-extension`'s rule).
+5. At least 3 surfaces move onto the port; `QuantickApp` loses at least 3
+   fields (before/after counts recorded); `draw_frame` no longer hand-calls
+   them.
+6. Behaviour identical: `visual-qa` PASS on every moved surface, or defects
+   explicitly accepted.
+7. Per-frame performance flat or better: `APP_HEALTH_SUMMARY` fps/frame_avg
+   against a `main` control run, numbers in the PR body.
+8. Four checks green, run as separate commands; `arch-review` run with every
+   Blocker/Should-fix resolved or deferred in the PR body; PR opened.
+9. Every artifact in English.
+
+## Order of work (risk-ascending, so the gate survives a failed port)
+
+Items 1-3 are additive and carry zero production risk; they stop the bleeding
+on their own. The port (4-5) comes second and starts with the surfaces that
+touch a single field. If the port fails, it is dropped and the gate still
+ships.
+
+## Done means
+
+The PR is open with green CI and the evidence in its body. Merging is the
+trader's call, never part of the mission.

--- a/.claude/skills/arch-review/SKILL.md
+++ b/.claude/skills/arch-review/SKILL.md
@@ -122,7 +122,7 @@ Read the neighbouring code before judging any of it. The repo's existing
 pattern is the standard; a change that invents a second way to do something
 already solved is a finding, even when the new way is prettier in isolation.
 
-## The eight dimensions
+## The nine dimensions
 
 ### 1. The docking test — modularity and extensibility
 
@@ -506,6 +506,61 @@ So the reviewer's job in this dimension is the part the guard cannot do:
 Report the guard's verdict and your own separately. "`language_guard` passes"
 is not the same claim as "I read the prose".
 
+### 9. The trunk — where did the registration lines land?
+
+Dimension 1 asks whether a capability *can* dock. This one asks where the
+docking went. The two are not the same question, and the gap between them is
+how this repo acquired a 36,000-line file while every review passed honestly.
+
+A change adds `pointer_compass.rs` — a real new module, a real port question
+answered yes — and then adds a field to `QuantickApp`, an init to
+`new_with_workspace`, a draw call to `draw_frame` and a hotkey to
+`draw_menu_bar`. Four edits, one file, and dimension 1 saw only the new
+module. Repeat sixty-eight times: 133 fields, a 1,149-line constructor, and a
+struct that *is* the registry — implemented as a struct, so the only way to
+extend it is to edit it.
+
+Look for:
+
+- **Growth in the trunk.** `crates/app/tests/size_guard.rs` records a ceiling
+  for every file over 1,500 production lines — every line outside a top-level
+  `#[cfg(test)]` item — and fails when one grows past it. Check what it counts
+  before trusting what it says: the first version of that guard stopped at the
+  first `#[cfg(test)]` of any kind, which scored `control/gateway.rs` at 72
+  lines of its 4,142 and left five of the largest files in the repo untracked.
+  A mechanical half that is blind where the debt is largest is worse than none,
+  because a review cites it and stops looking. That guard is this dimension's mechanical half, as `language_guard.rs`
+  is dimension 8's; the judgement half is yours. Raising a ceiling stays
+  legitimate — it is a visible, signed line in the diff — but it is a finding
+  to argue with, never a silent act. A branch that raises one without saying
+  why in the comment beside it has recorded a decision rather than made one.
+- **A registry that is a closed enum.** An entry that cannot join without a
+  `match` arm is a type switch wearing a registry's name, and dimension 1's
+  first bullet already forbids the shape. Two of the ports `new-extension`
+  recommends are exactly this today: `ChartLayer` carries 21 variants across
+  264 `ChartLayer::` sites in six files, `DockTab` another 64. Adding a layer
+  reopens `app.rs`, `pane.rs`, `tab.rs` and `toolbar.rs`. When a change adds a
+  variant, ask what a trait object in a registry would have cost instead — and
+  when it adds the *second* variant of a kind, that is the moment the port was
+  due.
+- **Blast radius in lines, not only files.** `new-extension` §3 counts files
+  added versus edited, and a change adding one file while pouring 2,000 lines
+  into thirteen others passes that count looking healthy. Count the lines too.
+  Mostly-edits by line is the finding dimension 1 already names, one magnitude
+  louder.
+- **Host or participant?** When a change puts state on the application's root
+  struct, ask whether that struct has any reason to know about it — whether
+  anything *else* reads the field. State a single surface owns belongs to that
+  surface, not to its host. Nine of `app.rs`'s twenty-one `draw_*` surfaces
+  touch one or two fields of `QuantickApp`; those are not entangled designs,
+  they are modules filed in the wrong place, and saying so is cheap while they
+  are still small.
+
+The distinction this dimension turns on: a codebase becomes unmaintainable
+from wiring debt long before it does from design debt, and the two look
+identical in a file listing. Establish which one is in front of you before
+prescribing — an extraction is mechanical and safe, a redesign is neither.
+
 ## Verify before reporting
 
 Reviews are judged on precision, not volume.
@@ -549,7 +604,10 @@ A clean change gets a short review saying it is clean and why. Never pad.
   to do a solved thing; a capability reachable only from a click handler; state
   that exists only as pixels; a capability that registers itself nowhere, or a
   list kept by hand beside the registry; something the trader was meant to vary
-  shipped as a compiled variant.
+  shipped as a compiled variant; a new field on the application root struct for
+  state only one surface reads; a new variant on a registry enum where a trait
+  object would have absorbed it; a `size_guard` ceiling raised with no comment
+  saying why.
 - **Consider** — clarity and structure improvements with no correctness,
   performance or extensibility consequence.
 
@@ -566,14 +624,15 @@ requires there. Chat scrolls away; the PR is where the next reader looks.
 Report findings with the `ReportFindings` tool when it is available, ranked
 most severe first, using categories `correctness` (step 0's, promoted here),
 `modularity`, `performance`, `hardcoded-values`, `test-coverage`,
-`test-layout`, `standardisation`, `agent-surface`, `language`, `readability`.
+`test-layout`, `standardisation`, `agent-surface`, `accumulation`, `language`,
+`readability`.
 Without that tool, write the same list as markdown grouped by severity.
 
 Each finding: `file:line`, what is wrong, why it matters *in this order of
 priorities*, and the concrete fix — the trait to extract, the constant to
 name, the test to add. Never a vague "consider refactoring".
 
-Close with a verdict in six lines:
+Close with a verdict in seven lines:
 
 - **Correctness** — what the step 0 code review returned, and whether anything
   from it is still open.
@@ -585,6 +644,10 @@ Close with a verdict in six lines:
 - **Proof** — which test would fail if this change regressed, and whether it
   is a unit test (`#[cfg(test)]`, private access) or an integration test
   (`tests/`, public API only).
+- **Accumulation** — did the trunk grow? Name the tracked files the diff
+  moved and by how many production lines, and say whether any `size_guard`
+  ceiling was raised and whether the comment beside it justifies the raise.
+  Say "trunk flat" when nothing tracked moved; never drop the line.
 - **Language** — two claims, not one: whether `language_guard` passed, and
   whether you read the prose, the branch name and the commit messages yourself.
   Say both rather than dropping the line — a silent language verdict is

--- a/.claude/skills/mission/SKILL.md
+++ b/.claude/skills/mission/SKILL.md
@@ -39,7 +39,7 @@ before it. Step 7 hands over the line to paste.
    | Adds a capability (feed, bar type, indicator, layer, panel, crate) | follow `new-extension`: port named, registration-only edits, defaults preserve today's behaviour, fake second implementation tested, blast radius (added vs. edited files) stated in the PR body |
    | Adds something a trader *does* (an action, a tool, a trade, a lock) | drivable without a mouse — read `arch-review`'s *The second operator* and take its act/read/discover criteria from there, rather than from a summary that drifts. Where the capability class has no registry yet (there is none today for actions like a trade or a platform lock), carving one is part of the work, per `new-extension`'s carve-the-port rule — name it in the plan or state why the capability stays local |
    | Engine / determinism territory | test-first: fixture + expected output written before the code; golden test guards determinism |
-   | Docs/skills only | four checks still run (they are cheap when nothing compiled changed); `arch-review`'s shape dimensions 1–7 waived — **dimension 8 (English) is not**, since docs are exactly where a foreign-language line hides, and neither is its step 0 bug pass; `pr-gate` still wants the marker, so the skill runs and reports what step 0 and dimension 8 found |
+   | Docs/skills only | four checks still run (they are cheap when nothing compiled changed); `arch-review`'s shape dimensions 1–7 and 9 waived — **dimension 8 (English) is not**, since docs are exactly where a foreign-language line hides, and neither is its step 0 bug pass; `pr-gate` still wants the marker, so the skill runs and reports what step 0 and dimension 8 found |
 
    Present the merged checklist to the user before starting work.
 

--- a/.claude/skills/new-extension/SKILL.md
+++ b/.claude/skills/new-extension/SKILL.md
@@ -21,6 +21,7 @@ repo's existing ports:
 | Indicator / kernel | `Indicator` trait (commit/preview + rollback) | `indicators` crate, or a `.pine` script compiled by `pine` |
 | Chart layer / overlay | chart layer registry (`QUANTICK_CHART_LAYERS` set) | new layer module in `app` |
 | Panel / dock tab | dock tab set | new module in `app`, one tab registration |
+| Floating UI surface (popup, toast, overlay box) | `Surface` trait + `SurfaceEnv`/`SurfaceResponse` | new module in `app/src/surfaces/`, one field on `Surfaces` |
 | Look / preset | config file (`bubbles.toml`, drawing presets) | data only — no code |
 | Sim/backtest behaviour | `sim` fill model + metrics | `sim` crate, consumed by chart and runner alike |
 
@@ -30,6 +31,25 @@ dock the feature into it. Never inline the feature and promise the
 abstraction later. If unsure the port is right, state the second concrete
 implementation you can imagine — if you cannot name one, the abstraction is
 speculative; keep the feature local and small instead.
+
+**A UI surface docks through the `Surface` port, never through a new field
+on `QuantickApp`.** Chrome that floats over the chart and owns the state it
+draws — a popup, a toast, a named-entry box — goes in its own module under
+`app/src/surfaces/` and appears in `Surfaces` as one field. What it *reads*
+from the application arrives in `SurfaceEnv`; what it *asks the application
+to do* goes back in `SurfaceResponse`, so it never holds a reference to the
+host and stays testable without one. The old shape — a field, a line in the
+constructor, a call in `draw_frame`, a hotkey in the menu — is what took
+`QuantickApp` to 130 fields and a 1,022-line constructor, and
+`crates/app/tests/size_guard.rs` fails the build when the trunk grows that way
+again — counting every line outside a top-level `#[cfg(test)]` item, so test
+code stays free while production code does not.
+
+Two rows above are honest about being the *old* pattern: `ChartLayer` and
+`DockTab` are closed enums, and a new entry means a variant plus a `match`
+arm at each of hundreds of sites. Use them when extending those existing
+sets, and read `arch-review` dimension 9 before adding the second variant of
+anything new — that is the point where the port was due.
 
 ## 2. Obey the frame
 
@@ -53,8 +73,10 @@ speculative; keep the feature local and small instead.
 - Everything tunable is named config or a unit-suffixed constant from birth
   (`_MS`, `_PX`, `_TICKS`) — retrofitting costs a review round.
 - Measure blast radius before opening the PR: files added vs. files
-  edited. Mostly edits → you missed a port or need to carve one; say which
-  in the PR body.
+  edited, **and lines added vs. lines poured into existing files**. One new
+  file beside 2,000 lines spread across thirteen others counts as edits, not
+  as a package — the file count alone reads healthy and hides it. Mostly
+  edits → you missed a port or need to carve one; say which in the PR body.
 
 ## 4. Performance is part of the port
 

--- a/.claude/skills/ui-harness/SKILL.md
+++ b/.claude/skills/ui-harness/SKILL.md
@@ -45,6 +45,9 @@ is the source of truth, this table is the index):
 | `QUANTICK_PANE_LAYOUTS=<name,name,name>` | one **layout per pane**, by name, in pane-address order — flow pane first, then the context stack top to bottom (`Layout 1,levels` puts the flow chart on `Layout 1` and the top context chart on `levels`). A name the book lacks is created empty; an empty entry leaves that pane alone. This is the capture of the whole point of per-pane layouts: two charts side by side on two indicator sets, each context header naming its layout and the strip naming the focused pane. Goes through `switch_pane_layout`, the call the strip's click makes for the focused pane |
 | `QUANTICK_LAYOUT_RENAME=1` | the strip's **rename box** open on the active layout on the first frame — the in-place text field a double-click opens. Pair with `QUANTICK_LAYOUT_TAB` to name which tab is being renamed |
 | `QUANTICK_STYLE_PANEL=1` | the appearance dialog open at launch (candle presets, body mode and colours, **the gap between candles**, outline, wicks, canvas). Behind the toolbar's LOOK button, which a scripted run cannot press |
+| `QUANTICK_AGENT_POPUP=1` | the **assistant's popup** on screen at launch. The real one arrives over the control plane from a connected assistant (`quantick_notify`), so a capture with no agent attached cannot raise one, and this is the only way to photograph the window, its attribution line and its Dismiss button. Goes through `AgentPopupSurface::show`, the same call the notification takes |
+| `QUANTICK_TOAST=plain\|undo` | the **acknowledgement toast** on screen: `plain` for an act with no way back (a workspace save), `undo` for one that has (a drawing delete), which is the state that paints the Undo button. Both are answers to something the trader just did, so a run that performs no delete photographs neither. Goes through `note` / `note_with_undo`, the two entry points the application itself uses; an unrecognised value raises nothing rather than guessing, so a typo cannot photograph the wrong state and call it a pass |
+| `QUANTICK_WORKSPACE_NAME_BOX=1` | the **Save-as box** open at launch — the name field, its replace-warning and the disabled Save button. Behind the Workspace menu's *Save as*, which a scripted run cannot click. Goes through `WorkspaceNameSurface::open`, the call the menu entry makes |
 | `QUANTICK_FOOTPRINT_SETTINGS=<toml>` / `QUANTICK_FOOTPRINT_PRESETS=<toml>` | where the footprint's saved knobs and named presets live. **Always point these at scratchpad files.** Without them a validation run reads — and, the moment it touches a knob, overwrites — the trader's real setups, the same rule `QUANTICK_UI_STATE` carries. |
 | `QUANTICK_FOOTPRINT_DEBUG=1` | appends the layer's own inputs to its legend (`[w<candle px> row<base row px> g<capture group> lvl<level> n<ladders>]`). The zoom-boundary bugs were all invisible from outside — this is the chart telling you which number it decided on |
 | `QUANTICK_INDICATORS_AUTOSTART` / `QUANTICK_INDICATOR_SCRIPTS_AUTOSTART` | indicator panes / pine scripts |
@@ -274,6 +277,13 @@ For a screen that represents the user's real setup, enable the trio:
 `QUANTICK_BOOK_AUTOSTART` + `QUANTICK_BUBBLES_AUTOSTART` +
 `QUANTICK_LIVE_STRIP_AUTOSTART`, with a preset from `config/bubbles.toml`
 (never bare defaults).
+
+A hook for a floating surface lives **in that surface's module** under
+`crates/app/src/surfaces/`, as an `apply_env_hook` the registry calls, not
+as another line in `app.rs`. That is the fifth hand-written edit per
+feature the `Surface` port removes — the other four being the field, the
+initialiser, the draw call and the hotkey — and `crates/app/tests/size_guard.rs`
+now fails a branch that adds it to the trunk instead.
 
 ## Launch and capture workflow
 

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -248,48 +248,8 @@ const PRICE_DRAG_STEPS: f64 = 200.0;
 const BAR_DRAG_SPEED: f64 = 0.25;
 /// Where the object manager first opens: under the toolbox's home corner.
 const DRAWING_MANAGER_DEFAULT_POSITION: egui::Pos2 = egui::pos2(70.0, 140.0);
-/// How long the delete toast keeps its Undo affordance on screen (UX spec).
-const TOAST_UNDO_MS: u64 = 8_000;
 /// Horizontal offset of a duplicated drawing, so the copy is visibly a copy.
 const DUPLICATE_OFFSET_BARS: f32 = 2.0;
-/// How far below the top edge the assistant's popup opens, clear of the menu
-/// row and the toolbar.
-const AGENT_POPUP_TOP_MARGIN_PX: f32 = 96.0;
-/// Widest the assistant's popup gets, so a long message wraps instead of
-/// covering the chart.
-const AGENT_POPUP_MAX_WIDTH_PX: f32 = 360.0;
-/// Room between the message and the attribution line under it.
-const AGENT_POPUP_SPACING_PX: f32 = 6.0;
-/// Vertical clearance between the toast and the bottom chrome.
-const TOAST_BOTTOM_MARGIN_PX: f32 = 44.0;
-/// Width of the Save-as box, in pixels. Wide enough that a name at the
-/// [`ui_state::MAX_WORKSPACE_NAME`] limit reads in one line.
-const WORKSPACE_NAME_BOX_WIDTH_PX: f32 = 280.0;
-
-/// Transient confirmation that the window did what was asked, with an escape
-/// hatch when the act has one. Undo works from the button for
-/// [`TOAST_UNDO_MS`] and from Ctrl+Z for as long as the history holds.
-///
-/// This is the window's one acknowledgement channel, not the drawings'. It
-/// floats over the chart's bottom edge instead of taking a cell on the status
-/// line, and that is the reason: the status bar's readings live at fixed
-/// positions Rafa's eye returns to without looking, and a cell that appears
-/// for eight seconds and then leaves would slide `bars` and `arrival`
-/// sideways twice per acknowledgement (`statusbar.rs`: "the layout never
-/// moves").
-#[derive(Debug)]
-struct Toast {
-    /// Borrowed for the fixed messages, owned when the act has a count to
-    /// report. Acknowledgements are event-driven and rare — never a frame
-    /// path — so an allocation here costs nothing anyone can see.
-    message: std::borrow::Cow<'static, str>,
-    shown_at: Instant,
-    /// Whether the toast offers Undo. A delete does; the honest clear after
-    /// a bar rebuild does not — its history is gone with the drawings, and
-    /// a dead Undo button would lie. Neither does a workspace save: the file
-    /// it replaced is gone, and `Reset startup layout` is the real way back.
-    offers_undo: bool,
-}
 
 /// Which inspector tab is open. Tabs exist per capability: every tool gets
 /// Style and Coordinates; a tool that brings its own tab (the Fib level
@@ -998,11 +958,10 @@ pub struct QuantickApp {
     // (slider/color/coordinate drag) is in flight; committed as one undo
     // entry once pointer and keyboard let go.
     inspector_edit_baseline: Option<InspectorEdit>,
-    toast: Option<Toast>,
-    /// The assistant's message, waiting to be read and dismissed. Drawn over
-    /// the chart, never modal: a trader mid-tape is never locked out of their
-    /// own window by something an assistant said.
-    agent_popup: Option<crate::control::AgentPopup>,
+    /// Floating chrome that owns the state it draws: the assistant's popup,
+    /// the acknowledgement toast. One field for the whole set, one module
+    /// per surface — see [`crate::surfaces::Surfaces`].
+    surfaces: crate::surfaces::Surfaces,
     // Inspector chrome state: open tab, dock pin, whether the user moved the
     // floating window this session (manual position wins over placement),
     // and the selection the last placement was computed for.
@@ -1164,8 +1123,6 @@ pub struct QuantickApp {
     inspector_pin_rect: Option<egui::Rect>,
     #[cfg(test)]
     context_bar_rect: Option<egui::Rect>,
-    #[cfg(test)]
-    toast_undo_rect: Option<egui::Rect>,
     #[cfg(test)]
     manager_action_rects: Vec<(usize, &'static str, egui::Rect)>,
 
@@ -1363,8 +1320,6 @@ pub struct QuantickApp {
     /// file: capturing the live window and saving it would drop the bookmarks
     /// on the floor if the app did not carry them between load and save.
     bookmarks: Vec<ui_state::NamedArrangement>,
-    /// The Save-as box, while it is open: what has been typed so far.
-    workspace_name_entry: Option<String>,
     /// Whether a workspace is on disk, so the menu can disable Reset without
     /// asking the filesystem. The menu body runs every frame it is open, and a
     /// `Path::exists` there is a syscall at 60 Hz for an answer that changes
@@ -1562,8 +1517,7 @@ impl QuantickApp {
             toolrail: ToolRail::new(),
             drawing_delete_confirm: false,
             inspector_edit_baseline: None,
-            toast: None,
-            agent_popup: None,
+            surfaces: crate::surfaces::Surfaces::default(),
             inspector_tab: InspectorTab::default(),
             inspector_pinned: false,
             inspector_open: false,
@@ -1606,8 +1560,6 @@ impl QuantickApp {
             inspector_pin_rect: None,
             #[cfg(test)]
             context_bar_rect: None,
-            #[cfg(test)]
-            toast_undo_rect: None,
             #[cfg(test)]
             manager_action_rects: Vec::new(),
             chart_layers_path: chart_layers::default_path(),
@@ -1663,7 +1615,6 @@ impl QuantickApp {
             save_on_exit: true,
             favorites_are_staged: false,
             bookmarks: Vec::new(),
-            workspace_name_entry: None,
             workspace_saved: false,
             recent_workspaces: Vec::new(),
             recent_on_disk: Vec::new(),
@@ -2804,45 +2755,6 @@ impl QuantickApp {
         self.active_tab
     }
 
-    /// The assistant's message on screen: a small window over the chart that
-    /// says who is speaking, carries one message and closes on a click.
-    ///
-    /// Deliberately not modal and deliberately not on the status line: a
-    /// trader reading the tape keeps every control they had, and the fixed
-    /// readings never move to make room for something that leaves again.
-    fn draw_agent_popup(&mut self, ctx: &egui::Context) {
-        let Some(popup) = self.agent_popup.clone() else {
-            return;
-        };
-        let mut open = true;
-        let mut dismissed = false;
-        egui::Window::new(&popup.title)
-            .id(egui::Id::new("agent_popup"))
-            .open(&mut open)
-            .collapsible(false)
-            .resizable(false)
-            .anchor(
-                egui::Align2::CENTER_TOP,
-                egui::vec2(0.0, AGENT_POPUP_TOP_MARGIN_PX),
-            )
-            .show(ctx, |ui| {
-                ui.set_max_width(AGENT_POPUP_MAX_WIDTH_PX);
-                ui.label(&popup.message);
-                ui.add_space(AGENT_POPUP_SPACING_PX);
-                ui.label(
-                    egui::RichText::new(format!("Sent by {}", popup.author))
-                        .small()
-                        .color(theme::TEXT_SUPPORT),
-                );
-                if ui.button("Dismiss").clicked() {
-                    dismissed = true;
-                }
-            });
-        if dismissed || !open {
-            self.agent_popup = None;
-        }
-    }
-
     /// Put one Quantick Pine script on the focused pane behind a fresh slot.
     ///
     /// The one door: the script library's click arrives here, and so does an
@@ -2914,18 +2826,14 @@ impl QuantickApp {
     /// the first rather than stacking windows over a chart someone is
     /// trading, and the trader dismisses it.
     pub(crate) fn show_agent_popup(&mut self, popup: crate::control::AgentPopup) {
-        self.agent_popup = Some(popup);
+        self.surfaces.agent_popup.show(popup);
     }
 
     /// Post one line to the window's own acknowledgement lane — the same
     /// channel a delete or a workspace save uses, with no Undo: there is
     /// nothing to take back from having been told something.
     pub(crate) fn show_agent_toast(&mut self, message: String) {
-        self.toast = Some(Toast {
-            message: message.into(),
-            shown_at: Instant::now(),
-            offers_undo: false,
-        });
+        self.surfaces.toast.note(message, Instant::now());
     }
 
     /// Ask for the platform's attention sound, through the same sink the
@@ -5632,73 +5540,6 @@ impl QuantickApp {
         saved
     }
 
-    /// The Save-as box: one text field, Save and Cancel.
-    ///
-    /// A window rather than an inline menu field, because a menu closes the
-    /// moment focus moves and a name is several keystrokes long. Enter saves,
-    /// Escape cancels, and the field takes the keyboard on the frame it opens
-    /// so the trader can type without clicking into it first.
-    fn draw_workspace_name_box(&mut self, ctx: &egui::Context) {
-        let Some(mut entry) = self.workspace_name_entry.take() else {
-            return;
-        };
-        let mut save = false;
-        let mut cancel = false;
-        let mut open = true;
-        egui::Window::new("Save workspace as")
-            .collapsible(false)
-            .resizable(false)
-            .open(&mut open)
-            .anchor(egui::Align2::CENTER_CENTER, egui::Vec2::ZERO)
-            .show(ctx, |ui| {
-                ui.set_min_width(WORKSPACE_NAME_BOX_WIDTH_PX);
-                ui.label("A name you will recognise later.");
-                let field = ui.add(
-                    egui::TextEdit::singleline(&mut entry)
-                        .hint_text("scalp WIN")
-                        .char_limit(ui_state::MAX_WORKSPACE_NAME)
-                        .desired_width(f32::INFINITY),
-                );
-                field.request_focus();
-                if field.lost_focus() && ui.input(|i| i.key_pressed(egui::Key::Enter)) {
-                    save = true;
-                }
-                // A name already in use replaces that bookmark. Saying so
-                // before the click is the difference between "save as" and
-                // "lose the arrangement I meant to keep".
-                if let Some(clean) = ui_state::clean_workspace_name(&entry)
-                    && self.bookmarks.iter().any(|held| held.name == clean)
-                {
-                    ui.label(
-                        egui::RichText::new(format!("Replaces the saved \"{clean}\"."))
-                            .color(theme::AMBER),
-                    );
-                }
-                ui.horizontal(|ui| {
-                    let named = ui_state::clean_workspace_name(&entry).is_some();
-                    if ui
-                        .add_enabled(named, egui::Button::new("Save"))
-                        .on_disabled_hover_text("Type a name first")
-                        .clicked()
-                    {
-                        save = true;
-                    }
-                    if ui.button("Cancel").clicked() {
-                        cancel = true;
-                    }
-                });
-            });
-        if ctx.input(|i| i.key_pressed(egui::Key::Escape)) {
-            cancel = true;
-        }
-        if save {
-            self.save_named_workspace(&entry);
-        } else if !cancel && open {
-            // Neither settled: keep what has been typed for the next frame.
-            self.workspace_name_entry = Some(entry);
-        }
-    }
-
     /// Write the bookmarks without disturbing the startup arrangement.
     ///
     /// Reads the file back and swaps only the named entries, rather than
@@ -6216,11 +6057,7 @@ impl QuantickApp {
     /// No Undo: the file it replaced is gone, and `Reset startup layout` is
     /// the honest way back rather than a button that pretends otherwise.
     fn note_workspace(&mut self, message: String) {
-        self.toast = Some(Toast {
-            message: message.into(),
-            shown_at: Instant::now(),
-            offers_undo: false,
-        });
+        self.surfaces.toast.note(message, Instant::now());
     }
 
     /// Periodically log a perf summary and warn on threshold breaches.
@@ -7104,7 +6941,7 @@ impl QuantickApp {
                             )
                             .clicked()
                         {
-                            self.workspace_name_entry = Some(String::new());
+                            self.surfaces.workspace_name.open();
                             ui.close_menu();
                         }
                         let mut open: Option<String> = None;
@@ -7316,11 +7153,7 @@ impl QuantickApp {
                     || "Drawing deleted.".to_owned(),
                     |name| format!("{name} deleted."),
                 );
-                self.toast = Some(Toast {
-                    message: message.into(),
-                    shown_at: now,
-                    offers_undo: true,
-                });
+                self.surfaces.toast.note_with_undo(message, now);
             }
             DeleteOutcome::NeedsConfirmation => self.drawing_delete_confirm = true,
             DeleteOutcome::NothingSelected => {}
@@ -7488,67 +7321,6 @@ impl QuantickApp {
             tab.pane_mut(edit.side)
                 .drawings
                 .record_edit_of(edit.index, edit.before);
-        }
-    }
-
-    /// The delete toast: visible for [`TOAST_UNDO_MS`], with an Undo button
-    /// driving the same history as Ctrl+Z.
-    fn draw_toast(&mut self, ctx: &egui::Context, now: Instant) {
-        // Expire first, so the borrow taken below is only ever of a toast that
-        // is still on screen.
-        if self.toast.as_ref().is_some_and(|toast| {
-            now.saturating_duration_since(toast.shown_at) >= Duration::from_millis(TOAST_UNDO_MS)
-        }) {
-            self.toast = None;
-        }
-        let Some(toast) = &self.toast else {
-            return;
-        };
-        // Borrowed, never cloned: the toast is painted on every frame of its
-        // eight seconds, and an owned message copied per frame would be ~500
-        // allocations for a string that never changes.
-        let message: &str = &toast.message;
-        let offers_undo = toast.offers_undo;
-        let mut undo_clicked = false;
-        #[cfg(test)]
-        let mut undo_rect = None;
-        egui::Area::new(egui::Id::new("toast"))
-            .anchor(
-                egui::Align2::CENTER_BOTTOM,
-                egui::vec2(0.0, -TOAST_BOTTOM_MARGIN_PX),
-            )
-            .order(egui::Order::Foreground)
-            .show(ctx, |ui| {
-                egui::Frame::none()
-                    .fill(theme::TAG_BG)
-                    .stroke(egui::Stroke::new(1.0_f32, theme::BORDER))
-                    .rounding(6.0_f32)
-                    .inner_margin(egui::Margin::symmetric(12.0, 8.0))
-                    .show(ui, |ui| {
-                        ui.horizontal(|ui| {
-                            ui.label(message);
-                            if offers_undo {
-                                let undo = ui.button("Undo");
-                                #[cfg(test)]
-                                {
-                                    undo_rect = Some(undo.rect);
-                                }
-                                undo_clicked = undo.clicked();
-                            }
-                        });
-                    });
-            });
-        #[cfg(test)]
-        {
-            self.toast_undo_rect = undo_rect;
-        }
-        if undo_clicked {
-            let pane = self.drawing_pane_mut();
-            pane.drawings.undo();
-            // Same orphan risk as the keyboard undo: the drawing an armed
-            // instance rides may just have been taken away.
-            pane.sweep_strategy_orphans();
-            self.toast = None;
         }
     }
 
@@ -8027,11 +7799,7 @@ impl QuantickApp {
                 if let Some(id) = doomed {
                     self.drawing_pane_mut().remove_strategy_for_drawing(id);
                 }
-                self.toast = Some(Toast {
-                    message: "Drawing deleted.".into(),
-                    shown_at: now,
-                    offers_undo: true,
-                });
+                self.surfaces.toast.note_with_undo("Drawing deleted.", now);
             }
         }
         if actions.close {
@@ -8048,11 +7816,7 @@ impl QuantickApp {
         }
         if let Some(saved) = actions.saved_default {
             // Nothing to undo: this changed a preference, not the chart.
-            self.toast = Some(Toast {
-                message: saved.message().into(),
-                shown_at: now,
-                offers_undo: false,
-            });
+            self.surfaces.toast.note(saved.message(), now);
         }
     }
 
@@ -9080,11 +8844,9 @@ impl QuantickApp {
         if sweep_authored {
             let removed = self.remove_every_authored_object();
             if removed > 0 {
-                self.toast = Some(Toast {
-                    message: format!("{removed} object(s) placed for you removed.").into(),
-                    shown_at: now,
-                    offers_undo: true,
-                });
+                self.surfaces
+                    .toast
+                    .note_with_undo(format!("{removed} object(s) placed for you removed."), now);
             }
         }
         if delete_all {
@@ -9094,11 +8856,9 @@ impl QuantickApp {
             // them now so no resting bot order outlives its badge.
             pane.sweep_strategy_orphans();
             if deleted > 0 {
-                self.toast = Some(Toast {
-                    message: "All drawings deleted.".into(),
-                    shown_at: now,
-                    offers_undo: true,
-                });
+                self.surfaces
+                    .toast
+                    .note_with_undo("All drawings deleted.", now);
             }
         }
         if let Some(index) = select_row {
@@ -11194,10 +10954,25 @@ impl QuantickApp {
         if let Some(access) = self.control_access.as_mut() {
             access.draw_panel(ctx);
         }
-        self.draw_agent_popup(ctx);
+        let surfaces = self.surfaces.draw_all(
+            ctx,
+            &crate::surfaces::SurfaceEnv {
+                bookmarks: &self.bookmarks,
+                now,
+            },
+        );
+        if let Some(name) = surfaces.save_workspace_as {
+            self.save_named_workspace(&name);
+        }
+        if surfaces.undo_drawing {
+            let pane = self.drawing_pane_mut();
+            pane.drawings.undo();
+            // Same orphan risk as the keyboard undo: the drawing an armed
+            // instance rides may just have been taken away.
+            pane.sweep_strategy_orphans();
+        }
         self.draw_toolbar(ctx);
         self.draw_source_picker(ctx);
-        self.draw_workspace_name_box(ctx);
         // Before the dialog is drawn, so a double click on a pane or a curve
         // opens it on the same frame the gesture happened rather than the next.
         self.open_requested_indicator_settings();
@@ -11590,7 +11365,6 @@ impl QuantickApp {
             tab.apply_strategy_cleanup();
         }
         self.play_pending_alarms();
-        self.draw_toast(ctx, now);
         // Both are window chrome reading the active tab, like the offline
         // corner and the transport strip: they speak for one market at a time.
         let tz = self.tz;
@@ -20472,7 +20246,7 @@ crosshair = false
         app.ui_state_path = scratch_ui_state(name);
         run_frame(app, ctx);
         app.save_workspace("test");
-        app.toast = None;
+        app.surfaces.toast.clear();
         assert!(app.ui_state_path.exists(), "the cockpit is on disk");
     }
 
@@ -20512,9 +20286,10 @@ crosshair = false
             "and nothing else — the drift is not adopted as the startup screen"
         );
         assert!(
-            !app.toast
-                .as_ref()
-                .is_some_and(|toast| toast.message.contains("Workspace saved")),
+            !app.surfaces
+                .toast
+                .message()
+                .is_some_and(|message| message.contains("Workspace saved")),
             "an autosave nobody asked for by name does not talk over the trader"
         );
         let _ = std::fs::remove_file(&app.ui_state_path);
@@ -21471,7 +21246,7 @@ crosshair = false
             "the manager's Delete lands the same command"
         );
         assert!(
-            app.toast.is_some(),
+            app.surfaces.toast.message().is_some(),
             "the manager delete raises the same Undo toast as the keyboard"
         );
         run_frame_with_modifiers(
@@ -24713,18 +24488,21 @@ crosshair = false
     fn saving_the_workspace_acknowledges_itself() {
         let (mut app, _commands) = app_with_history(50);
         app.ui_state_path = scratch_ui_state("notice");
-        assert!(app.toast.is_none());
+        assert!(app.surfaces.toast.message().is_none());
 
         app.save_workspace("test");
 
-        let toast = app.toast.as_ref().expect("the save reports itself");
+        let toast = app
+            .surfaces
+            .toast
+            .message()
+            .expect("the save reports itself");
         assert!(
-            toast.message.contains("saved"),
-            "the answer has to say what happened, got '{}'",
-            toast.message
+            toast.contains("saved"),
+            "the answer has to say what happened, got '{toast}'"
         );
         assert!(
-            !toast.offers_undo,
+            !app.surfaces.toast.offers_undo(),
             "the file it replaced is gone; an Undo button here would lie"
         );
         assert!(
@@ -25029,9 +24807,10 @@ crosshair = false
             "a refused save must not write the file either"
         );
         assert!(
-            app.toast
-                .as_ref()
-                .is_some_and(|toast| toast.message.contains("needs a name")),
+            app.surfaces
+                .toast
+                .message()
+                .is_some_and(|message| message.contains("needs a name")),
             "and the trader is told why nothing happened"
         );
     }
@@ -27314,7 +27093,11 @@ crosshair = false
         // A fresh egui Area sizes itself on its first frame.
         run_frame(&mut app, &ctx);
         run_frame(&mut app, &ctx);
-        let undo = app.toast_undo_rect.expect("the toast offers Undo");
+        let undo = app
+            .surfaces
+            .toast
+            .undo_rect()
+            .expect("the toast offers Undo");
         let divider = app
             .active_tab()
             .canvas_divider_rect()
@@ -32942,7 +32725,11 @@ crosshair = false
             "the label a panel shows names what acted: {}",
             author.label()
         );
-        let popup = app.agent_popup.as_ref().expect("the popup is on screen");
+        let popup = app
+            .surfaces
+            .agent_popup
+            .pending()
+            .expect("the popup is on screen");
         assert_eq!(popup.message, "look at 108k");
         assert!(popup.author.contains("agent"));
     }
@@ -35242,7 +35029,7 @@ plot(close)
             test_screenshot(width, height),
         );
         assert!(
-            app.toast.is_some(),
+            app.surfaces.toast.message().is_some(),
             "the trader is told when a picture of their window is taken"
         );
         let manifest = success_result(&response).clone();

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -71,6 +71,7 @@ mod store_home;
 mod strategy_anchors;
 mod strategy_presets;
 mod style;
+mod surfaces;
 mod symbols_file;
 mod tab;
 mod tabstrip;

--- a/crates/app/src/surfaces/agent_popup.rs
+++ b/crates/app/src/surfaces/agent_popup.rs
@@ -1,0 +1,136 @@
+//! The assistant's popup, as a [`Surface`].
+//!
+//! Raised over the control plane by `quantick_notify` and dismissed by the
+//! trader. It owns the one thing it draws, so moving it here took its state
+//! off `QuantickApp` with it — the point of the port, and the reason this
+//! file's existence is the whole registration.
+
+use std::time::Instant;
+
+use eframe::egui;
+
+use super::{Surface, SurfaceEnv, SurfaceResponse};
+use crate::control::AgentPopup;
+use crate::theme;
+
+/// How far below the top edge the assistant's popup opens, clear of the menu
+/// row and the toolbar.
+const TOP_MARGIN_PX: f32 = 96.0;
+/// Widest the assistant's popup gets, so a long message wraps instead of
+/// covering the chart.
+const MAX_WIDTH_PX: f32 = 360.0;
+/// Room between the message and the attribution line under it.
+const SPACING_PX: f32 = 6.0;
+
+/// The assistant's popup: at most one waiting to be read.
+#[derive(Default)]
+pub(crate) struct AgentPopupSurface {
+    pending: Option<AgentPopup>,
+}
+
+impl AgentPopupSurface {
+    /// Raise a popup, replacing any still on screen. Last message wins: the
+    /// assistant speaks to a trader who is watching a market, and a queue
+    /// would show them a stale line while the current one waits.
+    pub fn show(&mut self, popup: AgentPopup) {
+        self.pending = Some(popup);
+    }
+
+    /// The popup currently on screen, if any.
+    #[cfg(test)]
+    pub fn pending(&self) -> Option<&AgentPopup> {
+        self.pending.as_ref()
+    }
+}
+
+impl Surface for AgentPopupSurface {
+    fn id(&self) -> &'static str {
+        "agent_popup"
+    }
+
+    fn draw(&mut self, ctx: &egui::Context, _env: &SurfaceEnv<'_>) -> SurfaceResponse {
+        let id = self.id();
+        let mut open = true;
+        let mut dismissed = false;
+        // Borrowed, never cloned, for the reason the toast gives beside its own
+        // borrow — and more so here, because the popup has no deadline: it is
+        // painted every frame until the trader dismisses it, so two minutes on
+        // screen at 60 Hz would be ~21,600 copies of three strings that never
+        // change. The borrow ends with this block, before `pending` is cleared.
+        {
+            let Some(popup) = self.pending.as_ref() else {
+                return SurfaceResponse::default();
+            };
+            egui::Window::new(&popup.title)
+                .id(egui::Id::new(id))
+                .open(&mut open)
+                .collapsible(false)
+                .resizable(false)
+                .anchor(egui::Align2::CENTER_TOP, egui::vec2(0.0, TOP_MARGIN_PX))
+                .show(ctx, |ui| {
+                    ui.set_max_width(MAX_WIDTH_PX);
+                    ui.label(&popup.message);
+                    ui.add_space(SPACING_PX);
+                    ui.label(
+                        egui::RichText::new(format!("Sent by {}", popup.author))
+                            .small()
+                            .color(theme::TEXT_SUPPORT),
+                    );
+                    if ui.button("Dismiss").clicked() {
+                        dismissed = true;
+                    }
+                });
+        }
+        if dismissed || !open {
+            self.pending = None;
+        }
+        SurfaceResponse::default()
+    }
+
+    /// The real popup arrives over the control plane from a connected
+    /// assistant, so a scripted capture has no way to raise one — which is
+    /// exactly the case `ui-harness` says a hook must cover. It goes through
+    /// [`Self::show`], the same call `quantick_notify` makes.
+    fn apply_env_hook(&mut self, _now: Instant) {
+        if std::env::var("QUANTICK_AGENT_POPUP").is_ok_and(|value| value == "1") {
+            self.show(AgentPopup {
+                title: "Assistant".to_string(),
+                message: "Volume at 108k is three times the session median.".to_string(),
+                author: "capture".to_string(),
+            });
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn popup(message: &str) -> AgentPopup {
+        AgentPopup {
+            title: "Assistant".to_string(),
+            message: message.to_string(),
+            author: "tester".to_string(),
+        }
+    }
+
+    /// The surface starts empty, so an application that never hears from the
+    /// assistant paints no window.
+    #[test]
+    fn a_new_surface_has_nothing_to_show() {
+        assert!(AgentPopupSurface::default().pending().is_none());
+    }
+
+    /// Last message wins, rather than queueing behind one the trader has not
+    /// dismissed.
+    #[test]
+    fn a_second_popup_replaces_the_first() {
+        let mut surface = AgentPopupSurface::default();
+        surface.show(popup("first"));
+        surface.show(popup("second"));
+        assert_eq!(
+            surface.pending().map(|p| p.message.as_str()),
+            Some("second")
+        );
+    }
+}

--- a/crates/app/src/surfaces/mod.rs
+++ b/crates/app/src/surfaces/mod.rs
@@ -1,0 +1,318 @@
+//! The surface port — where a self-contained overlay docks.
+//!
+//! A *surface* here is a piece of chrome that floats over the chart, owns the
+//! state it draws, and is not part of any pane: the assistant's popup, the
+//! undo toast, the workspace-name box. Before this port each one was wired
+//! into `QuantickApp` by hand in four places — a field, a line in the
+//! constructor, a call in `draw_frame`, and sometimes a hotkey — so
+//! sixty-eight modules left the root struct holding 133 fields and a
+//! 1,149-line constructor. `arch-review` dimension 9 is the review half of
+//! that story and `size_guard.rs` the mechanical half; this module is the
+//! place the wiring goes instead.
+//!
+//! # Shape, and why it copies the dock
+//!
+//! [`SurfaceEnv`] and [`SurfaceResponse`] are deliberately the same pair
+//! `dock.rs` already uses: an env carrying the slice of the application a
+//! surface may read, and a response describing what it asked the host to do
+//! afterwards. Two things follow from copying a pattern that already works
+//! here rather than inventing a second one. A surface never reaches back into
+//! `QuantickApp`, so it cannot grow a dependency on the trunk; and
+//! [`SurfaceResponse`] is a **struct, not an enum**, so a new request is an
+//! added field that defaults to "did not ask", never a `match` arm that
+//! reopens every existing caller — the failure mode dimension 9 names in
+//! `ChartLayer`'s 21 variants across 264 call sites.
+//!
+//! # Why the registry is a typed struct, not `Vec<Box<dyn Surface>>`
+//!
+//! [`Surfaces`] names its members as fields. A trait-object list would let a
+//! surface register itself without being named here, which sounds stronger
+//! until the host needs to *command* one — `show_agent_popup` has to reach
+//! the assistant's popup specifically — and the only ways back to a concrete
+//! type from `Box<dyn Surface>` are downcasting, which dimension 1 calls a
+//! broken port, or a command enum, which is the growth this port exists to
+//! stop.
+//!
+//! So the trade is made in the open: adding a surface edits this file, on
+//! purpose. What matters is that the edit is one field and one line in a file
+//! of this size instead of four edits spread through a 11,874-line trunk, and
+//! that [`Surface`] keeps the draw contract uniform so the list below cannot
+//! drift into twenty bespoke call sites. When the count outgrows a legible
+//! struct, the move is to a keyed registry — and by then the trait every
+//! surface already implements is what makes that a local change.
+
+pub(crate) mod agent_popup;
+pub(crate) mod toast;
+pub(crate) mod workspace_name;
+
+use std::time::Instant;
+
+use eframe::egui;
+
+pub(crate) use agent_popup::AgentPopupSurface;
+pub(crate) use toast::ToastSurface;
+pub(crate) use workspace_name::WorkspaceNameSurface;
+
+/// What the surfaces need from the application, kept to what they actually
+/// read so a surface cannot quietly acquire the whole app.
+pub(crate) struct SurfaceEnv<'a> {
+    /// The saved arrangements, so the Save-as box can warn before a name
+    /// replaces one. Borrowed, never copied: a surface reads what the host
+    /// holds rather than keeping a copy that can go stale.
+    pub bookmarks: &'a [crate::ui_state::NamedArrangement],
+    /// The frame's clock reading, passed in rather than sampled, so a surface
+    /// that expires on a deadline stays as testable as the engine is.
+    pub now: Instant,
+}
+
+/// What drawing the surfaces asked the application to do.
+///
+/// A struct of defaults, like [`crate::dock::DockResponse`]: every field means
+/// "this was not asked for" until a surface sets it, so adding a request never
+/// touches an existing surface.
+#[derive(Default, Debug, Eq, PartialEq)]
+pub(crate) struct SurfaceResponse {
+    /// The toast's Undo button was pressed — the host owns the drawing stack,
+    /// and the sweep of any strategy left orphaned by the undo.
+    pub undo_drawing: bool,
+    /// The Save-as box settled on a name. The host owns the write, so the
+    /// surface hands over the name rather than touching the file.
+    pub save_workspace_as: Option<String>,
+}
+
+impl SurfaceResponse {
+    /// Fold one surface's response into the frame's. Requests are
+    /// independent, so a set flag stays set: no surface can cancel another's
+    /// ask by being drawn after it.
+    ///
+    /// Where a request carries a value rather than a flag, the **first**
+    /// surface to ask wins and a later one in the same frame is dropped. Two
+    /// surfaces cannot both be right about one workspace name, and dropping
+    /// the later ask deterministically beats writing the file twice or letting
+    /// draw order decide in silence. Only one surface produces it today; the
+    /// rule is pinned by a test so a second producer meets a documented answer
+    /// rather than a surprise.
+    fn merge(&mut self, other: Self) {
+        self.undo_drawing |= other.undo_drawing;
+        self.save_workspace_as = self.save_workspace_as.take().or(other.save_workspace_as);
+    }
+}
+
+/// One floating surface: it owns its state, draws itself, and reports what it
+/// needs the host to do.
+pub(crate) trait Surface {
+    /// Stable identifier. Each surface paints under `egui::Id::new(self.id())`
+    /// rather than a literal of its own, so the name a screenshot, a hook and a
+    /// log line use cannot drift from the layer the pixels are actually on.
+    fn id(&self) -> &'static str;
+
+    /// Draw this frame. A surface with nothing on screen returns early and
+    /// costs a branch, which is what keeps [`Surfaces::draw_all`] cheap
+    /// enough to run unconditionally per frame.
+    fn draw(&mut self, ctx: &egui::Context, env: &SurfaceEnv<'_>) -> SurfaceResponse;
+
+    /// Open whatever this surface's `QUANTICK_*` capture hook asks for, once,
+    /// before the first frame is drawn.
+    ///
+    /// On the trait rather than in a list held beside it, so a surface that
+    /// forgets its hook shows up as an empty override instead of compiling
+    /// silently: `ui-harness` requires one per surface, and a hook nobody
+    /// wrote is invisible to every test and to the size guard alike. The
+    /// default is no hook, which is the honest answer for a surface that
+    /// needs none.
+    fn apply_env_hook(&mut self, _now: Instant) {}
+}
+
+/// Every floating surface the application owns.
+#[derive(Default)]
+pub(crate) struct Surfaces {
+    /// Whether the capture hooks have run.
+    ///
+    /// They are applied on the first *drawn frame*, not at construction. The
+    /// toast expires on a deadline, so starting that clock before wgpu init
+    /// and the history backfill have finished can retire a hook-raised toast
+    /// before frame one ever reaches the screen — and the failure is silent,
+    /// read as "the toast isn't there" rather than as a mistimed hook.
+    hooks_applied: bool,
+    /// The assistant's popup — raised by `quantick_notify` over the control
+    /// plane, dismissed by the trader.
+    pub agent_popup: AgentPopupSurface,
+    /// The window's acknowledgement channel, with Undo where the act has one.
+    pub toast: ToastSurface,
+    /// The Save-as box, opened from the Workspace menu.
+    pub workspace_name: WorkspaceNameSurface,
+}
+
+impl Surfaces {
+    /// Draw every surface and return the merged asks.
+    ///
+    /// Per-frame path: one virtual call per registered surface, each of which
+    /// returns immediately when it has nothing to show. That is the whole
+    /// cost, and it replaces the same number of direct calls `draw_frame`
+    /// made by hand.
+    ///
+    /// Call order does not decide what covers what. Every surface here names
+    /// its own `egui::Order`, and egui sorts by layer before it considers the
+    /// sequence: the toast paints in `Foreground` wherever it is called from,
+    /// while the popup is an ordinary `Middle`-order window. That is what
+    /// makes it safe for one call site to replace the scattered ones — but it
+    /// is also why a surface added here must set its own order rather than
+    /// rely on being last.
+    pub fn draw_all(&mut self, ctx: &egui::Context, env: &SurfaceEnv<'_>) -> SurfaceResponse {
+        if !self.hooks_applied {
+            self.hooks_applied = true;
+            self.agent_popup.apply_env_hook(env.now);
+            self.toast.apply_env_hook(env.now);
+            self.workspace_name.apply_env_hook(env.now);
+        }
+        let mut response = SurfaceResponse::default();
+        response.merge(self.agent_popup.draw(ctx, env));
+        response.merge(self.toast.draw(ctx, env));
+        response.merge(self.workspace_name.draw(ctx, env));
+        response
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The second implementation of the port, which is what proves it is a
+    /// port at all: a surface written entirely outside this module, wired in
+    /// by nothing but the trait. `new-extension` asks for exactly this before
+    /// an abstraction is allowed to call itself one.
+    #[derive(Default)]
+    struct FakeSurface {
+        drawn: usize,
+        asks_undo: bool,
+    }
+
+    impl Surface for FakeSurface {
+        fn id(&self) -> &'static str {
+            "fake"
+        }
+
+        fn draw(&mut self, _ctx: &egui::Context, _env: &SurfaceEnv<'_>) -> SurfaceResponse {
+            self.drawn += 1;
+            SurfaceResponse {
+                undo_drawing: self.asks_undo,
+                ..SurfaceResponse::default()
+            }
+        }
+    }
+
+    fn env() -> SurfaceEnv<'static> {
+        SurfaceEnv {
+            bookmarks: &[],
+            now: Instant::now(),
+        }
+    }
+
+    /// Fold a surface's response exactly as [`Surfaces::draw_all`] does.
+    ///
+    /// The registry names its members as fields, so a fake cannot be inserted
+    /// into it. What can be shared is the thing that actually defines the
+    /// port: the call through `&mut dyn Surface` and the fold of what comes
+    /// back. Driving an outside type and a shipped one through the *same*
+    /// function is what makes this a port test rather than a cast.
+    fn drive(
+        surface: &mut dyn Surface,
+        ctx: &egui::Context,
+        env: &SurfaceEnv<'_>,
+    ) -> SurfaceResponse {
+        let mut response = SurfaceResponse::default();
+        response.merge(surface.draw(ctx, env));
+        response
+    }
+
+    /// A type declared outside this module satisfies [`Surface`] and its
+    /// request survives the fold — no field on the registry, no branch in the
+    /// host, nothing but the trait. `new-extension` asks for exactly this
+    /// before an abstraction is allowed to call itself a port.
+    #[test]
+    fn a_second_implementation_needs_only_the_trait() {
+        let ctx = egui::Context::default();
+        let mut fake = FakeSurface {
+            asks_undo: true,
+            ..FakeSurface::default()
+        };
+        assert_eq!(Surface::id(&fake), "fake");
+        let response = drive(&mut fake, &ctx, &env());
+        assert!(
+            response.undo_drawing,
+            "an outside surface's ask reaches the host through the fold"
+        );
+        assert_eq!(fake.drawn, 1);
+    }
+
+    /// The same function drives a surface that really ships, so the fake is
+    /// held to the contract the product is held to rather than a private one.
+    #[test]
+    fn a_shipped_surface_and_a_fake_take_the_same_path() {
+        let ctx = egui::Context::default();
+        let mut real = AgentPopupSurface::default();
+        let mut fake = FakeSurface::default();
+        let quiet_real = ctx.run(Default::default(), |ctx| {
+            let _ = drive(&mut real, ctx, &env());
+        });
+        let _ = quiet_real;
+        assert_eq!(
+            drive(&mut fake, &ctx, &env()),
+            SurfaceResponse::default(),
+            "a surface with nothing to show asks for nothing, whoever wrote it"
+        );
+    }
+
+    /// A surface that declares no capture hook gets the trait's default and
+    /// does nothing, rather than failing to compile — which is what lets the
+    /// trait carry the requirement without forcing every surface to restate
+    /// it.
+    #[test]
+    fn a_surface_without_a_hook_uses_the_default() {
+        let mut fake = FakeSurface::default();
+        fake.apply_env_hook(Instant::now());
+        assert_eq!(fake.drawn, 0);
+        assert!(!fake.asks_undo);
+    }
+
+    /// A request that carries a value is first-wins, which is the half of
+    /// `merge` the boolean cannot show. Pinned because the answer has to be
+    /// documented before a second producer exists, not after.
+    #[test]
+    fn merge_keeps_the_first_named_workspace() {
+        let mut merged = SurfaceResponse {
+            save_workspace_as: Some("first".to_string()),
+            ..SurfaceResponse::default()
+        };
+        merged.merge(SurfaceResponse {
+            save_workspace_as: Some("second".to_string()),
+            ..SurfaceResponse::default()
+        });
+        assert_eq!(merged.save_workspace_as.as_deref(), Some("first"));
+    }
+
+    /// And an earlier surface that asked for nothing does not block a later
+    /// one that did.
+    #[test]
+    fn merge_accepts_a_name_from_a_later_surface() {
+        let mut merged = SurfaceResponse::default();
+        merged.merge(SurfaceResponse {
+            save_workspace_as: Some("only".to_string()),
+            ..SurfaceResponse::default()
+        });
+        assert_eq!(merged.save_workspace_as.as_deref(), Some("only"));
+    }
+
+    /// Order must not decide the outcome: a later surface with nothing to ask
+    /// cannot clear an earlier surface's request. Folding with `|=` rather
+    /// than assignment is what buys that, and this pins it.
+    #[test]
+    fn a_quiet_surface_cannot_cancel_an_earlier_request() {
+        let mut merged = SurfaceResponse {
+            undo_drawing: true,
+            ..SurfaceResponse::default()
+        };
+        merged.merge(SurfaceResponse::default());
+        assert!(merged.undo_drawing);
+    }
+}

--- a/crates/app/src/surfaces/toast.rs
+++ b/crates/app/src/surfaces/toast.rs
@@ -1,0 +1,263 @@
+//! The acknowledgement toast, as a [`Surface`].
+//!
+//! Transient confirmation that the window did what was asked, with an escape
+//! hatch when the act has one. Undo works from the button for
+//! [`UNDO_MS`] and from Ctrl+Z for as long as the history holds.
+//!
+//! This is the window-level acknowledgement channel. It is not the only toast
+//! in the application — `paper_trading.rs` still carries its own, per tab and
+//! on its own 4-second clock, which predates this port and is the obvious next
+//! surface to move onto it. It floats over the chart's bottom edge instead of
+//! taking a cell on the status line, and that is the reason: the status bar's
+//! readings live at fixed
+//! positions the trader's eye returns to without looking, and a cell that
+//! appeared for eight seconds and then left would slide `bars` and `arrival`
+//! sideways twice per acknowledgement (`statusbar.rs`: "the layout never
+//! moves").
+//!
+//! The Undo the button asks for is *not* performed here. The drawing stack
+//! and the strategies riding on it belong to the host, so the surface reports
+//! the request through [`SurfaceResponse`] and the host acts — the boundary
+//! that keeps a surface from reaching back into `QuantickApp`.
+
+use std::borrow::Cow;
+use std::time::{Duration, Instant};
+
+use eframe::egui;
+
+use super::{Surface, SurfaceEnv, SurfaceResponse};
+use crate::theme;
+
+/// How long the delete toast keeps its Undo affordance on screen (UX spec).
+const UNDO_MS: u64 = 8_000;
+/// Vertical clearance between the toast and the bottom chrome.
+const BOTTOM_MARGIN_PX: f32 = 44.0;
+
+/// A message waiting to be read, and whether it can be taken back.
+#[derive(Debug)]
+struct Pending {
+    /// Borrowed for the fixed messages, owned when the act has a count to
+    /// report. Acknowledgements are event-driven and rare — never a frame
+    /// path — so an allocation here costs nothing anyone can see.
+    message: Cow<'static, str>,
+    shown_at: Instant,
+    /// Whether the toast offers Undo. A delete does; the honest clear after
+    /// a bar rebuild does not — its history is gone with the drawings, and
+    /// a dead Undo button would lie. Neither does a workspace save: the file
+    /// it replaced is gone, and `Reset startup layout` is the real way back.
+    offers_undo: bool,
+}
+
+/// The window's acknowledgement channel: at most one message on screen.
+#[derive(Default)]
+pub(crate) struct ToastSurface {
+    pending: Option<Pending>,
+    /// Where the Undo button landed, for the tests that click it. Test-only
+    /// state, and `#[cfg(test)]` so it neither exists in the shipped binary
+    /// nor changes what the surface does.
+    #[cfg(test)]
+    undo_rect: Option<egui::Rect>,
+}
+
+impl ToastSurface {
+    /// Acknowledge an act that cannot be taken back.
+    pub fn note(&mut self, message: impl Into<Cow<'static, str>>, now: Instant) {
+        self.pending = Some(Pending {
+            message: message.into(),
+            shown_at: now,
+            offers_undo: false,
+        });
+    }
+
+    /// Acknowledge an act the trader can undo, and offer the button for it.
+    pub fn note_with_undo(&mut self, message: impl Into<Cow<'static, str>>, now: Instant) {
+        self.pending = Some(Pending {
+            message: message.into(),
+            shown_at: now,
+            offers_undo: true,
+        });
+    }
+
+    /// Take the current message off screen. Test-only: in the product a
+    /// toast leaves on its own deadline or on Undo, never by command.
+    #[cfg(test)]
+    pub fn clear(&mut self) {
+        self.pending = None;
+    }
+
+    /// The message on screen, if any.
+    #[cfg(test)]
+    pub fn message(&self) -> Option<&str> {
+        self.pending.as_ref().map(|pending| &*pending.message)
+    }
+
+    /// Whether the message on screen offers Undo.
+    #[cfg(test)]
+    pub fn offers_undo(&self) -> bool {
+        self.pending
+            .as_ref()
+            .is_some_and(|pending| pending.offers_undo)
+    }
+
+    /// Where the Undo button was painted last frame, for tests that click it.
+    #[cfg(test)]
+    pub fn undo_rect(&self) -> Option<egui::Rect> {
+        self.undo_rect
+    }
+}
+
+impl Surface for ToastSurface {
+    fn id(&self) -> &'static str {
+        "toast"
+    }
+
+    /// `plain` for an act that cannot be taken back, `undo` for one that can.
+    ///
+    /// Both states are answers to something the trader just did — a delete, a
+    /// save — so a capture that never performs the act can photograph neither,
+    /// and the Undo button is the affordance most worth seeing. Goes through
+    /// the same two entry points the application uses.
+    fn apply_env_hook(&mut self, now: Instant) {
+        match std::env::var("QUANTICK_TOAST").as_deref() {
+            Ok("plain") => self.note("Workspace saved.", now),
+            Ok("undo") => self.note_with_undo("Trend line deleted.", now),
+            // A typo must not photograph the wrong state and call it a pass.
+            _ => {}
+        }
+    }
+
+    fn draw(&mut self, ctx: &egui::Context, env: &SurfaceEnv<'_>) -> SurfaceResponse {
+        let id = self.id();
+        // Expire first, so the borrow taken below is only ever of a toast that
+        // is still on screen.
+        if self.pending.as_ref().is_some_and(|pending| {
+            env.now.saturating_duration_since(pending.shown_at) >= Duration::from_millis(UNDO_MS)
+        }) {
+            self.pending = None;
+        }
+        let Some(pending) = &self.pending else {
+            return SurfaceResponse::default();
+        };
+        // Borrowed, never cloned: the toast is painted on every frame of its
+        // eight seconds, and an owned message copied per frame would be ~500
+        // allocations for a string that never changes.
+        let message: &str = &pending.message;
+        let offers_undo = pending.offers_undo;
+        let mut undo_clicked = false;
+        #[cfg(test)]
+        let mut undo_rect = None;
+        egui::Area::new(egui::Id::new(id))
+            .anchor(
+                egui::Align2::CENTER_BOTTOM,
+                egui::vec2(0.0, -BOTTOM_MARGIN_PX),
+            )
+            .order(egui::Order::Foreground)
+            .show(ctx, |ui| {
+                egui::Frame::none()
+                    .fill(theme::TAG_BG)
+                    .stroke(egui::Stroke::new(1.0_f32, theme::BORDER))
+                    .rounding(6.0_f32)
+                    .inner_margin(egui::Margin::symmetric(12.0, 8.0))
+                    .show(ui, |ui| {
+                        ui.horizontal(|ui| {
+                            ui.label(message);
+                            if offers_undo {
+                                let undo = ui.button("Undo");
+                                #[cfg(test)]
+                                {
+                                    undo_rect = Some(undo.rect);
+                                }
+                                undo_clicked = undo.clicked();
+                            }
+                        });
+                    });
+            });
+        #[cfg(test)]
+        {
+            self.undo_rect = undo_rect;
+        }
+        if undo_clicked {
+            self.pending = None;
+            return SurfaceResponse {
+                undo_drawing: true,
+                ..SurfaceResponse::default()
+            };
+        }
+        SurfaceResponse::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn env(now: Instant) -> SurfaceEnv<'static> {
+        SurfaceEnv {
+            bookmarks: &[],
+            now,
+        }
+    }
+
+    /// A toast leaves on its own after the undo window, without anyone having
+    /// to dismiss it.
+    #[test]
+    fn a_toast_expires_after_the_undo_window() {
+        let ctx = egui::Context::default();
+        let mut surface = ToastSurface::default();
+        let shown = Instant::now();
+        surface.note("Workspace saved.", shown);
+        assert_eq!(surface.message(), Some("Workspace saved."));
+
+        let _ = ctx.run(Default::default(), |ctx| {
+            surface.draw(ctx, &env(shown + Duration::from_millis(UNDO_MS - 1)));
+        });
+        assert_eq!(
+            surface.message(),
+            Some("Workspace saved."),
+            "still inside the window"
+        );
+
+        let _ = ctx.run(Default::default(), |ctx| {
+            surface.draw(ctx, &env(shown + Duration::from_millis(UNDO_MS)));
+        });
+        assert_eq!(surface.message(), None, "the window closed on the boundary");
+    }
+
+    /// The undo-bearing message is a different act from the plain one, and
+    /// only the former paints a button.
+    #[test]
+    fn only_an_undoable_act_paints_the_button() {
+        let ctx = egui::Context::default();
+        let now = Instant::now();
+
+        let mut plain = ToastSurface::default();
+        plain.note("Drawings cleared.", now);
+        let _ = ctx.run(Default::default(), |ctx| {
+            plain.draw(ctx, &env(now));
+        });
+        assert!(plain.undo_rect().is_none());
+
+        let mut undoable = ToastSurface::default();
+        undoable.note_with_undo("Trend line deleted.", now);
+        let _ = ctx.run(Default::default(), |ctx| {
+            undoable.draw(ctx, &env(now));
+        });
+        assert!(undoable.undo_rect().is_some());
+    }
+
+    /// Drawing a quiet surface asks the host for nothing. The undo request is
+    /// raised only by the click, which is what keeps the host's drawing stack
+    /// out of reach of an ordinary frame.
+    #[test]
+    fn an_untouched_toast_asks_the_host_for_nothing() {
+        let ctx = egui::Context::default();
+        let now = Instant::now();
+        let mut surface = ToastSurface::default();
+        surface.note_with_undo("Trend line deleted.", now);
+        let mut response = SurfaceResponse::default();
+        let _ = ctx.run(Default::default(), |ctx| {
+            response = surface.draw(ctx, &env(now));
+        });
+        assert_eq!(response, SurfaceResponse::default());
+    }
+}

--- a/crates/app/src/surfaces/workspace_name.rs
+++ b/crates/app/src/surfaces/workspace_name.rs
@@ -1,0 +1,207 @@
+//! The Save-as box, as a [`Surface`].
+//!
+//! A window rather than an inline menu field, because a menu closes the moment
+//! focus moves and a name is several keystrokes long. Enter saves, Escape
+//! cancels, and the field takes the keyboard on the frame it opens so the
+//! trader can type without clicking into it first.
+//!
+//! This is the surface that exercises both halves of the port. It *reads*
+//! something it does not own — the saved arrangements, to warn before one is
+//! replaced — and takes it from [`SurfaceEnv`] rather than from the host. And
+//! it *asks* for something it must not do itself — writing the workspace —
+//! and says so through [`SurfaceResponse`]. Neither direction gives it a
+//! reference to `QuantickApp`, which is the whole point: the surface stays
+//! testable without an application, and the application keeps the write.
+
+use std::time::Instant;
+
+use eframe::egui;
+
+use super::{Surface, SurfaceEnv, SurfaceResponse};
+use crate::{theme, ui_state};
+
+/// Width of the Save-as box, in pixels. Wide enough that a name at the
+/// [`ui_state::MAX_WORKSPACE_NAME`] limit reads in one line.
+const WIDTH_PX: f32 = 280.0;
+
+/// The Save-as box: one text field, Save and Cancel.
+#[derive(Default)]
+pub(crate) struct WorkspaceNameSurface {
+    /// What has been typed so far, or `None` while the box is closed. The
+    /// box being open *is* this being `Some`, so there is no second flag to
+    /// disagree with it.
+    entry: Option<String>,
+    /// Whether the field still owes itself the keyboard.
+    ///
+    /// Focus is taken on the frame the box opens and not afterwards. Asking
+    /// every frame would hold the keyboard for as long as the box is up, which
+    /// matters most under `QUANTICK_WORKSPACE_NAME_BOX=1`: the box is open from
+    /// launch, and every key a capture run sent would land in the name field
+    /// instead of reaching the chart.
+    focus_pending: bool,
+}
+
+impl WorkspaceNameSurface {
+    /// Open the box on an empty name, with the keyboard owed to its field.
+    pub fn open(&mut self) {
+        self.entry = Some(String::new());
+        self.focus_pending = true;
+    }
+
+    /// What has been typed, or `None` while the box is closed.
+    #[cfg(test)]
+    pub fn entry(&self) -> Option<&str> {
+        self.entry.as_deref()
+    }
+}
+
+impl Surface for WorkspaceNameSurface {
+    fn id(&self) -> &'static str {
+        "workspace_name_box"
+    }
+
+    /// The box is behind the Workspace menu's *Save as*, which a scripted run
+    /// cannot click. Goes through [`Self::open`], the call the menu entry
+    /// makes.
+    fn apply_env_hook(&mut self, _now: Instant) {
+        if std::env::var("QUANTICK_WORKSPACE_NAME_BOX").is_ok_and(|value| value == "1") {
+            self.open();
+        }
+    }
+
+    fn draw(&mut self, ctx: &egui::Context, env: &SurfaceEnv<'_>) -> SurfaceResponse {
+        let id = self.id();
+        let Some(mut entry) = self.entry.take() else {
+            return SurfaceResponse::default();
+        };
+        let mut save = false;
+        let mut cancel = false;
+        let mut open = true;
+        egui::Window::new("Save workspace as")
+            .id(egui::Id::new(id))
+            .collapsible(false)
+            .resizable(false)
+            .open(&mut open)
+            .anchor(egui::Align2::CENTER_CENTER, egui::Vec2::ZERO)
+            .show(ctx, |ui| {
+                ui.set_min_width(WIDTH_PX);
+                ui.label("A name you will recognise later.");
+                let field = ui.add(
+                    egui::TextEdit::singleline(&mut entry)
+                        .hint_text("scalp WIN")
+                        .char_limit(ui_state::MAX_WORKSPACE_NAME)
+                        .desired_width(f32::INFINITY),
+                );
+                if self.focus_pending {
+                    field.request_focus();
+                    self.focus_pending = false;
+                }
+                // Enter goes through the same gate as the Save button. Without
+                // it, Enter on an empty field closes the box and asks the host
+                // to save "", which it refuses with a "needs a name" toast —
+                // the trader loses the box for an input the button had already
+                // greyed out.
+                if field.lost_focus()
+                    && ui.input(|i| i.key_pressed(egui::Key::Enter))
+                    && ui_state::clean_workspace_name(&entry).is_some()
+                {
+                    save = true;
+                }
+                // A name already in use replaces that bookmark. Saying so
+                // before the click is the difference between "save as" and
+                // "lose the arrangement I meant to keep".
+                if let Some(clean) = ui_state::clean_workspace_name(&entry)
+                    && env.bookmarks.iter().any(|held| held.name == clean)
+                {
+                    ui.label(
+                        egui::RichText::new(format!("Replaces the saved \"{clean}\"."))
+                            .color(theme::AMBER),
+                    );
+                }
+                ui.horizontal(|ui| {
+                    let named = ui_state::clean_workspace_name(&entry).is_some();
+                    if ui
+                        .add_enabled(named, egui::Button::new("Save"))
+                        .on_disabled_hover_text("Type a name first")
+                        .clicked()
+                    {
+                        save = true;
+                    }
+                    if ui.button("Cancel").clicked() {
+                        cancel = true;
+                    }
+                });
+            });
+        if ctx.input(|i| i.key_pressed(egui::Key::Escape)) {
+            cancel = true;
+        }
+        if save {
+            return SurfaceResponse {
+                save_workspace_as: Some(entry),
+                ..SurfaceResponse::default()
+            };
+        }
+        if !cancel && open {
+            // Neither settled: keep what has been typed for the next frame.
+            self.entry = Some(entry);
+        }
+        SurfaceResponse::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The box being open is the entry being `Some`, so a fresh surface draws
+    /// nothing and asks for nothing.
+    #[test]
+    fn a_closed_box_draws_nothing_and_asks_nothing() {
+        let ctx = egui::Context::default();
+        let mut surface = WorkspaceNameSurface::default();
+        assert!(surface.entry().is_none());
+        let mut response = SurfaceResponse::default();
+        let _ = ctx.run(Default::default(), |ctx| {
+            response = surface.draw(
+                ctx,
+                &SurfaceEnv {
+                    now: std::time::Instant::now(),
+                    bookmarks: &[],
+                },
+            );
+        });
+        assert_eq!(response, SurfaceResponse::default());
+    }
+
+    /// Opening puts an empty name on screen, which is what makes the Save
+    /// button start disabled rather than saving an unnamed arrangement.
+    #[test]
+    fn opening_starts_from_an_empty_name() {
+        let mut surface = WorkspaceNameSurface::default();
+        surface.open();
+        assert_eq!(surface.entry(), Some(""));
+    }
+
+    /// What the trader typed survives a frame where they settled nothing —
+    /// the box is several keystrokes long, and losing them on any frame that
+    /// is not a click would make it unusable.
+    #[test]
+    fn an_unsettled_name_survives_the_frame() {
+        let ctx = egui::Context::default();
+        let mut surface = WorkspaceNameSurface::default();
+        surface.open();
+        let _ = ctx.run(Default::default(), |ctx| {
+            surface.draw(
+                ctx,
+                &SurfaceEnv {
+                    now: std::time::Instant::now(),
+                    bookmarks: &[],
+                },
+            );
+        });
+        assert!(
+            surface.entry().is_some(),
+            "the box stays open across a quiet frame"
+        );
+    }
+}

--- a/crates/app/tests/size_guard.rs
+++ b/crates/app/tests/size_guard.rs
@@ -1,0 +1,329 @@
+//! Ratchet guard for the size of the trunk.
+//!
+//! `arch-review` dimension 1 asks whether a new capability can dock as a new
+//! file plus one registration line, and recent features answered yes
+//! honestly — `pointer_compass.rs` really is a new file. `app.rs` still grew
+//! from 108 lines to over 36,000 in the five weeks after it was created,
+//! monotonically, never once shrinking. The review measures the leaf and
+//! never the trunk: nothing asks *where the registration lines accumulate*.
+//! They accumulate in `QuantickApp` and in its constructor, because a
+//! capability with no port is docked by hand — a field, an init, a draw call,
+//! a hotkey — and every one of those four edits lands in the same file.
+//!
+//! Nothing else in the repo can see that. fmt, clippy, build and the whole
+//! suite stay green while one file absorbs a crate, exactly as they stay
+//! green through a Portuguese comment (`language_guard.rs`) or a codepage
+//! round-trip (`source_encoding_guard.rs`). So the rule is enforced the same
+//! way those are: mechanically, because a rule that lives only in a skill's
+//! judgement drifts. `CLAUDE.md` already says as much about worktrees —
+//! "enforced by hooks, not by memory".
+//!
+//! # What is measured, and what is deliberately not
+//!
+//! **Production lines only** — everything before a file's test module. Two
+//! thirds of `app.rs` is `#[cfg(test)]`, and dimension 4 asks for exactly
+//! that. A guard counting total lines would fire on a well-tested change and
+//! teach the author to write fewer tests, which is worse than the disease.
+//! Test code may grow without limit, and files under `tests/` are not tracked
+//! at all, for the same reason.
+//!
+//! Keeping unit tests beside the code is the Rust convention, not an accident
+//! of this repo: a child module sees its parent's private items, so a test in
+//! the same file reaches a private function without widening its visibility,
+//! and `#[cfg(test)]` compiles the whole module out of the shipped binary.
+//! The convention assumes files stay navigable, which is the assumption this
+//! guard restores. When a surface moves out to its own module, its tests move
+//! with it — one extraction, both halves.
+//!
+//! # The ratchet has teeth in both directions
+//!
+//! A tracked file may not grow past its recorded ceiling, and may not sit far
+//! *below* it either: slack left unclaimed is only headroom for the next
+//! feature to refill silently, which is how the debt was run up the first
+//! time. Shrinking a file is therefore expected to tighten its entry in the
+//! same commit.
+//!
+//! # Raising a ceiling is allowed — it just has to be signed
+//!
+//! This guard does not forbid growth; it forbids *invisible* growth. There
+//! are two honest ways past a failure. The first, which the failure message
+//! asks for, is to put the new code in its own module behind a port, as
+//! `new-extension` describes. The second is to raise the number here on
+//! purpose, with a comment saying why. That stays legitimate: a reviewer sees
+//! a one-line diff saying "this file is allowed to be bigger now" and can
+//! argue with it, which is precisely what a silent +400 lines inside a
+//! 36,000-line file never let anyone do.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Production lines above which a file must carry a [`BASELINE`] entry. Files
+/// below it are not the problem this guard exists for, and tracking them
+/// would turn every ordinary edit into a baseline update — the reliable way
+/// to get a guard disabled.
+const THRESHOLD: usize = 1_500;
+
+/// How far below its ceiling a tracked file may sit before the entry must be
+/// tightened. Generous enough that ordinary churn stays quiet, small enough
+/// that a real extraction cannot leave room for a whole feature behind it.
+const SLACK: usize = 200;
+
+/// The recorded ceiling, in production lines, for every file over
+/// [`THRESHOLD`]. These are the sizes on the day the guard was written, not
+/// targets: each entry is debt, and the only direction one should ever move
+/// is down. `app.rs` at the top of the list is the reason the file exists.
+const BASELINE: &[(&str, usize)] = &[
+    // `app.rs` is the reason this file exists. Tightened by the change that
+    // added the guard: the agent popup, the acknowledgement toast and the
+    // Save-as box left for `src/surfaces/`, taking 223 production lines and
+    // three struct fields with them, and giving back one for the line that
+    // drives their capture hooks.
+    ("crates/app/src/app.rs", 11651),
+    // The five entries below `pane.rs` were invisible to the first version of
+    // this guard, which stopped counting at the first `#[cfg(test)]` of any
+    // kind: `gateway.rs` scored 72 lines of its 4,142, `drawings/mod.rs` 221
+    // of 2,283. They are recorded at today's true size, not at a target.
+    ("crates/app/src/paper_trading.rs", 8861),
+    ("crates/app/src/pane.rs", 7757),
+    ("crates/app/src/tab.rs", 4401),
+    ("crates/app/src/control/gateway.rs", 4142),
+    ("crates/app/src/orderflow_render.rs", 3075),
+    ("crates/app/src/orderflow_view.rs", 2485),
+    ("crates/app/src/drawings/mod.rs", 2283),
+    ("crates/app/src/footprint_render.rs", 2234),
+    ("crates/feed-mt5/src/stream.rs", 2142),
+    ("crates/app/src/toolrail.rs", 2114),
+    ("crates/app/src/orderflow/projection.rs", 1850),
+    ("crates/app/src/control/contract.rs", 1718),
+    ("crates/app/src/control/evidence.rs", 1708),
+    ("crates/pine/src/eval.rs", 1669),
+    ("crates/app/src/app/layout_wiring.rs", 1557),
+    ("crates/pine/src/compile.rs", 1540),
+    ("crates/app/src/orderflow/config.rs", 1523),
+];
+
+/// Lines of a source file that ship in the binary: every line that is not part
+/// of a top-level `#[cfg(test)]` item.
+///
+/// The obvious implementation — stop counting at the first `#[cfg(test)]` — was
+/// written first and was wrong in a way that mattered: fifteen files in this
+/// repo carry a top-level `#[cfg(test)] use`, `#[cfg(test)] const` or
+/// `#[cfg(test)] fn` *above* their test module, and truncating there scored
+/// `control/gateway.rs` at 72 lines of 4,566 and `drawings/mod.rs` at 221 of
+/// 4,455. The guard was blind on the largest files in the repo, and one
+/// `#[cfg(test)] use` at the top of `app.rs` would have switched it off there
+/// too. So the count skips each such item and keeps going.
+///
+/// Only column-0 attributes are considered. A `#[cfg(test)]` on a field or a
+/// method inside an `impl` is indented and governs something that is already
+/// inside an item being counted.
+///
+/// Test code above the module therefore costs nothing, and production code
+/// below it is counted — which is the direction a ratchet should err in.
+fn production_lines(source: &str) -> usize {
+    let lines: Vec<&str> = source.lines().collect();
+    let mut production = 0;
+    let mut index = 0;
+    while index < lines.len() {
+        if lines[index] != "#[cfg(test)]" {
+            production += 1;
+            index += 1;
+            continue;
+        }
+        // Step over the attribute, then any further attributes or doc lines,
+        // to reach the item itself.
+        index += 1;
+        while index < lines.len()
+            && (lines[index].starts_with("#[")
+                || lines[index].starts_with("//")
+                || lines[index].is_empty())
+        {
+            index += 1;
+        }
+        let Some(item) = lines.get(index) else { break };
+        // `use …;` and `mod tests;` end on their own line; everything else
+        // opens a block that closes on a brace back in column 0.
+        if item.ends_with(';') {
+            index += 1;
+            continue;
+        }
+        index += 1;
+        while index < lines.len() && lines[index] != "}" && lines[index] != "};" {
+            index += 1;
+        }
+        index += 1;
+    }
+    production
+}
+
+/// Every tracked `.rs` file under `crates`, as workspace-relative paths with
+/// forward slashes so [`BASELINE`] entries read the same on every platform.
+/// `tests/` is skipped whole: test code is asked for, not rationed.
+fn scan(dir: &Path, root: &Path, found: &mut Vec<(String, usize)>) {
+    for entry in fs::read_dir(dir).expect("source dir is readable") {
+        let path = entry.expect("dir entry is readable").path();
+        if path.is_dir() {
+            if path.file_name().is_some_and(|name| name == "tests") {
+                continue;
+            }
+            scan(&path, root, found);
+            continue;
+        }
+        if path.extension().is_none_or(|ext| ext != "rs") {
+            continue;
+        }
+        let source = fs::read_to_string(&path).expect("source file is readable UTF-8");
+        let relative = path
+            .strip_prefix(root)
+            .expect("scanned path sits under the workspace root")
+            .to_string_lossy()
+            .replace('\\', "/");
+        found.push((relative, production_lines(&source)));
+    }
+}
+
+#[test]
+fn no_tracked_file_grows_past_its_recorded_ceiling() {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("crates/app sits two levels below the workspace root")
+        .to_path_buf();
+
+    let mut found = Vec::new();
+    scan(&root.join("crates"), &root, &mut found);
+    found.sort();
+
+    let mut violations = Vec::new();
+
+    for (path, actual) in &found {
+        match BASELINE.iter().find(|(tracked, _)| tracked == path) {
+            Some((_, ceiling)) if actual > ceiling => violations.push(format!(
+                "  {path}: {actual} production lines, ceiling {ceiling} (+{})",
+                actual - ceiling
+            )),
+            Some((_, ceiling)) if ceiling.saturating_sub(*actual) > SLACK => {
+                violations.push(format!(
+                    "  {path}: down to {actual} from {ceiling} — good news, tighten the entry to \
+                     {actual}"
+                ))
+            }
+            None if *actual > THRESHOLD => violations.push(format!(
+                "  {path}: {actual} production lines, over the {THRESHOLD} threshold and absent \
+                 from BASELINE — add (\"{path}\", {actual})"
+            )),
+            _ => {}
+        }
+    }
+
+    for (path, _) in BASELINE {
+        if !found.iter().any(|(scanned, _)| scanned == path) {
+            violations.push(format!(
+                "  {path}: in BASELINE but no longer scanned — drop the stale entry"
+            ));
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "file sizes moved away from their recorded baseline:\n{}\n\nA file over its ceiling means \
+         a capability docked by editing the trunk instead of by adding a module. The fix asked \
+         for is the one in the new-extension skill: give the capability its own file and a port \
+         to dock into, so the edit here is a registration line rather than a body. Raising a \
+         ceiling on purpose is still allowed — change the number and say why in a comment, so a \
+         reviewer argues with a visible decision instead of missing an invisible one.",
+        violations.join("\n")
+    );
+}
+
+/// The test module does not count, so test code may grow without moving a
+/// ceiling. This is the whole reason the guard counts production lines rather
+/// than the file's length.
+#[test]
+fn production_lines_skips_the_test_module() {
+    let source = "fn ship() {}\n\n#[cfg(test)]\nmod tests {\n    fn a() {}\n    fn b() {}\n}\n";
+    assert_eq!(production_lines(source), 2);
+}
+
+/// The case that made the first implementation worthless: a `#[cfg(test)] use`
+/// above the production code. Stopping at it scored `control/gateway.rs` at 72
+/// lines of 4,566, so the guard reported nothing while the file was free to
+/// grow without limit.
+#[test]
+fn production_lines_counts_past_a_cfg_test_use() {
+    let source = "use std::fs;\n#[cfg(test)]\nuse std::io;\n\nfn ship() {}\nfn also_ships() {}\n";
+    // Six lines, less the attribute and the `use` it governs.
+    assert_eq!(production_lines(source), 4);
+}
+
+/// The same hole in its other spelling: a `#[cfg(test)]` helper *function*
+/// above the test module, which is what hid 1,250 production lines of
+/// `paper_trading.rs` behind a ceiling of 7,611.
+#[test]
+fn production_lines_counts_past_a_cfg_test_helper() {
+    let source = concat!(
+        "fn ship() {}\n",
+        "#[cfg(test)]\n",
+        "fn helper() {\n",
+        "    let _ = 1;\n",
+        "}\n",
+        "fn ships_too() {}\n",
+        "#[cfg(test)]\n",
+        "mod tests {\n",
+        "    fn t() {}\n",
+        "}\n",
+    );
+    assert_eq!(production_lines(source), 2);
+}
+
+/// An attribute stack above the test item must not swallow the item itself.
+#[test]
+fn production_lines_steps_over_stacked_attributes() {
+    let source = concat!(
+        "fn ship() {}\n",
+        "#[cfg(test)]\n",
+        "#[allow(clippy::pedantic)]\n",
+        "mod tests {\n",
+        "    fn t() {}\n",
+        "}\n",
+    );
+    assert_eq!(production_lines(source), 1);
+}
+
+/// A `#[cfg(test)]` on a field or method *inside* an item is indented, and
+/// `app.rs` carries dozens of them. They govern something already inside a
+/// counted item, so only column-0 attributes are considered.
+#[test]
+fn production_lines_ignores_an_indented_cfg_test() {
+    let source =
+        "struct App {\n    #[cfg(test)]\n    probe: bool,\n}\n\n#[cfg(test)]\nmod tests {\n}\n";
+    assert_eq!(production_lines(source), 5);
+}
+
+/// A file with no test module at all counts whole, so a pure-production file
+/// cannot slip under the threshold by omitting tests.
+///
+/// The trailing newline is a terminator, not a line: `str::lines` yields three
+/// items here, and a baseline generated by a script that splits on `\n`
+/// instead would sit one line high on exactly the files that have no test
+/// module — a line of unearned headroom, granted quietly. That happened while
+/// this guard was being written, to `layout_wiring.rs` and `compile.rs`, and
+/// this case is what caught it.
+#[test]
+fn production_lines_counts_a_file_with_no_test_module_whole() {
+    assert_eq!(production_lines("a\nb\nc\n"), 3);
+    assert_eq!(production_lines("a\nb\nc"), 3);
+}
+
+/// The lookup takes the first matching entry, so a duplicated path would leave
+/// the second — usually the tighter one a later branch added — dead, with
+/// nothing saying so. This file is meant to be edited often, which is exactly
+/// how two merges end up appending the same path.
+#[test]
+fn baseline_names_each_file_once() {
+    let mut seen: Vec<&str> = BASELINE.iter().map(|(path, _)| *path).collect();
+    let before = seen.len();
+    seen.sort_unstable();
+    seen.dedup();
+    assert_eq!(before, seen.len(), "BASELINE lists a path more than once");
+}


### PR DESCRIPTION
Stop the `app` crate's trunk from absorbing every new capability: add a mechanical size ratchet and an `arch-review` accumulation dimension, then carve the `Surface` port and move exemplary surfaces onto it.

**step 0: code-review at xhigh, 14 findings — 11 fixed, 1 fixed in part, 2 deferred (listed at the bottom).** One was a Blocker in this branch's own guard; see *What the review caught*.

## Why

`arch-review` dimension 1 asks whether a capability can dock as a new file plus one registration line. Recent features answered yes *honestly* — `pointer_compass.rs` really is a new file — and `app.rs` still went from 108 lines to over 36,000 in five weeks, monotonically, never once shrinking.

The review measures the leaf and never the trunk. Nothing asked **where the registration lines accumulate**. They accumulate in `QuantickApp` (133 fields) and `new_with_workspace` (1,149 lines), because a capability with no port is docked by hand in four places — a field, an initialiser, a draw call, a hotkey — and every one lands in the same file. `grep` for "line count | file size | god object | monolith" in `arch-review/SKILL.md` returned zero hits.

Measured coupling says the design underneath is sound, not rotten: **9 of 21 `draw_*` surfaces touch 1–2 fields** of `QuantickApp`; only `draw_frame` (14) and `draw_menu_bar` (17) are genuinely tangled. This is wiring debt, not architecture debt — which is why it is mechanical to repay.

## What is in it, in rising order of risk

**1. `crates/app/tests/size_guard.rs`** — a ratchet over *production* lines, meaning every line outside a top-level `#[cfg(test)]` item. Two thirds of `app.rs` is test code, and dimension 4 asks for exactly that: a guard counting total lines would fire on a well-tested change and teach the author to write fewer tests. It fails on growth past a recorded ceiling, and also when a file sits more than 200 lines *below* one, because unclaimed slack is only headroom for the next feature to refill silently. Raising a ceiling stays legal — it just has to be a signed line in the diff instead of an invisible +400 inside a 36,000-line file.

**2. `arch-review` dimension 9 and the `new-extension` rule** — the judgement half of that guard. Both name the shape they exist to stop: `ChartLayer` is a registry in name only, with 21 variants across 264 `ChartLayer::` sites in six files, so adding a layer reopens `app.rs`, `pane.rs`, `tab.rs` and `toolbar.rs`. `new-extension`'s blast radius now counts lines, not only files — one new file beside 2,000 lines poured into thirteen others reads healthy on a file count alone.

**3. The `Surface` port** — `SurfaceEnv` and `SurfaceResponse`, copied from `dock.rs`'s `DockEnv`/`DockResponse` rather than invented, so the repo keeps one way to do this. The response is a **struct, not an enum**: a new request is an added field defaulting to "did not ask", never a `match` arm that reopens every caller. The trait also carries `apply_env_hook`, so a surface that forgets its `ui-harness` hook shows up as an empty override instead of compiling silently. The agent popup, the acknowledgement toast and the Save-as box move onto it with their tests and their hooks — and `app.rs` now drives none of the three.

The registry is a typed struct rather than `Vec<Box<dyn Surface>>`, deliberately: the host must reach a specific surface to command it (`show_agent_popup`), and the routes back from a trait object are downcasting — which dimension 1 calls a broken port — or a command enum, which is the growth this port exists to stop. The trade is documented at the top of `surfaces/mod.rs`.

## What the review caught

Worth stating plainly, because it is the most useful thing in this branch: **step 0 found a Blocker in the size guard itself.** The first version stopped counting at the first `#[cfg(test)]` line of any kind, not at the test module. Fifteen files carry a top-level `#[cfg(test)] use` / `const` / `fn` above their tests, so the guard scored `control/gateway.rs` at **72 lines of its 4,142**, `drawings/mod.rs` at 221 of 2,283 and `toolrail.rs` at 96 of 2,114 — blind on the largest files in the repo, and one `#[cfg(test)] use` at the top of `app.rs` would have switched it off there too.

Fixed by counting every line outside a top-level `#[cfg(test)]` *item*, pinned by four cases including both spellings that caused it. The tracked set went from 13 files to 18, and `paper_trading.rs`'s ceiling from a false 7,611 to its real 8,861. Both skills were asserting a coverage the counter did not have; those sentences now say what it counts and how it was wrong.

## Evidence

| Criterion | Result |
| --- | --- |
| Ratchet fails on growth | **Verified both ways.** +5 lines in the production region → `FAILED … 11879 production lines, ceiling 11874 (+5)`. +5 lines inside `mod tests` → passes, by design. |
| Ratchet fails on unclaimed slack | Fired on its own author: `down to 11650 from 11874 — good news, tighten the entry to 11650`. |
| Ratchet is not blind | 18 files tracked, including the five the first version could not see. |
| `arch-review` dimension 9 | Added; severity list, `ReportFindings` categories and the closing verdict extended. Numbered 9, not renumbered, because `mission` and eight `GOAL-archive-*` files cite dimension 8 by number. |
| `new-extension` UI-surface rule | Added, with the `Surface` row in the port table. |
| Port + second implementation | `a_second_implementation_needs_only_the_trait` drives an outside type through the same fold `draw_all` uses and asserts its request survives; `a_shipped_surface_and_a_fake_take_the_same_path` holds the fake to the contract the product is held to. |
| 3 surfaces moved | `QuantickApp` **133 → 130 fields**; `app.rs` **11,874 → 11,651** production lines; `draw_frame` hand-calls none of them, and neither does `new_with_workspace`. |
| Behaviour preserved | `cargo test --workspace`: **2,497 passed** across 38 binaries. |
| Visual | All three surfaces captured twice — before and after the review fixes — at fps 56–59 and read: popup (title, message, attribution, Dismiss), toast (message + Undo, `Foreground` layer, unobstructed), Save-as (hint text, focus ring, Save correctly disabled on an empty name). **PASS.** |
| Per-frame performance | Flat. See below. |
| Blast radius | **5 new files, 1,253 lines; existing files +168 / −285 — net −117 lines of existing code.** A package, not a patch. |
| Four checks | fmt 0, clippy 0, build 0, test — one known-environmental failure, below. |

### Performance

Per-frame path, so it is measured, not asserted. `frame_avg_ms` is vsync-bound at ~16.7 ms on a 60 Hz desktop, so `frame_cpu_ms` is the number that moves. Three passes, with the order reversed in the second to separate the change from drift in market density and desktop load; the third is the code as shipped, after the review fixes.

| Pass | control (`origin/main`) | branch |
| --- | --- | --- |
| 1 — control first | 2.050 ms | 2.239 ms |
| 2 — branch first | 2.071 ms | 1.827 ms |
| 3 — final code | 2.066 ms | 2.021 ms |
| **mean** | **2.062 ms** | **2.029 ms** |

The ordering flips between passes and the branch's own runs span 0.41 ms — ten times the 0.03 ms difference in the means. The effect is below the noise floor, which is what the code predicts: production dispatch is **static**, `dyn Surface` appearing only inside `#[cfg(test)]`, so three direct calls replaced three direct calls. 19 health samples per run, dense frame (`QUANTICK_BOOK_AUTOSTART` + `QUANTICK_BUBBLES_AUTOSTART` + `QUANTICK_LIVE_STRIP_AUTOSTART`).

### Known-environmental test failure

`quantick-feed-mt5 :: the_bridge_paging_tests_pass` fails on this machine only: it tries `python3` first, which here is the Microsoft Store alias stub. Running the script the test wraps passes outright — `python bridge/mt5/tests/test_paging.py` → **all checks passed across 31 tests**. Unrelated to this branch (nothing here touches `feed-mt5` or the Python bridge) and green on CI's real `python3`.

## Deferred, deliberately

- **Toasts raised after `draw_all` paint one frame late.** `draw_all` sits where `draw_agent_popup` was, early in `draw_frame`, so an acknowledgement raised by the object manager or by `save_named_workspace` — both later in the frame — appears on frame N+1 rather than N. The call site was chosen to preserve the popup's `Middle`-order layering exactly; moving it late instead would put the popup above every dialog it currently sits below. A 16 ms deferral of a toast against a visible z-order change is the better trade, and no test detects it — but it is a real difference, recorded here rather than in a comment nobody reads.
- **A workspace-wide policy lives in `quantick-app`'s integration tests.** A `pine`-only branch that shrinks `compile.rs` past the slack has to edit an app-crate file to land. CI runs `cargo test --workspace`, so nothing escapes, but the altitude is wrong; the right home is an `xtask` or a tiny crate of its own. Kept here because moving it is its own change and this branch already carries three.
- **`paper_trading.rs` still has its own `Toast`** — per tab, on a 4-second clock, with its own 96 px lift. Pre-existing, so not a leftover of this extraction, and its doc claim of being "the window's one acknowledgement channel" has been corrected rather than left false. It is the obvious next implementation of the port, and converging it would be the strongest proof the port is real.
- **`Surfaces` is not enumerable.** `Surface::id()` gives each surface a stable id, and each paints under `egui::Id::new(self.id())` so the name cannot drift from the layer — but there is no iterator for the control plane to list what is on screen. Adding one now would ship an API with no caller (clippy's `dead_code` already caught that once here). It belongs with the first consumer that needs it.
- **The indicator legend paints over the agent popup.** Visible in the capture. **Not a regression** — `draw_agent_popup` sat at `draw_frame` line 83 and `draw_indicator_legends` at 91 on `origin/main`; on this branch they are 83 and 106. Same relative order, so the overlap predates this work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
