### PR TITLE
refactor(app): the drawing chrome leaves the trunk as one surface

### DIFF
--- a/.claude/GOAL-archive-surfaces-drawing-chrome.md
+++ b/.claude/GOAL-archive-surfaces-drawing-chrome.md
@@ -1,0 +1,83 @@
+# Mission (archived — PR opened)
+
+Move the drawing chrome — the inline text editor, the context bar, the
+inspector (floating and pinned) and the object manager — off `QuantickApp` and
+onto the `Surface` port as **one** `DrawingChrome` member, so the trunk stops
+holding one subsystem's state as twenty-one loose fields.
+
+## Why one member, not four
+
+The four surfaces share mutable state, measured on `origin/main` at 51c03d0:
+
+- `inspector_open` — written by the context bar's gear, read by the inspector.
+- `inspector_pinned` — read by the context bar (a gear that leads where the
+  eye already is would be a dead slot), written by the inspector's pin.
+- `inspector_last_selection` — cleared by the context bar, consumed by the
+  inspector's placement rule.
+- `drawing_delete_confirm` — read by the bar and the inspector body, cleared
+  by the shared action applier.
+- `inspector_edit_baseline` — read by the context bar to decide whether this
+  frame owes a clone.
+
+Four `Surface` members would leave that state in `QuantickApp` — the disease
+this mission exists to cure — or make `Surfaces::draw_all`'s call order
+load-bearing, which its own doc comment says it is not. One member keeps the
+sharing private to the subsystem, and `Surfaces` grows from 8 fields to 9.
+
+## Acceptance criteria
+
+1. `QuantickApp` loses the drawing-chrome cluster: `inspector_*` (13),
+   `drawing_manager_*` (3), `drawing_delete_confirm`, `context_bar`,
+   `inline_text_edit`, `pending_open_settings`, `pending_text_edit`,
+   `pending_text_note` — 21 production fields plus the 3 `#[cfg(test)]` rect
+   fields. Field count falls from 119.
+2. `Surfaces` gains exactly one member. No keyed registry, no downcast, no
+   command enum standing in for named surfaces.
+3. The inspector edits a **copy** of the selected drawing and hands it back
+   through `SurfaceResponse`; no `&mut` into `QuantickApp` or its panes.
+4. Cold path only: no dynamic dispatch added to the aggregator,
+   `Indicator::preview` or the renderer. Per-frame cost is one extra virtual
+   call that early-returns; env slices that cost an allocation are built only
+   while the surface that reads them is open.
+5. Every `QUANTICK_*` capture hook these surfaces answer to still fires, from
+   `apply_env_hook` — `ui-harness` keeps its reach.
+6. `crates/app/tests/size_guard.rs` entry for `app.rs` tightened in the same
+   commit as the shrink.
+7. Four checks green: `cargo fmt --all -- --check`,
+   `cargo clippy --workspace --all-targets -- -D warnings`,
+   `cargo build --workspace`, `cargo test --workspace`.
+8. `arch-review` run over `git diff main...HEAD`; every Blocker and Should-fix
+   resolved, or deferred in the PR body with a reason.
+9. `visual-qa` pass over the four surfaces — a pure move must not change a
+   pixel, and the screenshots are how that is proved rather than asserted.
+10. Every artifact in English.
+11. PR opened, with the one-member decision and its reason in the body, and
+    `draw_frame` / `draw_menu_bar` named as deliberately out of scope.
+
+## Out of scope
+
+`draw_frame` (79 coupling, 658 lines) and `draw_menu_bar` (38 coupling, 634
+lines). The `pending_*` (21), `scripted_*` (9) and remaining `inspector_*`
+clusters beyond the drawing chrome.
+
+## Outcome
+
+Met. `QuantickApp` 119 fields to 96; `app.rs` 11,248 production lines to
+9,700; `Surfaces` 8 members to 9. Two deviations from the plan above, both
+made deliberately and argued in the PR body:
+
+- Criterion 5 said the capture hooks would fire from `apply_env_hook`. They
+  fire from `apply_launch_hooks`, called where they were read before. The
+  registry applies `apply_env_hook` on the first *drawn* frame, which is
+  after the demo appliers — and one of them reads the state
+  `QUANTICK_DRAWING_INSPECTOR` sets. The hooks still live in the surface's
+  own file, beside the fields they set; only the timing went back.
+- Criterion 2 said the chrome would go on the `Surface` port. It is a
+  member of `Surfaces` with the port's shape — env in, ask out, no `&mut`
+  into the trunk — but it does not implement the trait: it is anchored to
+  the chart, drawn at two named points in the frame, and a uniform `draw`
+  would be handed an environment `draw_all` cannot fill and a response
+  nothing there reads.
+
+`code-review` at xhigh returned 10 findings; all 10 were confirmed and all
+10 are fixed on the branch.

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -179,13 +179,10 @@ enum WorkspacePick {
 /// call sites draws the list, and building a row per object for the site that
 /// does not would be a per-frame allocation for a window nobody is looking at.
 fn drawing_env<'a>(
-    tabs: &'a [Tab],
     tab: &'a Tab,
     toolrail: &ToolRail,
     presets: &'a drawings::presets::PresetStore,
-    selected_bbox: Option<egui::Rect>,
-    selected_band: Option<String>,
-    manager_rows: &'a [crate::surfaces::drawing_chrome::ManagerRow],
+    read: DrawingRead<'a>,
 ) -> crate::surfaces::DrawingEnv<'a> {
     let side = tab.drawing_side();
     let pane = tab.pane(side);
@@ -201,22 +198,32 @@ fn drawing_env<'a>(
         focused_chart_area: tab.focused_pane().last_chart_area,
         lane_divider_x: pane.last_lane_divider_x,
         auto_range: pane.last_auto_range,
-        selected_bbox,
-        selected_band,
+        selected_bbox: read.selected_bbox,
+        selected_band: read.selected_band,
         tab: tab.id,
         side,
         drawing_tool_armed: matches!(toolrail.tool(), Tool::Drawing(_)),
         toolbox_dock: toolrail.dock(),
-        // Only worth counting while the window that offers to take them back
-        // is on screen; the walk is over every pane of every tab.
-        authored_objects: if manager_rows.is_empty() {
-            0
-        } else {
-            QuantickApp::authored_object_count(tabs)
-        },
-        manager_rows,
+        authored_objects: read.authored_objects,
+        manager_rows: read.manager_rows,
         presets,
     }
+}
+
+/// The parts of [`drawing_env`] that cost something to work out, gathered by
+/// the caller so each pass pays only for what it draws.
+///
+/// Three fields and three prices. Projecting the selection's painted bounds
+/// walks its anchors through the price scale; naming its band formats a
+/// string; counting an assistant's objects walks every pane of every tab. All
+/// three are per-frame while a selection is on screen, which is why the pass
+/// that only runs the capture hooks gathers none of them and says so.
+#[derive(Default)]
+struct DrawingRead<'a> {
+    selected_bbox: Option<egui::Rect>,
+    selected_band: Option<String>,
+    authored_objects: usize,
+    manager_rows: &'a [crate::surfaces::drawing_chrome::ManagerRow],
 }
 
 /// The chart rectangle a settings dialog is previewing an unapplied draft on,
@@ -1475,6 +1482,13 @@ impl QuantickApp {
                 "partial" => Some(VenueHistoryDemo::Partial),
                 _ => None,
             });
+        // The drawing chrome's five hooks, read here rather than on the first
+        // drawn frame: the demo appliers run earlier in that frame and ask
+        // whether the inspector is open, so a hook another hook depends on has
+        // to be in place before any of them. They live with the fields they
+        // set — see `surfaces::drawing_chrome::apply_launch_hooks`.
+        crate::surfaces::drawing_chrome::apply_launch_hooks(&mut app.surfaces.drawing_chrome);
+
         // Same convenience for the aggression layer (bubbles + the live
         // column's footprint). Same code path as the toolbar toggle.
         if std::env::var("QUANTICK_BUBBLES_AUTOSTART").is_ok_and(|value| value == "1") {
@@ -6922,26 +6936,31 @@ impl QuantickApp {
             .collect()
     }
 
-    /// Where the selected object is painted, and what the band it lives on is
-    /// called: the two answers the chrome cannot work out for itself, because
-    /// both need the viewport and the price scale the host owns.
+    /// Where the selected object is painted, in screen points. The chrome
+    /// cannot work this out for itself: it needs the viewport and the price
+    /// scale the host owns.
     ///
-    /// Nothing is projected and no name is formatted while nothing is selected,
-    /// which is every frame of an ordinary session.
-    fn selected_drawing_geometry(&self) -> (Option<egui::Rect>, Option<String>) {
+    /// Two separate answers rather than one pair, because they cost different
+    /// things and not every pass wants both — this one walks the object's
+    /// anchors through the price scale. Nothing is projected while nothing is
+    /// selected, which is every frame of an ordinary session.
+    fn selected_drawing_bbox(&self) -> Option<egui::Rect> {
         let pane = self.drawing_pane();
-        let Some(index) = pane.drawings.selected() else {
-            return (None, None);
-        };
-        let bbox = pane
-            .last_chart_area
-            .and_then(|chart| self.drawing_bbox_on_screen(chart, index));
-        let band = pane
-            .drawings
-            .items()
-            .get(index)
-            .and_then(|drawing| self.focused_pane().band_label(drawing).chip());
-        (bbox, band)
+        let index = pane.drawings.selected()?;
+        let chart = pane.last_chart_area?;
+        self.drawing_bbox_on_screen(chart, index)
+    }
+
+    /// What the band the selected object lives on is called, for the
+    /// inspector's title. `None` on the price band, where a suffix on every
+    /// object would be noise. Formats a string, so it is asked for only by a
+    /// pass that shows the title.
+    fn selected_drawing_band(&self) -> Option<String> {
+        let pane = self.drawing_pane();
+        let index = pane.drawings.selected()?;
+        self.focused_pane()
+            .band_label(pane.drawings.items().get(index)?)
+            .chip()
     }
 
     /// Carry out what the drawing chrome asked for.
@@ -6985,6 +7004,11 @@ impl QuantickApp {
         }
         if ask.request_delete {
             self.request_delete_selected(now);
+        }
+        if ask.cancel_delete {
+            // After the request, never before: a frame carrying both must end
+            // with the prompt gone, and a delete on a locked object raises it.
+            self.surfaces.drawing_chrome.set_delete_confirm(false);
         }
         if ask.force_delete {
             let doomed = {
@@ -7031,7 +7055,10 @@ impl QuantickApp {
                     .note_with_undo("All drawings deleted.", now);
             }
         }
-        if let Some(index) = ask.manager_select {
+        if let Some(index) = ask
+            .manager_select
+            .filter(|index| *index < self.drawing_pane().drawings.items().len())
+        {
             self.drawing_pane_mut().drawings.select(Some(index));
             // Centre the viewport on the object's bar span.
             let slots = self.drawing_pane().slots();
@@ -7046,17 +7073,31 @@ impl QuantickApp {
                 }
             }
         }
-        if let Some(index) = ask.manager_toggle_hidden {
-            let hidden = self.drawing_pane().drawings.items()[index].hidden;
+        // Through `get`, never `[]`: the rows were snapshotted before any of
+        // the four pieces drew, and a destructive ask applied above — delete
+        // all, the assistant sweep, a confirmed delete — can have shortened
+        // the list under an index that was valid when the row was clicked. The
+        // store's own setters are already bounds-safe; these two reads were
+        // the only raw ones left.
+        if let Some(hidden) = ask.manager_toggle_hidden.and_then(|index| {
+            Some((
+                index,
+                self.drawing_pane().drawings.items().get(index)?.hidden,
+            ))
+        }) {
             self.drawing_pane_mut()
                 .drawings
-                .set_hidden_at(index, !hidden);
+                .set_hidden_at(hidden.0, !hidden.1);
         }
-        if let Some(index) = ask.manager_toggle_locked {
-            let locked = self.drawing_pane().drawings.items()[index].locked;
+        if let Some(locked) = ask.manager_toggle_locked.and_then(|index| {
+            Some((
+                index,
+                self.drawing_pane().drawings.items().get(index)?.locked,
+            ))
+        }) {
             self.drawing_pane_mut()
                 .drawings
-                .set_locked_at(index, !locked);
+                .set_locked_at(locked.0, !locked.1);
         }
         if let Some(index) = ask.manager_bring_to_front {
             self.drawing_pane_mut().drawings.bring_to_front(index);
@@ -7097,31 +7138,60 @@ impl QuantickApp {
         if !self.surfaces.drawing_chrome.inspector_pinned() {
             return;
         }
-        let ask = self.draw_drawing_chrome_part(ctx, false);
+        // No painted bounds: a docked panel has no placement rule to keep
+        // clear of the object, so the projection the floating one needs is not
+        // gathered here. The band still is — it is in the title.
+        let read = DrawingRead {
+            selected_band: self.selected_drawing_band(),
+            ..DrawingRead::default()
+        };
+        let ask = self.draw_chrome_pass(ctx, read, false);
         self.apply_drawing_chrome(ask, now);
     }
 
     /// The four floating pieces, registered after the canvas so they stay in
     /// front of the chart they are anchored to.
     fn draw_drawing_chrome(&mut self, ctx: &egui::Context, now: Instant) {
-        let ask = self.draw_drawing_chrome_part(ctx, true);
-        self.apply_drawing_chrome(ask, now);
-    }
-
-    /// One gather for both call sites. `floating` picks which of the surface's
-    /// two entry points runs; the rows the object manager lists are built only
-    /// for the one that draws it.
-    fn draw_drawing_chrome_part(
-        &mut self,
-        ctx: &egui::Context,
-        floating: bool,
-    ) -> crate::surfaces::drawing_chrome::DrawingChromeAsk {
-        let rows = if floating && self.surfaces.drawing_chrome.manager_open() {
+        let manager_open = self.surfaces.drawing_chrome.manager_open();
+        let rows = if manager_open {
             self.drawing_manager_rows()
         } else {
             Vec::new()
         };
-        let (selected_bbox, selected_band) = self.selected_drawing_geometry();
+        // The band name goes in the inspector's title and nowhere else, so
+        // it is formatted only when one of the two inspector hosts is on
+        // screen. A selection alone raises the context bar, which never shows
+        // it — and `band_label` scans the pane's indicator views and `chip`
+        // allocates, every frame, for a value nothing would read.
+        let inspector_showing = self.surfaces.drawing_chrome.inspector_open()
+            || self.surfaces.drawing_chrome.inspector_pinned();
+        let read = DrawingRead {
+            selected_bbox: self.selected_drawing_bbox(),
+            selected_band: inspector_showing
+                .then(|| self.selected_drawing_band())
+                .flatten(),
+            // Counted only for the window that offers to take them back, and
+            // over every tab: an object an assistant placed on another chart
+            // still belongs in that count.
+            authored_objects: if manager_open {
+                Self::authored_object_count(&self.tabs)
+            } else {
+                0
+            },
+            manager_rows: &rows,
+        };
+        let ask = self.draw_chrome_pass(ctx, read, true);
+        self.apply_drawing_chrome(ask, now);
+    }
+
+    /// One split for both call sites. `floating` picks which of the surface's
+    /// two entry points runs.
+    fn draw_chrome_pass(
+        &mut self,
+        ctx: &egui::Context,
+        read: DrawingRead<'_>,
+        floating: bool,
+    ) -> crate::surfaces::drawing_chrome::DrawingChromeAsk {
         // Split into disjoint borrows, like the surface registry above: the
         // chrome is drawn through `&mut` while what it reads is borrowed from
         // the rest of the application.
@@ -7133,15 +7203,7 @@ impl QuantickApp {
             drawing_presets,
             ..
         } = self;
-        let env = drawing_env(
-            tabs,
-            &tabs[*active_tab],
-            toolrail,
-            drawing_presets,
-            selected_bbox,
-            selected_band,
-            &rows,
-        );
+        let env = drawing_env(&tabs[*active_tab], toolrail, drawing_presets, read);
         if floating {
             surfaces.drawing_chrome.draw_floating(ctx, &env)
         } else {
@@ -8905,10 +8967,6 @@ impl QuantickApp {
         // application. That the compiler insists on the split is the port
         // working — a surface cannot be handed the trunk it is being kept
         // out of.
-        // Projected before the split, because it needs the viewport and the
-        // price scale: where the selected object is painted, and what the band
-        // it lives on is called. Both cost nothing while nothing is selected.
-        let (selected_bbox, selected_band) = self.selected_drawing_geometry();
         let Self {
             surfaces: registry,
             bookmarks,
@@ -8921,8 +8979,6 @@ impl QuantickApp {
             config,
             added_symbols,
             alert_failure,
-            drawing_presets,
-            toolrail,
             ..
         } = self;
         let focused_tab = &tabs[*active_tab];
@@ -8952,18 +9008,6 @@ impl QuantickApp {
                 active_tab: focused_tab.id,
                 counted_bar_sides: &counted_bar_sides,
                 alert_failure: alert_failure.as_deref(),
-                // No rows: the object manager is drawn from its own call site,
-                // after the canvas, and this one only carries the slice so the
-                // capture hooks can read it.
-                drawing: drawing_env(
-                    tabs,
-                    focused_tab,
-                    toolrail,
-                    drawing_presets,
-                    selected_bbox,
-                    selected_band,
-                    &[],
-                ),
             },
         );
         if let Some(name) = surfaces.save_workspace_as {
@@ -18843,6 +18887,52 @@ crosshair = false
             run_frame(&mut app, &ctx);
         }
 
+        assert!(!app.pending_drawing_demo, "the demo has run");
+        assert!(
+            app.drawing_pane().drawings.selected().is_some(),
+            "and left an object selected, which is what closes the panel"
+        );
+        assert!(
+            app.surfaces.drawing_chrome.inspector_open(),
+            "the panel the hook asked for survives the demo's own selection"
+        );
+    }
+
+    /// The same guarantee reached the way a capture run reaches it: through
+    /// the environment variable, not by setting the field first.
+    ///
+    /// The distinction is the whole test. `QUANTICK_DRAWING_INSPECTOR` used to
+    /// be read in the constructor, and when it moved to the surface's own hook
+    /// it landed in the pass the registry applies on the first *drawn* frame —
+    /// which runs after `apply_drawing_demo`, the very code that asks whether
+    /// the panel is open before it moves the selection. The panel then closed
+    /// itself and every capture pairing the two hooks photographed a chart
+    /// with no inspector. Nothing failed: the sibling test above sets the
+    /// field directly, so it could not see the order slip.
+    #[test]
+    fn the_inspector_hook_survives_the_demo_that_runs_before_it() {
+        let ctx = egui::Context::default();
+        // `set_var` is process-wide and the suite is threaded, and this one
+        // is a *real* hook name every `QuantickApp::new` in the suite reads —
+        // so unlike `store_home`'s unique-name trick, a lock is the only way
+        // a neighbour cannot see it.
+        static LAUNCH_HOOK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        let _guard = LAUNCH_HOOK.lock().unwrap_or_else(|held| held.into_inner());
+        // SAFETY: single-threaded section held by the lock above, and the
+        // variable is removed again before it is released.
+        unsafe { std::env::set_var("QUANTICK_DRAWING_INSPECTOR", "1") };
+        let (mut app, _commands) = app_with_history(500);
+        unsafe { std::env::remove_var("QUANTICK_DRAWING_INSPECTOR") };
+        app.ui_state_path = scratch_ui_state("hook-inspector");
+        app.pending_drawing_demo = true;
+
+        assert!(
+            app.surfaces.drawing_chrome.inspector_open(),
+            "the hook is read at launch, before any frame the demo runs in"
+        );
+        for _ in 0..4 {
+            run_frame(&mut app, &ctx);
+        }
         assert!(!app.pending_drawing_demo, "the demo has run");
         assert!(
             app.drawing_pane().drawings.selected().is_some(),

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -15,7 +15,6 @@
 use std::time::{Duration, Instant};
 
 use eframe::egui;
-use egui_phosphor::regular as icons;
 
 use crate::canvas_layout::{MAX_CANVAS_PANES, PaneIdAllocator};
 
@@ -23,10 +22,7 @@ mod layout_wiring;
 use crate::chart_layers::{self, ChartLayer};
 use crate::config::AppConfig;
 use crate::dock::{Dock, DockEnv, DockTab};
-use crate::drawings::{
-    self, DeleteOutcome, DrawingAuthor, MAX_DRAWING_FILL_ALPHA, MAX_DRAWING_WIDTH_PX,
-    MIN_DRAWING_WIDTH_PX, PresetHost as _,
-};
+use crate::drawings::{self, DeleteOutcome, DrawingAuthor};
 use crate::feed::{self, FeedCommand, FeedHandle, ReplayControl};
 use crate::feed_notice;
 use crate::indicator_legend;
@@ -52,7 +48,6 @@ use crate::timezone::TzOffset;
 use crate::toolbar::{self, ToolbarAction};
 use crate::toolrail::{Tool, ToolRail, ToolboxDock};
 use crate::ui_state;
-use crate::widgets::{IconButton, TOOLBAR_ICON};
 use crate::window_scale;
 use smallvec::SmallVec;
 
@@ -63,43 +58,6 @@ const TIME_STRIP: f32 = 24.0;
 /// Id of the tab the window opens with.
 const FIRST_TAB_ID: u64 = 0;
 
-/// The note being typed on the chart: which object, and how it looked before
-/// the first keystroke.
-///
-/// The baseline rides here rather than in the collection's gesture
-/// coalescing, and that is not a style choice: the inspector, the context bar
-/// and every drag share that one gesture slot, and any of them closing theirs
-/// while a note is being typed would swallow the note's undo entry — leaving
-/// Ctrl+Z to take back the *placement* instead of the words. Same shape as
-/// `inspector_edit_baseline`, same reason.
-///
-/// And the same *shape*, down to the tab and pane: an index alone identifies
-/// nothing once there are two panes, let alone two tabs. Switching tabs with
-/// an editor open would otherwise record the note's undo entry against
-/// whatever object happened to sit at that index on the tab now in front —
-/// swapping an unrelated drawing for a copy of the note on the next Ctrl+Z.
-struct InlineTextEdit {
-    tab: u64,
-    side: PaneSide,
-    index: usize,
-    before: drawings::Drawing,
-}
-
-/// Id of the on-chart note editor's floating area. One editor at a time —
-/// the keyboard has one caret.
-const INLINE_TEXT_AREA_ID: &str = "inline-text-editor";
-/// What an empty note's field says before anything is typed.
-const INLINE_TEXT_HINT: &str = "Add text";
-/// Width of the field. Wide enough for a sentence, narrow enough that it does
-/// not cover the price it is annotating.
-const INLINE_TEXT_WIDTH_PX: f32 = 180.0;
-/// Type size the editor falls back to when the tool declares none.
-const INLINE_TEXT_FALLBACK_PX: f32 = 12.0;
-/// Line height as a multiple of the type size, and the frame's own vertical
-/// padding — together, how tall the one-line field stands. Used to decide
-/// whether it still fits above the anchor.
-const INLINE_TEXT_LINE_FACTOR: f32 = 1.4;
-const INLINE_TEXT_FRAME_PAD_PX: f32 = 10.0;
 /// Frames the `QUANTICK_LOAD_OLDER` hook waits for a chart worth paging from.
 ///
 /// It cannot fire at startup: paging asks for trades older than the ones on
@@ -189,9 +147,6 @@ const DEMO_FALLBACK_BAND_FRACTION: f64 = 0.004;
 /// mark. Any distance the tab cannot possibly hold would do; an hour is
 /// unambiguous at every timeframe the chart offers.
 const DEMO_OFF_SERIES_LEAD_MS: i64 = 3_600_000;
-/// Initial position of the selected-drawing inspector, before
-/// [`inspector_placement`] has a size and a bbox to place it from.
-const DRAWING_INSPECTOR_DEFAULT_POSITION: egui::Pos2 = egui::pos2(90.0, 120.0);
 /// Length of the EMA the toolbar's hardcoded M1 entry adds (the settings UI
 /// generated from `InputSpec` replaces this in M4).
 const DEFAULT_EMA_LEN: usize = 9;
@@ -199,53 +154,8 @@ const DEFAULT_EMA_LEN: usize = 9;
 const SCRIPT_RELOAD_POLL_INTERVAL: Duration = Duration::from_millis(1_000);
 /// How long after the last indicator change the state file is written.
 const INDICATOR_STATE_SAVE_DEBOUNCE: Duration = Duration::from_millis(1_000);
-/// Inspector width bounds (UX spec: resizable between 300 and 440 px).
-const INSPECTOR_MIN_WIDTH_PX: f32 = 300.0;
-/// See [`INSPECTOR_MIN_WIDTH_PX`].
-const INSPECTOR_MAX_WIDTH_PX: f32 = 440.0;
-/// Default inspector width for the shipped tools (the spec reserves 360 px
-/// for the Fib level editor).
-const INSPECTOR_DEFAULT_WIDTH_PX: f32 = 320.0;
-/// Default inspector width for tools that mount a level editor tab.
-const INSPECTOR_LEVELS_WIDTH_PX: f32 = 360.0;
-/// Gap kept between the inspector and the selected object's bounding box.
-const INSPECTOR_OBJECT_GAP_PX: f32 = 12.0;
-/// Assumed inspector height for placement before its first frame reports one.
-const INSPECTOR_FALLBACK_HEIGHT_PX: f32 = 280.0;
-/// Below this chart width a fresh selection opens the inspector pinned —
-/// there is no floating position that would not crowd the geometry. Stops
-/// applying once the user touches the pin either way.
-const INSPECTOR_AUTO_PIN_CHART_WIDTH_PX: f32 = 1180.0;
-/// Height of the floating inspector's custom title bar.
-const INSPECTOR_TITLE_HEIGHT_PX: f32 = 28.0;
-/// Title-bar paint metrics: leading padding, the title column when the grip
-/// glyph precedes it, and the two font sizes.
-const INSPECTOR_TITLE_PAD_X_PX: f32 = 2.0;
-const INSPECTOR_TITLE_TEXT_X_PX: f32 = 18.0;
-const INSPECTOR_TITLE_GRIP_GLYPH_PX: f32 = 14.0;
-const INSPECTOR_TITLE_TEXT_PX: f32 = 13.0;
-/// Gap between the object manager and the rail edge it opens beside.
-const DRAWING_MANAGER_GAP_PX: f32 = 12.0;
-/// Dragging the price field across the whole visible range takes this many
-/// steps, whatever the symbol's price magnitude.
-const PRICE_DRAG_STEPS: f64 = 200.0;
-/// DragValue speed of bar-index coordinates, in bars per drag point.
-const BAR_DRAG_SPEED: f64 = 0.25;
-/// Where the object manager first opens: under the toolbox's home corner.
-const DRAWING_MANAGER_DEFAULT_POSITION: egui::Pos2 = egui::pos2(70.0, 140.0);
 /// Horizontal offset of a duplicated drawing, so the copy is visibly a copy.
 const DUPLICATE_OFFSET_BARS: f32 = 2.0;
-
-/// Which inspector tab is open. Tabs exist per capability: every tool gets
-/// Style and Coordinates; a tool that brings its own tab (the Fib level
-/// editor) mounts it as Extra without the central code knowing its fields.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-enum InspectorTab {
-    #[default]
-    Style,
-    Extra,
-    Coordinates,
-}
 
 /// What the open file dialog is for, so the one poll can land either answer.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -256,69 +166,56 @@ enum WorkspacePick {
     Import,
 }
 
-/// What the inspector body asked for this frame. The caller owns every
-/// mutation, so the pinned panel and the floating window share one rule set.
-/// Which default-style button the Style tab was pressed on, so the caller can
-/// say out loud that something was remembered — a silent save leaves the
-/// trader wondering whether it took.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum SavedDefault {
-    OneTool,
-    EveryTool,
-    Forgotten,
-}
-
-impl SavedDefault {
-    const fn message(self) -> &'static str {
-        match self {
-            Self::OneTool => "Saved - new drawings of this tool open configured like this one.",
-            Self::EveryTool => "Saved - every new drawing opens with this colour, width and fill.",
-            Self::Forgotten => "Reset - this tool goes back to how it opened out of the box.",
-        }
-    }
-}
-
-#[derive(Debug, Default, Clone, Copy)]
-struct InspectorActions {
-    toggle_hidden: bool,
-    toggle_lock: bool,
-    toggle_pin: bool,
-    delete: bool,
-    cancel_delete: bool,
-    force_delete: bool,
-    close: bool,
-    edited: bool,
-    /// Which default-style button was pressed, if any.
-    saved_default: Option<SavedDefault>,
-}
-
-impl InspectorActions {
-    /// Whether this frame asked for anything at all. The context bar reads
-    /// it to decide whether the undo baseline is worth cloning.
-    fn any(&self) -> bool {
-        self.toggle_hidden
-            || self.toggle_lock
-            || self.toggle_pin
-            || self.delete
-            || self.cancel_delete
-            || self.force_delete
-            || self.close
-            || self.edited
-            || self.saved_default.is_some()
-    }
-
-    /// Fold another frame section's requests into this one — the title bar
-    /// and the body each report intent, the host applies the union.
-    fn merge(&mut self, other: Self) {
-        self.toggle_hidden |= other.toggle_hidden;
-        self.toggle_lock |= other.toggle_lock;
-        self.toggle_pin |= other.toggle_pin;
-        self.delete |= other.delete;
-        self.cancel_delete |= other.cancel_delete;
-        self.force_delete |= other.force_delete;
-        self.close |= other.close;
-        self.edited |= other.edited;
-        self.saved_default = self.saved_default.or(other.saved_default);
+/// The slice the drawing chrome reads, assembled from the pieces of the
+/// application it is allowed to see.
+///
+/// A free function rather than a method for the reason
+/// [`indicator_preview_area`] is one: every caller has already split
+/// `QuantickApp` into disjoint borrows to draw a surface through `&mut`, and a
+/// method would want the whole of `self` back. That the compiler insists on
+/// the split is the port working.
+///
+/// `manager_rows` is handed in rather than gathered here. Only one of the two
+/// call sites draws the list, and building a row per object for the site that
+/// does not would be a per-frame allocation for a window nobody is looking at.
+fn drawing_env<'a>(
+    tabs: &'a [Tab],
+    tab: &'a Tab,
+    toolrail: &ToolRail,
+    presets: &'a drawings::presets::PresetStore,
+    selected_bbox: Option<egui::Rect>,
+    selected_band: Option<String>,
+    manager_rows: &'a [crate::surfaces::drawing_chrome::ManagerRow],
+) -> crate::surfaces::DrawingEnv<'a> {
+    let side = tab.drawing_side();
+    let pane = tab.pane(side);
+    let selected = pane.drawings.selected().and_then(|index| {
+        pane.drawings
+            .items()
+            .get(index)
+            .map(|drawing| crate::surfaces::drawing_chrome::SelectedDrawing { index, drawing })
+    });
+    crate::surfaces::DrawingEnv {
+        selected,
+        chart_area: pane.last_chart_area,
+        focused_chart_area: tab.focused_pane().last_chart_area,
+        lane_divider_x: pane.last_lane_divider_x,
+        auto_range: pane.last_auto_range,
+        selected_bbox,
+        selected_band,
+        tab: tab.id,
+        side,
+        drawing_tool_armed: matches!(toolrail.tool(), Tool::Drawing(_)),
+        toolbox_dock: toolrail.dock(),
+        // Only worth counting while the window that offers to take them back
+        // is on screen; the walk is over every pane of every tab.
+        authored_objects: if manager_rows.is_empty() {
+            0
+        } else {
+            QuantickApp::authored_object_count(tabs)
+        },
+        manager_rows,
+        presets,
     }
 }
 
@@ -413,185 +310,6 @@ pub fn plot_split(
 #[must_use]
 pub fn gesture_hits_lane_divider(divider_x: Option<f32>, x: f32, half_width: f32) -> bool {
     divider_x.is_some_and(|divider| (x - divider).abs() <= half_width)
-}
-
-/// `X,Y` in screen points, for the harness hook that parks the properties
-/// popup. `None` when the text is not two finite numbers.
-///
-/// Off-screen coordinates are accepted rather than refused: a position outside
-/// the chart is a state the app already has an answer for
-/// ([`clamp_into_chart`]), and reaching it on purpose is how that answer gets
-/// photographed. Only text that is not a point at all is turned away.
-fn parse_point(raw: &str) -> Option<egui::Pos2> {
-    let (x, y) = raw.split_once(',')?;
-    let x: f32 = x.trim().parse().ok()?;
-    let y: f32 = y.trim().parse().ok()?;
-    (x.is_finite() && y.is_finite()).then_some(egui::pos2(x, y))
-}
-
-/// Clamp a window of `size` at `position` into `chart`, top-left biased when
-/// the window is larger than the pane.
-fn clamp_into_chart(position: egui::Pos2, size: egui::Vec2, chart: egui::Rect) -> egui::Pos2 {
-    let max_x = (chart.right() - size.x).max(chart.left());
-    let max_y = (chart.bottom() - size.y).max(chart.top());
-    egui::pos2(
-        position.x.clamp(chart.left(), max_x),
-        position.y.clamp(chart.top(), max_y),
-    )
-}
-
-/// The rectangle the context bar may occupy: the pane, with the live lane
-/// taken off its right edge.
-///
-/// The lane is where the price the trader is reading is being formed, and
-/// losing sight of it is the trader's first veto — `context_bar::place` has
-/// kept clear of it since it was written. A *parked* bar is placed by a
-/// different rule and has to be held to the same one, so both go through this
-/// rectangle rather than through the pane's own.
-///
-/// Never narrower than the bar itself: a lane wider than the history area
-/// would otherwise leave nothing to place in, and a pane's own edge is a
-/// better answer than an empty rectangle.
-fn context_bar_bounds(chart: egui::Rect, right_limit: f32, size: egui::Vec2) -> egui::Rect {
-    let right = right_limit
-        .min(chart.right())
-        .max(chart.left() + size.x)
-        .min(chart.right());
-    egui::Rect::from_min_max(chart.min, egui::pos2(right, chart.bottom()))
-}
-
-/// Where the inspector goes, and how wide it may be there.
-///
-/// The width is `Some` only when the panel had to be narrowed to fit a gutter
-/// beside a drawing too big to place around — see [`inspector_placement`].
-#[derive(Debug, Clone, Copy, PartialEq)]
-struct InspectorPlacement {
-    position: egui::Pos2,
-    max_width: Option<f32>,
-}
-
-/// The inspector placement rule (`docs/ux/drawing-tools-2026-08.md` §D3).
-///
-/// The old rule scored least overlap with the object's *bounding box*, and a
-/// small object has a small box: "beside it with a 12 px gap" scored zero and
-/// won, dropping the panel straight onto the price action the trader drew the
-/// line to read. The read is the neighbourhood of the object, not its box.
-///
-/// So the corners come first, and the winner is the **farthest** clear one:
-///
-/// 1. the two **top** corners first, inset by the gap. Top before bottom is
-///    structural, not taste: a panel is positioned by its top-left and grows
-///    downwards, so a top corner always has the whole pane to grow into. A
-///    bottom-anchored panel that turns out taller than the placement assumed
-///    runs off the window and loses its last rows — and rows a trader cannot
-///    reach read as rows that do not exist;
-/// 2. of the two, the one that clears `bbox` and whose centre is farthest
-///    from the object wins, so the panel walks away from the drawing across
-///    the chart. An exact tie (a centred object) takes the left one, so the
-///    panel appears in the same place every time;
-/// 3. only if neither top corner is free, the bottom two on the same rule;
-/// 4. and if every corner is fouled — a large object covering the chart —
-///    the beside-the-object candidates, least overlap first.
-fn inspector_placement(
-    chart: egui::Rect,
-    bbox: egui::Rect,
-    size: egui::Vec2,
-) -> InspectorPlacement {
-    let gap = INSPECTOR_OBJECT_GAP_PX;
-    let top_corners = [
-        egui::pos2(chart.left() + gap, chart.top() + gap),
-        egui::pos2(chart.right() - gap - size.x, chart.top() + gap),
-    ];
-    let bottom_corners = [
-        egui::pos2(chart.left() + gap, chart.bottom() - gap - size.y),
-        egui::pos2(chart.right() - gap - size.x, chart.bottom() - gap - size.y),
-    ];
-    let farthest_clear = |candidates: [egui::Pos2; 2]| {
-        let mut best: Option<(egui::Pos2, f32)> = None;
-        for candidate in candidates {
-            let position = clamp_into_chart(candidate, size, chart);
-            let rect = egui::Rect::from_min_size(position, size);
-            if rect.intersect(bbox).is_positive() {
-                continue;
-            }
-            let distance = rect.center().distance(bbox.center());
-            if best.is_none_or(|(_, best)| distance > best) {
-                best = Some((position, distance));
-            }
-        }
-        best.map(|(position, _)| position)
-    };
-    if let Some(position) = farthest_clear(top_corners).or_else(|| farthest_clear(bottom_corners)) {
-        return InspectorPlacement {
-            position,
-            max_width: None,
-        };
-    }
-    // No corner is clear, which is what a big object — a volume profile, a
-    // range across the whole chart — does to all four of them. The panel then
-    // goes into whichever *gutter* the object leaves beside it, narrowed to
-    // fit, because a settings panel sitting on the drawing it configures is
-    // the one outcome this whole function exists to avoid.
-    //
-    // Horizontal gutters only. Narrowing a panel reflows it and its scroll
-    // area keeps every row reachable; shortening one hides rows, and rows a
-    // trader cannot reach read as rows that do not exist.
-    let left_gutter = bbox.left() - gap - chart.left();
-    let right_gutter = chart.right() - bbox.right() - gap;
-    let (gutter, gutter_left) = if right_gutter >= left_gutter {
-        (right_gutter, bbox.right() + gap)
-    } else {
-        (left_gutter, chart.left() + gap)
-    };
-    if gutter >= INSPECTOR_MIN_WIDTH_PX {
-        let width = gutter.min(size.x);
-        let position = clamp_into_chart(
-            egui::pos2(gutter_left, chart.top() + gap),
-            egui::vec2(width, size.y),
-            chart,
-        );
-        return InspectorPlacement {
-            position,
-            max_width: Some(width),
-        };
-    }
-
-    // The object leaves no strip wide enough to be a panel in. Nothing can be
-    // placed clear of it, and saying so by crowding it least is more honest
-    // than pretending: this is the one case the rule cannot keep.
-    let corners = [top_corners, bottom_corners].concat();
-    let fallbacks = [
-        egui::pos2(bbox.right() + gap, bbox.top()),
-        egui::pos2(bbox.left() - gap - size.x, bbox.top()),
-        egui::pos2(bbox.left(), bbox.bottom() + gap),
-        egui::pos2(bbox.left(), bbox.top() - gap - size.y),
-    ];
-    let mut best: Option<(egui::Pos2, f32, f32)> = None;
-    for candidate in fallbacks.into_iter().chain(corners.iter().copied()) {
-        let position = clamp_into_chart(candidate, size, chart);
-        let rect = egui::Rect::from_min_size(position, size);
-        let overlap = rect.intersect(bbox);
-        let overlap_area = if overlap.is_positive() {
-            overlap.area()
-        } else {
-            0.0
-        };
-        let distance = rect.center().distance(bbox.center());
-        let wins = match &best {
-            None => true,
-            Some((_, best_area, best_distance)) => {
-                overlap_area < *best_area
-                    || (overlap_area == *best_area && distance > *best_distance)
-            }
-        };
-        if wins {
-            best = Some((position, overlap_area, distance));
-        }
-    }
-    InspectorPlacement {
-        position: best.map_or_else(|| chart.left_top(), |(position, _, _)| position),
-        max_width: None,
-    }
 }
 
 /// Split the bottom time strip at the lane's divider: the candles' own time
@@ -942,42 +660,10 @@ pub struct QuantickApp {
     dock: Dock,
     toolrail: ToolRail,
 
-    // Delete confirmation for a locked drawing, shown next to the trigger.
-    drawing_delete_confirm: bool,
-    // Pre-edit copy of the selected drawing while an inspector edit gesture
-    // (slider/color/coordinate drag) is in flight; committed as one undo
-    // entry once pointer and keyboard let go.
-    inspector_edit_baseline: Option<InspectorEdit>,
     /// Floating chrome that owns the state it draws: the assistant's popup,
     /// the acknowledgement toast. One field for the whole set, one module
     /// per surface — see [`crate::surfaces::Surfaces`].
     surfaces: crate::surfaces::Surfaces,
-    // Inspector chrome state: open tab, dock pin, whether the user moved the
-    // floating window this session (manual position wins over placement),
-    // and the selection the last placement was computed for.
-    inspector_tab: InspectorTab,
-    inspector_pinned: bool,
-    /// Whether the floating inspector is open. Selecting a drawing no longer
-    /// opens it: the context bar is what a selection raises, and the gear on
-    /// that bar is the one thing that opens the full panel. The pinned dock
-    /// ignores this — pinning *is* the standing request to keep it open.
-    inspector_open: bool,
-    /// A tool asked for the panel while it was being placed (a text note has
-    /// no words until the panel gives it some).
-    ///
-    /// Separate from `inspector_open` because of frame order: placement runs
-    /// in the canvas pass, and the context bar runs after it and clears
-    /// `inspector_open` on every selection change — including the selection
-    /// the placement just made. The request survives that and is applied on
-    /// the far side of it.
-    pending_open_settings: bool,
-    /// Raised by a placement whose tool holds words: the object just made
-    /// wants the caret. Consumed by [`Self::draw_inline_text_editor`] on the
-    /// same frame, which turns it into `inline_text_edit`.
-    pending_text_edit: bool,
-    /// The `QUANTICK_TEXT_NOTE` hook: place a note and open its editor on the
-    /// first drawn frame. See [`Self::apply_text_note_hook`].
-    pending_text_note: bool,
     /// The `QUANTICK_CONTROL_ACCESS` hook: enable observer access on the
     /// first frame, through the panel button's own `enable`.
     pending_control_access_enable: bool,
@@ -1000,14 +686,6 @@ pub struct QuantickApp {
     /// The `QUANTICK_CONTROL_MARK` hook: take a mark on the first frame,
     /// through the hotkey's own action, with the note the hook carried.
     pending_control_mark: Option<String>,
-    /// The note being typed on the chart — the on-chart editor's whole
-    /// state. See [`InlineTextEdit`].
-    inline_text_edit: Option<InlineTextEdit>,
-    inspector_moved: bool,
-    inspector_last_selection: Option<usize>,
-    /// The selected object's context bar: the floating row of icons that
-    /// opens where the object is.
-    context_bar: drawings::context_bar::ContextBar,
     // The floating inspector's position: automatic placement until the user
     // drags the title bar, manual from then on (only ever re-clamped). The
     // chart rectangle it is placed against belongs to the focused
@@ -1065,7 +743,6 @@ pub struct QuantickApp {
     // placed when the run opens, with the pointer parked where the next one
     // would go. Consumed once.
     pending_drawing_draft: Option<usize>,
-    inspector_pos: Option<egui::Pos2>,
     /// The popup's position changed by hand this frame and the workspace has
     /// not been told yet.
     ///
@@ -1082,39 +759,9 @@ pub struct QuantickApp {
     /// the frame that closes the window flushes this before taking the exit
     /// save, so nothing can be dropped between the two.
     inspector_position_dirty: bool,
-    /// How wide the floating inspector may be where it was placed.
-    ///
-    /// `Some` only when it had to be narrowed into a gutter beside a drawing
-    /// too big to place around; `None` means the usual width range applies.
-    inspector_max_width: Option<f32>,
-    // The floating panel's size as it was last actually drawn. Read back from
-    // the window response rather than from egui's area memory: the memory
-    // lookup is empty on the frame the panel is being laid out, which is
-    // exactly the frame the placement and the clamp need a size.
-    inspector_size: Option<egui::Vec2>,
-    // Whether the user ever toggled the pin — the auto-pin width rule stops
-    // firing once they have expressed a preference.
-    inspector_pin_touched: bool,
-    // Set on the unpin frame: the side panel still occupies that frame's
-    // layout, so the floating host waits one frame and places against the
-    // settled chart instead of the pinned-era geometry.
-    inspector_settle_frame: bool,
-    drawing_manager_open: bool,
-    // Last frame's open state: the manager places itself beside the rail on
-    // the frame it opens, and only then.
-    drawing_manager_was_open: bool,
-    // The manager's delete-all confirmation row is showing (audit M7): the
-    // one command that removes locked objects too, so it is never one click.
-    drawing_manager_confirm_delete_all: bool,
     // Custom drawing presets (named payload exports + default-for-new),
     // persisted across restarts in a versioned file.
     drawing_presets: drawings::presets::PresetStore,
-    #[cfg(test)]
-    inspector_pin_rect: Option<egui::Rect>,
-    #[cfg(test)]
-    context_bar_rect: Option<egui::Rect>,
-    #[cfg(test)]
-    manager_action_rects: Vec<(usize, &'static str, egui::Rect)>,
 
     // Layer visibility (the right-click menu on a pane's canvas). The layers
     // belong to the pane that draws them; what lives here is where the choices
@@ -1332,19 +979,6 @@ pub struct QuantickApp {
     last_summary: Instant,
 }
 
-/// A drawing edit in flight, with the pane it was captured on.
-///
-/// The commit has to land on *that* pane: focus legitimately moves when the
-/// user clicks the other chart or another tab, and the index alone addresses
-/// a different object there. Pairing the baseline with its owner is what
-/// keeps one gesture one undo entry on one drawing.
-struct InspectorEdit {
-    tab: u64,
-    side: PaneSide,
-    index: usize,
-    before: drawings::Drawing,
-}
-
 /// An indicator slot together with the tab and pane that own it.
 ///
 /// Slot ids are allocated per pane, so the id alone identifies nothing once
@@ -1487,15 +1121,7 @@ impl QuantickApp {
             ),
             dock: Dock::new(),
             toolrail: ToolRail::new(),
-            drawing_delete_confirm: false,
-            inspector_edit_baseline: None,
             surfaces: crate::surfaces::Surfaces::default(),
-            inspector_tab: InspectorTab::default(),
-            inspector_pinned: false,
-            inspector_open: false,
-            pending_open_settings: false,
-            pending_text_edit: false,
-            pending_text_note: false,
             pending_control_access_enable: false,
             operator_slots: std::collections::BTreeSet::new(),
             pending_control_annotation: None,
@@ -1503,10 +1129,6 @@ impl QuantickApp {
             pending_control_evidence: None,
             control_evidence_hook_frames: 0,
             pending_control_mark: None,
-            inline_text_edit: None,
-            inspector_moved: false,
-            inspector_last_selection: None,
-            context_bar: drawings::context_bar::ContextBar::default(),
             pending_drawing_demo: false,
             pending_load_older: None,
             pending_load_older_candles: None,
@@ -1516,24 +1138,10 @@ impl QuantickApp {
             pending_replay_restart: None,
             pending_venue_history_demo: None,
             pending_drawing_draft: None,
-            inspector_pos: None,
             inspector_position_dirty: false,
-            inspector_max_width: None,
-            inspector_size: None,
-            inspector_pin_touched: false,
-            inspector_settle_frame: false,
-            drawing_manager_open: false,
-            drawing_manager_was_open: false,
-            drawing_manager_confirm_delete_all: false,
             drawing_presets: drawings::presets::PresetStore::load_from(
                 drawings::presets::PresetStore::default_path(),
             ),
-            #[cfg(test)]
-            inspector_pin_rect: None,
-            #[cfg(test)]
-            context_bar_rect: None,
-            #[cfg(test)]
-            manager_action_rects: Vec::new(),
             chart_layers_path: chart_layers::default_path(),
             saved_layer_mask: 0,
             saved_layer_tab: 0,
@@ -1729,11 +1337,6 @@ impl QuantickApp {
         if let Ok(family_id) = std::env::var("QUANTICK_TOOLBOX_FLYOUT") {
             app.toolrail.request_flyout(family_id.trim().to_owned());
         }
-        // The on-chart note editor exists only between a placement and the
-        // first click elsewhere, so no click-free launch could photograph it
-        // without a hook — the same gap `QUANTICK_DRAWING_DRAFT` fills for a
-        // half-placed object.
-        app.pending_text_note = std::env::var("QUANTICK_TEXT_NOTE").is_ok_and(|value| value == "1");
         app.pending_drawing_demo = std::env::var("QUANTICK_DRAWINGS_DEMO")
             .is_ok_and(|value| matches!(value.as_str(), "1" | "bands"));
         // The replay seek, scripted: restart the recording once the session
@@ -1872,57 +1475,6 @@ impl QuantickApp {
                 "partial" => Some(VenueHistoryDemo::Partial),
                 _ => None,
             });
-        // The object manager is where a mark that cannot be trusted says so —
-        // the "off series", "other market" and band badges live there, and a
-        // mark clamped to an edge may be nowhere near the visible window,
-        // making the list the only place it can be found. Reachable from a
-        // launch, like every other surface, or it cannot be checked without a
-        // mouse.
-        app.drawing_manager_open =
-            std::env::var("QUANTICK_DRAWINGS_MANAGER").is_ok_and(|value| value == "1");
-        // The context bar only exists while something is selected, so the
-        // hook that reaches it is a hook that *selects*: pair it with
-        // QUANTICK_DRAWINGS_DEMO_SELECT. This one opens the panel behind the
-        // gear on top, which is the state a screenshot cannot otherwise
-        // reach without a click.
-        app.inspector_open =
-            std::env::var("QUANTICK_DRAWING_INSPECTOR").is_ok_and(|value| value == "1");
-        // The trader's own drag, scripted: `x,y` in screen points parks the
-        // properties popup exactly as a hand on the title bar would, through
-        // that gesture's own function. Without it the remembered position is
-        // unreachable from a launch — a drag is the only way to set one, and a
-        // capture run has no hand. Nonsense is refused rather than guessed, so
-        // a typo photographs automatic placement instead of an invented pixel.
-        // Which tab the panel opens on. The panel is one hook away, but its
-        // tool-owned tab — where a Fib's levels and colours are built, and
-        // where the two default controls sit — is a click deeper, and a
-        // capture has no hand for it.
-        if let Ok(tab) = std::env::var("QUANTICK_DRAWING_INSPECTOR_TAB") {
-            match tab.trim() {
-                "style" => app.inspector_tab = InspectorTab::Style,
-                "extra" => app.inspector_tab = InspectorTab::Extra,
-                "coordinates" => app.inspector_tab = InspectorTab::Coordinates,
-                // Refused rather than guessed: a typo shows the default tab,
-                // never a confident capture of the wrong one.
-                other => tracing::warn!(tab = other, "unknown drawing inspector tab"),
-            }
-        }
-        if let Some(position) = std::env::var("QUANTICK_DRAWING_INSPECTOR_POS")
-            .ok()
-            .and_then(|value| parse_point(&value))
-        {
-            app.place_inspector_by_hand(position);
-        }
-        // And the same drag on the context bar, which now keeps its position
-        // across selections too. Its own gesture is the grip, and a capture
-        // run has no more hand for that one than for the title bar.
-        if let Some(position) = std::env::var("QUANTICK_CONTEXT_BAR_POS")
-            .ok()
-            .and_then(|value| parse_point(&value))
-        {
-            app.context_bar.set_manual(position);
-        }
-
         // Same convenience for the aggression layer (bubbles + the live
         // column's footprint). Same code path as the toolbar toggle.
         if std::env::var("QUANTICK_BUBBLES_AUTOSTART").is_ok_and(|value| value == "1") {
@@ -2953,9 +2505,8 @@ impl QuantickApp {
     /// every pane one can reach — an assistant may annotate any open tab, so
     /// counting the active pane alone would offer to take back a subset and
     /// call it all of them.
-    fn authored_object_count(&self) -> usize {
-        self.tabs
-            .iter()
+    fn authored_object_count(tabs: &[Tab]) -> usize {
+        tabs.iter()
             .map(|tab| {
                 tab.panes()
                     .map(|(pane, _side)| pane.drawings.authored_count())
@@ -4882,7 +4433,9 @@ impl QuantickApp {
             self.history_reach = reach;
         }
         self.venue_lead_in = chrome.venue_lead_in;
-        self.restore_inspector_position(chrome.inspector_position);
+        self.surfaces
+            .drawing_chrome
+            .restore_inspector_position(chrome.inspector_position);
     }
 
     /// The tabs and the chrome as they stand — the part a startup workspace
@@ -4945,7 +4498,7 @@ impl QuantickApp {
             history_reach: (self.history_reach != crate::history_reach::HistoryReach::default())
                 .then(|| self.history_reach.token().to_owned()),
             venue_lead_in: self.venue_lead_in,
-            inspector_position: self.remembered_inspector_position(),
+            inspector_position: self.surfaces.drawing_chrome.remembered_inspector_position(),
         };
         (tabs, chrome)
     }
@@ -5467,7 +5020,7 @@ impl QuantickApp {
         let Some(chrome) = file.chrome.as_mut() else {
             return false;
         };
-        let position = self.remembered_inspector_position();
+        let position = self.surfaces.drawing_chrome.remembered_inspector_position();
         if chrome.inspector_position == position {
             return false;
         }
@@ -7088,7 +6641,7 @@ impl QuantickApp {
         });
         match self.drawing_pane_mut().drawings.delete_selected(false) {
             DeleteOutcome::Deleted => {
-                self.drawing_delete_confirm = false;
+                self.surfaces.drawing_chrome.set_delete_confirm(false);
                 // The instance dies with its drawing, immediately — not on
                 // the next closed bar, which a quiet tape may never bring.
                 if let Some((id, _)) = &doomed {
@@ -7101,7 +6654,9 @@ impl QuantickApp {
                 );
                 self.surfaces.toast.note_with_undo(message, now);
             }
-            DeleteOutcome::NeedsConfirmation => self.drawing_delete_confirm = true,
+            DeleteOutcome::NeedsConfirmation => {
+                self.surfaces.drawing_chrome.set_delete_confirm(true);
+            }
             DeleteOutcome::NothingSelected => {}
         }
     }
@@ -7172,8 +6727,8 @@ impl QuantickApp {
                 // dropped; nothing else loses state on this press. Only the
                 // active tab can have one in flight — a background tab has
                 // no pointer over it to arm or grab with.
-            } else if self.drawing_delete_confirm {
-                self.drawing_delete_confirm = false;
+            } else if self.surfaces.drawing_chrome.delete_confirm() {
+                self.surfaces.drawing_chrome.set_delete_confirm(false);
             } else if self.inline_text_editing().is_some() {
                 // A note being typed is its own layer, and it has to be one:
                 // egui clears widget focus at the top of the frame Escape
@@ -7256,484 +6811,182 @@ impl QuantickApp {
         }
     }
 
-    /// Commit a pending inspector edit gesture as one undo entry.
-    fn commit_inspector_gesture(&mut self) {
-        let Some(edit) = self.inspector_edit_baseline.take() else {
-            return;
-        };
-        // The pane the edit started on. Its tab may have been closed under the
-        // gesture, in which case the object it described is gone with it.
-        if let Some(tab) = self.tabs.iter_mut().find(|tab| tab.id == edit.tab) {
-            tab.pane_mut(edit.side)
-                .drawings
-                .record_edit_of(edit.index, edit.before);
-        }
-    }
-
-    /// The inspector's title bar, shared by both hosts: grip + title, then
-    /// the view controls (hide, pin, close) as icon buttons. In the floating
-    /// host the whole bar is the drag surface — the body never is, so a
-    /// slider drag can never move the window; double-click re-runs the
-    /// automatic placement.
-    fn draw_inspector_title_bar(
+    /// Record one edit gesture as the single undo entry it earned, on the pane
+    /// it started on.
+    ///
+    /// That pane's tab may have been closed under the gesture, in which case
+    /// the object it described is gone with it.
+    fn record_drawing_edit(
         &mut self,
-        ui: &mut egui::Ui,
+        tab_id: u64,
+        side: PaneSide,
         index: usize,
-        floating: bool,
-    ) -> InspectorActions {
-        let mut actions = InspectorActions::default();
-        let drawing = &self.drawing_pane().drawings.items()[index];
-        let hidden = drawing.hidden;
-        // The band belongs in the title, because that is where "which of
-        // these two trend lines am I editing" is actually asked. Nothing is
-        // added on the price band: it is where drawings have always lived,
-        // and a suffix on every object would be noise.
-        let title = match self.focused_pane().band_label(drawing).chip() {
-            Some(band) => format!("{} · {band}", drawing.tool.settings_title()),
-            None => drawing.tool.settings_title().to_owned(),
-        };
-        let sense = if floating {
-            egui::Sense::click_and_drag()
-        } else {
-            egui::Sense::hover()
-        };
-        let (bar_rect, bar) = ui.allocate_exact_size(
-            egui::vec2(ui.available_width(), INSPECTOR_TITLE_HEIGHT_PX),
-            sense,
-        );
-        if ui.is_rect_visible(bar_rect) {
-            let painter = ui.painter();
-            if floating {
-                painter.text(
-                    egui::pos2(
-                        bar_rect.left() + INSPECTOR_TITLE_PAD_X_PX,
-                        bar_rect.center().y,
-                    ),
-                    egui::Align2::LEFT_CENTER,
-                    icons::DOTS_SIX_VERTICAL,
-                    egui::FontId::proportional(INSPECTOR_TITLE_GRIP_GLYPH_PX),
-                    theme::TEXT_FAINT,
-                );
-            }
-            let title_x = if floating {
-                INSPECTOR_TITLE_TEXT_X_PX
-            } else {
-                INSPECTOR_TITLE_PAD_X_PX
-            };
-            painter.text(
-                egui::pos2(bar_rect.left() + title_x, bar_rect.center().y),
-                egui::Align2::LEFT_CENTER,
-                title,
-                egui::FontId::proportional(INSPECTOR_TITLE_TEXT_PX),
-                theme::TEXT_PRIMARY,
-            );
+        before: drawings::Drawing,
+    ) {
+        if let Some(tab) = self.tabs.iter_mut().find(|tab| tab.id == tab_id) {
+            tab.pane_mut(side).drawings.record_edit_of(index, before);
         }
-        // The controls are registered after the bar, so they win its pointer.
-        ui.allocate_new_ui(egui::UiBuilder::new().max_rect(bar_rect), |ui| {
-            ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                let close = IconButton::new(icons::X, TOOLBAR_ICON)
-                    .hover_text("Close - keeps the drawing, clears the selection")
-                    .show(ui);
-                if close.clicked() {
-                    actions.close = true;
-                }
-                let pin_hover = if self.inspector_pinned {
-                    "Unpin - float the inspector over the chart"
-                } else {
-                    "Pin - dock the inspector at the side of the chart"
-                };
-                let pin = IconButton::new(icons::PUSH_PIN, TOOLBAR_ICON)
-                    .active(self.inspector_pinned)
-                    .hover_text(pin_hover)
-                    .show(ui);
-                #[cfg(test)]
-                {
-                    self.inspector_pin_rect = Some(pin.rect);
-                }
-                if pin.clicked() {
-                    actions.toggle_pin = true;
-                }
-                let eye_icon = if hidden { icons::EYE_SLASH } else { icons::EYE };
-                let eye_hover = if hidden {
-                    "Show this drawing again"
-                } else {
-                    "Hide this drawing - the inspector keeps the way back"
-                };
-                let eye = IconButton::new(eye_icon, TOOLBAR_ICON)
-                    .active(hidden)
-                    .hover_text(eye_hover)
-                    .show(ui);
-                if eye.clicked() {
-                    actions.toggle_hidden = true;
-                }
-            });
-        });
-        if floating {
-            let bar = bar.on_hover_text("Drag to move · double-click to reposition automatically");
-            if bar.double_clicked() {
-                // The reset path: back to automatic placement.
-                self.inspector_moved = false;
-                let placed = self.inspector_target_placement(ui.ctx(), index);
-                self.inspector_pos = placed.map(|placed| placed.position);
-                self.inspector_max_width = placed.and_then(|placed| placed.max_width);
-                // Giving the placement back is a decision too, and it has to
-                // reach the file: a reset that lived only until the next launch
-                // would hand the trader back the very position they discarded.
-                self.inspector_position_dirty = true;
-            } else if bar.dragged() {
-                // The gesture starts from where the window actually is, in
-                // preference to where it is remembered: the two differ
-                // whenever the pane is too small for the parked point and the
-                // host is drawing a clamped copy. Dragging the clamped window
-                // from the un-clamped point would make it jump the whole
-                // difference on the first pixel — and the trader is dragging
-                // what they can see.
-                if bar.drag_started()
-                    && let Some(drawn) = ui
-                        .ctx()
-                        .memory(|memory| memory.area_rect(egui::Id::new("drawing_inspector")))
-                        .map(|rect| rect.min)
-                {
-                    self.inspector_pos = Some(drawn);
-                }
-                // From there the delta accumulates on the *remembered* point,
-                // never on the drawn one. The window is positioned from
-                // `inspector_pos` before this bar is laid out, so the drawn
-                // rect is always one frame behind it: adding this frame's
-                // delta to that rect throws the previous frame's away, and
-                // the popup travels at half the speed of the hand — which is
-                // what "ela treme" was, reported from the running app.
-                match self.inspector_pos {
-                    Some(position) => self.place_inspector_by_hand(position + bar.drag_delta()),
-                    // No position to move yet — the window has not been laid
-                    // out. The hand is still down, so the flag alone records
-                    // that placement is no longer the app's to decide.
-                    None => self.inspector_moved = true,
-                }
-            }
-            // Written when the hand comes off the window, not while it is still
-            // moving: one file write per gesture, and the position it records
-            // is the one the trader stopped at.
-            if bar.drag_stopped() {
-                self.inspector_position_dirty = true;
-            }
-        }
-        ui.separator();
-        actions
     }
 
-    /// Everything the inspector shows for the selected object, shared by the
-    /// floating window and the pinned dock panel. Sections are driven by the
-    /// tool's capabilities — an unsupported property is absent, not disabled.
-    fn drawing_inspector_body(&mut self, ui: &mut egui::Ui, index: usize) -> InspectorActions {
-        let mut actions = InspectorActions::default();
-        let drawing = &self.drawing_pane().drawings.items()[index];
-        let tool = drawing.tool;
-        let locked = drawing.locked;
-        let hidden = drawing.hidden;
-        let author = drawing.author.as_ref().map(DrawingAuthor::label);
-        let shareable = drawing.shareable();
-        let mut shared = drawing.scope == drawings::DrawingScope::AllCharts;
-        let show_confirm = self.drawing_delete_confirm && locked;
-
-        // The always-visible textual actions (UX spec: never glyph-only,
-        // never behind a scroll). Identity and the view controls live in the
-        // host's title bar, not here.
-        let intent = drawings::action_bar::draw(ui, locked);
-        actions.toggle_lock |= intent.toggle_lock;
-        actions.delete |= intent.delete;
-
-        if let Some(author) = &author {
-            // Data honesty, where the trader decides what to do with the
-            // object: an assistant's mark never passes for their own.
-            ui.label(
-                egui::RichText::new(format!("Placed by {author} - not by you."))
-                    .small()
-                    .color(theme::TEXT_SUPPORT),
-            );
-        }
-        if locked {
-            ui.label(
-                egui::RichText::new(
-                    "Locked - protected from accidental moves. Style stays editable.",
-                )
-                .small()
-                .color(theme::TEXT_SUPPORT),
-            );
-        }
-        if hidden {
-            ui.label(
-                egui::RichText::new("Hidden - Show brings it back.")
-                    .small()
-                    .color(theme::TEXT_SUPPORT),
-            );
-        }
-        // Where the object appears. Always visible, never behind a tab.
-        //
-        // It used to live on the Coordinates tab, because sharing is a
-        // statement about the anchors — which is the implementer's mental
-        // model, not the trader's. Nobody hunting for "also show this on the
-        // other chart" opens a tab called Coordinates, and that is not even
-        // the tab the panel opens on. Reported as unfindable, and it was.
-        ui.separator();
-        let sharing = ui.add_enabled(
-            shareable,
-            egui::Checkbox::new(&mut shared, "Show on all charts"),
-        );
-        if sharing.changed()
-            && let Some(drawing) = self.drawing_pane_mut().drawings.selected_mut()
-        {
-            drawing.scope = if shared {
-                drawings::DrawingScope::AllCharts
-            } else {
-                drawings::DrawingScope::ThisChart
-            };
-            actions.edited = true;
-        }
-        // A disabled control with no reason reads as a bug.
-        let sharing_hint = if shareable {
-            "The other chart of this tab draws it at the same moment in market time"
-        } else {
-            "This drawing has an anchor past the newest bar, so there is no market time to place              it by on another chart"
-        };
-        sharing.on_hover_text(sharing_hint);
-        if !shareable {
-            ui.label(
-                egui::RichText::new(sharing_hint)
-                    .small()
-                    .color(theme::TEXT_SUPPORT),
-            );
-        }
-
-        if show_confirm {
-            ui.separator();
-            ui.label("Delete locked drawing?");
-            ui.horizontal(|ui| {
-                if ui.button("Cancel").clicked() {
-                    actions.cancel_delete = true;
-                }
-                if ui.button("Delete anyway").clicked() {
-                    actions.force_delete = true;
-                }
-            });
-        }
-        ui.separator();
-
-        if self.inspector_tab == InspectorTab::Extra && tool.extra_tab().is_none() {
-            // The previous selection had an extra tab; this tool brings none.
-            self.inspector_tab = InspectorTab::Style;
-        }
-        ui.horizontal(|ui| {
-            ui.selectable_value(&mut self.inspector_tab, InspectorTab::Style, "Style");
-            // A tool that brings its own tab (the Fib level editor) mounts it
-            // here by name; the central code never learns what is inside.
-            if let Some(extra) = tool.extra_tab() {
-                ui.selectable_value(&mut self.inspector_tab, InspectorTab::Extra, extra);
-            }
-            ui.selectable_value(
-                &mut self.inspector_tab,
-                InspectorTab::Coordinates,
-                "Coordinates",
-            );
-        });
-        ui.separator();
-
-        let tab = self.inspector_tab;
-        let price_speed = self.drawing_pane().last_auto_range.map_or(1.0, |(lo, hi)| {
-            ((hi - lo) / PRICE_DRAG_STEPS).abs().max(1e-9)
-        });
-        let side = self.active_tab().drawing_side();
+    /// Put the caret in a note, on the chart — the one call that opens the
+    /// editor, whether a placement, a double click or a script asked for it.
+    ///
+    /// The surface decides whether the caret is allowed: an object that holds
+    /// no words, or a locked one, refuses it, because an editor that opened and
+    /// then dropped every keystroke would be worse than none. The store command
+    /// and the per-pane stand-down are the host's, so they happen here.
+    pub fn begin_inline_text_edit(&mut self, index: usize) -> bool {
         let Self {
             tabs,
             active_tab,
-            drawing_presets,
+            surfaces,
             ..
         } = self;
-        let drawings = &mut tabs[*active_tab].pane_mut(side).drawings;
-        let Some(drawing) = drawings.selected_mut() else {
-            return actions;
+        let tab = &tabs[*active_tab];
+        let side = tab.drawing_side();
+        let Some(drawing) = tab.pane(side).drawings.items().get(index) else {
+            return false;
         };
-        match tab {
-            InspectorTab::Extra => {
-                actions.edited |= tool.draw_extra_tab(ui, drawing, drawing_presets);
-            }
-            InspectorTab::Style => {
-                ui.label("Style");
-                actions.edited |= ui
-                    .color_edit_button_srgba(&mut drawing.style.color)
-                    .changed();
-                // Capability-driven, like the fill slider below: a tool with
-                // no stroke has no line width, and the repo's rule is that an
-                // unsupported property is *absent*, not present and inert.
-                // Caught by the visual pass — the text note's Style tab was
-                // offering a slider that moved nothing.
-                if tool.supports_stroke_width() {
-                    actions.edited |= ui
-                        .add(
-                            egui::Slider::new(
-                                &mut drawing.style.width_px,
-                                MIN_DRAWING_WIDTH_PX..=MAX_DRAWING_WIDTH_PX,
-                            )
-                            .text("line width (px)"),
-                        )
-                        .changed();
-                }
-                if tool.supports_fill() {
-                    actions.edited |= ui
-                        .add(
-                            egui::Slider::new(
-                                &mut drawing.style.fill_alpha,
-                                0..=MAX_DRAWING_FILL_ALPHA,
-                            )
-                            .text("fill opacity"),
-                        )
-                        .changed();
-                }
-
-                // Stop asking for the same look every single time. Every tool
-                // has a Style tab, so every tool gets this — the named-preset
-                // editor only ever existed on the Fib tab, which left fifteen
-                // tools with no way to remember anything.
-                //
-                // New objects only: a default that repainted the marks already
-                // on the chart would be a bulk edit nobody asked for.
-                ui.separator();
-                ui.label(egui::RichText::new("Default for new drawings").small());
-                ui.horizontal(|ui| {
-                    let style = drawing.style;
-                    if ui
-                        .button("Save as default")
-                        .on_hover_text(format!(
-                            "New {} objects open configured exactly like this one",
-                            tool.name().to_lowercase()
-                        ))
-                        .clicked()
-                    {
-                        drawings::save_tool_default(drawing_presets, drawing);
-                        actions.saved_default = Some(SavedDefault::OneTool);
-                    }
-                    // Style only, and that is not a shortcut: a Fib's level
-                    // list means nothing to a rectangle, so the one property
-                    // every tool shares is the only one this can carry.
-                    if ui
-                        .button("Colour on all tools")
-                        .on_hover_text("Every new drawing opens with this colour, width and fill")
-                        .clicked()
-                    {
-                        for other in drawings::DRAWING_TOOLS {
-                            drawing_presets.set_default_style(other.id(), Some(style));
-                        }
-                        actions.saved_default = Some(SavedDefault::EveryTool);
-                    }
-                    if drawings::has_saved_default(drawing_presets, tool)
-                        && ui
-                            .button("Reset to factory")
-                            .on_hover_text(format!(
-                                concat!(
-                                    "New {} objects go back to how they opened ",
-                                    "out of the box. Clears the default preset ",
-                                    "choice too; saved presets are kept"
-                                ),
-                                tool.name().to_lowercase()
-                            ))
-                            .clicked()
-                    {
-                        drawings::reset_tool_default(drawing_presets, tool);
-                        actions.saved_default = Some(SavedDefault::Forgotten);
-                    }
-                });
-            }
-            InspectorTab::Coordinates => {
-                // Geometry through numbers: bar index and price per anchor,
-                // the same canonical coordinates drags write. Locked blocks
-                // geometry here exactly as it does on the canvas.
-                const ANCHOR_LABELS: [&str; 4] = ["A", "B", "C", "D"];
-                ui.add_enabled_ui(!locked, |ui| {
-                    for (point_index, point) in drawing.points.iter_mut().enumerate() {
-                        ui.horizontal(|ui| {
-                            ui.label(ANCHOR_LABELS.get(point_index).copied().unwrap_or("?"));
-                            actions.edited |= ui
-                                .add(
-                                    egui::DragValue::new(&mut point.bar)
-                                        .speed(BAR_DRAG_SPEED)
-                                        .prefix("bar "),
-                                )
-                                .changed();
-                            actions.edited |= ui
-                                .add(egui::DragValue::new(&mut point.price).speed(price_speed))
-                                .changed();
-                        });
-                    }
-                });
-                if locked {
-                    ui.label(
-                        egui::RichText::new("Unlock the drawing to edit its coordinates.").small(),
-                    );
-                }
-            }
+        if !surfaces
+            .drawing_chrome
+            .begin_inline_text_edit(tab.id, side, index, drawing)
+        {
+            return false;
         }
-        actions
+        self.drawing_pane_mut().drawings.select(Some(index));
+        self.sync_content_editing();
+        true
     }
 
-    /// Apply what the inspector body asked for, with the shared undo
-    /// coalescing: the pre-edit object is captured at the first change and
-    /// committed once pointer and keyboard let go.
-    fn apply_inspector_actions(
+    /// Close the editor, keeping whatever was typed and recording it as the one
+    /// edit it was — on the pane the note actually lives on, which is not
+    /// necessarily the one in front when it closes.
+    fn end_inline_text_edit(&mut self) {
+        if let Some(edit) = self.surfaces.drawing_chrome.end_inline_text_edit() {
+            self.record_drawing_edit(edit.tab, edit.side, edit.index, edit.before);
+        }
+        self.sync_content_editing();
+    }
+
+    /// Tell every pane whether one of its objects is having its content typed
+    /// somewhere else on screen, so exactly one object anywhere stands down.
+    ///
+    /// Every pane, not just the one in front: the flag is what suppresses the
+    /// object's own painting, and a pane left holding a stale index would keep
+    /// a note invisible for the rest of the session with no way back.
+    fn sync_content_editing(&mut self) {
+        let editing = self.surfaces.drawing_chrome.content_editing_target();
+        for tab in &mut self.tabs {
+            let target = editing
+                .filter(|(id, _, _)| *id == tab.id)
+                .map(|(_, side, index)| (side, index));
+            tab.set_content_editing(target);
+        }
+    }
+
+    /// Which note is being typed on the chart right now — what a second
+    /// operator reads to know the keyboard belongs to an object.
+    #[must_use]
+    pub fn inline_text_editing(&self) -> Option<usize> {
+        self.surfaces.drawing_chrome.inline_text_editing()
+    }
+
+    /// The rows the object manager lists.
+    ///
+    /// A row's facts come from the drawing, the pane's band registry and the
+    /// tab's layout, and assembling them here is what keeps the manager from
+    /// needing all three. Built only while the window is open, like the market
+    /// dialog's list of open markets: a dozen short strings once a frame, on a
+    /// window that is shut the rest of the session.
+    fn drawing_manager_rows(&self) -> Vec<crate::surfaces::drawing_chrome::ManagerRow> {
+        let pane = self.drawing_pane();
+        let selected = pane.drawings.selected();
+        let focused = self.focused_pane();
+        pane.drawings
+            .items()
+            .iter()
+            .enumerate()
+            .map(
+                |(index, drawing)| crate::surfaces::drawing_chrome::ManagerRow {
+                    name: drawing.display_label(index),
+                    selected: selected == Some(index),
+                    locked: drawing.locked,
+                    hidden: drawing.hidden,
+                    shared: drawing.scope == drawings::DrawingScope::AllCharts,
+                    off_series: drawing.off_series,
+                    foreign_market: drawing.foreign_market,
+                    author: drawing.author.as_ref().map(DrawingAuthor::label),
+                    band: focused.band_label(drawing),
+                },
+            )
+            .collect()
+    }
+
+    /// Where the selected object is painted, and what the band it lives on is
+    /// called: the two answers the chrome cannot work out for itself, because
+    /// both need the viewport and the price scale the host owns.
+    ///
+    /// Nothing is projected and no name is formatted while nothing is selected,
+    /// which is every frame of an ordinary session.
+    fn selected_drawing_geometry(&self) -> (Option<egui::Rect>, Option<String>) {
+        let pane = self.drawing_pane();
+        let Some(index) = pane.drawings.selected() else {
+            return (None, None);
+        };
+        let bbox = pane
+            .last_chart_area
+            .and_then(|chart| self.drawing_bbox_on_screen(chart, index));
+        let band = pane
+            .drawings
+            .items()
+            .get(index)
+            .and_then(|drawing| self.focused_pane().band_label(drawing).chip());
+        (bbox, band)
+    }
+
+    /// Carry out what the drawing chrome asked for.
+    ///
+    /// One applier for all four pieces, in the order the trunk applied them
+    /// when each drew itself: the edit lands before the gesture that coalesces
+    /// it is committed, and both land before anything that can delete the
+    /// object they describe.
+    fn apply_drawing_chrome(
         &mut self,
-        ctx: &egui::Context,
-        actions: InspectorActions,
-        index: usize,
-        before: drawings::Drawing,
+        ask: crate::surfaces::drawing_chrome::DrawingChromeAsk,
         now: Instant,
     ) {
-        if actions.edited && self.inspector_edit_baseline.is_none() {
-            self.inspector_edit_baseline = Some(InspectorEdit {
-                tab: self.active_tab().id,
-                side: self.active_tab().focused_side(),
-                index,
-                before,
-            });
+        if let Some(edited) = ask.edited {
+            // Through the selection, never `items_mut`: that hatch is
+            // documented for derived-state refresh only, and a style or a
+            // note's words take part in payload equality — writing them through
+            // it would let an unrelated in-flight gesture swallow this edit.
+            if let Some(drawing) = self.drawing_pane_mut().drawings.selected_mut() {
+                *drawing = *edited;
+            }
         }
-        let gesture_settled = ctx.input(|input| !input.pointer.any_down())
-            && ctx.memory(|memory| memory.focused().is_none());
-        if gesture_settled {
-            self.commit_inspector_gesture();
+        if let Some(edit) = ask.commit_edit_gesture {
+            self.record_drawing_edit(edit.tab, edit.side, edit.index, edit.before);
         }
-        if actions.toggle_hidden {
+        if ask.toggle_selected_hidden
+            && let Some(index) = self.drawing_pane().drawings.selected()
+        {
             let hidden = self.drawing_pane().drawings.items()[index].hidden;
             self.drawing_pane_mut()
                 .drawings
                 .set_selected_hidden(!hidden);
         }
-        if actions.toggle_lock {
+        if ask.toggle_selected_locked
+            && let Some(index) = self.drawing_pane().drawings.selected()
+        {
             let locked = self.drawing_pane().drawings.items()[index].locked;
             self.drawing_pane_mut()
                 .drawings
                 .set_selected_locked(!locked);
-            self.drawing_delete_confirm = false;
         }
-        if actions.toggle_pin {
-            self.inspector_pinned = !self.inspector_pinned;
-            // The user has expressed a preference: the auto-pin width rule
-            // stops firing for the rest of the session.
-            self.inspector_pin_touched = true;
-            if !self.inspector_pinned {
-                // Unpinning re-opens the floating window. The pinned host
-                // has been claiming the selection each frame, so treat it
-                // as fresh again — otherwise automatic placement never runs
-                // and the window falls back to the fixed default corner.
-                self.inspector_last_selection = None;
-                self.inspector_settle_frame = true;
-            }
-        }
-        if actions.delete {
+        if ask.request_delete {
             self.request_delete_selected(now);
         }
-        if actions.cancel_delete {
-            self.drawing_delete_confirm = false;
-        }
-        if actions.force_delete {
-            self.drawing_delete_confirm = false;
+        if ask.force_delete {
             let doomed = {
                 let pane = self.drawing_pane();
                 pane.drawings
@@ -7748,109 +7001,202 @@ impl QuantickApp {
                 self.surfaces.toast.note_with_undo("Drawing deleted.", now);
             }
         }
-        if actions.close {
-            // Closing the panel is now a smaller act than it used to be: it
-            // puts the trader back on the context bar, with the object still
-            // selected. Clearing the selection here would make the X the
-            // only control that answers a bigger question than it asks.
-            self.inspector_open = false;
-            if self.inspector_pinned {
-                self.inspector_pinned = false;
-                self.inspector_pin_touched = true;
-            }
-            self.drawing_delete_confirm = false;
+        if ask.duplicate {
+            self.duplicate_selected_drawing();
         }
-        if let Some(saved) = actions.saved_default {
+        if let Some(saved) = ask.saved_default {
             // Nothing to undo: this changed a preference, not the chart.
             self.surfaces.toast.note(saved.message(), now);
         }
-    }
-
-    /// Where a freshly opened floating inspector should sit, and how wide it
-    /// may be there: the farthest chart corner that clears the object, then a
-    /// gutter beside it narrowed to fit — see [`inspector_placement`]. The
-    /// chart pane already excludes both axes and the live lane, so the popup
-    /// can never cover them or leave the view.
-    fn inspector_target_placement(
-        &self,
-        ctx: &egui::Context,
-        index: usize,
-    ) -> Option<InspectorPlacement> {
-        let chart = self.drawing_pane().last_chart_area?;
-        let bbox = self.drawing_bbox_on_screen(chart, index)?;
-        Some(inspector_placement(chart, bbox, self.inspector_size(ctx)))
-    }
-
-    /// How big the floating inspector is, best answer available: the size it
-    /// was last drawn at, then egui's area memory, then the assumed default.
-    fn inspector_size(&self, ctx: &egui::Context) -> egui::Vec2 {
-        self.inspector_size
-            .or_else(|| {
-                ctx.memory(|memory| memory.area_rect(egui::Id::new("drawing_inspector")))
-                    .map(|rect| rect.size())
-            })
-            .unwrap_or(egui::vec2(
-                INSPECTOR_DEFAULT_WIDTH_PX,
-                INSPECTOR_FALLBACK_HEIGHT_PX,
-            ))
-    }
-
-    /// Park the properties popup where a hand put it: the position every later
-    /// selection reopens on, and the one the workspace records.
-    ///
-    /// The single door for all three callers — the title-bar drag, the harness
-    /// hook and a restored workspace — because the state is a *pair*. Setting
-    /// the position without the flag leaves automatic placement free to
-    /// overwrite it on the next selection; setting the flag without a position
-    /// pins the window to wherever it happens to be. Neither half is a state
-    /// worth being able to reach.
-    ///
-    /// The gutter width goes with it. `inspector_max_width` is set only by
-    /// automatic placement, to squeeze the panel into the strip beside a
-    /// drawing too big to place around — and automatic placement never runs
-    /// again once a hand has placed the window. Left behind, it would hold the
-    /// popup at a gutter's width out in open canvas for the rest of the
-    /// session, with nothing able to clear it.
-    fn place_inspector_by_hand(&mut self, position: egui::Pos2) {
-        self.inspector_pos = Some(position);
-        self.inspector_moved = true;
-        self.inspector_max_width = None;
-    }
-
-    /// The popup position a workspace should record: the one a hand placed,
-    /// never one the app computed.
-    ///
-    /// Automatic placement is a *rule* — beside the object, on the side with
-    /// room. Writing down the pixel that rule produced for yesterday's drawing
-    /// would freeze a stale answer into the file and stop the rule from ever
-    /// running again, which is the same bug as never forgetting a drag.
-    fn remembered_inspector_position(&self) -> Option<[f32; 2]> {
-        self.inspector_pos
-            .filter(|_| self.inspector_moved)
-            .map(|position| [position.x, position.y])
-    }
-
-    /// Adopt what a workspace remembers about the popup, including its
-    /// silence: no recorded position hands the window back to automatic
-    /// placement rather than leaving the previous cockpit's position behind.
-    ///
-    /// A non-finite pair is silence too. The file is hand-editable and TOML
-    /// spells `nan`, and NaN is the one value the repair below cannot walk
-    /// back: every comparison against it is false, so `f32::clamp` returns it
-    /// unchanged and the popup goes somewhere with no pixels — where its own
-    /// title bar, and with it the double-click that would undo this, cannot be
-    /// reached. It would then be written straight back at the next save. The
-    /// env hook already refuses the same input ([`parse_point`]); this is the
-    /// door the file comes through.
-    fn restore_inspector_position(&mut self, remembered: Option<[f32; 2]>) {
-        match remembered.filter(|[x, y]| x.is_finite() && y.is_finite()) {
-            Some([x, y]) => self.place_inspector_by_hand(egui::pos2(x, y)),
-            None => {
-                self.inspector_pos = None;
-                self.inspector_moved = false;
-                self.inspector_max_width = None;
+        for write in ask.presets {
+            write.apply_to(&mut self.drawing_presets);
+        }
+        if ask.sweep_authored {
+            let removed = self.remove_every_authored_object();
+            if removed > 0 {
+                self.surfaces
+                    .toast
+                    .note_with_undo(format!("{removed} object(s) placed for you removed."), now);
             }
         }
+        if ask.delete_all {
+            let pane = self.drawing_pane_mut();
+            let deleted = pane.drawings.delete_all();
+            // Every armed instance just lost its drawing at once; sweep them
+            // now so no resting bot order outlives its badge.
+            pane.sweep_strategy_orphans();
+            if deleted > 0 {
+                self.surfaces
+                    .toast
+                    .note_with_undo("All drawings deleted.", now);
+            }
+        }
+        if let Some(index) = ask.manager_select {
+            self.drawing_pane_mut().drawings.select(Some(index));
+            // Centre the viewport on the object's bar span.
+            let slots = self.drawing_pane().slots();
+            if let Some(chart) = self.drawing_pane().last_chart_area {
+                let points = &self.drawing_pane().drawings.items()[index].points;
+                if !points.is_empty() {
+                    let mid =
+                        points.iter().map(|point| point.bar).sum::<f32>() / points.len() as f32;
+                    self.drawing_pane_mut()
+                        .viewport
+                        .center_on_bar(mid, chart.width(), slots);
+                }
+            }
+        }
+        if let Some(index) = ask.manager_toggle_hidden {
+            let hidden = self.drawing_pane().drawings.items()[index].hidden;
+            self.drawing_pane_mut()
+                .drawings
+                .set_hidden_at(index, !hidden);
+        }
+        if let Some(index) = ask.manager_toggle_locked {
+            let locked = self.drawing_pane().drawings.items()[index].locked;
+            self.drawing_pane_mut()
+                .drawings
+                .set_locked_at(index, !locked);
+        }
+        if let Some(index) = ask.manager_bring_to_front {
+            self.drawing_pane_mut().drawings.bring_to_front(index);
+        }
+        if let Some(index) = ask.manager_delete {
+            // The exact same command path as the inspector button and the
+            // keyboard: select, then request. Locked rows raise the same
+            // confirmation in the inspector.
+            self.drawing_pane_mut().drawings.select(Some(index));
+            self.request_delete_selected(now);
+        }
+        if ask.show_all {
+            self.drawing_pane_mut().drawings.set_all_hidden(false);
+        }
+        if ask.unlock_all {
+            self.drawing_pane_mut().drawings.set_all_locked(false);
+        }
+        if ask.place_text_note && self.place_text_note() {
+            self.surfaces.drawing_chrome.note_text_note_placed();
+        }
+        if let Some(edit) = ask.record_inline_edit {
+            self.record_drawing_edit(edit.tab, edit.side, edit.index, edit.before);
+        }
+        if ask.content_editing_changed {
+            self.sync_content_editing();
+        }
+        if self.surfaces.drawing_chrome.take_inspector_position_dirty() {
+            self.inspector_position_dirty = true;
+        }
+    }
+
+    /// The docked inspector.
+    ///
+    /// Its own call site because a `SidePanel` has to be declared *before* the
+    /// central canvas — the canvas pays its width, and a panel declared after
+    /// it would overlay the chart instead of docking beside it.
+    fn draw_pinned_inspector(&mut self, ctx: &egui::Context, now: Instant) {
+        if !self.surfaces.drawing_chrome.inspector_pinned() {
+            return;
+        }
+        let ask = self.draw_drawing_chrome_part(ctx, false);
+        self.apply_drawing_chrome(ask, now);
+    }
+
+    /// The four floating pieces, registered after the canvas so they stay in
+    /// front of the chart they are anchored to.
+    fn draw_drawing_chrome(&mut self, ctx: &egui::Context, now: Instant) {
+        let ask = self.draw_drawing_chrome_part(ctx, true);
+        self.apply_drawing_chrome(ask, now);
+    }
+
+    /// One gather for both call sites. `floating` picks which of the surface's
+    /// two entry points runs; the rows the object manager lists are built only
+    /// for the one that draws it.
+    fn draw_drawing_chrome_part(
+        &mut self,
+        ctx: &egui::Context,
+        floating: bool,
+    ) -> crate::surfaces::drawing_chrome::DrawingChromeAsk {
+        let rows = if floating && self.surfaces.drawing_chrome.manager_open() {
+            self.drawing_manager_rows()
+        } else {
+            Vec::new()
+        };
+        let (selected_bbox, selected_band) = self.selected_drawing_geometry();
+        // Split into disjoint borrows, like the surface registry above: the
+        // chrome is drawn through `&mut` while what it reads is borrowed from
+        // the rest of the application.
+        let Self {
+            surfaces,
+            tabs,
+            active_tab,
+            toolrail,
+            drawing_presets,
+            ..
+        } = self;
+        let env = drawing_env(
+            tabs,
+            &tabs[*active_tab],
+            toolrail,
+            drawing_presets,
+            selected_bbox,
+            selected_band,
+            &rows,
+        );
+        if floating {
+            surfaces.drawing_chrome.draw_floating(ctx, &env)
+        } else {
+            surfaces.drawing_chrome.draw_pinned_panel(ctx, &env)
+        }
+    }
+
+    /// The `QUANTICK_TEXT_NOTE` hook's other half: place a note in the middle
+    /// of the window and open its editor, through the same two calls a click
+    /// makes.
+    ///
+    /// Here rather than in the surface because every line of it is the host's:
+    /// where the visible window is, what the tape last closed at, and the saved
+    /// defaults a fresh object opens with.
+    fn place_text_note(&mut self) -> bool {
+        let Some(tool) = drawings::DRAWING_TOOLS
+            .into_iter()
+            .find(|tool| tool.holds_text())
+        else {
+            return false;
+        };
+        let point = {
+            let pane = self.drawing_pane();
+            let slots = pane.slots();
+            if pane.last_chart_area.is_none() || slots == 0 {
+                // No laid-out pane yet, and nothing to place against. The ask
+                // stands and the next frame tries again.
+                return false;
+            }
+            let close = pane
+                .closed_bar(slots.saturating_sub(1))
+                .and_then(|bar| rust_decimal::prelude::ToPrimitive::to_f64(&bar.close))
+                .unwrap_or(1.0);
+            let centre = pane
+                .last_auto_range
+                .filter(|(lo, hi)| hi > lo)
+                .map_or(close, |(lo, hi)| (lo + hi) / 2.0);
+            let visible = DEMO_VISIBLE_SLOTS.min(slots);
+            let slot = (slots - visible / 2).min(slots.saturating_sub(1));
+            drawings::ChartPoint::at_time(slot as f32 + 0.5, centre, pane.slot_open_time(slot))
+        };
+        // Through the same door the click path uses, saved defaults and all —
+        // and on the same pane every drawing surface reads, so the index the
+        // editor opens on is the object this just placed.
+        let fresh = drawings::new_drawing_from_defaults(&self.drawing_presets, tool);
+        let placed = self.drawing_pane_mut().drawings.place_with(
+            tool,
+            &drawings::DrawingBand::Price,
+            point,
+            |_| fresh,
+        );
+        if placed && let Some(index) = self.drawing_pane().drawings.selected() {
+            self.begin_inline_text_edit(index);
+        }
+        placed
     }
 
     /// The selected object's screen bounding box, expanded by the anchor
@@ -7884,972 +7230,6 @@ impl QuantickApp {
         // profile while believing it had walked around it.
         let bbox = drawing.tool.painted_bounds(bbox, chart);
         Some(bbox.expand(DRAWING_ANCHOR_RADIUS_PX))
-    }
-
-    /// Shared prologue of both inspector hosts. Returns the selection and its
-    /// pre-frame copy, or cleans up when nothing is selected.
-    fn inspector_selection(&mut self) -> Option<(usize, drawings::Drawing)> {
-        let Some(index) = self.drawing_pane().drawings.selected() else {
-            self.drawing_delete_confirm = false;
-            self.commit_inspector_gesture();
-            self.inspector_last_selection = None;
-            return None;
-        };
-        // An edit gesture that outlived its object's selection commits now.
-        if self
-            .inspector_edit_baseline
-            .as_ref()
-            .is_some_and(|edit| edit.index != index)
-        {
-            self.commit_inspector_gesture();
-        }
-        Some((index, self.drawing_pane().drawings.items()[index].clone()))
-    }
-
-    /// Put the caret in a note, on the chart — the one call that opens the
-    /// editor, whether a placement, a double click or a script asked for it.
-    ///
-    /// Refused for an object that holds no words or is locked: a locked
-    /// object's geometry and content are both protected, and an editor that
-    /// opened and then dropped every keystroke would be worse than none.
-    pub fn begin_inline_text_edit(&mut self, index: usize) -> bool {
-        let tab = self.active_tab().id;
-        let side = self.active_tab().drawing_side();
-        let Some(drawing) = self.drawing_pane().drawings.items().get(index) else {
-            return false;
-        };
-        if drawing.locked || !drawing.tool.holds_text() {
-            return false;
-        }
-        // Typing is one edit: the note as it stands is kept here and recorded
-        // when the editor closes, so undo takes back the note, not the last
-        // letter of it.
-        let before = drawing.clone();
-        self.drawing_pane_mut().drawings.select(Some(index));
-        self.inline_text_edit = Some(InlineTextEdit {
-            tab,
-            side,
-            index,
-            before,
-        });
-        self.sync_content_editing();
-        true
-    }
-
-    /// Close the editor, keeping whatever was typed and recording it as the
-    /// one edit it was — on the pane the note actually lives on, which is not
-    /// necessarily the one in front when it closes.
-    fn end_inline_text_edit(&mut self) {
-        let Some(edit) = self.inline_text_edit.take() else {
-            return;
-        };
-        if let Some(tab) = self.tabs.iter_mut().find(|tab| tab.id == edit.tab) {
-            tab.pane_mut(edit.side)
-                .drawings
-                .record_edit_of(edit.index, edit.before);
-        }
-        self.sync_content_editing();
-    }
-
-    /// Tell every pane whether one of its objects is having its content typed
-    /// somewhere else on screen, so exactly one object anywhere stands down.
-    ///
-    /// Every pane, not just the one in front: the flag is what suppresses the
-    /// object's own painting, and a pane left holding a stale index would
-    /// keep a note invisible for the rest of the session with no way back.
-    fn sync_content_editing(&mut self) {
-        let editing = self
-            .inline_text_edit
-            .as_ref()
-            .map(|edit| (edit.tab, edit.side, edit.index));
-        for tab in &mut self.tabs {
-            let target = editing
-                .filter(|(id, _, _)| *id == tab.id)
-                .map(|(_, side, index)| (side, index));
-            tab.set_content_editing(target);
-        }
-    }
-
-    /// Which note is being typed on the chart right now — what a second
-    /// operator reads to know the keyboard belongs to an object.
-    #[must_use]
-    pub fn inline_text_editing(&self) -> Option<usize> {
-        self.inline_text_edit.as_ref().map(|edit| edit.index)
-    }
-
-    /// The on-chart note editor: a field where the words will be, opened by
-    /// the placement that made the note.
-    ///
-    /// The panel used to be the only way in, which put the note under the
-    /// pointer and the field that fills it on the far side of the screen. The
-    /// context bar the selection already raises carries the rest — colour,
-    /// type size, lock, delete — so what was missing was never a panel, only
-    /// a caret.
-    fn draw_inline_text_editor(&mut self, ctx: &egui::Context) {
-        // A placement that asked for the caret gets it here, on the frame it
-        // happened: the object it made is the selected one.
-        if std::mem::take(&mut self.pending_text_edit)
-            && let Some(index) = self.drawing_pane().drawings.selected()
-        {
-            self.begin_inline_text_edit(index);
-        }
-        let Some((tab, side, index)) = self
-            .inline_text_edit
-            .as_ref()
-            .map(|edit| (edit.tab, edit.side, edit.index))
-        else {
-            return;
-        };
-        // The object can go away underneath the editor — undo, delete, a tab
-        // switch, a click that moves the selection to the other pane. Any of
-        // those ends the editor, and it must not write into whatever now sits
-        // at that index: the note is only in front while its own tab and pane
-        // are the ones every drawing surface is reading.
-        if self.active_tab().id != tab
-            || self.active_tab().drawing_side() != side
-            || self.drawing_pane().drawings.selected() != Some(index)
-        {
-            self.end_inline_text_edit();
-            return;
-        }
-        let Some(chart) = self.drawing_pane().last_chart_area else {
-            self.end_inline_text_edit();
-            return;
-        };
-        let Some(bbox) = self.drawing_bbox_on_screen(chart, index) else {
-            self.end_inline_text_edit();
-            return;
-        };
-        let Some(drawing) = self.drawing_pane().drawings.items().get(index) else {
-            self.end_inline_text_edit();
-            return;
-        };
-        let tool = drawing.tool;
-        let Some(text) = tool.inline_text(drawing.payload.as_ref()) else {
-            self.end_inline_text_edit();
-            return;
-        };
-        // Read once, and only what the field needs: this runs every frame the
-        // editor is open, and the drawing behind it carries a boxed payload.
-        let mut buffer = text.to_owned();
-        let before = buffer.clone();
-        let size_px = tool
-            .glyph_size(drawing)
-            .map_or(INLINE_TEXT_FALLBACK_PX, |size| size.px);
-        let color = drawing.style.color;
-        let locked = drawing.locked;
-        if locked {
-            self.end_inline_text_edit();
-            return;
-        }
-
-        // Anchored where the words are painted, so the field opens over the
-        // object rather than beside it: the note is typed exactly where it
-        // will be read.
-        // Where the words are painted — above the anchor — unless there is no
-        // room up there, in which case it opens below it instead. A field
-        // pinned upward against the top of the chart lands on the flow legend
-        // and covers the very key it is annotating; flipping keeps both
-        // readable, the way a popover does.
-        //
-        // Constrained to the chart either way, like every other floating
-        // drawing surface: the object stands down while the editor is up, so
-        // a field that ran off the window would leave the trader typing blind
-        // into a widget they cannot see.
-        let field_height = size_px * INLINE_TEXT_LINE_FACTOR + INLINE_TEXT_FRAME_PAD_PX;
-        let (position, pivot) = if bbox.bottom() - field_height < chart.top() {
-            (bbox.left_top(), egui::Align2::LEFT_TOP)
-        } else {
-            (
-                egui::pos2(bbox.left(), bbox.bottom()),
-                egui::Align2::LEFT_BOTTOM,
-            )
-        };
-        let inner = egui::Area::new(egui::Id::new(INLINE_TEXT_AREA_ID))
-            .order(egui::Order::Foreground)
-            .fixed_pos(position)
-            .pivot(pivot)
-            .constrain_to(chart)
-            .show(ctx, |ui| {
-                // A frame around it, in the accent: over a candle chart an
-                // unframed field is a rectangle of dark on dark, and the one
-                // thing this surface has to say is "the keyboard is here
-                // now". The fill is opaque for the same reason — words typed
-                // over wicks are words nobody can read back.
-                egui::Frame::none()
-                    .fill(theme::CHROME)
-                    .stroke(egui::Stroke::new(1.0_f32, theme::ACCENT))
-                    .rounding(egui::Rounding::same(3.0))
-                    .inner_margin(egui::Margin::symmetric(4.0, 2.0))
-                    .show(ui, |ui| {
-                        let response = ui.add(
-                            egui::TextEdit::multiline(&mut buffer)
-                                .font(egui::FontId::proportional(size_px))
-                                .text_color(color)
-                                .hint_text(INLINE_TEXT_HINT)
-                                .desired_rows(1)
-                                .frame(false)
-                                .desired_width(INLINE_TEXT_WIDTH_PX),
-                        );
-                        // The caret on the first frame: a field that opens
-                        // unfocused asks for a click nobody was told about.
-                        if !response.has_focus() && ui.memory(|memory| memory.focused().is_none()) {
-                            response.request_focus();
-                        }
-                        response
-                    })
-                    .inner
-            })
-            .inner;
-
-        if buffer != before {
-            let text = buffer.clone();
-            // Through the selection, never `items_mut`: that hatch is
-            // documented for derived-state refresh only, and the words of a
-            // note take part in payload equality — writing them through it
-            // would let an unrelated in-flight gesture swallow this edit.
-            if let Some(drawing) = self.drawing_pane_mut().drawings.selected_mut() {
-                tool.set_inline_text(drawing.payload.as_mut(), text);
-            }
-        }
-        // Escape and clicking away both mean "done" — and Escape must not
-        // also fall through to the escape stack, which would drop the
-        // selection the bar is hanging off.
-        let escaped = inner.has_focus() && ctx.input(|input| input.key_pressed(egui::Key::Escape));
-        if escaped {
-            ctx.memory_mut(|memory| memory.surrender_focus(inner.id));
-        }
-        if escaped || inner.lost_focus() {
-            self.end_inline_text_edit();
-        }
-    }
-
-    /// The `QUANTICK_TEXT_NOTE` hook: place a note in the middle of the
-    /// window and open its editor, through the same two calls a click makes.
-    fn apply_text_note_hook(&mut self) {
-        if !self.pending_text_note {
-            return;
-        }
-        let Some(tool) = drawings::DRAWING_TOOLS
-            .into_iter()
-            .find(|tool| tool.holds_text())
-        else {
-            return;
-        };
-        let point = {
-            let pane = self.drawing_pane();
-            let slots = pane.slots();
-            if pane.last_chart_area.is_none() || slots == 0 {
-                return;
-            }
-            let close = pane
-                .closed_bar(slots.saturating_sub(1))
-                .and_then(|bar| rust_decimal::prelude::ToPrimitive::to_f64(&bar.close))
-                .unwrap_or(1.0);
-            let centre = pane
-                .last_auto_range
-                .filter(|(lo, hi)| hi > lo)
-                .map_or(close, |(lo, hi)| (lo + hi) / 2.0);
-            let visible = DEMO_VISIBLE_SLOTS.min(slots);
-            let slot = (slots - visible / 2).min(slots.saturating_sub(1));
-            drawings::ChartPoint::at_time(slot as f32 + 0.5, centre, pane.slot_open_time(slot))
-        };
-        self.pending_text_note = false;
-        // Through the same door the click path uses, saved defaults and all —
-        // and on the same pane every drawing surface reads, so the index the
-        // editor opens on is the object this just placed.
-        let fresh = drawings::new_drawing_from_defaults(&self.drawing_presets, tool);
-        let placed = self.drawing_pane_mut().drawings.place_with(
-            tool,
-            &drawings::DrawingBand::Price,
-            point,
-            |_| fresh,
-        );
-        if placed && let Some(index) = self.drawing_pane().drawings.selected() {
-            self.begin_inline_text_edit(index);
-        }
-    }
-
-    /// The selected object's context bar.
-    ///
-    /// This is what a selection raises now — one row of icons, where the
-    /// object is, for the handful of things a trader does with their eye on
-    /// the chart. Everything else stayed exactly where it was, behind the
-    /// gear. The bar re-uses [`Self::apply_inspector_actions`] verbatim, so
-    /// lock, delete, hide and the undo coalescing have one implementation
-    /// and cannot drift between the two hosts.
-    fn draw_drawing_context_bar(&mut self, ctx: &egui::Context, now: Instant) {
-        let selection = self.drawing_pane().drawings.selected();
-        if self.context_bar.note_selection(selection) {
-            // A new object is a new question: the panel the last one opened
-            // does not follow the selection around.
-            self.inspector_open = false;
-        }
-        // …except when the object just placed asked for it. Applied after
-        // the reset above, because the placement that made the request also
-        // made the selection change that clears it.
-        if std::mem::take(&mut self.pending_open_settings) {
-            self.inspector_open = true;
-            self.inspector_last_selection = None;
-        }
-        let Some(index) = selection else {
-            return;
-        };
-        // An armed tool means the trader is drawing, not editing. The bar is
-        // opaque to the pointer, so leaving it up would let it eat the click
-        // that places the next object — the selection it belongs to is the
-        // one they just finished, not the one they are starting.
-        if matches!(self.toolrail.tool(), Tool::Drawing(_)) {
-            return;
-        }
-        // Which gestures hide the bar is decided here, once, from the raw
-        // input — not at each of the six call sites that could move the
-        // world. A *click* never suppresses: it is how the trader reaches
-        // the bar. Only a decided drag does, and only when it began outside
-        // the bar, so dragging the grip does not hide what is being dragged.
-        //
-        // Note what is deliberately absent: the market moving. A drawing
-        // carried along by the auto-scroll carries the bar with it, smoothly
-        // — suppressing that would blink the bar all session on a live tape.
-        let now_ms = (ctx.input(|input| input.time) * 1000.0) as u64;
-        let bar_rect = self.context_bar.last_rect();
-        let (dragging, origin, zoomed, screen) = ctx.input(|input| {
-            (
-                input.pointer.is_decidedly_dragging(),
-                input.pointer.press_origin(),
-                input.raw_scroll_delta.y.abs() > f32::EPSILON
-                    || (input.zoom_delta() - 1.0).abs() > f32::EPSILON,
-                input.screen_rect,
-            )
-        });
-        // Against the rect the press *landed* on, not this frame's — the bar
-        // moves with a grip drag, so comparing against the moved rect makes
-        // the origin fall outside after ~20 px and suppresses the very
-        // gesture that is moving it. The grip is the escape hatch for a bar
-        // sitting over something the trader needs to see; it has to survive
-        // being used.
-        let on_the_bar = matches!(
-            (origin, self.context_bar.press_rect(origin, bar_rect)),
-            (Some(origin), Some(rect)) if rect.contains(origin)
-        );
-        if dragging && !on_the_bar {
-            self.context_bar.suppress_gesture();
-        } else if !dragging {
-            self.context_bar.release_gesture();
-        }
-        if zoomed {
-            self.context_bar.suppress_transient(now_ms);
-        }
-        self.context_bar.note_screen(screen, now_ms);
-        // Suppressed means suppressed: nothing below this line runs, so the
-        // bar cannot measure a world the gesture that suppressed it is still
-        // moving. That is the rule the drag gestures already learned.
-        if self.context_bar.suppressed(now_ms) {
-            return;
-        }
-        let Some(chart) = self.drawing_pane().last_chart_area else {
-            return;
-        };
-        let Some(bbox) = self.drawing_bbox_on_screen(chart, index) else {
-            return;
-        };
-        // Read the object, never clone it, on the way in. This runs every
-        // frame something is selected, and a `Drawing` carries a `Vec` of
-        // anchors plus a boxed payload — a pencil stroke is 512 of them. The
-        // clone the undo baseline needs is paid for below, only on the frame
-        // an action actually happened.
-        let drawing = &self.drawing_pane().drawings.items()[index];
-        let tool = drawing.tool;
-        let locked = drawing.locked;
-        let mut style = drawing.style;
-        let glyph_before = tool.glyph_size(drawing);
-        // One line, only for an object the trader did not place. Formatting
-        // it costs an allocation on the frames a selected annotation is on
-        // screen — never on the tape's path, and never for the objects the
-        // trader drew.
-        let author = drawing.author.as_ref().map(DrawingAuthor::label);
-        let mut object = drawings::context_bar::BarObject {
-            style: &mut style,
-            glyph_size: glyph_before,
-            author: author.as_deref(),
-            locked,
-            hidden: drawing.hidden,
-            supports_fill: tool.supports_fill(),
-            // Pinned, the full panel is already on screen: a gear leading
-            // where the eye already is would be the dead slot the bar's own
-            // contract forbids.
-            settings_available: !self.inspector_pinned,
-            confirming_delete: self.drawing_delete_confirm && locked,
-            tool_name: tool.name(),
-        };
-        let size = drawings::context_bar::bar_size(&drawings::context_bar::slots(
-            drawings::context_bar::capabilities(&object),
-        ));
-        // The live lane is off limits to the bar however it got where it is:
-        // that strip is where the price the trader is reading is being formed,
-        // and `place` has kept clear of it since it was written. A parked bar
-        // is placed by a different rule, not held to a different one.
-        let right_limit = self
-            .drawing_pane()
-            .last_lane_divider_x
-            .unwrap_or(chart.right());
-        let reachable = context_bar_bounds(chart, right_limit, size);
-        let position = match self.context_bar.manual_position() {
-            // Repair for drawing, never overwrite — the rule the properties
-            // popup already follows, for the same reason. A bar parked out
-            // near the right edge of a wide pane must stay reachable when the
-            // canvas is split and that pane is half as wide, and the repair
-            // leaves the parked point alone, so widening the pane gives it
-            // back. (A fresh drag is a fresh decision and does replace it,
-            // measured from where the bar is actually drawn — dragging from a
-            // point the window is not at would make it jump on the first
-            // pixel.)
-            //
-            // The clamp is against the pane the *selection* lives on, which is
-            // what makes a bar parked over one chart of a split come back
-            // inside the other one rather than hovering over its neighbour.
-            Some(parked) => parked,
-            None => drawings::context_bar::place(chart, right_limit, bbox, size),
-        };
-        // Both answers go through the same repair, so "clear of the live lane"
-        // is a property of the bar and not of the branch that placed it.
-        // `place` keeps clear of the lane on every path but its last one — the
-        // fallback for an object that covers the pane end to end, which clamps
-        // against the pane's own right edge — and that path is reachable with
-        // a full-height profile on a narrow split. It also keeps the popover
-        // bound below honest, which is derived from where the bar ends up.
-        let position = clamp_into_chart(position, size, reachable);
-        // What the popovers are clamped into: the same rectangle *without* the
-        // bar's width floor, but never narrower than the bar that was actually
-        // drawn.
-        //
-        // The floor exists so a history area narrower than the bar still has
-        // somewhere to put one — `place` makes the same call — and it is the
-        // bar's reason, not the palette's: a palette can be pushed left, so
-        // nothing buys it the right to sit on the forming column. But when the
-        // floor did have to push the bar into the lane, a bound that stopped
-        // short of it would leave the palette hanging off nothing, which is
-        // the failure the placement rule spends its effort on.
-        let popover_bounds = egui::Rect::from_min_max(
-            chart.min,
-            egui::pos2(
-                right_limit.min(chart.right()).max(position.x + size.x),
-                chart.bottom(),
-            ),
-        );
-        let intent = drawings::context_bar::show(
-            &mut self.context_bar,
-            ctx,
-            position,
-            popover_bounds,
-            &mut object,
-        );
-        let glyph_after = object.glyph_size;
-        #[cfg(test)]
-        {
-            self.context_bar_rect = self.context_bar.last_rect();
-        }
-
-        if intent.reset_position {
-            self.context_bar.clear_manual();
-        } else if intent.drag_delta != egui::Vec2::ZERO {
-            self.context_bar.set_manual(position + intent.drag_delta);
-        }
-        let actions = InspectorActions {
-            toggle_hidden: intent.toggle_hidden,
-            toggle_lock: intent.actions.toggle_lock,
-            delete: intent.actions.delete,
-            force_delete: intent.force_delete,
-            cancel_delete: intent.cancel_delete,
-            edited: intent.edited,
-            ..InspectorActions::default()
-        };
-        // The undo baseline, taken *before* the edit below lands — a copy
-        // made afterwards would equal the new state and the change would
-        // never make it into the history. It costs its allocation only on a
-        // frame that asked for something, or one with a gesture still open
-        // waiting to be committed; idle frames clone nothing.
-        let before = (actions.any() || self.inspector_edit_baseline.is_some())
-            .then(|| self.drawing_pane().drawings.items()[index].clone());
-        if intent.edited
-            && let Some(drawing) = self.drawing_pane_mut().drawings.selected_mut()
-        {
-            drawing.style = style;
-            if let Some(size) = glyph_after {
-                let tool = drawing.tool;
-                tool.set_glyph_size(drawing, size.px);
-            }
-        }
-        if intent.open_settings {
-            self.inspector_open = true;
-            // Place against the object the way a fresh selection would.
-            self.inspector_last_selection = None;
-        }
-        if intent.duplicate {
-            self.duplicate_selected_drawing();
-        }
-        if let Some(before) = before {
-            self.apply_inspector_actions(ctx, actions, index, before, now);
-        }
-    }
-
-    /// The pinned inspector: a dock panel at the chart's side. Declared with
-    /// the chrome, before the central canvas, so the canvas pays its width.
-    fn draw_drawing_inspector_panel(&mut self, ctx: &egui::Context, now: Instant) {
-        if !self.inspector_pinned {
-            return;
-        }
-        let Some((index, before)) = self.inspector_selection() else {
-            return;
-        };
-        self.inspector_last_selection = Some(index);
-        let mut actions = InspectorActions::default();
-        egui::SidePanel::right("drawing_inspector_panel")
-            .resizable(true)
-            .default_width(INSPECTOR_DEFAULT_WIDTH_PX)
-            .width_range(INSPECTOR_MIN_WIDTH_PX..=INSPECTOR_MAX_WIDTH_PX)
-            .show(ctx, |ui| {
-                actions = self.draw_inspector_title_bar(ui, index, false);
-                egui::ScrollArea::vertical().show(ui, |ui| {
-                    let body = self.drawing_inspector_body(ui, index);
-                    actions.merge(body);
-                });
-            });
-        self.apply_inspector_actions(ctx, actions, index, before, now);
-    }
-
-    /// The selected object's floating inspector. Non-modal by contract: it
-    /// never captures the whole canvas — but it is opaque to the pointer, so
-    /// a press on it never falls through to the chart. Opens beside the
-    /// selection; once the user drags the title bar, the manual position
-    /// wins for the rest of the session (selection changes never snap it
-    /// back; the only automatic move is the re-clamp when the pane shrinks).
-    fn draw_drawing_inspector(&mut self, ctx: &egui::Context, now: Instant) {
-        if self.inspector_pinned {
-            // The pinned panel already drew (and cleaned up) this frame.
-            return;
-        }
-        let Some((index, before)) = self.inspector_selection() else {
-            return;
-        };
-        // Selecting an object no longer opens this window — the context bar
-        // does. The gear on that bar is the one door, so the panel only
-        // covers the chart when the trader asked for the panel.
-        if !self.inspector_open {
-            return;
-        }
-        if std::mem::take(&mut self.inspector_settle_frame) {
-            // The unpin happened this frame: the side panel still occupies
-            // this frame's layout and the drawing projects against the
-            // pinned-era chart. Wait one frame and place against the
-            // settled geometry.
-            return;
-        }
-        let selection_changed = self.inspector_last_selection != Some(index);
-        // The auto-pin (§4.2): a fresh selection on a chart too narrow for a
-        // floating window opens pinned instead — decided here because this
-        // host is the one that would otherwise claim the selection. Stops
-        // firing once the user touches the pin.
-        //
-        // A parked window stops it too, and for the same reason: the rule
-        // reads "no floating position here would leave the geometry alone",
-        // and a trader who chose where the floating window goes has answered
-        // that. Without this clause the everyday layout never reaches the
-        // remembered position at all — a split canvas puts the pane a drawing
-        // lives on under the threshold, so every selection would re-dock the
-        // panel. The pin flag itself is left alone: it records that the *pin
-        // button* was pressed, and borrowing it here would leak a placement
-        // into the next workspace opened, which carries no pin preference.
-        if selection_changed
-            && !self.inspector_pin_touched
-            && !self.inspector_moved
-            && self
-                .drawing_pane()
-                .last_chart_area
-                .is_some_and(|chart| chart.width() < INSPECTOR_AUTO_PIN_CHART_WIDTH_PX)
-        {
-            self.inspector_pinned = true;
-            // The pinned panel draws from the next frame on.
-            return;
-        }
-        self.inspector_last_selection = Some(index);
-        // Automatic placement only while the window is untouched.
-        if selection_changed
-            && !self.inspector_moved
-            && let Some(placed) = self.inspector_target_placement(ctx, index)
-        {
-            self.inspector_pos = Some(placed.position);
-            self.inspector_max_width = placed.max_width;
-        }
-        // Repair for drawing, never overwrite: a position that does not fit
-        // the chart pane is clamped into it *for this frame*, and the point
-        // the trader parked survives in `inspector_pos` untouched.
-        //
-        // The clamp used to be written back, which was harmless while the
-        // position died with the process and is not now that the workspace
-        // keeps it. Every reason the popup does not fit is temporary — a
-        // taller panel for the tool just selected, the split canvas opened,
-        // the window pulled narrow, a smaller second monitor — and writing the
-        // repair back would ratchet the parked point away a little at a time,
-        // with no way back to where the hand put it. The file records what the
-        // trader did; this line decides only where it is drawn today.
-        let draw_at = self.inspector_pos.map(|position| {
-            self.drawing_pane()
-                .last_chart_area
-                .map_or(position, |chart| {
-                    clamp_into_chart(position, self.inspector_size(ctx), chart)
-                })
-        });
-        // The level editor earns the wider default the spec reserves for it.
-        let default_width = if before.tool.extra_tab().is_some() {
-            INSPECTOR_LEVELS_WIDTH_PX
-        } else {
-            INSPECTOR_DEFAULT_WIDTH_PX
-        };
-        // Bounded by the window and scrolled inside it. A tool's panel can be
-        // taller than the screen — the Fib level editor is — and an unbounded
-        // window simply gets cut at the edge with no way to reach the rest.
-        // Rows a trader cannot reach read as rows that do not exist, and the
-        // control that was out of reach here was the Fib's own "extend", the
-        // one that decides whether its targets project forward at all.
-        let max_height = (ctx.screen_rect().height()
-            - self
-                .drawing_pane()
-                .last_chart_area
-                .map_or(0.0, |chart| chart.top())
-            - 2.0 * INSPECTOR_OBJECT_GAP_PX)
-            .max(INSPECTOR_FALLBACK_HEIGHT_PX);
-        let mut window = egui::Window::new(before.tool.settings_title())
-            .id(egui::Id::new("drawing_inspector"))
-            .title_bar(false)
-            .default_pos(DRAWING_INSPECTOR_DEFAULT_POSITION)
-            .default_width(default_width)
-            .min_width(INSPECTOR_MIN_WIDTH_PX)
-            .max_width(
-                self.inspector_max_width
-                    .map_or(INSPECTOR_MAX_WIDTH_PX, |width| {
-                        width.clamp(INSPECTOR_MIN_WIDTH_PX, INSPECTOR_MAX_WIDTH_PX)
-                    }),
-            )
-            .max_height(max_height)
-            .movable(false)
-            .interactable(true)
-            .resizable(true);
-        if let Some(position) = draw_at {
-            window = window.current_pos(position);
-        }
-        let response = window.show(ctx, |ui| {
-            let mut actions = self.draw_inspector_title_bar(ui, index, true);
-            egui::ScrollArea::vertical()
-                .auto_shrink([false, true])
-                .show(ui, |ui| {
-                    actions.merge(self.drawing_inspector_body(ui, index));
-                });
-            actions
-        });
-        self.inspector_size = response
-            .as_ref()
-            .map(|response| response.response.rect.size());
-        let actions = response
-            .and_then(|response| response.inner)
-            .unwrap_or_default();
-        self.apply_inspector_actions(ctx, actions, index, before, now);
-    }
-
-    /// Where the object manager opens: one gap inboard of the rail's inner
-    /// edge, aligned with the rail's leading end, clamped into the chart —
-    /// beside the button that opened it in all four docks.
-    fn manager_target_position(&self, ctx: &egui::Context) -> Option<egui::Pos2> {
-        let chart = self.focused_pane().last_chart_area?;
-        let size = ctx
-            .memory(|memory| memory.area_rect(egui::Id::new("drawing_manager")))
-            .map_or(
-                egui::vec2(INSPECTOR_DEFAULT_WIDTH_PX, INSPECTOR_FALLBACK_HEIGHT_PX),
-                |rect| rect.size(),
-            );
-        let gap = DRAWING_MANAGER_GAP_PX;
-        let position = match self.toolrail.dock() {
-            ToolboxDock::Left | ToolboxDock::Top => {
-                egui::pos2(chart.left() + gap, chart.top() + gap)
-            }
-            ToolboxDock::Bottom => egui::pos2(chart.left() + gap, chart.bottom() - gap - size.y),
-        };
-        Some(clamp_into_chart(position, size, chart))
-    }
-
-    /// The object manager: a non-modal list of every drawing with the named
-    /// per-object actions. It sends the same store commands as the inspector
-    /// and the keyboard — nothing here re-implements lock or delete rules.
-    fn draw_drawing_manager(&mut self, ctx: &egui::Context, now: Instant) {
-        if !self.drawing_manager_open {
-            self.drawing_manager_was_open = false;
-            return;
-        }
-        let just_opened = !self.drawing_manager_was_open;
-        self.drawing_manager_was_open = true;
-        #[cfg(test)]
-        self.manager_action_rects.clear();
-        let mut open = true;
-        let mut select_row: Option<usize> = None;
-        let mut eye_row: Option<usize> = None;
-        let mut lock_row: Option<usize> = None;
-        let mut front_row: Option<usize> = None;
-        let mut delete_row: Option<usize> = None;
-        let mut show_all = false;
-        let mut unlock_all = false;
-        let mut delete_all = false;
-        let mut sweep_authored = false;
-        let mut window = egui::Window::new("Drawn objects")
-            .id(egui::Id::new("drawing_manager"))
-            .open(&mut open)
-            .default_pos(DRAWING_MANAGER_DEFAULT_POSITION)
-            .default_width(INSPECTOR_DEFAULT_WIDTH_PX)
-            .collapsible(false)
-            // Resizable, with the list scrolling below (audit M13): thirty
-            // objects used to grow the window past the screen and put the
-            // footer out of reach.
-            .resizable(true);
-        if just_opened && let Some(position) = self.manager_target_position(ctx) {
-            window = window.current_pos(position);
-        }
-        window.show(ctx, |ui| {
-            let count = self.drawing_pane().drawings.items().len();
-            if count == 0 {
-                ui.label("No drawings yet.");
-            }
-            // One gesture back from an assistant that drew too much. It
-            // appears only when there is something to take back, names the
-            // number, and is a single undo entry.
-            let authored = self.authored_object_count();
-            if authored > 0 {
-                if ui
-                    .button(format!("Remove {authored} object(s) placed for you"))
-                    .on_hover_text(
-                        "Removes every object an assistant placed on this chart. Ctrl+Z brings them back.",
-                    )
-                    .clicked()
-                {
-                    sweep_authored = true;
-                }
-                ui.add_space(4.0);
-            }
-            egui::ScrollArea::vertical()
-                .auto_shrink([false, true])
-                .show(ui, |ui| {
-                    // Walked in reverse: the manager lists top-most first, the
-                    // same order hit-testing resolves overlap.
-                    for index in (0..count).rev() {
-                        let drawing = &self.drawing_pane().drawings.items()[index];
-                        let selected = self.drawing_pane().drawings.selected() == Some(index);
-                        let locked = drawing.locked;
-                        let hidden = drawing.hidden;
-                        let shared = drawing.scope == drawings::DrawingScope::AllCharts;
-                        let off_series = drawing.off_series;
-                        let foreign_market = drawing.foreign_market;
-                        let name = drawing.display_label(index);
-                        let author = drawing.author.as_ref().map(DrawingAuthor::label);
-                        // Read out with the rest of the row's facts, so the
-                        // row closure holds no borrow of the pane.
-                        let band = self.focused_pane().band_label(drawing);
-                        let band_hint = band.hint();
-                        let band_chip = band.chip();
-                        ui.horizontal(|ui| {
-                            let mut label = egui::RichText::new(name);
-                            if hidden {
-                                label = label.weak();
-                            }
-                            if ui.selectable_label(selected, label).clicked() {
-                                select_row = Some(index);
-                            }
-                            if let Some(author) = &author {
-                                ui.label(
-                                    egui::RichText::new("assistant")
-                                        .small()
-                                        .color(theme::TEXT_SUPPORT),
-                                )
-                                .on_hover_text(format!("Placed by {author}, not by you"));
-                            }
-                            if locked {
-                                ui.label(egui::RichText::new("locked").small());
-                            }
-                            if hidden {
-                                ui.label(egui::RichText::new("hidden").small());
-                            }
-                            // Which band an object is on, for the objects that
-                            // are not on the candles. An object nothing on
-                            // screen is showing — its indicator removed,
-                            // hidden, collapsed or errored — is listed in
-                            // amber and says which of those it is. It still
-                            // exists; deleting it stays the trader's call.
-                            if let Some(chip) = band_chip {
-                                let text = egui::RichText::new(chip).small();
-                                match band_hint {
-                                    Some(hint) => {
-                                        ui.label(text.color(theme::AMBER)).on_hover_text(hint);
-                                    }
-                                    None => {
-                                        ui.label(text);
-                                    }
-                                }
-                            }
-                            if foreign_market {
-                                // The one state the chart alone cannot
-                                // explain: the mark resolves onto real bars,
-                                // at a price that belonged to another
-                                // instrument.
-                                ui.label(egui::RichText::new("other market").small())
-                                    .on_hover_text(
-                                        "Drawn while this tab showed a different instrument. The                                          moment still exists here; the price does not mean the                                          same thing",
-                                    );
-                            }
-                            if off_series {
-                                // The mark outlived the bars it was drawn on
-                                // and the chart fades it (§D7b). The list is
-                                // where it can be found and removed, since a
-                                // clamped object may be nowhere near the
-                                // window the trader is looking at.
-                                ui.label(egui::RichText::new("off series").small())
-                                    .on_hover_text(
-                                        "Drawn at a moment this chart's bars do not cover. It is                                          shown at the nearest edge, faded, until you move or                                          delete it",
-                                    );
-                            }
-                            if shared {
-                                // Which marks are global is a question the
-                                // list must answer at a glance (Marina, §D7).
-                                ui.label(egui::RichText::new("all charts").small())
-                                    .on_hover_text(
-                                        "Also drawn on the other chart of this tab, at the same \
-                                         moment in market time",
-                                    );
-                            }
-                            ui.with_layout(
-                                egui::Layout::right_to_left(egui::Align::Center),
-                                |ui| {
-                                    let delete = ui.small_button("Delete");
-                                    #[cfg(test)]
-                                    self.manager_action_rects
-                                        .push((index, "Delete", delete.rect));
-                                    if delete.clicked() {
-                                        delete_row = Some(index);
-                                    }
-                                    let front = ui.small_button("Front");
-                                    #[cfg(test)]
-                                    self.manager_action_rects.push((index, "Front", front.rect));
-                                    if front.clicked() {
-                                        front_row = Some(index);
-                                    }
-                                    let lock =
-                                        ui.small_button(if locked { "Unlock" } else { "Lock" });
-                                    #[cfg(test)]
-                                    self.manager_action_rects.push((index, "Lock", lock.rect));
-                                    if lock.clicked() {
-                                        lock_row = Some(index);
-                                    }
-                                    let eye = ui.small_button(if hidden { "Show" } else { "Hide" });
-                                    #[cfg(test)]
-                                    self.manager_action_rects.push((index, "Eye", eye.rect));
-                                    if eye.clicked() {
-                                        eye_row = Some(index);
-                                    }
-                                },
-                            );
-                        });
-                    }
-                });
-            ui.separator();
-            if self.drawing_manager_confirm_delete_all && count > 0 {
-                // The count-bearing gate (audit M7): deleting everything is
-                // one command, but never one stray click — and locked
-                // objects go too, which the question says out loud.
-                ui.horizontal(|ui| {
-                    ui.label(format!("Delete all {count} drawing(s), locked included?"));
-                    if ui.button("Delete all").clicked() {
-                        delete_all = true;
-                        self.drawing_manager_confirm_delete_all = false;
-                    }
-                    if ui.button("Keep").clicked() {
-                        self.drawing_manager_confirm_delete_all = false;
-                    }
-                });
-            } else {
-                self.drawing_manager_confirm_delete_all = false;
-                ui.horizontal(|ui| {
-                    if ui.button("Show all").clicked() {
-                        show_all = true;
-                    }
-                    if ui.button("Unlock all").clicked() {
-                        unlock_all = true;
-                    }
-                    if count > 0 && ui.button("Delete all…").clicked() {
-                        self.drawing_manager_confirm_delete_all = true;
-                    }
-                });
-            }
-        });
-        self.drawing_manager_open = open;
-        if sweep_authored {
-            let removed = self.remove_every_authored_object();
-            if removed > 0 {
-                self.surfaces
-                    .toast
-                    .note_with_undo(format!("{removed} object(s) placed for you removed."), now);
-            }
-        }
-        if delete_all {
-            let pane = self.drawing_pane_mut();
-            let deleted = pane.drawings.delete_all();
-            // Every armed instance just lost its drawing at once; sweep
-            // them now so no resting bot order outlives its badge.
-            pane.sweep_strategy_orphans();
-            if deleted > 0 {
-                self.surfaces
-                    .toast
-                    .note_with_undo("All drawings deleted.", now);
-            }
-        }
-        if let Some(index) = select_row {
-            self.drawing_pane_mut().drawings.select(Some(index));
-            // Centre the viewport on the object's bar span.
-            let slots = self.drawing_pane().slots();
-            if let Some(chart) = self.drawing_pane().last_chart_area {
-                let points = &self.drawing_pane().drawings.items()[index].points;
-                if !points.is_empty() {
-                    let mid =
-                        points.iter().map(|point| point.bar).sum::<f32>() / points.len() as f32;
-                    self.drawing_pane_mut()
-                        .viewport
-                        .center_on_bar(mid, chart.width(), slots);
-                }
-            }
-        }
-        if let Some(index) = eye_row {
-            let hidden = self.drawing_pane().drawings.items()[index].hidden;
-            self.drawing_pane_mut()
-                .drawings
-                .set_hidden_at(index, !hidden);
-        }
-        if let Some(index) = lock_row {
-            let locked = self.drawing_pane().drawings.items()[index].locked;
-            self.drawing_pane_mut()
-                .drawings
-                .set_locked_at(index, !locked);
-        }
-        if let Some(index) = front_row {
-            self.drawing_pane_mut().drawings.bring_to_front(index);
-        }
-        if let Some(index) = delete_row {
-            // The exact same command path as the inspector button and the
-            // keyboard: select, then request. Locked rows raise the same
-            // confirmation in the inspector.
-            self.drawing_pane_mut().drawings.select(Some(index));
-            self.request_delete_selected(now);
-        }
-        if show_all {
-            self.drawing_pane_mut().drawings.set_all_hidden(false);
-        }
-        if unlock_all {
-            self.drawing_pane_mut().drawings.set_all_locked(false);
-        }
     }
 
     /// Carry out what the replay interface asked for.
@@ -10262,7 +8642,7 @@ impl QuantickApp {
     /// looks merely uninteresting, and that is how three of these hooks came to
     /// disagree about it.
     fn carry_inspector_across_selection(&mut self) {
-        self.pending_open_settings |= self.inspector_open;
+        self.surfaces.drawing_chrome.carry_across_selection();
     }
 
     /// The `bands` half of the demo hook: on every indicator pane, a level on
@@ -10425,7 +8805,6 @@ impl QuantickApp {
         self.apply_load_older();
         self.apply_load_older_candles();
         self.apply_drawing_draft();
-        self.apply_text_note_hook();
         self.apply_venue_history_demo();
         self.apply_frvp_demo();
         self.apply_avwap_demo();
@@ -10526,6 +8905,10 @@ impl QuantickApp {
         // application. That the compiler insists on the split is the port
         // working — a surface cannot be handed the trunk it is being kept
         // out of.
+        // Projected before the split, because it needs the viewport and the
+        // price scale: where the selected object is painted, and what the band
+        // it lives on is called. Both cost nothing while nothing is selected.
+        let (selected_bbox, selected_band) = self.selected_drawing_geometry();
         let Self {
             surfaces: registry,
             bookmarks,
@@ -10538,6 +8921,8 @@ impl QuantickApp {
             config,
             added_symbols,
             alert_failure,
+            drawing_presets,
+            toolrail,
             ..
         } = self;
         let focused_tab = &tabs[*active_tab];
@@ -10567,6 +8952,18 @@ impl QuantickApp {
                 active_tab: focused_tab.id,
                 counted_bar_sides: &counted_bar_sides,
                 alert_failure: alert_failure.as_deref(),
+                // No rows: the object manager is drawn from its own call site,
+                // after the canvas, and this one only carries the slice so the
+                // capture hooks can read it.
+                drawing: drawing_env(
+                    tabs,
+                    focused_tab,
+                    toolrail,
+                    drawing_presets,
+                    selected_bbox,
+                    selected_band,
+                    &[],
+                ),
             },
         );
         if let Some(name) = surfaces.save_workspace_as {
@@ -10683,15 +9080,20 @@ impl QuantickApp {
             // The focused pane's objects: the toolbox lists and manages what a
             // click on the canvas would act on.
             let side = self.active_tab().focused_side();
-            let Self {
-                toolrail,
-                tabs,
-                active_tab,
-                drawing_manager_open,
-                ..
-            } = self;
-            let tab = &mut tabs[*active_tab];
-            toolrail.draw(ctx, &mut tab.pane_mut(side).drawings, drawing_manager_open);
+            // The flag lives with the window it opens, so it travels through
+            // a local rather than a `&mut` handed out of the surface.
+            let mut manager_open = self.surfaces.drawing_chrome.manager_open();
+            {
+                let Self {
+                    toolrail,
+                    tabs,
+                    active_tab,
+                    ..
+                } = self;
+                let tab = &mut tabs[*active_tab];
+                toolrail.draw(ctx, &mut tab.pane_mut(side).drawings, &mut manager_open);
+            }
+            self.surfaces.drawing_chrome.set_manager_open(manager_open);
         }
         // A star clicked this frame is on disk this frame, like the replay
         // folder above: the pinned rail is what the trader reaches for without
@@ -10807,7 +9209,7 @@ impl QuantickApp {
         self.poll_workspace_picker();
         // The pinned inspector is chrome: declared before the central canvas
         // so the chart pays its width, exactly like the dock.
-        self.draw_drawing_inspector_panel(ctx, now);
+        self.draw_pinned_inspector(ctx, now);
         // Respawn the feed if the feed/symbol selection changed (resets the
         // chart), then apply any bar-type change (no-op if unchanged).
         let (tab, config) = self.active_with_config();
@@ -10858,6 +9260,10 @@ impl QuantickApp {
         // words the editor is showing must stand down on the *same* frame,
         // or the note flashes its placeholder under the field for one.
         self.sync_content_editing();
+        // Raised by a placement that wants its note typed, and handed to the
+        // chrome below: the flag belongs to the editor that owns the caret,
+        // not to the canvas that asks for it.
+        let mut begin_text_edit = false;
         egui::CentralPanel::default()
             .frame(egui::Frame::none().fill(bg))
             .show(ctx, |ui| {
@@ -10868,7 +9274,6 @@ impl QuantickApp {
                         active_tab,
                         toolrail,
                         drawing_presets,
-                        pending_text_edit,
                         style,
                         tz,
                         layer_actions,
@@ -10878,7 +9283,7 @@ impl QuantickApp {
                     let mut chrome = CanvasChrome {
                         toolrail,
                         presets: drawing_presets,
-                        begin_text_edit: pending_text_edit,
+                        begin_text_edit: &mut begin_text_edit,
                         style,
                         tz: *tz,
                         capabilities,
@@ -10978,12 +9383,15 @@ impl QuantickApp {
                     }
                 }
             });
+        if begin_text_edit {
+            self.surfaces.drawing_chrome.request_text_edit();
+        }
         // Floating drawing controls must be registered after the opaque
-        // central canvas so they stay in front of the chart.
-        self.draw_drawing_context_bar(ctx, now);
-        self.draw_inline_text_editor(ctx);
-        self.draw_drawing_inspector(ctx, now);
-        self.draw_drawing_manager(ctx, now);
+        // central canvas so they stay in front of the chart. That is why the
+        // drawing chrome is the one surface `Surfaces::draw_all` does not
+        // draw: it is anchored *to* the chart rather than floating over the
+        // window, so it is commanded by name from here instead.
+        self.draw_drawing_chrome(ctx, now);
         // The menus above may have disarmed a bot over a resting retest
         // limit; its cancel goes to the simulator on this same frame, not
         // on the next print. Every tab, not just the active one: a menu
@@ -11258,10 +9666,17 @@ mod tests {
 
     use crate::canvas_layout::CANVAS_DIVIDER_PX;
     use crate::config::{AppConfig, FeedCapabilities, FeedConfig, ProviderKind};
-    use crate::drawings::{ChartPoint, PresetHost};
+    use crate::drawings::{ChartPoint, MAX_DRAWING_WIDTH_PX, PresetHost};
+    // The drawing chrome moved out to its own module; the tests that drive it
+    // through `QuantickApp` stay here, and reach its numbers by name.
     use crate::feed::{FeedConnectionState, FeedEvent, FeedNotice};
     use crate::pane::DEFAULT_PANE_FRACTION;
     use crate::pane::DrawingDrag;
+    use crate::surfaces::drawing_chrome::inline_editor::INLINE_TEXT_HINT;
+    use crate::surfaces::drawing_chrome::{
+        DRAWING_INSPECTOR_DEFAULT_POSITION, DRAWING_MANAGER_GAP_PX,
+        INSPECTOR_AUTO_PIN_CHART_WIDTH_PX, INSPECTOR_MIN_WIDTH_PX, InspectorTab,
+    };
     use crate::tab::BOOK_GENERATION_STRIDE;
     use crate::time_header;
     use crate::viewport::Viewport;
@@ -14477,12 +12892,12 @@ plot(close)
     ) -> R {
         let capabilities = app.active_tab().capabilities(&app.config);
         let side_inferred = app.active_tab().side_note(&app.config).is_some();
+        let mut begin_text_edit = false;
         let QuantickApp {
             tabs,
             active_tab,
             toolrail,
             drawing_presets,
-            pending_text_edit,
             style,
             tz,
             layer_actions,
@@ -14493,7 +12908,7 @@ plot(close)
         let mut chrome = pane::PaneChrome {
             toolrail,
             presets: drawing_presets,
-            begin_text_edit: pending_text_edit,
+            begin_text_edit: &mut begin_text_edit,
             style,
             tz: *tz,
             feed_gaps: &[],
@@ -17463,7 +15878,7 @@ crosshair = false
     /// trader does. `the_gear_on_the_context_bar_opens_the_inspector` is the
     /// test that proves this shortcut matches the real button.
     fn open_inspector(app: &mut QuantickApp, ctx: &egui::Context) {
-        app.inspector_open = true;
+        app.surfaces.drawing_chrome.set_inspector_open(true);
         // Two frames: the first opens the window, the second lets it settle
         // its size and automatic placement before anything reads its rect.
         run_frame(app, ctx);
@@ -17544,7 +15959,9 @@ crosshair = false
         run_frame(&mut app, &ctx);
 
         let style_tab_labels = |app: &mut QuantickApp, ctx: &egui::Context| -> Vec<String> {
-            app.inspector_tab = InspectorTab::Style;
+            app.surfaces
+                .drawing_chrome
+                .set_inspector_tab(InspectorTab::Style);
             open_inspector(app, ctx);
             painted_text(&run_frame(app, ctx))
         };
@@ -18479,7 +16896,9 @@ crosshair = false
 
         arm_drawing_from_toolbox(&mut app, &ctx, "horizontal-line");
         click_chart(&mut app, &ctx, egui::pos2(700.0, 300.0));
-        app.inspector_tab = InspectorTab::Coordinates;
+        app.surfaces
+            .drawing_chrome
+            .set_inspector_tab(InspectorTab::Coordinates);
         open_inspector(&mut app, &ctx);
         let texts = painted_text(&run_frame(&mut app, &ctx));
         assert!(
@@ -18647,8 +17066,8 @@ crosshair = false
 
         // Pinned, and the user has expressed the preference — the exact
         // state the report was in.
-        app.inspector_pinned = true;
-        app.inspector_pin_touched = true;
+        app.surfaces.drawing_chrome.set_inspector_pinned(true);
+        app.surfaces.drawing_chrome.set_inspector_pin_touched(true);
         app.active_tab_mut().flow_pane.drawings.select(None);
         run_frame(&mut app, &ctx);
         let wide = app
@@ -19248,11 +17667,13 @@ crosshair = false
         let inspector = ctx
             .memory(|memory| memory.area_rect(egui::Id::new("drawing_inspector")))
             .expect("placing the selected line opens its inspector");
-        app.inspector_moved = true;
-        app.inspector_pos = Some(egui::pos2(
-            inspector.left(),
-            anchor.y - inspector.height() / 2.0,
-        ));
+        app.surfaces.drawing_chrome.set_inspector_moved(true);
+        app.surfaces
+            .drawing_chrome
+            .set_inspector_pos(Some(egui::pos2(
+                inspector.left(),
+                anchor.y - inspector.height() / 2.0,
+            )));
         run_frame(&mut app, &ctx);
         let inspector = ctx
             .memory(|memory| memory.area_rect(egui::Id::new("drawing_inspector")))
@@ -19396,9 +17817,16 @@ crosshair = false
             .last_chart_area
             .expect("chart laid out");
 
-        let pin = app.inspector_pin_rect.expect("pin button rendered");
+        let pin = app
+            .surfaces
+            .drawing_chrome
+            .inspector_pin_rect()
+            .expect("pin button rendered");
         click_chart(&mut app, &ctx, pin.center());
-        assert!(app.inspector_pinned, "clicking Pin docks the inspector");
+        assert!(
+            app.surfaces.drawing_chrome.inspector_pinned(),
+            "clicking Pin docks the inspector"
+        );
         run_frame(&mut app, &ctx);
         let chart_after = app
             .active_tab()
@@ -19413,233 +17841,6 @@ crosshair = false
         assert!(
             texts.iter().any(|text| text.contains("Delete drawing")),
             "the docked panel still shows the named actions"
-        );
-    }
-
-    /// The eight §4.2 candidates, clamped — restated here so a drifted
-    /// implementation cannot silently shrink its own search space.
-    fn placement_candidates(
-        chart: egui::Rect,
-        bbox: egui::Rect,
-        size: egui::Vec2,
-    ) -> [egui::Pos2; 8] {
-        let gap = INSPECTOR_OBJECT_GAP_PX;
-        [
-            egui::pos2(bbox.right() + gap, bbox.top()),
-            egui::pos2(bbox.left() - gap - size.x, bbox.top()),
-            egui::pos2(bbox.left(), bbox.bottom() + gap),
-            egui::pos2(bbox.left(), bbox.top() - gap - size.y),
-            egui::pos2(chart.left() + gap, chart.top() + gap),
-            egui::pos2(chart.right() - gap - size.x, chart.top() + gap),
-            egui::pos2(chart.left() + gap, chart.bottom() - gap - size.y),
-            egui::pos2(chart.right() - gap - size.x, chart.bottom() - gap - size.y),
-        ]
-        .map(|candidate| clamp_into_chart(candidate, size, chart))
-    }
-
-    /// The session's complaint (`docs/ux/drawing-tools-2026-08.md` §F3): the
-    /// old rule put the panel 12 px beside a small object, right on top of
-    /// the price action the trader drew it to read. A corner must win.
-    /// The rule a volume profile broke: a drawing big enough to foul all four
-    /// corners used to get the panel dropped straight onto it.
-    ///
-    /// A profile is exactly that shape — tall enough to span the price axis,
-    /// wide enough to reach past every corner candidate — so "least overlap"
-    /// meant "on the figure", and the panel covered the thing it configures.
-    /// It goes into the gutter beside the object instead, narrowed to fit.
-    #[test]
-    fn a_drawing_too_big_for_any_corner_sends_the_panel_to_a_gutter_beside_it() {
-        let chart = egui::Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(1200.0, 700.0));
-        let size = egui::vec2(320.0, 280.0);
-        // A profile down the middle, wide enough that a panel parked at any
-        // corner overlaps it, and narrow enough that the strip beside it can
-        // still hold a narrowed one. That band is exactly what narrowing is
-        // for: the corner candidate assumes the full width and fouls, the
-        // gutter takes what fits.
-        let bbox = egui::Rect::from_min_max(egui::pos2(320.0, 0.0), egui::pos2(880.0, 700.0));
-        let gap = INSPECTOR_OBJECT_GAP_PX;
-        for corner in [
-            egui::pos2(chart.left() + gap, chart.top() + gap),
-            egui::pos2(chart.right() - gap - size.x, chart.top() + gap),
-            egui::pos2(chart.left() + gap, chart.bottom() - gap - size.y),
-            egui::pos2(chart.right() - gap - size.x, chart.bottom() - gap - size.y),
-        ] {
-            assert!(
-                egui::Rect::from_min_size(corner, size)
-                    .intersect(bbox)
-                    .is_positive(),
-                "the fixture has to actually foul every corner: {corner:?}"
-            );
-        }
-
-        let placed = inspector_placement(chart, bbox, size);
-        let rect = egui::Rect::from_min_size(
-            placed.position,
-            egui::vec2(placed.max_width.unwrap_or(size.x), size.y),
-        );
-        assert!(
-            !rect.intersect(bbox).is_positive(),
-            "the panel must not cover the drawing it configures: {rect:?} vs {bbox:?}"
-        );
-        assert!(
-            chart.contains_rect(rect),
-            "and it stays inside the chart: {rect:?}"
-        );
-        assert!(
-            placed
-                .max_width
-                .is_some_and(|w| w >= INSPECTOR_MIN_WIDTH_PX),
-            "narrowed, but never below what a panel needs: {:?}",
-            placed.max_width
-        );
-    }
-
-    /// The wider side wins, so the panel goes where there is most room — and
-    /// a corner that *is* free still beats any gutter, because the gutter is
-    /// the fallback, not the rule.
-    #[test]
-    fn the_gutter_is_the_wider_side_and_never_preferred_over_a_free_corner() {
-        let chart = egui::Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(1200.0, 700.0));
-        let size = egui::vec2(320.0, 280.0);
-
-        // Object hugging the left: the room is on its right.
-        let left_heavy = egui::Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(400.0, 700.0));
-        let placed = inspector_placement(chart, left_heavy, size);
-        assert!(
-            placed.position.x >= left_heavy.right(),
-            "the panel takes the wider side: {placed:?}"
-        );
-
-        // Object hugging the right: the room is on its left.
-        let right_heavy =
-            egui::Rect::from_min_max(egui::pos2(800.0, 0.0), egui::pos2(1200.0, 700.0));
-        let placed = inspector_placement(chart, right_heavy, size);
-        assert!(
-            placed.position.x + placed.max_width.unwrap_or(size.x) <= right_heavy.left(),
-            "and the other side when that is where the room is: {placed:?}"
-        );
-
-        // A small object leaves corners free, and a free corner is unnarrowed.
-        let small = egui::Rect::from_center_size(chart.center(), egui::vec2(40.0, 40.0));
-        let placed = inspector_placement(chart, small, size);
-        assert_eq!(
-            placed.max_width, None,
-            "a corner placement never narrows the panel: {placed:?}"
-        );
-    }
-
-    #[test]
-    fn placement_sends_the_panel_to_a_corner_not_beside_a_small_object() {
-        let chart = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(1_400.0, 800.0));
-        let bbox = egui::Rect::from_center_size(chart.center(), egui::vec2(40.0, 40.0));
-        let size = egui::vec2(320.0, 280.0);
-        let position = inspector_placement(chart, bbox, size).position;
-        let rect = egui::Rect::from_min_size(position, size);
-        assert!(!rect.intersects(bbox), "a clear candidate exists and wins");
-        assert!(chart.contains_rect(rect));
-        assert_ne!(
-            position,
-            egui::pos2(bbox.right() + INSPECTOR_OBJECT_GAP_PX, bbox.top()),
-            "beside-the-object is exactly the placement this rule replaced"
-        );
-        assert!(
-            placement_candidates(chart, bbox, size)[4..].contains(&position),
-            "the winner is one of the four chart corners"
-        );
-        assert_eq!(
-            position,
-            inspector_placement(chart, bbox, size).position,
-            "identical inputs give identical placements"
-        );
-    }
-
-    /// With the object centred, all four corners are equidistant, so the
-    /// order tie-break decides — and it must always decide the same way, or
-    /// the panel appears somewhere new every time (Duda, §D3).
-    #[test]
-    fn placement_prefers_the_top_left_corner_on_a_tie() {
-        let chart = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(1_400.0, 800.0));
-        let bbox = egui::Rect::from_center_size(chart.center(), egui::vec2(40.0, 40.0));
-        let size = egui::vec2(320.0, 280.0);
-        let gap = INSPECTOR_OBJECT_GAP_PX;
-        assert_eq!(
-            inspector_placement(chart, bbox, size).position,
-            egui::pos2(chart.left() + gap, chart.top() + gap)
-        );
-    }
-
-    /// A panel taller than the placement assumed must not be sent to a bottom
-    /// corner, where it would grow off the window and lose its last rows. The
-    /// top-first order is what guarantees that, so it is worth a test of its
-    /// own: whatever height the panel turns out to have, the chosen spot
-    /// leaves room for it below.
-    #[test]
-    fn placement_leaves_a_tall_panel_room_to_grow_downwards() {
-        let chart = egui::Rect::from_min_size(egui::pos2(60.0, 88.0), egui::vec2(1_224.0, 744.0));
-        let bbox = egui::Rect::from_center_size(egui::pos2(700.0, 300.0), egui::vec2(40.0, 40.0));
-        // The height the placement believes in, and the height the panel
-        // turns out to want once its level editor is open.
-        let assumed = egui::vec2(360.0, 280.0);
-        let actual = 620.0;
-        let position = inspector_placement(chart, bbox, assumed).position;
-        assert!(
-            position.y + actual <= chart.bottom(),
-            "a panel that grows to {actual} px must still fit below {position:?}"
-        );
-    }
-
-    /// The farthest clear corner wins, so the panel walks away from the
-    /// object instead of hugging the nearest empty spot.
-    #[test]
-    fn placement_picks_the_corner_farthest_from_the_object() {
-        let chart = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(1_400.0, 800.0));
-        // Object parked in the bottom-left quadrant.
-        let bbox = egui::Rect::from_center_size(egui::pos2(260.0, 640.0), egui::vec2(40.0, 40.0));
-        let size = egui::vec2(320.0, 280.0);
-        let gap = INSPECTOR_OBJECT_GAP_PX;
-        assert_eq!(
-            inspector_placement(chart, bbox, size).position,
-            egui::pos2(chart.right() - gap - size.x, chart.top() + gap),
-            "the opposite corner is the farthest clear one"
-        );
-    }
-
-    #[test]
-    fn placement_picks_the_least_overlap_when_nothing_clears() {
-        let chart = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(1_000.0, 600.0));
-        // The object spans ~90% of the pane: every candidate overlaps.
-        let bbox = chart.shrink2(egui::vec2(50.0, 30.0));
-        let size = egui::vec2(320.0, 280.0);
-        let position = inspector_placement(chart, bbox, size).position;
-        let chosen = egui::Rect::from_min_size(position, size)
-            .intersect(bbox)
-            .area();
-        for candidate in placement_candidates(chart, bbox, size) {
-            let overlap = egui::Rect::from_min_size(candidate, size)
-                .intersect(bbox)
-                .area();
-            assert!(
-                chosen <= overlap + 0.01,
-                "the chosen spot must cover the object least: {chosen} vs {overlap}"
-            );
-        }
-        assert!(chart.contains_rect(egui::Rect::from_min_size(position, size)));
-    }
-
-    #[test]
-    fn placement_never_returns_the_blind_first_candidate_at_the_right_edge() {
-        let chart = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(1_000.0, 600.0));
-        let bbox = egui::Rect::from_min_max(egui::pos2(900.0, 200.0), egui::pos2(1_000.0, 300.0));
-        let size = egui::vec2(320.0, 280.0);
-        let position = inspector_placement(chart, bbox, size).position;
-        let rect = egui::Rect::from_min_size(position, size);
-        assert!(
-            !rect.intersects(bbox),
-            "left of the object clears; the old code clamped right-of back onto it"
-        );
-        assert!(
-            position.x < bbox.left(),
-            "the panel must sit clear on the left, not clamp over the object"
         );
     }
 
@@ -19664,10 +17865,14 @@ crosshair = false
         let bar = egui::pos2(inspector.left() + 60.0, inspector.top() + 14.0);
         drag_chart(&mut app, &ctx, bar, bar + egui::vec2(150.0, 120.0));
         assert!(
-            app.inspector_moved,
+            app.surfaces.drawing_chrome.inspector_moved(),
             "a title-bar drag records the manual move"
         );
-        let held = app.inspector_pos.expect("the manual position is recorded");
+        let held = app
+            .surfaces
+            .drawing_chrome
+            .inspector_pos()
+            .expect("the manual position is recorded");
 
         // Selecting the other line must not snap the window back. The panel
         // closes with the selection now — the context bar is what the next
@@ -19677,11 +17882,14 @@ crosshair = false
         run_frame(&mut app, &ctx);
         open_inspector(&mut app, &ctx);
         assert_eq!(
-            app.inspector_pos,
+            app.surfaces.drawing_chrome.inspector_pos(),
             Some(held),
             "the manual position survives a selection change"
         );
-        assert!(app.inspector_moved, "the manual flag is never auto-cleared");
+        assert!(
+            app.surfaces.drawing_chrome.inspector_moved(),
+            "the manual flag is never auto-cleared"
+        );
     }
 
     #[test]
@@ -19700,7 +17908,7 @@ crosshair = false
             .expect("the inspector is open");
         let bar = egui::pos2(inspector.left() + 60.0, inspector.top() + 14.0);
         drag_chart(&mut app, &ctx, bar, bar + egui::vec2(120.0, 90.0));
-        assert!(app.inspector_moved);
+        assert!(app.surfaces.drawing_chrome.inspector_moved());
 
         let inspector = ctx
             .memory(|memory| memory.area_rect(egui::Id::new("drawing_inspector")))
@@ -19718,7 +17926,7 @@ crosshair = false
             ],
         );
         assert!(
-            !app.inspector_moved,
+            !app.surfaces.drawing_chrome.inspector_moved(),
             "double-click on the title bar re-arms automatic placement"
         );
     }
@@ -19836,7 +18044,10 @@ crosshair = false
         // The write is queued during the release frame and flushed at the top
         // of the next one, where every other workspace write lives.
         run_frame(app, ctx);
-        app.inspector_pos.expect("the drag records a position")
+        app.surfaces
+            .drawing_chrome
+            .inspector_pos()
+            .expect("the drag records a position")
     }
 
     /// A cockpit already on disk, which is what every session after the first
@@ -19910,7 +18121,7 @@ crosshair = false
         let parked = park_the_popup(&mut app, &ctx, egui::vec2(150.0, 90.0));
 
         assert_eq!(
-            app.inspector_pos,
+            app.surfaces.drawing_chrome.inspector_pos(),
             Some(parked),
             "the window still went where it was dragged"
         );
@@ -19963,12 +18174,12 @@ crosshair = false
         next.restore_workspace(ui_state::load(&app.ui_state_path).restore(&config));
 
         assert_eq!(
-            next.inspector_pos,
+            next.surfaces.drawing_chrome.inspector_pos(),
             Some(parked),
             "the popup opens where the last session left it"
         );
         assert!(
-            next.inspector_moved,
+            next.surfaces.drawing_chrome.inspector_moved(),
             "and counts as hand-placed, so nothing places it again"
         );
         let _ = std::fs::remove_file(&app.ui_state_path);
@@ -19988,7 +18199,9 @@ crosshair = false
 
         // What a restored workspace does, through the same one door.
         let remembered = egui::pos2(420.0, 200.0);
-        app.place_inspector_by_hand(remembered);
+        app.surfaces
+            .drawing_chrome
+            .place_inspector_by_hand(remembered);
 
         // A different drawing than the one selected when it was parked.
         click_chart(&mut app, &ctx, egui::pos2(400.0, 250.0));
@@ -20042,9 +18255,12 @@ crosshair = false
         // where it used to be" — and the last place it was is exactly the
         // value that would make a position assertion pass on a popup that is
         // no longer floating. Ask the app what it drew before reading egui.
-        assert!(app.inspector_open, "the gear's door is open");
         assert!(
-            !app.inspector_pinned,
+            app.surfaces.drawing_chrome.inspector_open(),
+            "the gear's door is open"
+        );
+        assert!(
+            !app.surfaces.drawing_chrome.inspector_pinned(),
             "and the popup is floating, not docked"
         );
         assert_eq!(
@@ -20087,7 +18303,10 @@ crosshair = false
         let grip = egui::pos2(popup.left() + 60.0, popup.top() + 14.0);
         drag_chart(&mut app, &ctx, grip, grip + egui::vec2(-220.0, 150.0));
         run_frame(&mut app, &ctx);
-        assert!(app.inspector_moved, "the drag records the manual move");
+        assert!(
+            app.surfaces.drawing_chrome.inspector_moved(),
+            "the drag records the manual move"
+        );
         let parked = ctx
             .memory(|memory| memory.area_rect(egui::Id::new("drawing_inspector")))
             .expect("still open")
@@ -20130,26 +18349,41 @@ crosshair = false
         app.drawing_pane_mut().drawings.select(Some(avwap));
         run_frame(&mut app, &ctx);
         run_frame(&mut app, &ctx);
-        let bar = app.context_bar_rect.expect("the selection raised the bar");
+        let bar = app
+            .surfaces
+            .drawing_chrome
+            .context_bar_rect()
+            .expect("the selection raised the bar");
         let grip = egui::pos2(bar.left() + 8.0, bar.center().y);
         drag_chart(&mut app, &ctx, grip, grip + egui::vec2(-180.0, 200.0));
         run_frame(&mut app, &ctx);
         assert!(
-            app.context_bar.manual_position().is_some(),
+            app.surfaces
+                .drawing_chrome
+                .context_bar()
+                .manual_position()
+                .is_some(),
             "the grip drag records a hand-placed position"
         );
-        let parked = app.context_bar_rect.expect("still up").min;
+        let parked = app
+            .surfaces
+            .drawing_chrome
+            .context_bar_rect()
+            .expect("still up")
+            .min;
 
         app.drawing_pane_mut().drawings.select(Some(profile));
         // The mirror is written only when the bar actually draws, and none of
         // the host's early returns clear it — so a stale value would answer
         // for a bar that stopped appearing, which is the regression this test
         // exists to catch. Blank it and let the frame fill it in.
-        app.context_bar_rect = None;
+        app.surfaces.drawing_chrome.forget_context_bar_rect();
         run_frame(&mut app, &ctx);
         run_frame(&mut app, &ctx);
         assert_eq!(
-            app.context_bar_rect
+            app.surfaces
+                .drawing_chrome
+                .context_bar_rect()
                 .expect("the next object raises it too")
                 .min,
             parked,
@@ -20172,7 +18406,11 @@ crosshair = false
         for _ in 0..quiet_frames {
             run_frame(&mut app, &ctx);
         }
-        let bar = app.context_bar_rect.expect("still up");
+        let bar = app
+            .surfaces
+            .drawing_chrome
+            .context_bar_rect()
+            .expect("still up");
         let grip = egui::pos2(bar.left() + 8.0, bar.center().y);
         run_frame_with_events(
             &mut app,
@@ -20185,10 +18423,10 @@ crosshair = false
                 pointer_button(grip, false),
             ],
         );
-        app.context_bar_rect = None;
+        app.surfaces.drawing_chrome.forget_context_bar_rect();
         run_frame(&mut app, &ctx);
         assert_eq!(
-            app.context_bar.manual_position(),
+            app.surfaces.drawing_chrome.context_bar().manual_position(),
             None,
             "the double-click hands placement back to the rule"
         );
@@ -20197,7 +18435,11 @@ crosshair = false
         // that is no longer the parked point. This is the only door out of the
         // parked state, and a door that clears the flag while leaving the bar
         // in a third place would be no door at all.
-        let placed = app.context_bar_rect.expect("the bar is still up");
+        let placed = app
+            .surfaces
+            .drawing_chrome
+            .context_bar_rect()
+            .expect("the bar is still up");
         let chart = app.drawing_pane().last_chart_area.expect("the pane drew");
         let expected = drawings::context_bar::place(
             chart,
@@ -20251,11 +18493,16 @@ crosshair = false
         app.drawing_pane_mut().drawings.select(Some(line));
         run_frame(&mut app, &ctx);
         let parked = egui::pos2(320.0, 240.0);
-        app.context_bar.set_manual(parked);
-        app.context_bar_rect = None;
+        app.surfaces
+            .drawing_chrome
+            .context_bar_mut()
+            .set_manual(parked);
+        app.surfaces.drawing_chrome.forget_context_bar_rect();
         run_frame(&mut app, &ctx);
         let drawn = app
-            .context_bar_rect
+            .surfaces
+            .drawing_chrome
+            .context_bar_rect()
             .expect("the bar is up where it was put")
             .min;
 
@@ -20271,7 +18518,7 @@ crosshair = false
             "the press does what the trader aimed it at: the selection goes"
         );
         assert_eq!(
-            app.context_bar.manual_position(),
+            app.surfaces.drawing_chrome.context_bar().manual_position(),
             Some(parked),
             "and the position they chose is still theirs on the next object"
         );
@@ -20282,54 +18529,18 @@ crosshair = false
         // against the parked point itself, so the test says "unchanged" and
         // not "happens to need no repair at this window size".
         app.drawing_pane_mut().drawings.select(Some(other));
-        app.context_bar_rect = None;
+        app.surfaces.drawing_chrome.forget_context_bar_rect();
         run_frame(&mut app, &ctx);
         run_frame(&mut app, &ctx);
         assert_eq!(
-            app.context_bar_rect.expect("the bar is back").min,
+            app.surfaces
+                .drawing_chrome
+                .context_bar_rect()
+                .expect("the bar is back")
+                .min,
             drawn,
             "the bar comes back parked, on another object, not beside it"
         );
-    }
-
-    /// The live lane is off limits to the bar however it got where it is.
-    ///
-    /// `context_bar::place` has kept clear of that strip since it was written
-    /// — it is where the price the trader is reading is being formed, and
-    /// losing sight of it is the trader's first veto. A parked bar is placed
-    /// by a different rule, so the bound both rules clamp into is what keeps
-    /// them honest: without it the repair would happily pin a parked bar at
-    /// the pane's own right edge, on top of the forming column, for every
-    /// object of the session.
-    #[test]
-    fn the_context_bar_bound_takes_the_live_lane_off_the_pane() {
-        let chart = egui::Rect::from_min_max(egui::pos2(60.0, 88.0), egui::pos2(1284.0, 832.0));
-        let size = egui::vec2(292.0, 40.0);
-        let divider = 900.0;
-
-        let bounds = context_bar_bounds(chart, divider, size);
-        assert_eq!(bounds.right(), divider, "the lane is not the bar's to use");
-        assert_eq!(
-            clamp_into_chart(egui::pos2(3000.0, 400.0), size, bounds).x,
-            divider - size.x,
-            "a bar parked out past the lane is repaired to its inner edge"
-        );
-
-        // No lane on this pane: the chart's own edge is the answer, exactly as
-        // the automatic rule takes `chart.right()` when the divider is None.
-        assert_eq!(
-            context_bar_bounds(chart, chart.right(), size).right(),
-            chart.right()
-        );
-
-        // A lane wider than the history area leaves nothing to place in. The
-        // pane's edge beats an empty rectangle — the same call `place` makes.
-        let all_lane = context_bar_bounds(chart, chart.left() + 10.0, size);
-        assert!(
-            all_lane.width() >= size.x.min(chart.width()),
-            "a bar still has somewhere to go: {all_lane:?}"
-        );
-        assert!(chart.contains_rect(all_lane), "and it is inside the pane");
     }
 
     /// A position parked on a full-width canvas has to survive the canvas
@@ -20353,13 +18564,16 @@ crosshair = false
 
         // Parked far to the right of what either pane of a split will offer.
         let parked = egui::pos2(1200.0, 780.0);
-        app.context_bar.set_manual(parked);
+        app.surfaces
+            .drawing_chrome
+            .context_bar_mut()
+            .set_manual(parked);
         app.active_tab_mut().set_layout(CanvasLayout::TimeAndFlow);
         // Blank the mirror first: it is written only when the bar reaches
         // `show`, and every early return leaves the previous frame's value —
         // here the full-width rect, which would satisfy the assertion below
         // with the repair never having run.
-        app.context_bar_rect = None;
+        app.surfaces.drawing_chrome.forget_context_bar_rect();
         run_frame(&mut app, &ctx);
         run_frame(&mut app, &ctx);
 
@@ -20367,13 +18581,17 @@ crosshair = false
             .drawing_pane()
             .last_chart_area
             .expect("the pane holding the selection drew");
-        let bar = app.context_bar_rect.expect("the bar is still up");
+        let bar = app
+            .surfaces
+            .drawing_chrome
+            .context_bar_rect()
+            .expect("the bar is still up");
         assert!(
             chart.contains_rect(bar),
             "the parked bar is repaired into {chart:?}, drawn at {bar:?}"
         );
         assert_eq!(
-            app.context_bar.manual_position(),
+            app.surfaces.drawing_chrome.context_bar().manual_position(),
             Some(parked),
             "and the point the hand chose survives the repair"
         );
@@ -20444,13 +18662,15 @@ crosshair = false
 
         // What a restored workspace does.
         let remembered = egui::pos2(300.0, 200.0);
-        app.restore_inspector_position(Some([remembered.x, remembered.y]));
-        app.inspector_open = true;
+        app.surfaces
+            .drawing_chrome
+            .restore_inspector_position(Some([remembered.x, remembered.y]));
+        app.surfaces.drawing_chrome.set_inspector_open(true);
         run_sized_frame(&mut app, &ctx, MIN_WINDOW, Vec::new());
         run_sized_frame(&mut app, &ctx, MIN_WINDOW, Vec::new());
 
         assert!(
-            !app.inspector_pinned,
+            !app.surfaces.drawing_chrome.inspector_pinned(),
             "the parked position wins over the narrow-chart auto-pin"
         );
         assert!(
@@ -20470,22 +18690,24 @@ crosshair = false
         app.ui_state_path = scratch_ui_state("popup-auto-pin-default");
         // A previous cockpit that *did* park the popup, so this proves the
         // silence is adopted rather than merely never contradicted.
-        app.place_inspector_by_hand(egui::pos2(300.0, 200.0));
-        app.restore_inspector_position(None);
+        app.surfaces
+            .drawing_chrome
+            .place_inspector_by_hand(egui::pos2(300.0, 200.0));
+        app.surfaces.drawing_chrome.restore_inspector_position(None);
         run_sized_frame(&mut app, &ctx, MIN_WINDOW, Vec::new());
         app.toolrail
             .arm(Tool::Drawing(drawing_tool("horizontal-line")));
         click_sized(&mut app, &ctx, MIN_WINDOW, egui::pos2(500.0, 300.0));
-        app.inspector_open = true;
+        app.surfaces.drawing_chrome.set_inspector_open(true);
         run_sized_frame(&mut app, &ctx, MIN_WINDOW, Vec::new());
         run_sized_frame(&mut app, &ctx, MIN_WINDOW, Vec::new());
 
         assert!(
-            !app.inspector_pin_touched,
+            !app.surfaces.drawing_chrome.inspector_pin_touched(),
             "silence in the file is not a preference about the pin"
         );
         assert!(
-            app.inspector_pinned,
+            app.surfaces.drawing_chrome.inspector_pinned(),
             "so a chart too narrow for a floating window still docks the panel"
         );
     }
@@ -20507,7 +18729,7 @@ crosshair = false
         app.ui_state_path = scratch_ui_state("popup-clamp");
         // The auto-pin owns a chart this narrow until the trader touches the
         // pin; this test is about the floating window, so say they have.
-        app.inspector_pin_touched = true;
+        app.surfaces.drawing_chrome.set_inspector_pin_touched(true);
         run_sized_frame(&mut app, &ctx, MIN_WINDOW, Vec::new());
         app.toolrail
             .arm(Tool::Drawing(drawing_tool("horizontal-line")));
@@ -20523,7 +18745,7 @@ crosshair = false
             Vec::new(),
             Some(chrome_with_popup_at(Some(parked))),
         ));
-        app.inspector_open = true;
+        app.surfaces.drawing_chrome.set_inspector_open(true);
         run_sized_frame(&mut app, &ctx, MIN_WINDOW, Vec::new());
         run_sized_frame(&mut app, &ctx, MIN_WINDOW, Vec::new());
 
@@ -20540,7 +18762,7 @@ crosshair = false
              {popup:?} against {chart:?}"
         );
         assert_eq!(
-            app.remembered_inspector_position(),
+            app.surfaces.drawing_chrome.remembered_inspector_position(),
             Some(parked),
             "and the point the trader parked is not eaten by the repair — the \
              desk monitor gets it back"
@@ -20555,7 +18777,7 @@ crosshair = false
         let ctx = egui::Context::default();
         let (mut app, _commands) = app_with_history(200);
         app.ui_state_path = scratch_ui_state("popup-ratchet");
-        app.inspector_pin_touched = true;
+        app.surfaces.drawing_chrome.set_inspector_pin_touched(true);
         run_sized_frame(&mut app, &ctx, MIN_WINDOW, Vec::new());
         app.toolrail
             .arm(Tool::Drawing(drawing_tool("horizontal-line")));
@@ -20565,14 +18787,14 @@ crosshair = false
         // Parked against the bottom-right of a big screen, then squeezed by a
         // small one for a while.
         let parked = egui::pos2(1_500.0, 900.0);
-        app.place_inspector_by_hand(parked);
-        app.inspector_open = true;
+        app.surfaces.drawing_chrome.place_inspector_by_hand(parked);
+        app.surfaces.drawing_chrome.set_inspector_open(true);
         for _ in 0..6 {
             run_sized_frame(&mut app, &ctx, MIN_WINDOW, Vec::new());
         }
 
         assert_eq!(
-            app.inspector_pos,
+            app.surfaces.drawing_chrome.inspector_pos(),
             Some(parked),
             "six frames of repair leave the parked point exactly as it was"
         );
@@ -20587,14 +18809,19 @@ crosshair = false
         let (mut app, _commands) = app_with_history(50);
 
         for pair in [[f32::NAN, 200.0], [200.0, f32::NAN], [f32::INFINITY, 200.0]] {
-            app.place_inspector_by_hand(egui::pos2(10.0, 10.0));
-            app.restore_inspector_position(Some(pair));
+            app.surfaces
+                .drawing_chrome
+                .place_inspector_by_hand(egui::pos2(10.0, 10.0));
+            app.surfaces
+                .drawing_chrome
+                .restore_inspector_position(Some(pair));
             assert_eq!(
-                app.inspector_pos, None,
+                app.surfaces.drawing_chrome.inspector_pos(),
+                None,
                 "{pair:?} is not a position, and must not survive as one"
             );
             assert!(
-                !app.inspector_moved,
+                !app.surfaces.drawing_chrome.inspector_moved(),
                 "{pair:?} hands the popup back to automatic placement"
             );
         }
@@ -20610,7 +18837,7 @@ crosshair = false
         let (mut app, _commands) = app_with_history(500);
         app.ui_state_path = scratch_ui_state("demo-inspector");
         app.pending_drawing_demo = true;
-        app.inspector_open = true;
+        app.surfaces.drawing_chrome.set_inspector_open(true);
 
         for _ in 0..4 {
             run_frame(&mut app, &ctx);
@@ -20622,20 +18849,9 @@ crosshair = false
             "and left an object selected, which is what closes the panel"
         );
         assert!(
-            app.inspector_open,
+            app.surfaces.drawing_chrome.inspector_open(),
             "the panel the hook asked for survives the demo's own selection"
         );
-    }
-
-    /// A harness hook that guessed would photograph an invented pixel and call
-    /// it the trader's. Refuse instead, and the capture shows the default.
-    #[test]
-    fn the_popup_position_hook_refuses_what_is_not_a_point() {
-        assert_eq!(parse_point("420,200"), Some(egui::pos2(420.0, 200.0)));
-        assert_eq!(parse_point(" 420 , 200.5 "), Some(egui::pos2(420.0, 200.5)));
-        for raw in ["", "420", "420,", ",200", "left,top", "420x200"] {
-            assert_eq!(parse_point(raw), None, "{raw:?} is not a point");
-        }
     }
 
     fn run_sized_frame(
@@ -20692,19 +18908,29 @@ crosshair = false
         // The auto-pin is about the *panel*, and the panel now opens on
         // request: asking for it on a chart this narrow is what trips the
         // rule, because a 320 px floating window has nowhere to go here.
-        app.inspector_open = true;
+        app.surfaces.drawing_chrome.set_inspector_open(true);
         run_sized_frame(&mut app, &ctx, narrow, Vec::new());
         assert!(
-            app.inspector_pinned,
+            app.surfaces.drawing_chrome.inspector_pinned(),
             "opening the panel on a narrow chart opens it pinned"
         );
 
         // The user unpins: their preference holds from here on.
         run_sized_frame(&mut app, &ctx, narrow, Vec::new());
-        let pin = app.inspector_pin_rect.expect("the panel renders its pin");
+        let pin = app
+            .surfaces
+            .drawing_chrome
+            .inspector_pin_rect()
+            .expect("the panel renders its pin");
         click_sized(&mut app, &ctx, narrow, pin.center());
-        assert!(!app.inspector_pinned, "the pin toggles the panel off");
-        assert!(app.inspector_pin_touched, "the preference is recorded");
+        assert!(
+            !app.surfaces.drawing_chrome.inspector_pinned(),
+            "the pin toggles the panel off"
+        );
+        assert!(
+            app.surfaces.drawing_chrome.inspector_pin_touched(),
+            "the preference is recorded"
+        );
 
         // Unpinning with the same selection must recompute placement — not
         // fall back to the fixed default corner (the pinned host claimed the
@@ -20741,7 +18967,7 @@ crosshair = false
         click_sized(&mut app, &ctx, narrow, egui::pos2(500.0, 300.0));
         run_sized_frame(&mut app, &ctx, narrow, Vec::new());
         assert!(
-            !app.inspector_pinned,
+            !app.surfaces.drawing_chrome.inspector_pinned(),
             "once touched, the auto-pin width rule stops firing"
         );
     }
@@ -20762,11 +18988,13 @@ crosshair = false
             .expect("the inspector is open");
         // Parked over the stroke by hand: automatic placement now clears the
         // object on purpose (§D3), and this proof needs the overlap.
-        app.inspector_moved = true;
-        app.inspector_pos = Some(egui::pos2(
-            inspector.left(),
-            300.0 - inspector.height() / 2.0,
-        ));
+        app.surfaces.drawing_chrome.set_inspector_moved(true);
+        app.surfaces
+            .drawing_chrome
+            .set_inspector_pos(Some(egui::pos2(
+                inspector.left(),
+                300.0 - inspector.height() / 2.0,
+            )));
         run_frame(&mut app, &ctx);
         let inspector = ctx
             .memory(|memory| memory.area_rect(egui::Id::new("drawing_inspector")))
@@ -20798,7 +19026,7 @@ crosshair = false
             .objects_button_rect()
             .expect("the rail shows the Objects entry");
         click_chart(&mut app, &ctx, objects.center());
-        assert!(app.drawing_manager_open);
+        assert!(app.surfaces.drawing_chrome.manager_open());
         run_frame(&mut app, &ctx);
 
         let manager = ctx
@@ -20829,13 +19057,15 @@ crosshair = false
         app.toolrail
             .arm(Tool::Drawing(drawing_tool("horizontal-line")));
         click_chart(&mut app, &ctx, egui::pos2(700.0, 300.0));
-        app.drawing_manager_open = true;
+        app.surfaces.drawing_chrome.set_manager_open(true);
         // Let the manager window settle its size before reading button rects.
         run_frame(&mut app, &ctx);
         run_frame(&mut app, &ctx);
 
         let delete = app
-            .manager_action_rects
+            .surfaces
+            .drawing_chrome
+            .manager_action_rects()
             .iter()
             .find(|(index, action, _)| *index == 0 && *action == "Delete")
             .map(|(_, _, rect)| *rect)
@@ -20878,13 +19108,15 @@ crosshair = false
             .expect("the toolbox shows the Objects entry");
         click_chart(&mut app, &ctx, objects.center());
         assert!(
-            app.drawing_manager_open,
+            app.surfaces.drawing_chrome.manager_open(),
             "the Objects button opens the manager"
         );
         run_frame(&mut app, &ctx);
 
         let rect_of = |app: &QuantickApp, index: usize, action: &str| {
-            app.manager_action_rects
+            app.surfaces
+                .drawing_chrome
+                .manager_action_rects()
                 .iter()
                 .find(|(row, name, _)| *row == index && *name == action)
                 .map(|(_, _, rect)| *rect)
@@ -20991,7 +19223,11 @@ crosshair = false
             .arm(Tool::Drawing(drawing_tool("horizontal-line")));
         click_chart(&mut app, &ctx, egui::pos2(700.0, 300.0));
         run_frame(&mut app, &ctx);
-        let before = app.context_bar_rect.expect("the bar is on screen");
+        let before = app
+            .surfaces
+            .drawing_chrome
+            .context_bar_rect()
+            .expect("the bar is on screen");
 
         // The grip is the leading cell; grab its middle and pull well past
         // the distance that used to break it.
@@ -21000,10 +19236,16 @@ crosshair = false
         run_frame(&mut app, &ctx);
 
         let after = app
-            .context_bar_rect
+            .surfaces
+            .drawing_chrome
+            .context_bar_rect()
             .expect("the bar must survive its own drag");
         assert!(
-            app.context_bar.manual_position().is_some(),
+            app.surfaces
+                .drawing_chrome
+                .context_bar()
+                .manual_position()
+                .is_some(),
             "the drag has to be recorded as a hand-placed position"
         );
         assert!(
@@ -21098,7 +19340,7 @@ crosshair = false
             "the field opens focused: a caret nobody can see is a click nobody was told about"
         );
         assert!(
-            !app.inspector_open,
+            !app.surfaces.drawing_chrome.inspector_open(),
             "the panel is no longer how a note is written"
         );
 
@@ -21402,7 +19644,7 @@ crosshair = false
         let (mut app, _commands) = app_with_history(200);
         let ctx = egui::Context::default();
         run_frame(&mut app, &ctx);
-        app.pending_text_note = true;
+        app.surfaces.drawing_chrome.set_pending_text_note(true);
         run_frame(&mut app, &ctx);
         let index = app
             .inline_text_editing()
@@ -21640,7 +19882,7 @@ crosshair = false
 
         assert_eq!(app.active_tab().flow_pane.drawings.selected(), Some(0));
         assert!(
-            app.context_bar_rect.is_some(),
+            app.surfaces.drawing_chrome.context_bar_rect().is_some(),
             "the selection raises the context bar"
         );
         for absent in ["Horizontal line settings", "Delete drawing", "Style"] {
@@ -21672,7 +19914,9 @@ crosshair = false
         let undo_before = app.active_tab().flow_pane.drawings.undo_depth();
 
         let swatch = app
-            .context_bar
+            .surfaces
+            .drawing_chrome
+            .context_bar()
             .color_rect()
             .expect("the bar renders its colour slot");
         click_chart(&mut app, &ctx, swatch.center());
@@ -21681,7 +19925,9 @@ crosshair = false
         // The palette's fourth entry is BUY — "this is the buy zone" is the
         // reason a level gets recoloured at all.
         let buy = app
-            .context_bar
+            .surfaces
+            .drawing_chrome
+            .context_bar()
             .swatch_rect(3)
             .expect("the palette opened under the slot");
         click_chart(&mut app, &ctx, buy.center());
@@ -21714,13 +19960,18 @@ crosshair = false
         click_chart(&mut app, &ctx, egui::pos2(700.0, 300.0));
         run_frame(&mut app, &ctx);
         let gear = app
-            .context_bar
+            .surfaces
+            .drawing_chrome
+            .context_bar()
             .gear_rect()
             .expect("the bar rendered its gear");
         click_chart(&mut app, &ctx, gear.center());
         run_frame(&mut app, &ctx);
 
-        assert!(app.inspector_open, "the gear opens the panel");
+        assert!(
+            app.surfaces.drawing_chrome.inspector_open(),
+            "the gear opens the panel"
+        );
         let texts = painted_text(&run_frame(&mut app, &ctx));
         assert!(
             texts
@@ -21742,14 +19993,17 @@ crosshair = false
             .arm(Tool::Drawing(drawing_tool("horizontal-line")));
         click_chart(&mut app, &ctx, egui::pos2(700.0, 300.0));
         run_frame(&mut app, &ctx);
-        assert!(app.context_bar_rect.is_some(), "the finished object has it");
+        assert!(
+            app.surfaces.drawing_chrome.context_bar_rect().is_some(),
+            "the finished object has it"
+        );
 
-        app.context_bar_rect = None;
+        app.surfaces.drawing_chrome.forget_context_bar_rect();
         app.toolrail
             .arm(Tool::Drawing(drawing_tool("horizontal-line")));
         run_frame(&mut app, &ctx);
         assert!(
-            app.context_bar_rect.is_none(),
+            app.surfaces.drawing_chrome.context_bar_rect().is_none(),
             "arming a tool clears the way for the next drawing"
         );
     }
@@ -22229,10 +20483,16 @@ crosshair = false
             .drawings
             .set_selected_locked(true);
         run_frame_with_events(&mut app, &ctx, vec![key_press(egui::Key::Delete)]);
-        assert!(app.drawing_delete_confirm, "the confirmation is pending");
+        assert!(
+            app.surfaces.drawing_chrome.delete_confirm(),
+            "the confirmation is pending"
+        );
 
         run_frame_with_events(&mut app, &ctx, vec![key_press(egui::Key::Escape)]);
-        assert!(!app.drawing_delete_confirm, "first Esc cancels the confirm");
+        assert!(
+            !app.surfaces.drawing_chrome.delete_confirm(),
+            "first Esc cancels the confirm"
+        );
         assert!(
             app.active_tab().flow_pane.drawings.selected().is_some(),
             "the selection survives"
@@ -22546,7 +20806,9 @@ crosshair = false
             "the tool-owned tab is offered by name; painted: {texts:?}"
         );
 
-        app.inspector_tab = InspectorTab::Extra;
+        app.surfaces
+            .drawing_chrome
+            .set_inspector_tab(InspectorTab::Extra);
         run_frame(&mut app, &ctx);
         // The level editor is taller than the window. Everything in it must
         // still be *reachable* — which is what the panel's scroll is for, and
@@ -23978,12 +22240,12 @@ crosshair = false
             "and every tab phrases its request that way"
         );
         assert_eq!(
-            app.inspector_pos,
+            app.surfaces.drawing_chrome.inspector_pos(),
             Some(egui::pos2(260.0, 480.0)),
             "the properties popup reopens where the trader parked it"
         );
         assert!(
-            app.inspector_moved,
+            app.surfaces.drawing_chrome.inspector_moved(),
             "and counts as hand-placed, so automatic placement does not undo it"
         );
     }
@@ -24407,13 +22669,17 @@ crosshair = false
         app.tz = TzOffset::new(0);
         // The properties popup is part of an arrangement like the dock and the
         // rail are, so a bookmark carries where it was parked.
-        app.place_inspector_by_hand(egui::pos2(510.0, 240.0));
+        app.surfaces
+            .drawing_chrome
+            .place_inspector_by_hand(egui::pos2(510.0, 240.0));
         app.save_named_workspace("context");
 
         // Drift away from it, then come back.
         app.active_tab_mut().set_layout(CanvasLayout::Single);
         app.tz = TzOffset::new(-180);
-        app.place_inspector_by_hand(egui::pos2(120.0, 640.0));
+        app.surfaces
+            .drawing_chrome
+            .place_inspector_by_hand(egui::pos2(120.0, 640.0));
         run_frame(&mut app, &ctx);
 
         app.open_named_workspace("context");
@@ -24424,7 +22690,7 @@ crosshair = false
         assert_eq!(app.active_tab().layout, CanvasLayout::Time);
         assert_eq!(app.tz.minutes(), 0, "the chrome comes back with it");
         assert_eq!(
-            app.inspector_pos,
+            app.surfaces.drawing_chrome.inspector_pos(),
             Some(egui::pos2(510.0, 240.0)),
             "including where the popup was parked when the bookmark was named"
         );
@@ -26719,12 +24985,10 @@ crosshair = false
         // An edit begun on the time pane: the baseline, then a real change to
         // the object (the store records an entry only if something moved).
         let before = app.active_tab().pane(PaneSide::Time(0)).drawings.items()[0].clone();
-        app.inspector_edit_baseline = Some(InspectorEdit {
-            tab: app.active_tab().id,
-            side: PaneSide::Time(0),
-            index: 0,
-            before,
-        });
+        let tab_id = app.active_tab().id;
+        app.surfaces
+            .drawing_chrome
+            .open_edit_gesture(tab_id, PaneSide::Time(0), 0, before);
         app.active_tab_mut()
             .pane_mut(PaneSide::Time(0))
             .drawings
@@ -26740,7 +25004,10 @@ crosshair = false
         let point = pane_point(&app, PaneSide::Flow);
         click_chart(&mut app, &ctx, point);
         assert_eq!(app.active_tab().focused_side(), PaneSide::Flow);
-        app.commit_inspector_gesture();
+        // No hand on the commit: the chrome notices that pointer and keyboard
+        // have let go, hands the baseline back through its response, and the
+        // host records it against the pane the edit named.
+        run_frame(&mut app, &ctx);
 
         assert_eq!(
             app.active_tab()
@@ -32365,7 +30632,7 @@ crosshair = false
         let (mut app, _commands) = app_with_history(8);
         run_frame(&mut app, &ctx);
         // The trader's own: the note hook takes the click path's own door.
-        app.pending_text_note = true;
+        app.surfaces.drawing_chrome.set_pending_text_note(true);
         run_frame(&mut app, &ctx);
         let after_trader = app.active_tab().drawing_pane().drawings.items().len();
         assert_eq!(after_trader, 1, "the trader placed one object");
@@ -32457,7 +30724,7 @@ crosshair = false
         let ctx = egui::Context::default();
         let (mut app, _commands) = app_with_history(8);
         run_frame(&mut app, &ctx);
-        app.pending_text_note = true;
+        app.surfaces.drawing_chrome.set_pending_text_note(true);
         run_frame(&mut app, &ctx);
         let mine = app.active_tab().drawing_pane().drawings.items()[0].id;
 
@@ -32521,7 +30788,7 @@ crosshair = false
         let ctx = egui::Context::default();
         let (mut app, _commands) = app_with_history(8);
         run_frame(&mut app, &ctx);
-        app.pending_text_note = true;
+        app.surfaces.drawing_chrome.set_pending_text_note(true);
         run_frame(&mut app, &ctx);
         let mine = app.active_tab().drawing_pane().drawings.items()[0].id.0;
 
@@ -34886,7 +33153,7 @@ plot(close)
         app.config.metatrader.listen_addr = "192.168.7.31:9100".to_owned();
         run_frame(&mut app, &ctx);
         // The trader's own words on the chart.
-        app.pending_text_note = true;
+        app.surfaces.drawing_chrome.set_pending_text_note(true);
         run_frame(&mut app, &ctx);
         {
             let tool = drawings::DRAWING_TOOLS

--- a/crates/app/src/app/layout_wiring.rs
+++ b/crates/app/src/app/layout_wiring.rs
@@ -474,20 +474,12 @@ impl QuantickApp {
     /// than recorded against another set's object. Other panes' edits are
     /// left alone.
     fn leave_pane_gestures(&mut self, tab: u64, side: PaneSide) {
-        if self
-            .inline_text_edit
-            .as_ref()
-            .is_some_and(|edit| edit.tab == tab && edit.side == side)
-        {
+        if self.surfaces.drawing_chrome.inline_edit_is_on(tab, side) {
             self.end_inline_text_edit();
         }
-        if self
-            .inspector_edit_baseline
-            .as_ref()
-            .is_some_and(|edit| edit.tab == tab && edit.side == side)
-        {
-            self.inspector_edit_baseline = None;
-        }
+        self.surfaces
+            .drawing_chrome
+            .drop_edit_baseline_on(tab, side);
     }
 
     /// Whether `side` names a pane the tab has built — `Tab::pane` answers

--- a/crates/app/src/surfaces/drawing_chrome/context_bar.rs
+++ b/crates/app/src/surfaces/drawing_chrome/context_bar.rs
@@ -1,0 +1,293 @@
+//! The selected object's context bar.
+//!
+//! This is what a selection raises — one row of icons, where the object is,
+//! for the handful of things a trader does with their eye on the chart.
+//! Everything else stayed behind the gear. The bar re-uses
+//! [`super::apply_actions`] verbatim, so lock, delete, hide and the undo
+//! coalescing have one implementation and cannot drift between the two hosts.
+
+use eframe::egui;
+
+use super::{
+    DrawingChromeAsk, DrawingChromeSurface, DrawingEnv, InspectorActions, clamp_into_chart,
+};
+use crate::drawings::{self, DrawingAuthor};
+
+/// The bar's own state: the widget's, plus the rectangle a test reads back.
+#[derive(Default)]
+pub(crate) struct ContextBarState {
+    pub bar: drawings::context_bar::ContextBar,
+    #[cfg(test)]
+    pub last_drawn_rect: Option<egui::Rect>,
+}
+
+/// The rectangle the context bar may occupy: the pane, with the live lane
+/// taken off its right edge.
+///
+/// The lane is where the price the trader is reading is being formed, and
+/// losing sight of it is the trader's first veto — `context_bar::place` has
+/// kept clear of it since it was written. A *parked* bar is placed by a
+/// different rule and has to be held to the same one, so both go through this
+/// rectangle rather than through the pane's own.
+///
+/// Never narrower than the bar itself: a lane wider than the history area
+/// would otherwise leave nothing to place in, and a pane's own edge is a
+/// better answer than an empty rectangle.
+pub(crate) fn bounds(chart: egui::Rect, right_limit: f32, size: egui::Vec2) -> egui::Rect {
+    let right = right_limit
+        .min(chart.right())
+        .max(chart.left() + size.x)
+        .min(chart.right());
+    egui::Rect::from_min_max(chart.min, egui::pos2(right, chart.bottom()))
+}
+
+/// Draw this frame.
+pub(crate) fn draw(
+    chrome: &mut DrawingChromeSurface,
+    ctx: &egui::Context,
+    env: &DrawingEnv<'_>,
+) -> DrawingChromeAsk {
+    let mut ask = DrawingChromeAsk::default();
+    let selection = env.selected_index();
+    if chrome.bar.bar.note_selection(selection) {
+        // A new object is a new question: the panel the last one opened does
+        // not follow the selection around.
+        chrome.shared.open = false;
+    }
+    // …except when the object just placed asked for it. Applied after the
+    // reset above, because the placement that made the request also made the
+    // selection change that clears it.
+    if std::mem::take(&mut chrome.pending_open_settings) {
+        chrome.shared.open = true;
+        chrome.shared.last_selection = None;
+    }
+    let Some(selected) = env.selected.as_ref() else {
+        return ask;
+    };
+    let index = selected.index;
+    // An armed tool means the trader is drawing, not editing. The bar is
+    // opaque to the pointer, so leaving it up would let it eat the click that
+    // places the next object — the selection it belongs to is the one they
+    // just finished, not the one they are starting.
+    if env.drawing_tool_armed {
+        return ask;
+    }
+    // Which gestures hide the bar is decided here, once, from the raw input —
+    // not at each of the six call sites that could move the world. A *click*
+    // never suppresses: it is how the trader reaches the bar. Only a decided
+    // drag does, and only when it began outside the bar, so dragging the grip
+    // does not hide what is being dragged.
+    //
+    // Note what is deliberately absent: the market moving. A drawing carried
+    // along by the auto-scroll carries the bar with it, smoothly —
+    // suppressing that would blink the bar all session on a live tape.
+    let now_ms = (ctx.input(|input| input.time) * 1000.0) as u64;
+    let bar_rect = chrome.bar.bar.last_rect();
+    let (dragging, origin, zoomed, screen) = ctx.input(|input| {
+        (
+            input.pointer.is_decidedly_dragging(),
+            input.pointer.press_origin(),
+            input.raw_scroll_delta.y.abs() > f32::EPSILON
+                || (input.zoom_delta() - 1.0).abs() > f32::EPSILON,
+            input.screen_rect,
+        )
+    });
+    // Against the rect the press *landed* on, not this frame's — the bar
+    // moves with a grip drag, so comparing against the moved rect makes the
+    // origin fall outside after ~20 px and suppresses the very gesture that
+    // is moving it. The grip is the escape hatch for a bar sitting over
+    // something the trader needs to see; it has to survive being used.
+    let on_the_bar = matches!(
+        (origin, chrome.bar.bar.press_rect(origin, bar_rect)),
+        (Some(origin), Some(rect)) if rect.contains(origin)
+    );
+    if dragging && !on_the_bar {
+        chrome.bar.bar.suppress_gesture();
+    } else if !dragging {
+        chrome.bar.bar.release_gesture();
+    }
+    if zoomed {
+        chrome.bar.bar.suppress_transient(now_ms);
+    }
+    chrome.bar.bar.note_screen(screen, now_ms);
+    // Suppressed means suppressed: nothing below this line runs, so the bar
+    // cannot measure a world the gesture that suppressed it is still moving.
+    // That is the rule the drag gestures already learned.
+    if chrome.bar.bar.suppressed(now_ms) {
+        return ask;
+    }
+    let (Some(chart), Some(bbox)) = (env.chart_area, env.selected_bbox) else {
+        return ask;
+    };
+    // Read the object, never clone it, on the way in. This runs every frame
+    // something is selected, and a `Drawing` carries a `Vec` of anchors plus a
+    // boxed payload — a pencil stroke is 512 of them. The copy the undo
+    // baseline needs is taken in `apply_actions`, only on the frame an edit
+    // actually opens a gesture; idle frames clone nothing.
+    let drawing = selected.drawing;
+    let tool = drawing.tool;
+    let locked = drawing.locked;
+    let mut style = drawing.style;
+    let glyph_before = tool.glyph_size(drawing);
+    // One line, only for an object the trader did not place. Formatting it
+    // costs an allocation on the frames a selected annotation is on screen —
+    // never on the tape's path, and never for the objects the trader drew.
+    let author = drawing.author.as_ref().map(DrawingAuthor::label);
+    let mut object = drawings::context_bar::BarObject {
+        style: &mut style,
+        glyph_size: glyph_before,
+        author: author.as_deref(),
+        locked,
+        hidden: drawing.hidden,
+        supports_fill: tool.supports_fill(),
+        // Pinned, the full panel is already on screen: a gear leading where
+        // the eye already is would be the dead slot the bar's own contract
+        // forbids.
+        settings_available: !chrome.shared.pinned,
+        confirming_delete: chrome.shared.delete_confirm && locked,
+        tool_name: tool.name(),
+    };
+    let size = drawings::context_bar::bar_size(&drawings::context_bar::slots(
+        drawings::context_bar::capabilities(&object),
+    ));
+    // The live lane is off limits to the bar however it got where it is: that
+    // strip is where the price the trader is reading is being formed, and
+    // `place` has kept clear of it since it was written. A parked bar is
+    // placed by a different rule, not held to a different one.
+    let right_limit = env.lane_divider_x.unwrap_or(chart.right());
+    let reachable = bounds(chart, right_limit, size);
+    let position = match chrome.bar.bar.manual_position() {
+        // Repair for drawing, never overwrite — the rule the properties popup
+        // already follows, for the same reason. A bar parked out near the
+        // right edge of a wide pane must stay reachable when the canvas is
+        // split and that pane is half as wide, and the repair leaves the
+        // parked point alone, so widening the pane gives it back. (A fresh
+        // drag is a fresh decision and does replace it, measured from where
+        // the bar is actually drawn — dragging from a point the window is not
+        // at would make it jump on the first pixel.)
+        //
+        // The clamp is against the pane the *selection* lives on, which is
+        // what makes a bar parked over one chart of a split come back inside
+        // the other one rather than hovering over its neighbour.
+        Some(parked) => parked,
+        None => drawings::context_bar::place(chart, right_limit, bbox, size),
+    };
+    // Both answers go through the same repair, so "clear of the live lane" is
+    // a property of the bar and not of the branch that placed it. `place`
+    // keeps clear of the lane on every path but its last one — the fallback
+    // for an object that covers the pane end to end, which clamps against the
+    // pane's own right edge — and that path is reachable with a full-height
+    // profile on a narrow split. It also keeps the popover bound below
+    // honest, which is derived from where the bar ends up.
+    let position = clamp_into_chart(position, size, reachable);
+    // What the popovers are clamped into: the same rectangle *without* the
+    // bar's width floor, but never narrower than the bar that was actually
+    // drawn.
+    //
+    // The floor exists so a history area narrower than the bar still has
+    // somewhere to put one — `place` makes the same call — and it is the
+    // bar's reason, not the palette's: a palette can be pushed left, so
+    // nothing buys it the right to sit on the forming column. But when the
+    // floor did have to push the bar into the lane, a bound that stopped
+    // short of it would leave the palette hanging off nothing, which is the
+    // failure the placement rule spends its effort on.
+    let popover_bounds = egui::Rect::from_min_max(
+        chart.min,
+        egui::pos2(
+            right_limit.min(chart.right()).max(position.x + size.x),
+            chart.bottom(),
+        ),
+    );
+    let intent = drawings::context_bar::show(
+        &mut chrome.bar.bar,
+        ctx,
+        position,
+        popover_bounds,
+        &mut object,
+    );
+    let glyph_after = object.glyph_size;
+    #[cfg(test)]
+    {
+        chrome.bar.last_drawn_rect = chrome.bar.bar.last_rect();
+    }
+
+    if intent.reset_position {
+        chrome.bar.bar.clear_manual();
+    } else if intent.drag_delta != egui::Vec2::ZERO {
+        chrome.bar.bar.set_manual(position + intent.drag_delta);
+    }
+    let actions = InspectorActions {
+        toggle_hidden: intent.toggle_hidden,
+        toggle_lock: intent.actions.toggle_lock,
+        delete: intent.actions.delete,
+        force_delete: intent.force_delete,
+        cancel_delete: intent.cancel_delete,
+        edited: intent.edited,
+        ..InspectorActions::default()
+    };
+    if intent.edited {
+        // The copy the trader is editing, handed back rather than written
+        // through a `&mut` into the pane: the host owns every object every
+        // renderer reads.
+        let mut edited = drawing.clone();
+        edited.style = style;
+        if let Some(size) = glyph_after {
+            tool.set_glyph_size(&mut edited, size.px);
+        }
+        ask.edited = Some(Box::new(edited));
+    }
+    if intent.open_settings {
+        chrome.shared.open = true;
+        // Place against the object the way a fresh selection would.
+        chrome.shared.last_selection = None;
+    }
+    ask.duplicate |= intent.duplicate;
+    ask.merge(super::apply_actions(chrome, ctx, actions, index, env));
+    ask
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The live lane is off limits to the bar however it got where it is.
+    ///
+    /// `context_bar::place` has kept clear of that strip since it was written
+    /// — it is where the price the trader is reading is being formed, and
+    /// losing sight of it is the trader's first veto. A parked bar is placed
+    /// by a different rule, so the bound both rules clamp into is what keeps
+    /// them honest: without it the repair would happily pin a parked bar at
+    /// the pane's own right edge, on top of the forming column, for every
+    /// object of the session.
+    #[test]
+    fn the_context_bar_bound_takes_the_live_lane_off_the_pane() {
+        let chart = egui::Rect::from_min_max(egui::pos2(60.0, 88.0), egui::pos2(1284.0, 832.0));
+        let size = egui::vec2(292.0, 40.0);
+        let divider = 900.0;
+
+        let reachable = bounds(chart, divider, size);
+        assert_eq!(
+            reachable.right(),
+            divider,
+            "the lane is not the bar's to use"
+        );
+        assert_eq!(
+            clamp_into_chart(egui::pos2(3000.0, 400.0), size, reachable).x,
+            divider - size.x,
+            "a bar parked out past the lane is repaired to its inner edge"
+        );
+
+        // No lane on this pane: the chart's own edge is the answer, exactly as
+        // the automatic rule takes `chart.right()` when the divider is None.
+        assert_eq!(bounds(chart, chart.right(), size).right(), chart.right());
+
+        // A lane wider than the history area leaves nothing to place in. The
+        // pane's edge beats an empty rectangle — the same call `place` makes.
+        let all_lane = bounds(chart, chart.left() + 10.0, size);
+        assert!(
+            all_lane.width() >= size.x.min(chart.width()),
+            "a bar still has somewhere to go: {all_lane:?}"
+        );
+        assert!(chart.contains_rect(all_lane), "and it is inside the pane");
+    }
+}

--- a/crates/app/src/surfaces/drawing_chrome/inline_editor.rs
+++ b/crates/app/src/surfaces/drawing_chrome/inline_editor.rs
@@ -8,7 +8,7 @@
 
 use eframe::egui;
 
-use super::{DrawingChromeAsk, DrawingChromeSurface, DrawingEnv, InlineTextEdit};
+use super::{DrawingChromeAsk, DrawingChromeSurface, DrawingEdit, DrawingEnv};
 use crate::drawings::Drawing;
 use crate::pane::PaneSide;
 use crate::theme;
@@ -32,7 +32,7 @@ const INLINE_TEXT_FRAME_PAD_PX: f32 = 10.0;
 /// The editor's state: at most one open edit.
 #[derive(Default)]
 pub(crate) struct InlineEditor {
-    edit: Option<InlineTextEdit>,
+    edit: Option<DrawingEdit>,
 }
 
 impl InlineEditor {
@@ -62,7 +62,7 @@ impl InlineEditor {
         // Typing is one edit: the note as it stands is kept here and recorded
         // when the editor closes, so undo takes back the note, not the last
         // letter of it.
-        self.edit = Some(InlineTextEdit {
+        self.edit = Some(DrawingEdit {
             tab,
             side,
             index,
@@ -74,7 +74,7 @@ impl InlineEditor {
     /// Close the editor, handing back what the undo history is owed — on the
     /// pane the note actually lives on, which is not necessarily the one in
     /// front when it closes.
-    pub fn end(&mut self) -> Option<InlineTextEdit> {
+    pub fn end(&mut self) -> Option<DrawingEdit> {
         self.edit.take()
     }
 }

--- a/crates/app/src/surfaces/drawing_chrome/inline_editor.rs
+++ b/crates/app/src/surfaces/drawing_chrome/inline_editor.rs
@@ -1,0 +1,296 @@
+//! The on-chart note editor: a field where the words will be, opened by the
+//! placement that made the note.
+//!
+//! The inspector used to be the only way in, which put the note under the
+//! pointer and the field that fills it on the far side of the screen. The
+//! context bar a selection raises carries the rest — colour, type size, lock,
+//! delete — so what was missing was never a panel, only a caret.
+
+use eframe::egui;
+
+use super::{DrawingChromeAsk, DrawingChromeSurface, DrawingEnv, InlineTextEdit};
+use crate::drawings::Drawing;
+use crate::pane::PaneSide;
+use crate::theme;
+
+/// Id of the on-chart note editor's floating area. One editor at a time —
+/// the keyboard has one caret.
+const INLINE_TEXT_AREA_ID: &str = "inline-text-editor";
+/// What an empty note's field says before anything is typed.
+pub(crate) const INLINE_TEXT_HINT: &str = "Add text";
+/// Width of the field. Wide enough for a sentence, narrow enough that it does
+/// not cover the price it is annotating.
+const INLINE_TEXT_WIDTH_PX: f32 = 180.0;
+/// Type size the editor falls back to when the tool declares none.
+const INLINE_TEXT_FALLBACK_PX: f32 = 12.0;
+/// Line height as a multiple of the type size, and the frame's own vertical
+/// padding — together, how tall the one-line field stands. Used to decide
+/// whether it still fits above the anchor.
+const INLINE_TEXT_LINE_FACTOR: f32 = 1.4;
+const INLINE_TEXT_FRAME_PAD_PX: f32 = 10.0;
+
+/// The editor's state: at most one open edit.
+#[derive(Default)]
+pub(crate) struct InlineEditor {
+    edit: Option<InlineTextEdit>,
+}
+
+impl InlineEditor {
+    /// Which note is being typed, by index alone — what a second operator
+    /// reads to know the keyboard belongs to an object.
+    pub fn editing_index(&self) -> Option<usize> {
+        self.edit.as_ref().map(|edit| edit.index)
+    }
+
+    /// The full target, which is what every pane needs to stand exactly one
+    /// object down: an index alone names a different object on each pane.
+    pub fn target(&self) -> Option<(u64, PaneSide, usize)> {
+        self.edit
+            .as_ref()
+            .map(|edit| (edit.tab, edit.side, edit.index))
+    }
+
+    /// Open the editor on this object.
+    ///
+    /// Refused for an object that holds no words or is locked: a locked
+    /// object's geometry and content are both protected, and an editor that
+    /// opened and then dropped every keystroke would be worse than none.
+    pub fn begin(&mut self, tab: u64, side: PaneSide, index: usize, drawing: &Drawing) -> bool {
+        if drawing.locked || !drawing.tool.holds_text() {
+            return false;
+        }
+        // Typing is one edit: the note as it stands is kept here and recorded
+        // when the editor closes, so undo takes back the note, not the last
+        // letter of it.
+        self.edit = Some(InlineTextEdit {
+            tab,
+            side,
+            index,
+            before: drawing.clone(),
+        });
+        true
+    }
+
+    /// Close the editor, handing back what the undo history is owed — on the
+    /// pane the note actually lives on, which is not necessarily the one in
+    /// front when it closes.
+    pub fn end(&mut self) -> Option<InlineTextEdit> {
+        self.edit.take()
+    }
+}
+
+/// Draw this frame.
+pub(crate) fn draw(
+    chrome: &mut DrawingChromeSurface,
+    ctx: &egui::Context,
+    env: &DrawingEnv<'_>,
+) -> DrawingChromeAsk {
+    let before_target = chrome.inline.target();
+    let mut ask = draw_inner(chrome, ctx, env);
+    // Said only when it changed. Every pane reads this to decide which of its
+    // objects stands down, and repeating an unchanged answer every frame
+    // would make an ask that means "nothing happened" indistinguishable from
+    // one that means "the caret moved".
+    if chrome.inline.target() != before_target {
+        ask.content_editing_changed = true;
+    }
+    ask
+}
+
+fn draw_inner(
+    chrome: &mut DrawingChromeSurface,
+    ctx: &egui::Context,
+    env: &DrawingEnv<'_>,
+) -> DrawingChromeAsk {
+    // The `QUANTICK_TEXT_NOTE` hook: the placement rules — where the middle
+    // of the visible window is, what the saved defaults say a note opens
+    // like — belong to the host, so the surface asks and the host places.
+    //
+    // Asked every frame until the host says it landed. At launch there is no
+    // laid-out pane and no bar to place at, and a hook that fired once into
+    // that would photograph nothing at all.
+    let mut ask = DrawingChromeAsk {
+        place_text_note: chrome.pending_text_note,
+        ..DrawingChromeAsk::default()
+    };
+    // A placement that asked for the caret gets it here, on the frame it
+    // happened: the object it made is the selected one.
+    if std::mem::take(&mut chrome.pending_text_edit)
+        && let Some(selected) = env.selected.as_ref()
+    {
+        chrome
+            .inline
+            .begin(env.tab, env.side, selected.index, selected.drawing);
+    }
+    let Some((tab, side, index)) = chrome.inline.target() else {
+        return ask;
+    };
+    // The object can go away underneath the editor — undo, delete, a tab
+    // switch, a click that moves the selection to the other pane. Any of
+    // those ends the editor, and it must not write into whatever now sits at
+    // that index: the note is only in front while its own tab and pane are
+    // the ones every drawing surface is reading.
+    let close = |ask: &mut DrawingChromeAsk, chrome: &mut DrawingChromeSurface| {
+        ask.record_inline_edit = chrome.inline.end().map(Box::new);
+    };
+    if env.tab != tab || env.side != side || env.selected_index() != Some(index) {
+        close(&mut ask, chrome);
+        return ask;
+    }
+    let (Some(chart), Some(bbox), Some(selected)) =
+        (env.chart_area, env.selected_bbox, env.selected.as_ref())
+    else {
+        close(&mut ask, chrome);
+        return ask;
+    };
+    let drawing = selected.drawing;
+    let tool = drawing.tool;
+    let Some(text) = tool.inline_text(drawing.payload.as_ref()) else {
+        close(&mut ask, chrome);
+        return ask;
+    };
+    // Read once, and only what the field needs: this runs every frame the
+    // editor is open, and the drawing behind it carries a boxed payload.
+    let mut buffer = text.to_owned();
+    let before = buffer.clone();
+    let size_px = tool
+        .glyph_size(drawing)
+        .map_or(INLINE_TEXT_FALLBACK_PX, |size| size.px);
+    let color = drawing.style.color;
+    if drawing.locked {
+        close(&mut ask, chrome);
+        return ask;
+    }
+
+    // Where the words are painted — above the anchor — unless there is no
+    // room up there, in which case it opens below it instead. A field pinned
+    // upward against the top of the chart lands on the flow legend and covers
+    // the very key it is annotating; flipping keeps both readable, the way a
+    // popover does.
+    //
+    // Constrained to the chart either way, like every other floating drawing
+    // surface: the object stands down while the editor is up, so a field that
+    // ran off the window would leave the trader typing blind into a widget
+    // they cannot see.
+    let field_height = size_px * INLINE_TEXT_LINE_FACTOR + INLINE_TEXT_FRAME_PAD_PX;
+    let (position, pivot) = if bbox.bottom() - field_height < chart.top() {
+        (bbox.left_top(), egui::Align2::LEFT_TOP)
+    } else {
+        (
+            egui::pos2(bbox.left(), bbox.bottom()),
+            egui::Align2::LEFT_BOTTOM,
+        )
+    };
+    let inner = egui::Area::new(egui::Id::new(INLINE_TEXT_AREA_ID))
+        .order(egui::Order::Foreground)
+        .fixed_pos(position)
+        .pivot(pivot)
+        .constrain_to(chart)
+        .show(ctx, |ui| {
+            // A frame around it, in the accent: over a candle chart an
+            // unframed field is a rectangle of dark on dark, and the one
+            // thing this surface has to say is "the keyboard is here now".
+            // The fill is opaque for the same reason — words typed over wicks
+            // are words nobody can read back.
+            egui::Frame::none()
+                .fill(theme::CHROME)
+                .stroke(egui::Stroke::new(1.0_f32, theme::ACCENT))
+                .rounding(egui::Rounding::same(3.0))
+                .inner_margin(egui::Margin::symmetric(4.0, 2.0))
+                .show(ui, |ui| {
+                    let response = ui.add(
+                        egui::TextEdit::multiline(&mut buffer)
+                            .font(egui::FontId::proportional(size_px))
+                            .text_color(color)
+                            .hint_text(INLINE_TEXT_HINT)
+                            .desired_rows(1)
+                            .frame(false)
+                            .desired_width(INLINE_TEXT_WIDTH_PX),
+                    );
+                    // The caret on the first frame: a field that opens
+                    // unfocused asks for a click nobody was told about.
+                    if !response.has_focus() && ui.memory(|memory| memory.focused().is_none()) {
+                        response.request_focus();
+                    }
+                    response
+                })
+                .inner
+        })
+        .inner;
+
+    if buffer != before {
+        // The copy is made here and nowhere else: on a keystroke, never on an
+        // idle frame. The host writes it back through the selection, so an
+        // unrelated in-flight gesture cannot swallow this edit.
+        let mut edited = drawing.clone();
+        tool.set_inline_text(edited.payload.as_mut(), buffer);
+        ask.edited = Some(Box::new(edited));
+    }
+    // Escape and clicking away both mean "done" — and Escape must not also
+    // fall through to the escape stack, which would drop the selection the
+    // bar is hanging off.
+    let escaped = inner.has_focus() && ctx.input(|input| input.key_pressed(egui::Key::Escape));
+    if escaped {
+        ctx.memory_mut(|memory| memory.surrender_focus(inner.id));
+    }
+    if escaped || inner.lost_focus() {
+        close(&mut ask, chrome);
+    }
+    ask
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::drawings::{ChartPoint, DRAWING_TOOLS, DrawingBand, Drawings};
+
+    fn note() -> Drawing {
+        let tool = DRAWING_TOOLS
+            .into_iter()
+            .find(|tool| tool.holds_text())
+            .expect("a tool that holds text");
+        let mut store = Drawings::default();
+        store.place_on(tool, &DrawingBand::Price, ChartPoint::at(1.0, 10.0));
+        store.items()[0].clone()
+    }
+
+    #[test]
+    fn a_locked_note_refuses_the_caret() {
+        let mut editor = InlineEditor::default();
+        let mut drawing = note();
+        drawing.locked = true;
+        assert!(
+            !editor.begin(1, PaneSide::Flow, 0, &drawing),
+            "an editor that opened and then dropped every keystroke is worse than none"
+        );
+        assert_eq!(editor.target(), None);
+    }
+
+    /// The caret belongs to words. A rectangle has none, and an editor that
+    /// opened over one would take the keyboard for nothing.
+    #[test]
+    fn an_object_without_words_refuses_the_caret() {
+        let mut editor = InlineEditor::default();
+        let mut wordless = note();
+        wordless.tool = DRAWING_TOOLS
+            .into_iter()
+            .find(|tool| !tool.holds_text())
+            .expect("a tool that holds no text");
+        assert!(!editor.begin(1, PaneSide::Flow, 0, &wordless));
+        assert_eq!(editor.target(), None);
+    }
+
+    /// The whole reason the target carries a tab and a pane: closing hands
+    /// back the pane the note lives on, not the one in front.
+    #[test]
+    fn closing_hands_back_the_pane_the_note_lives_on() {
+        let mut editor = InlineEditor::default();
+        assert!(editor.begin(7, PaneSide::Time(0), 3, &note()));
+        let closed = editor.end().expect("the editor was open");
+        assert_eq!(
+            (closed.tab, closed.side, closed.index),
+            (7, PaneSide::Time(0), 3)
+        );
+        assert!(editor.end().is_none(), "closing twice owes nothing twice");
+    }
+}

--- a/crates/app/src/surfaces/drawing_chrome/inspector.rs
+++ b/crates/app/src/surfaces/drawing_chrome/inspector.rs
@@ -1,0 +1,1163 @@
+//! The selected object's inspector, in both its hosts.
+//!
+//! Floating, it is non-modal by contract: it never captures the whole canvas
+//! — but it is opaque to the pointer, so a press on it never falls through to
+//! the chart. Pinned, it is a dock panel at the chart's side, declared with
+//! the chrome so the canvas pays its width.
+//!
+//! Both hosts share the title bar, the body and one action applier, which is
+//! what keeps "what does the pin do" from having two answers.
+
+use eframe::egui;
+
+use super::{
+    BAR_DRAG_SPEED, DrawingChromeAsk, DrawingChromeSurface, DrawingEnv, INSPECTOR_AREA_ID,
+    INSPECTOR_AUTO_PIN_CHART_WIDTH_PX, INSPECTOR_DEFAULT_WIDTH_PX, INSPECTOR_FALLBACK_HEIGHT_PX,
+    INSPECTOR_LEVELS_WIDTH_PX, INSPECTOR_MAX_WIDTH_PX, INSPECTOR_MIN_WIDTH_PX,
+    INSPECTOR_OBJECT_GAP_PX, INSPECTOR_TITLE_GRIP_GLYPH_PX, INSPECTOR_TITLE_HEIGHT_PX,
+    INSPECTOR_TITLE_PAD_X_PX, INSPECTOR_TITLE_TEXT_PX, INSPECTOR_TITLE_TEXT_X_PX, InspectorActions,
+    InspectorTab, PRICE_DRAG_STEPS, RecordingPresetHost, SavedDefault, clamp_into_chart,
+};
+use crate::drawings::{
+    self, DRAWING_TOOLS, Drawing, DrawingAuthor, MAX_DRAWING_FILL_ALPHA, MAX_DRAWING_WIDTH_PX,
+    MIN_DRAWING_WIDTH_PX, PresetHost as _,
+};
+use crate::theme;
+use crate::widgets::{IconButton, TOOLBAR_ICON};
+use egui_phosphor::regular as icons;
+
+/// Initial position of the selected-drawing inspector, before [`placement`]
+/// has a size and a bbox to place it from.
+const DEFAULT_POSITION: egui::Pos2 = super::DRAWING_INSPECTOR_DEFAULT_POSITION;
+
+/// The inspector's own state. What it shares with the context bar lives in
+/// [`super::Shared`]; this is what only it reads.
+#[derive(Default)]
+pub(crate) struct Inspector {
+    /// Which tab is open, remembered across selections so a trader working
+    /// through coordinates does not land back on Style every time.
+    pub tab: InspectorTab,
+    /// Whether the user moved the floating window this session. A manual
+    /// position wins over automatic placement from then on.
+    pub(super) moved: bool,
+    /// The parked point, in screen coordinates. What the file remembers.
+    pub(super) pos: Option<egui::Pos2>,
+    /// The parked point changed and the workspace file has not caught up.
+    pub(super) position_dirty: bool,
+    /// How wide the window may be where it was placed — `Some` only when it
+    /// had to be narrowed into a gutter beside an object too big to walk
+    /// around.
+    pub(super) max_width: Option<f32>,
+    /// The size it was last drawn at, which beats every guess about it.
+    pub(super) size: Option<egui::Vec2>,
+    /// Whether the pin button has been pressed either way. The auto-pin width
+    /// rule stops firing once the user has expressed a preference.
+    pub(super) pin_touched: bool,
+    /// The unpin happened this frame: skip one before placing, so the
+    /// placement measures settled geometry rather than the pinned era's.
+    pub(super) settle_frame: bool,
+    #[cfg(test)]
+    pub pin_rect: Option<egui::Rect>,
+}
+
+impl Inspector {
+    /// Park the window where a hand put it. The flag and the point move
+    /// together: a position without the flag would be overwritten by the next
+    /// automatic placement, and the narrowing a placement computed does not
+    /// survive a move the trader made.
+    ///
+    /// Deliberately *not* a file write. The drag calls this every frame the
+    /// hand moves; the write is owed when the hand comes off, which is where
+    /// [`Self::position_dirty`] is raised.
+    pub fn place_by_hand(&mut self, position: egui::Pos2) {
+        self.pos = Some(position);
+        self.moved = true;
+        self.max_width = None;
+    }
+
+    /// The popup position a workspace should record: the one a hand placed,
+    /// never one the app computed.
+    ///
+    /// Automatic placement is a *rule* — beside the object, on the side with
+    /// room. Writing down the pixel that rule produced for yesterday's drawing
+    /// would freeze a stale answer into the file and stop the rule from ever
+    /// running again, which is the same bug as never forgetting a drag.
+    pub fn remembered_position(&self) -> Option<[f32; 2]> {
+        self.pos
+            .filter(|_| self.moved)
+            .map(|position| [position.x, position.y])
+    }
+
+    /// Adopt what a workspace remembers about the popup, including its
+    /// silence: no recorded position hands the window back to automatic
+    /// placement rather than leaving the previous cockpit's position behind.
+    ///
+    /// A non-finite pair is silence too. The file is hand-editable and TOML
+    /// spells `nan`, and NaN is the one value the repair cannot walk back:
+    /// every comparison against it is false, so `f32::clamp` returns it
+    /// unchanged and the popup goes somewhere with no pixels — where its own
+    /// title bar, and with it the double-click that would undo this, cannot
+    /// be reached. It would then be written straight back at the next save.
+    /// The env hook already refuses the same input
+    /// ([`super::parse_point`]); this is the door the file comes through.
+    pub fn restore_position(&mut self, remembered: Option<[f32; 2]>) {
+        match remembered.filter(|[x, y]| x.is_finite() && y.is_finite()) {
+            Some([x, y]) => self.place_by_hand(egui::pos2(x, y)),
+            None => {
+                self.pos = None;
+                self.moved = false;
+                self.max_width = None;
+            }
+        }
+    }
+
+    /// Whether a file write is owed, taken so it is owed once.
+    pub fn take_position_dirty(&mut self) -> bool {
+        std::mem::take(&mut self.position_dirty)
+    }
+
+    /// How big the floating inspector is, best answer available: the size it
+    /// was last drawn at, then egui's area memory, then the assumed default.
+    fn size(&self, ctx: &egui::Context) -> egui::Vec2 {
+        self.size
+            .or_else(|| {
+                ctx.memory(|memory| memory.area_rect(egui::Id::new(INSPECTOR_AREA_ID)))
+                    .map(|rect| rect.size())
+            })
+            .unwrap_or(egui::vec2(
+                INSPECTOR_DEFAULT_WIDTH_PX,
+                INSPECTOR_FALLBACK_HEIGHT_PX,
+            ))
+    }
+}
+
+/// Where the inspector goes, and how wide it may be there.
+///
+/// The width is `Some` only when the panel had to be narrowed to fit a gutter
+/// beside a drawing too big to place around — see [`placement`].
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct InspectorPlacement {
+    pub position: egui::Pos2,
+    pub max_width: Option<f32>,
+}
+
+/// The inspector placement rule (`docs/ux/drawing-tools-2026-08.md` §D3).
+///
+/// The old rule scored least overlap with the object's *bounding box*, and a
+/// small object has a small box: "beside it with a 12 px gap" scored zero and
+/// won, dropping the panel straight onto the price action the trader drew the
+/// line to read. The read is the neighbourhood of the object, not its box.
+///
+/// So the corners come first, and the winner is the **farthest** clear one:
+///
+/// 1. the two **top** corners first, inset by the gap. Top before bottom is
+///    structural, not taste: a panel is positioned by its top-left and grows
+///    downwards, so a top corner always has the whole pane to grow into. A
+///    bottom-anchored panel that turns out taller than the placement assumed
+///    runs off the window and loses its last rows — and rows a trader cannot
+///    reach read as rows that do not exist;
+/// 2. of the two, the one that clears `bbox` and whose centre is farthest
+///    from the object wins, so the panel walks away from the drawing across
+///    the chart. An exact tie (a centred object) takes the left one, so the
+///    panel appears in the same place every time;
+/// 3. only if neither top corner is free, the bottom two on the same rule;
+/// 4. and if every corner is fouled — a large object covering the chart —
+///    the beside-the-object candidates, least overlap first.
+pub(crate) fn placement(
+    chart: egui::Rect,
+    bbox: egui::Rect,
+    size: egui::Vec2,
+) -> InspectorPlacement {
+    let gap = INSPECTOR_OBJECT_GAP_PX;
+    let top_corners = [
+        egui::pos2(chart.left() + gap, chart.top() + gap),
+        egui::pos2(chart.right() - gap - size.x, chart.top() + gap),
+    ];
+    let bottom_corners = [
+        egui::pos2(chart.left() + gap, chart.bottom() - gap - size.y),
+        egui::pos2(chart.right() - gap - size.x, chart.bottom() - gap - size.y),
+    ];
+    let farthest_clear = |candidates: [egui::Pos2; 2]| {
+        let mut best: Option<(egui::Pos2, f32)> = None;
+        for candidate in candidates {
+            let position = clamp_into_chart(candidate, size, chart);
+            let rect = egui::Rect::from_min_size(position, size);
+            if rect.intersect(bbox).is_positive() {
+                continue;
+            }
+            let distance = rect.center().distance(bbox.center());
+            if best.is_none_or(|(_, best)| distance > best) {
+                best = Some((position, distance));
+            }
+        }
+        best.map(|(position, _)| position)
+    };
+    if let Some(position) = farthest_clear(top_corners).or_else(|| farthest_clear(bottom_corners)) {
+        return InspectorPlacement {
+            position,
+            max_width: None,
+        };
+    }
+    // No corner is clear, which is what a big object — a volume profile, a
+    // range across the whole chart — does to all four of them. The panel then
+    // goes into whichever *gutter* the object leaves beside it, narrowed to
+    // fit, because a settings panel sitting on the drawing it configures is
+    // the one outcome this whole function exists to avoid.
+    //
+    // Horizontal gutters only. Narrowing a panel reflows it and its scroll
+    // area keeps every row reachable; shortening one hides rows, and rows a
+    // trader cannot reach read as rows that do not exist.
+    let left_gutter = bbox.left() - gap - chart.left();
+    let right_gutter = chart.right() - bbox.right() - gap;
+    let (gutter, gutter_left) = if right_gutter >= left_gutter {
+        (right_gutter, bbox.right() + gap)
+    } else {
+        (left_gutter, chart.left() + gap)
+    };
+    if gutter >= INSPECTOR_MIN_WIDTH_PX {
+        let width = gutter.min(size.x);
+        let position = clamp_into_chart(
+            egui::pos2(gutter_left, chart.top() + gap),
+            egui::vec2(width, size.y),
+            chart,
+        );
+        return InspectorPlacement {
+            position,
+            max_width: Some(width),
+        };
+    }
+
+    // The object leaves no strip wide enough to be a panel in. Nothing can be
+    // placed clear of it, and saying so by crowding it least is more honest
+    // than pretending: this is the one case the rule cannot keep.
+    let corners = [top_corners, bottom_corners].concat();
+    let fallbacks = [
+        egui::pos2(bbox.right() + gap, bbox.top()),
+        egui::pos2(bbox.left() - gap - size.x, bbox.top()),
+        egui::pos2(bbox.left(), bbox.bottom() + gap),
+        egui::pos2(bbox.left(), bbox.top() - gap - size.y),
+    ];
+    let mut best: Option<(egui::Pos2, f32, f32)> = None;
+    for candidate in fallbacks.into_iter().chain(corners.iter().copied()) {
+        let position = clamp_into_chart(candidate, size, chart);
+        let rect = egui::Rect::from_min_size(position, size);
+        let overlap = rect.intersect(bbox);
+        let overlap_area = if overlap.is_positive() {
+            overlap.area()
+        } else {
+            0.0
+        };
+        let distance = rect.center().distance(bbox.center());
+        let wins = match &best {
+            None => true,
+            Some((_, best_area, best_distance)) => {
+                overlap_area < *best_area
+                    || (overlap_area == *best_area && distance > *best_distance)
+            }
+        };
+        if wins {
+            best = Some((position, overlap_area, distance));
+        }
+    }
+    InspectorPlacement {
+        position: best.map_or_else(|| chart.left_top(), |(position, _, _)| position),
+        max_width: None,
+    }
+}
+
+/// Where a freshly opened floating inspector should sit, and how wide it may
+/// be there: the farthest chart corner that clears the object, then a gutter
+/// beside it narrowed to fit. The chart pane already excludes both axes and
+/// the live lane, so the popup can never cover them or leave the view.
+fn target_placement(
+    inspector: &Inspector,
+    ctx: &egui::Context,
+    env: &DrawingEnv<'_>,
+) -> Option<InspectorPlacement> {
+    let chart = env.chart_area?;
+    let bbox = env.selected_bbox?;
+    Some(placement(chart, bbox, inspector.size(ctx)))
+}
+
+/// The pinned inspector: a dock panel at the chart's side.
+pub(crate) fn draw_pinned(
+    chrome: &mut DrawingChromeSurface,
+    ctx: &egui::Context,
+    env: &DrawingEnv<'_>,
+) -> DrawingChromeAsk {
+    let mut ask = DrawingChromeAsk::default();
+    if !chrome.shared.pinned {
+        return ask;
+    }
+    let Some(selected) = prologue(chrome, env, &mut ask) else {
+        return ask;
+    };
+    let index = selected.index;
+    chrome.shared.last_selection = Some(index);
+    let mut edited = selected.drawing.clone();
+    let mut recorder = RecordingPresetHost::new(env.presets);
+    let mut actions = InspectorActions::default();
+    egui::SidePanel::right("drawing_inspector_panel")
+        .resizable(true)
+        .default_width(INSPECTOR_DEFAULT_WIDTH_PX)
+        .width_range(INSPECTOR_MIN_WIDTH_PX..=INSPECTOR_MAX_WIDTH_PX)
+        .show(ctx, |ui| {
+            actions = title_bar(chrome, ui, &edited, env, false);
+            egui::ScrollArea::vertical().show(ui, |ui| {
+                actions.merge(body(chrome, ui, &mut edited, env, &mut recorder));
+            });
+        });
+    settle(chrome, ctx, &mut ask, actions, edited, recorder, index, env);
+    ask
+}
+
+/// The floating inspector.
+///
+/// Opens beside the selection; once the user drags the title bar, the manual
+/// position wins for the rest of the session (selection changes never snap it
+/// back; the only automatic move is the re-clamp when the pane shrinks).
+pub(crate) fn draw_floating(
+    chrome: &mut DrawingChromeSurface,
+    ctx: &egui::Context,
+    env: &DrawingEnv<'_>,
+) -> DrawingChromeAsk {
+    let mut ask = DrawingChromeAsk::default();
+    if chrome.shared.pinned {
+        // The pinned panel already drew (and cleaned up) this frame.
+        return ask;
+    }
+    let Some(selected) = prologue(chrome, env, &mut ask) else {
+        return ask;
+    };
+    let index = selected.index;
+    // Selecting an object no longer opens this window — the context bar does.
+    // The gear on that bar is the one door, so the panel only covers the
+    // chart when the trader asked for the panel.
+    if !chrome.shared.open {
+        return ask;
+    }
+    if std::mem::take(&mut chrome.inspector.settle_frame) {
+        // The unpin happened this frame: the side panel still occupies this
+        // frame's layout and the drawing projects against the pinned-era
+        // chart. Wait one frame and place against the settled geometry.
+        return ask;
+    }
+    let selection_changed = chrome.shared.last_selection != Some(index);
+    // The auto-pin (§4.2): a fresh selection on a chart too narrow for a
+    // floating window opens pinned instead — decided here because this host
+    // is the one that would otherwise claim the selection. Stops firing once
+    // the user touches the pin.
+    //
+    // A parked window stops it too, and for the same reason: the rule reads
+    // "no floating position here would leave the geometry alone", and a
+    // trader who chose where the floating window goes has answered that.
+    // Without this clause the everyday layout never reaches the remembered
+    // position at all — a split canvas puts the pane a drawing lives on under
+    // the threshold, so every selection would re-dock the panel. The pin flag
+    // itself is left alone: it records that the *pin button* was pressed, and
+    // borrowing it here would leak a placement into the next workspace
+    // opened, which carries no pin preference.
+    if selection_changed
+        && !chrome.inspector.pin_touched
+        && !chrome.inspector.moved
+        && env
+            .chart_area
+            .is_some_and(|chart| chart.width() < INSPECTOR_AUTO_PIN_CHART_WIDTH_PX)
+    {
+        chrome.shared.pinned = true;
+        // The pinned panel draws from the next frame on.
+        return ask;
+    }
+    chrome.shared.last_selection = Some(index);
+    // Automatic placement only while the window is untouched.
+    if selection_changed
+        && !chrome.inspector.moved
+        && let Some(placed) = target_placement(&chrome.inspector, ctx, env)
+    {
+        chrome.inspector.pos = Some(placed.position);
+        chrome.inspector.max_width = placed.max_width;
+    }
+    // Repair for drawing, never overwrite: a position that does not fit the
+    // chart pane is clamped into it *for this frame*, and the point the
+    // trader parked survives in `pos` untouched.
+    //
+    // The clamp used to be written back, which was harmless while the
+    // position died with the process and is not now that the workspace keeps
+    // it. Every reason the popup does not fit is temporary — a taller panel
+    // for the tool just selected, the split canvas opened, the window pulled
+    // narrow, a smaller second monitor — and writing the repair back would
+    // ratchet the parked point away a little at a time, with no way back to
+    // where the hand put it. The file records what the trader did; this line
+    // decides only where it is drawn today.
+    let inspector_size = chrome.inspector.size(ctx);
+    let draw_at = chrome.inspector.pos.map(|position| {
+        env.chart_area.map_or(position, |chart| {
+            clamp_into_chart(position, inspector_size, chart)
+        })
+    });
+    let mut edited = selected.drawing.clone();
+    let mut recorder = RecordingPresetHost::new(env.presets);
+    // The level editor earns the wider default the spec reserves for it.
+    let default_width = if edited.tool.extra_tab().is_some() {
+        INSPECTOR_LEVELS_WIDTH_PX
+    } else {
+        INSPECTOR_DEFAULT_WIDTH_PX
+    };
+    // Bounded by the window and scrolled inside it. A tool's panel can be
+    // taller than the screen — the Fib level editor is — and an unbounded
+    // window simply gets cut at the edge with no way to reach the rest. Rows
+    // a trader cannot reach read as rows that do not exist, and the control
+    // that was out of reach here was the Fib's own "extend", the one that
+    // decides whether its targets project forward at all.
+    let max_height = (ctx.screen_rect().height()
+        - env.chart_area.map_or(0.0, |chart| chart.top())
+        - 2.0 * INSPECTOR_OBJECT_GAP_PX)
+        .max(INSPECTOR_FALLBACK_HEIGHT_PX);
+    let mut window = egui::Window::new(edited.tool.settings_title())
+        .id(egui::Id::new(INSPECTOR_AREA_ID))
+        .title_bar(false)
+        .default_pos(DEFAULT_POSITION)
+        .default_width(default_width)
+        .min_width(INSPECTOR_MIN_WIDTH_PX)
+        .max_width(
+            chrome
+                .inspector
+                .max_width
+                .map_or(INSPECTOR_MAX_WIDTH_PX, |width| {
+                    width.clamp(INSPECTOR_MIN_WIDTH_PX, INSPECTOR_MAX_WIDTH_PX)
+                }),
+        )
+        .max_height(max_height)
+        .movable(false)
+        .interactable(true)
+        .resizable(true);
+    if let Some(position) = draw_at {
+        window = window.current_pos(position);
+    }
+    let response = window.show(ctx, |ui| {
+        let mut actions = title_bar(chrome, ui, &edited, env, true);
+        egui::ScrollArea::vertical()
+            .auto_shrink([false, true])
+            .show(ui, |ui| {
+                actions.merge(body(chrome, ui, &mut edited, env, &mut recorder));
+            });
+        actions
+    });
+    chrome.inspector.size = response
+        .as_ref()
+        .map(|response| response.response.rect.size());
+    let actions = response
+        .and_then(|response| response.inner)
+        .unwrap_or_default();
+    settle(chrome, ctx, &mut ask, actions, edited, recorder, index, env);
+    ask
+}
+
+/// Shared prologue of both hosts: the selection, or the cleanup for none.
+///
+/// A gesture that outlives its object's selection is **committed**, never
+/// dropped: the trader made those edits, and an entry thrown away here would
+/// take a slider drag out of the undo history because the selection moved on
+/// before the pointer came up.
+fn prologue<'a>(
+    chrome: &mut DrawingChromeSurface,
+    env: &'a DrawingEnv<'a>,
+    ask: &mut DrawingChromeAsk,
+) -> Option<&'a super::SelectedDrawing<'a>> {
+    let Some(selected) = env.selected.as_ref() else {
+        chrome.shared.delete_confirm = false;
+        ask.commit_edit_gesture = chrome.shared.edit_baseline.take().map(Box::new);
+        chrome.shared.last_selection = None;
+        return None;
+    };
+    if chrome.baseline_is_stale(Some(selected.index)) {
+        ask.commit_edit_gesture = chrome.shared.edit_baseline.take().map(Box::new);
+    }
+    Some(selected)
+}
+
+/// Fold one host's frame into the ask: the edited copy when something changed,
+/// the preset writes, and everything [`super::apply_actions`] decides.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "the two hosts hand over exactly what they drew; bundling it into a \
+              struct used once at each of two call sites would hide the arguments \
+              rather than reduce them"
+)]
+fn settle(
+    chrome: &mut DrawingChromeSurface,
+    ctx: &egui::Context,
+    ask: &mut DrawingChromeAsk,
+    actions: InspectorActions,
+    edited: Drawing,
+    recorder: RecordingPresetHost<'_>,
+    index: usize,
+    env: &DrawingEnv<'_>,
+) {
+    if actions.edited {
+        ask.edited = Some(Box::new(edited));
+    }
+    ask.presets.extend(recorder.into_writes());
+    ask.merge(super::apply_actions(chrome, ctx, actions, index, env));
+}
+
+/// The inspector's title bar, shared by both hosts: grip + title, then the
+/// view controls (hide, pin, close) as icon buttons. In the floating host the
+/// whole bar is the drag surface — the body never is, so a slider drag can
+/// never move the window; double-click re-runs the automatic placement.
+fn title_bar(
+    chrome: &mut DrawingChromeSurface,
+    ui: &mut egui::Ui,
+    drawing: &Drawing,
+    env: &DrawingEnv<'_>,
+    floating: bool,
+) -> InspectorActions {
+    let mut actions = InspectorActions::default();
+    let hidden = drawing.hidden;
+    // The band belongs in the title, because that is where "which of these
+    // two trend lines am I editing" is actually asked. Nothing is added on
+    // the price band: it is where drawings have always lived, and a suffix on
+    // every object would be noise.
+    let title = match env.selected_band.as_deref() {
+        Some(band) => format!("{} · {band}", drawing.tool.settings_title()),
+        None => drawing.tool.settings_title().to_owned(),
+    };
+    let sense = if floating {
+        egui::Sense::click_and_drag()
+    } else {
+        egui::Sense::hover()
+    };
+    let (bar_rect, bar) = ui.allocate_exact_size(
+        egui::vec2(ui.available_width(), INSPECTOR_TITLE_HEIGHT_PX),
+        sense,
+    );
+    if ui.is_rect_visible(bar_rect) {
+        let painter = ui.painter();
+        if floating {
+            painter.text(
+                egui::pos2(
+                    bar_rect.left() + INSPECTOR_TITLE_PAD_X_PX,
+                    bar_rect.center().y,
+                ),
+                egui::Align2::LEFT_CENTER,
+                icons::DOTS_SIX_VERTICAL,
+                egui::FontId::proportional(INSPECTOR_TITLE_GRIP_GLYPH_PX),
+                theme::TEXT_FAINT,
+            );
+        }
+        let title_x = if floating {
+            INSPECTOR_TITLE_TEXT_X_PX
+        } else {
+            INSPECTOR_TITLE_PAD_X_PX
+        };
+        painter.text(
+            egui::pos2(bar_rect.left() + title_x, bar_rect.center().y),
+            egui::Align2::LEFT_CENTER,
+            title,
+            egui::FontId::proportional(INSPECTOR_TITLE_TEXT_PX),
+            theme::TEXT_PRIMARY,
+        );
+    }
+    // The controls are registered after the bar, so they win its pointer.
+    ui.allocate_new_ui(egui::UiBuilder::new().max_rect(bar_rect), |ui| {
+        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+            let close = IconButton::new(icons::X, TOOLBAR_ICON)
+                .hover_text("Close - keeps the drawing, clears the selection")
+                .show(ui);
+            if close.clicked() {
+                actions.close = true;
+            }
+            let pin_hover = if chrome.shared.pinned {
+                "Unpin - float the inspector over the chart"
+            } else {
+                "Pin - dock the inspector at the side of the chart"
+            };
+            let pin = IconButton::new(icons::PUSH_PIN, TOOLBAR_ICON)
+                .active(chrome.shared.pinned)
+                .hover_text(pin_hover)
+                .show(ui);
+            #[cfg(test)]
+            {
+                chrome.inspector.pin_rect = Some(pin.rect);
+            }
+            if pin.clicked() {
+                actions.toggle_pin = true;
+            }
+            let eye_icon = if hidden { icons::EYE_SLASH } else { icons::EYE };
+            let eye_hover = if hidden {
+                "Show this drawing again"
+            } else {
+                "Hide this drawing - the inspector keeps the way back"
+            };
+            let eye = IconButton::new(eye_icon, TOOLBAR_ICON)
+                .active(hidden)
+                .hover_text(eye_hover)
+                .show(ui);
+            if eye.clicked() {
+                actions.toggle_hidden = true;
+            }
+        });
+    });
+    if floating {
+        let bar = bar.on_hover_text("Drag to move · double-click to reposition automatically");
+        if bar.double_clicked() {
+            // The reset path: back to automatic placement.
+            chrome.inspector.moved = false;
+            let placed = target_placement(&chrome.inspector, ui.ctx(), env);
+            chrome.inspector.pos = placed.map(|placed| placed.position);
+            chrome.inspector.max_width = placed.and_then(|placed| placed.max_width);
+            // Giving the placement back is a decision too, and it has to
+            // reach the file: a reset that lived only until the next launch
+            // would hand the trader back the very position they discarded.
+            chrome.inspector.position_dirty = true;
+        } else if bar.dragged() {
+            // The gesture starts from where the window actually is, in
+            // preference to where it is remembered: the two differ whenever
+            // the pane is too small for the parked point and the host is
+            // drawing a clamped copy. Dragging the clamped window from the
+            // un-clamped point would make it jump the whole difference on the
+            // first pixel — and the trader is dragging what they can see.
+            if bar.drag_started()
+                && let Some(drawn) = ui
+                    .ctx()
+                    .memory(|memory| memory.area_rect(egui::Id::new(INSPECTOR_AREA_ID)))
+                    .map(|rect| rect.min)
+            {
+                chrome.inspector.pos = Some(drawn);
+            }
+            // From there the delta accumulates on the *remembered* point,
+            // never on the drawn one. The window is positioned from `pos`
+            // before this bar is laid out, so the drawn rect is always one
+            // frame behind it: adding this frame's delta to that rect throws
+            // the previous frame's away, and the popup travels at half the
+            // speed of the hand — which is what "ela treme" was, reported
+            // from the running app.
+            match chrome.inspector.pos {
+                Some(position) => chrome.inspector.place_by_hand(position + bar.drag_delta()),
+                // No position to move yet — the window has not been laid out.
+                // The hand is still down, so the flag alone records that
+                // placement is no longer the app's to decide.
+                None => chrome.inspector.moved = true,
+            }
+        }
+        // Written when the hand comes off the window, not while it is still
+        // moving: one file write per gesture, and the position it records is
+        // the one the trader stopped at.
+        if bar.drag_stopped() {
+            chrome.inspector.position_dirty = true;
+        }
+    }
+    ui.separator();
+    actions
+}
+
+/// Everything the inspector shows for the selected object, shared by the
+/// floating window and the pinned dock panel. Sections are driven by the
+/// tool's capabilities — an unsupported property is absent, not disabled.
+///
+/// `edited` is the host's object **copied**, not borrowed: every widget below
+/// writes into the copy, and the caller hands it back through the response.
+/// The original stays where every renderer reads it.
+fn body(
+    chrome: &mut DrawingChromeSurface,
+    ui: &mut egui::Ui,
+    edited: &mut Drawing,
+    env: &DrawingEnv<'_>,
+    presets: &mut RecordingPresetHost<'_>,
+) -> InspectorActions {
+    let mut actions = InspectorActions::default();
+    let tool = edited.tool;
+    let locked = edited.locked;
+    let hidden = edited.hidden;
+    let author = edited.author.as_ref().map(DrawingAuthor::label);
+    let shareable = edited.shareable();
+    let mut shared = edited.scope == drawings::DrawingScope::AllCharts;
+    let show_confirm = chrome.shared.delete_confirm && locked;
+
+    // The always-visible textual actions (UX spec: never glyph-only, never
+    // behind a scroll). Identity and the view controls live in the host's
+    // title bar, not here.
+    let intent = drawings::action_bar::draw(ui, locked);
+    actions.toggle_lock |= intent.toggle_lock;
+    actions.delete |= intent.delete;
+
+    if let Some(author) = &author {
+        // Data honesty, where the trader decides what to do with the object:
+        // an assistant's mark never passes for their own.
+        ui.label(
+            egui::RichText::new(format!("Placed by {author} - not by you."))
+                .small()
+                .color(theme::TEXT_SUPPORT),
+        );
+    }
+    if locked {
+        ui.label(
+            egui::RichText::new("Locked - protected from accidental moves. Style stays editable.")
+                .small()
+                .color(theme::TEXT_SUPPORT),
+        );
+    }
+    if hidden {
+        ui.label(
+            egui::RichText::new("Hidden - Show brings it back.")
+                .small()
+                .color(theme::TEXT_SUPPORT),
+        );
+    }
+    // Where the object appears. Always visible, never behind a tab.
+    //
+    // It used to live on the Coordinates tab, because sharing is a statement
+    // about the anchors — which is the implementer's mental model, not the
+    // trader's. Nobody hunting for "also show this on the other chart" opens
+    // a tab called Coordinates, and that is not even the tab the panel opens
+    // on. Reported as unfindable, and it was.
+    ui.separator();
+    let sharing = ui.add_enabled(
+        shareable,
+        egui::Checkbox::new(&mut shared, "Show on all charts"),
+    );
+    if sharing.changed() {
+        edited.scope = if shared {
+            drawings::DrawingScope::AllCharts
+        } else {
+            drawings::DrawingScope::ThisChart
+        };
+        actions.edited = true;
+    }
+    // A disabled control with no reason reads as a bug.
+    let sharing_hint = if shareable {
+        "The other chart of this tab draws it at the same moment in market time"
+    } else {
+        "This drawing has an anchor past the newest bar, so there is no market time to place          it by on another chart"
+    };
+    sharing.on_hover_text(sharing_hint);
+    if !shareable {
+        ui.label(
+            egui::RichText::new(sharing_hint)
+                .small()
+                .color(theme::TEXT_SUPPORT),
+        );
+    }
+
+    if show_confirm {
+        ui.separator();
+        ui.label("Delete locked drawing?");
+        ui.horizontal(|ui| {
+            if ui.button("Cancel").clicked() {
+                actions.cancel_delete = true;
+            }
+            if ui.button("Delete anyway").clicked() {
+                actions.force_delete = true;
+            }
+        });
+    }
+    ui.separator();
+
+    if chrome.inspector.tab == InspectorTab::Extra && tool.extra_tab().is_none() {
+        // The previous selection had an extra tab; this tool brings none.
+        chrome.inspector.tab = InspectorTab::Style;
+    }
+    ui.horizontal(|ui| {
+        ui.selectable_value(&mut chrome.inspector.tab, InspectorTab::Style, "Style");
+        // A tool that brings its own tab (the Fib level editor) mounts it
+        // here by name; the central code never learns what is inside.
+        if let Some(extra) = tool.extra_tab() {
+            ui.selectable_value(&mut chrome.inspector.tab, InspectorTab::Extra, extra);
+        }
+        ui.selectable_value(
+            &mut chrome.inspector.tab,
+            InspectorTab::Coordinates,
+            "Coordinates",
+        );
+    });
+    ui.separator();
+
+    let price_speed = env.auto_range.map_or(1.0, |(lo, hi)| {
+        ((hi - lo) / PRICE_DRAG_STEPS).abs().max(1e-9)
+    });
+    match chrome.inspector.tab {
+        InspectorTab::Extra => {
+            actions.edited |= tool.draw_extra_tab(ui, edited, presets);
+        }
+        InspectorTab::Style => {
+            ui.label("Style");
+            actions.edited |= ui
+                .color_edit_button_srgba(&mut edited.style.color)
+                .changed();
+            // Capability-driven, like the fill slider below: a tool with no
+            // stroke has no line width, and the repo's rule is that an
+            // unsupported property is *absent*, not present and inert. Caught
+            // by the visual pass — the text note's Style tab was offering a
+            // slider that moved nothing.
+            if tool.supports_stroke_width() {
+                actions.edited |= ui
+                    .add(
+                        egui::Slider::new(
+                            &mut edited.style.width_px,
+                            MIN_DRAWING_WIDTH_PX..=MAX_DRAWING_WIDTH_PX,
+                        )
+                        .text("line width (px)"),
+                    )
+                    .changed();
+            }
+            if tool.supports_fill() {
+                actions.edited |= ui
+                    .add(
+                        egui::Slider::new(&mut edited.style.fill_alpha, 0..=MAX_DRAWING_FILL_ALPHA)
+                            .text("fill opacity"),
+                    )
+                    .changed();
+            }
+
+            // Stop asking for the same look every single time. Every tool has
+            // a Style tab, so every tool gets this — the named-preset editor
+            // only ever existed on the Fib tab, which left fifteen tools with
+            // no way to remember anything.
+            //
+            // New objects only: a default that repainted the marks already on
+            // the chart would be a bulk edit nobody asked for.
+            ui.separator();
+            ui.label(egui::RichText::new("Default for new drawings").small());
+            ui.horizontal(|ui| {
+                let style = edited.style;
+                if ui
+                    .button("Save as default")
+                    .on_hover_text(format!(
+                        "New {} objects open configured exactly like this one",
+                        tool.name().to_lowercase()
+                    ))
+                    .clicked()
+                {
+                    drawings::save_tool_default(presets, edited);
+                    actions.saved_default = Some(SavedDefault::OneTool);
+                }
+                // Style only, and that is not a shortcut: a Fib's level list
+                // means nothing to a rectangle, so the one property every
+                // tool shares is the only one this can carry.
+                if ui
+                    .button("Colour on all tools")
+                    .on_hover_text("Every new drawing opens with this colour, width and fill")
+                    .clicked()
+                {
+                    for other in DRAWING_TOOLS {
+                        presets.set_default_style(other.id(), Some(style));
+                    }
+                    actions.saved_default = Some(SavedDefault::EveryTool);
+                }
+                if drawings::has_saved_default(presets, tool)
+                    && ui
+                        .button("Reset to factory")
+                        .on_hover_text(format!(
+                            concat!(
+                                "New {} objects go back to how they opened ",
+                                "out of the box. Clears the default preset ",
+                                "choice too; saved presets are kept"
+                            ),
+                            tool.name().to_lowercase()
+                        ))
+                        .clicked()
+                {
+                    drawings::reset_tool_default(presets, tool);
+                    actions.saved_default = Some(SavedDefault::Forgotten);
+                }
+            });
+        }
+        InspectorTab::Coordinates => {
+            // Geometry through numbers: bar index and price per anchor, the
+            // same canonical coordinates drags write. Locked blocks geometry
+            // here exactly as it does on the canvas.
+            const ANCHOR_LABELS: [&str; 4] = ["A", "B", "C", "D"];
+            ui.add_enabled_ui(!locked, |ui| {
+                for (point_index, point) in edited.points.iter_mut().enumerate() {
+                    ui.horizontal(|ui| {
+                        ui.label(ANCHOR_LABELS.get(point_index).copied().unwrap_or("?"));
+                        actions.edited |= ui
+                            .add(
+                                egui::DragValue::new(&mut point.bar)
+                                    .speed(BAR_DRAG_SPEED)
+                                    .prefix("bar "),
+                            )
+                            .changed();
+                        actions.edited |= ui
+                            .add(egui::DragValue::new(&mut point.price).speed(price_speed))
+                            .changed();
+                    });
+                }
+            });
+            if locked {
+                ui.label(
+                    egui::RichText::new("Unlock the drawing to edit its coordinates.").small(),
+                );
+            }
+        }
+    }
+    actions
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The eight §4.2 candidates, clamped — restated here so a drifted
+    /// implementation cannot silently shrink its own search space.
+    fn placement_candidates(
+        chart: egui::Rect,
+        bbox: egui::Rect,
+        size: egui::Vec2,
+    ) -> [egui::Pos2; 8] {
+        let gap = INSPECTOR_OBJECT_GAP_PX;
+        [
+            egui::pos2(bbox.right() + gap, bbox.top()),
+            egui::pos2(bbox.left() - gap - size.x, bbox.top()),
+            egui::pos2(bbox.left(), bbox.bottom() + gap),
+            egui::pos2(bbox.left(), bbox.top() - gap - size.y),
+            egui::pos2(chart.left() + gap, chart.top() + gap),
+            egui::pos2(chart.right() - gap - size.x, chart.top() + gap),
+            egui::pos2(chart.left() + gap, chart.bottom() - gap - size.y),
+            egui::pos2(chart.right() - gap - size.x, chart.bottom() - gap - size.y),
+        ]
+        .map(|candidate| clamp_into_chart(candidate, size, chart))
+    }
+
+    #[test]
+    fn placement_sends_the_panel_to_a_corner_not_beside_a_small_object() {
+        let chart = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(1_400.0, 800.0));
+        let bbox = egui::Rect::from_center_size(chart.center(), egui::vec2(40.0, 40.0));
+        let size = egui::vec2(320.0, 280.0);
+        let position = placement(chart, bbox, size).position;
+        let rect = egui::Rect::from_min_size(position, size);
+        assert!(!rect.intersects(bbox), "a clear candidate exists and wins");
+        assert!(chart.contains_rect(rect));
+        assert_ne!(
+            position,
+            egui::pos2(bbox.right() + INSPECTOR_OBJECT_GAP_PX, bbox.top()),
+            "beside-the-object is exactly the placement this rule replaced"
+        );
+        assert!(
+            placement_candidates(chart, bbox, size)[4..].contains(&position),
+            "the winner is one of the four chart corners"
+        );
+        assert_eq!(
+            position,
+            placement(chart, bbox, size).position,
+            "identical inputs give identical placements"
+        );
+    }
+
+    /// The farthest clear corner wins, so the panel walks away from the
+    /// object instead of hugging the nearest empty spot.
+    #[test]
+    fn placement_picks_the_corner_farthest_from_the_object() {
+        let chart = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(1_400.0, 800.0));
+        // Object parked in the bottom-left quadrant.
+        let bbox = egui::Rect::from_center_size(egui::pos2(260.0, 640.0), egui::vec2(40.0, 40.0));
+        let size = egui::vec2(320.0, 280.0);
+        let gap = INSPECTOR_OBJECT_GAP_PX;
+        assert_eq!(
+            placement(chart, bbox, size).position,
+            egui::pos2(chart.right() - gap - size.x, chart.top() + gap),
+            "the opposite corner is the farthest clear one"
+        );
+    }
+
+    /// With the object centred, all four corners are equidistant, so the
+    /// order tie-break decides — and it must always decide the same way, or
+    /// the panel appears somewhere new every time (Duda, §D3).
+    #[test]
+    fn placement_prefers_the_top_left_corner_on_a_tie() {
+        let chart = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(1_400.0, 800.0));
+        let bbox = egui::Rect::from_center_size(chart.center(), egui::vec2(40.0, 40.0));
+        let size = egui::vec2(320.0, 280.0);
+        let gap = INSPECTOR_OBJECT_GAP_PX;
+        assert_eq!(
+            placement(chart, bbox, size).position,
+            egui::pos2(chart.left() + gap, chart.top() + gap)
+        );
+    }
+
+    /// A panel taller than the placement assumed must not be sent to a bottom
+    /// corner, where it would grow off the window and lose its last rows. The
+    /// top-first order is what guarantees that, so it is worth a test of its
+    /// own: whatever height the panel turns out to have, the chosen spot
+    /// leaves room for it below.
+    #[test]
+    fn placement_leaves_a_tall_panel_room_to_grow_downwards() {
+        let chart = egui::Rect::from_min_size(egui::pos2(60.0, 88.0), egui::vec2(1_224.0, 744.0));
+        let bbox = egui::Rect::from_center_size(egui::pos2(700.0, 300.0), egui::vec2(40.0, 40.0));
+        // The height the placement believes in, and the height the panel
+        // turns out to want once its level editor is open.
+        let assumed = egui::vec2(360.0, 280.0);
+        let actual = 620.0;
+        let position = placement(chart, bbox, assumed).position;
+        assert!(
+            position.y + actual <= chart.bottom(),
+            "a panel that grows to {actual} px must still fit below {position:?}"
+        );
+    }
+
+    #[test]
+    fn placement_picks_the_least_overlap_when_nothing_clears() {
+        let chart = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(1_000.0, 600.0));
+        // The object spans ~90% of the pane: every candidate overlaps.
+        let bbox = chart.shrink2(egui::vec2(50.0, 30.0));
+        let size = egui::vec2(320.0, 280.0);
+        let position = placement(chart, bbox, size).position;
+        let chosen = egui::Rect::from_min_size(position, size)
+            .intersect(bbox)
+            .area();
+        for candidate in placement_candidates(chart, bbox, size) {
+            let overlap = egui::Rect::from_min_size(candidate, size)
+                .intersect(bbox)
+                .area();
+            assert!(
+                chosen <= overlap + 0.01,
+                "the chosen spot must cover the object least: {chosen} vs {overlap}"
+            );
+        }
+        assert!(chart.contains_rect(egui::Rect::from_min_size(position, size)));
+    }
+
+    #[test]
+    fn placement_never_returns_the_blind_first_candidate_at_the_right_edge() {
+        let chart = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(1_000.0, 600.0));
+        let bbox = egui::Rect::from_min_max(egui::pos2(900.0, 200.0), egui::pos2(1_000.0, 300.0));
+        let size = egui::vec2(320.0, 280.0);
+        let position = placement(chart, bbox, size).position;
+        let rect = egui::Rect::from_min_size(position, size);
+        assert!(
+            !rect.intersects(bbox),
+            "left of the object clears; the old code clamped right-of back onto it"
+        );
+        assert!(
+            position.x < bbox.left(),
+            "the panel must sit clear on the left, not clamp over the object"
+        );
+    }
+
+    /// The session's complaint (`docs/ux/drawing-tools-2026-08.md` §F3): the
+    /// old rule put the panel 12 px beside a small object, right on top of
+    /// the price action the trader drew it to read. A corner must win.
+    /// The rule a volume profile broke: a drawing big enough to foul all four
+    /// corners used to get the panel dropped straight onto it.
+    ///
+    /// A profile is exactly that shape — tall enough to span the price axis,
+    /// wide enough to reach past every corner candidate — so "least overlap"
+    /// meant "on the figure", and the panel covered the thing it configures.
+    /// It goes into the gutter beside the object instead, narrowed to fit.
+    #[test]
+    fn a_drawing_too_big_for_any_corner_sends_the_panel_to_a_gutter_beside_it() {
+        let chart = egui::Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(1200.0, 700.0));
+        let size = egui::vec2(320.0, 280.0);
+        // A profile down the middle, wide enough that a panel parked at any
+        // corner overlaps it, and narrow enough that the strip beside it can
+        // still hold a narrowed one. That band is exactly what narrowing is
+        // for: the corner candidate assumes the full width and fouls, the
+        // gutter takes what fits.
+        let bbox = egui::Rect::from_min_max(egui::pos2(320.0, 0.0), egui::pos2(880.0, 700.0));
+        let gap = INSPECTOR_OBJECT_GAP_PX;
+        for corner in [
+            egui::pos2(chart.left() + gap, chart.top() + gap),
+            egui::pos2(chart.right() - gap - size.x, chart.top() + gap),
+            egui::pos2(chart.left() + gap, chart.bottom() - gap - size.y),
+            egui::pos2(chart.right() - gap - size.x, chart.bottom() - gap - size.y),
+        ] {
+            assert!(
+                egui::Rect::from_min_size(corner, size)
+                    .intersect(bbox)
+                    .is_positive(),
+                "the fixture has to actually foul every corner: {corner:?}"
+            );
+        }
+
+        let placed = placement(chart, bbox, size);
+        let rect = egui::Rect::from_min_size(
+            placed.position,
+            egui::vec2(placed.max_width.unwrap_or(size.x), size.y),
+        );
+        assert!(
+            !rect.intersect(bbox).is_positive(),
+            "the panel must not cover the drawing it configures: {rect:?} vs {bbox:?}"
+        );
+        assert!(
+            chart.contains_rect(rect),
+            "and it stays inside the chart: {rect:?}"
+        );
+        assert!(
+            placed
+                .max_width
+                .is_some_and(|w| w >= INSPECTOR_MIN_WIDTH_PX),
+            "narrowed, but never below what a panel needs: {:?}",
+            placed.max_width
+        );
+    }
+
+    /// The wider side wins, so the panel goes where there is most room — and
+    /// a corner that *is* free still beats any gutter, because the gutter is
+    /// the fallback, not the rule.
+    #[test]
+    fn the_gutter_is_the_wider_side_and_never_preferred_over_a_free_corner() {
+        let chart = egui::Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(1200.0, 700.0));
+        let size = egui::vec2(320.0, 280.0);
+
+        // Object hugging the left: the room is on its right.
+        let left_heavy = egui::Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(400.0, 700.0));
+        let placed = placement(chart, left_heavy, size);
+        assert!(
+            placed.position.x >= left_heavy.right(),
+            "the panel takes the wider side: {placed:?}"
+        );
+
+        // Object hugging the right: the room is on its left.
+        let right_heavy =
+            egui::Rect::from_min_max(egui::pos2(800.0, 0.0), egui::pos2(1200.0, 700.0));
+        let placed = placement(chart, right_heavy, size);
+        assert!(
+            placed.position.x + placed.max_width.unwrap_or(size.x) <= right_heavy.left(),
+            "and the other side when that is where the room is: {placed:?}"
+        );
+
+        // A small object leaves corners free, and a free corner is unnarrowed.
+        let small = egui::Rect::from_center_size(chart.center(), egui::vec2(40.0, 40.0));
+        let placed = placement(chart, small, size);
+        assert_eq!(
+            placed.max_width, None,
+            "a corner placement never narrows the panel: {placed:?}"
+        );
+    }
+
+    /// Automatic placement is not a preference, so it is not written down.
+    /// Only a hand — or the hook standing in for one — makes a position the
+    /// file has to remember.
+    #[test]
+    fn only_a_hand_placed_position_reaches_the_file() {
+        let mut inspector = Inspector::default();
+        assert_eq!(inspector.remembered_position(), None);
+        inspector.pos = Some(egui::pos2(10.0, 20.0));
+        assert_eq!(
+            inspector.remembered_position(),
+            None,
+            "a placed position is the app's decision, not the trader's"
+        );
+        inspector.place_by_hand(egui::pos2(30.0, 40.0));
+        assert_eq!(inspector.remembered_position(), Some([30.0, 40.0]));
+        assert!(
+            !inspector.take_position_dirty(),
+            "parking alone owes nothing: the drag calls it on every frame the              hand moves, and the file write is owed when the hand comes off"
+        );
+        inspector.position_dirty = true;
+        assert!(inspector.take_position_dirty(), "and then exactly once");
+        assert!(!inspector.take_position_dirty());
+    }
+
+    /// A file with a nonsense position leaves automatic placement in charge
+    /// rather than parking the panel at an invented pixel.
+    #[test]
+    fn a_nonsense_remembered_position_is_refused() {
+        let mut inspector = Inspector::default();
+        inspector.place_by_hand(egui::pos2(30.0, 40.0));
+        inspector.restore_position(Some([f32::NAN, 0.0]));
+        assert_eq!(inspector.remembered_position(), None);
+        inspector.restore_position(Some([12.0, 34.0]));
+        assert_eq!(inspector.remembered_position(), Some([12.0, 34.0]));
+    }
+}

--- a/crates/app/src/surfaces/drawing_chrome/inspector.rs
+++ b/crates/app/src/surfaces/drawing_chrome/inspector.rs
@@ -494,7 +494,23 @@ fn settle(
     index: usize,
     env: &DrawingEnv<'_>,
 ) {
-    if actions.edited {
+    // Handed back because it *differs*, not because a flag said so.
+    //
+    // `Tool::draw_extra_tab` returns "did anything change", and its contract
+    // calls that an advisory hint the caller folds into the undo coalescing.
+    // While the tab wrote through a `&mut` into the live store, a tab that
+    // mutated and returned `false` still persisted the mutation. Editing a
+    // copy would quietly promote that hint to a commit flag, and the
+    // sixteenth tool — written from the unchanged doc comment — would lose
+    // every edit it made with no compile error and no failing test. The
+    // comparison costs one `PartialEq` on a copy this frame already made, and
+    // only while a panel is open.
+    if actions.edited
+        || env
+            .selected
+            .as_ref()
+            .is_none_or(|held| *held.drawing != edited)
+    {
         ask.edited = Some(Box::new(edited));
     }
     ask.presets.extend(recorder.into_writes());

--- a/crates/app/src/surfaces/drawing_chrome/manager.rs
+++ b/crates/app/src/surfaces/drawing_chrome/manager.rs
@@ -1,0 +1,291 @@
+//! The object manager: a non-modal list of every drawing with the named
+//! per-object actions.
+//!
+//! It sends the same store commands the inspector and the keyboard do —
+//! nothing here re-implements lock or delete rules. It is also the only place
+//! a mark clamped to the edge of the series can be *found*: an off-series
+//! object may be nowhere near the window the trader is looking at.
+
+use eframe::egui;
+
+use super::{
+    DRAWING_MANAGER_DEFAULT_POSITION, DRAWING_MANAGER_GAP_PX, DrawingChromeAsk,
+    DrawingChromeSurface, DrawingEnv, INSPECTOR_DEFAULT_WIDTH_PX, INSPECTOR_FALLBACK_HEIGHT_PX,
+    MANAGER_AREA_ID, clamp_into_chart,
+};
+use crate::theme;
+use crate::toolrail::ToolboxDock;
+
+/// The manager's own state.
+#[derive(Default)]
+pub(crate) struct Manager {
+    /// Whether the window is on screen.
+    pub open: bool,
+    /// Whether it was on screen last frame, which is what tells an opening
+    /// from a frame in the middle of a session: only the opening frame places
+    /// the window.
+    was_open: bool,
+    /// The count-bearing gate is showing and awaiting its answer.
+    confirm_delete_all: bool,
+    #[cfg(test)]
+    pub action_rects: Vec<(usize, &'static str, egui::Rect)>,
+}
+
+/// Where the object manager opens: one gap inboard of the rail's inner edge,
+/// aligned with the rail's leading end, clamped into the chart — beside the
+/// button that opened it in all four docks.
+fn target_position(
+    ctx: &egui::Context,
+    chart: Option<egui::Rect>,
+    dock: ToolboxDock,
+) -> Option<egui::Pos2> {
+    let chart = chart?;
+    let size = ctx
+        .memory(|memory| memory.area_rect(egui::Id::new(MANAGER_AREA_ID)))
+        .map_or(
+            egui::vec2(INSPECTOR_DEFAULT_WIDTH_PX, INSPECTOR_FALLBACK_HEIGHT_PX),
+            |rect| rect.size(),
+        );
+    let gap = DRAWING_MANAGER_GAP_PX;
+    let position = match dock {
+        ToolboxDock::Left | ToolboxDock::Top => egui::pos2(chart.left() + gap, chart.top() + gap),
+        ToolboxDock::Bottom => egui::pos2(chart.left() + gap, chart.bottom() - gap - size.y),
+    };
+    Some(clamp_into_chart(position, size, chart))
+}
+
+/// Draw this frame.
+pub(crate) fn draw(
+    chrome: &mut DrawingChromeSurface,
+    ctx: &egui::Context,
+    env: &DrawingEnv<'_>,
+) -> DrawingChromeAsk {
+    let mut ask = DrawingChromeAsk::default();
+    if !chrome.manager.open {
+        chrome.manager.was_open = false;
+        return ask;
+    }
+    let just_opened = !chrome.manager.was_open;
+    chrome.manager.was_open = true;
+    #[cfg(test)]
+    chrome.manager.action_rects.clear();
+    let mut open = true;
+    let mut confirm_delete_all = chrome.manager.confirm_delete_all;
+    let rows = env.manager_rows;
+    let count = rows.len();
+    let authored = env.authored_objects;
+    let mut window = egui::Window::new("Drawn objects")
+        .id(egui::Id::new(MANAGER_AREA_ID))
+        .open(&mut open)
+        .default_pos(DRAWING_MANAGER_DEFAULT_POSITION)
+        .default_width(INSPECTOR_DEFAULT_WIDTH_PX)
+        .collapsible(false)
+        // Resizable, with the list scrolling below (audit M13): thirty
+        // objects used to grow the window past the screen and put the footer
+        // out of reach.
+        .resizable(true);
+    if just_opened
+        && let Some(position) = target_position(ctx, env.focused_chart_area, env.toolbox_dock)
+    {
+        window = window.current_pos(position);
+    }
+    window.show(ctx, |ui| {
+        if count == 0 {
+            ui.label("No drawings yet.");
+        }
+        // One gesture back from an assistant that drew too much. It appears
+        // only when there is something to take back, names the number, and is
+        // a single undo entry.
+        if authored > 0 {
+            if ui
+                .button(format!("Remove {authored} object(s) placed for you"))
+                .on_hover_text(
+                    "Removes every object an assistant placed on this chart. Ctrl+Z brings them back.",
+                )
+                .clicked()
+            {
+                ask.sweep_authored = true;
+            }
+            ui.add_space(4.0);
+        }
+        egui::ScrollArea::vertical()
+            .auto_shrink([false, true])
+            .show(ui, |ui| {
+                // Walked in reverse: the manager lists top-most first, the
+                // same order hit-testing resolves overlap.
+                for index in (0..count).rev() {
+                    let row = &rows[index];
+                    ui.horizontal(|ui| {
+                        let mut label = egui::RichText::new(&row.name);
+                        if row.hidden {
+                            label = label.weak();
+                        }
+                        if ui.selectable_label(row.selected, label).clicked() {
+                            ask.manager_select = Some(index);
+                        }
+                        if let Some(author) = &row.author {
+                            ui.label(
+                                egui::RichText::new("assistant")
+                                    .small()
+                                    .color(theme::TEXT_SUPPORT),
+                            )
+                            .on_hover_text(format!("Placed by {author}, not by you"));
+                        }
+                        if row.locked {
+                            ui.label(egui::RichText::new("locked").small());
+                        }
+                        if row.hidden {
+                            ui.label(egui::RichText::new("hidden").small());
+                        }
+                        // Which band an object is on, for the objects that are
+                        // not on the candles. An object nothing on screen is
+                        // showing — its indicator removed, hidden, collapsed
+                        // or errored — is listed in amber and says which of
+                        // those it is. It still exists; deleting it stays the
+                        // trader's call.
+                        if let Some(chip) = row.band.chip() {
+                            let text = egui::RichText::new(chip).small();
+                            match row.band.hint() {
+                                Some(hint) => {
+                                    ui.label(text.color(theme::AMBER)).on_hover_text(hint);
+                                }
+                                None => {
+                                    ui.label(text);
+                                }
+                            }
+                        }
+                        if row.foreign_market {
+                            // The one state the chart alone cannot explain:
+                            // the mark resolves onto real bars, at a price
+                            // that belonged to another instrument.
+                            ui.label(egui::RichText::new("other market").small())
+                                .on_hover_text(
+                                    "Drawn while this tab showed a different instrument. The                                      moment still exists here; the price does not mean the                                      same thing",
+                                );
+                        }
+                        if row.off_series {
+                            // The mark outlived the bars it was drawn on and
+                            // the chart fades it (§D7b). The list is where it
+                            // can be found and removed, since a clamped object
+                            // may be nowhere near the window the trader is
+                            // looking at.
+                            ui.label(egui::RichText::new("off series").small())
+                                .on_hover_text(
+                                    "Drawn at a moment this chart's bars do not cover. It is                                      shown at the nearest edge, faded, until you move or                                      delete it",
+                                );
+                        }
+                        if row.shared {
+                            // Which marks are global is a question the list
+                            // must answer at a glance (Marina, §D7).
+                            ui.label(egui::RichText::new("all charts").small())
+                                .on_hover_text(
+                                    "Also drawn on the other chart of this tab, at the same \
+                                     moment in market time",
+                                );
+                        }
+                        ui.with_layout(
+                            egui::Layout::right_to_left(egui::Align::Center),
+                            |ui| {
+                                let delete = ui.small_button("Delete");
+                                #[cfg(test)]
+                                chrome
+                                    .manager
+                                    .action_rects
+                                    .push((index, "Delete", delete.rect));
+                                if delete.clicked() {
+                                    ask.manager_delete = Some(index);
+                                }
+                                let front = ui.small_button("Front");
+                                #[cfg(test)]
+                                chrome.manager.action_rects.push((index, "Front", front.rect));
+                                if front.clicked() {
+                                    ask.manager_bring_to_front = Some(index);
+                                }
+                                let lock =
+                                    ui.small_button(if row.locked { "Unlock" } else { "Lock" });
+                                #[cfg(test)]
+                                chrome.manager.action_rects.push((index, "Lock", lock.rect));
+                                if lock.clicked() {
+                                    ask.manager_toggle_locked = Some(index);
+                                }
+                                let eye = ui.small_button(if row.hidden { "Show" } else { "Hide" });
+                                #[cfg(test)]
+                                chrome.manager.action_rects.push((index, "Eye", eye.rect));
+                                if eye.clicked() {
+                                    ask.manager_toggle_hidden = Some(index);
+                                }
+                            },
+                        );
+                    });
+                }
+            });
+        ui.separator();
+        if confirm_delete_all && count > 0 {
+            // The count-bearing gate (audit M7): deleting everything is one
+            // command, but never one stray click — and locked objects go too,
+            // which the question says out loud.
+            ui.horizontal(|ui| {
+                ui.label(format!("Delete all {count} drawing(s), locked included?"));
+                if ui.button("Delete all").clicked() {
+                    ask.delete_all = true;
+                    confirm_delete_all = false;
+                }
+                if ui.button("Keep").clicked() {
+                    confirm_delete_all = false;
+                }
+            });
+        } else {
+            confirm_delete_all = false;
+            ui.horizontal(|ui| {
+                if ui.button("Show all").clicked() {
+                    ask.show_all = true;
+                }
+                if ui.button("Unlock all").clicked() {
+                    ask.unlock_all = true;
+                }
+                if count > 0 && ui.button("Delete all…").clicked() {
+                    confirm_delete_all = true;
+                }
+            });
+        }
+    });
+    chrome.manager.confirm_delete_all = confirm_delete_all;
+    chrome.manager.open = open;
+    ask
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CHART: egui::Rect =
+        egui::Rect::from_min_max(egui::pos2(100.0, 50.0), egui::pos2(900.0, 650.0));
+
+    /// The window opens beside the button that opened it, in every dock —
+    /// a list that appeared in a fixed corner would be nowhere near the hand.
+    #[test]
+    fn the_manager_opens_beside_the_rail_in_every_dock() {
+        let ctx = egui::Context::default();
+        let top = target_position(&ctx, Some(CHART), ToolboxDock::Top).expect("a chart");
+        let left = target_position(&ctx, Some(CHART), ToolboxDock::Left).expect("a chart");
+        assert_eq!(
+            top, left,
+            "a top rail and a left rail share a leading corner"
+        );
+        assert_eq!(top, egui::pos2(112.0, 62.0), "one gap inboard of the chart");
+        let bottom = target_position(&ctx, Some(CHART), ToolboxDock::Bottom).expect("a chart");
+        assert!(
+            bottom.y > top.y,
+            "a bottom rail opens the list at the bottom, where the button is"
+        );
+        assert!(CHART.contains(bottom), "and never outside the chart");
+    }
+
+    /// No laid-out chart, no placement — the window falls back to its own
+    /// default rather than being put at an invented pixel.
+    #[test]
+    fn without_a_chart_there_is_no_placement() {
+        let ctx = egui::Context::default();
+        assert_eq!(target_position(&ctx, None, ToolboxDock::Left), None);
+    }
+}

--- a/crates/app/src/surfaces/drawing_chrome/mod.rs
+++ b/crates/app/src/surfaces/drawing_chrome/mod.rs
@@ -60,7 +60,6 @@ pub(crate) mod manager;
 
 use eframe::egui;
 
-use super::{Surface, SurfaceEnv, SurfaceResponse};
 use crate::bands::BandLabel;
 use crate::drawings::{Drawing, DrawingStyle, PresetHost};
 use crate::pane::PaneSide;
@@ -175,27 +174,21 @@ impl InspectorActions {
     }
 }
 
-/// An inline text edit in flight: which object, on which pane of which tab,
-/// and what it said before the first keystroke.
+/// An edit in flight: which object, on which pane of which tab, and what it
+/// said before the first keystroke or the first drag.
 ///
-/// The tab and the pane, not the index alone: an index identifies nothing
-/// once there are two panes, let alone two tabs. Switching tabs with an
-/// editor open would otherwise record the note's undo entry against whatever
-/// object happened to sit at that index on the tab now in front — swapping an
+/// One record for both kinds of edit — the inline field's and the inspector's
+/// — because they are the same fact and end at the same call. Two identical
+/// structs would be two merge rules and two host branches to keep in step, and
+/// a fix applied to one would not reach the other.
+///
+/// The tab and the pane, not the index alone: an index identifies nothing once
+/// there are two panes, let alone two tabs. Switching tabs with an editor open
+/// would otherwise record the note's undo entry against whatever object
+/// happened to sit at that index on the tab now in front — swapping an
 /// unrelated drawing for a copy of the note on the next Ctrl+Z.
 #[derive(Debug, Clone, PartialEq)]
-pub(crate) struct InlineTextEdit {
-    pub tab: u64,
-    pub side: PaneSide,
-    pub index: usize,
-    pub before: Drawing,
-}
-
-/// The pre-edit copy held while an inspector gesture (a slider, a colour
-/// wheel, a coordinate drag) is in flight, so the whole gesture commits as one
-/// undo entry when pointer and keyboard let go.
-#[derive(Debug, Clone, PartialEq)]
-pub(crate) struct InspectorEdit {
+pub(crate) struct DrawingEdit {
     pub tab: u64,
     pub side: PaneSide,
     pub index: usize,
@@ -292,35 +285,6 @@ impl DrawingEnv<'_> {
     }
 }
 
-#[cfg(test)]
-impl DrawingEnv<'static> {
-    /// A pane with nothing selected and no manager open, for the tests.
-    ///
-    /// Written the way [`super::SurfaceEnv::quiet`] is, and for the same
-    /// reason: a field added here costs one line in this file rather than an
-    /// edit in each of the four surfaces' test modules.
-    pub fn quiet() -> Self {
-        /// A preset bank a test that does not care about presets gets.
-        static QUIET_PRESETS: crate::drawings::NullPresetHost = crate::drawings::NullPresetHost;
-        Self {
-            selected: None,
-            chart_area: None,
-            focused_chart_area: None,
-            lane_divider_x: None,
-            auto_range: None,
-            selected_bbox: None,
-            selected_band: None,
-            tab: 0,
-            side: PaneSide::Flow,
-            drawing_tool_armed: false,
-            toolbox_dock: ToolboxDock::Left,
-            authored_objects: 0,
-            manager_rows: &[],
-            presets: &QUIET_PRESETS,
-        }
-    }
-}
-
 /// One write to the preset bank, recorded rather than performed.
 ///
 /// The bank is host state that persists to disk on every write, so the
@@ -391,6 +355,13 @@ impl PresetWrite {
 /// [`PresetHost::load_custom_preset`] rather than from a copy of the store's
 /// rule, and `recorder_refuses_a_taken_name_exactly_as_the_bank_does` pins
 /// the two together.
+///
+/// **A read sees the writes this frame already made.** The bank is not
+/// mutated until the host replays the list, so consulting it alone would let
+/// one frame delete a preset and then be told the name it just freed is still
+/// taken — and would list a preset the trader deleted a moment ago. Every
+/// name-answering read therefore checks the pending writes first, newest
+/// wins, exactly as replaying them onto the bank would.
 pub(crate) struct RecordingPresetHost<'a> {
     bank: &'a dyn PresetHost,
     writes: Vec<PresetWrite>,
@@ -414,13 +385,69 @@ impl RecordingPresetHost<'_> {
     }
 }
 
+impl RecordingPresetHost<'_> {
+    /// Whether a preset by that name would exist once this frame's writes are
+    /// replayed. The newest pending write about the name wins; with none, the
+    /// bank answers.
+    fn pending_exists(&self, tool_id: &str, name: &str) -> Option<bool> {
+        self.writes.iter().rev().find_map(|write| match write {
+            PresetWrite::Save {
+                tool_id: t,
+                name: n,
+                ..
+            } if t == tool_id && n == name => Some(true),
+            PresetWrite::Delete {
+                tool_id: t,
+                name: n,
+            } if t == tool_id && n == name => Some(false),
+            _ => None,
+        })
+    }
+
+    fn exists(&self, tool_id: &str, name: &str) -> bool {
+        self.pending_exists(tool_id, name)
+            .unwrap_or_else(|| self.bank.load_custom_preset(tool_id, name).is_some())
+    }
+}
+
 impl PresetHost for RecordingPresetHost<'_> {
     fn custom_preset_names(&self, tool_id: &str) -> Vec<String> {
-        self.bank.custom_preset_names(tool_id)
+        let mut names = self.bank.custom_preset_names(tool_id);
+        for write in &self.writes {
+            match write {
+                PresetWrite::Save {
+                    tool_id: t, name, ..
+                } if t == tool_id => {
+                    if !names.contains(name) {
+                        names.push(name.clone());
+                    }
+                }
+                PresetWrite::Delete { tool_id: t, name } if t == tool_id => {
+                    names.retain(|held| held != name);
+                }
+                _ => {}
+            }
+        }
+        // The bank hands these back in `BTreeMap` order; a name appended here
+        // has to land in the same place, or the combo box reorders itself for
+        // one frame after a save.
+        names.sort();
+        names
     }
 
     fn load_custom_preset(&self, tool_id: &str, name: &str) -> Option<toml::Value> {
-        self.bank.load_custom_preset(tool_id, name)
+        match self.pending_exists(tool_id, name) {
+            Some(false) => None,
+            Some(true) => self.writes.iter().rev().find_map(|write| match write {
+                PresetWrite::Save {
+                    tool_id: t,
+                    name: n,
+                    value,
+                } if t == tool_id && n == name => Some(value.clone()),
+                _ => None,
+            }),
+            None => self.bank.load_custom_preset(tool_id, name),
+        }
     }
 
     fn save_custom_preset(
@@ -430,7 +457,7 @@ impl PresetHost for RecordingPresetHost<'_> {
         value: toml::Value,
         overwrite: bool,
     ) -> bool {
-        if !overwrite && self.bank.load_custom_preset(tool_id, name).is_some() {
+        if !overwrite && self.exists(tool_id, name) {
             return false;
         }
         self.writes.push(PresetWrite::Save {
@@ -507,7 +534,7 @@ pub(crate) struct DrawingChromeAsk {
     /// thing that produced it. Boxed for the reason [`Self::edited`] is: a
     /// `Drawing` inline here would be paid for by every surface in the
     /// application, on every frame, in a response returned by value.
-    pub commit_edit_gesture: Option<Box<InspectorEdit>>,
+    pub commit_edit_gesture: Option<Box<DrawingEdit>>,
     /// Hide or show the selection.
     pub toggle_selected_hidden: bool,
     /// Lock or unlock the selection.
@@ -517,6 +544,13 @@ pub(crate) struct DrawingChromeAsk {
     /// Delete the selection even though it is locked — the trader answered
     /// the question.
     pub force_delete: bool,
+    /// The trader answered "no" to that question.
+    ///
+    /// Applied by the host *after* [`Self::request_delete`], not cleared
+    /// surface-side during the draw: a frame that carries both — the bar's
+    /// confirm glyph and the body's Cancel — must end with the prompt gone,
+    /// and a delete request on a locked object raises it again.
+    pub cancel_delete: bool,
     /// Copy the selection, offset so the copy is visibly a copy.
     pub duplicate: bool,
     /// Place a text note in the middle of the pane and open its editor — the
@@ -526,7 +560,7 @@ pub(crate) struct DrawingChromeAsk {
     /// Record this object's pre-edit copy as one undo entry: the inline
     /// editor closed, on the pane the note actually lives on, which is not
     /// necessarily the one in front. Boxed like the two above.
-    pub record_inline_edit: Option<Box<InlineTextEdit>>,
+    pub record_inline_edit: Option<Box<DrawingEdit>>,
     /// The caret moved to a different object, or left the chart. Every pane
     /// has to be told, so exactly one object anywhere stands down; the host
     /// reads the new target back by name.
@@ -574,6 +608,7 @@ impl DrawingChromeAsk {
         self.toggle_selected_locked |= other.toggle_selected_locked;
         self.request_delete |= other.request_delete;
         self.force_delete |= other.force_delete;
+        self.cancel_delete |= other.cancel_delete;
         self.duplicate |= other.duplicate;
         self.place_text_note |= other.place_text_note;
         self.record_inline_edit = self.record_inline_edit.take().or(other.record_inline_edit);
@@ -609,7 +644,7 @@ pub(crate) struct Shared {
     /// A locked object's delete was asked for and is awaiting its answer.
     delete_confirm: bool,
     /// The pre-edit copy held across an in-flight edit gesture.
-    edit_baseline: Option<InspectorEdit>,
+    edit_baseline: Option<DrawingEdit>,
 }
 
 /// The chrome that speaks for the selected drawing: the context bar, the
@@ -685,8 +720,8 @@ impl DrawingChromeSurface {
         self.shared.open = open;
     }
 
-    /// Whether the inspector is open.
-    #[cfg(test)]
+    /// Whether the floating inspector is on screen. Read by the host before
+    /// it formats the band name, which only the inspector's title shows.
     pub fn inspector_open(&self) -> bool {
         self.shared.open
     }
@@ -756,13 +791,13 @@ impl DrawingChromeSurface {
 
     /// Close the editor, if one is open, and hand back what it owes the undo
     /// history.
-    pub fn end_inline_text_edit(&mut self) -> Option<InlineTextEdit> {
+    pub fn end_inline_text_edit(&mut self) -> Option<DrawingEdit> {
         self.inline.end()
     }
 
     /// Park the inspector where a hand put it. The hook that stands in for one
     /// reaches [`inspector::Inspector::place_by_hand`] directly, from
-    /// [`Surface::apply_env_hook`].
+    /// [`super::Surface::apply_env_hook`].
     #[cfg(test)]
     pub fn place_inspector_by_hand(&mut self, position: egui::Pos2) {
         self.inspector.place_by_hand(position);
@@ -903,7 +938,7 @@ impl DrawingChromeSurface {
     /// outlives its selection is committed rather than dropped.
     #[cfg(test)]
     pub fn open_edit_gesture(&mut self, tab: u64, side: PaneSide, index: usize, before: Drawing) {
-        self.shared.edit_baseline = Some(InspectorEdit {
+        self.shared.edit_baseline = Some(DrawingEdit {
             tab,
             side,
             index,
@@ -924,102 +959,6 @@ impl DrawingChromeSurface {
     #[cfg(test)]
     pub fn manager_action_rects(&self) -> &[(usize, &'static str, egui::Rect)] {
         &self.manager.action_rects
-    }
-}
-
-impl Surface for DrawingChromeSurface {
-    fn id(&self) -> &'static str {
-        "drawing-chrome"
-    }
-
-    /// The port's uniform entry, which forwards to [`Self::draw_floating`].
-    ///
-    /// [`Surfaces::draw_all`] deliberately does not call it: this surface is
-    /// anchored to the *chart* rather than floating over the window, so the
-    /// host registers it after the central canvas — both because a Background
-    /// panel drawn afterwards would sit over an `Area` created before it, and
-    /// because the pane geometry every piece here places against
-    /// (`last_chart_area`, `last_auto_range`, the lane divider) is written by
-    /// the canvas as it draws. Reading it a phase early would place the bar
-    /// and the panel against the previous frame's chart.
-    ///
-    /// Kept rather than dropped, and it is a forward rather than a second
-    /// implementation: this surface satisfies exactly the contract its eight
-    /// neighbours do, `apply_env_hook` hangs off the same trait, and if the
-    /// frame is ever reordered so the canvas comes first, adding this member
-    /// to `draw_all` is one line.
-    fn draw(&mut self, ctx: &egui::Context, env: &SurfaceEnv<'_>) -> SurfaceResponse {
-        SurfaceResponse {
-            drawing: self.draw_floating(ctx, &env.drawing),
-            ..SurfaceResponse::default()
-        }
-    }
-
-    /// Five `QUANTICK_*` hooks, all of them state this surface owns.
-    ///
-    /// They ran in the constructor before this module existed, which put the
-    /// hook for a surface in a different file from the surface. Here they are
-    /// beside the fields they set, and a hook that stops matching its field
-    /// stops compiling.
-    fn apply_env_hook(&mut self, _env: &SurfaceEnv<'_>) {
-        // The on-chart note editor exists only between a placement and the
-        // first click elsewhere, so no click-free launch could photograph it
-        // without a hook — the same gap `QUANTICK_DRAWING_DRAFT` fills for a
-        // half-placed object. The placement itself is the host's, so this
-        // raises the ask rather than making the object.
-        if std::env::var("QUANTICK_TEXT_NOTE").is_ok_and(|value| value == "1") {
-            self.pending_text_note = true;
-        }
-        // The object manager: where the "off series", "other market" and band
-        // badges live, and the only place a mark clamped to an edge can be
-        // found when it is nowhere near the visible window.
-        if std::env::var("QUANTICK_DRAWINGS_MANAGER").is_ok_and(|value| value == "1") {
-            self.manager.open = true;
-        }
-        // The context bar only exists while something is selected, so the
-        // hook that reaches it is a hook that *selects*: pair this with
-        // QUANTICK_DRAWINGS_DEMO_SELECT. This one opens the panel behind the
-        // gear on top, which is the state a screenshot cannot otherwise reach
-        // without a click.
-        if std::env::var("QUANTICK_DRAWING_INSPECTOR").is_ok_and(|value| value == "1") {
-            self.shared.open = true;
-        }
-        // Which tab the panel opens on. The panel is one hook away, but its
-        // tool-owned tab — where a Fib's levels and colours are built, and
-        // where the two default controls sit — is a click deeper, and a
-        // capture has no hand for it.
-        if let Ok(tab) = std::env::var("QUANTICK_DRAWING_INSPECTOR_TAB") {
-            match tab.trim() {
-                "style" => self.inspector.tab = InspectorTab::Style,
-                "extra" => self.inspector.tab = InspectorTab::Extra,
-                "coordinates" => self.inspector.tab = InspectorTab::Coordinates,
-                // Refused rather than guessed: a typo shows the default tab,
-                // never a confident capture of the wrong one.
-                other => tracing::warn!(tab = other, "unknown drawing inspector tab"),
-            }
-        }
-        // The trader's own drag, scripted: `x,y` in screen points parks the
-        // properties popup exactly as a hand on the title bar would, through
-        // that gesture's own function. Without it the remembered position is
-        // unreachable from a launch — a drag is the only way to set one, and
-        // a capture run has no hand. Nonsense is refused rather than guessed,
-        // so a typo photographs automatic placement instead of an invented
-        // pixel.
-        if let Some(position) = std::env::var("QUANTICK_DRAWING_INSPECTOR_POS")
-            .ok()
-            .and_then(|value| parse_point(&value))
-        {
-            self.inspector.place_by_hand(position);
-        }
-        // And the same drag on the context bar, which keeps its position
-        // across selections too. Its own gesture is the grip, and a capture
-        // run has no more hand for that one than for the title bar.
-        if let Some(position) = std::env::var("QUANTICK_CONTEXT_BAR_POS")
-            .ok()
-            .and_then(|value| parse_point(&value))
-        {
-            self.bar.bar.set_manual(position);
-        }
     }
 }
 
@@ -1046,7 +985,7 @@ fn apply_actions(
         && chrome.shared.edit_baseline.is_none()
         && let Some(selected) = env.selected.as_ref()
     {
-        chrome.shared.edit_baseline = Some(InspectorEdit {
+        chrome.shared.edit_baseline = Some(DrawingEdit {
             tab: env.tab,
             side: env.side,
             index,
@@ -1078,9 +1017,7 @@ fn apply_actions(
         }
     }
     ask.request_delete |= actions.delete;
-    if actions.cancel_delete {
-        chrome.shared.delete_confirm = false;
-    }
+    ask.cancel_delete |= actions.cancel_delete;
     if actions.force_delete {
         chrome.shared.delete_confirm = false;
         ask.force_delete = true;
@@ -1100,6 +1037,80 @@ fn apply_actions(
     // Nothing to undo: this changed a preference, not the chart.
     ask.saved_default = actions.saved_default;
     ask
+}
+
+/// Read the five `QUANTICK_*` capture hooks this surface owns.
+///
+/// Called from the constructor, where every launch hook is read — **not**
+/// from [`super::Surface::apply_env_hook`], which the registry applies on the first
+/// *drawn* frame. That is too late for two of these: the demo appliers run
+/// earlier in that same frame, and `QUANTICK_DRAWING_INSPECTOR=1` is a state
+/// they read (`carry_across_selection` asks whether the panel is open before
+/// it places an object and moves the selection). A hook another hook depends
+/// on has to be in place before any frame, and photographing a chart with no
+/// inspector because the order slipped is exactly the silent capture failure
+/// this file's own comments warn about.
+///
+/// Here rather than in `app.rs` because the fields are here: a hook that
+/// stops matching its field stops compiling.
+pub(crate) fn apply_launch_hooks(chrome: &mut DrawingChromeSurface) {
+    // The object manager: where the "off series", "other market" and band
+    // badges live, and the only place a mark clamped to an edge can be found
+    // when it is nowhere near the visible window.
+    if std::env::var("QUANTICK_DRAWINGS_MANAGER").is_ok_and(|value| value == "1") {
+        chrome.manager.open = true;
+    }
+    // The context bar only exists while something is selected, so the hook
+    // that reaches it is a hook that *selects*: pair this with
+    // QUANTICK_DRAWINGS_DEMO_SELECT. This one opens the panel behind the gear
+    // on top, which is the state a screenshot cannot otherwise reach without a
+    // click.
+    if std::env::var("QUANTICK_DRAWING_INSPECTOR").is_ok_and(|value| value == "1") {
+        chrome.shared.open = true;
+    }
+    // The on-chart note editor exists only between a placement and the first
+    // click elsewhere, so no click-free launch could photograph it without a
+    // hook — the same gap `QUANTICK_DRAWING_DRAFT` fills for a half-placed
+    // object. The placement itself is the host's, so this raises the ask
+    // rather than making the object.
+    if std::env::var("QUANTICK_TEXT_NOTE").is_ok_and(|value| value == "1") {
+        chrome.pending_text_note = true;
+    }
+    // Which tab the panel opens on. The panel is one hook away, but its
+    // tool-owned tab — where a Fib's levels and colours are built, and where
+    // the two default controls sit — is a click deeper, and a capture has no
+    // hand for it.
+    if let Ok(tab) = std::env::var("QUANTICK_DRAWING_INSPECTOR_TAB") {
+        match tab.trim() {
+            "style" => chrome.inspector.tab = InspectorTab::Style,
+            "extra" => chrome.inspector.tab = InspectorTab::Extra,
+            "coordinates" => chrome.inspector.tab = InspectorTab::Coordinates,
+            // Refused rather than guessed: a typo shows the default tab, never
+            // a confident capture of the wrong one.
+            other => tracing::warn!(tab = other, "unknown drawing inspector tab"),
+        }
+    }
+    // The trader's own drag, scripted: `x,y` in screen points parks the
+    // properties popup exactly as a hand on the title bar would, through that
+    // gesture's own function. Without it the remembered position is
+    // unreachable from a launch — a drag is the only way to set one, and a
+    // capture run has no hand. Nonsense is refused rather than guessed, so a
+    // typo photographs automatic placement instead of an invented pixel.
+    if let Some(position) = std::env::var("QUANTICK_DRAWING_INSPECTOR_POS")
+        .ok()
+        .and_then(|value| parse_point(&value))
+    {
+        chrome.inspector.place_by_hand(position);
+    }
+    // And the same drag on the context bar, which keeps its position across
+    // selections too. Its own gesture is the grip, and a capture run has no
+    // more hand for that one than for the title bar.
+    if let Some(position) = std::env::var("QUANTICK_CONTEXT_BAR_POS")
+        .ok()
+        .and_then(|value| parse_point(&value))
+    {
+        chrome.bar.bar.set_manual(position);
+    }
 }
 
 /// `x,y` in screen points, or nothing. Refused rather than guessed: a typo
@@ -1218,6 +1229,57 @@ mod tests {
         for raw in ["", "420", "420,", ",200", "left,top", "420x200"] {
             assert_eq!(parse_point(raw), None, "{raw:?} is not a point");
         }
+    }
+
+    /// A frame that deletes a preset and saves under the freed name must not
+    /// be told the name is taken. The bank is not written until the host
+    /// replays the list, so a recorder that consulted it alone would raise the
+    /// "Overwrite?" prompt for a name its own pending delete is about to free.
+    #[test]
+    fn a_read_sees_the_writes_the_same_frame_already_made() {
+        let store = bank("same-frame");
+        let mut recorder = RecordingPresetHost::new(&store);
+        assert!(
+            !recorder.save_custom_preset("fib", "taken", toml::Value::Integer(2), false),
+            "the name is taken and overwrite was not asked for"
+        );
+        recorder.delete_custom_preset("fib", "taken");
+        assert!(
+            recorder.save_custom_preset("fib", "taken", toml::Value::Integer(2), false),
+            "the delete this frame recorded freed the name"
+        );
+        let _ = std::fs::remove_file(store.path());
+    }
+
+    /// And the list the trader picks from is the list the frame's own writes
+    /// leave behind — a combo box that still offers a preset deleted a moment
+    /// ago is offering something that will not load.
+    #[test]
+    fn the_name_list_follows_the_frame_s_own_writes() {
+        let store = bank("name-list");
+        let mut recorder = RecordingPresetHost::new(&store);
+        assert_eq!(
+            recorder.custom_preset_names("fib"),
+            vec!["taken".to_owned()]
+        );
+        recorder.save_custom_preset("fib", "another", toml::Value::Integer(3), false);
+        assert_eq!(
+            recorder.custom_preset_names("fib"),
+            vec!["another".to_owned(), "taken".to_owned()],
+            "a saved name joins the list, in the order the bank would give it back"
+        );
+        assert_eq!(
+            recorder.load_custom_preset("fib", "another"),
+            Some(toml::Value::Integer(3)),
+            "and it loads what was saved rather than nothing"
+        );
+        recorder.delete_custom_preset("fib", "taken");
+        assert_eq!(
+            recorder.custom_preset_names("fib"),
+            vec!["another".to_owned()]
+        );
+        assert_eq!(recorder.load_custom_preset("fib", "taken"), None);
+        let _ = std::fs::remove_file(store.path());
     }
 
     /// The fold keeps a flag set and takes the first valued ask, which is the

--- a/crates/app/src/surfaces/drawing_chrome/mod.rs
+++ b/crates/app/src/surfaces/drawing_chrome/mod.rs
@@ -1,0 +1,1258 @@
+//! The drawing chrome: everything that speaks for the *selected drawing*.
+//!
+//! Four pieces of chrome appear when a trader selects an object — the context
+//! bar under it, the inline field for a note's words, the inspector (floating
+//! or docked at the side) and the object manager listing every mark on the
+//! chart. They were four `draw_*` methods on `QuantickApp` reading twenty-one
+//! of its fields, and this module is where that state lives instead.
+//!
+//! # Why one [`Surface`], not four
+//!
+//! They are one subsystem, not four neighbours. Five pieces of state are
+//! written by one and read by another:
+//!
+//! | State | Written by | Read by |
+//! | --- | --- | --- |
+//! | [`Shared::open`] | the context bar's gear | the inspector |
+//! | [`Shared::pinned`] | the inspector's pin | the context bar, to hide a gear leading where the eye already is |
+//! | [`Shared::last_selection`] | the context bar, on a new selection | the inspector's placement rule |
+//! | [`Shared::delete_confirm`] | the action applier | the bar and the inspector body |
+//! | [`Shared::edit_baseline`] | the action applier | the context bar, to decide whether this frame owes a clone |
+//!
+//! Registering four members would leave that sharing in `QuantickApp` — the
+//! disease this port exists to cure — or push it through the response and
+//! make [`super::Surfaces::draw_all`]'s call order load-bearing, which its own
+//! documentation says it is not. One member keeps the sharing private, and
+//! the order the four are drawn in is decided here, in writing, beside the
+//! reason.
+//!
+//! So [`super::Surfaces`] grows by exactly one field, 8 to 9. The typed-struct
+//! trade the registry documents is not under pressure from this change.
+//!
+//! # What it reads and what it asks for
+//!
+//! [`DrawingEnv`] is the read-only slice, nested inside [`super::SurfaceEnv`]
+//! rather than flattened into it: eleven more loose fields on the shared env
+//! would be the same disease one level out. Everything in it is borrowed or
+//! `Copy`, and the two entries that cost an allocation —
+//! [`DrawingEnv::manager_rows`] and [`DrawingEnv::selected_band`] — are built
+//! by the host only while the surface that reads them is on screen, the rule
+//! `open_markets` already follows.
+//!
+//! Writes go back through [`DrawingChromeAsk`]. The inspector **edits a copy**
+//! of the selected drawing and hands it over; it never holds a `&mut` into a
+//! pane. The store commands are named fields, not an enum, for the reason
+//! [`super::SurfaceResponse`] is a struct: a new ask is an added field that
+//! defaults to "did not ask", never a `match` arm that reopens every caller.
+//!
+//! # Cost
+//!
+//! Event-driven throughout. Nothing here runs per trade, per depth update or
+//! inside a renderer. Per frame the host pays one virtual call that returns
+//! after an `Option` test when nothing is selected and the manager is shut;
+//! the clone of the selected drawing is paid only while the inspector is
+//! actually open, which is what the trunk paid before.
+
+pub(crate) mod context_bar;
+pub(crate) mod inline_editor;
+pub(crate) mod inspector;
+pub(crate) mod manager;
+
+use eframe::egui;
+
+use super::{Surface, SurfaceEnv, SurfaceResponse};
+use crate::bands::BandLabel;
+use crate::drawings::{Drawing, DrawingStyle, PresetHost};
+use crate::pane::PaneSide;
+use crate::toolrail::ToolboxDock;
+
+/// Initial position of the selected-drawing inspector, before
+/// [`inspector::placement`] has a size and a bbox to place it from.
+pub(crate) const DRAWING_INSPECTOR_DEFAULT_POSITION: egui::Pos2 = egui::pos2(90.0, 120.0);
+/// Inspector width bounds (UX spec: resizable between 300 and 440 px).
+pub(crate) const INSPECTOR_MIN_WIDTH_PX: f32 = 300.0;
+/// See [`INSPECTOR_MIN_WIDTH_PX`].
+const INSPECTOR_MAX_WIDTH_PX: f32 = 440.0;
+/// Default inspector width for the shipped tools (the spec reserves 360 px
+/// for the Fib level editor).
+const INSPECTOR_DEFAULT_WIDTH_PX: f32 = 320.0;
+/// Default inspector width for tools that mount a level editor tab.
+const INSPECTOR_LEVELS_WIDTH_PX: f32 = 360.0;
+/// Gap kept between the inspector and the selected object's bounding box.
+const INSPECTOR_OBJECT_GAP_PX: f32 = 12.0;
+/// Assumed inspector height for placement before its first frame reports one.
+const INSPECTOR_FALLBACK_HEIGHT_PX: f32 = 280.0;
+/// Below this chart width a fresh selection opens the inspector pinned —
+/// there is no floating position that would not crowd the geometry. Stops
+/// applying once the user touches the pin either way.
+pub(crate) const INSPECTOR_AUTO_PIN_CHART_WIDTH_PX: f32 = 1180.0;
+/// Height of the floating inspector's custom title bar.
+const INSPECTOR_TITLE_HEIGHT_PX: f32 = 28.0;
+/// Title-bar paint metrics: leading padding, the title column when the grip
+/// glyph precedes it, and the two font sizes.
+const INSPECTOR_TITLE_PAD_X_PX: f32 = 2.0;
+const INSPECTOR_TITLE_TEXT_X_PX: f32 = 18.0;
+const INSPECTOR_TITLE_GRIP_GLYPH_PX: f32 = 14.0;
+const INSPECTOR_TITLE_TEXT_PX: f32 = 13.0;
+/// Gap between the object manager and the rail edge it opens beside.
+pub(crate) const DRAWING_MANAGER_GAP_PX: f32 = 12.0;
+/// Where the object manager first opens: under the toolbox's home corner.
+const DRAWING_MANAGER_DEFAULT_POSITION: egui::Pos2 = egui::pos2(70.0, 140.0);
+/// Dragging the price field across the whole visible range takes this many
+/// steps, whatever the symbol's price magnitude.
+const PRICE_DRAG_STEPS: f64 = 200.0;
+/// DragValue speed of bar-index coordinates, in bars per drag point.
+const BAR_DRAG_SPEED: f64 = 0.25;
+
+/// The egui id both inspector hosts and the placement rule agree on. One
+/// literal, because a placement that measured a different area than the one
+/// it moves would be silently wrong.
+const INSPECTOR_AREA_ID: &str = "drawing_inspector";
+/// Likewise for the manager, whose opening position is measured from the area
+/// egui remembers.
+const MANAGER_AREA_ID: &str = "drawing_manager";
+
+/// Which inspector tab is open. Tabs exist per capability: every tool gets
+/// Style and Coordinates; a tool that brings its own tab (the Fib level
+/// editor) mounts it as Extra without the central code knowing its fields.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) enum InspectorTab {
+    #[default]
+    Style,
+    Extra,
+    Coordinates,
+}
+
+/// Which default-style button the Style tab was pressed on, so the caller can
+/// say out loud that something was remembered — a silent save leaves the
+/// trader wondering whether it took.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SavedDefault {
+    OneTool,
+    EveryTool,
+    Forgotten,
+}
+
+impl SavedDefault {
+    pub(crate) const fn message(self) -> &'static str {
+        match self {
+            Self::OneTool => "Saved - new drawings of this tool open configured like this one.",
+            Self::EveryTool => "Saved - every new drawing opens with this colour, width and fill.",
+            Self::Forgotten => "Reset - this tool goes back to how it opened out of the box.",
+        }
+    }
+}
+
+/// What the inspector body asked for this frame. The applier owns every
+/// mutation, so the pinned panel and the floating window share one rule set.
+#[derive(Debug, Default, Clone, Copy)]
+pub(crate) struct InspectorActions {
+    pub toggle_hidden: bool,
+    pub toggle_lock: bool,
+    pub toggle_pin: bool,
+    pub delete: bool,
+    pub cancel_delete: bool,
+    pub force_delete: bool,
+    pub close: bool,
+    pub edited: bool,
+    /// Which default-style button was pressed, if any.
+    pub saved_default: Option<SavedDefault>,
+}
+
+impl InspectorActions {
+    /// Fold another frame section's requests into this one — the title bar
+    /// and the body each report intent, the applier takes the union.
+    pub fn merge(&mut self, other: Self) {
+        self.toggle_hidden |= other.toggle_hidden;
+        self.toggle_lock |= other.toggle_lock;
+        self.toggle_pin |= other.toggle_pin;
+        self.delete |= other.delete;
+        self.cancel_delete |= other.cancel_delete;
+        self.force_delete |= other.force_delete;
+        self.close |= other.close;
+        self.edited |= other.edited;
+        self.saved_default = self.saved_default.or(other.saved_default);
+    }
+}
+
+/// An inline text edit in flight: which object, on which pane of which tab,
+/// and what it said before the first keystroke.
+///
+/// The tab and the pane, not the index alone: an index identifies nothing
+/// once there are two panes, let alone two tabs. Switching tabs with an
+/// editor open would otherwise record the note's undo entry against whatever
+/// object happened to sit at that index on the tab now in front — swapping an
+/// unrelated drawing for a copy of the note on the next Ctrl+Z.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct InlineTextEdit {
+    pub tab: u64,
+    pub side: PaneSide,
+    pub index: usize,
+    pub before: Drawing,
+}
+
+/// The pre-edit copy held while an inspector gesture (a slider, a colour
+/// wheel, a coordinate drag) is in flight, so the whole gesture commits as one
+/// undo entry when pointer and keyboard let go.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct InspectorEdit {
+    pub tab: u64,
+    pub side: PaneSide,
+    pub index: usize,
+    pub before: Drawing,
+}
+
+/// The selected object, as the chrome reads it: borrowed, never cloned on the
+/// way in.
+///
+/// The inspector clones it — it has to, because it edits a copy — but the
+/// context bar and the inline editor read a handful of fields off a selection
+/// that may be a 512-anchor pencil stroke, on every frame something is
+/// selected. Handing them an owned `Drawing` would put that clone on the
+/// chart's idle path.
+pub(crate) struct SelectedDrawing<'a> {
+    pub index: usize,
+    pub drawing: &'a Drawing,
+}
+
+/// One row of the object manager, built by the host while the window is open.
+///
+/// Owned strings, and that is the point: the row's facts come from the pane,
+/// the band registry and the drawing itself, and the manager would otherwise
+/// need all three to assemble them. Built only while the window is on screen,
+/// like `open_markets` — a per-frame allocation for a surface nobody can see
+/// is exactly the cost this port was supposed to make visible rather than
+/// hide.
+pub(crate) struct ManagerRow {
+    pub name: String,
+    pub selected: bool,
+    pub locked: bool,
+    pub hidden: bool,
+    pub shared: bool,
+    pub off_series: bool,
+    pub foreign_market: bool,
+    pub author: Option<String>,
+    pub band: BandLabel,
+}
+
+/// What the drawing chrome needs from the application.
+///
+/// Nested inside [`super::SurfaceEnv`] rather than flattened into it: this is
+/// one subsystem's slice, and eleven more fields on the shared env would move
+/// the loose-field problem out one level instead of solving it.
+pub(crate) struct DrawingEnv<'a> {
+    /// The selected object on the pane the chrome speaks for, if any.
+    pub selected: Option<SelectedDrawing<'a>>,
+    /// That pane's chart rectangle, or `None` before it has been laid out.
+    pub chart_area: Option<egui::Rect>,
+    /// The *focused* pane's rectangle, which is not always the one above: a
+    /// shared mark can be selected from the chart it is mirrored on. The
+    /// object manager opens beside the toolbox button that opened it, and that
+    /// button is on the focused pane.
+    pub focused_chart_area: Option<egui::Rect>,
+    /// Where the live lane begins. Every popup keeps clear of it: that strip
+    /// is where the price the trader is reading is being formed.
+    pub lane_divider_x: Option<f32>,
+    /// The visible price range, which is what makes a coordinate drag move at
+    /// the same speed on a two-dollar symbol and a hundred-thousand one.
+    pub auto_range: Option<(f64, f64)>,
+    /// Where the selected object is painted, in screen points, already
+    /// expanded by the anchor radius and through the tool's own
+    /// `painted_bounds`. Projected by the host, which owns the viewport and
+    /// the price scale, and only when something is selected.
+    pub selected_bbox: Option<egui::Rect>,
+    /// Which band the selected object is on, for the inspector's title. `None`
+    /// on the price band, where a suffix on every object would be noise.
+    pub selected_band: Option<String>,
+    /// The **stable id** of the tab on screen, and the pane the chrome speaks
+    /// for. An inline edit outlives a tab switch and must not write into
+    /// whatever now sits at its index.
+    pub tab: u64,
+    pub side: PaneSide,
+    /// Whether a drawing tool is armed. The trader is drawing, not editing:
+    /// the context bar stands down so it cannot eat the click that places the
+    /// next object.
+    pub drawing_tool_armed: bool,
+    /// Where the toolbox sits, which is the corner the manager opens beside.
+    pub toolbox_dock: ToolboxDock,
+    /// How many objects on this chart an assistant placed, for the one
+    /// gesture that takes them all back.
+    pub authored_objects: usize,
+    /// Every object, as rows — empty unless the manager is open.
+    pub manager_rows: &'a [ManagerRow],
+    /// The saved tool defaults and named presets. Read-only here; the writes
+    /// go back through [`DrawingChromeAsk::presets`].
+    pub presets: &'a dyn PresetHost,
+}
+
+impl DrawingEnv<'_> {
+    /// The selection's index, when there is one.
+    fn selected_index(&self) -> Option<usize> {
+        self.selected.as_ref().map(|selected| selected.index)
+    }
+}
+
+#[cfg(test)]
+impl DrawingEnv<'static> {
+    /// A pane with nothing selected and no manager open, for the tests.
+    ///
+    /// Written the way [`super::SurfaceEnv::quiet`] is, and for the same
+    /// reason: a field added here costs one line in this file rather than an
+    /// edit in each of the four surfaces' test modules.
+    pub fn quiet() -> Self {
+        /// A preset bank a test that does not care about presets gets.
+        static QUIET_PRESETS: crate::drawings::NullPresetHost = crate::drawings::NullPresetHost;
+        Self {
+            selected: None,
+            chart_area: None,
+            focused_chart_area: None,
+            lane_divider_x: None,
+            auto_range: None,
+            selected_bbox: None,
+            selected_band: None,
+            tab: 0,
+            side: PaneSide::Flow,
+            drawing_tool_armed: false,
+            toolbox_dock: ToolboxDock::Left,
+            authored_objects: 0,
+            manager_rows: &[],
+            presets: &QUIET_PRESETS,
+        }
+    }
+}
+
+/// One write to the preset bank, recorded rather than performed.
+///
+/// The bank is host state that persists to disk on every write, so the
+/// surface cannot hold a `&mut` to it any more than it can hold one to a
+/// pane. [`RecordingPresetHost`] reads through the borrowed bank and pushes
+/// these; the host replays them.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum PresetWrite {
+    Save {
+        tool_id: String,
+        name: String,
+        value: toml::Value,
+    },
+    Delete {
+        tool_id: String,
+        name: String,
+    },
+    SetDefaultPreset {
+        tool_id: String,
+        name: Option<String>,
+    },
+    SetDefaultStyle {
+        tool_id: String,
+        style: Option<DrawingStyle>,
+    },
+    SetDefaultConfig {
+        tool_id: String,
+        value: Option<toml::Value>,
+    },
+}
+
+impl PresetWrite {
+    /// Replay this write onto the real bank.
+    ///
+    /// One `match` over an enum the host cannot extend by accident: a variant
+    /// added to [`PresetWrite`] without a line here does not compile, which is
+    /// the property that makes recording the writes safe at all.
+    pub(crate) fn apply_to(self, bank: &mut dyn PresetHost) {
+        match self {
+            Self::Save {
+                tool_id,
+                name,
+                value,
+            } => {
+                // Overwrite: the recorder already answered the "is that name
+                // taken" question against this same bank, and answering it
+                // twice would refuse a save the trader was told had succeeded.
+                bank.save_custom_preset(&tool_id, &name, value, true);
+            }
+            Self::Delete { tool_id, name } => bank.delete_custom_preset(&tool_id, &name),
+            Self::SetDefaultPreset { tool_id, name } => bank.set_default_preset(&tool_id, name),
+            Self::SetDefaultStyle { tool_id, style } => bank.set_default_style(&tool_id, style),
+            Self::SetDefaultConfig { tool_id, value } => bank.set_default_config(&tool_id, value),
+        }
+    }
+}
+
+/// A [`PresetHost`] that reads the real bank and writes into a list.
+///
+/// The tool-owned inspector tab talks to the bank through `PresetHost`, which
+/// is already a port — but its five mutating methods persist to disk, so the
+/// surface records them and the host replays them on the same frame. Every
+/// read is delegated, unchanged, to the bank the env borrowed.
+///
+/// [`PresetHost::save_custom_preset`] is the one method whose answer the
+/// caller reads immediately: `false` means "that name is taken and you did
+/// not say overwrite". It is answered here from the bank's own
+/// [`PresetHost::load_custom_preset`] rather than from a copy of the store's
+/// rule, and `recorder_refuses_a_taken_name_exactly_as_the_bank_does` pins
+/// the two together.
+pub(crate) struct RecordingPresetHost<'a> {
+    bank: &'a dyn PresetHost,
+    writes: Vec<PresetWrite>,
+}
+
+impl<'a> RecordingPresetHost<'a> {
+    fn new(bank: &'a dyn PresetHost) -> Self {
+        Self {
+            bank,
+            // Not `with_capacity`: the overwhelmingly common frame records
+            // nothing, and an empty `Vec` does not allocate.
+            writes: Vec::new(),
+        }
+    }
+}
+
+impl RecordingPresetHost<'_> {
+    /// The writes this frame recorded, in the order they were made.
+    fn into_writes(self) -> Vec<PresetWrite> {
+        self.writes
+    }
+}
+
+impl PresetHost for RecordingPresetHost<'_> {
+    fn custom_preset_names(&self, tool_id: &str) -> Vec<String> {
+        self.bank.custom_preset_names(tool_id)
+    }
+
+    fn load_custom_preset(&self, tool_id: &str, name: &str) -> Option<toml::Value> {
+        self.bank.load_custom_preset(tool_id, name)
+    }
+
+    fn save_custom_preset(
+        &mut self,
+        tool_id: &str,
+        name: &str,
+        value: toml::Value,
+        overwrite: bool,
+    ) -> bool {
+        if !overwrite && self.bank.load_custom_preset(tool_id, name).is_some() {
+            return false;
+        }
+        self.writes.push(PresetWrite::Save {
+            tool_id: tool_id.to_owned(),
+            name: name.to_owned(),
+            value,
+        });
+        true
+    }
+
+    fn delete_custom_preset(&mut self, tool_id: &str, name: &str) {
+        self.writes.push(PresetWrite::Delete {
+            tool_id: tool_id.to_owned(),
+            name: name.to_owned(),
+        });
+    }
+
+    fn default_preset(&self, tool_id: &str) -> Option<String> {
+        self.bank.default_preset(tool_id)
+    }
+
+    fn set_default_preset(&mut self, tool_id: &str, name: Option<String>) {
+        self.writes.push(PresetWrite::SetDefaultPreset {
+            tool_id: tool_id.to_owned(),
+            name,
+        });
+    }
+
+    fn default_style(&self, tool_id: &str) -> Option<DrawingStyle> {
+        self.bank.default_style(tool_id)
+    }
+
+    fn set_default_style(&mut self, tool_id: &str, style: Option<DrawingStyle>) {
+        self.writes.push(PresetWrite::SetDefaultStyle {
+            tool_id: tool_id.to_owned(),
+            style,
+        });
+    }
+
+    fn default_config(&self, tool_id: &str) -> Option<toml::Value> {
+        self.bank.default_config(tool_id)
+    }
+
+    fn set_default_config(&mut self, tool_id: &str, value: Option<toml::Value>) {
+        self.writes.push(PresetWrite::SetDefaultConfig {
+            tool_id: tool_id.to_owned(),
+            value,
+        });
+    }
+
+    fn has_default_config(&self, tool_id: &str) -> bool {
+        self.bank.has_default_config(tool_id)
+    }
+}
+
+/// What the drawing chrome asked the host to do.
+///
+/// A struct of defaults like [`super::SurfaceResponse`] itself: every field
+/// means "this was not asked for" until a surface sets it, so a new request
+/// never touches an existing caller. The store commands are named fields
+/// rather than an enum for exactly that reason.
+#[derive(Debug, Default, PartialEq)]
+pub(crate) struct DrawingChromeAsk {
+    /// The inspector edited its copy of the selected drawing. Boxed: it is by
+    /// far the largest thing a response can carry — a pencil stroke is 512
+    /// anchors — and every other surface would pay for its size in a response
+    /// returned by value on every frame.
+    pub edited: Option<Box<Drawing>>,
+    /// The pointer and the keyboard have let go: record this pre-edit copy as
+    /// the one undo entry the whole gesture earned.
+    ///
+    /// The copy travels with the ask rather than being fetched back off the
+    /// surface, so the host applies a response instead of interrogating the
+    /// thing that produced it. Boxed for the reason [`Self::edited`] is: a
+    /// `Drawing` inline here would be paid for by every surface in the
+    /// application, on every frame, in a response returned by value.
+    pub commit_edit_gesture: Option<Box<InspectorEdit>>,
+    /// Hide or show the selection.
+    pub toggle_selected_hidden: bool,
+    /// Lock or unlock the selection.
+    pub toggle_selected_locked: bool,
+    /// Delete the selection, through the confirmation rule the keyboard uses.
+    pub request_delete: bool,
+    /// Delete the selection even though it is locked — the trader answered
+    /// the question.
+    pub force_delete: bool,
+    /// Copy the selection, offset so the copy is visibly a copy.
+    pub duplicate: bool,
+    /// Place a text note in the middle of the pane and open its editor — the
+    /// `QUANTICK_TEXT_NOTE` hook, which needs the placement rules the host
+    /// owns.
+    pub place_text_note: bool,
+    /// Record this object's pre-edit copy as one undo entry: the inline
+    /// editor closed, on the pane the note actually lives on, which is not
+    /// necessarily the one in front. Boxed like the two above.
+    pub record_inline_edit: Option<Box<InlineTextEdit>>,
+    /// The caret moved to a different object, or left the chart. Every pane
+    /// has to be told, so exactly one object anywhere stands down; the host
+    /// reads the new target back by name.
+    pub content_editing_changed: bool,
+    /// Select this row, and bring it into view.
+    pub manager_select: Option<usize>,
+    /// Toggle this row's eye.
+    pub manager_toggle_hidden: Option<usize>,
+    /// Toggle this row's lock.
+    pub manager_toggle_locked: Option<usize>,
+    /// Raise this row above the rest.
+    pub manager_bring_to_front: Option<usize>,
+    /// Delete this row, through the same confirmation the inspector raises.
+    pub manager_delete: Option<usize>,
+    /// Show every hidden object.
+    pub show_all: bool,
+    /// Unlock every locked object.
+    pub unlock_all: bool,
+    /// Delete every object, locked ones included — the count-bearing gate was
+    /// answered.
+    pub delete_all: bool,
+    /// Take back every object an assistant placed on this chart.
+    pub sweep_authored: bool,
+    /// A named default was remembered, and is owed a line the trader can read.
+    pub saved_default: Option<SavedDefault>,
+    /// Writes to the preset bank, in the order the frame made them.
+    pub presets: Vec<PresetWrite>,
+}
+
+impl DrawingChromeAsk {
+    /// Fold one piece of chrome's asks into the frame's.
+    ///
+    /// Flags stay set, so no piece can cancel another's ask by being drawn
+    /// after it, and a valued ask keeps the **first** — the same rule
+    /// [`super::SurfaceResponse::merge`] follows, for the same reason: two
+    /// pieces cannot both be right about one row, and dropping the later ask
+    /// deterministically beats letting draw order decide in silence.
+    pub(super) fn merge(&mut self, other: Self) {
+        self.edited = self.edited.take().or(other.edited);
+        self.commit_edit_gesture = self
+            .commit_edit_gesture
+            .take()
+            .or(other.commit_edit_gesture);
+        self.toggle_selected_hidden |= other.toggle_selected_hidden;
+        self.toggle_selected_locked |= other.toggle_selected_locked;
+        self.request_delete |= other.request_delete;
+        self.force_delete |= other.force_delete;
+        self.duplicate |= other.duplicate;
+        self.place_text_note |= other.place_text_note;
+        self.record_inline_edit = self.record_inline_edit.take().or(other.record_inline_edit);
+        self.content_editing_changed |= other.content_editing_changed;
+        self.manager_select = self.manager_select.or(other.manager_select);
+        self.manager_toggle_hidden = self.manager_toggle_hidden.or(other.manager_toggle_hidden);
+        self.manager_toggle_locked = self.manager_toggle_locked.or(other.manager_toggle_locked);
+        self.manager_bring_to_front = self.manager_bring_to_front.or(other.manager_bring_to_front);
+        self.manager_delete = self.manager_delete.or(other.manager_delete);
+        self.show_all |= other.show_all;
+        self.unlock_all |= other.unlock_all;
+        self.delete_all |= other.delete_all;
+        self.sweep_authored |= other.sweep_authored;
+        self.saved_default = self.saved_default.or(other.saved_default);
+        self.presets.extend(other.presets);
+    }
+}
+
+/// The state the four pieces share, and the reason they are one surface.
+///
+/// Private to this module: the whole point of the member being one rather
+/// than four is that nothing outside can reach across the subsystem.
+#[derive(Default)]
+pub(crate) struct Shared {
+    /// Whether the floating inspector is open. Selecting a drawing no longer
+    /// opens it: the context bar is what a selection raises, and the gear on
+    /// that bar is the one thing that opens the full panel.
+    open: bool,
+    /// Whether the inspector is docked at the chart's side instead.
+    pinned: bool,
+    /// The selection the last automatic placement was computed for.
+    last_selection: Option<usize>,
+    /// A locked object's delete was asked for and is awaiting its answer.
+    delete_confirm: bool,
+    /// The pre-edit copy held across an in-flight edit gesture.
+    edit_baseline: Option<InspectorEdit>,
+}
+
+/// The chrome that speaks for the selected drawing: the context bar, the
+/// inline text editor, the inspector and the object manager.
+#[derive(Default)]
+pub(crate) struct DrawingChromeSurface {
+    shared: Shared,
+    inspector: inspector::Inspector,
+    bar: context_bar::ContextBarState,
+    manager: manager::Manager,
+    inline: inline_editor::InlineEditor,
+    /// One-shot: the placement that just happened asked for the caret. The
+    /// object it made is the selected one, so the editor opens on the frame
+    /// the placement landed.
+    pending_text_edit: bool,
+    /// One-shot: the `QUANTICK_TEXT_NOTE` hook wants a note placed and typed.
+    /// The placement rules belong to the host, so this leaves through
+    /// [`DrawingChromeAsk::place_text_note`].
+    pending_text_note: bool,
+    /// One-shot: the object just placed asked for its settings panel. Applied
+    /// *after* the new-selection reset, because the placement that made the
+    /// request also made the selection change that clears it.
+    pending_open_settings: bool,
+}
+
+impl DrawingChromeSurface {
+    // ---- What the host reads --------------------------------------------
+
+    /// Whether anything here is on screen or about to be, so the host knows
+    /// whether the env slices only an open surface reads are worth building.
+    ///
+    /// The manager alone, because it is the only piece whose slice costs an
+    /// allocation and whose visibility does not follow the selection: the
+    /// rest read borrowed fields the host has in hand either way.
+    pub fn manager_open(&self) -> bool {
+        self.manager.open
+    }
+
+    /// Whether the inspector is docked at the chart's side. The host asks
+    /// before it lays out the central canvas, because a docked panel is
+    /// declared with the chrome and the canvas pays its width.
+    pub fn inspector_pinned(&self) -> bool {
+        self.shared.pinned
+    }
+
+    /// Which note is being typed on the chart right now — what a second
+    /// operator reads to know the keyboard belongs to an object.
+    pub fn inline_text_editing(&self) -> Option<usize> {
+        self.inline.editing_index()
+    }
+
+    /// The same answer with the tab and pane that make it unambiguous: an
+    /// index alone names a different object on every pane.
+    pub fn content_editing_target(&self) -> Option<(u64, PaneSide, usize)> {
+        self.inline.target()
+    }
+
+    /// The parked inspector position, for the workspace file.
+    pub fn remembered_inspector_position(&self) -> Option<[f32; 2]> {
+        self.inspector.remembered_position()
+    }
+
+    // ---- What the host commands -----------------------------------------
+
+    /// Open the object manager, or shut it.
+    pub fn set_manager_open(&mut self, open: bool) {
+        self.manager.open = open;
+    }
+
+    /// Open the inspector, or shut it.
+    #[cfg(test)]
+    pub fn set_inspector_open(&mut self, open: bool) {
+        self.shared.open = open;
+    }
+
+    /// Whether the inspector is open.
+    #[cfg(test)]
+    pub fn inspector_open(&self) -> bool {
+        self.shared.open
+    }
+
+    /// Carry an open inspector across a selection the host is about to make.
+    ///
+    /// One method rather than the line copied into each hook, because the
+    /// omission is silent: the demo that forgets it produces a screenshot
+    /// that looks merely uninteresting, and that is how three of these hooks
+    /// came to disagree about it.
+    pub fn carry_across_selection(&mut self) {
+        self.pending_open_settings |= self.shared.open;
+    }
+
+    /// Ask for the caret on the next frame — the placement that just happened
+    /// wants its note typed.
+    pub fn request_text_edit(&mut self) {
+        self.pending_text_edit = true;
+    }
+
+    /// The host placed the note the `QUANTICK_TEXT_NOTE` hook asked for.
+    ///
+    /// The ask is repeated every frame until this lands, because at launch
+    /// there is no chart to place against and no bar to place at: the hook
+    /// waits for a laid-out pane rather than firing once into an empty one
+    /// and photographing nothing.
+    pub fn note_text_note_placed(&mut self) {
+        self.pending_text_note = false;
+    }
+
+    /// Whether the open inline edit belongs to this pane — asked before its
+    /// drawing store is swapped out from under the caret.
+    pub fn inline_edit_is_on(&self, tab: u64, side: PaneSide) -> bool {
+        self.inline
+            .target()
+            .is_some_and(|(edit_tab, edit_side, _)| edit_tab == tab && edit_side == side)
+    }
+
+    /// Drop an undo baseline that describes this pane, rather than record it.
+    ///
+    /// Its object is about to be replaced by another set's, and an entry
+    /// recorded against that would undo something the trader never did.
+    pub fn drop_edit_baseline_on(&mut self, tab: u64, side: PaneSide) {
+        if self
+            .shared
+            .edit_baseline
+            .as_ref()
+            .is_some_and(|edit| edit.tab == tab && edit.side == side)
+        {
+            self.shared.edit_baseline = None;
+        }
+    }
+
+    /// Put the caret in a note now. The host owns the store, so it hands the
+    /// object over; refused for one that holds no words or is locked, because
+    /// an editor that opened and then dropped every keystroke would be worse
+    /// than none.
+    pub fn begin_inline_text_edit(
+        &mut self,
+        tab: u64,
+        side: PaneSide,
+        index: usize,
+        drawing: &Drawing,
+    ) -> bool {
+        self.inline.begin(tab, side, index, drawing)
+    }
+
+    /// Close the editor, if one is open, and hand back what it owes the undo
+    /// history.
+    pub fn end_inline_text_edit(&mut self) -> Option<InlineTextEdit> {
+        self.inline.end()
+    }
+
+    /// Park the inspector where a hand put it. The hook that stands in for one
+    /// reaches [`inspector::Inspector::place_by_hand`] directly, from
+    /// [`Surface::apply_env_hook`].
+    #[cfg(test)]
+    pub fn place_inspector_by_hand(&mut self, position: egui::Pos2) {
+        self.inspector.place_by_hand(position);
+    }
+
+    /// Restore the position a workspace file remembered.
+    pub fn restore_inspector_position(&mut self, remembered: Option<[f32; 2]>) {
+        self.inspector.restore_position(remembered);
+    }
+
+    /// Whether the baseline in flight describes an object other than this
+    /// one, which is a gesture that outlived its selection and must commit.
+    pub fn baseline_is_stale(&self, index: Option<usize>) -> bool {
+        self.shared
+            .edit_baseline
+            .as_ref()
+            .is_some_and(|edit| Some(edit.index) != index)
+    }
+
+    /// Draw the docked inspector.
+    ///
+    /// A second entry point rather than a branch inside [`Self::draw_floating`],
+    /// because a `SidePanel` has to be declared *before* the central canvas —
+    /// the canvas pays its width, and a panel declared after it would overlay
+    /// the chart instead of docking beside it.
+    pub fn draw_pinned_panel(
+        &mut self,
+        ctx: &egui::Context,
+        env: &DrawingEnv<'_>,
+    ) -> DrawingChromeAsk {
+        inspector::draw_pinned(self, ctx, env)
+    }
+
+    /// Draw the four floating pieces, in the one order that is correct.
+    ///
+    /// Order matters *here* and nowhere else, which is part of why they are
+    /// one member. The context bar runs first because it owns the selection
+    /// reset that clears [`Shared::open`], and the inspector's placement rule
+    /// reads what that reset leaves behind — the reverse order would place the
+    /// panel against the previous selection for a frame.
+    ///
+    /// Between orders egui still decides what covers what: the bar and the
+    /// editor name `Foreground`, the windows are ordinary `Middle` areas
+    /// created on the frame they open. Nothing here relies on being called
+    /// last.
+    pub fn draw_floating(&mut self, ctx: &egui::Context, env: &DrawingEnv<'_>) -> DrawingChromeAsk {
+        let mut ask = context_bar::draw(self, ctx, env);
+        ask.merge(inline_editor::draw(self, ctx, env));
+        ask.merge(inspector::draw_floating(self, ctx, env));
+        ask.merge(manager::draw(self, ctx, env));
+        ask
+    }
+
+    /// Whether a locked object's delete is awaiting its answer. The keyboard
+    /// owns Escape and the Delete key, so it reads and clears this by name
+    /// rather than reaching into the surface.
+    pub fn delete_confirm(&self) -> bool {
+        self.shared.delete_confirm
+    }
+
+    /// Raise or drop that question.
+    pub fn set_delete_confirm(&mut self, confirming: bool) {
+        self.shared.delete_confirm = confirming;
+    }
+
+    /// Whether the parked inspector position owes the workspace file a write,
+    /// taken so it is owed once.
+    pub fn take_inspector_position_dirty(&mut self) -> bool {
+        self.inspector.take_position_dirty()
+    }
+
+    /// The rest is what a test needs to say about state that has no other
+    /// door: the pin it is about to click, the position it is about to check,
+    /// the flag a capture hook would otherwise have to be launched to set.
+    #[cfg(test)]
+    pub fn set_inspector_pinned(&mut self, pinned: bool) {
+        self.shared.pinned = pinned;
+    }
+
+    #[cfg(test)]
+    pub fn set_inspector_tab(&mut self, tab: InspectorTab) {
+        self.inspector.tab = tab;
+    }
+
+    #[cfg(test)]
+    pub fn inspector_pos(&self) -> Option<egui::Pos2> {
+        self.inspector.pos
+    }
+
+    #[cfg(test)]
+    pub fn set_inspector_pos(&mut self, position: Option<egui::Pos2>) {
+        self.inspector.pos = position;
+    }
+
+    #[cfg(test)]
+    pub fn inspector_moved(&self) -> bool {
+        self.inspector.moved
+    }
+
+    #[cfg(test)]
+    pub fn set_inspector_moved(&mut self, moved: bool) {
+        self.inspector.moved = moved;
+    }
+
+    #[cfg(test)]
+    pub fn inspector_pin_touched(&self) -> bool {
+        self.inspector.pin_touched
+    }
+
+    #[cfg(test)]
+    pub fn set_inspector_pin_touched(&mut self, touched: bool) {
+        self.inspector.pin_touched = touched;
+    }
+
+    #[cfg(test)]
+    pub fn context_bar(&self) -> &crate::drawings::context_bar::ContextBar {
+        &self.bar.bar
+    }
+
+    #[cfg(test)]
+    pub fn context_bar_mut(&mut self) -> &mut crate::drawings::context_bar::ContextBar {
+        &mut self.bar.bar
+    }
+
+    #[cfg(test)]
+    pub fn set_pending_text_note(&mut self, pending: bool) {
+        self.pending_text_note = pending;
+    }
+
+    /// Forget the rectangle the bar was last drawn at, so a test can prove a
+    /// frame drew it again rather than read a stale one.
+    #[cfg(test)]
+    pub fn forget_context_bar_rect(&mut self) {
+        self.bar.last_drawn_rect = None;
+    }
+
+    /// Open an edit gesture by hand, so a test can prove that one which
+    /// outlives its selection is committed rather than dropped.
+    #[cfg(test)]
+    pub fn open_edit_gesture(&mut self, tab: u64, side: PaneSide, index: usize, before: Drawing) {
+        self.shared.edit_baseline = Some(InspectorEdit {
+            tab,
+            side,
+            index,
+            before,
+        });
+    }
+
+    #[cfg(test)]
+    pub fn context_bar_rect(&self) -> Option<egui::Rect> {
+        self.bar.last_drawn_rect
+    }
+
+    #[cfg(test)]
+    pub fn inspector_pin_rect(&self) -> Option<egui::Rect> {
+        self.inspector.pin_rect
+    }
+
+    #[cfg(test)]
+    pub fn manager_action_rects(&self) -> &[(usize, &'static str, egui::Rect)] {
+        &self.manager.action_rects
+    }
+}
+
+impl Surface for DrawingChromeSurface {
+    fn id(&self) -> &'static str {
+        "drawing-chrome"
+    }
+
+    /// The port's uniform entry, which forwards to [`Self::draw_floating`].
+    ///
+    /// [`Surfaces::draw_all`] deliberately does not call it: this surface is
+    /// anchored to the *chart* rather than floating over the window, so the
+    /// host registers it after the central canvas — both because a Background
+    /// panel drawn afterwards would sit over an `Area` created before it, and
+    /// because the pane geometry every piece here places against
+    /// (`last_chart_area`, `last_auto_range`, the lane divider) is written by
+    /// the canvas as it draws. Reading it a phase early would place the bar
+    /// and the panel against the previous frame's chart.
+    ///
+    /// Kept rather than dropped, and it is a forward rather than a second
+    /// implementation: this surface satisfies exactly the contract its eight
+    /// neighbours do, `apply_env_hook` hangs off the same trait, and if the
+    /// frame is ever reordered so the canvas comes first, adding this member
+    /// to `draw_all` is one line.
+    fn draw(&mut self, ctx: &egui::Context, env: &SurfaceEnv<'_>) -> SurfaceResponse {
+        SurfaceResponse {
+            drawing: self.draw_floating(ctx, &env.drawing),
+            ..SurfaceResponse::default()
+        }
+    }
+
+    /// Five `QUANTICK_*` hooks, all of them state this surface owns.
+    ///
+    /// They ran in the constructor before this module existed, which put the
+    /// hook for a surface in a different file from the surface. Here they are
+    /// beside the fields they set, and a hook that stops matching its field
+    /// stops compiling.
+    fn apply_env_hook(&mut self, _env: &SurfaceEnv<'_>) {
+        // The on-chart note editor exists only between a placement and the
+        // first click elsewhere, so no click-free launch could photograph it
+        // without a hook — the same gap `QUANTICK_DRAWING_DRAFT` fills for a
+        // half-placed object. The placement itself is the host's, so this
+        // raises the ask rather than making the object.
+        if std::env::var("QUANTICK_TEXT_NOTE").is_ok_and(|value| value == "1") {
+            self.pending_text_note = true;
+        }
+        // The object manager: where the "off series", "other market" and band
+        // badges live, and the only place a mark clamped to an edge can be
+        // found when it is nowhere near the visible window.
+        if std::env::var("QUANTICK_DRAWINGS_MANAGER").is_ok_and(|value| value == "1") {
+            self.manager.open = true;
+        }
+        // The context bar only exists while something is selected, so the
+        // hook that reaches it is a hook that *selects*: pair this with
+        // QUANTICK_DRAWINGS_DEMO_SELECT. This one opens the panel behind the
+        // gear on top, which is the state a screenshot cannot otherwise reach
+        // without a click.
+        if std::env::var("QUANTICK_DRAWING_INSPECTOR").is_ok_and(|value| value == "1") {
+            self.shared.open = true;
+        }
+        // Which tab the panel opens on. The panel is one hook away, but its
+        // tool-owned tab — where a Fib's levels and colours are built, and
+        // where the two default controls sit — is a click deeper, and a
+        // capture has no hand for it.
+        if let Ok(tab) = std::env::var("QUANTICK_DRAWING_INSPECTOR_TAB") {
+            match tab.trim() {
+                "style" => self.inspector.tab = InspectorTab::Style,
+                "extra" => self.inspector.tab = InspectorTab::Extra,
+                "coordinates" => self.inspector.tab = InspectorTab::Coordinates,
+                // Refused rather than guessed: a typo shows the default tab,
+                // never a confident capture of the wrong one.
+                other => tracing::warn!(tab = other, "unknown drawing inspector tab"),
+            }
+        }
+        // The trader's own drag, scripted: `x,y` in screen points parks the
+        // properties popup exactly as a hand on the title bar would, through
+        // that gesture's own function. Without it the remembered position is
+        // unreachable from a launch — a drag is the only way to set one, and
+        // a capture run has no hand. Nonsense is refused rather than guessed,
+        // so a typo photographs automatic placement instead of an invented
+        // pixel.
+        if let Some(position) = std::env::var("QUANTICK_DRAWING_INSPECTOR_POS")
+            .ok()
+            .and_then(|value| parse_point(&value))
+        {
+            self.inspector.place_by_hand(position);
+        }
+        // And the same drag on the context bar, which keeps its position
+        // across selections too. Its own gesture is the grip, and a capture
+        // run has no more hand for that one than for the title bar.
+        if let Some(position) = std::env::var("QUANTICK_CONTEXT_BAR_POS")
+            .ok()
+            .and_then(|value| parse_point(&value))
+        {
+            self.bar.bar.set_manual(position);
+        }
+    }
+}
+
+/// Apply what a frame of chrome asked for.
+///
+/// One implementation for three hosts — the context bar, the floating
+/// inspector and the docked panel — so lock, delete, hide, the pin and the
+/// undo coalescing cannot drift between them. What this surface owns it
+/// changes here; what the host owns leaves as an ask.
+fn apply_actions(
+    chrome: &mut DrawingChromeSurface,
+    ctx: &egui::Context,
+    actions: InspectorActions,
+    index: usize,
+    env: &DrawingEnv<'_>,
+) -> DrawingChromeAsk {
+    let mut ask = DrawingChromeAsk::default();
+    // The undo baseline, taken *before* the edit this frame asked for lands.
+    // A copy made afterwards would equal the new state and the change would
+    // never reach the history. `env` still describes the object as it was at
+    // the top of the frame, which is exactly the copy that is wanted — and it
+    // costs its allocation only on the frame a gesture opens.
+    if actions.edited
+        && chrome.shared.edit_baseline.is_none()
+        && let Some(selected) = env.selected.as_ref()
+    {
+        chrome.shared.edit_baseline = Some(InspectorEdit {
+            tab: env.tab,
+            side: env.side,
+            index,
+            before: selected.drawing.clone(),
+        });
+    }
+    let gesture_settled = ctx.input(|input| !input.pointer.any_down())
+        && ctx.memory(|memory| memory.focused().is_none());
+    if gesture_settled {
+        ask.commit_edit_gesture = chrome.shared.edit_baseline.take().map(Box::new);
+    }
+    ask.toggle_selected_hidden |= actions.toggle_hidden;
+    if actions.toggle_lock {
+        ask.toggle_selected_locked = true;
+        chrome.shared.delete_confirm = false;
+    }
+    if actions.toggle_pin {
+        chrome.shared.pinned = !chrome.shared.pinned;
+        // The user has expressed a preference: the auto-pin width rule stops
+        // firing for the rest of the session.
+        chrome.inspector.pin_touched = true;
+        if !chrome.shared.pinned {
+            // Unpinning re-opens the floating window. The pinned host has been
+            // claiming the selection each frame, so treat it as fresh again —
+            // otherwise automatic placement never runs and the window falls
+            // back to the fixed default corner.
+            chrome.shared.last_selection = None;
+            chrome.inspector.settle_frame = true;
+        }
+    }
+    ask.request_delete |= actions.delete;
+    if actions.cancel_delete {
+        chrome.shared.delete_confirm = false;
+    }
+    if actions.force_delete {
+        chrome.shared.delete_confirm = false;
+        ask.force_delete = true;
+    }
+    if actions.close {
+        // Closing the panel is a smaller act than it used to be: it puts the
+        // trader back on the context bar, with the object still selected.
+        // Clearing the selection here would make the X the only control that
+        // answers a bigger question than it asks.
+        chrome.shared.open = false;
+        if chrome.shared.pinned {
+            chrome.shared.pinned = false;
+            chrome.inspector.pin_touched = true;
+        }
+        chrome.shared.delete_confirm = false;
+    }
+    // Nothing to undo: this changed a preference, not the chart.
+    ask.saved_default = actions.saved_default;
+    ask
+}
+
+/// `x,y` in screen points, or nothing. Refused rather than guessed: a typo
+/// photographs the automatic behaviour, never an invented pixel.
+fn parse_point(raw: &str) -> Option<egui::Pos2> {
+    let (x, y) = raw.split_once(',')?;
+    let x: f32 = x.trim().parse().ok()?;
+    let y: f32 = y.trim().parse().ok()?;
+    (x.is_finite() && y.is_finite()).then_some(egui::pos2(x, y))
+}
+
+/// Clamp a window of `size` at `position` into `chart`, top-left biased when
+/// the window is larger than the pane.
+pub(crate) fn clamp_into_chart(
+    position: egui::Pos2,
+    size: egui::Vec2,
+    chart: egui::Rect,
+) -> egui::Pos2 {
+    let max_x = (chart.right() - size.x).max(chart.left());
+    let max_y = (chart.bottom() - size.y).max(chart.top());
+    egui::pos2(
+        position.x.clamp(chart.left(), max_x),
+        position.y.clamp(chart.top(), max_y),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A bank with one saved preset, to test the recorder's refusal against
+    /// the real store's.
+    ///
+    /// Its own file every call. The store persists on every write, so two
+    /// banks sharing a path would let the first call's save leak into the
+    /// second and turn a free name into a taken one.
+    fn bank(tag: &str) -> crate::drawings::presets::PresetStore {
+        let mut store =
+            crate::drawings::presets::PresetStore::load_from(std::env::temp_dir().join(format!(
+                "quantick-drawing-chrome-{}-{:?}-{tag}.toml",
+                std::process::id(),
+                std::thread::current().id()
+            )));
+        // Start from a clean file even if an earlier run left one behind.
+        for name in store.custom_preset_names("fib") {
+            store.delete_custom_preset("fib", &name);
+        }
+        store.save_custom_preset("fib", "taken", toml::Value::Integer(1), false);
+        store
+    }
+
+    /// The one rule the recorder has to answer for itself, pinned against the
+    /// bank that would otherwise answer it. Two surfaces that disagree about
+    /// whether a name is free would let the inspector's "name already used?"
+    /// prompt appear when the save would have succeeded, or skip it when the
+    /// save is about to overwrite.
+    #[test]
+    fn recorder_refuses_a_taken_name_exactly_as_the_bank_does() {
+        for (name, overwrite) in [
+            ("taken", false),
+            ("taken", true),
+            ("free", false),
+            ("free", true),
+        ] {
+            let mut real = bank(&format!("real-{name}-{overwrite}"));
+            let real_answer =
+                real.save_custom_preset("fib", name, toml::Value::Integer(2), overwrite);
+            let read_only = bank(&format!("copy-{name}-{overwrite}"));
+            let mut recorder = RecordingPresetHost::new(&read_only);
+            let recorded =
+                recorder.save_custom_preset("fib", name, toml::Value::Integer(2), overwrite);
+            assert_eq!(
+                recorded, real_answer,
+                "the recorder and the bank disagreed about {name:?} with overwrite={overwrite}"
+            );
+            assert_eq!(
+                recorder.writes.is_empty(),
+                !real_answer,
+                "a refused save must record nothing, and an accepted one exactly one write"
+            );
+            let _ = std::fs::remove_file(real.path());
+            let _ = std::fs::remove_file(read_only.path());
+        }
+    }
+
+    /// Every read is the bank's own answer, so a tool tab cannot see a
+    /// different world through the recorder than through the store.
+    #[test]
+    fn recorder_delegates_every_read_to_the_bank() {
+        let store = bank("reads");
+        let recorder = RecordingPresetHost::new(&store);
+        assert_eq!(
+            recorder.custom_preset_names("fib"),
+            store.custom_preset_names("fib")
+        );
+        assert_eq!(
+            recorder.load_custom_preset("fib", "taken"),
+            store.load_custom_preset("fib", "taken")
+        );
+        assert_eq!(recorder.default_preset("fib"), store.default_preset("fib"));
+        assert_eq!(recorder.default_style("fib"), store.default_style("fib"));
+        assert_eq!(recorder.default_config("fib"), store.default_config("fib"));
+        assert_eq!(
+            recorder.has_default_config("fib"),
+            store.has_default_config("fib")
+        );
+        let _ = std::fs::remove_file(store.path());
+    }
+
+    /// A harness hook that guessed would photograph an invented pixel and call
+    /// it the trader's. Refuse instead, and the capture shows the default.
+    #[test]
+    fn the_popup_position_hook_refuses_what_is_not_a_point() {
+        assert_eq!(parse_point("420,200"), Some(egui::pos2(420.0, 200.0)));
+        assert_eq!(parse_point(" 420 , 200.5 "), Some(egui::pos2(420.0, 200.5)));
+        for raw in ["", "420", "420,", ",200", "left,top", "420x200"] {
+            assert_eq!(parse_point(raw), None, "{raw:?} is not a point");
+        }
+    }
+
+    /// The fold keeps a flag set and takes the first valued ask, which is the
+    /// half of a merge a newly added field is most likely to get wrong.
+    #[test]
+    fn the_fold_keeps_flags_and_the_first_value() {
+        let mut first = DrawingChromeAsk {
+            show_all: true,
+            manager_delete: Some(3),
+            presets: vec![PresetWrite::Delete {
+                tool_id: "fib".into(),
+                name: "a".into(),
+            }],
+            ..DrawingChromeAsk::default()
+        };
+        first.merge(DrawingChromeAsk {
+            unlock_all: true,
+            manager_delete: Some(7),
+            presets: vec![PresetWrite::Delete {
+                tool_id: "fib".into(),
+                name: "b".into(),
+            }],
+            ..DrawingChromeAsk::default()
+        });
+        assert!(first.show_all, "a set flag survives the fold");
+        assert!(first.unlock_all, "and the other side's flag arrives");
+        assert_eq!(
+            first.manager_delete,
+            Some(3),
+            "the first valued ask wins; the later one is dropped"
+        );
+        assert_eq!(
+            first.presets.len(),
+            2,
+            "preset writes are a sequence, not an answer to one question: both land, in order"
+        );
+    }
+}

--- a/crates/app/src/surfaces/mod.rs
+++ b/crates/app/src/surfaces/mod.rs
@@ -131,14 +131,6 @@ pub(crate) struct SurfaceEnv<'a> {
     /// the alarm controls, so a trader auditioning a clip learns immediately
     /// that the signal would have been silent too.
     pub alert_failure: Option<&'a str>,
-    /// What the drawing chrome reads: the selected object, where it is
-    /// painted, and the pane it lives on.
-    ///
-    /// Nested rather than flattened. That subsystem needs a dozen more
-    /// answers than any other surface, and spreading them here would leave
-    /// this struct holding one subsystem's slice as loose fields — the shape
-    /// `Surfaces` exists to stop `QuantickApp` having.
-    pub drawing: DrawingEnv<'a>,
 }
 
 #[cfg(test)]
@@ -188,7 +180,6 @@ impl SurfaceEnv<'static> {
             active_tab: 0,
             counted_bar_sides: &[],
             alert_failure: None,
-            drawing: DrawingEnv::quiet(),
         }
     }
 }
@@ -228,9 +219,6 @@ pub(crate) struct SurfaceResponse {
     /// A sound was auditioned. The host owns the one speaker every armed
     /// instance shares, so it plays this and reports what happened.
     pub test_alert: Option<crate::audio::Cue>,
-    /// What the drawing chrome asked for. Nested for the reason
-    /// [`SurfaceEnv::drawing`] is: one subsystem, one field here.
-    pub drawing: drawing_chrome::DrawingChromeAsk,
 }
 
 /// Ask the host to arm a strategy instance.
@@ -323,7 +311,6 @@ impl SurfaceResponse {
         self.market = self.market.take().or(other.market);
         self.arm_strategy = self.arm_strategy.take().or(other.arm_strategy);
         self.test_alert = self.test_alert.take().or(other.test_alert);
-        self.drawing.merge(other.drawing);
     }
 }
 
@@ -390,6 +377,18 @@ pub(crate) struct Surfaces {
     /// inline note editor, the inspector in both its hosts, and the object
     /// manager. One member for four pieces of chrome, because they share five
     /// pieces of state — see [`drawing_chrome`] for the table and the reason.
+    ///
+    /// The one member [`Self::draw_all`] does not draw, and the only one that
+    /// does not implement [`Surface`]. It is anchored to the *chart* rather
+    /// than floating over the window, so the host draws it at two specific
+    /// points in the frame — the docked inspector before the central canvas,
+    /// which pays its width, and the floating pieces after it, because every
+    /// one of them places against pane geometry the canvas writes as it draws.
+    /// A uniform `draw` here would have to be handed an environment this pass
+    /// cannot fill and a response this pass does not read; naming the two
+    /// entry points instead is the honest shape, and it is the same
+    /// command-a-member-by-name the host already does for the toast and the
+    /// arming dialog.
     pub drawing_chrome: DrawingChromeSurface,
 }
 
@@ -436,7 +435,6 @@ impl Surfaces {
             self.style_panel.apply_env_hook(env);
             self.toast.apply_env_hook(env);
             self.workspace_name.apply_env_hook(env);
-            self.drawing_chrome.apply_env_hook(env);
         }
         let mut response = SurfaceResponse::default();
         response.merge(self.agent_popup.draw(ctx, env));
@@ -447,10 +445,7 @@ impl Surfaces {
         response.merge(self.style_panel.draw(ctx, env));
         response.merge(self.toast.draw(ctx, env));
         response.merge(self.workspace_name.draw(ctx, env));
-        // Deliberately not `self.drawing_chrome`: it is anchored to the chart
-        // rather than floating over the window, so the host draws it after the
-        // central canvas — see `DrawingChromeSurface::draw`. Its hooks still
-        // run above, because they run once and before any frame.
+        // Deliberately not `self.drawing_chrome` — see the field's own note.
         response
     }
 }
@@ -592,7 +587,6 @@ mod tests {
                 symbol: "SECOND".to_owned(),
             }),
             arm_strategy: None,
-            drawing: drawing_chrome::DrawingChromeAsk::default(),
             test_alert: Some(crate::audio::Cue::new(
                 crate::audio::AlertSound::Critical,
                 None,

--- a/crates/app/src/surfaces/mod.rs
+++ b/crates/app/src/surfaces/mod.rs
@@ -42,6 +42,7 @@
 //! surface already implements is what makes that a local change.
 
 pub(crate) mod agent_popup;
+pub(crate) mod drawing_chrome;
 pub(crate) mod footprint_settings;
 pub(crate) mod indicator_preview;
 pub(crate) mod source_picker;
@@ -55,6 +56,7 @@ use std::time::Instant;
 use eframe::egui;
 
 pub(crate) use agent_popup::AgentPopupSurface;
+pub(crate) use drawing_chrome::{DrawingChromeSurface, DrawingEnv};
 pub(crate) use footprint_settings::FootprintSettingsSurface;
 pub(crate) use indicator_preview::IndicatorPreviewSurface;
 pub(crate) use source_picker::SourcePickerSurface;
@@ -129,6 +131,14 @@ pub(crate) struct SurfaceEnv<'a> {
     /// the alarm controls, so a trader auditioning a clip learns immediately
     /// that the signal would have been silent too.
     pub alert_failure: Option<&'a str>,
+    /// What the drawing chrome reads: the selected object, where it is
+    /// painted, and the pane it lives on.
+    ///
+    /// Nested rather than flattened. That subsystem needs a dozen more
+    /// answers than any other surface, and spreading them here would leave
+    /// this struct holding one subsystem's slice as loose fields — the shape
+    /// `Surfaces` exists to stop `QuantickApp` having.
+    pub drawing: DrawingEnv<'a>,
 }
 
 #[cfg(test)]
@@ -178,6 +188,7 @@ impl SurfaceEnv<'static> {
             active_tab: 0,
             counted_bar_sides: &[],
             alert_failure: None,
+            drawing: DrawingEnv::quiet(),
         }
     }
 }
@@ -217,6 +228,9 @@ pub(crate) struct SurfaceResponse {
     /// A sound was auditioned. The host owns the one speaker every armed
     /// instance shares, so it plays this and reports what happened.
     pub test_alert: Option<crate::audio::Cue>,
+    /// What the drawing chrome asked for. Nested for the reason
+    /// [`SurfaceEnv::drawing`] is: one subsystem, one field here.
+    pub drawing: drawing_chrome::DrawingChromeAsk,
 }
 
 /// Ask the host to arm a strategy instance.
@@ -309,6 +323,7 @@ impl SurfaceResponse {
         self.market = self.market.take().or(other.market);
         self.arm_strategy = self.arm_strategy.take().or(other.arm_strategy);
         self.test_alert = self.test_alert.take().or(other.test_alert);
+        self.drawing.merge(other.drawing);
     }
 }
 
@@ -371,6 +386,11 @@ pub(crate) struct Surfaces {
     pub toast: ToastSurface,
     /// The Save-as box, opened from the Workspace menu.
     pub workspace_name: WorkspaceNameSurface,
+    /// Everything that speaks for the selected drawing: the context bar, the
+    /// inline note editor, the inspector in both its hosts, and the object
+    /// manager. One member for four pieces of chrome, because they share five
+    /// pieces of state — see [`drawing_chrome`] for the table and the reason.
+    pub drawing_chrome: DrawingChromeSurface,
 }
 
 impl Surfaces {
@@ -416,6 +436,7 @@ impl Surfaces {
             self.style_panel.apply_env_hook(env);
             self.toast.apply_env_hook(env);
             self.workspace_name.apply_env_hook(env);
+            self.drawing_chrome.apply_env_hook(env);
         }
         let mut response = SurfaceResponse::default();
         response.merge(self.agent_popup.draw(ctx, env));
@@ -426,6 +447,10 @@ impl Surfaces {
         response.merge(self.style_panel.draw(ctx, env));
         response.merge(self.toast.draw(ctx, env));
         response.merge(self.workspace_name.draw(ctx, env));
+        // Deliberately not `self.drawing_chrome`: it is anchored to the chart
+        // rather than floating over the window, so the host draws it after the
+        // central canvas — see `DrawingChromeSurface::draw`. Its hooks still
+        // run above, because they run once and before any frame.
         response
     }
 }
@@ -567,6 +592,7 @@ mod tests {
                 symbol: "SECOND".to_owned(),
             }),
             arm_strategy: None,
+            drawing: drawing_chrome::DrawingChromeAsk::default(),
             test_alert: Some(crate::audio::Cue::new(
                 crate::audio::AlertSound::Critical,
                 None,

--- a/crates/app/tests/size_guard.rs
+++ b/crates/app/tests/size_guard.rs
@@ -86,12 +86,12 @@ const BASELINE: &[(&str, usize)] = &[
     // The third batch was the drawing chrome: the context bar, the on-chart
     // note editor, the inspector in both its hosts and the object manager,
     // with the title bar, the body, the placement rule and the action applier
-    // they share. 1,592 production lines and twenty-one struct fields, out to
+    // they share. 1,548 production lines and twenty-one struct fields, out to
     // `src/surfaces/drawing_chrome/` as one member — they are one subsystem,
     // and four members would have left the state they share behind. The
     // number below is what that left, not a target: this file is still six
     // times the threshold.
-    ("crates/app/src/app.rs", 9656),
+    ("crates/app/src/app.rs", 9700),
     // The five entries below `pane.rs` were invisible to the first version of
     // this guard, which stopped counting at the first `#[cfg(test)]` of any
     // kind: `gateway.rs` scored 72 lines of its 4,142, `drawings/mod.rs` 221

--- a/crates/app/tests/size_guard.rs
+++ b/crates/app/tests/size_guard.rs
@@ -73,7 +73,7 @@ const SLACK: usize = 200;
 /// targets: each entry is debt, and the only direction one should ever move
 /// is down. `app.rs` at the top of the list is the reason the file exists.
 const BASELINE: &[(&str, usize)] = &[
-    // `app.rs` is the reason this file exists. Tightened twice now. The
+    // `app.rs` is the reason this file exists. Tightened three times now. The
     // guard's own change took the agent popup, the acknowledgement toast and
     // the Save-as box out to `src/surfaces/`; the second batch took the
     // indicator-preview watermark, the appearance window, the footprint
@@ -82,7 +82,16 @@ const BASELINE: &[(&str, usize)] = &[
     // the environment the port hands them instead, plus the review's fixes
     // and the `QUANTICK_TOAST=paper` hook that photographs the converged
     // acknowledgement lane.
-    ("crates/app/src/app.rs", 11248),
+    //
+    // The third batch was the drawing chrome: the context bar, the on-chart
+    // note editor, the inspector in both its hosts and the object manager,
+    // with the title bar, the body, the placement rule and the action applier
+    // they share. 1,592 production lines and twenty-one struct fields, out to
+    // `src/surfaces/drawing_chrome/` as one member — they are one subsystem,
+    // and four members would have left the state they share behind. The
+    // number below is what that left, not a target: this file is still six
+    // times the threshold.
+    ("crates/app/src/app.rs", 9656),
     // The five entries below `pane.rs` were invisible to the first version of
     // this guard, which stopped counting at the first `#[cfg(test)]` of any
     // kind: `gateway.rs` scored 72 lines of its 4,142, `drawings/mod.rs` 221


### PR DESCRIPTION
The third batch of floating surfaces leaves the trunk: the context bar, the
on-chart note editor, the inspector in both its hosts, and the object
manager — with the title bar, the body, the placement rule and the action
applier they share. **1,548 production lines and twenty-three struct fields**
move to `crates/app/src/surfaces/drawing_chrome/`.

| | before | after |
| --- | --- | --- |
| `QuantickApp` fields | 119 | **96** |
| `app.rs` production lines | 11,248 | **9,700** |
| `Surfaces` members | 8 | **9** |

## One member, not four — the question the mission asked to be answered

They are one subsystem, not four surfaces that happen to be adjacent. Five
pieces of state are written by one and read by another:

| State | Written by | Read by |
| --- | --- | --- |
| `open` | the context bar's gear | the inspector |
| `pinned` | the inspector's pin | the context bar, to hide a gear leading where the eye already is |
| `last_selection` | the context bar, on a new selection | the inspector's placement rule |
| `delete_confirm` | the action applier | the bar and the inspector body |
| `edit_baseline` | the action applier | the inspector, to commit a gesture that outlived its selection |

Four members would leave that sharing in `QuantickApp` — the disease this
change exists to cure — or push it through the response and make
`Surfaces::draw_all`'s call order load-bearing, which its own documentation
says it is not. One member keeps the sharing private, and the order the four
are drawn in is decided in one place, in writing, beside the reason.

**No keyed registry.** The count went 8 → 9, so the trade the typed struct
documents was never under pressure. No downcast, no command enum.

## Two deviations from the plan, both deliberate

**The chrome does not implement `Surface`.** It has the port's shape — a
read-only env in, an ask struct out, no `&mut` into the trunk, its own state
— and it is a member of `Surfaces`. But it is anchored to the *chart*, not
floating over the window, so the host draws it at two specific points in the
frame: the docked inspector before the central canvas, which pays its width,
and the floating pieces after it, because every one of them places against
pane geometry (`last_chart_area`, `last_auto_range`, the lane divider) that
the canvas writes as it draws. Reading it a phase early would place the bar
and the panel against the previous frame's chart.

A uniform `draw` was written first and taken back out: `draw_all` cannot
fill that surface's slice and does not read its response, so the trait
method was a forward nobody called that would have drawn the chrome twice
had anyone honoured it (finding 7 below). Two named entry points is the
honest shape, and it is the same command-a-member-by-name the host already
does for the toast and the arming dialog.

**The capture hooks fire at launch, not from `apply_env_hook`.** The plan
said they would move onto the trait's hook. They did, and it broke them: the
registry applies `apply_env_hook` on the first *drawn* frame, which runs
after the demo appliers — and `carry_inspector_across_selection` reads the
state `QUANTICK_DRAWING_INSPECTOR` sets. Every capture pairing that hook
with `QUANTICK_DRAWINGS_DEMO` photographed a chart with no inspector. They
live in the surface's file, beside the fields they set; only the timing went
back. All five still fire.

## The inspector edits a copy

`SurfaceEnv` hands the chrome the selected object **borrowed**; the
inspector clones it, the widgets write into the clone, and it comes back
through the response. Nothing here holds a `&mut` into a pane. The context
bar and the inline editor still read the borrow — a pencil stroke is 512
anchors, and they run on every frame something is selected.

The preset bank is reached through a `RecordingPresetHost` that delegates
every read to the real bank and records the five writes for the host to
replay. That keeps `PresetHost` — already a port — intact for the tool-owned
tab, and keeps the disk write the host's.

## Performance

Cold path throughout; nothing added to the aggregator, `Indicator::preview`
or a renderer. Per frame the host pays two branches and a struct of borrows.
Everything that costs something is gathered by the pass that draws it, in
`DrawingRead`: the painted-bounds projection, the band name, the manager's
rows and the assistant count. `draw_all` gathers none of them.

Two costs went **down** against `main`: the context bar no longer clones the
selected drawing on a frame with a gesture merely open (only on the frame
one is created), and the band name is no longer formatted while the panel is
shut.

## Review

**Step 0: `code-review` at xhigh — 10 findings, all 10 confirmed, all 10
fixed** (commit 2). Two were regressions this move introduced that the
existing tests could not see:

1. **The inspector hook read a frame too late** — described above.
   `the_inspector_hook_survives_the_demo_that_runs_before_it` now drives the
   environment variable instead of the field, and fails without the fix
   (verified by reverting it).
2. **`Tool::draw_extra_tab`'s return value silently became load-bearing** —
   it is an advisory undo hint, and while the tab wrote through a `&mut` a
   tool that mutated and returned `false` still persisted. Editing a copy
   would have discarded it. The copy is now handed back because it *differs*,
   not because a flag said so.

The rest: a response lane nothing consumed; a dead trait forward that would
have drawn the chrome twice; the recorder's reads could not see the writes
the same frame already made (delete-then-save under the freed name was
refused); the delete confirmation survived its own Cancel; the manager's row
indices were unchecked against a list a destructive ask can shorten; the band
name was formatted for a closed panel; and two byte-identical edit records
are now one `DrawingEdit`.

Nothing deferred.

**Shape (dimensions 1–8).** Docking: a new floating surface still docks as a
file plus one field; a second *chart-anchored* one would add a line to
`draw_drawing_chrome` rather than to `Surfaces` — the one place this port is
not yet a registry, and with exactly one member it is not worth carving.
Hardcoded: every moved constant kept its name, its unit and its reason, and
two repeated egui id literals became `INSPECTOR_AREA_ID` / `MANAGER_AREA_ID`.
Second operator: no new capability; all five hooks preserved, every host
command a named method. Language: `language_guard` passes, and I read the
prose, the branch name and the commit messages myself.

## Verification

Four checks, each run on its own: `cargo fmt --all -- --check`, `cargo clippy
--workspace --all-targets -- -D warnings`, `cargo build --workspace`, `cargo
test --workspace` — all exit 0. Two known-flaky exceptions, both verified to
behave identically on a clean `origin/main` tree: `the_bridge_paging_tests_pass`
(a `python3` shim issue on this machine — `python tools/mt5/test_export_session.py`
passes, all 5 tests), and `a_close_refreshes_an_open_report_by_itself` (stale
temp dirs; green on rerun).

`size_guard.rs` fired on the slack, as the ratchet should, and its entry is
tightened in the same commit — twice, because the review fixes added lines
back.

## Visual QA

Seven states captured on both this branch and an `origin/main` control
build, under a **deterministic replay** (WDOU26 2026-08-18 at 200×) so the
two runs see the same tape: context bar, inline editor, floating inspector,
the tool-owned Levels tab, the docked inspector on a narrow window, the
object manager, and both parked positions with an agent-authored object.
All seven at **59–60 fps**, no `APP_SLOW_FRAMES`.

The comparison that matters, on the same scene:

| Region | branch vs main | same build, two runs |
| --- | --- | --- |
| tool rail (untouched control) | **0.00 %** | — |
| context bar | 0.62 % | 0.62 % / 2.15 % |

The cross-build difference **equals the run-to-run floor**, and an untouched
control is pixel-identical — which is what validates the method. The bar's
residue is the tape showing through a deliberately translucent surface, not
a moved control. Read against the defect checklist: nothing clipped, the
Levels tab's disabled Apply/Delete are honestly greyed (nothing selected),
the assistant chip and the "Remove 1 object(s) placed for you" sweep are on
the authored object, and the parked context bar is repaired back inside the
pane and clear of the live lane.

One pre-existing defect seen and **not** introduced here: at 1000×760 the
status bar's tape cell and its trade/fps cell overlap. Identical on the
`main` control; left alone.

## Out of scope

`draw_frame` (79 coupling, 658 lines) and `draw_menu_bar` (38 coupling, 634
lines), as the goal specified. Also untouched: the remaining `pending_*` (18)
and `scripted_*` (9) clusters, and `inspector_position_dirty`, which stays on
the trunk because it is about the workspace file rather than the panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H3K1og1xk9BLpXShNNxCWV
