### PR TITLE
fix(strategy): name the gate that held a bar, and measure the force floor across the candle

### DIFF
--- a/.claude/GOAL-archive-sell-zone-entry-diagnosis.md
+++ b/.claude/GOAL-archive-sell-zone-entry-diagnosis.md
@@ -256,25 +256,30 @@ reports **all checks passed across 31 tests**, exit 0 — which is what CI runs.
 
 ### G3 — performance impact, by rate class
 
-- `ForceWindow::weigh` — **per closed bar** (rare). One extra subtraction
-  (`high - low`), computed once and reused by the gate and the `ForceBar`
-  it builds. No allocation.
+**Rewritten after `delivery-review` found the previous version describing a
+build that is not this branch.** It claimed `ArmedStrategy` caches the ruler's
+reading, that the badge borrows it, and that a named test pins the cache — all
+true of a commit that was then reverted, and left standing in this file. A
+performance declaration that describes code which is not shipped is worse than
+none, because it is read as measurement.
+
+What the shipped branch actually does:
+
+- `ForceWindow::weigh` — **per closed bar, and also per print**. One extra
+  subtraction (`high - low`), read once and reused by the gate and the
+  `ForceBar` it builds; no allocation. The per-print half was missed in the
+  first declaration and is the reason **G4** below is not N/A: `weigh` is
+  reached from `ForceTrigger::preview`, which the alarm's forming-bar path
+  calls on every print through `preview_opportunity`.
 - `ArmedStrategy::on_closed_bar` — **per closed bar** (rare). Unchanged.
-- `ChartPane::badge_text_for` — **per frame**, once per armed instance
-  (hot). The first version of this fix called `Trigger::status()` here,
-  which returns an owned `String` — a `format!` per armed instance per
-  frame, and a dimension-2 finding against my own change. It was caught in
-  arch-review and removed rather than declared: `ArmedStrategy` now caches
-  the ruler's reading in `trigger_status`, refreshed at the three sites
-  that can change what the ruler would say (a judged bar, a warmup, a
-  re-arm that resets the series), and the badge **borrows** it. The
-  allocation moved from 60 Hz to the bar rate, and
-  `the_cached_ruler_reading_never_drifts_from_the_trigger` pins the cache
-  to the trigger so the saving cannot become a stale badge — the exact
-  failure this branch exists to fix.
-- `ArmedStrategy::status_line` now reads the same cached string, so the
-  chart badge and the right-click menu quote **one** value rather than two
-  calls that happen to agree.
+- `ChartPane::badge_text_for` — **per frame**, once per armed instance. It
+  calls `Trigger::status()`, which formats two `Decimal`s and returns an owned
+  `String`. That is the same call `status_line` has always made, and it is not
+  new to this path so much as newly *reached* from it. A cache was written to
+  avoid it and reverted: it moved the cost onto every closed bar of every
+  backtest session, which never reads the string, to save one allocation of
+  several on a paint path that allocates regardless. `status_line` makes its
+  own separate call; the two are not shared.
 
 ### G4 and G5 — what could not be finished, and why
 
@@ -286,9 +291,10 @@ A run of the branch build reached the armed-instance surface
 trader's workspace could not be touched) and stayed healthy for its whole
 life: **fps 59–60, frame_avg 16.64–16.67 ms, frame_cpu 1.9–4.5 ms** on a
 live Binance tape at ~39 trades/s. That is the vsync ceiling, so nothing in
-this change costs a visible frame. Those numbers were taken **before**
-the cache above landed, so they measure the more expensive version; the
-shipped one does strictly less work per frame.
+this change costs a visible frame. Those numbers were taken before the
+cache was written *and* the cache was later reverted, so they measure the
+shape that shipped — not, as an earlier version of this file claimed, a
+more expensive one the branch improved on.
 
 It is short of what G4 asked for on two counts, and both are stated rather
 than glossed: there is **no `main` control run** to compare against, and the

--- a/.claude/GOAL-archive-sell-zone-entry-diagnosis.md
+++ b/.claude/GOAL-archive-sell-zone-entry-diagnosis.md
@@ -1,0 +1,338 @@
+# Mission — why no sell was taken at the top of the sell zone, and the fix
+
+**Objective.** Identify why no sell was taken on the bar the trader marked at
+the top of the `SellGainAlarm` region on BTCUSDT (2000-tick bars, ~15:03), and
+correct the defect that made the cause unreadable — without changing the
+trading rule, which stays the trader's call.
+
+**Why it matters.** The trader looked at the chart to answer "why did nothing
+fire here?" and the badge answered with a sentence about a *different bar*.
+The strategy kernel's own doc comment states the standard it is held to — "a
+strategy that stays silent about *why* it is not firing reads as broken"
+(`crates/strategy/src/force.rs:73`). On this bar it did worse than stay
+silent: it gave a confident, wrong-bar answer.
+
+## Request ledger
+
+| # | Ask | Source |
+| --- | --- | --- |
+| R1 | Identify the cause of no sell being taken on the marked bar at the upper part of the sell zone. | verbatim: *"identficar a causa de nao ter feito essa venda na parte superior na zona de venda"* |
+| R2 | Correct it. Scoped by **D1** to proven defects; a trading-rule change is returned to the trader as a decision. | verbatim: *"e faça a correção"* |
+| R3 | Change the absolute floor so it measures the **candle's size** (`high - low`) instead of the body (`\|close - open\|`). | verbatim: *"achoq ue esse min body deveria ser min tamanho do candle nao?"* |
+
+`R3` arrived mid-mission, after the diagnosis was presented. It is a
+**trading-rule change**, which **D1** reserves to the trader — so it was put
+to them as a decision rather than taken, and **D5** records the answer. It is
+scope the trader added, not scope this mission invented.
+
+## Decisions taken by the trader (D)
+
+- **D1 — What "faça a correção" means.** Diagnose against the real tape, prove
+  which gate held *that* bar, and fix only what is a genuine defect (the
+  per-bar reason, plus any real bug). A change to the trading rule itself
+  comes back as the trader's decision, never taken unilaterally. *Rationale
+  given: a rule change moves money.*
+- **D2 — Which bar.** Only the bar the red arrow marks (~15:03), not the whole
+  14:48–15:05 window.
+- **D3 — The `min_body` floor.** Trader did not know the live value; agent to
+  read the saved preset and report the real one. **Answered from evidence:**
+  `SellGainAlarm` carries `min_body = "100"` in
+  `~/Documents/Quantick/quantick-strategies.toml`.
+- **D4 — Alarm or order.** The instance should have **placed an order**.
+  **Confirmed from evidence:** the preset carries `alarm_only = false`.
+- **D5 — The floor measures the candle, not the body.** Put to the trader
+  with the trade-off stated plainly: the ratio half of the ruler is
+  body-based (`body / avg(body)`), so a range-based floor lets a
+  wick-dominated doji clear a gate its body could not — the very bar
+  `region.rs`'s wick rule exists to refuse. **The trader chose the
+  range-based floor after that concern was raised**, which under this repo's
+  working rules is their decision to make and mine to implement in full. The
+  doji exposure is accepted, named here, and called out in the PR body so it
+  is a known position rather than a surprise.
+- **D6 — One PR.** The reporting fix and the rule change ship together, at
+  the trader's instruction. (I had recommended splitting them so a
+  money-moving change could be reviewed alone; the trader chose one PR, and
+  the PR body separates the two so a reviewer can still weigh them apart.)
+
+## Assumptions (S)
+
+- **S1** — The marked bar's body is under 100 price units. Read from the
+  screenshot's price axis (bars in that congestion span roughly 30–80 USD
+  against a 180,000 price). Safe to assume for *scoping*, and it is not
+  load-bearing: criterion **A1** proves the gate from a reconstructed bar
+  rather than from this estimate, and the fix in **A3** is correct whichever
+  ruler verdict actually held the bar.
+- **S2** — The stale reason on the badge ("the body never cut the region")
+  came from a later bar below the region, where price sat from ~15:10. Not
+  load-bearing either: **A2** proves the *mechanism* by which any unrelated
+  bar's reason reaches this badge, without needing to identify which one did.
+- **S3** *(wanted to ask, cut by the four-question cap)* — Whether the trader
+  wants the badge to keep naming a stale reason at all, or to fall silent
+  once it is not about the current bar. Went with: **keep it, but never let
+  it impersonate a fresh answer** — the existing `HoldReason.fresh` flag
+  already encodes that intent, so honouring it is repair rather than
+  redesign.
+- **S4** *(wanted to ask, cut by the cap)* — Whether `Quiet`, `Exhaustion`,
+  `Warmup` and `FlatAverage` deserve the same badge treatment as
+  `UnderFloor`. Went with: **yes, all of them** — they are the same class of
+  silence, and fixing one arm while leaving four identical holes would
+  reproduce this exact bug report on the next verdict.
+
+## The cause (R1) — established from source, pending tape confirmation
+
+The chain, each link read in the code rather than inferred:
+
+1. `SellGainAlarm` carries `min_body = "100"` — an absolute body floor whose
+   own doc comment (`force.rs:33-40`) records that it was calibrated on a
+   **WINV26** session. It is applied unchanged to BTCUSDT.
+2. The marked bar's body is under that floor, so `ForceWindow::weigh` returns
+   `BarVerdict::UnderFloor` (`force.rs:227`) — the arm that exists precisely
+   to say "the relative band would have called this force, and the absolute
+   floor held it".
+3. `signal_from` maps every non-`Force` verdict to `None`
+   (`trigger.rs:167`). No `Signal` is produced.
+4. `ArmedStrategy::judge` takes the no-signal path and **clears the note**:
+   `let Some(signal) = signal else { self.note = None; return Vec::new(); }`
+   (`armed.rs:449-452`). No hold reason is recorded for this bar at all.
+5. `hold_reason()` therefore falls back to `last_hold` — the most recent
+   refusal from *any* earlier bar (`armed.rs:786-789`).
+6. The chart badge renders `hold_reason()` **and nothing else**
+   (`pane.rs:2405-2412`). It never renders `trigger.status()`.
+
+Step 4's own comment says the no-signal path is safe because it "lets the
+trigger's own status narrate". **On the chart, it does not.** `status_line()`
+includes `trigger.status()`; the chart badge does not call `status_line()`.
+The compensation the design relies on is absent from the one surface the
+trader actually reads — so a bar the ruler refused shows another bar's
+refusal, present-tense-adjacent, with no way to tell.
+
+**Two findings, deliberately separated:**
+
+- **Defect (mine to fix, R2 under D1)** — the trigger's own refusal never
+  becomes a hold reason, and the chart badge presents an unrelated bar's
+  reason in its place.
+- **Rule/config (the trader's, D1)** — `min_body = 100` is instrument-blind:
+  right for WINV26, arbitrary for BTC at 180,000. Reported with numbers,
+  **not** changed by this mission.
+
+## Acceptance criteria
+
+- [x] **A1** — The gate that held the marked bar is named with its measured
+      numbers (body, average body, ratio, floor) from a reconstructed bar,
+      not from a screenshot estimate.
+      *Evidence:* a test asserting the verdict for that bar's geometry.
+      → `crates/strategy/src/armed.rs` tests + `.claude/GOAL-archive-*.md`. *(R1)*
+- [x] **A2** — A regression test proves today's defect: a bar whose ruler
+      refuses it leaves the badge showing an **earlier, unrelated** bar's
+      reason, with nothing marking it as not-about-this-bar.
+      *Evidence:* a test that fails on `origin/main` and passes after A3.
+      → `crates/app/src/pane.rs` or `crates/strategy/src/armed.rs` tests. *(R1, R2)*
+- [x] **A3** — The trigger's own refusal becomes a first-class hold reason:
+      a bar the ruler declined names *that* gate, on the bar it happened,
+      carrying the numbers a trader can act on.
+      *Evidence:* tests over `UnderFloor`, `Quiet`, `Exhaustion`, `Warmup`,
+      `FlatAverage`; badge text asserted.
+      → `crates/strategy/src/armed.rs`, `crates/app/src/pane.rs`. *(R2)*
+- [x] **A4** — A stale reason can no longer read as an answer about the
+      current bar: what the badge shows is either fresh, or explicitly
+      marked as not about this bar.
+      *Evidence:* test asserting the badge over a ruler-refused bar.
+      → `crates/app/src/pane.rs` tests. *(R2)*
+- [x] **A5** — **The reporting fix changes no trading behaviour**, and the
+      rule change (**A7**) is the branch's *only* behavioural change. The two
+      are separable in the diff: the badge work touches no gate, and the
+      floor work touches no reason string.
+      *Evidence:* the badge change confined to `crates/app/src/pane.rs`
+      (a surface that emits no `Command`); every pre-existing
+      command-emission test in `armed.rs` and `backtest` passing unchanged
+      except those that assert the floor's own semantics, each such change
+      listed in the PR body with why.
+      → `cargo test --workspace` output + PR body. *(D1, R2)*
+
+      *Originally written as "the trading rule is unchanged", which **D5**
+      superseded. Re-scoped rather than deleted so the record shows the
+      criterion moved by the trader's decision and not by my convenience.*
+- [x] **A6** — The `min_body = 100` finding is reported to the trader with
+      the numbers and the instrument-calibration problem named.
+      *Evidence:* a section in the PR body quoting the WINV26 calibration
+      note and the BTC figure. → PR body. *(D1, R1)*
+- [x] **A7** — The absolute floor measures the candle's **size**
+      (`high - low`), not its body. A bar whose body is under the floor but
+      whose candle clears it is now **force**, and the marked bar is exactly
+      that case.
+      *Evidence:* a test over the marked bar's reconstructed geometry
+      asserting `Force` where today it is `UnderFloor`, plus the renamed
+      field carrying the new meaning in its name and docs.
+      → `crates/strategy/src/force.rs` tests. *(R3, D5)*
+- [x] **A8** — A preset saved before this change keeps working, and its
+      stored number is carried into the new meaning **visibly**, not
+      silently: the trader's own `min_body = "100"` becomes a 100-unit
+      *candle-size* floor, and that reinterpretation is stated in the PR
+      body rather than discovered by a changed fill.
+      *Evidence:* a round-trip test loading a pre-change preset file.
+      → `crates/app/src/strategy_presets.rs` tests. *(R3, D5)*
+- [x] **A9** — The doji exposure **D5** accepts is proven and bounded, not
+      hand-waved: a test shows what now clears the floor that did not
+      before, so the trader can see the shape of what they took on.
+      *Evidence:* a test naming the wick-dominated bar case.
+      → `crates/strategy/src/force.rs` tests. *(D5)*
+
+### Injected gates
+
+- [x] **G1** — Every artifact in English (`CLAUDE.md` owns the rule and its
+      exemptions; the verbatim request section below is the one marked,
+      attributed quotation).
+      *Evidence:* `cargo test -p quantick-app language_guard`; arch-review
+      dimension 8. → CI output.
+- [x] **G2** — Four checks green after rebasing on latest `main`, each run
+      **separately** (a chained `|| echo` has reported a false all-clear here
+      before).
+      *Evidence:* four separate exit codes. → PR body.
+- [x] **G3** — Performance impact declared by rate class. `judge` is
+      **per-closed-bar** (rare); the alarm's `wants_forming_check` path is
+      **per-print** (hot). Any allocation added to the per-print path is a
+      defect, and the declaration says which paths were touched.
+      *Evidence:* a stated classification per touched function. → PR body.
+- [ ] *(partial - numbers taken, no `main` control run)* **G4** — If the per-print path is touched at all, evidence that
+      performance is flat: `APP_HEALTH_SUMMARY` fps/frame_avg under a dense
+      tape vs. a `main` control run.
+      *Evidence:* both runs' numbers. → PR body. *(Expected N/A — see below.)*
+- [ ] *(partial - screenshot blocked by the environment)* **G5** — User-visible change (the badge sentence): `ui-harness` hook
+      for the surface, `visual-qa` pass, `trader-ux-review` with no
+      unresolved Blocker.
+      *Evidence:* screenshot paths + both verdicts. → PR body.
+- [ ] *(runs after this file is archived)* **G6** — `arch-review` run over `git diff origin/main...HEAD`, every
+      Blocker and Should-fix resolved or deferred in the PR body.
+      *Evidence:* the review's verdict. → PR body.
+- [x] **G7** — No new magic number: the floor, the ratio and the window are
+      already named parameters and stay that way; any new threshold is named
+      and justified.
+      *Evidence:* arch-review dimension on hardcoded values. → PR body.
+
+### Not applicable, and why
+
+- **`new-extension`** — this adds no feed, bar type, indicator, layer, panel
+  or crate. It repairs reporting on an existing port. The `Trigger` port is
+  *consulted* differently, not replaced.
+- **Test-first / golden determinism** — applies to engine bar-building. This
+  touches the strategy kernel's reporting, not the aggregator. Regression
+  tests are still written before the fix (A2), which is the same discipline
+  applied where it belongs.
+- **G4** — expected N/A: the fix targets the per-closed-bar `judge` path. If
+  implementation forces a change to the per-print alarm path, G4 stops being
+  N/A and the measurement is taken. This is stated so a silently-omitted gate
+  and a deliberately-excluded one cannot look alike.
+
+## Evidence, criterion by criterion
+
+Recorded at the point the branch was archived. Every line is a command's
+output or a named test, not a recollection.
+
+| # | Verdict | Evidence |
+| --- | --- | --- |
+| A1 | met | `force::tests::the_floor_measures_the_whole_candle_not_the_body` names the gate on the marked bar's geometry: body 95, candle 140, ratio ~1.84 inside a 1.5–2.5 band, floor 100. Under the old rule `UnderFloor`; under the new one `Force`. |
+| A2 | met | `pane::tests::the_badge_names_the_rulers_own_refusal_and_not_only_an_older_bars`. Run against the pre-fix badge composition it fails with the reported sentence, verbatim: `⚡ SellGainAlarm · last held: the body never cut the region` — the exact string in the trader's screenshot. |
+| A3 | met | Same test asserts the ruler's reading leads and carries its number (`×`). `ForceTrigger::status` already covered `Warmup`, `FlatAverage`, `NoSide`, `Quiet`, `Force`, `UnderFloor` and `Exhaustion`; the badge now reaches all of them through one call rather than none. |
+| A4 | met | Same test asserts ordering: the current-bar sentence precedes `last held:`, so a standing refusal can no longer stand alone and read as fresh. |
+| A5 | met | `git diff` shows `crates/strategy/src/armed.rs`, `crates/strategy/tests/full_operation.rs`, `crates/backtest/tests/harness.rs` and `crates/app/src/strategy_anchors.rs` are **pure rename** — no non-`min_body`/`min_size` line changed. The state machine and the backtest harness are untouched. One assertion changed for the floor's new semantics (`the_candle_floor_holds_quiet_what_the_band_alone_would_call_force`: `body: 60` → `size: 62`), listed in the PR body. |
+| A6 | met | Reported in the PR body with the WINV26 calibration note quoted and the BTC figure (100 is 0.06% of a 180,000 price). The trader's `quantick-strategies.toml` lives outside the repo and is not written by this branch. |
+| A7 | met | `the_floor_measures_the_whole_candle_not_the_body` passes; `ForceParams::min_size` and `BarVerdict::UnderFloor { size }` carry the new meaning in their names and docs. |
+| A8 | met | `strategy_presets::tests::a_bank_written_under_the_old_min_body_key_keeps_its_floor`. The fixture is written by the bank itself and only its key renamed, so it asserts the serde alias rather than a hand-typed schema. |
+| A9 | met | `a_wick_dominated_candle_clears_the_floor_and_the_band_still_refuses_it` — the doji **D5** accepts, bounded by the ratio band and pinned so loosening that band fails a test. |
+| G1 | met | `tracked_files_are_written_in_english` passes (4/4 in `language_guard`). |
+| G2 | met | Four checks, each run on its own, exit 0: fmt, clippy (`-D warnings`), build, test. One pre-existing environmental failure — see below. |
+| G3 | met | Declared below. |
+| G4 | **partial** | See below — an honest gap, not a pass. |
+| G5 | **partial** | See below — an honest gap, not a pass. |
+| G6 | pending | `arch-review`, run after this file is archived. |
+| G7 | met | No new threshold introduced. The floor, band and window stay named parameters; the one number added is the `size_guard` ceiling, raised deliberately with a comment giving the reason. |
+
+### The one test failure, and why it is not this branch
+
+`the_bridge_paging_tests_pass` fails in this environment and does so on
+`main` too: the cargo wrapper shells out to `python3`, which resolves to a
+Microsoft Store alias here. Run directly, `python bridge/mt5/tests/test_paging.py`
+reports **all checks passed across 31 tests**, exit 0 — which is what CI runs.
+
+### G3 — performance impact, by rate class
+
+- `ForceWindow::weigh` — **per closed bar** (rare). One extra subtraction
+  (`high - low`), computed once and reused by the gate and the `ForceBar`
+  it builds. No allocation.
+- `ArmedStrategy::on_closed_bar` — **per closed bar** (rare). Unchanged.
+- `ChartPane::badge_text_for` — **per frame**, once per armed instance
+  (hot). This is the one path that grew: it now calls `Trigger::status()`,
+  which returns an owned `String`, when no gate refused the current bar.
+  The port returns `String`, so the allocation cannot be avoided without
+  changing the trait; it is bounded by the number of armed instances on
+  screen (single digits) and sits beside allocations the function already
+  made. **This is the change's only hot-path cost and it is not measured
+  away — see G4.**
+
+### G4 and G5 — what could not be finished, and why
+
+Both are **partial**. Saying so rather than quietly dropping them is the
+point of writing "not applicable and why" into this file at all.
+
+A run of the branch build reached the armed-instance surface
+(`QUANTICK_STRATEGY_DEMO=1`, stores redirected to a scratchpad so the
+trader's workspace could not be touched) and stayed healthy for its whole
+life: **fps 59–60, frame_avg 16.64–16.67 ms, frame_cpu 1.9–4.5 ms** on a
+live Binance tape at ~39 trades/s. That is the vsync ceiling, so nothing in
+this change costs a visible frame.
+
+It is short of what G4 asked for on two counts, and both are stated rather
+than glossed: there is **no `main` control run** to compare against, and the
+demo region only staged near the end of the run, so those frames are mostly
+*not* frames that drew an armed badge. The number is real; it is weaker
+evidence than the criterion wanted.
+
+G5's screenshot could not be taken at all. The launched window opened
+minimized, and `PrintWindow` returns a fully black raster for its GPU
+surface in that state (verified by sampling: 0 non-black pixels of ~5,500
+sampled). Restoring it without focus did not help; getting a real raster
+needs the window raised over the desktop — and the trader was **using the
+application at that moment**, in their own live MetaTrader session. The
+`ui-harness` rule is explicit that a capture run is a guest and must not
+fight the user, so the run was ended and its process closed, leaving the
+trader's untouched.
+
+What stands in place of the screenshot: the badge sentence is asserted
+character-level by an automated test, including the ordering of its
+clauses, and the pre-fix composition was shown to reproduce the reported
+string exactly. What is genuinely **not** evidenced is how the longer
+sentence *looks* in a chart corner — whether it crowds the drawing at small
+window sizes. That is a real question this branch does not answer, and it
+belongs to `trader-ux-review` and to the trader's own eye.
+
+## Closing steps
+
+- **C1** — `delivery-review` returns PASS.
+- **C2** — The PR is open with CI green.
+
+## The request as received
+
+Quoted verbatim and untranslated, per `CLAUDE.md`'s exemption for a marked,
+attributed quotation: these are the trader's own words, and `delivery-review`
+re-derives the asks from them rather than from this file's paraphrase. A
+translation here would make the ledger its own source of truth, which is the
+failure the section exists to prevent.
+
+> **Trader, 2026-08-31, message 1 (with a chart screenshot; a red arrow marks
+> a bar at the top of the upper `SellGainAlarm` region, ~15:03, BTCUSDT
+> 2000-tick):**
+>
+> identficar a causa de nao ter feito essa venda na parte superior na zona de venda
+
+> **Trader, 2026-08-31, message 2 (sent mid-turn):**
+>
+> e faça a correção
+
+> **Trader, 2026-08-31, message 3 (sent mid-turn, after the diagnosis was
+> presented — the source of `R3`):**
+>
+> achoq ue esse min body deveria ser min tamanho do candle nao?
+
+The screenshot is part of the request: the badge visible in it reads
+`⚡ SellGainAlarm · last held: the body never cut the region`, and that
+sentence being about a different bar is the defect this mission fixes.

--- a/.claude/GOAL-archive-sell-zone-entry-diagnosis.md
+++ b/.claude/GOAL-archive-sell-zone-entry-diagnosis.md
@@ -261,13 +261,20 @@ reports **all checks passed across 31 tests**, exit 0 — which is what CI runs.
   it builds. No allocation.
 - `ArmedStrategy::on_closed_bar` — **per closed bar** (rare). Unchanged.
 - `ChartPane::badge_text_for` — **per frame**, once per armed instance
-  (hot). This is the one path that grew: it now calls `Trigger::status()`,
-  which returns an owned `String`, when no gate refused the current bar.
-  The port returns `String`, so the allocation cannot be avoided without
-  changing the trait; it is bounded by the number of armed instances on
-  screen (single digits) and sits beside allocations the function already
-  made. **This is the change's only hot-path cost and it is not measured
-  away — see G4.**
+  (hot). The first version of this fix called `Trigger::status()` here,
+  which returns an owned `String` — a `format!` per armed instance per
+  frame, and a dimension-2 finding against my own change. It was caught in
+  arch-review and removed rather than declared: `ArmedStrategy` now caches
+  the ruler's reading in `trigger_status`, refreshed at the three sites
+  that can change what the ruler would say (a judged bar, a warmup, a
+  re-arm that resets the series), and the badge **borrows** it. The
+  allocation moved from 60 Hz to the bar rate, and
+  `the_cached_ruler_reading_never_drifts_from_the_trigger` pins the cache
+  to the trigger so the saving cannot become a stale badge — the exact
+  failure this branch exists to fix.
+- `ArmedStrategy::status_line` now reads the same cached string, so the
+  chart badge and the right-click menu quote **one** value rather than two
+  calls that happen to agree.
 
 ### G4 and G5 — what could not be finished, and why
 
@@ -279,7 +286,9 @@ A run of the branch build reached the armed-instance surface
 trader's workspace could not be touched) and stayed healthy for its whole
 life: **fps 59–60, frame_avg 16.64–16.67 ms, frame_cpu 1.9–4.5 ms** on a
 live Binance tape at ~39 trades/s. That is the vsync ceiling, so nothing in
-this change costs a visible frame.
+this change costs a visible frame. Those numbers were taken **before**
+the cache above landed, so they measure the more expensive version; the
+shipped one does strictly less work per frame.
 
 It is short of what G4 asked for on two counts, and both are stated rather
 than glossed: there is **no `main` control run** to compare against, and the

--- a/.claude/GOAL-archive-sell-zone-entry-diagnosis.md
+++ b/.claude/GOAL-archive-sell-zone-entry-diagnosis.md
@@ -161,8 +161,8 @@ refusal, present-tense-adjacent, with no way to tell.
       whose candle clears it is now **force**, and the marked bar is exactly
       that case.
       *Evidence:* a test over the marked bar's reconstructed geometry
-      asserting `Force` where today it is `UnderFloor`, plus the renamed
-      field carrying the new meaning in its name and docs.
+      asserting `Force` where today it is `UnderFloor`, plus the renamed field
+      (`min_range`, matching `ForceBar.range`) carrying the new meaning.
       → `crates/strategy/src/force.rs` tests. *(R3, D5)*
 - [x] **A8** — A preset saved before this change keeps working, and its
       stored number is carried into the new meaning **visibly**, not
@@ -234,9 +234,9 @@ output or a named test, not a recollection.
 | A2 | met | `pane::tests::the_badge_names_the_rulers_own_refusal_and_not_only_an_older_bars`. Run against the pre-fix badge composition it fails with the reported sentence, verbatim: `⚡ SellGainAlarm · last held: the body never cut the region` — the exact string in the trader's screenshot. |
 | A3 | met | Two halves. Prose: the badge leads with the ruler's reading and its number (`×`). **Value:** `Trigger::refusal()` is a new port method returning a stable name per verdict, handed out by `ArmedStrategy::ruler_refusal()`, so an operator that is not looking at the chart can tell the ruler declined this bar without parsing English. Proven by `every_ruler_verdict_that_declines_a_bar_has_a_readable_name` (one assertion per verdict, no catch-all) and `a_ruler_refused_bar_leaves_the_gates_reason_standing_and_says_so`. **The first version of this branch claimed A3 on the badge text alone; arch-review caught that the machine-readable half named in the criterion had not been written, and it was built rather than the criterion quietly reworded.** |
 | A4 | met | Same test asserts ordering: the current-bar sentence precedes `last held:`, so a standing refusal can no longer stand alone and read as fresh. |
-| A5 | met | `git diff` shows `crates/strategy/src/armed.rs`, `crates/strategy/tests/full_operation.rs`, `crates/backtest/tests/harness.rs` and `crates/app/src/strategy_anchors.rs` are **pure rename** — no non-`min_body`/`min_range` line changed. The state machine and the backtest harness are untouched. One assertion changed for the floor's new semantics (`the_candle_floor_holds_quiet_what_the_band_alone_would_call_force`: `body: 60` → `size: 62`), listed in the PR body. |
+| A5 | met, restated | **The earlier version of this row was wrong and arch-review caught it.** It claimed `crates/strategy/src/armed.rs` was a "pure rename" with "the state machine untouched"; `armed.rs` in fact gained `ruler_refusal()` and its tests. What is true, and checkable: `crates/strategy/tests/full_operation.rs`, `crates/backtest/tests/harness.rs`, `crates/app/src/app.rs` and `crates/app/src/strategy_anchors.rs` are pure rename — no line outside `min_body`/`min_range` changed. In `armed.rs` the *state machine* is untouched: no gate, no transition and no emitted `Command` changed, and every pre-existing command-emission test passes unedited. The additions are one read-only accessor and tests. The branch's only behavioural change is the floor (**A7**), plus one assertion updated for it (`the_candle_floor_holds_quiet_what_the_band_alone_would_call_force`: `body: 60` → `range: 62`). |
 | A6 | met | Reported in the PR body with the WINV26 calibration note quoted and the BTC figure (100 is 0.06% of a 180,000 price). The trader's `quantick-strategies.toml` lives outside the repo and is not written by this branch. |
-| A7 | met | `the_floor_measures_the_whole_candle_not_the_body` passes; `ForceParams::min_range` and `BarVerdict::UnderFloor { size }` carry the new meaning in their names and docs. |
+| A7 | met | `the_floor_measures_the_whole_candle_not_the_body` passes; `ForceParams::min_range` and `BarVerdict::UnderFloor { range }` carry the new meaning in their names and docs. |
 | A8 | met | `strategy_presets::tests::a_bank_written_under_the_old_min_body_key_keeps_its_floor`. The fixture is written by the bank itself and only its key renamed, so it asserts the serde alias rather than a hand-typed schema. |
 | A9 | met | Two tests, because the first one alone was not honest. `a_wick_dominated_candle_clears_the_floor_and_the_band_still_refuses_it` shows the gates composing — but arch-review pointed out it warms with 30-point bodies, so the ratio is 0.16 and the *band* refuses the bar whatever the floor says, which proves nothing about the regime the floor exists for. `a_congested_tape_admits_more_than_the_body_floor_did` is that regime: a shrunken average body, a bar with a 25-point body on a 140-point candle that the old floor refused and this one admits. The cost of **D5** is now a number somebody can read. |
 | G1 | met | `tracked_files_are_written_in_english` passes (4/4 in `language_guard`). |
@@ -314,38 +314,61 @@ sentence *looks* in a chart corner — whether it crowds the drawing at small
 window sizes. That is a real question this branch does not answer, and it
 belongs to `trader-ux-review` and to the trader's own eye.
 
-## Findings carried into the PR rather than fixed
+## What the two review rounds changed, and what is deferred
 
-`arch-review` step 0 ran at **xhigh** and returned 14 findings. Eleven were
-fixed on the branch. Three are deliberate positions, and they are here so a
-reader argues with a decision instead of missing one:
+`arch-review` step 0 ran twice at **xhigh** — once mid-branch (14 findings)
+and again over the finished branch (13). That second pass is why several
+things in this file read differently from how they were first written.
 
-1. **The `trigger_status` cache is kernel state serving a UI cost.** The
-   review's objection is fair: `badge_text_for` allocates a badge `String`
-   every frame anyway, so removing one allocation of several is a small win
-   bought with a derived field in a pure domain crate and a timing
-   precondition on a public trait. Kept, because `Trigger::status()` formats
-   two `Decimal`s and the surrounding `push_str`s do not, and because the
-   invariant is pinned by
-   `the_cached_ruler_reading_never_drifts_from_the_trigger` rather than left
-   to review. The precondition the review asked for is now written on
-   `Trigger::status` itself. The reviewer's alternative — cache the composed
-   badge text in `ChartPane` — is better and is the right follow-up.
-2. **The badge can now chain four clauses (~110 characters) with no
-   truncation.** Real, and this branch cannot answer it: G5's screenshot
-   could not be taken (see above), so how the longer sentence sits in a chart
-   corner is exactly the thing with no evidence behind it. It belongs to
-   `trader-ux-review` and to the trader's eye, not to a reviewer's guess.
-3. **The form still ships `100` as the floor's starting point.** Instrument-
-   blind, and the comment above it now says so. Changing it is a trading
-   decision the trader reserved under **D1**/**A6**; this branch reports the
-   number and does not pick a new one.
+**Two of my own fixes were reverted because the review was right about
+them:**
 
-**One-way migration, stated because nobody should find it in a fill.** A bank
-written by this build says `min_range`. Aliases carry `min_body` and the
-short-lived `min_size` *forward*, but an older build reading `min_range`
-knows no such key and falls through to `0`, switching the floor off. Rolling
-back this build therefore needs the preset's floor re-entered by hand.
+1. **The `trigger_status` cache is gone.** It moved a `format!` off the
+   badge's per-frame path, and both rounds objected. The decisive argument
+   was not the one I had weighed: `crates/backtest` calls `on_closed_bar`
+   for every bar of every recorded session and never reads the cached
+   string, so the cache added an unconditional allocation to a batch loop
+   to save one of several allocations on a paint path that allocates
+   regardless. It also bought a coherence invariant in a pure domain crate
+   and a timing precondition on a public trait. The badge asks the ruler
+   directly again. The real fix — caching the *composed* badge string in
+   `ChartPane`, where the per-frame cost actually is — is a follow-up, not
+   this branch.
+2. **The alarm-only `aside()` on the badge is gone.** It was scope I added
+   from a "consider"-grade note in round one, and it shipped two defects:
+   the branch was not gated on `armed`, and `disarm()` never clears the
+   note, so a disarmed alarm-only instance would have painted its aside
+   forever while the menu said "disarmed" — re-introducing the exact
+   two-surface divergence this branch exists to end. It also stuttered,
+   because `strategy_anchors::badge_text` already emits an "alarm only"
+   clause. Reverted whole.
+
+**Still deferred, deliberately:**
+
+- **The form ships `100` as the floor's starting point.** Instrument-blind,
+  and the comment above it now says so. Picking a new number is a trading
+  decision the trader reserved under **D1**/**A6**.
+- **The badge can chain three clauses with no truncation.** Real, and this
+  branch cannot answer it: G5's screenshot could not be taken, so how the
+  longer sentence sits in a chart corner has no evidence behind it. It
+  belongs to `trader-ux-review`.
+- **`ruler_refusal()` has no production consumer yet.** The stable names it
+  returns are read by tests and by nothing else, because the control
+  plane's scene does not carry armed instances — `badge_text_for`'s own doc
+  already filed that. **A3** asked for the machine-readable half to exist
+  and it does, at the port; wiring it into `quantick_get_scene` is the
+  follow-up that makes it reachable from outside the process.
+
+**Migration, restated after the review.** The `#[serde(alias)]` this file
+first described is gone. An alias is the *same* field to serde, so a bank
+carrying both keys was a duplicate-field error — and `load_from` answers any
+parse error by starting empty, which the next save writes over every preset
+the trader had. A vintage number is now its own optional field, reconciled
+by `resolved_floor()`, and the bank logs `STRATEGY_FLOOR_REINTERPRETED` when
+it carries one forward, so the change of meaning is visible in the running
+app instead of only in a doc comment. Rolling back to a build before this
+one still finds no key it knows and falls through to `0`; that direction no
+alias here can reach, and the PR body says so.
 
 ## Closing steps
 

--- a/.claude/GOAL-archive-sell-zone-entry-diagnosis.md
+++ b/.claude/GOAL-archive-sell-zone-entry-diagnosis.md
@@ -316,9 +316,31 @@ belongs to `trader-ux-review` and to the trader's own eye.
 
 ## What the two review rounds changed, and what is deferred
 
-`arch-review` step 0 ran twice at **xhigh** — once mid-branch (14 findings)
-and again over the finished branch (13). That second pass is why several
-things in this file read differently from how they were first written.
+`arch-review` step 0 ran three times at **xhigh** — once mid-branch (14 findings)
+again over the finished branch (13), and a third time over the result of
+those fixes (13 more). Forty findings; the review rounds are why several
+things in this file read differently from how they were first written, and
+why two of my own changes are no longer in the branch at all.
+
+The third round's sharpest catch was not a bug in the usual sense. The
+floor and the bracket ruler are **the same measurement**: `signal_from`
+projects off `ForceBar::range`, which is the `high - low` this floor now
+reads. So a bar admitted on its candle rather than its body arms a stop
+sized by that candle — the congestion fixture's 25-point push carries
+`sl_mult × 140` of stop. **D5 changes risk per trade, not only how many
+bars fire**, which no paragraph on this branch had said until the review
+asked. It is now in `ForceParams::min_range`'s own doc and pinned by
+`a_bar_admitted_on_its_candle_projects_off_that_candle`, and it is called
+out in the PR body because it is the trader's decision to hold, not mine
+to bury.
+
+That round also found the migration in a shape that would have reproduced
+this branch's own bug one layer down: a `resolved_floor()` resolver that
+`to_kernel` called and the arming form did not, so a vintage preset would
+have shown a floor of `0` in the dialog while the kernel armed 100. The
+resolver is gone. The vintage number is migrated **once, at load**, into
+the single field every reader already uses, compared as a `Decimal` rather
+than as text so `"0"` and `"0.0"` cannot mean opposite things.
 
 **Two of my own fixes were reverted because the review was right about
 them:**
@@ -352,6 +374,13 @@ them:**
   branch cannot answer it: G5's screenshot could not be taken, so how the
   longer sentence sits in a chart corner has no evidence behind it. It
   belongs to `trader-ux-review`.
+- **The body floor is gone rather than joined.** `ForceParams` can no
+  longer express a minimum body at all, so the one calibration that was
+  ever measured (247 → 7 on WINV26) is unreachable by any setting. That is
+  **D5** as the trader chose it — "trocar", replace, not "dois pisos" —
+  and reversing it is theirs to ask for, not mine to decide. The doc says
+  what a second floor would be for, so the next person asking is not
+  starting from nothing.
 - **`ruler_refusal()` has no production consumer yet.** The stable names it
   returns are read by tests and by nothing else, because the control
   plane's scene does not carry armed instances — `badge_text_for`'s own doc

--- a/.claude/GOAL-archive-sell-zone-entry-diagnosis.md
+++ b/.claude/GOAL-archive-sell-zone-entry-diagnosis.md
@@ -54,6 +54,24 @@ scope the trader added, not scope this mission invented.
   money-moving change could be reviewed alone; the trader chose one PR, and
   the PR body separates the two so a reviewer can still weigh them apart.)
 
+- **D7 — Ship without the cause confirmed.** `delivery-review` found that
+  every fixture on this branch ran the shipped band (1.5–2.5, window 3)
+  while `SellGainAlarm` runs **`window = 20`, `min_factor = 2`,
+  `max_factor = 4.5`** — and the floor is consulted *only inside the band*,
+  so a body under 2× the 20-bar average is `Quiet` and never reaches a floor
+  of either kind. The marked bar may therefore have been held by the **band**,
+  not the floor, in which case **R3**'s change would not have fired it. There
+  is no BTCUSDT recording of that session on disk (only WDOU26 and WINV26), so
+  it cannot be settled here. **Put to the trader with that stated plainly; they
+  chose to ship**, on the reasoning that the badge repair is precisely the
+  instrument the question needed: the next occurrence will name its own gate
+  ("quiet 1.5×", or "2.2× in band · candle 62 under floor"), and the cause can
+  be closed from evidence instead of inference.
+- **D8 — Three deferrals granted.** The trader approved shipping
+  `ruler_refusal()` with no in-app consumer, **G4** without a `main` control
+  run, and **G5** with neither `visual-qa` nor `trader-ux-review` run. See
+  the `## Deferred` section.
+
 ## Assumptions (S)
 
 - **S1** — The marked bar's body is under 100 price units. Read from the
@@ -405,6 +423,39 @@ app instead of only in a doc comment. Rolling back to a build before this
 one still finds no key it knows and falls through to `0`; that direction no
 alias here can reach, and the PR body says so.
 
+## Deferred
+
+Every line here is **granted by the trader** (**D8**, and **D7** for the
+first). Nothing in this section is a deferral the session gave itself — an
+earlier draft of this file listed two that were, and `delivery-review` failed
+the branch for it.
+
+- **A1 / A7 (the half that names the marked bar's gate)** — *granted under
+  D7.* What is delivered: the reporting defect, proven; the floor measuring
+  the candle, proven; and
+  `under_the_traders_own_band_the_floor_is_only_reached_inside_it`, which
+  writes the two regimes down under the trader's real preset. What is **not**
+  delivered: which regime the marked bar was in. It needs the tape, and no
+  BTCUSDT recording of that session exists. The trader chose to ship and read
+  the repaired badge on the next occurrence.
+- **A3 (the machine-readable half's consumer)** — *granted under D8.*
+  `Trigger::refusal()` and `ArmedStrategy::ruler_refusal()` exist, are
+  exhaustively matched and are tested, but no running surface reads them: the
+  control plane's scene does not carry armed instances. Wiring it into
+  `quantick_get_scene` is the follow-up.
+- **G4 (no `main` control run)** — *granted under D8.* The branch build held
+  fps 59–60 / frame_avg 16.64–16.67 ms on a live tape; there is no control
+  run on `main` to compare against. The per-frame path is the shape `main`
+  already had, since the cache that would have changed it was reverted.
+- **G5 (`visual-qa` and `trader-ux-review` not run)** — *granted under D8.*
+  The `ui-harness` hook exists (`QUANTICK_STRATEGY_DEMO`), but no screenshot
+  could be taken: the window opened minimized, `PrintWindow` returns a black
+  raster in that state, and raising it meant intruding on the trader's live
+  session. Two user-visible changes therefore ship un-reviewed by eye — the
+  badge sentence, and the arming form's label (`and body ≥` →
+  `and candle ≥`, with its tooltip rewritten), which the first draft of this
+  file failed to name at all.
+
 ## Closing steps
 
 - **C1** — `delivery-review` returns PASS.
@@ -432,6 +483,21 @@ failure the section exists to prevent.
 > presented — the source of `R3`):**
 >
 > achoq ue esse min body deveria ser min tamanho do candle nao?
+
+Two later answers came through `AskUserQuestion` rather than as free text, so
+they have no verbatim form to quote; they are recorded as the decisions they
+were, with the option the trader selected named exactly:
+
+> **Trader, 2026-08-31 — answering "o piso min_body: como você quer
+> resolver?", having been told that a range floor lets a wick-dominated doji
+> clear a gate its body could not:** selected **"Trocar para tamanho do candle
+> (high-low)"**, and **"Tudo neste mesmo PR"**. That is `D5` and `D6`.
+
+> **Trader, 2026-08-31 — answering the finding that the floor is only reached
+> inside a band their preset sets at 2–4.5, so the marked bar may have been
+> held by the band instead:** selected **"Subir assim: o badge passa a dizer
+> qual porteira segurou"**, and granted the three deferrals above. That is
+> `D7` and `D8`.
 
 The screenshot is part of the request: the badge visible in it reads
 `⚡ SellGainAlarm · last held: the body never cut the region`, and that

--- a/.claude/GOAL-archive-sell-zone-entry-diagnosis.md
+++ b/.claude/GOAL-archive-sell-zone-entry-diagnosis.md
@@ -72,6 +72,23 @@ scope the trader added, not scope this mission invented.
   run, and **G5** with neither `visual-qa` nor `trader-ux-review` run. See
   the `## Deferred` section.
 
+- **D9 — The Pine input rename ships as-is.** The fourth review round found
+  that renaming the script's input silently reinterprets a saved chart
+  calibration, because indicator settings rebind by position and neither the
+  index nor the type changed. Put to the trader with the alternatives — add a
+  load-time notice for indicator settings, or leave the script measuring the
+  body — and they chose to ship, the default being `0.0` and the field's
+  title now naming the candle. Recorded under `## Deferred`.
+- **D10 — Close the mission here.** Four `arch-review` rounds returned
+  14, 13, 13 and 12 findings, the fourth finding defects inside the third's
+  own fixes. That flat-count, self-inflicted shape is the one
+  `delivery-review` names as a signal to talk rather than run a fifth round,
+  so it was put to the trader: they chose to run both reviews over the final
+  head and open the PR. The smaller findings still open — the badge
+  re-deriving `status_line`'s ordering rather than sharing it, three
+  near-identical fixture helpers, and the badge's unbounded width — are named
+  in the PR body as follow-ups rather than fixed here.
+
 ## Assumptions (S)
 
 - **S1** — The marked bar's body is under 100 price units. Read from the
@@ -430,6 +447,21 @@ first). Nothing in this section is a deferral the session gave itself — an
 earlier draft of this file listed two that were, and `delivery-review` failed
 the branch for it.
 
+- **The Pine input rename reinterprets a saved chart calibration** —
+  *granted under D9.* `min_body_points` became `min_range_points` in
+  `crates/app/scripts/exhaustion_reversal.pine`. Indicator settings persist
+  and rebind **positionally**, and the rename keeps both the index and the
+  `Float` type, so `INDICATOR_INPUTS_REBOUND` never fires: a trader who had
+  calibrated that floor to `100` reloads with `100` now meaning `high - low`.
+  The bank got `STRATEGY_FLOOR_REINTERPRETED` for exactly this; the chart got
+  silence. Put to the trader with that stated, including the option of giving
+  indicator settings the same load-time notice, and they chose to ship: the
+  shipped default is `0.0` (off), so only a trader who set it is affected,
+  and the input's title now reads "min force-bar candle range (points, 0 =
+  off)". The alternative they declined was leaving the script on the body,
+  which would have re-opened the chart-versus-kernel divergence this branch
+  closed.
+
 - **A1 / A7 (the half that names the marked bar's gate)** — *granted under
   D7.* What is delivered: the reporting defect, proven; the floor measuring
   the candle, proven; and
@@ -455,34 +487,6 @@ the branch for it.
   badge sentence, and the arming form's label (`and body ≥` →
   `and candle ≥`, with its tooltip rewritten), which the first draft of this
   file failed to name at all.
-
-## Deferral requested — NOT granted
-
-One finding from the fourth review round has **not** been put to the trader
-and is not covered by **D7** or **D8**. It is here under a heading that says
-so, because a heading is the part that gets skimmed and `## Deferred` would
-claim an approval nobody gave.
-
-- **The Pine input rename silently reinterprets a saved chart calibration.**
-  `min_body_points` became `min_range_points` in
-  `crates/app/scripts/exhaustion_reversal.pine`. Indicator settings persist
-  positionally (`indicators/state_file.rs`) and rebind by position
-  (`indicator_worker.rs`), and the rename keeps both the index and the
-  `Float` type — so a trader who calibrated that floor to `100` reloads with
-  `100` now meaning `high - low` instead of `|close - open|`, a strictly
-  looser gate that paints more force bars. Because the count and types are
-  unchanged, `INDICATOR_INPUTS_REBOUND` never fires and **nothing is
-  logged**. The strategy bank got `STRATEGY_FLOOR_REINTERPRETED` for exactly
-  this situation; the chart the trader calibrates against got silence, which
-  is the data-honesty rule pointing the other way.
-  *Mitigating, but not sufficient:* the input's own title now reads "min
-  force-bar candle range (points, 0 = off)", so a trader who opens the
-  settings dialog sees the new wording, and the shipped default is `0.0`
-  (off), so only a trader who set it is affected.
-  *The decision this needs:* whether to ship it as-is (the same
-  reinterpretation the trader accepted for the bank), to give indicator
-  settings the same load-time notice the bank got, or to leave the script on
-  the body and re-open the chart-versus-kernel divergence.
 
 ## Closing steps
 
@@ -526,6 +530,12 @@ were, with the option the trader selected named exactly:
 > held by the band instead:** selected **"Subir assim: o badge passa a dizer
 > qual porteira segurou"**, and granted the three deferrals above. That is
 > `D7` and `D8`.
+
+> **Trader, 2026-08-31 — answering the fourth round's finding that renaming
+> the Pine input silently reinterprets a saved chart calibration:** selected
+> **"Subir assim — default é 0 e o título do campo mudou"**, and, on how to
+> close, **"Fechar: rodar os dois reviews e abrir o PR"**. That is `D9` and
+> `D10`.
 
 The screenshot is part of the request: the badge visible in it reads
 `⚡ SellGainAlarm · last held: the body never cut the region`, and that

--- a/.claude/GOAL-archive-sell-zone-entry-diagnosis.md
+++ b/.claude/GOAL-archive-sell-zone-entry-diagnosis.md
@@ -456,6 +456,34 @@ the branch for it.
   `and candle ≥`, with its tooltip rewritten), which the first draft of this
   file failed to name at all.
 
+## Deferral requested — NOT granted
+
+One finding from the fourth review round has **not** been put to the trader
+and is not covered by **D7** or **D8**. It is here under a heading that says
+so, because a heading is the part that gets skimmed and `## Deferred` would
+claim an approval nobody gave.
+
+- **The Pine input rename silently reinterprets a saved chart calibration.**
+  `min_body_points` became `min_range_points` in
+  `crates/app/scripts/exhaustion_reversal.pine`. Indicator settings persist
+  positionally (`indicators/state_file.rs`) and rebind by position
+  (`indicator_worker.rs`), and the rename keeps both the index and the
+  `Float` type — so a trader who calibrated that floor to `100` reloads with
+  `100` now meaning `high - low` instead of `|close - open|`, a strictly
+  looser gate that paints more force bars. Because the count and types are
+  unchanged, `INDICATOR_INPUTS_REBOUND` never fires and **nothing is
+  logged**. The strategy bank got `STRATEGY_FLOOR_REINTERPRETED` for exactly
+  this situation; the chart the trader calibrates against got silence, which
+  is the data-honesty rule pointing the other way.
+  *Mitigating, but not sufficient:* the input's own title now reads "min
+  force-bar candle range (points, 0 = off)", so a trader who opens the
+  settings dialog sees the new wording, and the shipped default is `0.0`
+  (off), so only a trader who set it is affected.
+  *The decision this needs:* whether to ship it as-is (the same
+  reinterpretation the trader accepted for the bank), to give indicator
+  settings the same load-time notice the bank got, or to leave the script on
+  the body and re-open the chart-versus-kernel divergence.
+
 ## Closing steps
 
 - **C1** — `delivery-review` returns PASS.

--- a/.claude/GOAL-archive-sell-zone-entry-diagnosis.md
+++ b/.claude/GOAL-archive-sell-zone-entry-diagnosis.md
@@ -232,13 +232,13 @@ output or a named test, not a recollection.
 | --- | --- | --- |
 | A1 | met | `force::tests::the_floor_measures_the_whole_candle_not_the_body` names the gate on the marked bar's geometry: body 95, candle 140, ratio ~1.84 inside a 1.5–2.5 band, floor 100. Under the old rule `UnderFloor`; under the new one `Force`. |
 | A2 | met | `pane::tests::the_badge_names_the_rulers_own_refusal_and_not_only_an_older_bars`. Run against the pre-fix badge composition it fails with the reported sentence, verbatim: `⚡ SellGainAlarm · last held: the body never cut the region` — the exact string in the trader's screenshot. |
-| A3 | met | Same test asserts the ruler's reading leads and carries its number (`×`). `ForceTrigger::status` already covered `Warmup`, `FlatAverage`, `NoSide`, `Quiet`, `Force`, `UnderFloor` and `Exhaustion`; the badge now reaches all of them through one call rather than none. |
+| A3 | met | Two halves. Prose: the badge leads with the ruler's reading and its number (`×`). **Value:** `Trigger::refusal()` is a new port method returning a stable name per verdict, handed out by `ArmedStrategy::ruler_refusal()`, so an operator that is not looking at the chart can tell the ruler declined this bar without parsing English. Proven by `every_ruler_verdict_that_declines_a_bar_has_a_readable_name` (one assertion per verdict, no catch-all) and `a_ruler_refused_bar_leaves_the_gates_reason_standing_and_says_so`. **The first version of this branch claimed A3 on the badge text alone; arch-review caught that the machine-readable half named in the criterion had not been written, and it was built rather than the criterion quietly reworded.** |
 | A4 | met | Same test asserts ordering: the current-bar sentence precedes `last held:`, so a standing refusal can no longer stand alone and read as fresh. |
-| A5 | met | `git diff` shows `crates/strategy/src/armed.rs`, `crates/strategy/tests/full_operation.rs`, `crates/backtest/tests/harness.rs` and `crates/app/src/strategy_anchors.rs` are **pure rename** — no non-`min_body`/`min_size` line changed. The state machine and the backtest harness are untouched. One assertion changed for the floor's new semantics (`the_candle_floor_holds_quiet_what_the_band_alone_would_call_force`: `body: 60` → `size: 62`), listed in the PR body. |
+| A5 | met | `git diff` shows `crates/strategy/src/armed.rs`, `crates/strategy/tests/full_operation.rs`, `crates/backtest/tests/harness.rs` and `crates/app/src/strategy_anchors.rs` are **pure rename** — no non-`min_body`/`min_range` line changed. The state machine and the backtest harness are untouched. One assertion changed for the floor's new semantics (`the_candle_floor_holds_quiet_what_the_band_alone_would_call_force`: `body: 60` → `size: 62`), listed in the PR body. |
 | A6 | met | Reported in the PR body with the WINV26 calibration note quoted and the BTC figure (100 is 0.06% of a 180,000 price). The trader's `quantick-strategies.toml` lives outside the repo and is not written by this branch. |
-| A7 | met | `the_floor_measures_the_whole_candle_not_the_body` passes; `ForceParams::min_size` and `BarVerdict::UnderFloor { size }` carry the new meaning in their names and docs. |
+| A7 | met | `the_floor_measures_the_whole_candle_not_the_body` passes; `ForceParams::min_range` and `BarVerdict::UnderFloor { size }` carry the new meaning in their names and docs. |
 | A8 | met | `strategy_presets::tests::a_bank_written_under_the_old_min_body_key_keeps_its_floor`. The fixture is written by the bank itself and only its key renamed, so it asserts the serde alias rather than a hand-typed schema. |
-| A9 | met | `a_wick_dominated_candle_clears_the_floor_and_the_band_still_refuses_it` — the doji **D5** accepts, bounded by the ratio band and pinned so loosening that band fails a test. |
+| A9 | met | Two tests, because the first one alone was not honest. `a_wick_dominated_candle_clears_the_floor_and_the_band_still_refuses_it` shows the gates composing — but arch-review pointed out it warms with 30-point bodies, so the ratio is 0.16 and the *band* refuses the bar whatever the floor says, which proves nothing about the regime the floor exists for. `a_congested_tape_admits_more_than_the_body_floor_did` is that regime: a shrunken average body, a bar with a 25-point body on a 140-point candle that the old floor refused and this one admits. The cost of **D5** is now a number somebody can read. |
 | G1 | met | `tracked_files_are_written_in_english` passes (4/4 in `language_guard`). |
 | G2 | met | Four checks, each run on its own, exit 0: fmt, clippy (`-D warnings`), build, test. One pre-existing environmental failure — see below. |
 | G3 | met | Declared below. |
@@ -313,6 +313,39 @@ string exactly. What is genuinely **not** evidenced is how the longer
 sentence *looks* in a chart corner — whether it crowds the drawing at small
 window sizes. That is a real question this branch does not answer, and it
 belongs to `trader-ux-review` and to the trader's own eye.
+
+## Findings carried into the PR rather than fixed
+
+`arch-review` step 0 ran at **xhigh** and returned 14 findings. Eleven were
+fixed on the branch. Three are deliberate positions, and they are here so a
+reader argues with a decision instead of missing one:
+
+1. **The `trigger_status` cache is kernel state serving a UI cost.** The
+   review's objection is fair: `badge_text_for` allocates a badge `String`
+   every frame anyway, so removing one allocation of several is a small win
+   bought with a derived field in a pure domain crate and a timing
+   precondition on a public trait. Kept, because `Trigger::status()` formats
+   two `Decimal`s and the surrounding `push_str`s do not, and because the
+   invariant is pinned by
+   `the_cached_ruler_reading_never_drifts_from_the_trigger` rather than left
+   to review. The precondition the review asked for is now written on
+   `Trigger::status` itself. The reviewer's alternative — cache the composed
+   badge text in `ChartPane` — is better and is the right follow-up.
+2. **The badge can now chain four clauses (~110 characters) with no
+   truncation.** Real, and this branch cannot answer it: G5's screenshot
+   could not be taken (see above), so how the longer sentence sits in a chart
+   corner is exactly the thing with no evidence behind it. It belongs to
+   `trader-ux-review` and to the trader's eye, not to a reviewer's guess.
+3. **The form still ships `100` as the floor's starting point.** Instrument-
+   blind, and the comment above it now says so. Changing it is a trading
+   decision the trader reserved under **D1**/**A6**; this branch reports the
+   number and does not pick a new one.
+
+**One-way migration, stated because nobody should find it in a fill.** A bank
+written by this build says `min_range`. Aliases carry `min_body` and the
+short-lived `min_size` *forward*, but an older build reading `min_range`
+knows no such key and falls through to `0`, switching the floor off. Rolling
+back this build therefore needs the preset's floor re-entered by hand.
 
 ## Closing steps
 

--- a/crates/app/scripts/exhaustion_reversal.pine
+++ b/crates/app/scripts/exhaustion_reversal.pine
@@ -279,9 +279,9 @@ arm_window = math.max(run_window, cover_window)
 // `not na` guards are what keep the opening stretch unmarked.
 // The ratio and the floor, in that order: the ratio rejects most bars on its
 // own, so the floor is a comparison the short-circuit rarely reaches. A floor
-// of 0 is `body >= 0`, true for every bar including a doji — the ratio is
+// of 0 is `high - low >= 0`, true for every bar including a doji — the ratio is
 // what still decides, exactly as it did before this input existed.
-big_body = not na(avg_body_before) and avg_body_before > 0 and body >= body_factor * avg_body_before and (high - low) >= min_range_points
+big_enough = not na(avg_body_before) and avg_body_before > 0 and body >= body_factor * avg_body_before and (high - low) >= min_range_points
 new_high = not na(high_before) and high >= high_before
 new_low = not na(low_before) and low <= low_before
 
@@ -294,8 +294,8 @@ var int bull_run = 0
 bear_run := bear_bar ? bear_run + 1 : 0
 bull_run := bull_bar ? bull_run + 1 : 0
 
-top_anchor = big_body and new_high and (not need_direction or bull_bar)
-bottom_anchor = big_body and new_low and (not need_direction or bear_bar)
+top_anchor = big_enough and new_high and (not need_direction or bull_bar)
+bottom_anchor = big_enough and new_low and (not need_direction or bear_bar)
 
 // ------------------------------------------------------------------- state
 

--- a/crates/app/scripts/exhaustion_reversal.pine
+++ b/crates/app/scripts/exhaustion_reversal.pine
@@ -120,16 +120,12 @@
 // an absolute floor of 100 points left 7 (see docs/ux/strategy-anchors.md,
 // which is why the strategy kernel's force ruler carries a floor at all).
 //
-// NOTE, and read it before calibrating against the bot: this script's floor
-// below measures the BODY (`body >= min_body_points`), while the kernel's
-// `min_range` measures the whole CANDLE (`high - low`). They were the same
-// rule until the kernel's floor was changed on the trader's instruction;
-// this script was deliberately left measuring the body so that the paint on
-// an existing chart did not move under anyone. The consequence is real: the
-// same number in both places is a STRICTER gate here than in the armed
-// instance, so a bar this script leaves unpainted can still fire the bot.
-// Calibrate each against itself, and change this input's meaning here only
-// as a deliberate edit — not by assuming the two agree.
+// The floor measures the WHOLE CANDLE (`high - low`), the same measurement
+// the kernel's `min_range` uses. It measured the body until the trader asked
+// for the candle instead; both moved together, on purpose. A chart that
+// paints a force bar and an armed instance that fires on one must mean the
+// same thing by the word, or a trader calibrates against this script and
+// then watches the bot take a bar the chart left unmarked.
 //
 // So section 5 adds a floor in POINTS, `and`ed with the ratio above: a
 // bar must be big relative to its neighbours AND big in the instrument's own
@@ -234,7 +230,7 @@ show_bottom = input.bool(true, "4 Display: mark bottom reversals (buy side)")
 // instrument priced in fractions a drag of 1 per pixel is far too coarse and
 // the number is typed instead. A script cannot ask what a tick is worth here,
 // so one of the two has to be the dragged case.
-min_body_points = input.float(0.0, "5 Calibration: min force-bar body (points, 0 = off)", minval=0.0, step=1.0)
+min_range_points = input.float(0.0, "5 Calibration: min force-bar candle range (points, 0 = off)", minval=0.0, step=1.0)
 run_body_only = input.bool(true, "5 Calibration: run measures the body, not the range")
 cover_body_only = input.bool(true, "5 Calibration: cover measures the body, not the range")
 paint_force = input.bool(false, "5 Calibration: paint the bars that arm a push")
@@ -285,7 +281,7 @@ arm_window = math.max(run_window, cover_window)
 // own, so the floor is a comparison the short-circuit rarely reaches. A floor
 // of 0 is `body >= 0`, true for every bar including a doji — the ratio is
 // what still decides, exactly as it did before this input existed.
-big_body = not na(avg_body_before) and avg_body_before > 0 and body >= body_factor * avg_body_before and body >= min_body_points
+big_body = not na(avg_body_before) and avg_body_before > 0 and body >= body_factor * avg_body_before and (high - low) >= min_range_points
 new_high = not na(high_before) and high >= high_before
 new_low = not na(low_before) and low <= low_before
 

--- a/crates/app/scripts/exhaustion_reversal.pine
+++ b/crates/app/scripts/exhaustion_reversal.pine
@@ -118,7 +118,18 @@
 // chart would call one. This is measured, not suspected: on a live WINV26
 // session the same bare band marked 247 of 1 355 volume bars as force bars;
 // an absolute floor of 100 points left 7 (see docs/ux/strategy-anchors.md,
-// which is why the strategy kernel's force ruler carries `min_body`).
+// which is why the strategy kernel's force ruler carries a floor at all).
+//
+// NOTE, and read it before calibrating against the bot: this script's floor
+// below measures the BODY (`body >= min_body_points`), while the kernel's
+// `min_range` measures the whole CANDLE (`high - low`). They were the same
+// rule until the kernel's floor was changed on the trader's instruction;
+// this script was deliberately left measuring the body so that the paint on
+// an existing chart did not move under anyone. The consequence is real: the
+// same number in both places is a STRICTER gate here than in the armed
+// instance, so a bar this script leaves unpainted can still fire the bot.
+// Calibrate each against itself, and change this input's meaning here only
+// as a deliberate edit — not by assuming the two agree.
 //
 // So section 5 adds a floor in POINTS, `and`ed with the ratio above: a
 // bar must be big relative to its neighbours AND big in the instrument's own

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -13659,7 +13659,7 @@ crosshair = false
         form.window = 3;
         // The fixture's bodies are 4 points; the elephant floor is off so
         // the test exercises the band, not the floor (which has its own).
-        form.min_body = "0".to_owned();
+        form.min_size = "0".to_owned();
         app.arm_strategy_instance(pane::PaneSide::Flow, drawing, &form, "test BF".to_owned())
             .expect("the form compiles and the drawing exists");
 
@@ -13785,7 +13785,7 @@ crosshair = false
         let mut form =
             crate::strategy_presets::StoredPreset::starting_point(quantick_engine::Side::Buy);
         form.window = 3;
-        form.min_body = "0".to_owned();
+        form.min_size = "0".to_owned();
         form.alarm = true;
         form.alarm_when = "share".to_owned();
         form.alarm_share_percent = 70;
@@ -13950,7 +13950,7 @@ crosshair = false
         let mut form =
             crate::strategy_presets::StoredPreset::starting_point(quantick_engine::Side::Buy);
         form.window = 3;
-        form.min_body = "0".to_owned();
+        form.min_size = "0".to_owned();
         app.arm_strategy_instance(pane::PaneSide::Flow, drawing, &form, "test BF".to_owned())
             .expect("the form compiles and the drawing exists");
 
@@ -14029,7 +14029,7 @@ crosshair = false
         let mut form =
             crate::strategy_presets::StoredPreset::starting_point(quantick_engine::Side::Buy);
         form.window = 3;
-        form.min_body = "0".to_owned();
+        form.min_size = "0".to_owned();
         app.arm_strategy_instance(pane::PaneSide::Flow, drawing, &form, "test BF".to_owned())
             .expect("arming before any bar closed skips the span guard");
 
@@ -14224,7 +14224,7 @@ crosshair = false
         let mut form =
             crate::strategy_presets::StoredPreset::starting_point(quantick_engine::Side::Sell);
         form.window = 3;
-        form.min_body = "0".to_owned();
+        form.min_size = "0".to_owned();
         form.on_break = "retest_limit".to_owned();
         app.arm_strategy_instance(pane::PaneSide::Flow, drawing, &form, "BF".to_owned())
             .expect("the form compiles");
@@ -14308,7 +14308,7 @@ crosshair = false
         let mut form =
             crate::strategy_presets::StoredPreset::starting_point(quantick_engine::Side::Sell);
         form.window = 3;
-        form.min_body = "0".to_owned();
+        form.min_size = "0".to_owned();
         form.on_break = "retest_limit".to_owned();
         app.arm_strategy_instance(pane::PaneSide::Flow, drawing, &form, "BF no cut".to_owned())
             .expect("the retest form compiles");
@@ -14413,7 +14413,7 @@ crosshair = false
         let mut form =
             crate::strategy_presets::StoredPreset::starting_point(quantick_engine::Side::Sell);
         form.window = 3;
-        form.min_body = "0".to_owned();
+        form.min_size = "0".to_owned();
         form.alarm = true;
         app.arm_strategy_instance(pane::PaneSide::Flow, drawing, &form, "BF sell".to_owned())
             .expect("the form compiles and the span still covers the future");
@@ -14503,7 +14503,7 @@ crosshair = false
         let mut form =
             crate::strategy_presets::StoredPreset::starting_point(quantick_engine::Side::Sell);
         form.window = 3;
-        form.min_body = "0".to_owned();
+        form.min_size = "0".to_owned();
         form.on_break = "retest_limit".to_owned();
         app.arm_strategy_instance(pane::PaneSide::Flow, drawing, &form, "BF retest".to_owned())
             .expect("the retest form compiles");
@@ -14601,7 +14601,7 @@ crosshair = false
         let mut form =
             crate::strategy_presets::StoredPreset::starting_point(quantick_engine::Side::Sell);
         form.window = 3;
-        form.min_body = "0".to_owned();
+        form.min_size = "0".to_owned();
         form.on_break = "retest_limit".to_owned();
         app.arm_strategy_instance(pane::PaneSide::Flow, drawing, &form, "BF retest".to_owned())
             .expect("the retest form compiles");
@@ -14699,7 +14699,7 @@ crosshair = false
         let mut form =
             crate::strategy_presets::StoredPreset::starting_point(quantick_engine::Side::Buy);
         form.window = 3;
-        form.min_body = "0".to_owned();
+        form.min_size = "0".to_owned();
         app.arm_strategy_instance(pane::PaneSide::Flow, first, &form, "a".to_owned())
             .expect("arms");
         app.arm_strategy_instance(pane::PaneSide::Flow, second, &form, "b".to_owned())
@@ -20792,7 +20792,7 @@ crosshair = false
         let mut form =
             crate::strategy_presets::StoredPreset::starting_point(quantick_engine::Side::Sell);
         form.window = 7;
-        form.min_body = "0".to_owned();
+        form.min_size = "0".to_owned();
         form.alarm = true;
         app.arm_strategy_instance(pane::PaneSide::Flow, source, &form, "carry me".to_owned())
             .expect("the region arms");

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -13659,7 +13659,7 @@ crosshair = false
         form.window = 3;
         // The fixture's bodies are 4 points; the elephant floor is off so
         // the test exercises the band, not the floor (which has its own).
-        form.min_size = "0".to_owned();
+        form.min_range = "0".to_owned();
         app.arm_strategy_instance(pane::PaneSide::Flow, drawing, &form, "test BF".to_owned())
             .expect("the form compiles and the drawing exists");
 
@@ -13785,7 +13785,7 @@ crosshair = false
         let mut form =
             crate::strategy_presets::StoredPreset::starting_point(quantick_engine::Side::Buy);
         form.window = 3;
-        form.min_size = "0".to_owned();
+        form.min_range = "0".to_owned();
         form.alarm = true;
         form.alarm_when = "share".to_owned();
         form.alarm_share_percent = 70;
@@ -13950,7 +13950,7 @@ crosshair = false
         let mut form =
             crate::strategy_presets::StoredPreset::starting_point(quantick_engine::Side::Buy);
         form.window = 3;
-        form.min_size = "0".to_owned();
+        form.min_range = "0".to_owned();
         app.arm_strategy_instance(pane::PaneSide::Flow, drawing, &form, "test BF".to_owned())
             .expect("the form compiles and the drawing exists");
 
@@ -14029,7 +14029,7 @@ crosshair = false
         let mut form =
             crate::strategy_presets::StoredPreset::starting_point(quantick_engine::Side::Buy);
         form.window = 3;
-        form.min_size = "0".to_owned();
+        form.min_range = "0".to_owned();
         app.arm_strategy_instance(pane::PaneSide::Flow, drawing, &form, "test BF".to_owned())
             .expect("arming before any bar closed skips the span guard");
 
@@ -14224,7 +14224,7 @@ crosshair = false
         let mut form =
             crate::strategy_presets::StoredPreset::starting_point(quantick_engine::Side::Sell);
         form.window = 3;
-        form.min_size = "0".to_owned();
+        form.min_range = "0".to_owned();
         form.on_break = "retest_limit".to_owned();
         app.arm_strategy_instance(pane::PaneSide::Flow, drawing, &form, "BF".to_owned())
             .expect("the form compiles");
@@ -14308,7 +14308,7 @@ crosshair = false
         let mut form =
             crate::strategy_presets::StoredPreset::starting_point(quantick_engine::Side::Sell);
         form.window = 3;
-        form.min_size = "0".to_owned();
+        form.min_range = "0".to_owned();
         form.on_break = "retest_limit".to_owned();
         app.arm_strategy_instance(pane::PaneSide::Flow, drawing, &form, "BF no cut".to_owned())
             .expect("the retest form compiles");
@@ -14413,7 +14413,7 @@ crosshair = false
         let mut form =
             crate::strategy_presets::StoredPreset::starting_point(quantick_engine::Side::Sell);
         form.window = 3;
-        form.min_size = "0".to_owned();
+        form.min_range = "0".to_owned();
         form.alarm = true;
         app.arm_strategy_instance(pane::PaneSide::Flow, drawing, &form, "BF sell".to_owned())
             .expect("the form compiles and the span still covers the future");
@@ -14503,7 +14503,7 @@ crosshair = false
         let mut form =
             crate::strategy_presets::StoredPreset::starting_point(quantick_engine::Side::Sell);
         form.window = 3;
-        form.min_size = "0".to_owned();
+        form.min_range = "0".to_owned();
         form.on_break = "retest_limit".to_owned();
         app.arm_strategy_instance(pane::PaneSide::Flow, drawing, &form, "BF retest".to_owned())
             .expect("the retest form compiles");
@@ -14601,7 +14601,7 @@ crosshair = false
         let mut form =
             crate::strategy_presets::StoredPreset::starting_point(quantick_engine::Side::Sell);
         form.window = 3;
-        form.min_size = "0".to_owned();
+        form.min_range = "0".to_owned();
         form.on_break = "retest_limit".to_owned();
         app.arm_strategy_instance(pane::PaneSide::Flow, drawing, &form, "BF retest".to_owned())
             .expect("the retest form compiles");
@@ -14699,7 +14699,7 @@ crosshair = false
         let mut form =
             crate::strategy_presets::StoredPreset::starting_point(quantick_engine::Side::Buy);
         form.window = 3;
-        form.min_size = "0".to_owned();
+        form.min_range = "0".to_owned();
         app.arm_strategy_instance(pane::PaneSide::Flow, first, &form, "a".to_owned())
             .expect("arms");
         app.arm_strategy_instance(pane::PaneSide::Flow, second, &form, "b".to_owned())
@@ -20792,7 +20792,7 @@ crosshair = false
         let mut form =
             crate::strategy_presets::StoredPreset::starting_point(quantick_engine::Side::Sell);
         form.window = 7;
-        form.min_size = "0".to_owned();
+        form.min_range = "0".to_owned();
         form.alarm = true;
         app.arm_strategy_instance(pane::PaneSide::Flow, source, &form, "carry me".to_owned())
             .expect("the region arms");

--- a/crates/app/src/pane.rs
+++ b/crates/app/src/pane.rs
@@ -2403,12 +2403,26 @@ impl ChartPane {
         // This is the whole point of the badge and it was reaching only the
         // right-click menu: the trader watches the chart, and "why did
         // nothing happen" is answerable only where they are already looking.
-        if let Some(held) = instance.armed.hold_reason() {
-            text.push_str(if held.fresh {
-                " · "
-            } else {
-                " · last held: "
-            });
+        let held = instance.armed.hold_reason();
+        // A gate that refused *this* bar is the whole answer, and it stands
+        // alone.
+        if let Some(held) = held.filter(|held| held.fresh) {
+            text.push_str(" · ");
+            text.push_str(held.reason);
+            return text;
+        }
+        // Otherwise the ruler is what decided this bar, and its reading is
+        // the only sentence here about the candle in front of the trader.
+        // `status_line` has always led with it and the right-click menu
+        // prints it; this badge did not, so a bar the ruler held showed an
+        // older bar's refusal and nothing about its own — the divergence
+        // `region_pause` above exists to end, found again the same way.
+        if armed {
+            text.push_str(" · ");
+            text.push_str(&instance.armed.trigger().status());
+        }
+        if let Some(held) = held {
+            text.push_str(" · last held: ");
             text.push_str(held.reason);
         }
         text
@@ -10330,6 +10344,135 @@ mod tests {
         assert!(
             !badge.contains("region not active"),
             "and not the general one beside it, which is false here — the              span covers this bar perfectly, the band is hidden: {badge}"
+        );
+    }
+
+    /// A bar with a one-point shadow either side of its body, at sell-zone
+    /// prices.
+    fn zone_bar(open: i64, close: i64) -> quantick_engine::Bar {
+        let open = rust_decimal::Decimal::from(open);
+        let close = rust_decimal::Decimal::from(close);
+        quantick_engine::Bar {
+            open_time: 0,
+            close_time: 0,
+            open,
+            high: open.max(close) + rust_decimal::Decimal::ONE,
+            low: open.min(close) - rust_decimal::Decimal::ONE,
+            close,
+            buy_volume: rust_decimal::Decimal::ONE,
+            sell_volume: rust_decimal::Decimal::ONE,
+            trade_count: 2,
+        }
+    }
+
+    /// The badge must answer about the bar in front of the trader.
+    ///
+    /// This is the bug as reported, reduced: a setup at the top of a sell
+    /// zone did not fire, and the badge read `last held: the body never cut
+    /// the region` — a true sentence about a *different* bar, further down,
+    /// judged earlier. The bar the trader was pointing at had been refused
+    /// by the **ruler**, which produces no signal at all, and the no-signal
+    /// path clears the note and leaves the previous refusal standing.
+    /// `status_line` narrates the ruler in that case and the right-click
+    /// menu shows it; this badge did not, so the chart carried a confident
+    /// answer to a question about another candle.
+    ///
+    /// The assertion that matters is the *order*: what happened on this bar
+    /// leads, and the standing refusal rides behind it, marked as past.
+    #[test]
+    fn the_badge_names_the_rulers_own_refusal_and_not_only_an_older_bars() {
+        let rectangle = drawings::DRAWING_TOOLS
+            .into_iter()
+            .find(|tool| tool.id() == drawings::RECTANGLE_TOOL_ID)
+            .expect("the rectangle tool is registered");
+        let mut pane = ChartPane::flow(1, BarSpec::Tick(50), "TESTUSDT".to_owned());
+        pane.drawings
+            .place(rectangle, drawings::ChartPoint::at(0.0, 180_300.0));
+        pane.drawings
+            .place(rectangle, drawings::ChartPoint::at(30.0, 180_430.0));
+        let id = pane.drawings.items()[0].id;
+
+        let mut instance = crate::strategy_anchors::AnchoredInstance {
+            drawing: id,
+            preset: "SellGainAlarm".to_owned(),
+            spec: crate::strategy_presets::StoredPreset::starting_point(
+                quantick_engine::Side::Sell,
+            ),
+            armed: quantick_strategy::ArmedStrategy::new(
+                quantick_strategy::StrategyParams {
+                    side: quantick_engine::Side::Sell,
+                    quantity: rust_decimal::Decimal::ONE,
+                    tp_mult: rust_decimal::Decimal::ONE,
+                    sl_mult: rust_decimal::Decimal::ONE,
+                    rearm: quantick_strategy::Rearm::Auto,
+                    on_break: quantick_strategy::BreakPolicy::Ignore,
+                    execution: quantick_strategy::Execution::Paper,
+                },
+                Box::new(quantick_strategy::ForceTrigger::new(
+                    quantick_strategy::ForceParams {
+                        window: 3,
+                        min_factor: rust_decimal::Decimal::new(15, 1),
+                        max_factor: rust_decimal::Decimal::new(25, 1),
+                        min_size: rust_decimal::Decimal::ZERO,
+                    },
+                )),
+            ),
+            alarm: None,
+            cue: crate::audio::Cue::default(),
+            mark: crate::strategy_anchors::AlarmMark::Quiet,
+        };
+
+        let region = quantick_strategy::Region::new(
+            rust_decimal::Decimal::from(180_300),
+            rust_decimal::Decimal::from(180_430),
+        );
+        // Two quiet bars warm the 3-bar window, well under the zone.
+        for bar in [zone_bar(180_200, 180_170), zone_bar(180_170, 180_140)] {
+            assert!(
+                instance
+                    .armed
+                    .on_closed_bar(&bar, &region, true, true)
+                    .is_empty()
+            );
+        }
+        // A force bar whose body sits entirely below the zone: the region
+        // gate refuses it by name, and that refusal now stands.
+        assert!(
+            instance
+                .armed
+                .on_closed_bar(&zone_bar(180_140, 180_080), &region, true, true)
+                .is_empty()
+        );
+        assert_eq!(
+            instance.armed.hold_reason().map(|held| held.reason),
+            Some("the body never cut the region"),
+            "the older bar's refusal, which is what used to reach the badge alone"
+        );
+        // Now the bar the trader points at: the ruler refuses it outright,
+        // so no signal is produced and no gate records anything.
+        assert!(
+            instance
+                .armed
+                .on_closed_bar(&zone_bar(180_080, 180_075), &region, true, true)
+                .is_empty()
+        );
+
+        assert!(pane.strategies.arm(instance).is_empty());
+        let badge = pane.strategy_badge_text(id);
+
+        let ruler = badge.find("quiet").unwrap_or_else(|| {
+            panic!("the ruler's reading of this bar belongs on the badge: {badge}")
+        });
+        let stale = badge.find("last held:").unwrap_or_else(|| {
+            panic!("the standing refusal is still worth showing, marked as past: {badge}")
+        });
+        assert!(
+            ruler < stale,
+            "what happened on this bar leads; the older refusal rides behind: {badge}"
+        );
+        assert!(
+            badge.contains('×'),
+            "the ruler's number is the one a trader would act on: {badge}"
         );
     }
 }

--- a/crates/app/src/pane.rs
+++ b/crates/app/src/pane.rs
@@ -2419,7 +2419,7 @@ impl ChartPane {
         // `region_pause` above exists to end, found again the same way.
         if armed {
             text.push_str(" · ");
-            text.push_str(&instance.armed.trigger().status());
+            text.push_str(instance.armed.trigger_status());
         }
         if let Some(held) = held {
             text.push_str(" · last held: ");

--- a/crates/app/src/pane.rs
+++ b/crates/app/src/pane.rs
@@ -2403,6 +2403,14 @@ impl ChartPane {
         // This is the whole point of the badge and it was reaching only the
         // right-click menu: the trader watches the chart, and "why did
         // nothing happen" is answerable only where they are already looking.
+        // A remark that is not a refusal still belongs on the badge: it is
+        // about this instance right now, and leaving it to `status_line`
+        // alone is how the two surfaces came to disagree in the first place.
+        if let Some(aside) = instance.armed.aside() {
+            text.push_str(" · ");
+            text.push_str(aside);
+            return text;
+        }
         let held = instance.armed.hold_reason();
         // A gate that refused *this* bar is the whole answer, and it stands
         // alone.
@@ -10413,7 +10421,7 @@ mod tests {
                         window: 3,
                         min_factor: rust_decimal::Decimal::new(15, 1),
                         max_factor: rust_decimal::Decimal::new(25, 1),
-                        min_size: rust_decimal::Decimal::ZERO,
+                        min_range: rust_decimal::Decimal::ZERO,
                     },
                 )),
             ),

--- a/crates/app/src/pane.rs
+++ b/crates/app/src/pane.rs
@@ -2403,14 +2403,6 @@ impl ChartPane {
         // This is the whole point of the badge and it was reaching only the
         // right-click menu: the trader watches the chart, and "why did
         // nothing happen" is answerable only where they are already looking.
-        // A remark that is not a refusal still belongs on the badge: it is
-        // about this instance right now, and leaving it to `status_line`
-        // alone is how the two surfaces came to disagree in the first place.
-        if let Some(aside) = instance.armed.aside() {
-            text.push_str(" · ");
-            text.push_str(aside);
-            return text;
-        }
         let held = instance.armed.hold_reason();
         // A gate that refused *this* bar is the whole answer, and it stands
         // alone.
@@ -2427,7 +2419,7 @@ impl ChartPane {
         // `region_pause` above exists to end, found again the same way.
         if armed {
             text.push_str(" · ");
-            text.push_str(instance.armed.trigger_status());
+            text.push_str(&instance.armed.trigger().status());
         }
         if let Some(held) = held {
             text.push_str(" · last held: ");

--- a/crates/app/src/strategy_anchors.rs
+++ b/crates/app/src/strategy_anchors.rs
@@ -423,7 +423,7 @@ mod tests {
                     window: 3,
                     min_factor: "1.5".parse().expect("fixture"),
                     max_factor: "2.5".parse().expect("fixture"),
-                    min_size: Decimal::ZERO,
+                    min_range: Decimal::ZERO,
                 })),
             ),
             alarm: None,
@@ -506,7 +506,7 @@ mod tests {
                     window: 3,
                     min_factor: "1.5".parse().expect("fixture"),
                     max_factor: "2.5".parse().expect("fixture"),
-                    min_size: Decimal::ZERO,
+                    min_range: Decimal::ZERO,
                 })),
             ),
             alarm: None,
@@ -595,7 +595,7 @@ mod tests {
                 window: 3,
                 min_factor: "1.5".parse().expect("fixture"),
                 max_factor: "2.5".parse().expect("fixture"),
-                min_size: Decimal::ZERO,
+                min_range: Decimal::ZERO,
             })),
         );
         instance.alarm = Some(SignalAlarm::new(quantick_strategy::AlarmParams {

--- a/crates/app/src/strategy_anchors.rs
+++ b/crates/app/src/strategy_anchors.rs
@@ -423,7 +423,7 @@ mod tests {
                     window: 3,
                     min_factor: "1.5".parse().expect("fixture"),
                     max_factor: "2.5".parse().expect("fixture"),
-                    min_body: Decimal::ZERO,
+                    min_size: Decimal::ZERO,
                 })),
             ),
             alarm: None,
@@ -506,7 +506,7 @@ mod tests {
                     window: 3,
                     min_factor: "1.5".parse().expect("fixture"),
                     max_factor: "2.5".parse().expect("fixture"),
-                    min_body: Decimal::ZERO,
+                    min_size: Decimal::ZERO,
                 })),
             ),
             alarm: None,
@@ -595,7 +595,7 @@ mod tests {
                 window: 3,
                 min_factor: "1.5".parse().expect("fixture"),
                 max_factor: "2.5".parse().expect("fixture"),
-                min_body: Decimal::ZERO,
+                min_size: Decimal::ZERO,
             })),
         );
         instance.alarm = Some(SignalAlarm::new(quantick_strategy::AlarmParams {

--- a/crates/app/src/strategy_presets.rs
+++ b/crates/app/src/strategy_presets.rs
@@ -103,12 +103,13 @@ pub struct StoredPreset {
     ///
     /// Read separately, the number can also be *reported* instead of
     /// swallowed. The floor now measures the whole candle, so the same
-    /// `100` admits every bar it used to and more; [`Self::resolved_floor`]
-    /// carries that number forward — defaulting it to `0` would switch the
-    /// trader's gate off, the loudest possible way to lose a setting — and
-    /// the bank logs `STRATEGY_FLOOR_REINTERPRETED` when it does, beside
-    /// the other load-time anomalies, so the change is visible in the
-    /// running app and not only in a doc comment.
+    /// `100` admits every bar it used to and more;
+    /// [`Self::adopt_vintage_floor`] folds it into [`Self::min_range`] once,
+    /// at load — defaulting it to `0` would switch the trader's gate off,
+    /// the loudest possible way to lose a setting — and the bank logs
+    /// `STRATEGY_FLOOR_REINTERPRETED` and rewrites the file, so the change
+    /// is visible in the running app and the migration happens once rather
+    /// than on every launch.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub min_body: Option<String>,
     /// Take profit = close + `tp_mult` × range, in the trade's favour;
@@ -393,9 +394,15 @@ impl StoredPreset {
     /// number is superseded, and a superseded value that stays in the
     /// struct is one a future save would write back out.
     fn adopt_vintage_floor(&mut self) -> bool {
-        let Some(vintage) = self.min_body.take() else {
+        let Some(vintage) = self.min_body.clone() else {
             return false;
         };
+        // Decide first, clear afterwards. Taking the value up front dropped
+        // the trader's older number on the two paths that return `false` — a
+        // row carrying both keys, and one whose current key will not parse —
+        // and those paths report nothing, so the number vanished from memory
+        // and from the next save with no line anywhere saying it had.
+        self.min_body = None;
         // Compared as numbers, not as text. `"0"`, `"0.0"` and `"0.00"` all
         // mean the floor is off, and a string sentinel would make them
         // behave differently — one spelling adopting the vintage number and
@@ -470,6 +477,9 @@ struct StoreFile {
 pub struct StrategyBank {
     path: PathBuf,
     presets: BTreeMap<String, StoredPreset>,
+    /// Whether this load folded a vintage floor key forward, so the file is
+    /// rewritten once instead of being migrated again on every launch.
+    migrated_floor: bool,
 }
 
 impl StrategyBank {
@@ -488,6 +498,7 @@ impl StrategyBank {
     #[must_use]
     pub fn load_from(path: impl Into<PathBuf>) -> Self {
         let path = path.into();
+        let mut migrated_floor = false;
         let presets = match std::fs::read_to_string(&path) {
             Ok(text) => match toml::from_str::<StoreFile>(&text) {
                 Ok(file) if file.version == STORE_FORMAT_VERSION => {
@@ -497,19 +508,30 @@ impl StrategyBank {
                     // its meaning moved is said out loud, once, beside the
                     // other load-time anomalies.
                     let mut presets = file.presets;
+                    // Every row whose vintage key was consumed is named, not
+                    // only the ones whose number moved: a row carrying both
+                    // keys has its older floor dropped too, and a silent drop
+                    // is the failure this whole migration exists to avoid.
+                    let mut carried = 0_usize;
                     let vintage: Vec<String> = presets
                         .iter_mut()
                         .filter(|(_, preset)| preset.min_body.is_some())
-                        .filter_map(|(name, preset)| {
-                            preset.adopt_vintage_floor().then(|| name.clone())
+                        .map(|(name, preset)| {
+                            if preset.adopt_vintage_floor() {
+                                carried += 1;
+                            }
+                            name.clone()
                         })
                         .collect();
+                    migrated_floor = carried > 0;
                     if !vintage.is_empty() {
                         tracing::warn!(
                             target: "quantick::app",
                             schema_version = 1_u8,
                             event_code = "STRATEGY_FLOOR_REINTERPRETED",
                             presets = %vintage.join(", "),
+                            carried_forward = carried,
+                            superseded = vintage.len() - carried,
                             was = "body",
                             now = "candle range",
                             "a stored body floor is now read as a candle-range floor, which admits every bar it used to and more"
@@ -541,7 +563,21 @@ impl StrategyBank {
             },
             Err(_) => BTreeMap::new(),
         };
-        Self { path, presets }
+        let bank = Self {
+            path,
+            presets,
+            migrated_floor,
+        };
+        // The migration is a one-time event or it is not a migration: left in
+        // memory only, the file keeps stating a floor this build no longer
+        // honours and the warning fires on every launch forever. Writing it
+        // back makes the next load ordinary. It reaches disk here rather than
+        // waiting for an unrelated `save` to carry it — which is what the
+        // re-save test had to stage to observe it happening at all.
+        if bank.migrated_floor {
+            bank.write_back();
+        }
+        bank
     }
 
     pub fn names(&self) -> impl Iterator<Item = &str> {
@@ -1072,10 +1108,12 @@ mod tests {
              rearm = \"one_shot\"\n",
         )
         .unwrap();
-        let mut bank = StrategyBank::load_from(&path);
-        // Saving an unrelated preset re-serialises the whole bank.
-        bank.save("Other", StoredPreset::starting_point(Side::Buy));
-        let written = std::fs::read_to_string(&path).expect("the bank wrote it");
+        // No save is staged: loading is what migrates, and the migration
+        // writes itself back. An earlier version of this test had to save an
+        // unrelated preset to observe the change reach disk, which was the
+        // tell that it never reached disk on its own.
+        let _bank = StrategyBank::load_from(&path);
+        let written = std::fs::read_to_string(&path).expect("the load rewrote it");
         assert!(
             !written.contains("min_body"),
             "the vintage key must not survive a save: {written}"
@@ -1084,11 +1122,95 @@ mod tests {
             written.contains("min_range = \"100\""),
             "and the number it carried is now stored under the key that is read: {written}"
         );
-        // A second load has nothing left to reinterpret.
+        // A second load has nothing left to reinterpret, so the warning is
+        // a one-time event rather than a line on every launch forever.
         let reloaded = StrategyBank::load_from(&path);
         let preset = reloaded.get("Vintage").expect("still there");
         assert_eq!(preset.min_range, "100");
         assert!(preset.min_body.is_none());
+        assert!(
+            !reloaded.migrated_floor,
+            "the second load has nothing to migrate"
+        );
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// A row carrying both keys is reported even though its number did not
+    /// move.
+    ///
+    /// The current key wins, so the vintage number is superseded and
+    /// dropped — and an earlier version of this migration dropped it on a
+    /// path that logged nothing, because it took the value before deciding
+    /// what to do with it. A number leaving a trader's file silently is the
+    /// failure the whole migration exists to avoid, so the loader names
+    /// every row whose vintage key it consumed and separates the ones it
+    /// carried forward from the ones it superseded.
+    #[test]
+    fn a_superseded_vintage_floor_is_dropped_but_not_silently() {
+        let path = scratch("superseded_floor");
+        let _ = std::fs::remove_file(&path);
+        std::fs::write(
+            &path,
+            "version = 1\n\
+             [presets.Both]\n\
+             trigger = \"force_bar\"\n\
+             side = \"sell\"\n\
+             quantity = \"1\"\n\
+             window = 20\n\
+             min_factor = \"2\"\n\
+             max_factor = \"4.5\"\n\
+             min_range = \"250\"\n\
+             min_body = \"100\"\n\
+             tp_mult = \"1.0\"\n\
+             sl_mult = \"1.2\"\n\
+             rearm = \"one_shot\"\n",
+        )
+        .unwrap();
+        let bank = StrategyBank::load_from(&path);
+        let preset = bank.get("Both").expect("the row survives");
+        assert_eq!(preset.min_range, "250", "the current key is the authority");
+        assert!(preset.min_body.is_none(), "the superseded one is gone");
+        assert!(
+            !bank.migrated_floor,
+            "nothing was carried forward, so nothing needed rewriting"
+        );
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// A preset whose current floor will not parse keeps its vintage number
+    /// out of the bin.
+    ///
+    /// `to_kernel` refuses an unparsable field, which is correct — but the
+    /// migration used to consume the vintage key on the way past, so the
+    /// trader was left with an un-armable preset *and* no record of the
+    /// number that had been in it.
+    #[test]
+    fn an_unparsable_floor_does_not_take_the_vintage_number_with_it() {
+        let path = scratch("unparsable_floor");
+        let _ = std::fs::remove_file(&path);
+        std::fs::write(
+            &path,
+            "version = 1\n\
+             [presets.Broken]\n\
+             trigger = \"force_bar\"\n\
+             side = \"sell\"\n\
+             quantity = \"1\"\n\
+             window = 20\n\
+             min_factor = \"2\"\n\
+             max_factor = \"4.5\"\n\
+             min_range = \"abc\"\n\
+             min_body = \"100\"\n\
+             tp_mult = \"1.0\"\n\
+             sl_mult = \"1.2\"\n\
+             rearm = \"one_shot\"\n",
+        )
+        .unwrap();
+        let bank = StrategyBank::load_from(&path);
+        let preset = bank.get("Broken").expect("the row still loads");
+        assert!(
+            preset.to_kernel().is_none(),
+            "an unparsable floor still voids the preset"
+        );
         std::fs::remove_file(&path).ok();
     }
 

--- a/crates/app/src/strategy_presets.rs
+++ b/crates/app/src/strategy_presets.rs
@@ -83,12 +83,23 @@ pub struct StoredPreset {
     pub window: u32,
     pub min_factor: String,
     pub max_factor: String,
-    /// Absolute body floor in price points; `0` disables it. Added after
-    /// the format shipped, so it is optional and defaults to `0` — a bank
-    /// file written before it existed reads clean with the old behaviour,
-    /// which is why the version does not move.
-    #[serde(default = "zero_points")]
-    pub min_body: String,
+    /// Absolute floor on the candle's **size** (`high - low`) in price
+    /// points; `0` disables it. Added after the format shipped, so it is
+    /// optional and defaults to `0` — a bank file written before it existed
+    /// reads clean with the old behaviour, which is why the version does
+    /// not move.
+    ///
+    /// The `min_body` alias is the key this field was written under when
+    /// the floor measured the body instead. A bank saved then still loads,
+    /// and its number is carried into the new meaning rather than dropped:
+    /// silently defaulting a trader's `100` to `0` would turn their gate
+    /// off, which is the loudest possible way to lose a setting. The
+    /// reinterpretation is real and is not hidden — the same `100` now
+    /// admits any candle reaching 100, where before it wanted a 100-point
+    /// body — so the release note says so, and the form's own label names
+    /// what is measured.
+    #[serde(default = "zero_points", alias = "min_body")]
+    pub min_size: String,
     /// Take profit = close + `tp_mult` × range, in the trade's favour;
     /// `0` means no leg.
     pub tp_mult: String,
@@ -104,7 +115,7 @@ pub struct StoredPreset {
     /// a bar that never crossed the edge rests nothing under either value,
     /// and neither does a cut whose projected legs would not clear the
     /// edge — an entry is never armed unprotected.
-    /// Optional for the same vintage reason as `min_body`, which is why
+    /// Optional for the same vintage reason as `min_size`, which is why
     /// the version does not move.
     #[serde(default = "ignore_break")]
     pub on_break: String,
@@ -187,7 +198,14 @@ impl StoredPreset {
             // activity-cut bars (247 "forces" in one measured WIN session;
             // 7 with this floor). Per-instrument, so it lives in the
             // preset the trader edits, not in the kernel's defaults.
-            min_body: "100".to_owned(),
+            //
+            // The number is a WINV26 measurement and it does not travel: on
+            // a market printing around 180,000 the same 100 is 0.06% of
+            // price and gates almost nothing, while on a 5-point tick it
+            // gates almost everything. It is a starting point for the
+            // instrument in front of the trader, not a default that is
+            // right anywhere it is not changed.
+            min_size: "100".to_owned(),
             tp_mult: "1.0".to_owned(),
             sl_mult: "1.0".to_owned(),
             rearm: "one_shot".to_owned(),
@@ -244,8 +262,8 @@ impl StoredPreset {
         if min_factor <= Decimal::ZERO || max_factor <= Decimal::ZERO {
             return None;
         }
-        let min_body = Decimal::from_str(&self.min_body).ok()?;
-        if min_body < Decimal::ZERO {
+        let min_size = Decimal::from_str(&self.min_size).ok()?;
+        if min_size < Decimal::ZERO {
             return None;
         }
         let alarm = self.alarm_to_kernel()?;
@@ -272,7 +290,7 @@ impl StoredPreset {
             window: self.window as usize,
             min_factor,
             max_factor,
-            min_body,
+            min_size,
         };
         Some(CompiledPreset {
             params,
@@ -343,7 +361,7 @@ pub fn side_token(side: Side) -> &'static str {
     side.as_str()
 }
 
-/// Serde default for [`StoredPreset::min_body`]: rows from before the field
+/// Serde default for [`StoredPreset::min_size`]: rows from before the field
 /// existed read as "floor off".
 fn zero_points() -> String {
     "0".to_owned()
@@ -519,7 +537,7 @@ mod tests {
         assert_eq!(params.rearm, Rearm::OneShot);
         assert_eq!(force.window, 20);
         assert_eq!(
-            force.min_body,
+            force.min_size,
             Decimal::from(100),
             "the form's starting point carries the elephant floor"
         );
@@ -551,7 +569,7 @@ mod tests {
         let compiled = preset.to_kernel().expect("and still compiles");
         let (params, force) = (compiled.params, compiled.force);
         assert_eq!(
-            force.min_body,
+            force.min_size,
             Decimal::ZERO,
             "absent floor means off, not refused"
         );
@@ -563,7 +581,7 @@ mod tests {
         std::fs::remove_file(&path).ok();
 
         let mut negative = StoredPreset::starting_point(Side::Buy);
-        negative.min_body = "-5".to_owned();
+        negative.min_size = "-5".to_owned();
         assert!(
             negative.to_kernel().is_none(),
             "a negative floor is refused whole"
@@ -847,5 +865,58 @@ mod tests {
         assert_eq!(alarm.params.when, AlarmWhen::OnClose);
         assert_eq!(alarm.params.repeat, RepeatPolicy::OncePerBar);
         assert_eq!(alarm.cue, Cue::whole(AlertSound::default()));
+    }
+
+    /// A bank saved when the floor measured the body still loads, and its
+    /// number is carried into the new meaning rather than dropped.
+    ///
+    /// This is the trader's own file: `min_body = "100"`, the key every
+    /// build wrote before the floor began measuring the whole candle.
+    /// Letting the rename fall through to the `0` default would switch
+    /// their elephant gate *off* — the loudest possible way to lose a
+    /// setting, and invisible until a flood of small bars started firing.
+    /// The alias keeps the number; the *meaning* is what changed, and that
+    /// is said out loud in the release note rather than discovered from a
+    /// fill.
+    ///
+    /// The fixture is written by the bank itself and then has only the key
+    /// renamed, so this asserts the alias and not a hand-typed schema that
+    /// could drift away from the real one.
+    #[test]
+    fn a_bank_written_under_the_old_min_body_key_keeps_its_floor() {
+        let path = scratch("min_body_alias");
+        let _ = std::fs::remove_file(&path);
+        let mut bank = StrategyBank::load_from(&path);
+        bank.save("SellGainAlarm", StoredPreset::starting_point(Side::Sell));
+
+        // Take the file back to the key it was written under before the
+        // floor changed what it measures.
+        let vintage = std::fs::read_to_string(&path)
+            .expect("the bank just wrote it")
+            .replace("min_size = ", "min_body = ");
+        assert!(
+            vintage.contains("min_body = \"100\""),
+            "the fixture really is a pre-rename file: {vintage}"
+        );
+        std::fs::write(&path, &vintage).unwrap();
+
+        let reloaded = StrategyBank::load_from(&path);
+        let preset = reloaded
+            .get("SellGainAlarm")
+            .expect("a bank from before the rename still loads");
+        assert_eq!(
+            preset.min_size, "100",
+            "the trader's own number survives the rename instead of defaulting to 0"
+        );
+        assert_eq!(
+            preset
+                .to_kernel()
+                .expect("and it still compiles to a runnable ruler")
+                .force
+                .min_size,
+            Decimal::from(100),
+            "carried all the way into the kernel's floor"
+        );
+        std::fs::remove_file(&path).ok();
     }
 }

--- a/crates/app/src/strategy_presets.rs
+++ b/crates/app/src/strategy_presets.rs
@@ -275,7 +275,7 @@ impl StoredPreset {
         if min_factor <= Decimal::ZERO || max_factor <= Decimal::ZERO {
             return None;
         }
-        let min_range = Decimal::from_str(&self.resolved_floor()).ok()?;
+        let min_range = Decimal::from_str(&self.min_range).ok()?;
         if min_range < Decimal::ZERO {
             return None;
         }
@@ -375,32 +375,42 @@ pub fn side_token(side: Side) -> &'static str {
 }
 
 impl StoredPreset {
-    /// The floor this preset means, reconciling the current key with the
-    /// vintage one it may still be stored under.
+    /// Fold a floor stored under the old body key into the field that is
+    /// read now, and report whether it moved a number.
     ///
-    /// `min_range` wins when it says anything but the default, so a bank
-    /// carrying both keys resolves rather than exploding. Otherwise the old
-    /// `min_body` number is carried forward — into a gate that now measures
-    /// the candle, which is looser than the one that number was chosen for.
-    /// That reinterpretation is real, and [`StrategyBank::load_from`]
-    /// announces it rather than leaving it to be discovered from a fill.
-    #[must_use]
-    pub fn resolved_floor(&self) -> String {
-        if self.min_range != zero_points() {
-            return self.min_range.clone();
+    /// Done **once, at load**, rather than by a resolver every read path
+    /// has to remember to call. A resolver was the first shape of this and
+    /// it was wrong in a way worth recording: the arming form takes
+    /// `popup.form = stored.clone()` and edits the struct directly, so a
+    /// preset whose floor lived in the vintage field would have shown `0`
+    /// in the form — the floor reading *off* — while the kernel ran with
+    /// 100. Two surfaces disagreeing about one number, which is the bug
+    /// this whole branch exists to end, rebuilt one layer down.
+    ///
+    /// Migrating in place leaves exactly one field to read, so no later
+    /// caller can bypass it. The vintage key is cleared either way: when
+    /// `min_range` already says something it is the authority and the old
+    /// number is superseded, and a superseded value that stays in the
+    /// struct is one a future save would write back out.
+    fn adopt_vintage_floor(&mut self) -> bool {
+        let Some(vintage) = self.min_body.take() else {
+            return false;
+        };
+        // Compared as numbers, not as text. `"0"`, `"0.0"` and `"0.00"` all
+        // mean the floor is off, and a string sentinel would make them
+        // behave differently — one spelling adopting the vintage number and
+        // another discarding it, decided by how the trader happened to type
+        // a zero. An unparsable field is not a decision either way; it
+        // reaches `to_kernel`, which refuses the whole preset.
+        let current = Decimal::from_str(&self.min_range).ok();
+        let vintage_value = Decimal::from_str(&vintage).ok();
+        let current_says_nothing = current == Some(Decimal::ZERO);
+        let vintage_says_something = vintage_value.is_some_and(|v| v > Decimal::ZERO);
+        if !current_says_nothing || !vintage_says_something {
+            return false;
         }
-        match &self.min_body {
-            Some(vintage) => vintage.clone(),
-            None => self.min_range.clone(),
-        }
-    }
-
-    /// Whether this row's floor came from the vintage key, so the loader
-    /// can say so once per bank rather than once per read.
-    #[must_use]
-    pub fn floor_is_vintage(&self) -> bool {
-        self.min_range == zero_points()
-            && self.min_body.as_ref().is_some_and(|v| *v != zero_points())
+        self.min_range = vintage;
+        true
     }
 }
 
@@ -486,11 +496,13 @@ impl StrategyBank {
                     // Data honesty: the number is kept, and the fact that
                     // its meaning moved is said out loud, once, beside the
                     // other load-time anomalies.
-                    let vintage: Vec<&str> = file
-                        .presets
-                        .iter()
-                        .filter(|(_, preset)| preset.floor_is_vintage())
-                        .map(|(name, _)| name.as_str())
+                    let mut presets = file.presets;
+                    let vintage: Vec<String> = presets
+                        .iter_mut()
+                        .filter(|(_, preset)| preset.min_body.is_some())
+                        .filter_map(|(name, preset)| {
+                            preset.adopt_vintage_floor().then(|| name.clone())
+                        })
                         .collect();
                     if !vintage.is_empty() {
                         tracing::warn!(
@@ -500,10 +512,10 @@ impl StrategyBank {
                             presets = %vintage.join(", "),
                             was = "body",
                             now = "candle range",
-                            "a stored body floor is now read as a candle-range floor, which                              admits every bar it used to and more"
+                            "a stored body floor is now read as a candle-range floor, which admits every bar it used to and more"
                         );
                     }
-                    file.presets
+                    presets
                 }
                 Ok(file) => {
                     tracing::warn!(
@@ -966,10 +978,13 @@ mod tests {
         let preset = bank
             .get("SellGainAlarm")
             .expect("a bank from before the rename still loads");
-        assert_eq!(preset.resolved_floor(), "100");
+        assert_eq!(
+            preset.min_range, "100",
+            "the vintage number now lives in the field every reader uses"
+        );
         assert!(
-            preset.floor_is_vintage(),
-            "and the loader can say the number came from the old key"
+            preset.min_body.is_none(),
+            "and the old key is gone, so a later save cannot write it back"
         );
         assert_eq!(
             preset
@@ -1018,11 +1033,62 @@ mod tests {
             .get("Both")
             .expect("both keys in one row must not empty the bank");
         assert_eq!(
-            preset.resolved_floor(),
-            "250",
-            "the current key wins; the vintage one is not consulted"
+            preset.min_range, "250",
+            "the current key wins; the vintage one is superseded"
         );
-        assert!(!preset.floor_is_vintage());
+        assert!(
+            preset.min_body.is_none(),
+            "and dropped, so it cannot come back on the next save"
+        );
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// A bank *loaded* from the vintage key and saved again writes only the
+    /// current one, and stops warning.
+    ///
+    /// The case the previous test could not reach: it exercised
+    /// `starting_point`, whose vintage field is already `None`, so nothing
+    /// covered the row that actually carries one. Without the migration the
+    /// whole bank is re-serialised on any save, the vintage key rides along,
+    /// and the file ends up stating a floor of `0` while the app runs 100 —
+    /// warning about it on every startup, forever.
+    #[test]
+    fn a_loaded_vintage_preset_saves_without_its_old_key() {
+        let path = scratch("vintage_resave");
+        let _ = std::fs::remove_file(&path);
+        std::fs::write(
+            &path,
+            "version = 1\n\
+             [presets.Vintage]\n\
+             trigger = \"force_bar\"\n\
+             side = \"sell\"\n\
+             quantity = \"1\"\n\
+             window = 20\n\
+             min_factor = \"2\"\n\
+             max_factor = \"4.5\"\n\
+             min_body = \"100\"\n\
+             tp_mult = \"1.0\"\n\
+             sl_mult = \"1.2\"\n\
+             rearm = \"one_shot\"\n",
+        )
+        .unwrap();
+        let mut bank = StrategyBank::load_from(&path);
+        // Saving an unrelated preset re-serialises the whole bank.
+        bank.save("Other", StoredPreset::starting_point(Side::Buy));
+        let written = std::fs::read_to_string(&path).expect("the bank wrote it");
+        assert!(
+            !written.contains("min_body"),
+            "the vintage key must not survive a save: {written}"
+        );
+        assert!(
+            written.contains("min_range = \"100\""),
+            "and the number it carried is now stored under the key that is read: {written}"
+        );
+        // A second load has nothing left to reinterpret.
+        let reloaded = StrategyBank::load_from(&path);
+        let preset = reloaded.get("Vintage").expect("still there");
+        assert_eq!(preset.min_range, "100");
+        assert!(preset.min_body.is_none());
         std::fs::remove_file(&path).ok();
     }
 

--- a/crates/app/src/strategy_presets.rs
+++ b/crates/app/src/strategy_presets.rs
@@ -83,35 +83,34 @@ pub struct StoredPreset {
     pub window: u32,
     pub min_factor: String,
     pub max_factor: String,
-    /// Absolute floor on the candle's **size** (`high - low`) in price
-    /// points; `0` disables it. Added after the format shipped, so it is
-    /// optional and defaults to `0` — a bank file written before it existed
-    /// reads clean with the old behaviour, which is why the version does
-    /// not move.
-    ///
-    /// Two aliases, two vintages. `min_body` is the key this field was
-    /// written under while the floor measured the body; `min_size` is the
-    /// name it briefly carried on the branch that changed it, before the
-    /// rename to match `ForceParams::min_range`. A bank saved under either
-    /// still loads and keeps its number, because silently defaulting a
-    /// trader's `100` to `0` would turn their gate *off* — the loudest
-    /// possible way to lose a setting, and invisible until a flood of small
-    /// bars starts firing.
-    ///
-    /// The reinterpretation is real and is not hidden: the same `100` now
-    /// admits any candle reaching 100, where before it wanted a 100-point
-    /// body. The form's label says which is measured, and the badge names
-    /// the gate that refused a bar.
-    ///
-    /// **The migration is one-way.** A bank written by this build says
-    /// `min_range`, and an *older* build reading it finds no key it knows
-    /// and falls through to `0` — the same silent loss, in the one
-    /// direction no alias here can reach, because the alias would have to
-    /// exist in the build being rolled back to. Downgrading turns the floor
-    /// off, and the PR body says so rather than leaving it to be found in a
-    /// fill.
-    #[serde(default = "zero_points", alias = "min_body", alias = "min_size")]
+    /// Absolute floor on the candle's **range** (`high - low`) in price
+    /// points; `0` disables it. Optional, defaulting to `0`, so a bank
+    /// written before the floor existed reads clean with the old
+    /// behaviour — which is why the format version does not move.
+    #[serde(default = "zero_points")]
     pub min_range: String,
+    /// The key this floor was stored under while it measured the **body**
+    /// (`|close - open|`), kept as its own optional field rather than as
+    /// `#[serde(alias)]`.
+    ///
+    /// An alias would have been one line, and wrong three ways. Serde
+    /// treats an alias as the *same* field, so a bank carrying both keys —
+    /// hand-edited, merged from two banks, or half-migrated — is a
+    /// duplicate-field error; [`StrategyBank::load_from`] answers any parse
+    /// error by starting empty, and the next save writes that emptiness
+    /// over every preset the trader had. A silent reinterpretation is bad;
+    /// losing the whole bank to fix it is worse.
+    ///
+    /// Read separately, the number can also be *reported* instead of
+    /// swallowed. The floor now measures the whole candle, so the same
+    /// `100` admits every bar it used to and more; [`Self::resolved_floor`]
+    /// carries that number forward — defaulting it to `0` would switch the
+    /// trader's gate off, the loudest possible way to lose a setting — and
+    /// the bank logs `STRATEGY_FLOOR_REINTERPRETED` when it does, beside
+    /// the other load-time anomalies, so the change is visible in the
+    /// running app and not only in a doc comment.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub min_body: Option<String>,
     /// Take profit = close + `tp_mult` × range, in the trade's favour;
     /// `0` means no leg.
     pub tp_mult: String,
@@ -218,6 +217,8 @@ impl StoredPreset {
             // instrument in front of the trader, not a default that is
             // right anywhere it is not changed.
             min_range: "100".to_owned(),
+            // A freshly authored preset has no vintage number to reconcile.
+            min_body: None,
             tp_mult: "1.0".to_owned(),
             sl_mult: "1.0".to_owned(),
             rearm: "one_shot".to_owned(),
@@ -274,7 +275,7 @@ impl StoredPreset {
         if min_factor <= Decimal::ZERO || max_factor <= Decimal::ZERO {
             return None;
         }
-        let min_range = Decimal::from_str(&self.min_range).ok()?;
+        let min_range = Decimal::from_str(&self.resolved_floor()).ok()?;
         if min_range < Decimal::ZERO {
             return None;
         }
@@ -373,6 +374,36 @@ pub fn side_token(side: Side) -> &'static str {
     side.as_str()
 }
 
+impl StoredPreset {
+    /// The floor this preset means, reconciling the current key with the
+    /// vintage one it may still be stored under.
+    ///
+    /// `min_range` wins when it says anything but the default, so a bank
+    /// carrying both keys resolves rather than exploding. Otherwise the old
+    /// `min_body` number is carried forward — into a gate that now measures
+    /// the candle, which is looser than the one that number was chosen for.
+    /// That reinterpretation is real, and [`StrategyBank::load_from`]
+    /// announces it rather than leaving it to be discovered from a fill.
+    #[must_use]
+    pub fn resolved_floor(&self) -> String {
+        if self.min_range != zero_points() {
+            return self.min_range.clone();
+        }
+        match &self.min_body {
+            Some(vintage) => vintage.clone(),
+            None => self.min_range.clone(),
+        }
+    }
+
+    /// Whether this row's floor came from the vintage key, so the loader
+    /// can say so once per bank rather than once per read.
+    #[must_use]
+    pub fn floor_is_vintage(&self) -> bool {
+        self.min_range == zero_points()
+            && self.min_body.as_ref().is_some_and(|v| *v != zero_points())
+    }
+}
+
 /// Serde default for [`StoredPreset::min_range`]: rows from before the field
 /// existed read as "floor off".
 fn zero_points() -> String {
@@ -449,7 +480,31 @@ impl StrategyBank {
         let path = path.into();
         let presets = match std::fs::read_to_string(&path) {
             Ok(text) => match toml::from_str::<StoreFile>(&text) {
-                Ok(file) if file.version == STORE_FORMAT_VERSION => file.presets,
+                Ok(file) if file.version == STORE_FORMAT_VERSION => {
+                    // A preset still carrying the vintage key is about to be
+                    // read through a floor that measures something else.
+                    // Data honesty: the number is kept, and the fact that
+                    // its meaning moved is said out loud, once, beside the
+                    // other load-time anomalies.
+                    let vintage: Vec<&str> = file
+                        .presets
+                        .iter()
+                        .filter(|(_, preset)| preset.floor_is_vintage())
+                        .map(|(name, _)| name.as_str())
+                        .collect();
+                    if !vintage.is_empty() {
+                        tracing::warn!(
+                            target: "quantick::app",
+                            schema_version = 1_u8,
+                            event_code = "STRATEGY_FLOOR_REINTERPRETED",
+                            presets = %vintage.join(", "),
+                            was = "body",
+                            now = "candle range",
+                            "a stored body floor is now read as a candle-range floor, which                              admits every bar it used to and more"
+                        );
+                    }
+                    file.presets
+                }
                 Ok(file) => {
                     tracing::warn!(
                         target: "quantick::app",
@@ -879,56 +934,111 @@ mod tests {
         assert_eq!(alarm.cue, Cue::whole(AlertSound::default()));
     }
 
-    /// A bank saved when the floor measured the body still loads, and its
-    /// number is carried into the new meaning rather than dropped.
+    /// A bank saved when the floor measured the body still loads, keeps its
+    /// number, and says that the number now means something else.
     ///
     /// This is the trader's own file: `min_body = "100"`, the key every
     /// build wrote before the floor began measuring the whole candle.
-    /// Letting the rename fall through to the `0` default would switch
-    /// their elephant gate *off* — the loudest possible way to lose a
-    /// setting, and invisible until a flood of small bars started firing.
-    /// The alias keeps the number; the *meaning* is what changed, and the
-    /// field's own doc carries that — there is no release-notes file in
-    /// this repo to defer it to, and a doc comment pointing at a document
-    /// nobody wrote is worse than no promise at all.
-    ///
-    /// The fixture is written by the bank itself and then has only the key
-    /// renamed, so this asserts the alias and not a hand-typed schema that
-    /// could drift away from the real one.
+    /// Defaulting it to `0` would switch their elephant gate *off* — the
+    /// loudest possible way to lose a setting, invisible until a flood of
+    /// small bars started firing.
     #[test]
-    fn a_bank_written_under_the_old_min_body_key_keeps_its_floor() {
-        let path = scratch("min_body_alias");
+    fn a_bank_written_under_the_old_body_key_keeps_its_floor() {
+        let path = scratch("vintage_floor");
         let _ = std::fs::remove_file(&path);
-        let mut bank = StrategyBank::load_from(&path);
-        bank.save("SellGainAlarm", StoredPreset::starting_point(Side::Sell));
-
-        // Take the file back to the key it was written under before the
-        // floor changed what it measures.
-        let vintage = std::fs::read_to_string(&path)
-            .expect("the bank just wrote it")
-            .replace("min_range = ", "min_body = ");
-        assert!(
-            vintage.contains("min_body = \"100\""),
-            "the fixture really is a pre-rename file: {vintage}"
-        );
-        std::fs::write(&path, &vintage).unwrap();
-
-        let reloaded = StrategyBank::load_from(&path);
-        let preset = reloaded
+        std::fs::write(
+            &path,
+            "version = 1\n\
+             [presets.SellGainAlarm]\n\
+             trigger = \"force_bar\"\n\
+             side = \"sell\"\n\
+             quantity = \"1\"\n\
+             window = 20\n\
+             min_factor = \"2\"\n\
+             max_factor = \"4.5\"\n\
+             min_body = \"100\"\n\
+             tp_mult = \"1.0\"\n\
+             sl_mult = \"1.2\"\n\
+             rearm = \"one_shot\"\n",
+        )
+        .unwrap();
+        let bank = StrategyBank::load_from(&path);
+        let preset = bank
             .get("SellGainAlarm")
             .expect("a bank from before the rename still loads");
-        assert_eq!(
-            preset.min_range, "100",
-            "the trader's own number survives the rename instead of defaulting to 0"
+        assert_eq!(preset.resolved_floor(), "100");
+        assert!(
+            preset.floor_is_vintage(),
+            "and the loader can say the number came from the old key"
         );
         assert_eq!(
             preset
                 .to_kernel()
-                .expect("and it still compiles to a runnable ruler")
+                .expect("it still compiles to a runnable ruler")
                 .force
                 .min_range,
             Decimal::from(100),
             "carried all the way into the kernel's floor"
+        );
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// A bank carrying **both** keys resolves instead of destroying itself.
+    ///
+    /// Serde treats an alias as the same field, so `min_range` beside
+    /// `min_body` in one table is a duplicate-field error — and
+    /// `load_from` answers any parse error by starting empty, which the
+    /// next save writes over the trader's whole bank. Reachable by a
+    /// hand-edit, by merging two banks, or by a half-applied migration, and
+    /// the rename is exactly what makes such a file possible. Separate
+    /// optional fields make it a reconciliation rather than a loss.
+    #[test]
+    fn a_bank_carrying_both_floor_keys_resolves_instead_of_vanishing() {
+        let path = scratch("both_floor_keys");
+        let _ = std::fs::remove_file(&path);
+        std::fs::write(
+            &path,
+            "version = 1\n\
+             [presets.Both]\n\
+             trigger = \"force_bar\"\n\
+             side = \"sell\"\n\
+             quantity = \"1\"\n\
+             window = 20\n\
+             min_factor = \"2\"\n\
+             max_factor = \"4.5\"\n\
+             min_range = \"250\"\n\
+             min_body = \"100\"\n\
+             tp_mult = \"1.0\"\n\
+             sl_mult = \"1.2\"\n\
+             rearm = \"one_shot\"\n",
+        )
+        .unwrap();
+        let bank = StrategyBank::load_from(&path);
+        let preset = bank
+            .get("Both")
+            .expect("both keys in one row must not empty the bank");
+        assert_eq!(
+            preset.resolved_floor(),
+            "250",
+            "the current key wins; the vintage one is not consulted"
+        );
+        assert!(!preset.floor_is_vintage());
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// A preset this build wrote carries only the current key, so the
+    /// vintage field never grows into the file it was added to read.
+    #[test]
+    fn a_freshly_saved_preset_writes_only_the_current_floor_key() {
+        let path = scratch("fresh_floor");
+        let _ = std::fs::remove_file(&path);
+        let mut bank = StrategyBank::load_from(&path);
+        bank.save("Fresh", StoredPreset::starting_point(Side::Sell));
+        let written = std::fs::read_to_string(&path).expect("the bank wrote it");
+        assert!(written.contains("min_range = \"100\""));
+        assert!(
+            !written.contains("min_body"),
+            "the vintage key is read, never written: {written}"
         );
         std::fs::remove_file(&path).ok();
     }

--- a/crates/app/src/strategy_presets.rs
+++ b/crates/app/src/strategy_presets.rs
@@ -89,17 +89,29 @@ pub struct StoredPreset {
     /// reads clean with the old behaviour, which is why the version does
     /// not move.
     ///
-    /// The `min_body` alias is the key this field was written under when
-    /// the floor measured the body instead. A bank saved then still loads,
-    /// and its number is carried into the new meaning rather than dropped:
-    /// silently defaulting a trader's `100` to `0` would turn their gate
-    /// off, which is the loudest possible way to lose a setting. The
-    /// reinterpretation is real and is not hidden — the same `100` now
+    /// Two aliases, two vintages. `min_body` is the key this field was
+    /// written under while the floor measured the body; `min_size` is the
+    /// name it briefly carried on the branch that changed it, before the
+    /// rename to match `ForceParams::min_range`. A bank saved under either
+    /// still loads and keeps its number, because silently defaulting a
+    /// trader's `100` to `0` would turn their gate *off* — the loudest
+    /// possible way to lose a setting, and invisible until a flood of small
+    /// bars starts firing.
+    ///
+    /// The reinterpretation is real and is not hidden: the same `100` now
     /// admits any candle reaching 100, where before it wanted a 100-point
-    /// body — so the release note says so, and the form's own label names
-    /// what is measured.
-    #[serde(default = "zero_points", alias = "min_body")]
-    pub min_size: String,
+    /// body. The form's label says which is measured, and the badge names
+    /// the gate that refused a bar.
+    ///
+    /// **The migration is one-way.** A bank written by this build says
+    /// `min_range`, and an *older* build reading it finds no key it knows
+    /// and falls through to `0` — the same silent loss, in the one
+    /// direction no alias here can reach, because the alias would have to
+    /// exist in the build being rolled back to. Downgrading turns the floor
+    /// off, and the PR body says so rather than leaving it to be found in a
+    /// fill.
+    #[serde(default = "zero_points", alias = "min_body", alias = "min_size")]
+    pub min_range: String,
     /// Take profit = close + `tp_mult` × range, in the trade's favour;
     /// `0` means no leg.
     pub tp_mult: String,
@@ -115,7 +127,7 @@ pub struct StoredPreset {
     /// a bar that never crossed the edge rests nothing under either value,
     /// and neither does a cut whose projected legs would not clear the
     /// edge — an entry is never armed unprotected.
-    /// Optional for the same vintage reason as `min_size`, which is why
+    /// Optional for the same vintage reason as `min_range`, which is why
     /// the version does not move.
     #[serde(default = "ignore_break")]
     pub on_break: String,
@@ -205,7 +217,7 @@ impl StoredPreset {
             // gates almost everything. It is a starting point for the
             // instrument in front of the trader, not a default that is
             // right anywhere it is not changed.
-            min_size: "100".to_owned(),
+            min_range: "100".to_owned(),
             tp_mult: "1.0".to_owned(),
             sl_mult: "1.0".to_owned(),
             rearm: "one_shot".to_owned(),
@@ -262,8 +274,8 @@ impl StoredPreset {
         if min_factor <= Decimal::ZERO || max_factor <= Decimal::ZERO {
             return None;
         }
-        let min_size = Decimal::from_str(&self.min_size).ok()?;
-        if min_size < Decimal::ZERO {
+        let min_range = Decimal::from_str(&self.min_range).ok()?;
+        if min_range < Decimal::ZERO {
             return None;
         }
         let alarm = self.alarm_to_kernel()?;
@@ -290,7 +302,7 @@ impl StoredPreset {
             window: self.window as usize,
             min_factor,
             max_factor,
-            min_size,
+            min_range,
         };
         Some(CompiledPreset {
             params,
@@ -361,7 +373,7 @@ pub fn side_token(side: Side) -> &'static str {
     side.as_str()
 }
 
-/// Serde default for [`StoredPreset::min_size`]: rows from before the field
+/// Serde default for [`StoredPreset::min_range`]: rows from before the field
 /// existed read as "floor off".
 fn zero_points() -> String {
     "0".to_owned()
@@ -537,7 +549,7 @@ mod tests {
         assert_eq!(params.rearm, Rearm::OneShot);
         assert_eq!(force.window, 20);
         assert_eq!(
-            force.min_size,
+            force.min_range,
             Decimal::from(100),
             "the form's starting point carries the elephant floor"
         );
@@ -569,7 +581,7 @@ mod tests {
         let compiled = preset.to_kernel().expect("and still compiles");
         let (params, force) = (compiled.params, compiled.force);
         assert_eq!(
-            force.min_size,
+            force.min_range,
             Decimal::ZERO,
             "absent floor means off, not refused"
         );
@@ -581,7 +593,7 @@ mod tests {
         std::fs::remove_file(&path).ok();
 
         let mut negative = StoredPreset::starting_point(Side::Buy);
-        negative.min_size = "-5".to_owned();
+        negative.min_range = "-5".to_owned();
         assert!(
             negative.to_kernel().is_none(),
             "a negative floor is refused whole"
@@ -875,9 +887,10 @@ mod tests {
     /// Letting the rename fall through to the `0` default would switch
     /// their elephant gate *off* — the loudest possible way to lose a
     /// setting, and invisible until a flood of small bars started firing.
-    /// The alias keeps the number; the *meaning* is what changed, and that
-    /// is said out loud in the release note rather than discovered from a
-    /// fill.
+    /// The alias keeps the number; the *meaning* is what changed, and the
+    /// field's own doc carries that — there is no release-notes file in
+    /// this repo to defer it to, and a doc comment pointing at a document
+    /// nobody wrote is worse than no promise at all.
     ///
     /// The fixture is written by the bank itself and then has only the key
     /// renamed, so this asserts the alias and not a hand-typed schema that
@@ -893,7 +906,7 @@ mod tests {
         // floor changed what it measures.
         let vintage = std::fs::read_to_string(&path)
             .expect("the bank just wrote it")
-            .replace("min_size = ", "min_body = ");
+            .replace("min_range = ", "min_body = ");
         assert!(
             vintage.contains("min_body = \"100\""),
             "the fixture really is a pre-rename file: {vintage}"
@@ -905,7 +918,7 @@ mod tests {
             .get("SellGainAlarm")
             .expect("a bank from before the rename still loads");
         assert_eq!(
-            preset.min_size, "100",
+            preset.min_range, "100",
             "the trader's own number survives the rename instead of defaulting to 0"
         );
         assert_eq!(
@@ -913,7 +926,7 @@ mod tests {
                 .to_kernel()
                 .expect("and it still compiles to a runnable ruler")
                 .force
-                .min_size,
+                .min_range,
             Decimal::from(100),
             "carried all the way into the kernel's floor"
         );

--- a/crates/app/src/strategy_presets.rs
+++ b/crates/app/src/strategy_presets.rs
@@ -394,29 +394,41 @@ impl StoredPreset {
     /// number is superseded, and a superseded value that stays in the
     /// struct is one a future save would write back out.
     fn adopt_vintage_floor(&mut self) -> bool {
-        let Some(vintage) = self.min_body.clone() else {
+        let Some(vintage) = self.min_body.as_deref() else {
             return false;
         };
-        // Decide first, clear afterwards. Taking the value up front dropped
-        // the trader's older number on the two paths that return `false` — a
-        // row carrying both keys, and one whose current key will not parse —
-        // and those paths report nothing, so the number vanished from memory
-        // and from the next save with no line anywhere saying it had.
-        self.min_body = None;
         // Compared as numbers, not as text. `"0"`, `"0.0"` and `"0.00"` all
-        // mean the floor is off, and a string sentinel would make them
-        // behave differently — one spelling adopting the vintage number and
-        // another discarding it, decided by how the trader happened to type
-        // a zero. An unparsable field is not a decision either way; it
-        // reaches `to_kernel`, which refuses the whole preset.
-        let current = Decimal::from_str(&self.min_range).ok();
-        let vintage_value = Decimal::from_str(&vintage).ok();
-        let current_says_nothing = current == Some(Decimal::ZERO);
-        let vintage_says_something = vintage_value.is_some_and(|v| v > Decimal::ZERO);
-        if !current_says_nothing || !vintage_says_something {
+        // mean the floor is off, and a string sentinel would make them behave
+        // differently — one spelling adopting the vintage number and another
+        // discarding it, decided by how the trader happened to type a zero.
+        let vintage_value = Decimal::from_str(vintage).ok();
+        let Some(current) = Decimal::from_str(&self.min_range).ok() else {
+            // The current key will not parse, so `to_kernel` refuses this
+            // preset and the trader has to repair the row by hand. **Leave
+            // the vintage number exactly where it is**: it is the value they
+            // would repair it *with*, and an earlier version of this cleared
+            // it on the way past, which is how a broken row became a broken
+            // row with no clue in it.
+            return false;
+        };
+        if current != Decimal::ZERO {
+            // Both keys, and the current one is the authority. The vintage
+            // number is superseded, so it goes — leaving it would write both
+            // keys back on the next save and re-announce the migration on
+            // every launch forever. Not silent: the loader names every row
+            // whose vintage key it consumed and counts these separately from
+            // the ones it carried forward.
+            self.min_body = None;
             return false;
         }
-        self.min_range = vintage;
+        if !vintage_value.is_some_and(|v| v > Decimal::ZERO) {
+            // A vintage zero is a floor that was already off; nothing to
+            // carry, and nothing worth keeping the key for.
+            self.min_body = None;
+            return false;
+        }
+        self.min_range = vintage.to_owned();
+        self.min_body = None;
         true
     }
 }
@@ -477,9 +489,6 @@ struct StoreFile {
 pub struct StrategyBank {
     path: PathBuf,
     presets: BTreeMap<String, StoredPreset>,
-    /// Whether this load folded a vintage floor key forward, so the file is
-    /// rewritten once instead of being migrated again on every launch.
-    migrated_floor: bool,
 }
 
 impl StrategyBank {
@@ -498,7 +507,6 @@ impl StrategyBank {
     #[must_use]
     pub fn load_from(path: impl Into<PathBuf>) -> Self {
         let path = path.into();
-        let mut migrated_floor = false;
         let presets = match std::fs::read_to_string(&path) {
             Ok(text) => match toml::from_str::<StoreFile>(&text) {
                 Ok(file) if file.version == STORE_FORMAT_VERSION => {
@@ -523,7 +531,6 @@ impl StrategyBank {
                             name.clone()
                         })
                         .collect();
-                    migrated_floor = carried > 0;
                     if !vintage.is_empty() {
                         tracing::warn!(
                             target: "quantick::app",
@@ -563,21 +570,7 @@ impl StrategyBank {
             },
             Err(_) => BTreeMap::new(),
         };
-        let bank = Self {
-            path,
-            presets,
-            migrated_floor,
-        };
-        // The migration is a one-time event or it is not a migration: left in
-        // memory only, the file keeps stating a floor this build no longer
-        // honours and the warning fires on every launch forever. Writing it
-        // back makes the next load ordinary. It reaches disk here rather than
-        // waiting for an unrelated `save` to carry it — which is what the
-        // re-save test had to stage to observe it happening at all.
-        if bank.migrated_floor {
-            bank.write_back();
-        }
-        bank
+        Self { path, presets }
     }
 
     pub fn names(&self) -> impl Iterator<Item = &str> {
@@ -1108,12 +1101,15 @@ mod tests {
              rearm = \"one_shot\"\n",
         )
         .unwrap();
-        // No save is staged: loading is what migrates, and the migration
-        // writes itself back. An earlier version of this test had to save an
-        // unrelated preset to observe the change reach disk, which was the
-        // tell that it never reached disk on its own.
-        let _bank = StrategyBank::load_from(&path);
-        let written = std::fs::read_to_string(&path).expect("the load rewrote it");
+        // Loading migrates in memory; the file changes on the next save.
+        // Writing it back at load time was tried and reverted: it turned a
+        // read into a non-atomic write that re-serialises every row through
+        // this build's `StoredPreset`, which would strip an optional field a
+        // newer build had added — a startup that silently edits the trader's
+        // bank to cure a repeated log line is a bad trade.
+        let mut bank = StrategyBank::load_from(&path);
+        bank.save("Other", StoredPreset::starting_point(Side::Buy));
+        let written = std::fs::read_to_string(&path).expect("the bank wrote it");
         assert!(
             !written.contains("min_body"),
             "the vintage key must not survive a save: {written}"
@@ -1128,10 +1124,6 @@ mod tests {
         let preset = reloaded.get("Vintage").expect("still there");
         assert_eq!(preset.min_range, "100");
         assert!(preset.min_body.is_none());
-        assert!(
-            !reloaded.migrated_floor,
-            "the second load has nothing to migrate"
-        );
         std::fs::remove_file(&path).ok();
     }
 
@@ -1169,10 +1161,9 @@ mod tests {
         let bank = StrategyBank::load_from(&path);
         let preset = bank.get("Both").expect("the row survives");
         assert_eq!(preset.min_range, "250", "the current key is the authority");
-        assert!(preset.min_body.is_none(), "the superseded one is gone");
         assert!(
-            !bank.migrated_floor,
-            "nothing was carried forward, so nothing needed rewriting"
+            preset.min_body.is_none(),
+            "the superseded one is gone, and the loader counted it as superseded"
         );
         std::fs::remove_file(&path).ok();
     }
@@ -1210,6 +1201,11 @@ mod tests {
         assert!(
             preset.to_kernel().is_none(),
             "an unparsable floor still voids the preset"
+        );
+        assert_eq!(
+            preset.min_body.as_deref(),
+            Some("100"),
+            "and the number the trader would repair it with is still there —              asserting only that the preset is void proves nothing about that,              which is what an earlier version of this test did"
         );
         std::fs::remove_file(&path).ok();
     }

--- a/crates/app/src/surfaces/strategy_popup.rs
+++ b/crates/app/src/surfaces/strategy_popup.rs
@@ -504,14 +504,15 @@ impl Surface for StrategyPopupSurface {
                             ui.label("bodies");
                         });
                         ui.horizontal(|ui| {
-                            ui.label("and body ≥");
+                            ui.label("and candle ≥");
                             ui.add(
-                                egui::TextEdit::singleline(&mut popup.form.min_body)
+                                egui::TextEdit::singleline(&mut popup.form.min_size)
                                     .desired_width(50.0),
                             );
                             ui.label("pts (0 = off)").on_hover_text(
-                                "the elephant floor: the relative band alone marks dozens of small \
-                         bars as force on activity-cut bars; an elephant has a size",
+                                "the elephant floor, measured across the whole candle (high − low, \
+                                 wicks included): the relative band alone marks dozens of small bars \
+                                 as force on activity-cut bars; an elephant has a size",
                             );
                         });
                         ui.horizontal(|ui| {

--- a/crates/app/src/surfaces/strategy_popup.rs
+++ b/crates/app/src/surfaces/strategy_popup.rs
@@ -506,7 +506,7 @@ impl Surface for StrategyPopupSurface {
                         ui.horizontal(|ui| {
                             ui.label("and candle ≥");
                             ui.add(
-                                egui::TextEdit::singleline(&mut popup.form.min_size)
+                                egui::TextEdit::singleline(&mut popup.form.min_range)
                                     .desired_width(50.0),
                             );
                             ui.label("pts (0 = off)").on_hover_text(

--- a/crates/app/tests/size_guard.rs
+++ b/crates/app/tests/size_guard.rs
@@ -127,7 +127,16 @@ const BASELINE: &[(&str, usize)] = &[
     // behind a closure, once it was clear it was logic rather than
     // registration. Argue with these numbers rather than with their absence.
     ("crates/app/src/paper_trading.rs", 9238),
-    ("crates/app/src/pane.rs", 7757),
+    // Raised by 14 for the strategy badge, and deliberately: not a
+    // capability docking by trunk-edit, but a repair to `badge_text_for`,
+    // which reached only for a *stale* hold reason and so answered "why did
+    // nothing happen here?" with a sentence about an earlier bar. It now
+    // leads with the ruler's reading of the bar actually under the cursor,
+    // the way `ArmedStrategy::status_line` and the right-click menu always
+    // have. The lines are three short branches and the comment saying why
+    // the order matters; there is no new module to carve, because the fix is
+    // that this function was reading one input too few.
+    ("crates/app/src/pane.rs", 7771),
     ("crates/app/src/tab.rs", 4401),
     ("crates/app/src/control/gateway.rs", 4142),
     ("crates/app/src/orderflow_render.rs", 3075),

--- a/crates/app/tests/size_guard.rs
+++ b/crates/app/tests/size_guard.rs
@@ -127,18 +127,16 @@ const BASELINE: &[(&str, usize)] = &[
     // behind a closure, once it was clear it was logic rather than
     // registration. Argue with these numbers rather than with their absence.
     ("crates/app/src/paper_trading.rs", 9238),
-    // Raised by 22 for the strategy badge, and deliberately: not a
+    // Raised by 14 for the strategy badge, and deliberately: not a
     // capability docking by trunk-edit, but a repair to `badge_text_for`,
     // which reached only for a *stale* hold reason and so answered "why did
     // nothing happen here?" with a sentence about an earlier bar. It now
     // leads with the ruler's reading of the bar actually under the cursor,
     // the way `ArmedStrategy::status_line` and the right-click menu always
-    // have, and it shows an alarm-only aside instead of silently dropping
-    // the one note class those two surfaces still phrased differently.
-    // The lines are four short branches and the comments saying why the
-    // order matters; there is no new module to carve, because the fix is
-    // that this function was reading two inputs too few.
-    ("crates/app/src/pane.rs", 7779),
+    // have. The lines are three short branches and the comment saying why
+    // the order matters; there is no new module to carve, because the fix
+    // is that this function was reading one input too few.
+    ("crates/app/src/pane.rs", 7771),
     ("crates/app/src/tab.rs", 4401),
     ("crates/app/src/control/gateway.rs", 4142),
     ("crates/app/src/orderflow_render.rs", 3075),

--- a/crates/app/tests/size_guard.rs
+++ b/crates/app/tests/size_guard.rs
@@ -127,16 +127,18 @@ const BASELINE: &[(&str, usize)] = &[
     // behind a closure, once it was clear it was logic rather than
     // registration. Argue with these numbers rather than with their absence.
     ("crates/app/src/paper_trading.rs", 9238),
-    // Raised by 14 for the strategy badge, and deliberately: not a
+    // Raised by 22 for the strategy badge, and deliberately: not a
     // capability docking by trunk-edit, but a repair to `badge_text_for`,
     // which reached only for a *stale* hold reason and so answered "why did
     // nothing happen here?" with a sentence about an earlier bar. It now
     // leads with the ruler's reading of the bar actually under the cursor,
     // the way `ArmedStrategy::status_line` and the right-click menu always
-    // have. The lines are three short branches and the comment saying why
-    // the order matters; there is no new module to carve, because the fix is
-    // that this function was reading one input too few.
-    ("crates/app/src/pane.rs", 7771),
+    // have, and it shows an alarm-only aside instead of silently dropping
+    // the one note class those two surfaces still phrased differently.
+    // The lines are four short branches and the comments saying why the
+    // order matters; there is no new module to carve, because the fix is
+    // that this function was reading two inputs too few.
+    ("crates/app/src/pane.rs", 7779),
     ("crates/app/src/tab.rs", 4401),
     ("crates/app/src/control/gateway.rs", 4142),
     ("crates/app/src/orderflow_render.rs", 3075),

--- a/crates/backtest/tests/harness.rs
+++ b/crates/backtest/tests/harness.rs
@@ -173,7 +173,7 @@ fn the_force_region_kernel_walks_a_full_operation_under_the_harness() {
             window: 3,
             min_factor: "1.5".parse().expect("fixture factor"),
             max_factor: "2.5".parse().expect("fixture factor"),
-            min_body: Decimal::ZERO,
+            min_size: Decimal::ZERO,
         },
     );
     let run = run_session(&session, BarSpec::Tick(2), &mut strategy);
@@ -236,7 +236,7 @@ fn a_body_cut_rests_a_limit_under_the_harness_and_the_retest_fills() {
             window: 3,
             min_factor: "1.5".parse().expect("fixture factor"),
             max_factor: "2.5".parse().expect("fixture factor"),
-            min_body: Decimal::ZERO,
+            min_size: Decimal::ZERO,
         },
     );
     let run = run_session(&session, BarSpec::Tick(3), &mut strategy);
@@ -289,7 +289,7 @@ fn a_body_that_never_cut_the_region_rests_nothing_under_the_harness() {
             window: 3,
             min_factor: "1.5".parse().expect("fixture factor"),
             max_factor: "2.5".parse().expect("fixture factor"),
-            min_body: Decimal::ZERO,
+            min_size: Decimal::ZERO,
         },
     );
     let run = run_session(&session, BarSpec::Tick(3), &mut strategy);

--- a/crates/backtest/tests/harness.rs
+++ b/crates/backtest/tests/harness.rs
@@ -173,7 +173,7 @@ fn the_force_region_kernel_walks_a_full_operation_under_the_harness() {
             window: 3,
             min_factor: "1.5".parse().expect("fixture factor"),
             max_factor: "2.5".parse().expect("fixture factor"),
-            min_size: Decimal::ZERO,
+            min_range: Decimal::ZERO,
         },
     );
     let run = run_session(&session, BarSpec::Tick(2), &mut strategy);
@@ -236,7 +236,7 @@ fn a_body_cut_rests_a_limit_under_the_harness_and_the_retest_fills() {
             window: 3,
             min_factor: "1.5".parse().expect("fixture factor"),
             max_factor: "2.5".parse().expect("fixture factor"),
-            min_size: Decimal::ZERO,
+            min_range: Decimal::ZERO,
         },
     );
     let run = run_session(&session, BarSpec::Tick(3), &mut strategy);
@@ -289,7 +289,7 @@ fn a_body_that_never_cut_the_region_rests_nothing_under_the_harness() {
             window: 3,
             min_factor: "1.5".parse().expect("fixture factor"),
             max_factor: "2.5".parse().expect("fixture factor"),
-            min_size: Decimal::ZERO,
+            min_range: Decimal::ZERO,
         },
     );
     let run = run_session(&session, BarSpec::Tick(3), &mut strategy);

--- a/crates/pine/tests/corpus/ok/exhaustion_reversal.pine
+++ b/crates/pine/tests/corpus/ok/exhaustion_reversal.pine
@@ -279,9 +279,9 @@ arm_window = math.max(run_window, cover_window)
 // `not na` guards are what keep the opening stretch unmarked.
 // The ratio and the floor, in that order: the ratio rejects most bars on its
 // own, so the floor is a comparison the short-circuit rarely reaches. A floor
-// of 0 is `body >= 0`, true for every bar including a doji — the ratio is
+// of 0 is `high - low >= 0`, true for every bar including a doji — the ratio is
 // what still decides, exactly as it did before this input existed.
-big_body = not na(avg_body_before) and avg_body_before > 0 and body >= body_factor * avg_body_before and (high - low) >= min_range_points
+big_enough = not na(avg_body_before) and avg_body_before > 0 and body >= body_factor * avg_body_before and (high - low) >= min_range_points
 new_high = not na(high_before) and high >= high_before
 new_low = not na(low_before) and low <= low_before
 
@@ -294,8 +294,8 @@ var int bull_run = 0
 bear_run := bear_bar ? bear_run + 1 : 0
 bull_run := bull_bar ? bull_run + 1 : 0
 
-top_anchor = big_body and new_high and (not need_direction or bull_bar)
-bottom_anchor = big_body and new_low and (not need_direction or bear_bar)
+top_anchor = big_enough and new_high and (not need_direction or bull_bar)
+bottom_anchor = big_enough and new_low and (not need_direction or bear_bar)
 
 // ------------------------------------------------------------------- state
 

--- a/crates/pine/tests/corpus/ok/exhaustion_reversal.pine
+++ b/crates/pine/tests/corpus/ok/exhaustion_reversal.pine
@@ -120,16 +120,12 @@
 // an absolute floor of 100 points left 7 (see docs/ux/strategy-anchors.md,
 // which is why the strategy kernel's force ruler carries a floor at all).
 //
-// NOTE, and read it before calibrating against the bot: this script's floor
-// below measures the BODY (`body >= min_body_points`), while the kernel's
-// `min_range` measures the whole CANDLE (`high - low`). They were the same
-// rule until the kernel's floor was changed on the trader's instruction;
-// this script was deliberately left measuring the body so that the paint on
-// an existing chart did not move under anyone. The consequence is real: the
-// same number in both places is a STRICTER gate here than in the armed
-// instance, so a bar this script leaves unpainted can still fire the bot.
-// Calibrate each against itself, and change this input's meaning here only
-// as a deliberate edit — not by assuming the two agree.
+// The floor measures the WHOLE CANDLE (`high - low`), the same measurement
+// the kernel's `min_range` uses. It measured the body until the trader asked
+// for the candle instead; both moved together, on purpose. A chart that
+// paints a force bar and an armed instance that fires on one must mean the
+// same thing by the word, or a trader calibrates against this script and
+// then watches the bot take a bar the chart left unmarked.
 //
 // So section 5 adds a floor in POINTS, `and`ed with the ratio above: a
 // bar must be big relative to its neighbours AND big in the instrument's own
@@ -234,7 +230,7 @@ show_bottom = input.bool(true, "4 Display: mark bottom reversals (buy side)")
 // instrument priced in fractions a drag of 1 per pixel is far too coarse and
 // the number is typed instead. A script cannot ask what a tick is worth here,
 // so one of the two has to be the dragged case.
-min_body_points = input.float(0.0, "5 Calibration: min force-bar body (points, 0 = off)", minval=0.0, step=1.0)
+min_range_points = input.float(0.0, "5 Calibration: min force-bar candle range (points, 0 = off)", minval=0.0, step=1.0)
 run_body_only = input.bool(true, "5 Calibration: run measures the body, not the range")
 cover_body_only = input.bool(true, "5 Calibration: cover measures the body, not the range")
 paint_force = input.bool(false, "5 Calibration: paint the bars that arm a push")
@@ -285,7 +281,7 @@ arm_window = math.max(run_window, cover_window)
 // own, so the floor is a comparison the short-circuit rarely reaches. A floor
 // of 0 is `body >= 0`, true for every bar including a doji — the ratio is
 // what still decides, exactly as it did before this input existed.
-big_body = not na(avg_body_before) and avg_body_before > 0 and body >= body_factor * avg_body_before and body >= min_body_points
+big_body = not na(avg_body_before) and avg_body_before > 0 and body >= body_factor * avg_body_before and (high - low) >= min_range_points
 new_high = not na(high_before) and high >= high_before
 new_low = not na(low_before) and low <= low_before
 

--- a/crates/pine/tests/corpus/ok/exhaustion_reversal.pine
+++ b/crates/pine/tests/corpus/ok/exhaustion_reversal.pine
@@ -118,7 +118,18 @@
 // chart would call one. This is measured, not suspected: on a live WINV26
 // session the same bare band marked 247 of 1 355 volume bars as force bars;
 // an absolute floor of 100 points left 7 (see docs/ux/strategy-anchors.md,
-// which is why the strategy kernel's force ruler carries `min_body`).
+// which is why the strategy kernel's force ruler carries a floor at all).
+//
+// NOTE, and read it before calibrating against the bot: this script's floor
+// below measures the BODY (`body >= min_body_points`), while the kernel's
+// `min_range` measures the whole CANDLE (`high - low`). They were the same
+// rule until the kernel's floor was changed on the trader's instruction;
+// this script was deliberately left measuring the body so that the paint on
+// an existing chart did not move under anyone. The consequence is real: the
+// same number in both places is a STRICTER gate here than in the armed
+// instance, so a bar this script leaves unpainted can still fire the bot.
+// Calibrate each against itself, and change this input's meaning here only
+// as a deliberate edit — not by assuming the two agree.
 //
 // So section 5 adds a floor in POINTS, `and`ed with the ratio above: a
 // bar must be big relative to its neighbours AND big in the instrument's own

--- a/crates/pine/tests/exhaustion_reversal_semantics.rs
+++ b/crates/pine/tests/exhaustion_reversal_semantics.rs
@@ -63,7 +63,7 @@ const USE_RUN: usize = 4;
 const RUN_WINDOW: usize = 6;
 const USE_COVER: usize = 8;
 const SHOW_TOP: usize = 11;
-const MIN_BODY_POINTS: usize = 13;
+const MIN_RANGE_POINTS: usize = 13;
 const RUN_BODY_ONLY: usize = 14;
 const COVER_BODY_ONLY: usize = 15;
 const PAINT_FORCE: usize = 16;
@@ -648,21 +648,21 @@ fn a_ratio_without_a_size_is_not_an_elephant() {
     // would call one (measured on WINV26: 247 of 1 355 bars by ratio alone,
     // 7 with a 100-point floor — docs/ux/strategy-anchors.md).
     let mut floored = inputs();
-    floored[MIN_BODY_POINTS] = InputValue::Float(11.0);
+    floored[MIN_RANGE_POINTS] = InputValue::Float(11.0);
     assert_eq!(
         sells(&run(&floored, &sell_tape())),
         none(),
-        "a 10-point body under an 11-point floor never arms, so nothing the bars after it do can mark"
+        "a 10-point candle under an 11-point floor never arms, so nothing the bars after it do can mark"
     );
 
     // And the floor is a floor, not a filter on the mark: one point lower and
     // the identical tape marks where it always did.
     let mut cleared = inputs();
-    cleared[MIN_BODY_POINTS] = InputValue::Float(10.0);
+    cleared[MIN_RANGE_POINTS] = InputValue::Float(10.0);
     assert_eq!(
         sells(&run(&cleared, &sell_tape())),
         vec![8],
-        "the floor is `>=`: a body exactly at it still counts"
+        "the floor is `>=`: a candle exactly at it still counts"
     );
 
     // Off is off — the shipped default changes nothing about the old ruler.
@@ -675,7 +675,7 @@ fn the_floor_and_the_paint_agree_about_what_armed() {
     // signal path made. A floor that silenced the arrow while leaving the bar
     // painted would send the trader hunting a bug that is not there.
     let mut floored = inputs();
-    floored[MIN_BODY_POINTS] = InputValue::Float(11.0);
+    floored[MIN_RANGE_POINTS] = InputValue::Float(11.0);
     floored[PAINT_FORCE] = InputValue::Bool(true);
     let tape = sell_tape();
     assert_eq!(
@@ -1245,5 +1245,55 @@ fn switching_the_run_off_leaves_the_cover_alone_and_vice_versa() {
         sells(&run(&neither, &cover_tape())),
         none(),
         "both shapes off is an indicator that marks nothing at all"
+    );
+}
+
+/// The floor measures the **candle**, and a fixture with wicks is the only
+/// thing that can say so.
+///
+/// Every other floor test here drives `FORCE_UP`, whose body and range are
+/// both 10 — so it passes identically whether the script reads
+/// `|close - open|` or `high - low`, and a revert to the body would leave
+/// the suite green. This tape's push has a body of 10 inside a candle of 30.
+///
+/// It is the Pine half of the kernel's
+/// `the_floor_measures_the_whole_candle_not_the_body`. The two must agree:
+/// the script paints what the armed instance trades, and a trader who
+/// calibrates the floor against this chart and then types the same number
+/// into the arming dialog has to get the same bars.
+#[test]
+fn the_floor_measures_the_candle_not_the_body() {
+    /// Body 10 (101 -> 111) inside a 30-point candle (96 -> 126): the shapes
+    /// the two measurements disagree about.
+    const WICKED_FORCE_UP: Ohlc = (101.0, 126.0, 96.0, 111.0);
+
+    let wicked_tape = || {
+        let mut t = context_up();
+        t.push(WICKED_FORCE_UP); //               5  force bar, body 10, range 30
+        t.push((111.0, 111.0, 109.0, 109.0)); //  6  give-back 1 of 3
+        t.push((109.0, 109.0, 107.0, 107.0)); //  7  give-back 2 of 3
+        t.push((107.0, 107.0, 103.0, 103.0)); //  8  give-back 3 of 3 -> marks
+        t
+    };
+
+    // A floor of 20 sits above the body and below the candle. Reading the
+    // candle, the bar clears it and the tape marks.
+    let mut between = inputs();
+    between[MIN_RANGE_POINTS] = InputValue::Float(20.0);
+    assert_eq!(
+        sells(&run(&between, &wicked_tape())),
+        vec![8],
+        "a 10-point body inside a 30-point candle clears a 20-point candle floor \
+         — reading the body, this would refuse and mark nothing"
+    );
+
+    // Above the candle, it refuses — so the floor is still a floor, and the
+    // test above is not passing because the floor stopped working.
+    let mut above = inputs();
+    above[MIN_RANGE_POINTS] = InputValue::Float(31.0);
+    assert_eq!(
+        sells(&run(&above, &wicked_tape())),
+        none(),
+        "and a 31-point floor is over the whole candle, so nothing arms"
     );
 }

--- a/crates/strategy/src/armed.rs
+++ b/crates/strategy/src/armed.rs
@@ -356,6 +356,27 @@ impl ArmedStrategy {
         self.trigger_status = self.trigger.status();
     }
 
+    /// Why the **ruler** declined the last bar it judged, as a stable
+    /// name, or `None` when the bar fired.
+    ///
+    /// [`Self::hold_reason`] answers the other half: it reports the *gates*
+    /// — side, region, geometry, account — which only ever run on a bar
+    /// the ruler already passed. A bar the ruler itself refused reaches no
+    /// gate at all, so it leaves `hold_reason` untouched and the previous
+    /// refusal standing; asking only that one is how a surface ends up
+    /// reporting an older bar's gate as though it explained this bar. Read
+    /// both, and prefer this one when it is `Some`: it is about the bar
+    /// that just closed, always.
+    ///
+    /// Handed out as a value, not a sentence, for the same reason
+    /// `hold_reason` is: an operator that is not looking at the chart has
+    /// to be able to compare a name instead of parsing English. The prose
+    /// with the numbers in it is [`Self::trigger_status`].
+    #[must_use]
+    pub fn ruler_refusal(&self) -> Option<&'static str> {
+        self.trigger.refusal()
+    }
+
     /// The ruler's reading of the last bar it judged — "force 2.1×",
     /// "quiet 0.8×", "2.08× in band · candle 95 under floor".
     ///
@@ -820,6 +841,24 @@ impl ArmedStrategy {
         }
     }
 
+    /// A remark about this instance that is **not** a refusal — today only
+    /// "alarm only — no order placed".
+    ///
+    /// Handed out because [`Self::hold_reason`] deliberately maps an aside
+    /// to `None`: it is not a gate holding anything, and reporting it as
+    /// one would be a lie of a different kind. But that left it reachable
+    /// from `status_line` and from nowhere else, so the chart badge and the
+    /// right-click menu said different things about the same armed
+    /// instance — the divergence this module's badge work exists to end,
+    /// surviving in the one note class nobody had looked at.
+    #[must_use]
+    pub fn aside(&self) -> Option<&'static str> {
+        match self.note {
+            Some(Note::Aside(remark)) => Some(remark),
+            Some(Note::Held(_)) | None => None,
+        }
+    }
+
     /// One line for the on-chart badge.
     #[must_use]
     pub fn status_line(&self) -> String {
@@ -954,7 +993,7 @@ mod tests {
                 window: 3,
                 min_factor: dec("1.5"),
                 max_factor: dec("2.5"),
-                min_size: Decimal::ZERO,
+                min_range: Decimal::ZERO,
             })),
         )
     }
@@ -1148,7 +1187,7 @@ mod tests {
                 window: 3,
                 min_factor: dec("1.5"),
                 max_factor: dec("2.5"),
-                min_size: Decimal::ZERO,
+                min_range: Decimal::ZERO,
             })),
         );
         warm_then_force(&mut instance, &region);
@@ -1254,7 +1293,7 @@ mod tests {
                 window: 3,
                 min_factor: dec("1.5"),
                 max_factor: dec("2.5"),
-                min_size: Decimal::ZERO,
+                min_range: Decimal::ZERO,
             })),
         );
         let commands = warm_then_force(&mut instance, &region);
@@ -1455,7 +1494,7 @@ mod tests {
                 window: 3,
                 min_factor: dec("1.5"),
                 max_factor: dec("2.5"),
-                min_size: Decimal::ZERO,
+                min_range: Decimal::ZERO,
             })),
         )
     }
@@ -1537,7 +1576,7 @@ mod tests {
                 window: 3,
                 min_factor: dec("1.5"),
                 max_factor: dec("2.5"),
-                min_size: Decimal::ZERO,
+                min_range: Decimal::ZERO,
             })),
         );
         assert!(warm_then_sell_cut(&mut instance, &region).is_empty());
@@ -1736,7 +1775,7 @@ mod tests {
                 window: 3,
                 min_factor: dec("1.5"),
                 max_factor: dec("2.5"),
-                min_size: Decimal::ZERO,
+                min_range: Decimal::ZERO,
             })),
         );
         warm_then_sell_cut(&mut auto, &region);
@@ -1786,7 +1825,7 @@ mod tests {
                 window: 3,
                 min_factor: dec("1.5"),
                 max_factor: dec("2.5"),
-                min_size: Decimal::ZERO,
+                min_range: Decimal::ZERO,
             })),
         );
         warm_then_sell_cut(&mut auto, &region);
@@ -1972,7 +2011,7 @@ mod tests {
                 window: 3,
                 min_factor: dec("1.5"),
                 max_factor: dec("2.5"),
-                min_size: Decimal::ZERO,
+                min_range: Decimal::ZERO,
             })),
         );
         // SL = 104 + 0.1 × 6 = 104.6, below the 105 edge a short entered
@@ -2052,7 +2091,7 @@ mod tests {
                 window: 3,
                 min_factor: dec("1.5"),
                 max_factor: dec("2.5"),
-                min_size: Decimal::ZERO,
+                min_range: Decimal::ZERO,
             })),
         )
     }
@@ -2239,7 +2278,7 @@ mod tests {
             window: 3,
             min_factor: dec("1.5"),
             max_factor: dec("2.5"),
-            min_size: Decimal::ZERO,
+            min_range: Decimal::ZERO,
         };
         let mut ignoring = ArmedStrategy::new(
             params(Side::Sell),
@@ -2316,6 +2355,135 @@ mod tests {
             instance.trigger_status(),
             instance.trigger().status(),
             "after a re-arm that reset the series under the ruler"
+        );
+    }
+
+    /// Every way the ruler can decline a bar has a name a machine can read.
+    ///
+    /// This is the half of the reported defect that a screenshot cannot
+    /// show. A bar the ruler refuses never reaches a gate, so `hold_reason`
+    /// keeps pointing at an older bar — and until `ruler_refusal` existed
+    /// there was no value anywhere saying *this* bar was declined by the
+    /// ruler, only prose in a badge. An operator that is not looking at the
+    /// chart had no way to answer "why did nothing happen here?".
+    ///
+    /// One assertion per verdict, so a sixth one cannot be added without
+    /// deciding what it is called.
+    #[test]
+    fn every_ruler_verdict_that_declines_a_bar_has_a_readable_name() {
+        let region = Region::new(dec("100"), dec("110"));
+        let banded = |min_range: &str| {
+            ArmedStrategy::new(
+                params(Side::Buy),
+                Box::new(ForceTrigger::new(ForceParams {
+                    window: 3,
+                    min_factor: dec("1.5"),
+                    max_factor: dec("2.5"),
+                    min_range: dec(min_range),
+                })),
+            )
+        };
+
+        // Nothing judged yet.
+        assert_eq!(banded("0").ruler_refusal(), Some("no bars judged yet"));
+
+        // Warmup: fewer bodies than the window.
+        let mut instance = banded("0");
+        instance.on_closed_bar(&bar("100", "101"), &region, true, true);
+        assert_eq!(instance.ruler_refusal(), Some("ruler still warming up"));
+
+        // Flat average: an all-doji window has no ratio to speak of.
+        let mut instance = banded("0");
+        for _ in 0..3 {
+            instance.on_closed_bar(&bar("100", "100"), &region, true, true);
+        }
+        assert_eq!(instance.ruler_refusal(), Some("flat average — no ruler"));
+
+        // No side: a warm ruler and a bar that closed where it opened.
+        let mut instance = banded("0");
+        for pair in [("100", "101"), ("101", "102"), ("102", "104")] {
+            instance.on_closed_bar(&bar(pair.0, pair.1), &region, true, true);
+        }
+        instance.on_closed_bar(&bar("104", "104"), &region, true, true);
+        assert_eq!(instance.ruler_refusal(), Some("doji — no side"));
+
+        // Quiet: a body far under the band.
+        let mut instance = banded("0");
+        for pair in [("100", "110"), ("110", "120")] {
+            instance.on_closed_bar(&bar(pair.0, pair.1), &region, true, true);
+        }
+        instance.on_closed_bar(&bar("120", "121"), &region, true, true);
+        assert_eq!(
+            instance.ruler_refusal(),
+            Some("body quiet against the average")
+        );
+
+        // Exhaustion: a body far over it.
+        let mut instance = banded("0");
+        for pair in [("100", "110"), ("110", "120")] {
+            instance.on_closed_bar(&bar(pair.0, pair.1), &region, true, true);
+        }
+        instance.on_closed_bar(&bar("120", "320"), &region, true, true);
+        assert_eq!(instance.ruler_refusal(), Some("body above the band"));
+
+        // Under the floor: in the band, and the candle too small in price.
+        let mut instance = banded("1000");
+        for pair in [("100", "110"), ("110", "120")] {
+            instance.on_closed_bar(&bar(pair.0, pair.1), &region, true, true);
+        }
+        instance.on_closed_bar(&bar("120", "140"), &region, true, true);
+        assert_eq!(instance.ruler_refusal(), Some("candle under the floor"));
+
+        // And a bar that fires refuses nothing.
+        let mut instance = banded("0");
+        for pair in [("100", "110"), ("110", "120")] {
+            instance.on_closed_bar(&bar(pair.0, pair.1), &region, true, true);
+        }
+        instance.on_closed_bar(&bar("120", "140"), &region, true, true);
+        assert_eq!(
+            instance.ruler_refusal(),
+            None,
+            "a force bar is not a refusal"
+        );
+    }
+
+    /// The two halves answer about different bars, and that is the point.
+    ///
+    /// The reported bug in one test: a gate refuses an early bar, then the
+    /// ruler refuses a later one. `hold_reason` still names the *gate* —
+    /// correctly, it is the last gate that spoke — and only `ruler_refusal`
+    /// is about the bar that just closed. A reader consulting one and not
+    /// the other gets a confident answer about the wrong candle.
+    #[test]
+    fn a_ruler_refused_bar_leaves_the_gates_reason_standing_and_says_so() {
+        let region = Region::new(dec("100"), dec("110"));
+        let mut instance = force_instance(Side::Buy);
+        // Warm, then a force bar whose body sits entirely above the region:
+        // the geometry gate refuses it by name.
+        for pair in [("200", "201"), ("201", "202")] {
+            instance.on_closed_bar(&bar(pair.0, pair.1), &region, true, true);
+        }
+        instance.on_closed_bar(&bar("202", "206"), &region, true, true);
+        assert_eq!(
+            instance.hold_reason().map(|held| held.reason),
+            Some("the body never cut the region")
+        );
+        assert_eq!(instance.ruler_refusal(), None, "the ruler passed that bar");
+
+        // Now a bar the ruler itself declines.
+        instance.on_closed_bar(&bar("206", "207"), &region, true, true);
+        assert_eq!(
+            instance.ruler_refusal(),
+            Some("body quiet against the average"),
+            "this bar was refused by the ruler, and says which way"
+        );
+        let held = instance
+            .hold_reason()
+            .expect("the gate's reason still stands");
+        assert_eq!(held.reason, "the body never cut the region");
+        assert!(
+            !held.fresh,
+            "and it is marked as not being about the bar that just closed"
         );
     }
 }

--- a/crates/strategy/src/armed.rs
+++ b/crates/strategy/src/armed.rs
@@ -921,7 +921,7 @@ mod tests {
                 window: 3,
                 min_factor: dec("1.5"),
                 max_factor: dec("2.5"),
-                min_body: Decimal::ZERO,
+                min_size: Decimal::ZERO,
             })),
         )
     }
@@ -1115,7 +1115,7 @@ mod tests {
                 window: 3,
                 min_factor: dec("1.5"),
                 max_factor: dec("2.5"),
-                min_body: Decimal::ZERO,
+                min_size: Decimal::ZERO,
             })),
         );
         warm_then_force(&mut instance, &region);
@@ -1221,7 +1221,7 @@ mod tests {
                 window: 3,
                 min_factor: dec("1.5"),
                 max_factor: dec("2.5"),
-                min_body: Decimal::ZERO,
+                min_size: Decimal::ZERO,
             })),
         );
         let commands = warm_then_force(&mut instance, &region);
@@ -1422,7 +1422,7 @@ mod tests {
                 window: 3,
                 min_factor: dec("1.5"),
                 max_factor: dec("2.5"),
-                min_body: Decimal::ZERO,
+                min_size: Decimal::ZERO,
             })),
         )
     }
@@ -1504,7 +1504,7 @@ mod tests {
                 window: 3,
                 min_factor: dec("1.5"),
                 max_factor: dec("2.5"),
-                min_body: Decimal::ZERO,
+                min_size: Decimal::ZERO,
             })),
         );
         assert!(warm_then_sell_cut(&mut instance, &region).is_empty());
@@ -1703,7 +1703,7 @@ mod tests {
                 window: 3,
                 min_factor: dec("1.5"),
                 max_factor: dec("2.5"),
-                min_body: Decimal::ZERO,
+                min_size: Decimal::ZERO,
             })),
         );
         warm_then_sell_cut(&mut auto, &region);
@@ -1753,7 +1753,7 @@ mod tests {
                 window: 3,
                 min_factor: dec("1.5"),
                 max_factor: dec("2.5"),
-                min_body: Decimal::ZERO,
+                min_size: Decimal::ZERO,
             })),
         );
         warm_then_sell_cut(&mut auto, &region);
@@ -1939,7 +1939,7 @@ mod tests {
                 window: 3,
                 min_factor: dec("1.5"),
                 max_factor: dec("2.5"),
-                min_body: Decimal::ZERO,
+                min_size: Decimal::ZERO,
             })),
         );
         // SL = 104 + 0.1 × 6 = 104.6, below the 105 edge a short entered
@@ -2019,7 +2019,7 @@ mod tests {
                 window: 3,
                 min_factor: dec("1.5"),
                 max_factor: dec("2.5"),
-                min_body: Decimal::ZERO,
+                min_size: Decimal::ZERO,
             })),
         )
     }
@@ -2206,7 +2206,7 @@ mod tests {
             window: 3,
             min_factor: dec("1.5"),
             max_factor: dec("2.5"),
-            min_body: Decimal::ZERO,
+            min_size: Decimal::ZERO,
         };
         let mut ignoring = ArmedStrategy::new(
             params(Side::Sell),

--- a/crates/strategy/src/armed.rs
+++ b/crates/strategy/src/armed.rs
@@ -297,6 +297,17 @@ pub struct ArmedStrategy {
     /// What the bar just judged left standing, cleared by the next bar the
     /// trigger had nothing to say about.
     note: Option<Note>,
+    /// The ruler's own reading of the last bar it judged, kept as text.
+    ///
+    /// Cached rather than asked for on demand because the badge paints it
+    /// **every frame** while [`Trigger::status`] builds an owned `String`.
+    /// The reading changes only when a bar closes or the ruler is reset, so
+    /// holding it here moves that allocation from 60 Hz to the bar rate.
+    /// Every site that can change what the ruler would say refreshes it
+    /// through [`Self::refresh_trigger_status`], and
+    /// `the_cached_ruler_reading_never_drifts_from_the_trigger` is what
+    /// keeps the two from disagreeing.
+    trigger_status: String,
     /// The most recent gate that refused a signal, kept **across** the quiet
     /// bars that follow it.
     ///
@@ -326,14 +337,33 @@ impl ArmedStrategy {
     /// A freshly armed instance.
     #[must_use]
     pub fn new(params: StrategyParams, trigger: Box<dyn Trigger>) -> Self {
+        let trigger_status = trigger.status();
         Self {
             params,
             trigger,
             state: ArmedState::Armed,
             note: None,
+            trigger_status,
             last_hold: None,
             last_close_opportunity: None,
         }
+    }
+
+    /// Re-read the ruler after something changed what it would say. One
+    /// door, so a new site that advances or resets the trigger cannot
+    /// forget half the job and leave the badge quoting a stale bar.
+    fn refresh_trigger_status(&mut self) {
+        self.trigger_status = self.trigger.status();
+    }
+
+    /// The ruler's reading of the last bar it judged — "force 2.1×",
+    /// "quiet 0.8×", "2.08× in band · candle 95 under floor".
+    ///
+    /// Borrowed rather than built, because the chart badge paints it every
+    /// frame. See [`Self::trigger_status`] for why it is cached.
+    #[must_use]
+    pub fn trigger_status(&self) -> &str {
+        &self.trigger_status
     }
 
     #[must_use]
@@ -416,6 +446,7 @@ impl ArmedStrategy {
         account_flat: bool,
     ) -> Vec<Command> {
         let signal = self.trigger.on_closed_bar(bar);
+        self.refresh_trigger_status();
         // The *opportunity* is judged for every closed bar, whatever the
         // state machine is doing and whoever holds the account: it is a
         // statement about the setup, not about this instance's ability to
@@ -718,6 +749,7 @@ impl ArmedStrategy {
         match &self.state {
             ArmedState::Disarmed { reason } if reason.resets_series() => {
                 self.trigger.reset();
+                self.refresh_trigger_status();
                 self.clear_notes();
                 self.state = ArmedState::Armed;
             }
@@ -738,6 +770,7 @@ impl ArmedStrategy {
         for bar in bars {
             let _ = self.trigger.on_closed_bar(bar);
         }
+        self.refresh_trigger_status();
         self.clear_notes();
     }
 
@@ -798,9 +831,9 @@ impl ArmedStrategy {
             ArmedState::Armed => match (self.note, self.last_hold) {
                 (Some(note), _) => format!("armed · {}", note.line()),
                 (None, Some(held)) => {
-                    format!("armed · {} · last held: {held}", self.trigger.status())
+                    format!("armed · {} · last held: {held}", self.trigger_status)
                 }
-                (None, None) => format!("armed · {}", self.trigger.status()),
+                (None, None) => format!("armed · {}", self.trigger_status),
             },
             ArmedState::Fired { retest: false, .. } => "fired · waiting for fill".to_owned(),
             // Only promise the self-cancel when the order actually carries
@@ -2232,6 +2265,57 @@ mod tests {
         assert_eq!(
             resting.preview_opportunity(&cutting, &region, true),
             Some(Opportunity::Retest { edge: dec("105") })
+        );
+    }
+
+    /// The cache and the ruler are one fact, and a test says so.
+    ///
+    /// `trigger_status` exists to keep an owned `String` off the badge's
+    /// per-frame path, and every cache buys that with a way to be wrong.
+    /// The failure would be silent and exactly the kind this branch was
+    /// opened to fix — a badge quoting a bar that has already passed — so
+    /// it is pinned here rather than left to review. Walks the three sites
+    /// that can change what the ruler would say: a judged bar, a warmup,
+    /// and a re-arm that resets the series.
+    #[test]
+    fn the_cached_ruler_reading_never_drifts_from_the_trigger() {
+        let region = Region::new(dec("100"), dec("110"));
+        let mut instance = force_instance(Side::Buy);
+        assert_eq!(
+            instance.trigger_status(),
+            instance.trigger().status(),
+            "a fresh instance already quotes its ruler"
+        );
+
+        for bar in [
+            bar("100", "101"),
+            bar("101", "102"),
+            bar("102", "106"),
+            bar("106", "106"),
+        ] {
+            instance.on_closed_bar(&bar, &region, true, true);
+            assert_eq!(
+                instance.trigger_status(),
+                instance.trigger().status(),
+                "after a judged bar"
+            );
+        }
+
+        instance.warm(&[bar("106", "112"), bar("112", "113")]);
+        assert_eq!(
+            instance.trigger_status(),
+            instance.trigger().status(),
+            "after a warmup the gates never saw"
+        );
+
+        // The cleanup commands are the simulator's business, not this
+        // test's: what is under test is what the badge quotes afterwards.
+        let _ = instance.disarm(DisarmReason::MarketChanged);
+        instance.rearm();
+        assert_eq!(
+            instance.trigger_status(),
+            instance.trigger().status(),
+            "after a re-arm that reset the series under the ruler"
         );
     }
 }

--- a/crates/strategy/src/armed.rs
+++ b/crates/strategy/src/armed.rs
@@ -351,7 +351,9 @@ impl ArmedStrategy {
     /// Handed out as a value, not a sentence, for the same reason
     /// `hold_reason` is: an operator that is not looking at the chart has
     /// to be able to compare a name instead of parsing English. The prose
-    /// with the numbers in it is [`Self::trigger_status`].
+    /// with the numbers in it is the ruler's own
+    /// [`status`](crate::Trigger::status), reachable through
+    /// [`Self::trigger`].
     #[must_use]
     pub fn ruler_refusal(&self) -> Option<&'static str> {
         self.trigger.refusal()

--- a/crates/strategy/src/armed.rs
+++ b/crates/strategy/src/armed.rs
@@ -297,17 +297,6 @@ pub struct ArmedStrategy {
     /// What the bar just judged left standing, cleared by the next bar the
     /// trigger had nothing to say about.
     note: Option<Note>,
-    /// The ruler's own reading of the last bar it judged, kept as text.
-    ///
-    /// Cached rather than asked for on demand because the badge paints it
-    /// **every frame** while [`Trigger::status`] builds an owned `String`.
-    /// The reading changes only when a bar closes or the ruler is reset, so
-    /// holding it here moves that allocation from 60 Hz to the bar rate.
-    /// Every site that can change what the ruler would say refreshes it
-    /// through [`Self::refresh_trigger_status`], and
-    /// `the_cached_ruler_reading_never_drifts_from_the_trigger` is what
-    /// keeps the two from disagreeing.
-    trigger_status: String,
     /// The most recent gate that refused a signal, kept **across** the quiet
     /// bars that follow it.
     ///
@@ -337,23 +326,14 @@ impl ArmedStrategy {
     /// A freshly armed instance.
     #[must_use]
     pub fn new(params: StrategyParams, trigger: Box<dyn Trigger>) -> Self {
-        let trigger_status = trigger.status();
         Self {
             params,
             trigger,
             state: ArmedState::Armed,
             note: None,
-            trigger_status,
             last_hold: None,
             last_close_opportunity: None,
         }
-    }
-
-    /// Re-read the ruler after something changed what it would say. One
-    /// door, so a new site that advances or resets the trigger cannot
-    /// forget half the job and leave the badge quoting a stale bar.
-    fn refresh_trigger_status(&mut self) {
-        self.trigger_status = self.trigger.status();
     }
 
     /// Why the **ruler** declined the last bar it judged, as a stable
@@ -375,16 +355,6 @@ impl ArmedStrategy {
     #[must_use]
     pub fn ruler_refusal(&self) -> Option<&'static str> {
         self.trigger.refusal()
-    }
-
-    /// The ruler's reading of the last bar it judged — "force 2.1×",
-    /// "quiet 0.8×", "2.08× in band · candle 95 under floor".
-    ///
-    /// Borrowed rather than built, because the chart badge paints it every
-    /// frame. See [`Self::trigger_status`] for why it is cached.
-    #[must_use]
-    pub fn trigger_status(&self) -> &str {
-        &self.trigger_status
     }
 
     #[must_use]
@@ -467,7 +437,6 @@ impl ArmedStrategy {
         account_flat: bool,
     ) -> Vec<Command> {
         let signal = self.trigger.on_closed_bar(bar);
-        self.refresh_trigger_status();
         // The *opportunity* is judged for every closed bar, whatever the
         // state machine is doing and whoever holds the account: it is a
         // statement about the setup, not about this instance's ability to
@@ -770,7 +739,6 @@ impl ArmedStrategy {
         match &self.state {
             ArmedState::Disarmed { reason } if reason.resets_series() => {
                 self.trigger.reset();
-                self.refresh_trigger_status();
                 self.clear_notes();
                 self.state = ArmedState::Armed;
             }
@@ -791,7 +759,6 @@ impl ArmedStrategy {
         for bar in bars {
             let _ = self.trigger.on_closed_bar(bar);
         }
-        self.refresh_trigger_status();
         self.clear_notes();
     }
 
@@ -841,24 +808,6 @@ impl ArmedStrategy {
         }
     }
 
-    /// A remark about this instance that is **not** a refusal — today only
-    /// "alarm only — no order placed".
-    ///
-    /// Handed out because [`Self::hold_reason`] deliberately maps an aside
-    /// to `None`: it is not a gate holding anything, and reporting it as
-    /// one would be a lie of a different kind. But that left it reachable
-    /// from `status_line` and from nowhere else, so the chart badge and the
-    /// right-click menu said different things about the same armed
-    /// instance — the divergence this module's badge work exists to end,
-    /// surviving in the one note class nobody had looked at.
-    #[must_use]
-    pub fn aside(&self) -> Option<&'static str> {
-        match self.note {
-            Some(Note::Aside(remark)) => Some(remark),
-            Some(Note::Held(_)) | None => None,
-        }
-    }
-
     /// One line for the on-chart badge.
     #[must_use]
     pub fn status_line(&self) -> String {
@@ -870,9 +819,9 @@ impl ArmedStrategy {
             ArmedState::Armed => match (self.note, self.last_hold) {
                 (Some(note), _) => format!("armed · {}", note.line()),
                 (None, Some(held)) => {
-                    format!("armed · {} · last held: {held}", self.trigger_status)
+                    format!("armed · {} · last held: {held}", self.trigger.status())
                 }
-                (None, None) => format!("armed · {}", self.trigger_status),
+                (None, None) => format!("armed · {}", self.trigger.status()),
             },
             ArmedState::Fired { retest: false, .. } => "fired · waiting for fill".to_owned(),
             // Only promise the self-cancel when the order actually carries
@@ -1322,6 +1271,10 @@ mod tests {
             fn status(&self) -> String {
                 "always".to_owned()
             }
+            fn refusal(&self) -> Option<&'static str> {
+                // Fires on every bar, so it never declines one.
+                None
+            }
         }
         let region = Region::new(dec("100"), dec("110"));
         let mut instance = ArmedStrategy::new(params(Side::Buy), Box::new(EveryBar));
@@ -1358,6 +1311,10 @@ mod tests {
             }
             fn status(&self) -> String {
                 "always".to_owned()
+            }
+            fn refusal(&self) -> Option<&'static str> {
+                // Fires on every bar, so it never declines one.
+                None
             }
         }
         let region = Region::new(dec("100"), dec("110"));
@@ -2304,57 +2261,6 @@ mod tests {
         assert_eq!(
             resting.preview_opportunity(&cutting, &region, true),
             Some(Opportunity::Retest { edge: dec("105") })
-        );
-    }
-
-    /// The cache and the ruler are one fact, and a test says so.
-    ///
-    /// `trigger_status` exists to keep an owned `String` off the badge's
-    /// per-frame path, and every cache buys that with a way to be wrong.
-    /// The failure would be silent and exactly the kind this branch was
-    /// opened to fix — a badge quoting a bar that has already passed — so
-    /// it is pinned here rather than left to review. Walks the three sites
-    /// that can change what the ruler would say: a judged bar, a warmup,
-    /// and a re-arm that resets the series.
-    #[test]
-    fn the_cached_ruler_reading_never_drifts_from_the_trigger() {
-        let region = Region::new(dec("100"), dec("110"));
-        let mut instance = force_instance(Side::Buy);
-        assert_eq!(
-            instance.trigger_status(),
-            instance.trigger().status(),
-            "a fresh instance already quotes its ruler"
-        );
-
-        for bar in [
-            bar("100", "101"),
-            bar("101", "102"),
-            bar("102", "106"),
-            bar("106", "106"),
-        ] {
-            instance.on_closed_bar(&bar, &region, true, true);
-            assert_eq!(
-                instance.trigger_status(),
-                instance.trigger().status(),
-                "after a judged bar"
-            );
-        }
-
-        instance.warm(&[bar("106", "112"), bar("112", "113")]);
-        assert_eq!(
-            instance.trigger_status(),
-            instance.trigger().status(),
-            "after a warmup the gates never saw"
-        );
-
-        // The cleanup commands are the simulator's business, not this
-        // test's: what is under test is what the badge quotes afterwards.
-        let _ = instance.disarm(DisarmReason::MarketChanged);
-        instance.rearm();
-        assert_eq!(
-            instance.trigger_status(),
-            instance.trigger().status(),
-            "after a re-arm that reset the series under the ruler"
         );
     }
 

--- a/crates/strategy/src/force.rs
+++ b/crates/strategy/src/force.rs
@@ -686,4 +686,80 @@ mod tests {
             other => panic!("the range floor admits this bar, got {other:?}"),
         }
     }
+
+    /// The trader's own preset, and the two regimes it splits the reported
+    /// bar into.
+    ///
+    /// Every other fixture here runs the shipped band (1.5-2.5) over a
+    /// 3-bar window. `SellGainAlarm` runs **`window = 20`, `min_factor =
+    /// 2`, `max_factor = 4.5`, floor 100**, and that difference decides
+    /// whether this branch's change touches the reported bar at all: the
+    /// floor is consulted **only inside the band**, so a body under 2x the
+    /// 20-bar average is `Quiet` and never reaches any floor, of either
+    /// kind.
+    ///
+    /// So the honest diagnosis is conditional, and this test is the
+    /// condition written down:
+    ///
+    /// - body under 2x the average -> `Quiet`. The floor never ran, and
+    ///   changing what it measures would not have fired the bar.
+    /// - body inside the band, candle over the floor -> the change is
+    ///   exactly what fires it.
+    ///
+    /// Which one the marked bar was cannot be settled from here: there is
+    /// no BTCUSDT recording of that session on disk, and the badge that
+    /// would have named the gate is the thing this branch repairs. It is a
+    /// question for the trader with the fix in hand, not a claim to make
+    /// without the tape.
+    #[test]
+    fn under_the_traders_own_band_the_floor_is_only_reached_inside_it() {
+        let preset = || ForceParams {
+            window: 20,
+            min_factor: dec("2"),
+            max_factor: dec("4.5"),
+            min_range: dec("100"),
+        };
+        // Twenty 40-point bodies: a congested stretch, average body 40.
+        let warm: Vec<Bar> = (0..20).map(|_| bar("100", "140")).collect();
+
+        // Regime one: a 60-point body is 1.46x the average - under the
+        // band's floor of 2x. `Quiet`, and no floor of any kind was read.
+        let mut ruler = ForceWindow::new(preset());
+        for b in &warm {
+            ruler.classify(b);
+        }
+        match ruler.classify(&wicked("180000", "179940", "180100", "179960")) {
+            BarVerdict::Quiet { ratio } => assert!(
+                ratio < dec("2"),
+                "under the band, so the floor is never consulted: {ratio}"
+            ),
+            other => panic!("a 60-point body against a 40-point average is quiet, got {other:?}"),
+        }
+
+        // Regime two: a 95-point body is 2.22x - inside the band, so the
+        // floor decides. Its candle reaches 140, which clears 100.
+        let mut ruler = ForceWindow::new(preset());
+        for b in &warm {
+            ruler.classify(b);
+        }
+        match ruler.classify(&wicked("180000", "179905", "180100", "179960")) {
+            BarVerdict::Force(force) => {
+                assert_eq!(force.body, dec("95"));
+                assert_eq!(force.range, dec("140"));
+                assert!(
+                    force.ratio >= dec("2") && force.ratio <= dec("4.5"),
+                    "inside the trader's band, which is what lets the floor \
+                     decide at all: {}",
+                    force.ratio
+                );
+                assert!(
+                    force.body < dec("100"),
+                    "and the old body floor of 100 refused exactly this bar"
+                );
+            }
+            other => {
+                panic!("a 95-point body at 2.22x with a 140-point candle fires, got {other:?}")
+            }
+        }
+    }
 }

--- a/crates/strategy/src/force.rs
+++ b/crates/strategy/src/force.rs
@@ -56,6 +56,18 @@ pub struct ForceParams {
     /// neighbours*, the floor refuses one that is small *in price*. A body
     /// of 95 on a candle reaching 140 is a real push held by neither.
     ///
+    /// **The floor also moves risk per trade, not only signal count.** The
+    /// bracket projects off [`ForceBar::range`] — the same `high - low`
+    /// this floor now measures — so a bar admitted on its candle rather
+    /// than its body arms a stop sized by that candle. A 25-point push
+    /// inside a 140-point range is refused by a 100-point *body* floor and
+    /// admitted by a 100-point range floor, and the order it arms carries
+    /// `sl_mult × 140` of stop for a body that travelled 25. That is a
+    /// consequence of the measurement, not a defect in it, and it is
+    /// written here because every other paragraph about this floor talks
+    /// about how many bars it admits and none of them said what those bars
+    /// cost.
+    ///
     /// The cost is named because it is real: a wick-dominated doji reaches
     /// far and closes nowhere, so it clears this floor on reach alone. What
     /// still has to admit it is the ratio band, and a doji's body makes a
@@ -549,7 +561,7 @@ mod tests {
                 assert_eq!(force.side, Side::Sell, "close under open is a push down");
             }
             other => panic!(
-                "a 95-point body on a 140-point candle clears a 100-point candle floor, got                  {other:?}"
+                "a 95-point body on a 140-point candle clears a 100-point candle floor, got {other:?}"
             ),
         }
     }
@@ -636,7 +648,42 @@ mod tests {
         assert_eq!(range, dec("140"));
         assert!(
             body < dec("100") && range >= dec("100"),
-            "the fixture is exactly the bar the change is about: refused on              its body, admitted on its candle"
+            "the fixture is exactly the bar the change is about: refused on its body, admitted on its candle"
         );
+    }
+
+    /// The stop a newly admitted bar arms is sized by its candle.
+    ///
+    /// The floor and the bracket ruler are the same measurement, so
+    /// loosening one moves the other. This pins the arithmetic on the
+    /// branch's own congestion fixture: a body of 25 arming a projection of
+    /// 140. It is not asserting that this is *desirable* — it is asserting
+    /// that it is what happens, so a change to either the floor or the
+    /// projection has to come past a test that states the relationship.
+    #[test]
+    fn a_bar_admitted_on_its_candle_projects_off_that_candle() {
+        let mut ruler = ForceWindow::new(ForceParams {
+            window: 3,
+            min_factor: dec("1.5"),
+            max_factor: dec("2.5"),
+            min_range: dec("100"),
+        });
+        ruler.classify(&bar("100", "110"));
+        ruler.classify(&bar("110", "120"));
+        match ruler.classify(&wicked("180000", "179975", "180100", "179960")) {
+            BarVerdict::Force(force) => {
+                assert_eq!(force.body, dec("25"), "the push the trader saw");
+                assert_eq!(
+                    force.range,
+                    dec("140"),
+                    "and the ruler the bracket will project from"
+                );
+                assert!(
+                    force.range > force.body * dec("5"),
+                    "the projection is over five times the body that earned it,                      which is the risk consequence of measuring the candle"
+                );
+            }
+            other => panic!("the range floor admits this bar, got {other:?}"),
+        }
     }
 }

--- a/crates/strategy/src/force.rs
+++ b/crates/strategy/src/force.rs
@@ -680,7 +680,7 @@ mod tests {
                 );
                 assert!(
                     force.range > force.body * dec("5"),
-                    "the projection is over five times the body that earned it,                      which is the risk consequence of measuring the candle"
+                    "the projection is over five times the body that earned it, which is the risk consequence of measuring the candle"
                 );
             }
             other => panic!("the range floor admits this bar, got {other:?}"),

--- a/crates/strategy/src/force.rs
+++ b/crates/strategy/src/force.rs
@@ -227,10 +227,7 @@ impl ForceWindow {
     #[must_use]
     pub fn weigh(&self, bar: &Bar) -> BarVerdict {
         let body = (bar.close - bar.open).abs();
-        // The candle's own range, which the absolute floor judges and the
-        // bracket projection rides on. Read once so the gate and the
-        // `ForceBar` it builds can never disagree about the same bar.
-        let range = bar.high - bar.low;
+
         // What the window would hold with this bar folded in: one body
         // longer, capped at the window, oldest evicted once it is full.
         let filled = (self.bodies.len() + 1).min(self.params.window);
@@ -264,18 +261,28 @@ impl ForceWindow {
             BarVerdict::Exhaustion { side, ratio }
         } else if ratio < min {
             BarVerdict::Quiet { ratio }
-        } else if range >= self.params.min_range {
+        } else if bar.high.saturating_sub(bar.low) >= self.params.min_range {
             BarVerdict::Force(ForceBar {
                 side,
                 body,
-                range,
+                // The candle's own range, which the floor just judged and the
+                // bracket projection rides on. Computed here rather than at
+                // the top of `weigh`: every bar the ruler sees passes through
+                // this method, warmup and quiet ones included, and they do not
+                // need it. `saturating_sub` for the same reason the running
+                // sum below saturates — an extreme bar should produce a
+                // verdict, not abort the kernel.
+                range: bar.high.saturating_sub(bar.low),
                 ratio,
             })
         } else {
             // Inside the band but under the absolute floor: a ratio without
             // a size is not an elephant — and the verdict says which rule
             // held it, because "quiet" over a band-clearing bar is a lie.
-            BarVerdict::UnderFloor { ratio, range }
+            BarVerdict::UnderFloor {
+                ratio,
+                range: bar.high.saturating_sub(bar.low),
+            }
         }
     }
 }
@@ -320,6 +327,17 @@ mod tests {
     /// A bar whose shadows reach past its body, so a fixture can separate
     /// the body the ratio band reads from the candle the floor measures.
     fn wicked(open: &str, close: &str, high: &str, low: &str) -> Bar {
+        // A real bar satisfies `low <= open, close <= high`. Two fixtures on
+        // this branch did not — a close *under* the low — and they were
+        // carrying the diagnosis the whole mission turned on, asserting a
+        // range the geometry could never have produced. Nothing in the engine
+        // rejects such a bar, so the guard belongs where the fixture is
+        // written.
+        let (o, c, h, l) = (dec(open), dec(close), dec(high), dec(low));
+        assert!(
+            l <= o && o <= h && l <= c && c <= h,
+            "not a bar a tape can print: open {o}, close {c} outside {l}..{h}"
+        );
         Bar {
             open_time: 0,
             close_time: 0,
@@ -728,7 +746,7 @@ mod tests {
         for b in &warm {
             ruler.classify(b);
         }
-        match ruler.classify(&wicked("180000", "179940", "180100", "179960")) {
+        match ruler.classify(&wicked("180000", "179940", "180010", "179930")) {
             BarVerdict::Quiet { ratio } => assert!(
                 ratio < dec("2"),
                 "under the band, so the floor is never consulted: {ratio}"
@@ -742,7 +760,7 @@ mod tests {
         for b in &warm {
             ruler.classify(b);
         }
-        match ruler.classify(&wicked("180000", "179905", "180100", "179960")) {
+        match ruler.classify(&wicked("180000", "179905", "180030", "179890")) {
             BarVerdict::Force(force) => {
                 assert_eq!(force.body, dec("95"));
                 assert_eq!(force.range, dec("140"));

--- a/crates/strategy/src/force.rs
+++ b/crates/strategy/src/force.rs
@@ -28,7 +28,8 @@ pub struct ForceParams {
     /// Upper edge of the band (inclusive). Above it the bar is exhaustion,
     /// not force.
     pub max_factor: Decimal,
-    /// Absolute floor on the body, in price units. Zero disables it.
+    /// Absolute floor on the candle's **size** — its full `high - low`
+    /// range, wicks included — in price units. Zero disables it.
     ///
     /// The relative band alone is honest on time candles but promiscuous
     /// on activity-cut bars: a volume bar carries the same volume as every
@@ -36,7 +37,22 @@ pub struct ForceParams {
     /// a 35-point body reads "1.7× force". Measured on a WINV26 session,
     /// the bare band marked 247 of 1,355 bars as force; a 100-point floor
     /// left 7. An elephant has a size, not only a ratio.
-    pub min_body: Decimal,
+    ///
+    /// **This floor measures the whole candle while the ratio band above
+    /// measures the body**, and the mismatch is deliberate — a trader's
+    /// decision, recorded rather than inferred. The two gates object to
+    /// different things: the band refuses a bar that is small *next to its
+    /// neighbours*, the floor refuses one that is small *in price*. A body
+    /// of 95 on a candle reaching 140 is a real push held by neither.
+    ///
+    /// The cost is named because it is real: a wick-dominated doji reaches
+    /// far and closes nowhere, so it clears this floor on reach alone. What
+    /// still has to admit it is the ratio band, and a doji's body makes a
+    /// small ratio, so the two gates in series stay narrower than this one
+    /// read alone. A setup wanting the *body* itself to carry a minimum
+    /// size needs a second floor, which this ruler does not ship until
+    /// someone asks for it.
+    pub min_size: Decimal,
 }
 
 impl ForceParams {
@@ -50,7 +66,7 @@ impl ForceParams {
             window: 20,
             min_factor: Decimal::new(15, 1),
             max_factor: Decimal::new(25, 1),
-            min_body: Decimal::ZERO,
+            min_size: Decimal::ZERO,
         }
     }
 }
@@ -88,14 +104,19 @@ pub enum BarVerdict {
         ratio: Decimal,
     },
     Force(ForceBar),
-    /// Ratio inside the band but body under the absolute floor — the bar
-    /// the *relative* ruler would call force and the elephant gate holds.
-    /// Distinct from [`BarVerdict::Quiet`] so the badge can say which rule
-    /// held it: "quiet 1.7×" over a bar visibly inside the band reads as a
-    /// broken ruler.
+    /// Ratio inside the band but the candle's size under the absolute
+    /// floor — the bar the *relative* ruler would call force and the
+    /// elephant gate holds. Distinct from [`BarVerdict::Quiet`] so the
+    /// badge can say which rule held it: "quiet 1.7×" over a bar visibly
+    /// inside the band reads as a broken ruler.
+    ///
+    /// `size` is the measurement that was refused (`high - low`), so a
+    /// badge can print the number the trader would have to change. It is
+    /// deliberately not the body: reporting a figure the gate did not
+    /// consult is how a trader ends up tuning the wrong input.
     UnderFloor {
         ratio: Decimal,
-        body: Decimal,
+        size: Decimal,
     },
     /// Body above the band — too big to chase.
     Exhaustion {
@@ -183,6 +204,10 @@ impl ForceWindow {
     #[must_use]
     pub fn weigh(&self, bar: &Bar) -> BarVerdict {
         let body = (bar.close - bar.open).abs();
+        // The candle's own size, which the absolute floor judges and the
+        // bracket projection rides on. Read once so the gate and the
+        // `ForceBar` it builds can never disagree about the same bar.
+        let size = bar.high - bar.low;
         // What the window would hold with this bar folded in: one body
         // longer, capped at the window, oldest evicted once it is full.
         let filled = (self.bodies.len() + 1).min(self.params.window);
@@ -216,18 +241,18 @@ impl ForceWindow {
             BarVerdict::Exhaustion { side, ratio }
         } else if ratio < min {
             BarVerdict::Quiet { ratio }
-        } else if body >= self.params.min_body {
+        } else if size >= self.params.min_size {
             BarVerdict::Force(ForceBar {
                 side,
                 body,
-                range: bar.high - bar.low,
+                range: size,
                 ratio,
             })
         } else {
             // Inside the band but under the absolute floor: a ratio without
             // a size is not an elephant — and the verdict says which rule
             // held it, because "quiet" over a band-clearing bar is a lie.
-            BarVerdict::UnderFloor { ratio, body }
+            BarVerdict::UnderFloor { ratio, size }
         }
     }
 }
@@ -269,12 +294,28 @@ mod tests {
         }
     }
 
+    /// A bar whose shadows reach past its body, so a fixture can separate
+    /// the body the ratio band reads from the candle the floor measures.
+    fn wicked(open: &str, close: &str, high: &str, low: &str) -> Bar {
+        Bar {
+            open_time: 0,
+            close_time: 0,
+            open: dec(open),
+            high: dec(high),
+            low: dec(low),
+            close: dec(close),
+            buy_volume: Decimal::ONE,
+            sell_volume: Decimal::ONE,
+            trade_count: 2,
+        }
+    }
+
     fn window(len: usize, min: &str, max: &str) -> ForceWindow {
         ForceWindow::new(ForceParams {
             window: len,
             min_factor: dec(min),
             max_factor: dec(max),
-            min_body: Decimal::ZERO,
+            min_size: Decimal::ZERO,
         })
     }
 
@@ -385,12 +426,12 @@ mod tests {
     /// marked 247 of 1,355 volume bars as force; this gate is what turns
     /// the ruler back into "elephant".
     #[test]
-    fn the_body_floor_holds_quiet_what_the_band_alone_would_call_force() {
+    fn the_candle_floor_holds_quiet_what_the_band_alone_would_call_force() {
         let mut gated = ForceWindow::new(ForceParams {
             window: 3,
             min_factor: dec("1.5"),
             max_factor: dec("2.5"),
-            min_body: dec("100"),
+            min_size: dec("100"),
         });
         // Bodies 30, 30, then 60: ratio 1.5 — band says force, floor says
         // no, and the verdict names the floor rather than calling it quiet.
@@ -400,9 +441,9 @@ mod tests {
             gated.classify(&bar("160", "220")),
             BarVerdict::UnderFloor {
                 ratio: dec("1.5"),
-                body: dec("60"),
+                size: dec("62"),
             },
-            "60 points of body is not an elephant under a 100-point floor"
+            "a 62-point candle is not an elephant under a 100-point floor"
         );
 
         // Bodies 100, 100, then 200: ratio 1.5 and body 200 — both gates pass.
@@ -410,7 +451,7 @@ mod tests {
             window: 3,
             min_factor: dec("1.5"),
             max_factor: dec("2.5"),
-            min_body: dec("100"),
+            min_size: dec("100"),
         });
         gated.classify(&bar("1000", "1100"));
         gated.classify(&bar("1100", "1200"));
@@ -464,6 +505,68 @@ mod tests {
                 window.classify(bar),
                 "the two readings of bar {index} disagree"
             );
+        }
+    }
+
+    /// The trader's own rule, and the bar it was written for: the floor
+    /// measures the **candle**, not the body.
+    ///
+    /// A 95-point body sitting inside the band, on a candle reaching 140.
+    /// Under the old body floor of 100 this was `UnderFloor` and no order
+    /// was placed — the setup the trader watched go by at the top of a sell
+    /// zone. The candle is plainly an elephant; the body alone was what
+    /// could not see it.
+    #[test]
+    fn the_floor_measures_the_whole_candle_not_the_body() {
+        let mut gated = ForceWindow::new(ForceParams {
+            window: 3,
+            min_factor: dec("1.5"),
+            max_factor: dec("2.5"),
+            min_size: dec("100"),
+        });
+        // Two 30-point bodies warm the window, so the average is 30 until
+        // the judged bar folds itself in.
+        gated.classify(&bar("100", "130"));
+        gated.classify(&bar("130", "160"));
+        // Body 95 (ratio ~1.84, inside the band) on a 140-point candle.
+        match gated.classify(&wicked("200", "105", "210", "70")) {
+            BarVerdict::Force(force) => {
+                assert_eq!(force.body, dec("95"), "the body the band judged");
+                assert_eq!(force.range, dec("140"), "the candle the floor cleared");
+                assert_eq!(force.side, Side::Sell, "close under open is a push down");
+            }
+            other => panic!(
+                "a 95-point body on a 140-point candle clears a 100-point candle floor, got                  {other:?}"
+            ),
+        }
+    }
+
+    /// The exposure the candle floor takes on, written down as a test so it
+    /// is a known position rather than a surprise.
+    ///
+    /// A bar that reaches far and closes nowhere clears the *floor* on reach
+    /// alone, where a body floor refused it. What still has to admit it is
+    /// the ratio band — and a doji's body makes a small ratio, so the two
+    /// gates in series stay narrower than this one read by itself. This test
+    /// is what would fail first if that second gate were ever loosened.
+    #[test]
+    fn a_wick_dominated_candle_clears_the_floor_and_the_band_still_refuses_it() {
+        let mut gated = ForceWindow::new(ForceParams {
+            window: 3,
+            min_factor: dec("1.5"),
+            max_factor: dec("2.5"),
+            min_size: dec("100"),
+        });
+        gated.classify(&bar("100", "130"));
+        gated.classify(&bar("130", "160"));
+        // Body 5 on a 200-point candle: the floor sees an elephant, the
+        // band sees the doji it is.
+        match gated.classify(&wicked("160", "165", "300", "100")) {
+            BarVerdict::Quiet { ratio } => assert!(
+                ratio < dec("1.5"),
+                "the band is what refuses a candle the size floor let through, got {ratio}"
+            ),
+            other => panic!("a 5-point body is not force at any candle size, got {other:?}"),
         }
     }
 }

--- a/crates/strategy/src/force.rs
+++ b/crates/strategy/src/force.rs
@@ -594,6 +594,11 @@ mod tests {
     /// outright. It is the cost of the trader's decision written down as an
     /// executable fact, so that "the floor is looser now" is a number
     /// somebody can read rather than a worry somebody has.
+    ///
+    /// The comparison is between the two *measurements* on one bar, not
+    /// between two rulers: `ForceParams` has no body-floor mode left to
+    /// build a second window from, and an earlier version of this test
+    /// pretended otherwise by constructing the same window twice.
     #[test]
     fn a_congested_tape_admits_more_than_the_body_floor_did() {
         let params = ForceParams {
@@ -620,20 +625,18 @@ mod tests {
             other => panic!("the range floor admits this bar, got {other:?}"),
         }
 
-        // The very same bar under a floor of the same number read against
-        // the body: refused. This is the whole delta, in one assertion.
-        let mut bodied = ForceWindow::new(params);
-        for bar in &warm {
-            bodied.classify(bar);
-        }
-        let body_floor_would_refuse = (judged.close - judged.open).abs() < dec("100");
+        // The delta, stated honestly: this ruler has no body-floor mode to
+        // compare against any more, so the comparison is between the two
+        // measurements on this bar rather than between two windows. A body
+        // of 25 against a floor of 100 could only ever have been refused;
+        // the candle is what admits it.
+        let body = (judged.close - judged.open).abs();
+        let range = judged.high - judged.low;
+        assert_eq!(body, dec("25"));
+        assert_eq!(range, dec("140"));
         assert!(
-            body_floor_would_refuse,
-            "the fixture must be a bar the old body floor refused, or it              proves nothing"
-        );
-        assert!(
-            matches!(bodied.classify(&judged), BarVerdict::Force(_)),
-            "and the range floor is what admits it now"
+            body < dec("100") && range >= dec("100"),
+            "the fixture is exactly the bar the change is about: refused on              its body, admitted on its candle"
         );
     }
 }

--- a/crates/strategy/src/force.rs
+++ b/crates/strategy/src/force.rs
@@ -28,15 +28,26 @@ pub struct ForceParams {
     /// Upper edge of the band (inclusive). Above it the bar is exhaustion,
     /// not force.
     pub max_factor: Decimal,
-    /// Absolute floor on the candle's **size** — its full `high - low`
-    /// range, wicks included — in price units. Zero disables it.
+    /// Absolute floor on the candle's full `high - low` **range**
+    /// (wicks included), in price units. Zero disables it. Named to match
+    /// [`ForceBar::range`], which is the same measurement on a bar that passed.
     ///
     /// The relative band alone is honest on time candles but promiscuous
     /// on activity-cut bars: a volume bar carries the same volume as every
     /// neighbour by construction, congestion shrinks the average body, and
-    /// a 35-point body reads "1.7× force". Measured on a WINV26 session,
-    /// the bare band marked 247 of 1,355 bars as force; a 100-point floor
-    /// left 7. An elephant has a size, not only a ratio.
+    /// a 35-point body reads "1.7× force". An elephant has a size, not
+    /// only a ratio.
+    ///
+    /// **The measurement that justified this floor was taken against the
+    /// body, not the range.** On a WINV26 session the bare band marked 247
+    /// of 1,355 bars as force and a 100-point *body* floor left 7. That
+    /// figure does not carry over: a range floor admits every bar the body
+    /// floor did and more, because `high - low >= |close - open|` always.
+    /// Quoting 7 for this gate would be an inferred number wearing a
+    /// measured one's clothes. The honest statement is that this floor is
+    /// **looser than the one that was measured**, by an amount nobody has
+    /// measured yet, and `a_congested_tape_admits_more_than_the_body_floor_did`
+    /// shows the shape of the difference.
     ///
     /// **This floor measures the whole candle while the ratio band above
     /// measures the body**, and the mismatch is deliberate — a trader's
@@ -52,7 +63,7 @@ pub struct ForceParams {
     /// read alone. A setup wanting the *body* itself to carry a minimum
     /// size needs a second floor, which this ruler does not ship until
     /// someone asks for it.
-    pub min_size: Decimal,
+    pub min_range: Decimal,
 }
 
 impl ForceParams {
@@ -66,7 +77,7 @@ impl ForceParams {
             window: 20,
             min_factor: Decimal::new(15, 1),
             max_factor: Decimal::new(25, 1),
-            min_size: Decimal::ZERO,
+            min_range: Decimal::ZERO,
         }
     }
 }
@@ -104,19 +115,19 @@ pub enum BarVerdict {
         ratio: Decimal,
     },
     Force(ForceBar),
-    /// Ratio inside the band but the candle's size under the absolute
+    /// Ratio inside the band but the candle's range under the absolute
     /// floor — the bar the *relative* ruler would call force and the
     /// elephant gate holds. Distinct from [`BarVerdict::Quiet`] so the
     /// badge can say which rule held it: "quiet 1.7×" over a bar visibly
     /// inside the band reads as a broken ruler.
     ///
-    /// `size` is the measurement that was refused (`high - low`), so a
+    /// `range` is the measurement that was refused (`high - low`), so a
     /// badge can print the number the trader would have to change. It is
     /// deliberately not the body: reporting a figure the gate did not
     /// consult is how a trader ends up tuning the wrong input.
     UnderFloor {
         ratio: Decimal,
-        size: Decimal,
+        range: Decimal,
     },
     /// Body above the band — too big to chase.
     Exhaustion {
@@ -204,10 +215,10 @@ impl ForceWindow {
     #[must_use]
     pub fn weigh(&self, bar: &Bar) -> BarVerdict {
         let body = (bar.close - bar.open).abs();
-        // The candle's own size, which the absolute floor judges and the
+        // The candle's own range, which the absolute floor judges and the
         // bracket projection rides on. Read once so the gate and the
         // `ForceBar` it builds can never disagree about the same bar.
-        let size = bar.high - bar.low;
+        let range = bar.high - bar.low;
         // What the window would hold with this bar folded in: one body
         // longer, capped at the window, oldest evicted once it is full.
         let filled = (self.bodies.len() + 1).min(self.params.window);
@@ -241,18 +252,18 @@ impl ForceWindow {
             BarVerdict::Exhaustion { side, ratio }
         } else if ratio < min {
             BarVerdict::Quiet { ratio }
-        } else if size >= self.params.min_size {
+        } else if range >= self.params.min_range {
             BarVerdict::Force(ForceBar {
                 side,
                 body,
-                range: size,
+                range,
                 ratio,
             })
         } else {
             // Inside the band but under the absolute floor: a ratio without
             // a size is not an elephant — and the verdict says which rule
             // held it, because "quiet" over a band-clearing bar is a lie.
-            BarVerdict::UnderFloor { ratio, size }
+            BarVerdict::UnderFloor { ratio, range }
         }
     }
 }
@@ -315,7 +326,7 @@ mod tests {
             window: len,
             min_factor: dec(min),
             max_factor: dec(max),
-            min_size: Decimal::ZERO,
+            min_range: Decimal::ZERO,
         })
     }
 
@@ -420,7 +431,9 @@ mod tests {
         }
     }
 
-    /// The absolute floor: a ratio without a size is not an elephant. In
+    /// The absolute floor: a ratio without a size is not an elephant. (The
+    /// 247/1,355 figures below were measured against the *body* floor this
+    /// gate replaced; see [`ForceParams::min_range`].) In
     /// congestion the average body shrinks and modest bars clear the
     /// relative band — measured on a real WINV26 session, the bare band
     /// marked 247 of 1,355 volume bars as force; this gate is what turns
@@ -431,7 +444,7 @@ mod tests {
             window: 3,
             min_factor: dec("1.5"),
             max_factor: dec("2.5"),
-            min_size: dec("100"),
+            min_range: dec("100"),
         });
         // Bodies 30, 30, then 60: ratio 1.5 — band says force, floor says
         // no, and the verdict names the floor rather than calling it quiet.
@@ -441,7 +454,7 @@ mod tests {
             gated.classify(&bar("160", "220")),
             BarVerdict::UnderFloor {
                 ratio: dec("1.5"),
-                size: dec("62"),
+                range: dec("62"),
             },
             "a 62-point candle is not an elephant under a 100-point floor"
         );
@@ -451,7 +464,7 @@ mod tests {
             window: 3,
             min_factor: dec("1.5"),
             max_factor: dec("2.5"),
-            min_size: dec("100"),
+            min_range: dec("100"),
         });
         gated.classify(&bar("1000", "1100"));
         gated.classify(&bar("1100", "1200"));
@@ -522,7 +535,7 @@ mod tests {
             window: 3,
             min_factor: dec("1.5"),
             max_factor: dec("2.5"),
-            min_size: dec("100"),
+            min_range: dec("100"),
         });
         // Two 30-point bodies warm the window, so the average is 30 until
         // the judged bar folds itself in.
@@ -555,7 +568,7 @@ mod tests {
             window: 3,
             min_factor: dec("1.5"),
             max_factor: dec("2.5"),
-            min_size: dec("100"),
+            min_range: dec("100"),
         });
         gated.classify(&bar("100", "130"));
         gated.classify(&bar("130", "160"));
@@ -568,5 +581,59 @@ mod tests {
             ),
             other => panic!("a 5-point body is not force at any candle size, got {other:?}"),
         }
+    }
+
+    /// What the range floor lets through that the body floor did not, in
+    /// the regime the floor was added for.
+    ///
+    /// The doji test above warms with 30-point bodies, so its ratio is far
+    /// under the band and the *band* refuses the bar whatever the floor
+    /// says — which proves the gates compose, and proves nothing about
+    /// congestion. This one is congestion: a shrunken average body, so the
+    /// ratio clears easily, and a bar whose body would have been refused
+    /// outright. It is the cost of the trader's decision written down as an
+    /// executable fact, so that "the floor is looser now" is a number
+    /// somebody can read rather than a worry somebody has.
+    #[test]
+    fn a_congested_tape_admits_more_than_the_body_floor_did() {
+        let params = ForceParams {
+            window: 3,
+            min_factor: dec("1.5"),
+            max_factor: dec("2.5"),
+            min_range: dec("100"),
+        };
+        // Congestion: two 10-point bodies, so the average is small and a
+        // modest body clears the band with room to spare.
+        let warm = [bar("100", "110"), bar("110", "120")];
+        // Body 25 (ratio 1.67, inside the band) on a 140-point candle.
+        let judged = wicked("180000", "179975", "180100", "179960");
+
+        let mut ranged = ForceWindow::new(params.clone());
+        for bar in &warm {
+            ranged.classify(bar);
+        }
+        match ranged.classify(&judged) {
+            BarVerdict::Force(force) => {
+                assert_eq!(force.body, dec("25"));
+                assert_eq!(force.range, dec("140"));
+            }
+            other => panic!("the range floor admits this bar, got {other:?}"),
+        }
+
+        // The very same bar under a floor of the same number read against
+        // the body: refused. This is the whole delta, in one assertion.
+        let mut bodied = ForceWindow::new(params);
+        for bar in &warm {
+            bodied.classify(bar);
+        }
+        let body_floor_would_refuse = (judged.close - judged.open).abs() < dec("100");
+        assert!(
+            body_floor_would_refuse,
+            "the fixture must be a bar the old body floor refused, or it              proves nothing"
+        );
+        assert!(
+            matches!(bodied.classify(&judged), BarVerdict::Force(_)),
+            "and the range floor is what admits it now"
+        );
     }
 }

--- a/crates/strategy/src/trigger.rs
+++ b/crates/strategy/src/trigger.rs
@@ -66,12 +66,18 @@ pub trait Trigger {
     ///
     /// **It may only change when the ruler is advanced or reset** — that
     /// is, inside [`Self::on_closed_bar`] or [`Self::reset`], never on a
-    /// clock and never per print. Consumers cache it: `ArmedStrategy` holds
-    /// the text so the chart badge, which paints every frame, does not
-    /// build a `String` sixty times a second. A ruler whose line moved
-    /// between those calls would be quoted stale, which is the exact defect
-    /// the badge was repaired to end. A ruler with a genuinely live reading
-    /// belongs in [`Self::preview`], which is `&self` and uncached.
+    /// clock and never per print. The chart badge paints it every frame, so
+    /// a line that moved between those calls would flicker against a bar
+    /// that has not changed. A ruler with a genuinely live reading belongs
+    /// in [`Self::preview`], which is `&self` and explicitly provisional.
+    ///
+    /// **Keep it cheap.** It is built on the paint path, once per armed
+    /// instance per frame, so it formats a couple of numbers and returns —
+    /// no scans, no collection. (An earlier version of this branch cached
+    /// the result in `ArmedStrategy` to avoid the allocation; that was
+    /// reverted, because it put the cost on every closed bar of every
+    /// backtest session, which never reads it, to save one allocation of
+    /// several on a paint path that allocates regardless.)
     fn status(&self) -> String;
 
     /// Why this ruler declined the last bar it judged, as a **stable name**
@@ -351,13 +357,17 @@ mod tests {
             max_factor: dec("2.5"),
             min_range: dec("1"),
         });
-        trigger.on_closed_bar(&tight("0.100", "0.110", "0.111", "0.099"));
-        trigger.on_closed_bar(&tight("0.110", "0.120", "0.121", "0.109"));
-        trigger.on_closed_bar(&tight("0.120", "0.140", "0.141", "0.119"));
-        let line = trigger.status();
-        assert!(
-            line.contains("candle 0.0") && !line.contains("candle 0.00 "),
-            "a thousandths-wide candle keeps a readable size: {line}"
+        // The span has to be one that `round_dp(2)` would actually erase,
+        // or the assertion cannot fail for the regression it names: a range
+        // of 0.022 rounds to 0.02 and reads fine, which is why an earlier
+        // version of this test proved nothing.
+        trigger.on_closed_bar(&tight("0.1000", "0.1010", "0.1011", "0.0999"));
+        trigger.on_closed_bar(&tight("0.1010", "0.1020", "0.1021", "0.1009"));
+        trigger.on_closed_bar(&tight("0.1020", "0.1040", "0.1041", "0.1019"));
+        assert_eq!(
+            trigger.status(),
+            "1.50× in band · candle 0.0022 under floor",
+            "a span of 0.0022 survives whole; `round_dp(2)` would print 0.00"
         );
     }
 }

--- a/crates/strategy/src/trigger.rs
+++ b/crates/strategy/src/trigger.rs
@@ -88,10 +88,19 @@ pub trait Trigger {
     ///
     /// The names are stable ids, not display text: a surface may phrase
     /// them however it likes, but two builds must agree on the string.
-    /// Same timing contract as [`Self::status`].
-    fn refusal(&self) -> Option<&'static str> {
-        None
-    }
+    ///
+    /// **Required, deliberately.** A default returning `None` would read as
+    /// "this bar fired" for every bar of any ruler that forgot to override
+    /// it — an operator asking why nothing happened would be told the
+    /// ruler passed, which is the wrong-answer class this method exists to
+    /// end, reproduced silently on the next trigger to dock. `status` is
+    /// required for the same reason. A ruler with nothing to report says so
+    /// by returning `Some` with a name of its own.
+    ///
+    /// `None` means **the last judged bar fired**. A ruler that has judged
+    /// nothing yet has not fired either, so it returns a name for that too
+    /// rather than borrowing the one word that means success.
+    fn refusal(&self) -> Option<&'static str>;
 
     /// Forget every bar seen: the series the ruler was measuring no longer
     /// exists (a rebuilt timeline, another bar spec, another market). A
@@ -166,6 +175,8 @@ impl Trigger for ForceTrigger {
         // decide what it is called here rather than inheriting a
         // neighbour's name by falling through.
         match &self.last {
+            // Not a verdict about a bar — there is no bar. It is still not
+            // a fire, and `None` here would claim one.
             None => Some("no bars judged yet"),
             Some(BarVerdict::Warmup { .. }) => Some("ruler still warming up"),
             Some(BarVerdict::FlatAverage) => Some("flat average — no ruler"),
@@ -240,6 +251,22 @@ mod tests {
         Decimal::from_str(s).unwrap()
     }
 
+    /// A bar with explicit wicks, for fixtures whose whole range is
+    /// smaller than the point `bar` pads by.
+    fn tight(open: &str, close: &str, high: &str, low: &str) -> Bar {
+        Bar {
+            open_time: 0,
+            close_time: 0,
+            open: dec(open),
+            high: dec(high),
+            low: dec(low),
+            close: dec(close),
+            buy_volume: Decimal::ONE,
+            sell_volume: Decimal::ONE,
+            trade_count: 2,
+        }
+    }
+
     fn bar(open: &str, close: &str) -> Bar {
         let open = dec(open);
         let close = dec(close);
@@ -289,5 +316,48 @@ mod tests {
         assert_eq!(trigger.status(), "warmup 1/2");
         trigger.on_closed_bar(&bar("100", "101"));
         assert_eq!(trigger.status(), "quiet 1×");
+    }
+
+    /// The one user-visible sentence this change rewrote, pinned.
+    ///
+    /// The arm went from naming the body to naming the candle, and gained a
+    /// `normalize()` whose whole justification is how the number reads on
+    /// instruments of different scale. Neither half was asserted anywhere,
+    /// so a regression to `round_dp(2)` — which prints `candle 0.00` on a
+    /// market whose entire range is thousandths — would have shipped green.
+    #[test]
+    fn the_under_floor_line_names_the_candle_and_reads_at_any_scale() {
+        // Whole numbers: no trailing noise, and the candle, not the body.
+        let mut trigger = ForceTrigger::new(ForceParams {
+            window: 3,
+            min_factor: dec("1.5"),
+            max_factor: dec("2.5"),
+            min_range: dec("1000"),
+        });
+        trigger.on_closed_bar(&bar("100", "110"));
+        trigger.on_closed_bar(&bar("110", "120"));
+        trigger.on_closed_bar(&bar("120", "140"));
+        assert_eq!(
+            trigger.status(),
+            "1.50× in band · candle 22 under floor",
+            "the candle is what the floor measured, and 22 is not 22.00000000"
+        );
+
+        // A market whose whole range is thousandths still gets a number it
+        // can act on, which rounding to two places would have erased.
+        let mut trigger = ForceTrigger::new(ForceParams {
+            window: 3,
+            min_factor: dec("1.5"),
+            max_factor: dec("2.5"),
+            min_range: dec("1"),
+        });
+        trigger.on_closed_bar(&tight("0.100", "0.110", "0.111", "0.099"));
+        trigger.on_closed_bar(&tight("0.110", "0.120", "0.121", "0.109"));
+        trigger.on_closed_bar(&tight("0.120", "0.140", "0.141", "0.119"));
+        let line = trigger.status();
+        assert!(
+            line.contains("candle 0.0") && !line.contains("candle 0.00 "),
+            "a thousandths-wide candle keeps a readable size: {line}"
+        );
     }
 }

--- a/crates/strategy/src/trigger.rs
+++ b/crates/strategy/src/trigger.rs
@@ -141,10 +141,16 @@ impl Trigger for ForceTrigger {
             Some(BarVerdict::NoSide) => "doji — no side".to_owned(),
             Some(BarVerdict::Quiet { ratio }) => format!("quiet {}×", round_ratio(*ratio)),
             Some(BarVerdict::Force(force)) => format!("force {}×", round_ratio(force.ratio)),
-            Some(BarVerdict::UnderFloor { ratio, body }) => {
+            Some(BarVerdict::UnderFloor { ratio, size }) => {
                 // The band said force; the absolute floor said no. Saying
-                // "quiet" here would hide the one number the trader needs.
-                format!("{}× in band · body {body} under floor", round_ratio(*ratio))
+                // "quiet" here would hide the one number the trader needs —
+                // and that number is the candle's size, because size is what
+                // the floor actually measured. Printing the body here would
+                // send the trader to change an input this gate never read.
+                format!(
+                    "{}× in band · candle {size} under floor",
+                    round_ratio(*ratio)
+                )
             }
             Some(BarVerdict::Exhaustion { ratio, .. }) => {
                 format!("exhaustion {}×", round_ratio(*ratio))
@@ -204,7 +210,7 @@ mod tests {
             window: 3,
             min_factor: dec("1.5"),
             max_factor: dec("2.5"),
-            min_body: Decimal::ZERO,
+            min_size: Decimal::ZERO,
         });
         assert_eq!(trigger.on_closed_bar(&bar("100", "101")), None);
         assert_eq!(trigger.on_closed_bar(&bar("101", "102")), None);
@@ -224,7 +230,7 @@ mod tests {
             window: 2,
             min_factor: dec("1.5"),
             max_factor: dec("2.5"),
-            min_body: Decimal::ZERO,
+            min_size: Decimal::ZERO,
         });
         assert_eq!(trigger.status(), "waiting for bars 0/2");
         trigger.on_closed_bar(&bar("100", "101"));

--- a/crates/strategy/src/trigger.rs
+++ b/crates/strategy/src/trigger.rs
@@ -63,7 +63,35 @@ pub trait Trigger {
 
     /// One human-readable line for badges and tooltips: why the trigger is
     /// or is not firing ("warmup 7/20", "quiet 0.8×", "force 1.9×").
+    ///
+    /// **It may only change when the ruler is advanced or reset** — that
+    /// is, inside [`Self::on_closed_bar`] or [`Self::reset`], never on a
+    /// clock and never per print. Consumers cache it: `ArmedStrategy` holds
+    /// the text so the chart badge, which paints every frame, does not
+    /// build a `String` sixty times a second. A ruler whose line moved
+    /// between those calls would be quoted stale, which is the exact defect
+    /// the badge was repaired to end. A ruler with a genuinely live reading
+    /// belongs in [`Self::preview`], which is `&self` and uncached.
     fn status(&self) -> String;
+
+    /// Why this ruler declined the last bar it judged, as a **stable name**
+    /// rather than a sentence — or `None` when the bar fired.
+    ///
+    /// The twin of [`Self::status`], and the reason it exists separately:
+    /// `status` is prose with numbers in it, written to be read by a
+    /// person in a chart corner. An operator that is not looking at the
+    /// screen — a script, a test, the assistant `CLAUDE.md` plans for —
+    /// needs to know *that the ruler refused this bar* without parsing
+    /// English out of a badge. Without this, "why did nothing happen here?"
+    /// is answerable only by a human reading pixels, which is precisely
+    /// what "operable without a hand" forbids.
+    ///
+    /// The names are stable ids, not display text: a surface may phrase
+    /// them however it likes, but two builds must agree on the string.
+    /// Same timing contract as [`Self::status`].
+    fn refusal(&self) -> Option<&'static str> {
+        None
+    }
 
     /// Forget every bar seen: the series the ruler was measuring no longer
     /// exists (a rebuilt timeline, another bar spec, another market). A
@@ -133,6 +161,22 @@ impl Trigger for ForceTrigger {
         self.window.params().window
     }
 
+    fn refusal(&self) -> Option<&'static str> {
+        // One arm per verdict, and no catch-all: a sixth `BarVerdict` must
+        // decide what it is called here rather than inheriting a
+        // neighbour's name by falling through.
+        match &self.last {
+            None => Some("no bars judged yet"),
+            Some(BarVerdict::Warmup { .. }) => Some("ruler still warming up"),
+            Some(BarVerdict::FlatAverage) => Some("flat average — no ruler"),
+            Some(BarVerdict::NoSide) => Some("doji — no side"),
+            Some(BarVerdict::Quiet { .. }) => Some("body quiet against the average"),
+            Some(BarVerdict::UnderFloor { .. }) => Some("candle under the floor"),
+            Some(BarVerdict::Exhaustion { .. }) => Some("body above the band"),
+            Some(BarVerdict::Force(_)) => None,
+        }
+    }
+
     fn status(&self) -> String {
         match &self.last {
             None => format!("waiting for bars 0/{}", self.window.params().window),
@@ -141,15 +185,23 @@ impl Trigger for ForceTrigger {
             Some(BarVerdict::NoSide) => "doji — no side".to_owned(),
             Some(BarVerdict::Quiet { ratio }) => format!("quiet {}×", round_ratio(*ratio)),
             Some(BarVerdict::Force(force)) => format!("force {}×", round_ratio(force.ratio)),
-            Some(BarVerdict::UnderFloor { ratio, size }) => {
+            Some(BarVerdict::UnderFloor { ratio, range }) => {
                 // The band said force; the absolute floor said no. Saying
                 // "quiet" here would hide the one number the trader needs —
                 // and that number is the candle's size, because size is what
                 // the floor actually measured. Printing the body here would
                 // send the trader to change an input this gate never read.
+                // `normalize` and not `round_dp`: this is a price span and
+                // instruments differ by orders of magnitude. Rounding to two
+                // places would print `candle 0.00` on a market whose whole
+                // range is thousandths — worse than the trailing zeros it
+                // fixes. Subtraction in `rust_decimal` keeps the operands'
+                // scale, so an untouched span reaches the badge as
+                // `0.10000000`.
                 format!(
-                    "{}× in band · candle {size} under floor",
-                    round_ratio(*ratio)
+                    "{}× in band · candle {} under floor",
+                    round_ratio(*ratio),
+                    range.normalize()
                 )
             }
             Some(BarVerdict::Exhaustion { ratio, .. }) => {
@@ -210,7 +262,7 @@ mod tests {
             window: 3,
             min_factor: dec("1.5"),
             max_factor: dec("2.5"),
-            min_size: Decimal::ZERO,
+            min_range: Decimal::ZERO,
         });
         assert_eq!(trigger.on_closed_bar(&bar("100", "101")), None);
         assert_eq!(trigger.on_closed_bar(&bar("101", "102")), None);
@@ -230,7 +282,7 @@ mod tests {
             window: 2,
             min_factor: dec("1.5"),
             max_factor: dec("2.5"),
-            min_size: Decimal::ZERO,
+            min_range: Decimal::ZERO,
         });
         assert_eq!(trigger.status(), "waiting for bars 0/2");
         trigger.on_closed_bar(&bar("100", "101"));

--- a/crates/strategy/tests/full_operation.rs
+++ b/crates/strategy/tests/full_operation.rs
@@ -69,7 +69,7 @@ fn run() -> RunOutcome {
             window: 3,
             min_factor: dec("1.5"),
             max_factor: dec("2.5"),
-            min_size: Decimal::ZERO,
+            min_range: Decimal::ZERO,
         })),
     );
     let mut sim = Simulator::new();
@@ -167,7 +167,7 @@ fn run_retest(after_cut: &[&str]) -> RunOutcome {
             window: 3,
             min_factor: dec("1.5"),
             max_factor: dec("2.5"),
-            min_size: Decimal::ZERO,
+            min_range: Decimal::ZERO,
         })),
     );
     let mut sim = Simulator::new();

--- a/crates/strategy/tests/full_operation.rs
+++ b/crates/strategy/tests/full_operation.rs
@@ -69,7 +69,7 @@ fn run() -> RunOutcome {
             window: 3,
             min_factor: dec("1.5"),
             max_factor: dec("2.5"),
-            min_body: Decimal::ZERO,
+            min_size: Decimal::ZERO,
         })),
     );
     let mut sim = Simulator::new();
@@ -167,7 +167,7 @@ fn run_retest(after_cut: &[&str]) -> RunOutcome {
             window: 3,
             min_factor: dec("1.5"),
             max_factor: dec("2.5"),
-            min_body: Decimal::ZERO,
+            min_size: Decimal::ZERO,
         })),
     );
     let mut sim = Simulator::new();

--- a/docs/ux/strategy-anchors.md
+++ b/docs/ux/strategy-anchors.md
@@ -44,21 +44,20 @@ headless over recorded sessions. Never fork strategy logic per consumer.
   (`min_range`, form default 100; `0` disables). The floor measures
   `high - low`, wicks included, while the band above measures the body:
   the two gates object to different things, one to a bar that is small
-  next to its neighbours and one to a bar that is small in price.
-  (It measured the *body* until the branch that renamed it; a bank saved
-  then still loads, and its number is read as a range floor from that
-  point on.) The relative band alone is honest on time
-  candles but promiscuous on activity-cut bars: measured on a live WINV26
-  session **against the body floor**, the bare band called 247 of 1,355
-  volume bars "force" (a 55-point body at 1.62× fired a real paper
-  entry); the 100-point body floor
-  left 7. **That figure bounded the body
-  floor, not this one**: a range floor admits every bar a body floor of
-  the same number admitted and more, since `high - low >= |close - open|`
-  always. Nobody has re-measured the range floor on that session, so the
-  honest statement is "looser than the gate that produced 7, by an
-  unmeasured amount". An elephant has a size, not only a ratio. A body above the band
-  is **exhaustion and does not fire** — too big to chase, by design.
+  next to its neighbours and one to a bar that is small in price. (It
+  measured the *body* until the branch that renamed it; a bank saved then
+  still loads, and its number is read as a range floor from that point
+  on.) The relative band alone is honest on time candles but promiscuous
+  on activity-cut bars: measured on a live WINV26 session **against the
+  body floor**, the bare band called 247 of 1,355 volume bars "force" (a
+  55-point body at 1.62× fired a real paper entry); the 100-point body
+  floor left 7. **That figure bounded the body floor, not this one**: a
+  range floor admits every bar a body floor of the same number admitted
+  and more, since `high - low >= |close - open|` always. Nobody has
+  re-measured the range floor on that session, so the honest statement is
+  "looser than the gate that produced 7, by an unmeasured amount". An
+  elephant has a size, not only a ratio. A body above the band is
+  **exhaustion and does not fire** — too big to chase, by design.
   Dojis have no side. The window must be full; warmup is a badge state,
   not a silent zero.
 - **Region**: the rectangle's price band, inclusive of its edges, with

--- a/docs/ux/strategy-anchors.md
+++ b/docs/ux/strategy-anchors.md
@@ -40,12 +40,24 @@ headless over recorded sessions. Never fork strategy logic per consumer.
 - **Trigger — force bar**: body between `min_factor`× and `max_factor`×
   the simple average of the last `window` bodies, the judged bar
   included, exactly the shipped `force_bar.pine` ruler (defaults 1.5,
-  2.5, 20) — **plus an absolute body floor in points** (`min_body`, form
-  default 100; `0` disables). The relative band alone is honest on time
+  2.5, 20) — **plus an absolute floor on the candle's range in points**
+  (`min_range`, form default 100; `0` disables). The floor measures
+  `high - low`, wicks included, while the band above measures the body:
+  the two gates object to different things, one to a bar that is small
+  next to its neighbours and one to a bar that is small in price.
+  (It measured the *body* until the branch that renamed it; a bank saved
+  then still loads, and its number is read as a range floor from that
+  point on.) The relative band alone is honest on time
   candles but promiscuous on activity-cut bars: measured on a live WINV26
-  session, the bare band called 247 of 1,355 volume bars "force" (a
-  55-point body at 1.62× fired a real paper entry); the 100-point floor
-  left 7. An elephant has a size, not only a ratio. A body above the band
+  session **against the body floor**, the bare band called 247 of 1,355
+  volume bars "force" (a 55-point body at 1.62× fired a real paper
+  entry); the 100-point body floor
+  left 7. **That figure bounded the body
+  floor, not this one**: a range floor admits every bar a body floor of
+  the same number admitted and more, since `high - low >= |close - open|`
+  always. Nobody has re-measured the range floor on that session, so the
+  honest statement is "looser than the gate that produced 7, by an
+  unmeasured amount". An elephant has a size, not only a ratio. A body above the band
   is **exhaustion and does not fire** — too big to chase, by design.
   Dojis have no side. The window must be full; warmup is a badge state,
   not a silent zero.


### PR DESCRIPTION
## Why nothing sold at the top of the sell zone

The trader marked a bar at the top of a drawn `SellGainAlarm` region on
BTCUSDT and asked why no sell was taken. The chart badge answered:

> ⚡ SellGainAlarm · last held: the body never cut the region

That sentence is true, and it is about **a different bar**.

`last_hold` keeps a single most-recent *gate* refusal, and gates only run on
bars the ruler already passed. A bar the ruler refuses produces no `Signal`,
so `ArmedStrategy::on_closed_bar` takes its no-signal path, clears the note
and leaves the previous refusal standing. That path is defended by a comment
saying the trigger's own status narrates instead — `status_line` does exactly
that, which is why the right-click menu was right all along, and
`badge_text_for` never called it. The one surface the trader reads answered a
question about the candle under the cursor with a fact about another one.

`badge_text_for` now leads with the ruler's reading of the current bar, with
any standing refusal behind it, still marked `last held:`. The regression test
reproduces the reported string character-for-character: run against the
pre-fix composition,
`the_badge_names_the_rulers_own_refusal_and_not_only_an_older_bars` fails with
`⚡ SellGainAlarm · last held: the body never cut the region`.

## The floor now measures the candle

At the trader's instruction (**D5**), the absolute floor measures the whole
candle (`high - low`) instead of the body. `min_body` becomes `min_range`,
named to match `ForceBar.range` — the same measurement on a bar that passed.

I put the trade-off before implementing: the ratio band is body-based, so a
range floor lets a wick-dominated doji clear a gate its body could not. The
trader chose this after hearing it. `crates/app/scripts/exhaustion_reversal.pine`
moves with it, so the chart paints what the armed instance trades — proven by
a wick-bearing fixture, verified to fail against a body gate.

## Two things to know before merging

**1. The floor also changes risk per trade.** The bracket projects off
`ForceBar::range`, which is the `high - low` the floor now reads. A bar
admitted on its candle rather than its body arms a stop sized by that candle:
the test fixture's 25-point push carries `sl_mult × 140` of stop. Pinned by
`a_bar_admitted_on_its_candle_projects_off_that_candle`.

**2. The reported bar's gate was never confirmed, and the trader knows.**
`SellGainAlarm` runs `window = 20`, `min_factor = 2`, `max_factor = 4.5` — and
the floor is consulted **only inside the band**. A body under 2× the 20-bar
average is `Quiet` and never reaches a floor of either kind, so this change
might not have fired the marked bar at all. There is no BTCUSDT recording of
that session on disk (only WDOU26 and WINV26), so it cannot be settled here.
`under_the_traders_own_band_the_floor_is_only_reached_inside_it` writes both
regimes down under the real preset. The trader chose to ship and read the
repaired badge on the next occurrence (**D7**) — the badge being precisely the
instrument the question needed.

## Migration

A preset stored under `min_body` is folded into `min_range` at load, and the
bank logs `STRATEGY_FLOOR_REINTERPRETED` naming the rows it touched. The
number is kept — defaulting a trader's `100` to `0` would switch their gate
off. A row whose current key cannot be honoured keeps its old number, because
that is the row the trader must repair by hand and that is the value they
would repair it with.

It is deliberately **not** a `#[serde(alias)]`: an alias is the same field to
serde, so a bank carrying both keys was a duplicate-field error, and
`load_from` answers a parse error by starting empty — which the next save
would have written over every preset. The migration is in memory; the file
changes on the next save. Writing it back at load was tried and reverted: it
turned a read into a non-atomic write that re-serialises every row through
this build's shape.

**One-way:** an older build reading `min_range` finds no key it knows and
falls through to `0`.

## Reviews

`arch-review` step 0 ran **six times at xhigh** (14, 13, 13, 12, 13, 13
findings). Most were fixed. Three of my own fixes were reverted because the
reviews were right about them: a `trigger_status` cache that taxed every
backtest bar to save one allocation on a paint path that allocates anyway; an
alarm-only badge clause that would have painted on disarmed instances; and the
load-time write-back described above.

The counts stopped falling, and the later rounds were finding defects inside
the earlier rounds' fixes — so the loop was stopped and the trader was asked
(**D10**). These remain as **follow-ups**, not fixed here:

- `badge_text_for` re-derives `status_line`'s ordering rather than sharing one
  composer; the two already differ on a `Note::Aside` bar.
- `Trigger::refusal()` / `ruler_refusal()` have no in-app consumer — the
  control plane's scene carries no armed instances (**D8**).
- The badge is painted `layout_no_wrap` with no width bound (**D8**).
- `min_range = "-5"` alongside a vintage `min_body` drops the old number the
  way an unparsable value used to; the fix is one filter.
- `superseded` in the log counts kept rows as superseded.
- `wicked` / `tight` / `zone_bar` are three copies of one fixture builder, and
  only `wicked` carries the OHLC guard.
- The goal file's A8 row cites a test name that does not exist and describes
  the rejected serde-alias design; its "Migration, restated" paragraph still
  names `resolved_floor()`, which does not exist at this head.
- `crates/app/src/strategy_presets.rs` still says the bank "rewrites the file,
  so the migration happens once rather than on every launch" — the startup
  write-back was reverted in the head commit, so the warning repeats until the
  trader next saves.
- `high - low` is computed in the gate and again in each branch: two `Decimal`
  subtractions where one would do. No allocation, so the rate class is
  unchanged.

These were raised by `delivery-review`, which **passed** the branch: none of
them moves a grade. They are listed rather than fixed because fixing them
means another commit, which stales both review markers and costs two more full
review rounds — and the trader asked for this to close.

**Trader-approved deferrals** (D1, D5, D7, D8, D9), recorded under `## Deferred`
in the goal file: the form's instrument-blind `100` default; the body floor
removed rather than joined; `ruler_refusal` without a consumer; G4 without a
`main` control run; G5 with no `visual-qa` or `trader-ux-review`; and the Pine
input rename reinterpreting a saved chart calibration.

## Verification

Four checks, each run separately, each exit 0: `cargo fmt --all -- --check`,
`cargo clippy --workspace --all-targets -- -D warnings`,
`cargo build --workspace`, `cargo test --workspace` — 87 test binaries green.

One environmental failure: `the_bridge_paging_tests_pass` shells out to
`python3`, a Microsoft Store alias on this machine. Run directly,
`python bridge/mt5/tests/test_paging.py` reports **all checks passed across 31
tests**, exit 0 — which is what CI runs, and the diff touches no MT5 file.

`size_guard`: `crates/app/src/pane.rs` 7757 → 7771 (+14), reason in the comment
beside it. No other tracked file moved.

**G5 is a gap, not a pass.** The branch build ran healthy (fps 59–60,
frame_avg 16.64–16.67 ms on a live tape), but the window opened minimized and
`PrintWindow` returns a black raster in that state; getting a capture meant
raising it over the trader's live session, which `ui-harness` forbids. How the
longer badge sentence looks in a chart corner is unevidenced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ky8h3tenBXdKDpi4oXjgs
