### PR TITLE
perf(skills): arm the cheap half of the flow instead of paying at the review

### DIFF
--- a/.claude/GOAL-archive-mission-review-throughput.md
+++ b/.claude/GOAL-archive-mission-review-throughput.md
@@ -1,8 +1,15 @@
 # Mission — arm the cheap half of the workflow
 
-**Tier:** `small`. Three documentation files, 71 changed lines, no compiled
-code. The work is a correction to instructions, and the one change it makes to
-behaviour is that a hook which was reporting nothing starts reporting.
+**Tier:** `small`. Documentation only, well under the ceiling, no compiled code.
+
+Be exact about what that buys, because the branch is a set of instructions and
+instructions only run if someone follows them. Nothing here *forces* the guards
+binary to exist: `guard-watch` still treats absence and cleanliness as the same
+observable, and a `cargo clean` returns a worktree to silence with no signal.
+What the branch changes is that the arming step now appears in all three places
+a worktree is created, instead of nowhere. Follow-up 6 is the version that does
+not depend on being read, and it needs an authorisation this session did not
+have.
 
 ## Objective
 
@@ -63,11 +70,18 @@ code is written, not at the PR.
       `mission` step 6 carries `cargo build -p quantick-guards`; measured at
       1.80s in this worktree, and `./target/debug/quantick-guards` then exits 0.
       → `.claude/skills/mission/SKILL.md` *(R2, R4)*
-- [x] **A3** — `delivery-review` starts at its cheapest shape rather than its
-      most expensive, without losing the fresh-context stranger. *Evidence:*
-      the *Cost discipline* section — stat over diff, one fix round before
-      escalating, never re-grade unchanged lines.
-      → `.claude/skills/delivery-review/SKILL.md` *(R1, R3)*
+- [ ] **A3** — `delivery-review` starts at its cheapest shape rather than its
+      most expensive, without losing the fresh-context stranger.
+      **WITHDRAWN, not delivered.** A *Cost discipline* section was written and
+      then reverted after step 0 returned six findings against it, all tracing
+      to one omission: the section was added without editing steps 2, 4 and 5,
+      so it argued against five passages that still stood. The worst was not a
+      contradiction but a new hole — grading from `branch.stat` plus the files
+      as they stand lets a reviewer quote a sentence that was already on
+      `origin/main` and mark the criterion DELIVERED, which is a false pass the
+      full diff was the only input able to prevent. Making it correct means
+      rewriting three steps of that skill; that is its own branch, not a
+      paragraph bolted onto this one. *(R1, R3 — carried forward, undischarged)*
 
 ## Not applicable, and why
 
@@ -109,10 +123,25 @@ session finds the analysis rather than re-deriving it.
    files and every large one live. Every file already opens with a `//!` line;
    a `--map` mode on the dependency-free guards binary would emit the index and
    keep it from going stale.
-5. **A shared cargo target directory.** 18 worktrees each hold 12–16 GB and
-   every mission starts from a cold dependency graph. Not shipped here because
-   CI caches `./target` via `Swatinem/rust-cache@v2` and a tracked
-   `.cargo/config.toml` would silently miss that cache.
+5. **A shared cargo target directory.** Every worktree holds its own 12–16 GB
+   and every mission starts from a cold dependency graph. **Do not do this
+   without changing `guard-watch` first.** `guardrails.sh:582` hardcodes
+   `binary="$root/target/debug/quantick-guards"`, where `$root` is the worktree
+   toplevel. Redirecting `CARGO_TARGET_DIR` moves the binary out from under that
+   path, `[ -x "$binary" ] || exit 0` goes silent again — indistinguishably from
+   clean — and every worktree loses the arming this branch just added, at once.
+   The build-time win would silently buy back the exact defect this branch
+   fixed. It is also why the change was not shipped here as a tracked
+   `.cargo/config.toml`: CI caches `./target` via `Swatinem/rust-cache@v2` and
+   would miss the cache too.
+6. **Make `guard-watch` report its own absence.** The deepest fix, and the one
+   that makes 5 safe. Today absence and cleanliness are the same observable, so
+   a `cargo clean` or a wiped `target/` returns a worktree to silence
+   mid-mission with nothing to notice. One `context` line the first time the
+   hook finds no binary, naming the build command, turns a property every agent
+   in every worktree has to remember into one the mechanism reports about
+   itself. It touches `guardrails.sh`, so it needs the same authorisation as
+   the marker change above.
 
 ## The request as received
 

--- a/.claude/GOAL-archive-mission-review-throughput.md
+++ b/.claude/GOAL-archive-mission-review-throughput.md
@@ -1,0 +1,138 @@
+# Mission — arm the cheap half of the workflow
+
+**Tier:** `small`. Three documentation files, 71 changed lines, no compiled
+code. The work is a correction to instructions, and the one change it makes to
+behaviour is that a hook which was reporting nothing starts reporting.
+
+## Objective
+
+Cut the wall-clock cost of a `/mission` without removing a review, by fixing
+the two places where the flow's *cheap* half was switched off: the edit-time
+guard hook never fires, and the fast build loop has no name anywhere in the
+repository.
+
+## Why it matters
+
+The trader's complaint is that missions take hours and days, and that the
+review chain never ends. Five agents analysed the flow. The measurement
+refuted the obvious diagnosis: across the last 20 merged PRs, ordinary code
+branches average **~1 review-fix commit**. The branches that burn rounds
+(21 commits / 6 rounds; 9 / 3) are the ones with **zero production lines** —
+meta-work on the workflow itself. The gate is not what is slow for coding.
+
+What is slow is that the coding phase has no support:
+
+| Measured in this checkout | Value |
+| --- | --- |
+| `target/debug/quantick-guards` present | **no** |
+| Live worktrees, each with its own `target/` | **18** |
+| `cargo check` in every `.md` in the repo | **0 occurrences** |
+| `cargo build -p quantick-guards` (dependency-free) | **1.80s** |
+
+The `guard-watch` hook runs `target/debug/quantick-guards` and is documented as
+"silent when the binary has not been built". The binary is not built, and a
+fresh worktree never builds it — so the hook that exists to report a crossed
+size ceiling at the edit that caused it has been reporting **nothing**, for
+every mission. The repository's cheapest structural check was off in exactly
+the phase it was designed for, and the cost went to the reviews at the end.
+
+That is also the answer to the modularity question. `delivery-review` was added
+in response to `crates/app` reaching 72% of the repository — but it grades
+conformance to the request ledger and never looks at file growth. The
+mechanism that moved that number is the size ratchet (`QuantickApp` fields
+133 → 97), and it is mechanical, costs ~1s, and fires at edit time. The lesson
+is that a structural property is enforced most cheaply at the point where the
+code is written, not at the PR.
+
+## Request ledger
+
+- **R1** — the flow is too slow; missions take hours and days.
+- **R2** — keep the low-coupling quality while doing it. *"manter a
+  performance de entrega rapida e mantendo qualidade de baixo acoplamento"*
+- **R3** — stop the chains of reviews that never end and burn tokens.
+- **R4** — improve the AI engineering workflow, not the product code.
+
+## Acceptance criteria
+
+- [x] **A1** — the repository names its edit-time loop, distinct from the four
+      gate checks. *Evidence:* `CLAUDE.md` *Verification loop* states
+      `cargo check -p <crate>` as the loop and the four as the gate.
+      → `CLAUDE.md` *(R1, R4)*
+- [x] **A2** — a fresh worktree arms `guard-watch` before the first edit, so
+      the size ratchet reports while the code is being written. *Evidence:*
+      `mission` step 6 carries `cargo build -p quantick-guards`; measured at
+      1.80s in this worktree, and `./target/debug/quantick-guards` then exits 0.
+      → `.claude/skills/mission/SKILL.md` *(R2, R4)*
+- [x] **A3** — `delivery-review` starts at its cheapest shape rather than its
+      most expensive, without losing the fresh-context stranger. *Evidence:*
+      the *Cost discipline* section — stat over diff, one fix round before
+      escalating, never re-grade unchanged lines.
+      → `.claude/skills/delivery-review/SKILL.md` *(R1, R3)*
+
+## Not applicable, and why
+
+- **Hot path / performance evidence** — no compiled code changed.
+- **`ui-harness`, `visual-qa`, `trader-ux-review`** — no surface changed.
+- **`new-extension`** — no capability added.
+
+## Deferral requested — NOT granted
+
+**The second marker.** The largest single source of the "reviews behind
+reviews" is that `arch-review-ok` and `delivery-review-ok` both key on the same
+branch diff, so any fix commit stales *both* and a finding from the later
+review sends the branch back through the earlier one from scratch. The fix is
+one marker, with `delivery-review` running first and cheaply and `arch-review`
+recording the marker last over the final branch.
+
+It is **not in this branch.** Implementing it means editing
+`.claude/hooks/guardrails.sh` to remove a gate, and the session's auto-mode
+classifier denied those edits — correctly, since it is a guardrail being
+loosened by an agent. The half-applied edit was reverted; `guardrails.sh` is
+untouched on this branch and `guardrails_test.sh` passes 96/0.
+
+This needs the trader's explicit authorisation. It is recorded here so the next
+session finds the analysis rather than re-deriving it.
+
+## Recommended follow-ups, not in this branch
+
+1. **One marker** (above) — the biggest remaining win.
+2. **Collapse the four tiers to two.** `pr-gate` can see exactly one
+   distinction, and `medium` vs `high` differ at the gate by nothing. Four
+   names for one cliff, and it quadruples the leading-word misparse surface
+   `mission` already admits it cannot close. No archive sampled declares a tier
+   at all.
+3. **Fix the size measurement's pathspec.** `guardrails.sh:281` uses `-- .`,
+   which is cwd-relative: `cd <worktree>/crates/app && gh pr create` measures
+   only that subtree and stops matching `SIZE_EXCLUDES`, which is anchored at
+   `.claude/`. Should be `-- :/` with `:(exclude,top)`.
+4. **A generated `codebase-map`.** Nothing maps inside `crates/app`, where 168
+   files and every large one live. Every file already opens with a `//!` line;
+   a `--map` mode on the dependency-free guards binary would emit the index and
+   keep it from going stale.
+5. **A shared cargo target directory.** 18 worktrees each hold 12–16 GB and
+   every mission starts from a cold dependency graph. Not shipped here because
+   CI caches `./target` via `Swatinem/rust-cache@v2` and a tracked
+   `.cargo/config.toml` would silently miss that cache.
+
+## The request as received
+
+Quoted verbatim, in the trader's own language, under `CLAUDE.md`'s exemption
+for a marked and attributed quotation: the wording carries the ask, and
+translating it would make this section a paraphrase of the thing it exists to
+preserve.
+
+> A gnt tem fluxo de trabalho com IA. Hoje eu utilizo a Mission. /mission Esse
+> fluxo tem o objetivo de manter um código mais modular, com o acoplamento
+> possível. Daí eu vi que ele não estava seguindo as regras do arquivo app tava
+> ficando gigante com 70% das linhas de codigo. Então eu crei outros skill
+> delivery review e pedi para nao acomplar mais com arquivos gigtantes. O
+> probleam o fluxo ficou pesado demorando horas e dias para terminar tarefas.
+> Isso prejudica nosso trabalho. Eu quero manter a performance de entrega
+> rapida e mantendo qualidad ede baixo acoplomanteo. A gnt a se prendendo em
+> vários reviews em cadeia que nao terminam nunca além de queimar ainda mais
+> tokens. O objetivo é melhroar os fluxo de engenharia de IA de como usamos Ia
+> para trabalho e não para melhorar o codigo. O codigo quem vai fazer isso
+> serão os agentes duranteo desenvovimento
+
+> podemos manter o delivery review mas precisa ser menos gastgante mesmo
+> reviravolta...

--- a/.claude/skills/delivery-review/SKILL.md
+++ b/.claude/skills/delivery-review/SKILL.md
@@ -43,10 +43,36 @@ the exemption is bounded by how large the branch turns out to be, and neither
 is something to arrange at the point of shipping. If you are here because a
 gate refused a branch, the branch owes this review — run it.
 
+## Cost discipline — read this before assembling anything
+
+This review is worth what it catches and no more, and it has been measured
+costing more than that. The default is the **cheapest shape that still keeps a
+stranger in the loop**; the expensive shape is what a finding escalates *to*,
+never where a branch starts.
+
+- **Hand over the stat, not the diff.** The reviewer gets the checklist,
+  `branch.stat` and `branch.log`, and reads the specific files a criterion
+  names. `branch.diff` goes over only when a criterion cannot be graded without
+  it, and the verdict says which ones needed it.
+- **One fix round before escalating.** Step 5's bound is three, and three is
+  for a loop that is converging. A round returning the same count as the last
+  is not converging: its remaining gaps go to the trader as findings, not into
+  another dossier. The archives record a branch that spent four rounds with the
+  count flat at 15 — that is the shape this bullet exists to stop.
+- **Never re-grade what did not change.** A re-run reads the criteria that
+  failed and the files the fix touched. Re-grading a `DELIVERED` line whose
+  code nobody edited is spend with no possible finding behind it.
+
+None of this touches the stranger. The reviewer is still a fresh-context
+subagent that never sees the implementing session's account of its own work,
+because that is the entire property this skill provides — and it is the one
+thing a cheaper shape must not buy its way out of.
+
 ## Two modes, and the tier picks one
 
 **Full** (`high`, `max`, and any direct invocation): everything below — the
-dossier, the fresh subagent, all three passes, every `A` and `G` graded.
+dossier, the fresh subagent, all three passes, every `A` and `G` graded, under
+the cost discipline above.
 
 **Completeness-only** (`medium`): step 1, then the **completeness pass alone**,
 run inline in the calling session. No dossier, no subagent, no criteria pass.

--- a/.claude/skills/delivery-review/SKILL.md
+++ b/.claude/skills/delivery-review/SKILL.md
@@ -43,36 +43,10 @@ the exemption is bounded by how large the branch turns out to be, and neither
 is something to arrange at the point of shipping. If you are here because a
 gate refused a branch, the branch owes this review — run it.
 
-## Cost discipline — read this before assembling anything
-
-This review is worth what it catches and no more, and it has been measured
-costing more than that. The default is the **cheapest shape that still keeps a
-stranger in the loop**; the expensive shape is what a finding escalates *to*,
-never where a branch starts.
-
-- **Hand over the stat, not the diff.** The reviewer gets the checklist,
-  `branch.stat` and `branch.log`, and reads the specific files a criterion
-  names. `branch.diff` goes over only when a criterion cannot be graded without
-  it, and the verdict says which ones needed it.
-- **One fix round before escalating.** Step 5's bound is three, and three is
-  for a loop that is converging. A round returning the same count as the last
-  is not converging: its remaining gaps go to the trader as findings, not into
-  another dossier. The archives record a branch that spent four rounds with the
-  count flat at 15 — that is the shape this bullet exists to stop.
-- **Never re-grade what did not change.** A re-run reads the criteria that
-  failed and the files the fix touched. Re-grading a `DELIVERED` line whose
-  code nobody edited is spend with no possible finding behind it.
-
-None of this touches the stranger. The reviewer is still a fresh-context
-subagent that never sees the implementing session's account of its own work,
-because that is the entire property this skill provides — and it is the one
-thing a cheaper shape must not buy its way out of.
-
 ## Two modes, and the tier picks one
 
 **Full** (`high`, `max`, and any direct invocation): everything below — the
-dossier, the fresh subagent, all three passes, every `A` and `G` graded, under
-the cost discipline above.
+dossier, the fresh subagent, all three passes, every `A` and `G` graded.
 
 **Completeness-only** (`medium`): step 1, then the **completeness pass alone**,
 run inline in the calling session. No dossier, no subagent, no criteria pass.

--- a/.claude/skills/mission/SKILL.md
+++ b/.claude/skills/mission/SKILL.md
@@ -376,10 +376,22 @@ a review. `.claude/hooks/README.md` owns the rest of the mechanism.
    worktree:
 
    ```sh
+   WT=/path/to/worktree
+   CRATE=quantick-app          # the crate you are about to edit
    cd "$WT" &&
      cargo build -p quantick-guards &&   # arms guard-watch; no dependencies
-     cargo check -p <the crate you will edit> --all-targets
+     cargo check -p "$CRATE" --all-targets
    ```
+
+   Both assignments are inside the fence on purpose, and the second is a
+   variable rather than an angle-bracket placeholder. `WT` does not survive
+   between tool calls, so a block opening on `cd "$WT"` with nothing assigning
+   it aborts the whole `&&` chain and the guards binary is never built — the
+   failure this step exists to prevent, produced by the step itself. And
+   `<the crate you will edit>` is not a placeholder to `sh`: it is two
+   redirections, which would read a file named `the` and create one named
+   `--all-targets`. `delivery-review` step 2 already carries this warning; it
+   is repeated here because a snippet is pasted, not read.
 
    `CLAUDE.md`'s *Verification loop* owns why — what the hook's silence costs,
    and why the edit loop is not the four checks. It is not repeated here: a

--- a/.claude/skills/mission/SKILL.md
+++ b/.claude/skills/mission/SKILL.md
@@ -372,15 +372,8 @@ a review. `.claude/hooks/README.md` owns the rest of the mechanism.
    it is *performed* first, so the goal file lands on the branch that will
    carry it.
 
-   **Arm the worktree before the first edit.** A fresh worktree has no
-   `target/`, so `target/debug/quantick-guards` does not exist — and the
-   `guard-watch` hook is silent when it is missing. Silent, not clean: the size
-   ratchet, the language scan and the encoding check report *nothing* for the
-   whole mission, and the news they exist to deliver early arrives at the
-   review instead. Measured across eighteen worktrees in this repo: the binary
-   was absent from all of them. Two commands, seconds each, and they are the
-   difference between a crossed ceiling reported at the edit that caused it and
-   one reported after the code is written:
+   **Arm the worktree before the first edit**, with both commands, in the new
+   worktree:
 
    ```sh
    cd "$WT" &&
@@ -388,10 +381,13 @@ a review. `.claude/hooks/README.md` owns the rest of the mechanism.
      cargo check -p <the crate you will edit> --all-targets
    ```
 
-   The second primes the incremental cache, so the first `cargo check` *after*
-   an edit is incremental rather than a cold build of the dependency graph.
-   `CLAUDE.md`'s *Verification loop* owns the distinction between that loop and
-   the four checks at the gate; do not restate it here.
+   `CLAUDE.md`'s *Verification loop* owns why — what the hook's silence costs,
+   and why the edit loop is not the four checks. It is not repeated here: a
+   measurement kept in two files is one that disagrees with itself on the first
+   edit, which is the failure this repo files against a duplicated constant.
+   What belongs here is only that the two commands run **before the first
+   edit**, since a guard armed afterwards has already missed the edit worth
+   reporting.
 
    **Record the tier here**, in the new worktree, before the first line of
    work. It goes beside the two review markers, in that worktree's own git dir,

--- a/.claude/skills/mission/SKILL.md
+++ b/.claude/skills/mission/SKILL.md
@@ -372,6 +372,27 @@ a review. `.claude/hooks/README.md` owns the rest of the mechanism.
    it is *performed* first, so the goal file lands on the branch that will
    carry it.
 
+   **Arm the worktree before the first edit.** A fresh worktree has no
+   `target/`, so `target/debug/quantick-guards` does not exist — and the
+   `guard-watch` hook is silent when it is missing. Silent, not clean: the size
+   ratchet, the language scan and the encoding check report *nothing* for the
+   whole mission, and the news they exist to deliver early arrives at the
+   review instead. Measured across eighteen worktrees in this repo: the binary
+   was absent from all of them. Two commands, seconds each, and they are the
+   difference between a crossed ceiling reported at the edit that caused it and
+   one reported after the code is written:
+
+   ```sh
+   cd "$WT" &&
+     cargo build -p quantick-guards &&   # arms guard-watch; no dependencies
+     cargo check -p <the crate you will edit> --all-targets
+   ```
+
+   The second primes the incremental cache, so the first `cargo check` *after*
+   an edit is incremental rather than a cold build of the dependency graph.
+   `CLAUDE.md`'s *Verification loop* owns the distinction between that loop and
+   the four checks at the gate; do not restate it here.
+
    **Record the tier here**, in the new worktree, before the first line of
    work. It goes beside the two review markers, in that worktree's own git dir,
    so it is per-branch and never committed:

--- a/.claude/skills/new-task/SKILL.md
+++ b/.claude/skills/new-task/SKILL.md
@@ -18,9 +18,14 @@ Argument: the issue number (e.g. `/new-task 3`). If missing, list open issues in
    ```sh
    git fetch origin
    git worktree add -b <prefix>/<short-kebab-slug> ../quantick-worktrees/<prefix>-<short-kebab-slug> origin/main
+   cd ../quantick-worktrees/<prefix>-<short-kebab-slug> && cargo build -p quantick-guards
    ```
 
    Then work from inside `../quantick-worktrees/<prefix>-<short-kebab-slug>`.
+   That `cargo build` arms `guard-watch`, which reports nothing — not "clean",
+   *nothing* — until the binary exists; `CLAUDE.md`'s *Verification loop* owns
+   why. A branch started here is exactly the one that would otherwise miss it,
+   since the arming rule used to live only in `mission` step 6.
 
    Prefix from the issue's labels: `bug` or `type:fix` → `fix/`, `type:docs` → `docs/`, everything else → `feat/`. Slug: short kebab-case from the issue title.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,27 +55,33 @@ Every change must pass all four checks before commit — no exceptions:
 3. `cargo build --workspace`
 4. `cargo test --workspace`
 
-The four are the gate, and they are **not** the edit loop. Running them after every
-edit is the most expensive habit available in this repo: `cargo check -p
-quantick-app --all-targets` answers in about 40 seconds warm, while `cargo build
---workspace` links the largest crate in the repo to tell you the same thing.
-**While you work, the loop is `cargo check -p <the crate you are editing>` and
-`cargo test -p <crate> <filter>`; the four run once, before the commit.** This was
-unwritten until it was measured, and `cargo check` appeared nowhere in this
-repository's documentation — an agent with no name for the fast path defaults to
-the slow one, on every edit, for the length of a mission.
+The four are the gate, and they are **not** the edit loop. **While you work, the
+loop is `cargo check -p <crate>` over the crate you are editing, plus
+`cargo test -p <crate> <filter>`; the four run once, before the commit.** A
+one-package `cargo check` skips codegen and linking, so on `quantick-app` it
+answers in well under a minute where a workspace build takes many — the two are
+not the same question, which is exactly why the loop is not the gate: `check`
+proves nothing about linking and does not stand in for `clippy`, so it belongs
+between edits and never in place of the four.
+
+This was unwritten until it was measured: `cargo check` appeared nowhere in this
+repository's documentation, so the gate was doubling as the edit loop. An agent
+with no name for the fast path defaults to the slow one, on every edit, for the
+length of a mission.
 
 Nothing replaces the four at the gate. What can also move earlier is the repository guards: `cargo test -p quantick-guards` runs the size ratchet, the language scan and the encoding check in about a second, because that crate has no dependencies to build. Ask it after a batch of edits rather than discovering a crossed ceiling at the end of a full suite run — and when the ratchet reports a file that *shrank*, `cargo run -p quantick-guards -- --tighten` writes the new number, since that direction has nothing for a human to decide. A `PostToolUse` hook runs the same binary over each edited file; it is advisory and silent when the binary has not been built, so it reports early and gates nothing.
 
 **That silence is why the hook has to be armed on purpose.** A fresh worktree has
 no `target/`, so `target/debug/quantick-guards` does not exist, so the hook reports
-nothing — not "clean", *nothing* — for the whole mission. Measured in this
-checkout: the binary was absent, across eighteen worktrees. The cheapest structural
-check in the repo was switched off in exactly the phase it was built for, and the
-cost went to the reviews at the end instead. So **`cargo build -p quantick-guards`
-is part of setting up a worktree**, not an optimisation: it takes seconds, the
-crate has no dependencies, and it is the difference between a crossed size ceiling
-reported at the edit that caused it and one reported after the code is written.
+nothing — not "clean", *nothing* — for as long as that stays true. This was found
+switched off across every worktree in one checkout at once, which is the state a
+`git worktree add` leaves behind by default rather than an accident someone had to
+cause. So **`cargo build -p quantick-guards` is part of setting up a worktree**,
+not an optimisation: the crate has no dependencies, so it costs seconds, and it is
+the difference between a crossed size ceiling reported at the edit that caused it
+and one reported after the code is written. `.claude/hooks/README.md` owns why the
+hook never blocks and never builds; this is the one line that section cannot
+state, because arming happens outside the hook.
 
 CI (`.github/workflows/ci.yml`) enforces the same four checks on every PR and on pushes to `main`, plus four the workspace cannot see: `sh .claude/hooks/guardrails_test.sh`, `ruff check --select F` over `tools/mt5/` and `bridge/mt5/`, `python3 tools/mt5/test_export_session.py`, and every `python3 bridge/mt5/tests/test_*.py`. The MetaTrader bridge and the session exporter are Python — cargo never compiles them, and an undefined name there ships silently. Run the ones your change touches; the bridge's paging tests are the step whose own comment records that without it a revert to `COPY_TICKS_ALL` ships green. After pushing a PR, watch CI with `gh pr checks <n> --watch` and fix any failure before requesting review or merging. A PR with red CI is never merged.
 
@@ -88,7 +94,14 @@ CI (`.github/workflows/ci.yml`) enforces the same four checks on every PR and on
   ```sh
   git fetch origin
   git worktree add -b <prefix>/<slug> ../quantick-worktrees/<prefix>-<slug> origin/main
+  cd ../quantick-worktrees/<prefix>-<slug> && cargo build -p quantick-guards
   ```
+
+  That last line is not optional and not an optimisation — it arms `guard-watch`,
+  which reports nothing at all until the binary exists. See *Verification loop*
+  above for what its silence costs. It belongs in this snippet, and in
+  `new-task`'s, because a rule stated only in `mission` step 6 leaves every
+  branch that did not start from a mission unarmed.
 
   Work happens inside that directory. After the branch is merged, clean up from the main checkout: `git worktree remove ../quantick-worktrees/<prefix>-<slug>` then `git branch -d <prefix>/<slug>`.
 - **One mission, one tier**: `/mission` takes an optional leading tier — `small` (the default), `medium`, `high` or `max` — that scales the ceremony to the size of the work: how much is interrogated, which gates are injected, how hard the bug pass looks, and whether `delivery-review` runs at all. `small` is the only one the hooks can see, and the only one that changes what they require. The skill owns the table; `.claude/hooks/README.md` owns what the gate does with it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,27 @@ Every change must pass all four checks before commit — no exceptions:
 3. `cargo build --workspace`
 4. `cargo test --workspace`
 
-The four are the gate and nothing replaces them. What can move earlier is the repository guards: `cargo test -p quantick-guards` runs the size ratchet, the language scan and the encoding check in about a second, because that crate has no dependencies to build. Ask it after a batch of edits rather than discovering a crossed ceiling at the end of a full suite run — and when the ratchet reports a file that *shrank*, `cargo run -p quantick-guards -- --tighten` writes the new number, since that direction has nothing for a human to decide. A `PostToolUse` hook runs the same binary over each edited file; it is advisory and silent when the binary has not been built, so it reports early and gates nothing.
+The four are the gate, and they are **not** the edit loop. Running them after every
+edit is the most expensive habit available in this repo: `cargo check -p
+quantick-app --all-targets` answers in about 40 seconds warm, while `cargo build
+--workspace` links the largest crate in the repo to tell you the same thing.
+**While you work, the loop is `cargo check -p <the crate you are editing>` and
+`cargo test -p <crate> <filter>`; the four run once, before the commit.** This was
+unwritten until it was measured, and `cargo check` appeared nowhere in this
+repository's documentation — an agent with no name for the fast path defaults to
+the slow one, on every edit, for the length of a mission.
+
+Nothing replaces the four at the gate. What can also move earlier is the repository guards: `cargo test -p quantick-guards` runs the size ratchet, the language scan and the encoding check in about a second, because that crate has no dependencies to build. Ask it after a batch of edits rather than discovering a crossed ceiling at the end of a full suite run — and when the ratchet reports a file that *shrank*, `cargo run -p quantick-guards -- --tighten` writes the new number, since that direction has nothing for a human to decide. A `PostToolUse` hook runs the same binary over each edited file; it is advisory and silent when the binary has not been built, so it reports early and gates nothing.
+
+**That silence is why the hook has to be armed on purpose.** A fresh worktree has
+no `target/`, so `target/debug/quantick-guards` does not exist, so the hook reports
+nothing — not "clean", *nothing* — for the whole mission. Measured in this
+checkout: the binary was absent, across eighteen worktrees. The cheapest structural
+check in the repo was switched off in exactly the phase it was built for, and the
+cost went to the reviews at the end instead. So **`cargo build -p quantick-guards`
+is part of setting up a worktree**, not an optimisation: it takes seconds, the
+crate has no dependencies, and it is the difference between a crossed size ceiling
+reported at the edit that caused it and one reported after the code is written.
 
 CI (`.github/workflows/ci.yml`) enforces the same four checks on every PR and on pushes to `main`, plus four the workspace cannot see: `sh .claude/hooks/guardrails_test.sh`, `ruff check --select F` over `tools/mt5/` and `bridge/mt5/`, `python3 tools/mt5/test_export_session.py`, and every `python3 bridge/mt5/tests/test_*.py`. The MetaTrader bridge and the session exporter are Python — cargo never compiles them, and an undefined name there ships silently. Run the ones your change touches; the bridge's paging tests are the step whose own comment records that without it a revert to `COPY_TICKS_ALL` ships green. After pushing a PR, watch CI with `gh pr checks <n> --watch` and fix any failure before requesting review or merging. A PR with red CI is never merged.
 


### PR DESCRIPTION
## What and why

The trader's report was that `/mission` takes hours and days, and that the
review chain never ends. Five agents analysed the flow. **The measurement
refuted the obvious diagnosis.** Across the last 20 merged PRs, ordinary code
branches average **~1 review-fix commit**. The branches that burn rounds
(21 commits / 6 rounds; 9 / 3) are the ones with **zero production lines** —
meta-work on the workflow itself. The gate is not what is slow for coding.

What is slow is that the coding phase had no support, and the repository's own
cheap machinery was switched off:

| Measured | Value |
| --- | --- |
| `target/debug/quantick-guards` present | **no**, in every worktree checked |
| `cargo check` in every `.md` in the repo | **0 occurrences** |
| `cargo build -p quantick-guards` | **1.80s** (no dependencies) |
| `cargo check -p quantick-app --all-targets`, warm | **35s** |

`guard-watch` runs that binary and is documented as silent when it is missing.
A fresh worktree never builds it — so the size ratchet, the language scan and
the encoding check reported **nothing** for the whole of every mission. Silent,
not clean. The cheapest structural check in the repo was off in exactly the
phase it was designed for, and the cost went to the reviews at the end.

That is also the answer to the modularity question. `delivery-review` was added
in response to `crates/app` reaching 72% of the repository, but it grades
conformance to the request ledger and never looks at file growth. What moved
that number is the size ratchet (`QuantickApp` fields 133 → 97) — mechanical,
~1s, and it fires at edit time. **A structural property is enforced most
cheaply where the code is written, not at the PR.**

## Changes

- `CLAUDE.md` — names the edit loop (`cargo check -p <crate>`) as distinct from
  the four gate checks. `cargo check` appeared nowhere in this repo's docs, so
  the gate was doubling as the edit loop.
- `CLAUDE.md`, `mission` step 6, `new-task` step 3 — `cargo build -p
  quantick-guards` when a worktree is created, in all three places a worktree
  is born.

## Verification

`cargo fmt --check` 0 · `cargo clippy --workspace --all-targets -D warnings` 0 ·
`cargo build --workspace` 0 · `cargo test --workspace` 0 ·
`sh .claude/hooks/guardrails_test.sh` **96 passed, 0 failed**

Each run separately, with its own exit code read directly — an earlier run in
this session reported exit 0 from a pipeline whose `cargo` had exited 101.

**Mission tier: `small`** (69 changed lines, ceiling 300), so this PR opens on
`arch-review-ok` alone and states so publicly rather than only to the hook.

## Review

`step 0: code-review at xhigh, 15 findings, 13 confirmed, 11 fixed, 2 deferred.`
It reused a level from a prior session rather than the `low` the tier sets;
recorded so a long pass is not mistaken for a short one.

Two were **Blockers in this branch's own new text**, and the first is the
branch reintroducing the defect it exists to fix: the arming snippet opened
with `cd "$WT"` while nothing assigned `WT`, so the `&&` chain aborted and the
binary was never built. The second, `<the crate you will edit>` inside an `sh`
fence, is two redirections. Both fixed and verified by execution.

**The `delivery-review` change was reverted.** Six findings traced to one
omission — a cost-discipline section added without editing steps 2, 4 and 5 —
and one was a new false pass: grading from the stat plus the files as they
stand lets a reviewer quote a sentence that was already on `origin/main`.
Making it correct means rewriting three steps of that skill. That is its own
branch, and the ask it serves is carried forward undischarged in the archive.

## Deferred, and why

- **`guard-watch` cannot report its own absence.** `[ -x "$binary" ] || exit 0`
  makes absence and cleanliness one observable, so a `cargo clean` returns a
  worktree to silence with no signal. The durable fix is a one-line note when
  the binary is missing. It edits `guardrails.sh`.
- **The size measurement under-counts, permissively.** `guardrails.sh:281` uses
  a cwd-relative `-- .` and a non-top-anchored `SIZE_EXCLUDES`, so a `cd` into
  a subdirectory before `gh pr create` under-measures — and that is the sole
  bound on the `small` tier's exemption, so the error favours the branch.

Both edit the guardrail script, which this session's auto-mode classifier
declined to let an agent loosen. That is the right call and the authorisation
is the trader's. A third follow-up is recorded in the archive: **do not adopt a
shared cargo target directory** before fixing the hook's hardcoded
`$root/target/debug/` path, or it silently un-arms every worktree at once.

## Not claimed

This branch changes no executable line. Nothing here forces the binary to
exist; what changed is that the step now appears everywhere a worktree is
created instead of nowhere. The version that does not depend on being read is
the first deferral above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Py1gv2x6E5ud5wwCPNhjk
