### PR TITLE
fix(skills): pass the effort level where code-review can read it

### DIFF
--- a/.claude/GOAL-archive-arch-review-effort-level.md
+++ b/.claude/GOAL-archive-arch-review-effort-level.md
@@ -1,0 +1,200 @@
+# Mission — prove the bug pass ran at the level the tier bought
+
+**Objective:** make `arch-review`'s step 0 provably run the bundled
+`code-review` at the effort level the mission's declared tier buys, instead of
+reporting whichever level happened to run.
+
+**Tier:** `medium`. The diff is small and almost entirely markdown, which
+argues for `small` — but the request carries one decision that is the trader's
+and not the implementer's: what `arch-review` does when it discovers the bug
+pass ran at the wrong level. Re-invoking buys a second bug pass, which is the
+opposite of the goal; aborting stalls the review; warning is what happens today
+and did not prevent anything. `medium` buys the two questions that decision
+needs, and the completeness pass that checks the answer actually shipped.
+
+**Why it matters:** the tier exists to let the trader buy less review on
+purpose. A step 0 that silently runs at a level nobody selected spends the
+budget the tier was meant to cap — measured at 192,701 subagent tokens on a
+markdown branch — and reports the overspend as though it were the plan.
+
+## Request ledger
+
+| | Ask |
+| --- | --- |
+| **R1** | The effort argument does not reach `code-review`; step 0 runs at a level the tier did not buy. The defect goes. |
+| **R2** | The fix cannot live in `code-review` — it is the bundled skill and does not live in `.claude/skills/`. It lives in *"como o arch-review a chama, ou em como o arch-review verifica o que voltou"*. |
+| **R3** | An `arch-review` running under a declared tier must **prove** the bug pass ran at the level that tier buys — *"prove que a passada de bug rodou no nível que aquele tier compra"* — rather than reporting the level that happened to run. |
+| **R4** | Today the skill only asks to name the level in the header, which records the error without preventing it. That is not enough. |
+| **R5** | Reproduce before fixing: test the invocation forms and establish whether the argument passes at all — *"Comece reproduzindo antes de consertar"*. |
+| **R6** | If it cannot pass in any form, the deliverable is `arch-review` handling that honestly — *"não uma prosa dizendo que passa"*. |
+| **R7** | Decide, with the trader, what `arch-review` does on discovering it ran at the wrong level: re-invoke, abort, or warn. |
+| **R8** | Establish first whether it reproduces at all. *"se não reproduzir, o achado vira 'não reproduzível' e isso é um resultado legítimo, não um fracasso"* — one sighting, possibly specific to that session. |
+
+## Decisions taken by the trader
+
+- **D1** *(answers R7)* — **Asymmetric re-run.** On divergence, re-invoke once
+  at the tier's level **only when the pass ran below** what the tier bought.
+  When it ran **above** — today's failure mode, `xhigh` for a `medium` tier —
+  accept the result and record the overspend in the header and the PR body: a
+  deeper pass has already answered the question, and a second pass is the exact
+  cost this mission exists to remove. One retry, never two.
+- **D2** *(answers R3, R6)* — **Construction plus a negative check.** Invoke
+  effort-first, so the parser structurally takes the level as explicit; treat
+  any "No effort level given / reusing X" line in the returned report as proof
+  of failure. No such line means the requested level ran, and the header says
+  both the level and that no reuse notice came back.
+
+## Assumptions
+
+- **S1** — The fix ships as an edit to `.claude/skills/arch-review/SKILL.md`
+  plus the one other tracked file that teaches the same wrong argument order
+  (`docs/control-plane/roadmap.md`). Repairing a second copy of the exact
+  defect is discharging R1, not scope invented beyond it; historical evidence
+  files that *record* the old invocation are left alone, because they are a
+  record of what happened rather than an instruction to repeat it.
+- **S2** — Reproduction runs against a tiny in-repo path target rather than the
+  branch, so the two invocation forms can be compared without paying for two
+  full branch reviews. The parser does not care what the target is; only the
+  token position matters.
+- **S3** — No Rust changes, so the four checks are expected to be a formality;
+  they still run, per the injected gate.
+- **S4** *(wanted to ask; the two-question budget went to D1 and D2)* — the
+  header line's exact wording was decided rather than asked. It extends the
+  existing `step 0: code-review at <level>` line instead of replacing it, so
+  every archived arch-review stays readable against the new one.
+
+## Acceptance criteria
+
+- [x] **A1** — The reproduction is recorded as a measurement, not a claim: the
+      parser's actual argument order, the persisted `codeReviewLastEffort`
+      value, and the two live invocations with what each returned. The record
+      says explicitly whether the defect reproduces.
+      *Evidence:* a written reproduction record naming each observation and how
+      it was obtained. → `.claude/evidence/arch-review-effort-level/reproduction.md`. *(R5, R8)*
+- [x] **A2** — `arch-review`'s step 0 documents the invocation form the parser
+      actually accepts, with the level first, and says why the order is
+      load-bearing rather than stylistic.
+      *Evidence:* the revised step 0 block. → `.claude/skills/arch-review/SKILL.md`. *(R1, R2)*
+- [x] **A3** — Step 0 carries a verification the reviewer performs on the
+      returned report — the negative check of D2 — stated as a step that can
+      fail, not as a request to name a level.
+      *Evidence:* the verification paragraph. → `.claude/skills/arch-review/SKILL.md`. *(R3, R4)*
+- [x] **A4** — Step 0 states what happens on divergence, exactly as D1 decided:
+      the re-run is asymmetric, bounded to one, and an accepted overspend is
+      recorded in the header and the PR body.
+      *Evidence:* the divergence paragraph. → `.claude/skills/arch-review/SKILL.md`. *(R7)*
+- [x] **A5** — The skill states honestly what it cannot prove: the level is
+      established by construction and by the absence of a notice, never by a
+      positive statement from a skill this repository cannot edit.
+      *Evidence:* the honesty paragraph. → `.claude/skills/arch-review/SKILL.md`. *(R6)*
+- [x] **A6** — No other tracked file still teaches the wrong argument order.
+      *Evidence:* a grep over the tree for the invocation form, with its output,
+      in the reproduction record.
+      → `.claude/evidence/arch-review-effort-level/reproduction.md`. *(R1)*
+
+### Injected gates
+
+- [x] **G1** — Every artifact in this branch is English: the prose, the branch
+      name, the commit messages, and the goal file bar its one marked
+      quotation.
+      *Evidence:* `cargo test -p quantick-guards` green plus the arch-review
+      dimension 8 verdict. → the PR body.
+- [x] **G2** — The four checks pass on the rebased branch.
+      *Evidence:* the four command exit codes. → the PR body.
+- [x] **G3** — Performance impact declared. No code path is touched — the diff
+      is markdown — so the rate classification is "no touched path", stated
+      rather than omitted.
+      *Evidence:* the statement. → the PR body.
+- [ ] **G4** — `arch-review` run over the final branch with every Blocker and
+      Should-fix resolved, or deferred in the PR body.
+      *Evidence:* the arch-review verdict and the `arch-review-ok` marker.
+      → the PR body.
+
+## Evidence recorded
+
+- **A1** — `.claude/evidence/arch-review-effort-level/reproduction.md`. Verdict:
+  reproduces 2/2, deterministically. Run A (documented order) opened with
+  "Reusing your last effort level, xhigh"; 111,465 subagent tokens, 405 s, on a
+  129-line file with no diff, for a requested `low`. Run B (effort first)
+  returned inline with no notice.
+- **A2** — `.claude/skills/arch-review/SKILL.md`, step 0 invocation block, now
+  `"<effort> <target>"`, followed by the paragraph naming why the order is
+  load-bearing and what the wrong order cost.
+- **A3** — same file, *Then prove it, because naming it is what failed*: proof
+  is construction plus the negative check on the returned report.
+- **A4** — same file, *On divergence, the re-run is asymmetric and bounded to
+  one*, exactly as D1 decided, including the recorded overspend.
+- **A5** — same file, *Say what cannot be proven, rather than implying it was*.
+- **A6** — grep in section 4 of the reproduction record; two live instructions
+  fixed, two historical records deliberately left.
+- **G1** — `cargo test -p quantick-guards`: exit 0, 4 + 5 tests passed.
+- **G2** — `cargo fmt --all -- --check` exit 0; `cargo clippy --workspace
+  --all-targets -- -D warnings` exit 0 (2m 28s); `cargo build --workspace`
+  exit 0 (5m 19s); `cargo test --workspace` exit 0, zero failures.
+- **G3** — no code path touched; the diff is markdown only. Rate class: none.
+- **G4** — see the arch-review verdict recorded for this branch.
+
+### Not applicable, and why
+
+- **Hot path** — nothing per-trade, per-depth or per-frame is touched; the diff
+  is markdown. No measurement is owed, and G3 says so rather than staying
+  quiet.
+- **User-visible surface** — no UI, so `ui-harness`, `visual-qa` and
+  `trader-ux-review` do not apply.
+- **New capability** — `new-extension` does not apply: no port, no registry, no
+  new crate. The change repairs an existing instruction.
+- **Engine / determinism** — no engine code, so the test-first rule has nothing
+  to bind to. The reproduction record is this branch's equivalent evidence.
+- **Second operator** — the change adds nothing a trader *does*, so the
+  drivable-without-a-mouse rule has no surface to grade.
+
+### Closing steps
+
+- **C1** — `delivery-review` returns PASS (completeness pass, `medium` tier).
+- **C2** — the PR is open, naming the tier beside the verification boxes.
+
+## The request as received
+
+Quoted verbatim, in the trader's own words and language, as `mission` step 5
+requires and `CLAUDE.md`'s exemption for a marked, attributed quotation allows.
+It is not translated because a translation would be a paraphrase, and the
+paraphrase is exactly what `delivery-review` exists to check the ledger
+against. Received 2026-09-01 from the trader, as the argument to
+`/mission medium`.
+
+> o step 0 do arch-review roda no nível errado: o argumento de
+> effort não chega na skill code-review e ela reusa o nível da sessão anterior.
+>
+> Evidência, do PR #274 (branch refactor/leaner-agentic-flow):
+> - arch-review/SKILL.md manda invocar `Skill(code-review), args: "<target> <effort>"`
+>   e diz "Never omit it: with no level the skill reuses whatever was typed last,
+>   in some other session".
+> - Invoquei exatamente assim, com args "refactor/leaner-agentic-flow medium",
+>   numa missão de tier `high` (que mapeia para `medium`).
+> - A skill respondeu: "No effort level was typed, so I reused xhigh — the level
+>   from last time" e rodou o protocolo xhigh completo: 10 ângulos inline, dedup,
+>   varredura de lacunas.
+> - Custo: 192.701 tokens de subagente numa branch quase toda markdown. O tier
+>   tinha comprado `medium`.
+>
+> Note que `code-review` é a skill embutida, não vive em .claude/skills/, então o
+> conserto não pode ser nela — tem que ser em como o arch-review a chama, ou em
+> como o arch-review verifica o que voltou.
+>
+> O que eu quero: que um arch-review rodando sob um tier declarado prove que a
+> passada de bug rodou no nível que aquele tier compra, em vez de reportar o nível
+> que calhou de rodar. Hoje o skill só pede para "nomear o nível no cabeçalho", o
+> que registra o erro sem impedir.
+>
+> Comece reproduzindo antes de consertar — teste as formas de invocação e descubra
+> se o argumento passa de alguma maneira. Se não passar de jeito nenhum, o
+> entregável é o arch-review lidando com isso honestamente, não uma prosa dizendo
+> que passa.
+>
+> Duas coisas que eu deixei de propósito dentro do prompt em vez de decidir por você:
+>
+> Por que medium e não small. O diff é pequeno, mas tem uma decisão que não é minha: o que o arch-review faz quando descobre que rodou no nível errado. Re-invocar custa uma segunda passada de bug — que é o oposto do objetivo. Abortar trava a review. Só avisar é o que já acontece hoje e não impediu nada. Essa é escolha sua, e medium dá duas perguntas para ela ser feita.
+>
+> Por que "comece reproduzindo". Eu não sei qual é a forma correta de invocação — sei só que a documentada não funcionou uma vez. Se o próximo agente partir de "a forma X é a certa", ele escreve prosa afirmando algo que ninguém mediu, que é exatamente o defeito que esta branch levou três rodadas para tirar de mim.
+>
+> Uma ressalva honesta: eu vi isso uma vez. Pode ser específico da minha sessão. A primeira coisa que a missão deve estabelecer é se reproduz — se não reproduzir, o achado vira "não reproduzível" e isso é um resultado legítimo, não um fracasso.

--- a/.claude/evidence/arch-review-effort-level/reproduction.md
+++ b/.claude/evidence/arch-review-effort-level/reproduction.md
@@ -1,0 +1,100 @@
+# Reproduction — step 0 ran at a level the tier never bought
+
+Measured 2026-09-01, on the machine that filed the report, against Claude Code
+`2.1.258`. The trader saw the failure once and said so: *"eu vi isso uma vez.
+Pode ser específico da minha sessão."* It is not. It reproduces on demand, it
+has a single mechanical cause, and the cause is in this repository's own
+instructions rather than in the bundled skill.
+
+**Verdict: reproduces, 2/2, deterministically.**
+
+## 1. The parser takes the effort as the *first* token
+
+The bundled `code-review` is not a file under `.claude/skills/`; it is compiled
+into the CLI. Its own published argument hint, read out of the shipped binary,
+is:
+
+```
+[low|medium|high|xhigh|max|ultra] [--fix] [--comment] [<pr#>|<branch>|<path>]
+```
+
+Effort first, flags second, target last. The parser behind it reads the first
+non-flag token, tests it against the level list, and branches:
+
+- first token **is** a level → that level is `explicit`, and the target is
+  everything *after* it;
+- first token is **not** a level → `explicit` is undefined, and **the entire
+  argument string becomes the target**, effort word and all.
+
+There is no third branch. A first token that is not a level is not an error the
+skill reports — it is a target.
+
+So `arch-review`'s documented form, `args: "<target> <effort>"`, failed twice
+over on one call. It lost the level, *and* it handed the review a target of the
+shape `my-branch medium`. The second half is what the skill's own *Check the
+scope it comes back with* paragraph had been catching for months, without ever
+naming what caused it.
+
+## 2. The level it falls back to is global, not per session
+
+With no explicit level, the skill reads `codeReviewLastEffort` from
+`~/.claude.json` — a single value shared by every session and every project on
+the machine, persisted only when a human *types* a level at the prompt. Read
+directly from that file on this machine at the time of the report:
+
+```
+codeReviewLastEffort = xhigh
+```
+
+Exactly the level the trader saw run. Nothing about the failure was specific to
+that session; any session on this machine, invoking the documented form, would
+have got `xhigh`.
+
+## 3. Two live invocations, differing only in token order
+
+Same target, same session, minutes apart. The only variable is which word comes
+first.
+
+| | Run A — documented order | Run B — effort first |
+| --- | --- | --- |
+| args | `crates/guards/src/lib.rs low` | `low crates/guards/src/lib.rs` |
+| opening line of the report | **"Reusing your last effort level, xhigh — type a level (for example `/code-review high`) to change it."** | *(no notice at all)* |
+| where it ran | forked to a background agent | inline |
+| wall clock | 405 s | returned immediately |
+| subagent tokens | **111,465** | none — no subagent |
+| what came back | 15 findings across the whole guards crate, its callers and its tests | correctly reported that the target has no reviewable diff |
+
+Run A asked for `low` and was given `xhigh`, on a 129-line file with no changes
+in any diff. Run B asked for `low` and got `low`.
+
+One honest note about run A: the report says *"I reviewed
+`crates/guards/src/lib.rs` as the target"*, so the agent recovered the path by
+judgement from the mangled string it was handed. That recovery is the agent
+being sensible, not the parser working — and it is precisely why the defect
+survived so long. The target usually still resolves, so the only symptom left
+to notice is the bill.
+
+## 4. What this repository still taught
+
+Grep over tracked files for the wrong argument order, after the fix:
+
+```
+$ grep -rn "code-review <PR>\|args: \"<target>" --include=*.md .
+./.claude/GOAL-archive-control-scene.md:46:  ... (step 0 `code-review <PR> high`) ...
+./.claude/GOAL.md:145:> - arch-review/SKILL.md manda invocar `Skill(code-review), args: "<target> <effort>"`
+```
+
+Two live instructions carried the wrong order and are fixed on this branch:
+`.claude/skills/arch-review/SKILL.md` (the invocation block) and
+`docs/control-plane/roadmap.md` (`code-review <PR> high` → `code-review high
+<PR>`). The two hits above are deliberately left alone — the first is an
+archived goal file and the second is the trader's own quoted bug report inside
+this branch's goal file. Both are records of what happened, not instructions to
+repeat it.
+
+## 5. Incidental, and not this branch's work
+
+Run A's 15 findings are real and are about `crates/guards/`, which this branch
+does not touch. They are recorded here as the by-product of a reproduction, not
+adopted as scope: acting on them would be exactly the widening this mission's
+ledger exists to prevent. They are worth an issue of their own.

--- a/.claude/skills/arch-review/SKILL.md
+++ b/.claude/skills/arch-review/SKILL.md
@@ -774,9 +774,13 @@ code-review at high (effort-first, no reuse notice), 12 findings, 3 confirmed`
 is the claim that failed on PR #274, and the two words after it are the whole
 difference between a level that was requested and one that ran. When the pass
 diverged, the line says so and says which way — `step 0: code-review at xhigh
-(tier bought medium; reuse notice, accepted per the asymmetric rule), …`. On
-the `ReportFindings` path that line is
-the text accompanying the call, since the tool carries no header field. It is
+(tier bought medium; reuse notice, accepted per the asymmetric rule), …` — and
+when the report settles nothing either way, it says that instead of rounding it
+up: `step 0: code-review at medium (effort-first; level unverified), …`. Three
+shapes, and the header always carries exactly one of them.
+
+On the `ReportFindings` path that line is the text accompanying the call, since
+the tool carries no header field. It is
 the only signal that the bug pass was skipped, so it is never dropped — and it
 goes into the PR body too, next to the deferred findings `CLAUDE.md` already
 requires there. Chat scrolls away; the PR is where the next reader looks.

--- a/.claude/skills/arch-review/SKILL.md
+++ b/.claude/skills/arch-review/SKILL.md
@@ -17,22 +17,38 @@ you first: see step 0.
 
 Correctness outranks architecture (priority 0), so the bug pass starts before
 the shape pass and the review never closes without it. Run the bundled
-`code-review` — the skill that takes a target plus an effort level
-(`low`…`ultra`). A plugin command of the same name appears prefixed,
+`code-review` — the skill that takes an effort level (`low`…`ultra`) and then
+a target, in that order. A plugin command of the same name appears prefixed,
 `code-review:code-review`; that one posts to the PR by itself and is not what
 this step calls.
 
 ```
-Skill(code-review), args: "<target> <effort>"      one string, in that order
+Skill(code-review), args: "<effort> <target>"      one string, effort FIRST
 
-  <target>   a PR number once one exists — the least ambiguous target there
-             is — otherwise a branch name, or omitted for the working diff.
-             Never a revision range: `main...HEAD` is not a target it parses.
   <effort>   `high` for a branch or PR, `medium` for a working diff.
              Never omit it: with no level the skill reuses whatever was typed
              last, in some other session, and this review has to name the
              level it used.
+  <target>   a PR number once one exists — the least ambiguous target there
+             is — otherwise a branch name, or omitted for the working diff.
+             Never a revision range: `main...HEAD` is not a target it parses.
 ```
+
+**The order is load-bearing, not stylistic, and this file taught it backwards
+until 2026-09-01.** The bundled skill reads the level from the **first token
+only**. A first token that is not a level is not an error it reports: the level
+silently becomes "not given", *and the whole argument string — effort word
+included — becomes the target*. So the `"<target> <effort>"` form documented
+here lost both halves at once. The review fell back to the level cached in
+`~/.claude.json` from some other session, and it went looking for a target
+named `my-branch medium`. That second half is what the *Check the scope it
+comes back with* warning below had been catching for months without ever naming
+its cause.
+
+Measured on this repository, not inferred:
+`.claude/evidence/arch-review-effort-level/reproduction.md` records the CLI's
+own published argument hint, the cached level actually sitting on this machine,
+and two live invocations differing only in token order.
 
 **A mission's tier overrides that default**, because the tier is the trader's
 own statement of how much this change is worth reviewing: **`low` for `small`
@@ -80,6 +96,43 @@ defaults above rather than guessing at a middle level.
 short pass is never mistaken for a thorough one — and say so when this file and
 the goal file's `**Tier:**` line disagree. Two surfaces disagreeing about one
 branch is a finding in itself, and this review is what sees it.
+
+**Then prove it, because naming it is what failed.** The old rule stopped at
+the header, and a header is written by the same agent that got the invocation
+wrong: on PR #274 it faithfully recorded `xhigh` on a branch whose tier had
+bought `medium`, and the record changed nothing. Proof here is two things
+together, and neither alone is enough:
+
+- **By construction** — the level went in as the first token, so the parser
+  took it as explicit and never consulted the cached one. That is what the
+  block above buys.
+- **By the absence of a notice** — when the bundled skill falls back to the
+  cached level it *says so*, in a line of the shape "No effort level given —
+  reusing `<level>`, the level the user typed last time". Read the returned
+  report for that line before reading it for findings. It is the one signal
+  this repository gets, and a report carrying it is a failed invocation whatever
+  else it found.
+
+**On divergence, the re-run is asymmetric and bounded to one.** If the notice
+says the pass ran **below** the level the tier bought, re-invoke once,
+effort-first, at the tier's level — a shallower pass has not answered the
+question the tier asked. If it ran **above** — the `xhigh`-for-`medium` case,
+and the likelier one — **accept it and do not re-run.** A deeper pass has
+already answered; a second pass would spend the very budget this rule exists to
+protect. Record the overspend instead: name it in the header and carry it into
+the PR body beside the deferred findings, so the cost is visible and arguable
+rather than absorbed in silence. One retry, never two — if a second invocation
+still comes back reused, that is a finding to report, not a third attempt.
+
+**Say what cannot be proven, rather than implying it was.** `code-review` is
+bundled — it does not live in `.claude/skills/`, so this repository cannot make
+it state the level it ran at. The level is established by construction and by
+the absence of a fallback notice, never by a positive statement from the pass
+itself. The header claims exactly that much and no more: the level requested,
+that it was passed as the first token, and that no reuse notice came back — or,
+when the report is silent in a way that settles nothing, that the level is
+**unverified**, which is a thing to write down rather than a thing to round up
+to a pass.
 
 **Check the scope it comes back with.** When the target does not pin a range
 the skill derives one, so it can end up reviewing another branch's merged work
@@ -714,9 +767,15 @@ A clean change gets a short review saying it is clean and why. Never pad.
 
 ## Output
 
-Open with one line for step 0: the effort level it ran at and how many findings
-came back, including zero — `step 0: code-review at high, 12 findings, 3
-confirmed` — or why it did not run. On the `ReportFindings` path that line is
+Open with one line for step 0: the effort level it ran at, **how that level was
+proven**, and how many findings came back, including zero — `step 0:
+code-review at high (effort-first, no reuse notice), 12 findings, 3 confirmed`
+— or why it did not run. The parenthetical is not decoration: `at high` alone
+is the claim that failed on PR #274, and the two words after it are the whole
+difference between a level that was requested and one that ran. When the pass
+diverged, the line says so and says which way — `step 0: code-review at xhigh
+(tier bought medium; reuse notice, accepted per the asymmetric rule), …`. On
+the `ReportFindings` path that line is
 the text accompanying the call, since the tool carries no header field. It is
 the only signal that the bug pass was skipped, so it is never dropped — and it
 goes into the PR body too, next to the deferred findings `CLAUDE.md` already

--- a/docs/control-plane/roadmap.md
+++ b/docs/control-plane/roadmap.md
@@ -436,7 +436,7 @@ Acceptance (plan PR 5c = MVP acceptance):
 
 ## 6. Gates for every pull request in section 5
 
-Beyond CLAUDE.md's four checks, `arch-review` with step 0 `code-review <PR> high`,
+Beyond CLAUDE.md's four checks, `arch-review` with step 0 `code-review high <PR>`,
 the `pr-gate` marker written before `gh pr create`, and CI watched with
 `gh pr checks <n> --watch`:
 


### PR DESCRIPTION
`arch-review`'s step 0 documented `Skill(code-review), args: "<target> <effort>"`.
The bundled skill reads the level from the **first token only**, so that form
lost the level *and* handed the review a target of the shape `my-branch medium`.
With no explicit level it falls back to `codeReviewLastEffort` in
`~/.claude.json` — one value shared by every session and every project on the
machine, sitting at `xhigh` here. On PR #274 a mission whose tier had bought
`medium` got `xhigh` and 192,701 subagent tokens on a markdown branch, and the
header dutifully recorded the overspend without preventing it.

**Mission tier: `medium`.**

## Reproduced before anything was changed

Full record: `.claude/evidence/arch-review-effort-level/reproduction.md`.
Verdict: **reproduces 2/2, deterministically** — not specific to one session.
Same target, same session, token order the only variable:

| | documented order | effort first |
| --- | --- | --- |
| args | `crates/guards/src/lib.rs low` | `low crates/guards/src/lib.rs` |
| opening line | **"Reusing your last effort level, xhigh"** | *(no notice)* |
| wall clock | 405 s | immediate |
| subagent tokens | **111,465** | none — ran inline |

The CLI's own published argument hint agrees:
`[low|medium|high|xhigh|max|ultra] [--fix] [--comment] [<pr#>|<branch>|<path>]`.

## What changed

- Step 0 invokes **effort-first**, with a paragraph saying why the order is
  load-bearing and what the wrong order cost — including that the corrupted
  target is what the existing *Check the scope it comes back with* warning had
  been catching for months without naming its cause.
- The level is now **proven, not named**: by construction (first token, so the
  parser takes it as explicit) *and* by the absence of the fallback notice in
  the returned report. Naming it in the header is what already failed.
- **On divergence the re-run is asymmetric and bounded to one** — re-run when
  the pass ran *below* the tier's level; **accept and record** when it ran
  *above*, because a second pass is the exact cost this rule exists to remove.
- The skill says what it **cannot** prove: `code-review` is bundled and cannot
  be made to state its own level, so a report that settles nothing is reported
  as `level unverified` rather than rounded up to a pass.
- `docs/control-plane/roadmap.md` carried the same wrong order and is fixed.
  Two historical records that merely *document* the old form are left alone.

## Verification

- [x] `cargo fmt --all -- --check` — exit 0
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — exit 0
- [x] `cargo build --workspace` — exit 0
- [x] `cargo test --workspace` — exit 0, zero failures (`quantick-guards`
      re-run at the final head, the only check that reads markdown)

**Performance impact:** no code path touched — the diff is markdown. Rate
class: none. The only rate that moved is the review's own, measured on this
branch: step 0 ran at `low` in 6–8 s / ~54,000 tokens against the 405 s /
111,465 of a mis-invoked pass.

## Reviews

`step 0: code-review at low (effort-first, no reuse notice), 0 findings` — run
twice, at `019bcf4` and again at `2ca3898` after the shape fix. The fix
verified itself: both invocations came back with no reuse notice.

**arch-review** — shape dimensions 1–7 and 9 waived (docs/skills change);
dimension 8 graded and passes. Trunk flat, no surface, no open findings.
Nothing deferred.

**delivery-review** — **completeness pass only**, the `medium` tier's mode, run
inline rather than by a fresh-context subagent. All eight asks derived
independently from the verbatim request appear in the ledger; nothing
`UNLEDGERED`. One near-miss named in the verdict: the request's general
"don't write prose asserting what nobody measured" is carried operationally by
R5 and R6 rather than stated as its own ledger line.

## Incidental, not adopted as scope

The reproduction's run A returned 15 real findings about `crates/guards/`,
which this branch does not touch. They are recorded in the evidence file and
deliberately not acted on here; they are worth an issue of their own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018mPVfw6Wkerorwwo8jhmf3