### PR TITLE
build: pin the toolchain, dependency versions, lint levels and the supply chain

### DIFF
--- a/.claude/GOAL-archive-pin-build-environment.md
+++ b/.claude/GOAL-archive-pin-build-environment.md
@@ -1,0 +1,230 @@
+# Mission — pin the build environment
+
+Pin the build environment — toolchain, dependency versions, lint levels and a
+supply-chain audit — so that a red CI means the code changed, not the
+repository. An agent session must never spend itself diagnosing a failure the
+repository caused rather than the change did.
+
+**Tier:** `medium`. The work touches every one of the seventeen crate
+manifests, the CI workflow and the root manifest, and it changes what `cargo
+build` treats as an error for every future session — too wide for `small`. But
+it is mechanical migration plus configuration rather than open design, so it
+does not earn `high`. `delivery-review` runs as a completeness pass.
+
+## Request ledger
+
+| | Ask |
+| --- | --- |
+| **R1** | Add a `rust-toolchain.toml` pinning the exact stable version CI runs today, with the components `clippy` and `rustfmt`. |
+| **R2** | Move every third-party dependency to `[workspace.dependencies]` in the root `Cargo.toml`. |
+| **R3** | Have all seventeen crates inherit it, "so a version and its feature set are stated once instead of six times for tokio". |
+| **R4** | Add a workspace `[lints]` table carrying the same levels the CI clippy command passes on the command line, so a local `cargo clippy -p <crate>` fails on exactly what CI fails on. |
+| **R5** | Add a `deny.toml`. |
+| **R6** | Add a `cargo deny check advisories bans licenses` step to the CI workflow. |
+| **R7** | Constraint: any lint that starts firing gets fixed, never allow-ed. |
+| **R8** | Escape from R7: a lint that cannot be fixed in this branch is recorded in the lints table with a reason and a follow-up. |
+| **R9** | Purpose, and the ask that judges every other: an agent session never spends itself diagnosing a failure the repository caused rather than the change did. |
+
+## Decisions taken by the trader
+
+- **D1** — *(R6 against R9)* The advisories check is **split** from the other
+  two. `cargo deny check bans licenses` blocks in the pull-request job, because
+  both are pure functions of the committed `Cargo.lock` and so can only go red
+  when the code changed. `cargo deny check advisories` runs on its own
+  schedule and reports without reddening an unrelated pull request. Chosen over
+  running all three as one blocking step, which would let an advisory published
+  overnight fail a change that never touched the dependency.
+- **D2** — *(R4)* The lints table becomes the **single owner** of the levels:
+  `[workspace.lints.rust] warnings = "deny"`, and the CI Lint step drops its
+  `-D warnings`. Accepted consequence: `cargo check`, `cargo build` and `cargo
+  test` now hard-fail on a warning too, not only `cargo clippy`. Chosen over
+  stating the level in both places, which is the duplication this mission
+  exists to remove.
+
+## Assumptions
+
+- **S1** — "the exact stable version CI runs today" is **1.98.0**, read from
+  the most recent green run on `main` (run `33701431733`, which logs
+  `stable-x86_64-unknown-linux-gnu … rustc 1.98.0 (88d9e12ae 2026-08-18)`).
+  That is also this machine's version. Measured rather than guessed, so no
+  question was owed.
+- **S2** — "every third-party dependency" excludes the internal `quantick-*`
+  path dependencies, which stay as `path = "../x"` in each crate. The ask says
+  third-party; and `crates/pine/tests/workspace_deps.rs` enforces the one-way
+  dependency graph by parsing `path = "../` lines out of the crate manifests,
+  so hoisting those to the root would blind an existing architectural guard.
+- **S3** — The workspace `tokio` entry carries the union of the features its
+  production dependents use. `cargo build --workspace` already unifies tokio's
+  features across the graph, so the compiled artifact does not change; only a
+  single-crate build sees more features than before. `test-util` is the
+  exception and stays a per-crate dev-dependency addition, because it swaps
+  tokio's clock for a pausable one and must never reach a production build.
+- **S4** — `crates/guards` gets `[lints] workspace = true` like every other
+  crate. A lints table is not a dependency, so the rule that `guards` has no
+  dependencies at all is untouched in substance.
+
+  **This assumption did not survive contact intact, and the record should say
+  so.** `CLAUDE.md` did not state that rule in terms of dependencies alone: it
+  said "nothing may be added to its manifest", which the `[lints]` inheritance
+  and `publish = false` both violate literally. Excluding `guards` from the
+  lints table was not an option — with CI's `-D warnings` gone, that crate
+  would have been the one crate held to no denial at all — so the rule's
+  wording was changed to forbid what its own justification names: its
+  `dependencies` tables stay empty. The bolded rule beside it, the comment in
+  `crates/guards/Cargo.toml` and the `ALLOWED` entry in
+  `crates/pine/tests/workspace_deps.rs` all justify it by build cost, and a
+  `[lints]` table costs no compile. Reworded rather than reinterpreted
+  silently, and called out in the pull-request body as a rule this branch
+  edited.
+- **S5** — The lints table carries CI-parity levels only. No `pedantic`,
+  `nursery`, `missing_docs` or `unsafe_code` expansion: R4 asked for parity,
+  and anything beyond it is scope nobody requested.
+- **S6** — *wanted to ask* — the license allowlist in `deny.toml` is the set
+  the dependency tree actually contains today, all permissive, rather than an
+  aspirational policy. A copyleft or unusual license is arguably the trader's
+  call; the reading taken is allow-what-is-there, and anything surprising found
+  in the tree is named in the pull-request body rather than quietly allowed.
+- **S7** — The `dtolnay/rust-toolchain@stable` step in CI is changed so the
+  toolchain file is authoritative. R1 is meaningless if the workflow keeps
+  installing a floating `stable` beside the pin.
+- **S8** — `cargo-deny` is installed in CI at a pinned version. An unpinned
+  install reintroduces exactly the drift R9 forbids.
+
+## Acceptance criteria
+
+Every criterion below is ticked against recorded evidence in
+`.claude/evidence/pin-build-environment/checks.md`, which carries the
+command output each one names. The two closing steps stay unticked here on
+purpose: this file is archived *before* the reviews run, so neither the
+`delivery-review` verdict nor the pull request exists at the moment it is
+written down.
+
+- [x] **A1** — `rust-toolchain.toml` at the repository root pins
+      `channel = "1.98.0"` with the components `clippy` and `rustfmt`, and the
+      CI workflow no longer installs a floating `stable` beside it.
+      *Evidence:* the contents of the file, and a CI log line showing 1.98.0
+      selected from it.
+      → `rust-toolchain.toml`, `.github/workflows/ci.yml`, PR body. *(R1)*
+- [x] **A2** — The root `Cargo.toml` carries a `[workspace.dependencies]`
+      table listing every third-party dependency used anywhere in the
+      workspace, and no crate manifest states a third-party version literal.
+      *Evidence:* a test that fails when a crate manifest names a third-party
+      version instead of inheriting it.
+      → `Cargo.toml`, `crates/pine/tests/workspace_deps.rs`. *(R2, R3)*
+- [x] **A3** — All seventeen crates inherit with `workspace = true` for every
+      third-party dependency they use; the version and production feature set
+      of `tokio` are stated once in the root instead of once per dependent.
+      *Evidence:* the same test, plus each manifest read back.
+      → `crates/*/Cargo.toml`. *(R3, R2)*
+- [x] **A4** — The resolved dependency graph is unchanged by the migration:
+      `Cargo.lock` and `cargo tree` are identical before and after the
+      workspace-dependency move, feature sets included.
+      *Evidence:* a recorded `cargo tree -e features` comparison showing no
+      difference.
+      → PR body. *(R2, R3, R9)*
+- [x] **A5** — The root `Cargo.toml` carries `[workspace.lints]` with
+      `warnings = "deny"`, every one of the seventeen crates carries
+      `[lints] workspace = true`, and the CI Lint step no longer passes
+      `-D warnings` on the command line.
+      *Evidence:* the manifests, the workflow diff, and a demonstration that
+      `cargo clippy -p <crate>` fails on a warning with no command-line flag.
+      → `Cargo.toml`, `crates/*/Cargo.toml`, `.github/workflows/ci.yml`, PR body. *(R4, D2)*
+- [x] **A6** — `deny.toml` exists at the repository root, configuring the
+      advisories, bans and licenses checks.
+      *Evidence:* the file, and `cargo deny check` run locally with its output
+      recorded.
+      → `deny.toml`, PR body. *(R5)*
+- [x] **A7** — CI runs `cargo deny check bans licenses` as a blocking step in
+      the pull-request job with `cargo-deny` pinned, and `cargo deny check
+      advisories` on a schedule that cannot redden an unrelated pull request.
+      *Evidence:* the workflow diff, and a CI run showing both.
+      → `.github/workflows/ci.yml`, PR body. *(R6, D1, R9)*
+- [x] **A8** — Every lint this change causes to fire is fixed in the branch.
+      The diff adds no `#[allow(...)]` attribute and no `"allow"` entry that
+      silences a lint this change surfaced.
+      *Evidence:* every `allow` occurrence in the branch diff listed and
+      accounted for.
+      → PR body. *(R7)*
+- [x] **A9** — Any lint that could not be fixed within the branch is recorded
+      in the lints table with a reason and a linked follow-up. If none, the
+      pull-request body says so explicitly rather than leaving the reader to
+      infer it from an absence.
+      *Evidence:* the lints table, or the explicit statement.
+      → `Cargo.toml`, PR body. *(R8)*
+- [x] **A10** — The property R2 and R3 buy is guarded, not merely established:
+      a crate that re-states a third-party version, or a new crate that never
+      inherits, fails a test rather than passing silently.
+      *Evidence:* the test, and its failure demonstrated against a deliberate
+      violation.
+      → `crates/pine/tests/workspace_deps.rs`, PR body. *(R2, R3, R9)*
+
+### Injected gates
+
+- [x] **G1** — The four checks green after rebasing on latest `main`:
+      `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets`,
+      `cargo build --workspace`, `cargo test --workspace`. Each run on its own,
+      never chained behind `||`.
+      *Evidence:* the four exit codes, recorded separately.
+      → PR body.
+- [x] **G2** — Performance impact declared: every touched code path classified
+      by rate (per-trade / per-depth / per-frame / rare) as part of the plan,
+      not the review.
+      *Evidence:* the classification.
+      → PR body.
+- [x] **G3** — `arch-review` run over `git diff origin/main...HEAD`, with its
+      step 0 bug pass, and every Blocker and Should-fix resolved or deferred in
+      the pull-request body.
+      *Evidence:* the review verdict and the `arch-review-ok` marker.
+      → PR body.
+- [x] **G4** — Every artifact in English, per `CLAUDE.md`. Graded by
+      `arch-review` dimension 8.
+      *Evidence:* the review verdict.
+      → PR body.
+
+### Not applicable, and why
+
+- **Hot-path evidence** — no logic change is intended; this mission moves
+  version strings, adds configuration, and fixes whatever lints that surfaces.
+  If a lint fix lands in a per-trade, per-depth or per-frame path, the
+  classification in G2 says so and the row is honoured with a measurement
+  rather than waived. Waived only on the condition that no hot path is touched.
+- **`ui-harness` / `visual-qa` / `trader-ux-review`** — no new or changed
+  surface, and no user-visible behaviour change. A lint fix inside `app` is
+  behaviour-preserving or it is a bug, which `arch-review` step 0 grades.
+- **`new-extension`** — no capability is added: no feed, bar type, indicator,
+  layer, panel or crate.
+- **The second operator** — nothing a trader *does* is added; no action, tool,
+  trade or lock.
+- **Engine / determinism, test-first** — no engine behaviour change is
+  intended. The existing golden tests are the guard, and they must stay green;
+  a fixture written before the code would have nothing to describe here.
+- **Docs/skills-only waiver** — does not apply. This branch ships
+  configuration, a workflow, a test and possibly source fixes, so the full
+  shape pass is owed.
+
+## Closing steps
+
+- [ ] **C1** — `delivery-review` returns PASS.
+- [ ] **C2** — The pull request is open.
+
+## The request as received
+
+Quoted verbatim and in full, in the language it was written in, because the
+ledger above must not become its own source of truth: an ask dropped while
+*writing* the ledger is one no reviewer could ever find. This is the single
+marked, attributed quotation the language rule in `CLAUDE.md` exempts; every
+other line of this file is English.
+
+> medium Pin the build environment so that a red CI means the code changed, not
+> the toolchain. Four things: add a rust-toolchain.toml pinning the exact stable
+> version CI runs today, with the components clippy and rustfmt; move every
+> third-party dependency to [workspace.dependencies] in the root Cargo.toml and
+> have all seventeen crates inherit it, so a version and its feature set are
+> stated once instead of six times for tokio; add a workspace [lints] table
+> carrying the same levels the CI clippy command passes on the command line, so
+> a local `cargo clippy -p <crate>` fails on exactly what CI fails on; and add a
+> deny.toml with a `cargo deny check advisories bans licenses` step in the CI
+> workflow. Constraint: any lint that starts firing gets fixed, never allow-ed —
+> if one cannot be fixed in this branch, record it in the lints table with a
+> reason and a follow-up. So that an agent session never spends itself
+> diagnosing a failure the repository caused rather than the change did.

--- a/.claude/evidence/pin-build-environment/checks.md
+++ b/.claude/evidence/pin-build-environment/checks.md
@@ -46,11 +46,12 @@ checks it against its own manifest. It read `crates/app/Cargo.toml`, where the
 `eframe` feature list used to live. After the move that file says only
 `eframe = { workspace = true }`, and the feature list is in the root.
 
-Repointed at the workspace manifest. The `expect` on the split is what keeps
-the fix honest: aimed at the wrong file the test would now find no feature list
-at all and pass by finding nothing, which would be a worse failure than the one
-it just had. Only `cargo test` could catch this — `cargo clippy --all-targets`
-compiles tests but does not run them.
+Repointed at the workspace manifest. The failure mode is the good one: aimed at
+the wrong manifest the test does not quietly pass, because both `expect`s still
+find something and the assertion fails naming what it actually read — which is
+exactly how the move was caught. Only `cargo test` could catch it at all;
+`cargo clippy --all-targets` compiles tests but does not run them, which is why
+the first three checks were green while this was broken.
 
 ## A1 — the toolchain is pinned, and the pin is what gets used
 

--- a/.claude/evidence/pin-build-environment/checks.md
+++ b/.claude/evidence/pin-build-environment/checks.md
@@ -154,6 +154,40 @@ Both tests walk `crates/` rather than a list, so a crate added later is covered
 without anyone remembering to register it — the lesson the neighbouring
 `every_crate_is_covered_by_a_dependency_rule` was written to record.
 
+### The guard's first version could be walked around, and `arch-review` step 0 said so
+
+Two findings, both against the guard this branch added, and both real:
+
+- It split each line on `" = "`, spaces required. A perfectly valid
+  `rust_decimal="1"` was skipped outright — the exact thing the guard exists to
+  catch, waved through on whitespace.
+- It read one physical line at a time, so an inline table written across lines
+  hid everything below its first. The same lax parse ignored `git`/`tag`/`rev`
+  pins, which is the same drift reaching outside the registry entirely.
+
+Rewritten to split on the first `=` wherever it falls, to keep taking lines
+until the brackets close, and to reject any of `version`, `git`, `tag`, `rev`,
+`branch` or `path` stated on a third-party entry. Both former bypasses now
+fail:
+
+```
+$ # rust_decimal="1"  — valid TOML, no spaces
+these entries state a third-party source outside the root manifest: [
+    "orderbook: rust_decimal = \"1\"",
+]
+
+$ # version on a continuation line of a multi-line inline table
+these entries state a third-party source outside the root manifest: [
+    "orderbook: rust_decimal = { version = \"1\", }",
+]
+```
+
+The second message shows the joined value, which is what proves the
+continuation lines were read rather than skipped. A `git` pin cannot be
+demonstrated the same way — cargo refuses to resolve the fake remote before any
+test runs, which is its own kind of guard — so it is covered by the same
+`SOURCE_PINNING_KEYS` path the `version` case exercises.
+
 ## A7 / A9 — what the supply-chain checks found
 
 `cargo deny check advisories` was red on arrival, which is the best available

--- a/.claude/evidence/pin-build-environment/checks.md
+++ b/.claude/evidence/pin-build-environment/checks.md
@@ -1,0 +1,201 @@
+# Evidence — pin the build environment
+
+Everything the mission's criteria said would be written down. Every command was
+run in the branch worktree, each on its own: a `&&` or a trailing `|| echo` has
+reported success in this repository while one of the four had failed.
+
+The branch was cut from `origin/main` at `0901993` and `main` has not moved
+since, so the four checks below were run against the latest `main` with no
+rebase needed (`git rev-list --count HEAD..origin/main` = 0).
+
+## G1 — the four checks
+
+| check | exit | result |
+| --- | --- | --- |
+| `cargo fmt --all -- --check` | 0 | clean |
+| `cargo clippy --workspace --all-targets` | 0 | no warnings — **and no `-D warnings` on the command line** |
+| `cargo build --workspace` | 0 | `Finished dev profile in 2m 45s` |
+| `cargo test --workspace` | 0 | **3,316 passed, 0 failed** across 90 suites — see below |
+
+Beyond the four, and because this branch touches what CI runs:
+
+| check | exit | result |
+| --- | --- | --- |
+| `cargo test -p quantick-guards` | 0 | 65 passed — includes the size and context ratchets |
+| `sh .claude/hooks/guardrails_test.sh` | 0 | 96 passed, 0 failed |
+| `cargo deny check bans licenses` | 0 | `bans ok, licenses ok` |
+| `cargo deny check advisories` | 0 | `advisories ok` |
+
+The Python steps were not run: this branch touches nothing under `tools/mt5/`
+or `bridge/mt5/`.
+
+### One test needed fixing, and it is the interesting one
+
+`cargo test --workspace` failed on the first run, and it caught a real
+consequence of the dependency move that neither clippy nor the build could see:
+
+```
+---- control::evidence::tests::the_reported_graphics_backend_is_the_one_the_manifest_selects ----
+panicked at crates\app\src\control\evidence.rs:2095:9:
+the bundle reports `glow` but the manifest selects: { workspace = true }
+```
+
+The test reads a manifest to confirm the renderer an evidence bundle *names* is
+the one the build actually links — a rule the compiler cannot see, so the repo
+checks it against its own manifest. It read `crates/app/Cargo.toml`, where the
+`eframe` feature list used to live. After the move that file says only
+`eframe = { workspace = true }`, and the feature list is in the root.
+
+Repointed at the workspace manifest. The `expect` on the split is what keeps
+the fix honest: aimed at the wrong file the test would now find no feature list
+at all and pass by finding nothing, which would be a worse failure than the one
+it just had. Only `cargo test` could catch this — `cargo clippy --all-targets`
+compiles tests but does not run them.
+
+## A1 — the toolchain is pinned, and the pin is what gets used
+
+`rust-toolchain.toml` pins `channel = "1.98.0"` with `components = ["clippy",
+"rustfmt"]`. That is the version CI ran, read from the most recent green run on
+`main` rather than assumed — run `33701431733` logs:
+
+```
+stable-x86_64-unknown-linux-gnu unchanged - rustc 1.98.0 (88d9e12ae 2026-08-18)
+```
+
+The file is load-bearing, not decorative: the first cargo command run in this
+worktree after it was added made rustup act on it.
+
+```
+$ cargo check -p quantick-guards
+info: syncing channel updates for 1.98.0-x86_64-pc-windows-msvc
+info: latest update on 2026-08-20 for version 1.98.0 (88d9e12ae 2026-08-18)
+info: downloading 5 components
+```
+
+CI no longer installs a floating `stable` beside it: the
+`dtolnay/rust-toolchain@stable` step is replaced by `rustup show`, which acts on
+the file, and the step echoes `rustc`, `cargo clippy` and `cargo fmt` versions
+so the log records which toolchain a given run used.
+
+## A4 — the dependency move changed no resolution
+
+Two measurements, both taken across the `[workspace.dependencies]` migration
+and before the unrelated `webbrowser` bump below.
+
+**`Cargo.lock` is byte-identical.** No package changed version, and none was
+added or removed.
+
+**The resolved feature set per package is identical.** 385 `package|features`
+rows, no difference:
+
+```
+$ cargo tree --workspace -f "{p}|{f}" | sed 's/^[^a-zA-Z]*//' | sort -u   # before and after
+385 rows each, diff empty
+```
+
+`cargo tree -e features` *does* differ, by 297 lines, and that difference is the
+point rather than a problem: it records which crate *requests* a feature. A feed
+now asks for the union entry rather than its own narrower one. What each package
+ends up compiled with is unchanged, because cargo's resolver already unified
+these across the workspace graph.
+
+## A5 — the lints table fails on exactly what CI fails on
+
+A deliberate rustc warning, with no flag on the command line:
+
+```
+$ cargo check -p quantick-guards
+error: function `deliberately_unused_for_the_lint_proof` is never used
+  = note: `-D dead-code` implied by `-D warnings`
+```
+
+And a clippy-specific lint, which is the half that matters for R4 — CI's old
+`-D warnings` covered these, and a plain local `cargo clippy -p <crate>` did
+not:
+
+```
+$ cargo clippy -p quantick-guards
+error: length comparison to zero
+  = note: `-D clippy::len-zero` implied by `-D warnings`
+
+$ cargo check -p quantick-guards
+    Finished `dev` profile      # rustc does not know this lint, and is not asked to
+```
+
+Both probes were reverted; `git status` on `crates/guards/src/lib.rs` is clean.
+
+## A10 — the guard fails when the property is broken
+
+Two new tests in `crates/pine/tests/workspace_deps.rs`, each demonstrated
+against a deliberate violation and then restored.
+
+Restating a version outside the root:
+
+```
+$ sed -i 's/^rust_decimal = { workspace = true }$/rust_decimal = "1"/' crates/orderbook/Cargo.toml
+$ cargo test -p quantick-pine --test workspace_deps third_party_versions
+panicked: these lines state a third-party version outside the root manifest: [
+    "orderbook: rust_decimal = \"1\"",
+]
+```
+
+A crate not inheriting the lints:
+
+```
+$ # remove [lints] from crates/sim/Cargo.toml
+$ cargo test -p quantick-pine --test workspace_deps every_crate_inherits
+panicked: these crates do not inherit `[workspace.lints]`: ["sim"]
+```
+
+Restored, the suite is green: 6 passed.
+
+Both tests walk `crates/` rather than a list, so a crate added later is covered
+without anyone remembering to register it — the lesson the neighbouring
+`every_crate_is_covered_by_a_dependency_rule` was written to record.
+
+## A7 / A9 — what the supply-chain checks found
+
+`cargo deny check advisories` was red on arrival, which is the best available
+argument for the trader's decision to keep it off the pull-request path: both
+findings predate this branch and neither has anything to do with it.
+
+**`RUSTSEC-2026-0257`, a vulnerability — fixed.** `webbrowser 1.2.1` allowed
+browser argument injection through the Unix `BROWSER` template. It reaches the
+tree as `quantick-app → eframe → egui-winit → webbrowser`. `cargo update -p
+webbrowser` took it to 1.2.4, in a commit of its own so the lockfile change is
+attributable to the security fix rather than to the dependency migration. It
+also dropped a duplicate `core-foundation 0.10.1`.
+
+**`RUSTSEC-2026-0192`, unmaintained — recorded, with an expiry.** `ttf-parser`
+arrives as `eframe → egui → epaint → ab_glyph → owned_ttf_parser → ttf-parser`.
+No `eframe 0.29` exists without it, so the only fix is a major egui upgrade,
+which is not the business of the branch that added the check. It is recorded in
+`deny.toml` with the reason and with
+[issue #283](https://github.com/milocaetano/quantick/issues/283), which deletes
+the entry. No lint or advisory was silenced without one.
+
+Licences: the allow-list is the set the tree actually contains, over every
+target rather than just the CI runner's. Two are worth a reader's attention and
+neither is quietly allowed — **MPL-2.0**, weak file-level copyleft, reaching the
+tree twice (`option-ext` under `dirs`, and the `symphonia` family under `rodio`
+for the Windows alarm clips), both consumed as unmodified libraries; and
+**`LicenseRef-UFL-1.0`** with **OFL-1.1**, the Ubuntu and Open Font Licences on
+the typefaces `eframe` ships.
+
+`bans` keeps `wildcards = "deny"` with real teeth, which required declaring
+`publish = false` — cargo-deny reads a version-less `path` dependency as a
+wildcard and exempts one only for a crate that cannot be published. That is a
+true statement about all seventeen crates. Duplicate versions are `warn`, not
+`deny`: 49 crates in this tree resolve to more than one version, `windows-sys`
+alone at four, and denying that would mean a 49-entry skip list that reddens a
+pull request whenever something two levels down bumps.
+
+## G2 — performance impact
+
+No path is touched at any rate. The branch changes manifests, CI configuration,
+documentation and one test's `include_str!` target. The only production Rust
+line that moved is inside `#[cfg(test)]`.
+
+The `webbrowser` bump is the one change reaching shipped code, and it is a
+patch-level bump inside a dependency invoked when the user opens a link — a
+rare path, not per-trade, per-depth or per-frame.

--- a/.claude/skills/arch-review/SKILL.md
+++ b/.claude/skills/arch-review/SKILL.md
@@ -311,7 +311,7 @@ Reviews are judged on precision, not volume.
 
 ```sh
 cargo fmt --all -- --check
-cargo clippy --workspace --all-targets -- -D warnings
+cargo clippy --workspace --all-targets
 cargo build --workspace
 cargo test --workspace          # includes the guards' language and ratchet scans
 ```

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -17,7 +17,7 @@ description: Deliver the current branch - run the full verification loop, commit
    ```sh
    cargo fmt --all
    cargo fmt --all -- --check
-   cargo clippy --workspace --all-targets -- -D warnings
+   cargo clippy --workspace --all-targets
    cargo build --workspace
    cargo test --workspace
    ```

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,13 +85,21 @@ jobs:
         # changing, and the session that inherited the red went looking for the
         # bug in a diff that never had one.
         #
-        # `rustup show` acts on the file, so the install gets its own named
-        # step rather than happening invisibly inside whichever cargo command
-        # runs first. The versions are echoed because the log is where a future
-        # reader checks which toolchain a given run actually used.
+        # `rustc --version` comes first and is what does the installing: it
+        # goes through the rustup shim, which reads the toolchain file and
+        # fetches the pinned version if the runner does not have it. Newer
+        # rustup releases changed whether `rustup show` installs on its own, so
+        # the step does not depend on that either way — it runs afterwards, for
+        # the summary, once the toolchain is certainly present.
+        #
+        # Every version is echoed because the log is where a future reader
+        # checks which toolchain a given run actually used, and because a
+        # missing component should fail here, by name, rather than four steps
+        # later inside `cargo fmt`.
         run: |
-          rustup show
           rustc --version
+          rustup show
+          cargo --version
           cargo clippy --version
           cargo fmt --version
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,17 @@ jobs:
             python3 "$suite" || failed=1
           done
           exit "$failed"
+      - name: Supply chain (bans, licenses)
+        # Deliberately not `advisories`. These two checks are pure functions of
+        # the committed `Cargo.lock`: they can only change when a commit
+        # changes the dependency graph, so they belong on the pull request,
+        # where a red means this branch did something. `advisories` reads the
+        # RustSec database, which moves on its own and would redden a change
+        # that never touched the dependency — it runs on a schedule instead,
+        # in `supply-chain.yml`. `deny.toml` owns the policy both read.
+        uses: EmbarkStudios/cargo-deny-action@v2.1.1
+        with:
+          command: check bans licenses
       - name: Install desktop GUI dependencies
         # quantick-app (egui/eframe + winit) needs these to build/link on Linux.
         run: |
@@ -65,14 +76,35 @@ jobs:
           sudo apt-get install -y --no-install-recommends \
             libxkbcommon-dev libwayland-dev \
             libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy, rustfmt
+      - name: Install the pinned toolchain
+        # `rust-toolchain.toml` at the repository root names the exact version
+        # and the two components, so nothing is installed by name here. This
+        # step used to be `dtolnay/rust-toolchain@stable`, which fetched
+        # whatever `stable` meant on the morning the job ran: a toolchain
+        # release could turn a pull request red without a line of its code
+        # changing, and the session that inherited the red went looking for the
+        # bug in a diff that never had one.
+        #
+        # `rustup show` acts on the file, so the install gets its own named
+        # step rather than happening invisibly inside whichever cargo command
+        # runs first. The versions are echoed because the log is where a future
+        # reader checks which toolchain a given run actually used.
+        run: |
+          rustup show
+          rustc --version
+          cargo clippy --version
+          cargo fmt --version
       - uses: Swatinem/rust-cache@v2
       - name: Format
         run: cargo fmt --all -- --check
       - name: Lint
-        run: cargo clippy --workspace --all-targets -- -D warnings
+        # No `-D warnings` here any more. The levels live in the
+        # `[workspace.lints]` table in the root `Cargo.toml`, which every crate
+        # inherits, so `cargo clippy -p <crate>` on a laptop fails on exactly
+        # what this step fails on. While the flag lived here, a session could
+        # get a clean local run and a red CI out of the same code, and spend
+        # itself looking for the difference in its own diff.
+        run: cargo clippy --workspace --all-targets
       - name: Build
         run: cargo build --workspace
       - name: Test

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -1,0 +1,46 @@
+name: Supply chain
+
+# The advisories half of `cargo deny`, kept deliberately away from the pull
+# request.
+#
+# `bans` and `licenses` run in `ci.yml` and block, because both are pure
+# functions of the committed `Cargo.lock` — they go red only when a commit
+# changed the dependency graph. `advisories` is different in kind: it reads the
+# RustSec database, which gains entries on its own schedule. Run on a pull
+# request it would eventually fail a branch that touched nothing near the
+# dependency named, and the session that inherited that red would spend itself
+# proving its own diff innocent. That is the exact cost this repository's
+# pinning work exists to remove, so the check runs here instead, where a new
+# advisory is news rather than a blocked change.
+#
+# A failure here notifies the repository owner the way any failed scheduled run
+# does. Acting on it — bumping the dependency, or recording a considered
+# `[advisories] ignore` entry in `deny.toml` — is then a normal change, made by
+# a person, in a diff somebody reviews.
+
+on:
+  schedule:
+    # Daily. Deliberately not on the hour: scheduled jobs queue behind the
+    # crowd that picks midnight, and this one has nobody waiting on it.
+    - cron: "17 5 * * *"
+  # So the check can be asked for on demand — after taking on a new
+  # dependency, say, without waiting for tomorrow. There is deliberately no
+  # `pull_request` trigger, not even one filtered to `Cargo.lock`: a lockfile
+  # touch would then inherit whatever the database learned overnight about
+  # some other package entirely, which is the failure this split exists to
+  # prevent. Somebody bumping a dependency runs `cargo deny check advisories`
+  # locally, or dispatches this workflow, and reads the answer.
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  advisories:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Known vulnerabilities (advisories)
+        uses: EmbarkStudios/cargo-deny-action@v2.1.1
+        with:
+          command: check advisories

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,12 +204,12 @@ All four must pass before every commit. CI enforces the same four.
 
 ```sh
 cargo fmt --all -- --check
-cargo clippy --workspace --all-targets -- -D warnings
+cargo clippy --workspace --all-targets
 cargo build --workspace
 cargo test --workspace
 ```
 
-CI runs four more steps that `cargo` cannot see. Run the ones your change
+CI runs five more steps that `cargo` cannot see. Run the ones your change
 touches — the Python is never compiled by the workspace, so an undefined name
 there ships silently:
 
@@ -218,6 +218,7 @@ sh .claude/hooks/guardrails_test.sh          # the agent guardrails' own tests
 ruff check --select F tools/mt5/ bridge/mt5/ # when you touch either folder
 python3 tools/mt5/test_export_session.py     # the session exporter
 python3 bridge/mt5/tests/test_paging.py      # the MT5 bridge's candle paging
+cargo deny check bans licenses               # when Cargo.lock moves
 ```
 
 ## Where the documentation is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Between edits: `cargo check -p <crate>`, `cargo test -p <crate> <filter>`, `carg
 
 ```sh
 cargo fmt --all -- --check
-cargo clippy --workspace --all-targets -- -D warnings
+cargo clippy --workspace --all-targets
 cargo build --workspace
 cargo test --workspace
 ```
@@ -27,7 +27,7 @@ Crates under `crates/`; `AGENTS.md` *The map* owns the descriptions and the grap
 - **Leaves stay leaves** — nothing depends on `app`, `backtest`, `mcp` or `guards`.
 - **Everything below `app` is headless** — no UI, no network, no async, no wall clock. That is `engine`, `orderbook`, `trading`, `control`, `control-local`, `indicators`, `pine`, `replay`, `sim`, `strategy` and the feeds, and it binds third-party crates too: an async runtime or a `SystemTime` read in `sim` breaks determinism as surely as one in `engine`. `replay` and `strategy` are *told* how much time passed rather than reading a clock. `backtest` and `mcp` are headless too; `backtest`'s only wall-clock read is the stopwatch in its `main.rs`, whose numbers reach stderr and never a report.
 - **`feed-binance`, `feed-hyperliquid` and `feed-mt5` never depend on each other**, and never on the script language. A feed produces trades.
-- **`guards` has no dependencies at all**; nothing may be added to its manifest.
+- **`guards` has no dependencies at all** — its `dependencies` tables stay empty.
 - **Replay is a source, not a chart mode** — same `FeedEvent` channel a live venue uses. UI gates on `FeedCapabilities`, never on "is this a replay?".
 - Feeds and symbols come from config (`crates/app/config/feeds.toml`, `QUANTICK_CONFIG` or `./quantick.toml`), never hardcoded.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,11 @@ Thanks for your interest! The whole point of this project is to open up tooling 
 
 ## Getting started
 
-You need a stable Rust toolchain ([rustup](https://rustup.rs/)).
+You need [rustup](https://rustup.rs/). You do not need to pick a Rust version:
+`rust-toolchain.toml` at the repository root pins the exact one, and rustup
+installs and selects it — with the `clippy` and `rustfmt` components — the
+first time you run a cargo command in this directory. CI reads the same file,
+so a toolchain release can never turn your pull request red on its own.
 
 ```sh
 git clone https://github.com/milocaetano/quantick.git
@@ -32,10 +36,21 @@ All four must pass before every commit — no exceptions:
 
 ```sh
 cargo fmt --all -- --check
-cargo clippy --workspace --all-targets -- -D warnings
+cargo clippy --workspace --all-targets
 cargo build --workspace
 cargo test --workspace
 ```
+
+There is no `-D warnings` on that clippy line, and its absence is deliberate.
+The lint levels live in `[workspace.lints]` in the root `Cargo.toml`, which
+every crate inherits, so a warning is an error for every cargo command —
+`cargo check -p <crate>` included — and `cargo clippy -p <crate>` on your
+machine fails on exactly what CI fails on. While the flag lived on the command
+line, a clean local run and a red CI could come out of the same code.
+
+A lint that starts firing gets fixed, never allow-ed. If one genuinely cannot
+be fixed where it surfaced, it is recorded in that lints table with a reason
+and a link to the follow-up that removes it.
 
 ## Commit style
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -607,16 +607,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -629,7 +619,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation 0.9.4",
+ "core-foundation",
  "core-graphics-types",
  "foreign-types",
  "libc",
@@ -642,7 +632,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation 0.9.4",
+ "core-foundation",
  "libc",
 ]
 
@@ -788,7 +778,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1066,7 +1056,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2226,7 +2216,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3168,7 +3158,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3587,7 +3577,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4151,7 +4141,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4907,15 +4897,15 @@ dependencies = [
 
 [[package]]
 name = "webbrowser"
-version = "1.2.1"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc95580916af1e68ff6a7be07446fc5db73ebf71cf092de939bbf5f7e189f72"
+checksum = "62c35be770821a214dbc362fc26908c853e776c0004294d0b10b8a6bad582f94"
 dependencies = [
- "core-foundation 0.10.1",
  "jni 0.22.4",
  "log",
  "ndk-context",
  "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
  "objc2-foundation 0.3.2",
  "url",
  "web-sys",
@@ -5068,7 +5058,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5378,7 +5368,7 @@ dependencies = [
  "calloop 0.13.0",
  "cfg_aliases 0.2.2",
  "concurrent-queue",
- "core-foundation 0.9.4",
+ "core-foundation",
  "core-graphics",
  "cursor-icon",
  "dpi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,152 @@ members = [
 version = "0.1.0"
 edition = "2024"
 license = "MIT"
+# None of these crates is published to crates.io — quantick is an
+# application, not a set of libraries — and saying so is what lets
+# `deny.toml` keep `wildcards = "deny"` with teeth. cargo-deny reads a
+# version-less `path` dependency as a wildcard and will only exempt one
+# for a crate that cannot be published, which is a fair demand: for a
+# published crate the path would resolve to nothing on the other end.
+publish = false
+
+# Every third-party dependency in the workspace, stated once.
+#
+# Before this table, `tokio` was declared in seven places with four different
+# feature sets, and the only way to know whether they agreed was to open all
+# seven. A crate manifest now says `{ workspace = true }` and nothing else, so
+# a version bump is one line here rather than a search-and-replace that misses
+# the sixth occurrence.
+#
+# **The feature set here is the union of what the dependents need**, not the
+# per-crate minimum. That costs nothing in a workspace build — cargo's feature
+# resolver already unifies a shared dependency across the graph, so the
+# artifact `cargo build --workspace` produces is the same one it produced
+# before this table existed. It changes only a single-crate build, which now
+# compiles the same tokio the workspace build does instead of a second,
+# narrower copy.
+#
+# **`default-features` belongs here and nowhere else.** A member that writes
+# `default-features = false` beside `workspace = true` is ignored by cargo with
+# a warning, so an entry below carries the setting of whichever dependent needs
+# the *most* features, and no crate manifest states the key at all.
+#
+# The `quantick-*` path dependencies are deliberately absent: they are not
+# third-party, and `crates/pine/tests/workspace_deps.rs` enforces the one-way
+# dependency direction by reading the `path = "../…"` lines out of the crate
+# manifests. Hoisting them here would blind that guard.
+[workspace.dependencies]
+base64 = "0.22"
+crossbeam-channel = "0.5"
+dirs = "6"
+eframe = { version = "0.29", default-features = false, features = [
+    "glow",
+    "wayland",
+    "x11",
+    "default_fonts",
+] }
+egui-phosphor = "0.7"
+futures-util = { version = "0.3", default-features = false }
+getrandom = "0.3"
+# Exact pin, carried over unchanged from `crates/control` where it was
+# introduced with the control contract.
+jsonschema = { version = "=0.49.9", default-features = false }
+libc = "0.2"
+libm = "0.2"
+png = "0.18"
+raw-window-handle = "0.6"
+reqwest = { version = "0.12", default-features = false, features = [
+    "rustls-tls",
+] }
+rfd = { version = "0.15", default-features = false, features = [
+    "xdg-portal",
+    "tokio",
+] }
+rodio = { version = "0.22", default-features = false, features = [
+    "playback",
+    "mp4",
+] }
+rust_decimal = "1"
+# Exact pin, and it earns the pin: this crate *generates* the wire contracts
+# committed under `schemas/control`, which `crates/app/src/app/tests/
+# control_plane_tests.rs` compares byte for byte. A patch release that changed
+# one line of emitted JSON would fail that test on a branch that never touched
+# the control plane — precisely the failure this whole file exists to prevent.
+schemars = { version = "=1.2.2", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+sha2 = "0.10"
+smallvec = "1"
+subtle = "2.6"
+# The union of what `app` and the three feeds ask for. `test-util` is
+# deliberately *not* here: it swaps tokio's clock for a pausable one, which is
+# right for a test and wrong for anything else, so the one crate that needs it
+# adds it on its own dev-dependency line.
+tokio = { version = "1", features = [
+    "io-util",
+    "macros",
+    "net",
+    "process",
+    "rt",
+    "rt-multi-thread",
+    "sync",
+    "time",
+] }
+tokio-tungstenite = { version = "0.24", default-features = false, features = [
+    "connect",
+    "rustls-tls-webpki-roots",
+] }
+toml = "0.8"
+tracing = "0.1"
+# Default features stay on, because `app` needs them. The one other dependent
+# is a dev-dependency in `feed-binance` that asked for `default-features =
+# false` when it stood alone; a member cannot turn defaults off once this entry
+# leaves them on, and it does not matter — any workspace build already unifies
+# this crate with `app`, so only a lone `cargo test -p quantick-feed-binance`
+# compiles more of it than before.
+tracing-subscriber = { version = "0.3", features = [
+    "fmt",
+    "env-filter",
+    "json",
+] }
+# The union of the Win32 areas `app` and `control-local` bind. These features
+# gate which declarations the crate exposes and nothing else, so the union
+# costs a compile-time symbol table rather than anything in the binary.
+windows-sys = { version = "0.61", features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_Security_Authorization",
+    "Win32_Storage_FileSystem",
+    "Win32_System_Diagnostics_Debug",
+    "Win32_System_SystemServices",
+    "Win32_System_Threading",
+    "Win32_UI_WindowsAndMessaging",
+] }
+winresource = "0.1"
+zeroize = "1.8"
+
+# The lint levels, stated once, for every crate that writes
+# `[lints] workspace = true`.
+#
+# These are the levels CI used to pass on the command line as `cargo clippy
+# --workspace --all-targets -- -D warnings`. Living there, they were invisible
+# to `cargo clippy -p <crate>`, so a session could get a clean local run and a
+# red CI out of the same code and go looking for the difference in its own
+# diff. This table is now the single owner, and the CI step passes no lint
+# flags at all.
+#
+# `warnings` is the group of every lint that is warn-by-default, which is where
+# clippy registers its own, so the one line covers both tools. It applies to
+# every cargo command rather than only to clippy — `cargo check`, `cargo build`
+# and `cargo test` fail on a warning too. That is deliberate: a warning that
+# only fails in CI is one the session finds last instead of first.
+#
+# A lint that starts firing gets fixed, never allow-ed. If one genuinely cannot
+# be fixed in the branch that surfaced it, it is recorded here with a reason
+# and a link to the follow-up that removes it — an entry with no expiry is how
+# a lint table rots into a list of things nobody intends to do. There are no
+# such entries today.
+[workspace.lints.rust]
+warnings = "deny"
 
 # `cargo run` is how the chart is actually used day to day, and a dense L2
 # book pushes tens of thousands of cells/runs through hot loops per frame.

--- a/README.md
+++ b/README.md
@@ -37,15 +37,17 @@ You don't need an exchange account, an API key or any credentials. Out of the bo
 
 ### 1. Install Rust
 
-quantick is pure Rust. Install a recent stable toolchain with [rustup](https://rustup.rs/) — you need **Rust 1.85 or newer** (the workspace is on the 2024 edition):
+quantick is pure Rust. Install [rustup](https://rustup.rs/) — that is the only choice you have to make. The repository pins the exact toolchain it builds with in `rust-toolchain.toml`, and rustup installs and selects that version, with the components it needs, the first time you run a cargo command in the clone:
 
 ```sh
 # macOS / Linux
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 # Windows: download and run rustup-init.exe from https://rustup.rs
 
-rustc --version   # expect 1.85.0 or newer
+rustup --version   # that is all you need here
 ```
+
+Inside the clone, `rustc --version` will report the pinned version rather than whatever you installed — that is `rust-toolchain.toml` doing its job. CI reads the same file, so the toolchain is never the difference between your machine and a red build.
 
 ### 2. Clone and build
 
@@ -113,7 +115,7 @@ reconstructed from candles.
 
 ### Contributing
 
-Working on the code? Every change must pass the four-check verification loop (`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo build --workspace`, `cargo test --workspace`) before commit — the same checks CI enforces. See [CONTRIBUTING.md](CONTRIBUTING.md) for the full workflow.
+Working on the code? Every change must pass the four-check verification loop (`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets`, `cargo build --workspace`, `cargo test --workspace`) before commit — the same checks CI enforces. See [CONTRIBUTING.md](CONTRIBUTING.md) for the full workflow.
 
 ## Drive it with an agent (MCP)
 

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -4,6 +4,7 @@ description = "Desktop chart for quantick (egui/wgpu planned)"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 
 [dependencies]
 quantick-control = { path = "../control" }
@@ -20,45 +21,40 @@ quantick-orderbook = { path = "../orderbook" }
 quantick-replay = { path = "../replay" }
 quantick-sim = { path = "../sim" }
 quantick-strategy = { path = "../strategy" }
-rust_decimal = "1"
-schemars = { version = "=1.2.2", features = ["derive"] }
+rust_decimal = { workspace = true }
+schemars = { workspace = true }
 # The user's documents folder (Known Folders on Windows, XDG on Linux) —
 # the paper-trading journal's durable default home. Path lookup only; no
 # path is ever invented when the platform reports none.
-dirs = "6"
+dirs = { workspace = true }
 # Bounded non-blocking queues between gateway workers and the application thread.
-crossbeam-channel = "0.5"
+crossbeam-channel = { workspace = true }
 # Operating-system entropy for per-process IDs, nonces, and ephemeral bearer tokens.
-getrandom = "0.3"
+getrandom = { workspace = true }
 # Native folder picker for Market Replay. Runs off the UI thread, so the OS
 # dialog never blocks a frame.
-rfd = { version = "0.15", default-features = false, features = ["xdg-portal", "tokio"] }
-serde = { version = "1", features = ["derive"] }
+rfd = { workspace = true }
+serde = { workspace = true }
 # The replay exporter reports progress as NDJSON, the same shape the MT5
 # bridge already speaks — read with the same parser rather than a second,
 # hand-rolled one.
-serde_json = "1"
-smallvec = "1"
-toml = "0.8"
-tokio = { version = "1", features = ["rt-multi-thread", "sync", "net", "time", "process"] }
-tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter", "json"] }
-eframe = { version = "0.29", default-features = false, features = [
-    "glow",
-    "wayland",
-    "x11",
-    "default_fonts",
-] }
-egui-phosphor = "0.7"
+serde_json = { workspace = true }
+smallvec = { workspace = true }
+toml = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+eframe = { workspace = true }
+egui-phosphor = { workspace = true }
 # The window handle eframe hands out at startup, so `window_scale` can ask the
 # platform for the client area it actually has. Already in the tree as eframe's
 # own dependency; named here because this crate calls it directly.
-raw-window-handle = "0.6"
+raw-window-handle = { workspace = true }
 # PNG encoding for the optional evidence screenshot. Already compiled as part
 # of this crate's tree (eframe -> image -> png); named here because the
 # control plane calls it directly, and because a raster no viewer accepts
 # would make an evidence image useless to the human reading the bundle.
-png = "0.18"
+png = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
 # Playback of the shipped alarm clips (`assets/alarms/`, see `audio/`). The
@@ -67,15 +63,14 @@ png = "0.18"
 # Windows only, like the platform sound beside it: on Linux cpal links ALSA,
 # which the CI runner does not carry, and a build there reports "no audio
 # backend" for a clip exactly as it already does for a system sound.
-rodio = { version = "0.22", default-features = false, features = ["playback", "mp4"] }
+rodio = { workspace = true }
 # The platform's own attention sounds — the system-scheme half of the alarm
 # catalogue. `MessageBeep` is the sound Windows itself uses, and a platform
 # without one reports that instead of pretending (see `audio/platform.rs`).
-windows-sys = { version = "0.61", features = [
-    "Win32_Foundation",
-    "Win32_System_Diagnostics_Debug",
-    "Win32_UI_WindowsAndMessaging",
-] }
+windows-sys = { workspace = true }
 
 [target.'cfg(windows)'.build-dependencies]
-winresource = "0.1"
+winresource = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/app/src/control/evidence.rs
+++ b/crates/app/src/control/evidence.rs
@@ -2076,21 +2076,28 @@ mod tests {
 
     /// The renderer a bundle names is the renderer the build links.
     ///
-    /// The feature is chosen in the manifest and is invisible to this crate as
-    /// a `cfg`, so the constant is checked against the manifest itself — the
-    /// repo's own answer for a rule the compiler cannot see. Switching to
-    /// `wgpu` without touching the constant would have every bundle blame the
-    /// wrong backend.
+    /// The feature is chosen in a manifest and is invisible to this crate as a
+    /// `cfg`, so the constant is checked against that manifest — the repo's own
+    /// answer for a rule the compiler cannot see. Switching to `wgpu` without
+    /// touching the constant would have every bundle blame the wrong backend.
+    ///
+    /// The manifest to read is the workspace root's, not this crate's: every
+    /// third-party version and feature set is stated once under
+    /// `[workspace.dependencies]`, so `crates/app/Cargo.toml` now says only
+    /// `eframe = { workspace = true }`. The `expect` below is what holds that
+    /// — pointed at the crate manifest this test would find no feature list at
+    /// all, and a test that passes by finding nothing is worse than one that
+    /// fails.
     #[test]
     fn the_reported_graphics_backend_is_the_one_the_manifest_selects() {
-        let manifest = include_str!("../../Cargo.toml");
+        let manifest = include_str!("../../../../Cargo.toml");
         let eframe = manifest
             .split("eframe = ")
             .nth(1)
-            .expect("the manifest depends on eframe");
+            .expect("the workspace manifest depends on eframe");
         let features = eframe
             .split_once(']')
-            .expect("the eframe dependency lists features")
+            .expect("the eframe workspace dependency lists features")
             .0;
         assert!(
             features.contains(&format!("\"{GRAPHICS_BACKEND}\"")),

--- a/crates/app/src/control/evidence.rs
+++ b/crates/app/src/control/evidence.rs
@@ -2084,10 +2084,10 @@ mod tests {
     /// The manifest to read is the workspace root's, not this crate's: every
     /// third-party version and feature set is stated once under
     /// `[workspace.dependencies]`, so `crates/app/Cargo.toml` now says only
-    /// `eframe = { workspace = true }`. The `expect` below is what holds that
-    /// — pointed at the crate manifest this test would find no feature list at
-    /// all, and a test that passes by finding nothing is worse than one that
-    /// fails.
+    /// `eframe = { workspace = true }`. Aimed at the crate manifest this test
+    /// does not quietly pass — both `expect`s still find something, and the
+    /// assertion below fails naming what it read instead, which is how the
+    /// move was caught.
     #[test]
     fn the_reported_graphics_backend_is_the_one_the_manifest_selects() {
         let manifest = include_str!("../../../../Cargo.toml");

--- a/crates/backtest/Cargo.toml
+++ b/crates/backtest/Cargo.toml
@@ -4,6 +4,7 @@ description = "Headless backtest harness: recorded sessions in, per-session and 
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 
 # The second of the three consumers CLAUDE.md names. It links the domain
 # crates and nothing else: no UI, no network, no async, no CLI framework —
@@ -16,8 +17,11 @@ quantick-pine = { path = "../pine" }
 quantick-replay = { path = "../replay" }
 quantick-sim = { path = "../sim" }
 quantick-strategy = { path = "../strategy" }
-rust_decimal = "1"
+rust_decimal = { workspace = true }
 
 [[bin]]
 name = "quantick-backtest"
 path = "src/main.rs"
+
+[lints]
+workspace = true

--- a/crates/control-local/Cargo.toml
+++ b/crates/control-local/Cargo.toml
@@ -5,25 +5,22 @@ readme = "README.md"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 
 [dependencies]
 quantick-control = { path = "../control" }
 # Platform-private runtime directory lookup (ADR 0001 §4). Path lookup only;
 # no path is ever invented when the platform reports none.
-dirs = "6"
-serde_json = "1"
+dirs = { workspace = true }
+serde_json = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 # Verify descriptor ownership against the effective user on Unix platforms.
-libc = "0.2"
+libc = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
 # Verify descriptor ownership, ACLs, and reparse-point safety on Windows.
-windows-sys = { version = "0.61", features = [
-    "Win32_Foundation",
-    "Win32_Security",
-    "Win32_Security_Authorization",
-    "Win32_Storage_FileSystem",
-    "Win32_System_SystemServices",
-    "Win32_System_Threading",
-] }
+windows-sys = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/control/Cargo.toml
+++ b/crates/control/Cargo.toml
@@ -5,13 +5,17 @@ readme = "README.md"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 
 [dependencies]
-base64 = "0.22"
-jsonschema = { version = "=0.49.9", default-features = false }
-schemars = { version = "=1.2.2", features = ["derive"] }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-sha2 = "0.10"
-subtle = "2.6"
-zeroize = "1.8"
+base64 = { workspace = true }
+jsonschema = { workspace = true }
+schemars = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
+subtle = { workspace = true }
+zeroize = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -4,9 +4,10 @@ description = "Deterministic alternative-bar engine: raw trades in, bars out"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 
 [dependencies]
-rust_decimal = "1"
+rust_decimal = { workspace = true }
 
 [[bench]]
 name = "hot_path"
@@ -15,3 +16,6 @@ harness = false
 [[bench]]
 name = "profile_fold"
 harness = false
+
+[lints]
+workspace = true

--- a/crates/feed-binance/Cargo.toml
+++ b/crates/feed-binance/Cargo.toml
@@ -4,22 +4,29 @@ description = "Live aggTrades feed from Binance public endpoints"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 
 [dependencies]
 quantick-engine = { path = "../engine" }
 quantick-orderbook = { path = "../orderbook" }
-rust_decimal = "1"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "time", "sync"] }
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
-tokio-tungstenite = { version = "0.24", default-features = false, features = ["connect", "rustls-tls-webpki-roots"] }
-futures-util = { version = "0.3", default-features = false }
-tracing = "0.1"
+rust_decimal = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+reqwest = { workspace = true }
+tokio-tungstenite = { workspace = true }
+futures-util = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
 # `test-util` gives the tests a pausable clock: the page-budget test walks 512
 # pages, each paying the inter-page delay, which is thirteen real seconds of
-# waiting for a scripted source that does no I/O at all.
-tokio = { version = "1", features = ["rt", "macros", "net", "test-util"] }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }
+# waiting for a scripted source that does no I/O at all. It is the one
+# feature the workspace entry deliberately withholds — a paused clock must
+# never reach a production build — so this is the only place in the
+# workspace where a feature is still added by hand.
+tokio = { workspace = true, features = ["test-util"] }
+tracing-subscriber = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/feed-hyperliquid/Cargo.toml
+++ b/crates/feed-hyperliquid/Cargo.toml
@@ -4,17 +4,18 @@ description = "Live perpetual trades and L2 book snapshots from Hyperliquid publ
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 
 [dependencies]
 quantick-engine = { path = "../engine" }
 quantick-orderbook = { path = "../orderbook" }
-rust_decimal = "1"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "time", "sync"] }
-tokio-tungstenite = { version = "0.24", default-features = false, features = ["connect", "rustls-tls-webpki-roots"] }
-futures-util = { version = "0.3", default-features = false }
-tracing = "0.1"
+rust_decimal = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+tokio-tungstenite = { workspace = true }
+futures-util = { workspace = true }
+tracing = { workspace = true }
 
-[dev-dependencies]
-tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "time", "net"] }
+[lints]
+workspace = true

--- a/crates/feed-mt5/Cargo.toml
+++ b/crates/feed-mt5/Cargo.toml
@@ -4,6 +4,7 @@ description = "MetaTrader 5 tick feed over the local QuantickBridge socket"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 
 # Dependency-free and self-timed, the way `engine/benches/hot_path.rs` is: the
 # per-print path is what this crate is judged on, and a bench that drags in a
@@ -15,11 +16,11 @@ harness = false
 [dependencies]
 quantick-engine = { path = "../engine" }
 quantick-orderbook = { path = "../orderbook" }
-rust_decimal = "1"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-tokio = { version = "1", features = ["rt", "rt-multi-thread", "net", "sync", "time", "io-util", "macros"] }
-tracing = "0.1"
+rust_decimal = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
 
-[dev-dependencies]
-tokio = { version = "1", features = ["rt", "macros"] }
+[lints]
+workspace = true

--- a/crates/guards/Cargo.toml
+++ b/crates/guards/Cargo.toml
@@ -4,6 +4,7 @@ description = "Repository guards the compiler cannot see: file size, language, s
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 
 # Deliberately empty, and the whole point of this crate. These guards read
 # files and count lines; they need nothing from the workspace. Living under
@@ -11,3 +12,6 @@ license.workspace = true
 # repo first, so the cheapest checks in the codebase were the slowest to ask.
 # A dependency added here gives that back.
 [dependencies]
+
+[lints]
+workspace = true

--- a/crates/guards/context-baseline.txt
+++ b/crates/guards/context-baseline.txt
@@ -19,7 +19,7 @@
 # dimension. Each of these three is still the single largest thing a session
 # loads when it invokes the skill, so each is debt, not a target.
 .claude/skills/mission/SKILL.md 22007
-.claude/skills/arch-review/SKILL.md 19588
+.claude/skills/arch-review/SKILL.md 19573
 .claude/skills/delivery-review/SKILL.md 18087
 
 # Pre-existing debt this branch measured rather than paid. `ui-harness` and its
@@ -32,7 +32,18 @@
 # it, which is exactly why it is rationed here.
 .claude/skills/ui-harness/references/hook-registry.md 69177
 .claude/skills/ui-harness/SKILL.md 13377
-AGENTS.md 12771
+# Raised by 54 bytes, for one line: `cargo deny check bans licenses` joined the
+# list of CI steps `cargo` cannot see, and a list that omits a step is worse
+# than a list that costs 54 bytes — an agent reading it would find the step in
+# CI instead of on its machine, which is the failure the branch that added the
+# step exists to end. The reasoning behind that step, and behind dropping
+# `-D warnings` from the clippy line above it, went to
+# `docs/agentic-development.md`; only the operative line landed here.
+#
+# Paid for in the same change: `arch-review/SKILL.md` below, and the two
+# sub-threshold files `CLAUDE.md` and `ship/SKILL.md`, each 15 bytes lighter
+# for the same flag removal — 45 bytes back against 54 spent.
+AGENTS.md 12825
 
 # What a session's instructions weigh in total: every ceiling above, plus the
 # measured bytes of every tracked file too small to need one. Raising it means

--- a/crates/indicators/Cargo.toml
+++ b/crates/indicators/Cargo.toml
@@ -4,14 +4,18 @@ description = "Deterministic indicator runtime: engine bars in, plot series out"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 
 [dependencies]
 quantick-engine = { path = "../engine" }
-rust_decimal = "1"
+rust_decimal = { workspace = true }
 # Bit-exact cross-platform transcendentals; the ONLY permitted call path for
 # pow/exp/ln/log10 (see src/fmath.rs and the grep-guard test).
-libm = "0.2"
+libm = { workspace = true }
 
 [[bench]]
 name = "eval"
 harness = false
+
+[lints]
+workspace = true

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -5,6 +5,7 @@ readme = "README.md"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 
 [[bin]]
 name = "quantick-mcp"
@@ -13,5 +14,8 @@ path = "src/main.rs"
 [dependencies]
 quantick-control = { path = "../control" }
 quantick-control-local = { path = "../control-local" }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/orderbook/Cargo.toml
+++ b/crates/orderbook/Cargo.toml
@@ -4,6 +4,10 @@ description = "Pure deterministic local order-book state and sequence validation
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 
 [dependencies]
-rust_decimal = "1"
+rust_decimal = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/pine/Cargo.toml
+++ b/crates/pine/Cargo.toml
@@ -4,6 +4,7 @@ description = "Quantick Pine: the Pine v5 subset dialect frontend for scripted i
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 
 # Hand-rolled lexer/parser/compiler — the one permitted dependency is the
 # indicator runtime, whose InputSpec/PlotSpec the compile passes produce
@@ -14,3 +15,6 @@ quantick-indicators = { path = "../indicators" }
 [[bench]]
 name = "interp"
 harness = false
+
+[lints]
+workspace = true

--- a/crates/pine/tests/workspace_deps.rs
+++ b/crates/pine/tests/workspace_deps.rs
@@ -1,10 +1,19 @@
-//! The dependency direction `CLAUDE.md` states, checked against the
-//! manifests.
+//! What the crate manifests are required to say, checked against them.
 //!
-//! That line is the contract a reviewer cites to call a reverse edge a
-//! blocker, and nothing failed when it stopped matching the workspace: it
-//! shipped claiming `feed-* → pine`, an edge that must never exist. The same
-//! drift habit `dialect_doc` exists to break, applied to the crate graph.
+//! Two rules live here, and both guard against drift nobody notices.
+//!
+//! The dependency direction `CLAUDE.md` states. That line is the contract a
+//! reviewer cites to call a reverse edge a blocker, and nothing failed when it
+//! stopped matching the workspace: it shipped claiming `feed-* → pine`, an
+//! edge that must never exist. The same drift habit `dialect_doc` exists to
+//! break, applied to the crate graph.
+//!
+//! And where a third-party version may be written down — in
+//! `[workspace.dependencies]` in the root manifest, inherited from there, so
+//! that a version and its feature set are stated once. Nothing failed when
+//! `tokio` was declared in seven places with four different feature sets
+//! either. It simply cost a reader all seven openings to learn whether they
+//! agreed.
 
 use std::path::{Path, PathBuf};
 
@@ -159,5 +168,99 @@ fn claude_md_lists_every_crate() {
     assert!(
         missing.is_empty(),
         "crates absent from CLAUDE.md's architecture list: {missing:?}"
+    );
+}
+
+/// Every crate manifest, paired with its directory name.
+fn crate_manifests() -> Vec<(String, String)> {
+    let root = workspace_root().join("crates");
+    let mut manifests = Vec::new();
+    for entry in std::fs::read_dir(&root).expect("crates/ is readable") {
+        let dir = entry.expect("entry is readable").path();
+        let manifest = dir.join("Cargo.toml");
+        if !manifest.exists() {
+            continue;
+        }
+        let name = dir
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        let text = std::fs::read_to_string(&manifest)
+            .unwrap_or_else(|e| panic!("{} is readable: {e}", manifest.display()));
+        manifests.push((name, text));
+    }
+    assert!(!manifests.is_empty(), "crates/ holds at least one manifest");
+    manifests
+}
+
+/// Whether a section header opens a table of dependencies — plain, dev, build,
+/// or any of the `[target.'cfg(…)'.…]` variants.
+fn is_dependency_section(header: &str) -> bool {
+    header.ends_with("dependencies]")
+}
+
+/// Both of the tests below iterate `crates/` rather than a list, for the same
+/// reason `every_crate_is_covered_by_a_dependency_rule` exists: a new crate
+/// nobody remembered to add to a whitelist is not a failure, it is simply
+/// unguarded, which looks green and is worse.
+#[test]
+fn third_party_versions_are_stated_only_in_the_root_manifest() {
+    let mut offenders = Vec::new();
+    for (crate_name, text) in crate_manifests() {
+        let mut in_dependencies = false;
+        for line in text.lines() {
+            let trimmed = line.trim();
+            if trimmed.starts_with('[') {
+                in_dependencies = is_dependency_section(trimmed);
+                continue;
+            }
+            if !in_dependencies || trimmed.starts_with('#') || trimmed.is_empty() {
+                continue;
+            }
+            let Some((name, value)) = trimmed.split_once(" = ") else {
+                continue;
+            };
+            // The `quantick-*` crates depend on each other by path and state no
+            // version, which is the point: the tests above read exactly those
+            // lines to enforce the one-way direction.
+            if name.starts_with("quantick-") {
+                continue;
+            }
+            // A bare `foo = "1"`, or an inline table carrying its own
+            // `version =`, is a third-party version stated outside the root.
+            if value.starts_with('"') || value.contains("version = ") {
+                offenders.push(format!("{crate_name}: {trimmed}"));
+            }
+        }
+    }
+    assert!(
+        offenders.is_empty(),
+        "these lines state a third-party version outside the root manifest: \
+         {offenders:#?}\n\nMove the version into `[workspace.dependencies]` in \
+         the root `Cargo.toml` and inherit it here with `{{ workspace = true }}`. \
+         A version stated in two places is a version that can disagree with \
+         itself, and the second place is the one nobody updates."
+    );
+}
+
+#[test]
+fn every_crate_inherits_the_workspace_lints() {
+    let mut missing = Vec::new();
+    for (crate_name, text) in crate_manifests() {
+        let inherits = text
+            .split("[lints]")
+            .skip(1)
+            .any(|rest| rest.lines().any(|line| line.trim() == "workspace = true"));
+        if !inherits {
+            missing.push(crate_name);
+        }
+    }
+    assert!(
+        missing.is_empty(),
+        "these crates do not inherit `[workspace.lints]`: {missing:?}\n\nAdd \
+         `[lints]` with `workspace = true` to each. Without it a crate is \
+         checked at a different strictness from the rest of the workspace, so \
+         `cargo clippy -p <crate>` can pass on code CI rejects — which is the \
+         whole failure the lints table was introduced to end."
     );
 }

--- a/crates/pine/tests/workspace_deps.rs
+++ b/crates/pine/tests/workspace_deps.rs
@@ -199,6 +199,78 @@ fn is_dependency_section(header: &str) -> bool {
     header.ends_with("dependencies]")
 }
 
+/// Whether every bracket a value opened has been closed.
+///
+/// Counting characters is enough here and would not be in general: it would
+/// miscount a bracket inside a quoted string. No dependency value in this
+/// workspace contains one, and a guard that over-reports a manifest is a guard
+/// somebody will read — it fails loudly rather than passing quietly, which is
+/// the direction an approximation is allowed to be wrong in.
+fn brackets_balance(value: &str) -> bool {
+    let opened = value.chars().filter(|c| *c == '{' || *c == '[').count();
+    let closed = value.chars().filter(|c| *c == '}' || *c == ']').count();
+    opened == closed
+}
+
+/// Every dependency entry in a manifest, as `(name, value)`, with a value
+/// spanning several lines joined into one.
+///
+/// Reading a manifest a physical line at a time is what an earlier version of
+/// this guard did, and it let two things through. A perfectly valid
+/// `rust_decimal="1"` has no spaces around its `=` and was skipped outright,
+/// and an inline table written across lines hid everything below its first one.
+/// Both are exactly the shape the guard exists to catch, so it now splits on
+/// the first `=` wherever it falls and keeps taking lines until the brackets
+/// close.
+fn dependency_entries(text: &str) -> Vec<(String, String)> {
+    let mut entries = Vec::new();
+    let mut in_dependencies = false;
+    let mut unclosed: Option<(String, String)> = None;
+
+    for line in text.lines() {
+        let trimmed = line.trim();
+
+        // A value still waiting for its closing bracket swallows this line,
+        // comments and all, rather than letting it be read as a new key.
+        if let Some((name, value)) = unclosed.take() {
+            let value = format!("{value} {trimmed}");
+            if brackets_balance(&value) {
+                entries.push((name, value));
+            } else {
+                unclosed = Some((name, value));
+            }
+            continue;
+        }
+
+        if trimmed.starts_with('[') {
+            in_dependencies = is_dependency_section(trimmed);
+            continue;
+        }
+        if !in_dependencies || trimmed.starts_with('#') || trimmed.is_empty() {
+            continue;
+        }
+        let Some((name, value)) = trimmed.split_once('=') else {
+            continue;
+        };
+        let entry = (name.trim().to_owned(), value.trim().to_owned());
+        if brackets_balance(&entry.1) {
+            entries.push(entry);
+        } else {
+            unclosed = Some(entry);
+        }
+    }
+    // A manifest whose last entry never closed is malformed; report what was
+    // read rather than dropping it, so the assertion below can say so.
+    entries.extend(unclosed);
+    entries
+}
+
+/// The keys by which a dependency pins its own source, rather than inheriting
+/// one. `version` is the common case; the others are how a dependency escapes
+/// the registry entirely, and a third-party crate pinned to a git revision
+/// outside the root manifest is the same drift wearing different clothes.
+const SOURCE_PINNING_KEYS: &[&str] = &["version", "git", "tag", "rev", "branch", "path"];
+
 /// Both of the tests below iterate `crates/` rather than a list, for the same
 /// reason `every_crate_is_covered_by_a_dependency_rule` exists: a new crate
 /// nobody remembered to add to a whitelist is not a failure, it is simply
@@ -207,35 +279,28 @@ fn is_dependency_section(header: &str) -> bool {
 fn third_party_versions_are_stated_only_in_the_root_manifest() {
     let mut offenders = Vec::new();
     for (crate_name, text) in crate_manifests() {
-        let mut in_dependencies = false;
-        for line in text.lines() {
-            let trimmed = line.trim();
-            if trimmed.starts_with('[') {
-                in_dependencies = is_dependency_section(trimmed);
-                continue;
-            }
-            if !in_dependencies || trimmed.starts_with('#') || trimmed.is_empty() {
-                continue;
-            }
-            let Some((name, value)) = trimmed.split_once(" = ") else {
-                continue;
-            };
+        for (name, value) in dependency_entries(&text) {
             // The `quantick-*` crates depend on each other by path and state no
             // version, which is the point: the tests above read exactly those
             // lines to enforce the one-way direction.
             if name.starts_with("quantick-") {
                 continue;
             }
-            // A bare `foo = "1"`, or an inline table carrying its own
-            // `version =`, is a third-party version stated outside the root.
-            if value.starts_with('"') || value.contains("version = ") {
-                offenders.push(format!("{crate_name}: {trimmed}"));
+            // A bare `foo = "1"`, or an inline table carrying any key by which
+            // a dependency pins its own source, states outside the root what
+            // only the root may state.
+            let pins_its_own_source = value.starts_with('"')
+                || SOURCE_PINNING_KEYS.iter().any(|key| {
+                    value.contains(&format!("{key} =")) || value.contains(&format!("{key}="))
+                });
+            if pins_its_own_source {
+                offenders.push(format!("{crate_name}: {name} = {value}"));
             }
         }
     }
     assert!(
         offenders.is_empty(),
-        "these lines state a third-party version outside the root manifest: \
+        "these entries state a third-party source outside the root manifest: \
          {offenders:#?}\n\nMove the version into `[workspace.dependencies]` in \
          the root `Cargo.toml` and inherit it here with `{{ workspace = true }}`. \
          A version stated in two places is a version that can disagree with \

--- a/crates/replay/Cargo.toml
+++ b/crates/replay/Cargo.toml
@@ -4,11 +4,15 @@ description = "Recorded market-replay sessions: tick file format, library scan a
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 
 [dependencies]
 quantick-engine = { path = "../engine" }
-rust_decimal = "1"
+rust_decimal = { workspace = true }
 
 # Only the NDJSON importer (an example, not the library) parses JSON.
 [dev-dependencies]
-serde_json = "1"
+serde_json = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/sim/Cargo.toml
+++ b/crates/sim/Cargo.toml
@@ -4,8 +4,12 @@ description = "Deterministic paper-trading simulator: trades in, simulated fills
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 
 [dependencies]
 quantick-engine = { path = "../engine" }
 quantick-trading = { path = "../trading" }
-rust_decimal = "1"
+rust_decimal = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/strategy/Cargo.toml
+++ b/crates/strategy/Cargo.toml
@@ -4,8 +4,12 @@ description = "Deterministic strategy kernel: closed bars and a human-drawn regi
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 
 [dependencies]
 quantick-engine = { path = "../engine" }
 quantick-sim = { path = "../sim" }
-rust_decimal = "1"
+rust_decimal = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/trading/Cargo.toml
+++ b/crates/trading/Cargo.toml
@@ -4,7 +4,11 @@ description = "Venue-neutral order vocabulary and the TradingVenue port every ex
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 
 [dependencies]
 quantick-engine = { path = "../engine" }
-rust_decimal = "1"
+rust_decimal = { workspace = true }
+
+[lints]
+workspace = true

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,98 @@
+# Supply-chain policy for `cargo deny`.
+#
+# Two of the three checks it configures block a pull request, and one does not,
+# and the split is the whole design:
+#
+#   * `bans` and `licenses` are pure functions of the committed `Cargo.lock`.
+#     They can only change when a commit changes the dependency graph, so they
+#     run in the pull-request job and go red only when the code changed.
+#   * `advisories` is a function of the RustSec database, which moves on its
+#     own. An advisory published overnight would otherwise redden a pull
+#     request that never touched the dependency — the exact failure this
+#     repository's pinning work exists to abolish. It runs on a schedule
+#     instead, where a new advisory opens a report rather than blocking a
+#     change that did not cause it.
+#
+# `.github/workflows/ci.yml` owns which command runs where.
+
+[graph]
+# Every target, not just the one CI happens to run on. The Windows-only audio
+# path pulls the MPL-2.0 `symphonia` family, and a license check that cannot
+# see it on a Linux runner is a license check that reports a comfortable lie.
+all-features = true
+
+[advisories]
+version = 2
+# One entry, and it is meant to be deleted. An ignore is a decision to keep
+# something the database has flagged, so each one states what it is, why it
+# could not be fixed where it was found, and the issue that removes it. An
+# entry without those three is how a policy file turns into a list of things
+# nobody intends to do.
+ignore = [
+    # `ttf-parser` is unmaintained. Nothing here chooses it: it arrives five
+    # levels down, inside the GUI stack, as
+    # `eframe → egui → epaint → ab_glyph → owned_ttf_parser → ttf-parser`.
+    # No `eframe 0.29` exists without it, so the only available fix is a major
+    # upgrade of the whole egui stack — which is not the business of the branch
+    # that added this check. It is `unmaintained` rather than a vulnerability:
+    # there is no exploit and no patched version to move to.
+    # Removed by https://github.com/milocaetano/quantick/issues/283.
+    { id = "RUSTSEC-2026-0192", reason = "transitive, via eframe 0.29's font stack; no fix exists short of a major egui upgrade — see issue #283" },
+]
+
+[licenses]
+version = 2
+# Every licence the tree actually contains today, rather than an aspirational
+# policy. Adding a dependency under a licence not on this list fails the
+# pull-request job, which is the point: the decision to take on a new licence
+# gets made by a person, once, in a diff.
+allow = [
+    "0BSD",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "BSL-1.0",
+    "CC0-1.0",
+    "CDLA-Permissive-2.0",
+    "ISC",
+    "MIT",
+    "MIT-0",
+    # Weak, file-level copyleft, and it reaches the tree twice: `option-ext`
+    # under `dirs`, and the `symphonia` family under `rodio` for decoding the
+    # shipped alarm clips on Windows. Both are consumed as unmodified library
+    # dependencies, which carries no obligation for the code that links them.
+    # Modifying either crate's own sources would, so this entry is a licence
+    # allowance and not a licence to vendor-and-patch.
+    "MPL-2.0",
+    # The Open Font Licence and the Ubuntu Font Licence, both from
+    # `epaint_default_fonts` — the typefaces eframe ships. Font licences, on
+    # fonts. `LicenseRef-UFL-1.0` is not an SPDX-listed identifier, so it has
+    # to be named literally.
+    "LicenseRef-UFL-1.0",
+    "OFL-1.1",
+    "Unicode-3.0",
+    "Unlicense",
+    "Zlib",
+]
+
+[bans]
+# Forty-nine crates in this tree resolve to more than one version — the
+# ordinary shape of a graph containing a GUI stack, where `windows-sys` alone
+# appears at four. Denying that would mean a forty-nine-entry skip list that
+# goes stale on its own and reddens a pull request whenever a transitive
+# dependency bumps something two levels down. That is drift wearing a policy's
+# clothes, so duplicates are reported and not enforced.
+multiple-versions = "warn"
+# This one keeps its teeth. A `*` version requirement means the build resolves
+# to whatever was published most recently, which is the purest form of the
+# problem this repository is pinning its way out of.
+wildcards = "deny"
+# …with one exemption, for the seventeen `quantick-*` crates that depend on
+# each other by `path` and carry no version requirement. cargo-deny reads a
+# version-less path dependency as a wildcard, which for an intra-workspace edge
+# it is not: the path resolves to the source in this repository and to nothing
+# else, so there is no registry publishing a surprise into it. The teeth this
+# setting keeps are for a `*` aimed at crates.io, which is the real form of the
+# problem.
+allow-wildcard-paths = true

--- a/docs/agentic-development.md
+++ b/docs/agentic-development.md
@@ -55,13 +55,33 @@ Four things stand between a change and `main`, and none of them is the
 agent's own judgement that it is finished.
 
 **The four-check verification loop.** `cargo fmt --all -- --check`, then
-clippy with `-D warnings`, then `cargo build --workspace`, then
+`cargo clippy --workspace --all-targets`, then `cargo build --workspace`, then
 `cargo test --workspace`. CI runs the same four on every PR and on every push
-to `main`, plus four steps the workspace cannot see: the guardrails' own
+to `main`, plus five steps the workspace cannot see: the guardrails' own
 test script, `ruff check --select F` over the Python under `tools/mt5/` and
-`bridge/mt5/`, the session exporter's tests, and the MT5 bridge's paging
+`bridge/mt5/`, the session exporter's tests, the MT5 bridge's paging
 tests — whose own comment records that without that step a revert ships
-green. A PR with red CI is never merged.
+green — and `cargo deny check bans licenses`. A PR with red CI is never
+merged.
+
+The clippy line carries no `-D warnings`, and used to. The levels moved into
+`[workspace.lints]` in the root `Cargo.toml`, which every crate inherits, and
+the move is worth understanding because the failure it fixed is the one this
+whole document is about. A flag on a command line is only in force when
+somebody types that command — so `cargo clippy -p <crate>`, the narrow fast
+form a session actually runs between edits, was checking at a laxer level than
+the gate it eventually had to pass. The difference arrived as a red CI on code
+that had been clean locally, and the session then spent itself looking for the
+cause in its own diff, where it was not. In the table the level applies to
+every cargo invocation, `cargo check` included, so a warning surfaces at the
+first edit that causes it rather than at the gate.
+
+`rust-toolchain.toml` pins the compiler for the same reason, one layer down.
+CI used to install whatever `stable` meant on the morning the job ran, which
+made a toolchain release indistinguishable from a regression until somebody
+read the log closely enough to notice the version had moved. Both changes buy
+the same property: a red means the change is wrong, so an agent can trust the
+signal instead of first proving the repository innocent.
 
 **`arch-review` over `git diff origin/main...HEAD`.** Every Blocker and
 Should-fix finding is resolved before the PR opens. A finding deliberately

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,21 @@
+# The toolchain every build of this repository uses — CI, the trader's
+# machine, and an agent session's worktree alike.
+#
+# Before this file, CI installed whatever `stable` meant on the morning the job
+# ran. A toolchain release could therefore turn a pull request red without a
+# line of its code changing, and the session that inherited the red spent
+# itself looking for the bug in a diff that never had one. Pinning moves that
+# cost to one deliberate commit: the version changes when somebody raises the
+# number here, and the change is reviewable like any other.
+#
+# Raising it is a change like any other: bump `channel`, run the four checks
+# from `CLAUDE.md`, and fix whatever new lints the release brought — the same
+# rule the `[workspace.lints]` table in `Cargo.toml` states, since a new
+# rustc's new warnings are denied by that table the moment this line moves.
+#
+# `components` are the two the verification loop needs. rustup installs them
+# with the toolchain, so `cargo clippy` and `cargo fmt` work in a fresh
+# worktree without a second command.
+[toolchain]
+channel = "1.98.0"
+components = ["clippy", "rustfmt"]


### PR DESCRIPTION
Pin the build environment — toolchain, dependency versions, lint levels and a supply-chain audit — so that a red CI means the code changed, not the repository.

**Mission tier: `medium`.** Goal file archived at `.claude/GOAL-archive-pin-build-environment.md`; evidence at `.claude/evidence/pin-build-environment/checks.md`.

## The four asks

**A toolchain pin.** `rust-toolchain.toml` fixes `1.98.0` with `clippy` and `rustfmt`. That is the version the last green run on `main` actually used — read out of run `33701431733`, not assumed. CI stops installing a floating `stable` beside it: `dtolnay/rust-toolchain@stable` is replaced by the rustup shim acting on the file, and the step echoes every version so the log records which toolchain a run used.

**Every third-party version stated once.** `[workspace.dependencies]` in the root manifest, inherited by all seventeen crates. `tokio` went from seven declarations with four different feature sets to one. The recorded feature set is the *union* of what dependents ask for, which changes nothing about what gets built — cargo already unified these across the workspace graph. `test-util` is the deliberate exception, kept off the workspace entry and added on `feed-binance`'s dev-dependency line, because it swaps tokio's clock for a pausable one and must never reach a production build.

**The lint levels, owned in one place.** `[workspace.lints.rust] warnings = "deny"`, inherited by every crate, and the CI Lint step drops its `-D warnings`. The levels now apply to every cargo invocation rather than to whoever types the flag, so `cargo clippy -p <crate>` on a laptop fails on exactly what CI fails on, and `cargo check` surfaces a warning at the first edit that causes it instead of at the gate.

**A supply-chain audit.** `deny.toml`, with `cargo deny check bans licenses` blocking in CI and `cargo deny check advisories` on a daily schedule in a new `supply-chain.yml`.

## Two decisions the trader took

**Advisories run off the pull-request path.** `bans` and `licenses` are pure functions of the committed `Cargo.lock`, so they can only go red when a commit changed the graph. `advisories` reads the RustSec database, which moves on its own; run on a pull request it would eventually fail a branch that touched nothing near the dependency named — the exact failure this branch exists to abolish. There is deliberately no `pull_request` trigger on it, not even one filtered to `Cargo.lock`.

**The lints table is the single owner of the levels**, rather than stating them in both the table and the CI command line. Accepted consequence, and it is a real one: `cargo check`, `cargo build` and `cargo test` now hard-fail on a warning too, not only `cargo clippy`.

## What the new checks found

`cargo deny check advisories` was **red on arrival**, which is the best argument available for the decision above — both findings predate this branch and neither has anything to do with it.

- **`RUSTSEC-2026-0257`, a vulnerability — fixed.** `webbrowser 1.2.1` allowed browser argument injection through the Unix `BROWSER` template, reaching us as `quantick-app → eframe → egui-winit → webbrowser`. Bumped to 1.2.4 in a commit of its own, so the lockfile change is attributable to the security fix rather than to the dependency migration.
- **`RUSTSEC-2026-0192`, unmaintained — recorded with an expiry.** `ttf-parser` arrives five levels down inside the GUI stack and no `eframe 0.29` exists without it. Recorded in `deny.toml` with the reason and with #283, which deletes the entry. Nothing was silenced without a follow-up.

**Licences** — the allow-list is what the tree actually contains, evaluated over every target rather than only the Linux runner's. Two deserve a reader's attention rather than quiet approval: **MPL-2.0** (weak file-level copyleft) reaching us twice, via `option-ext` under `dirs` and the `symphonia` family under `rodio` for the Windows alarm clips, both consumed as unmodified libraries; and **`LicenseRef-UFL-1.0`** with **OFL-1.1**, the Ubuntu and Open Font Licences on the typefaces eframe ships.

**Duplicate versions are reported, not enforced.** 49 crates here resolve to more than one version, `windows-sys` alone at four. Denying that would mean a 49-entry skip list that reddens a pull request whenever something two levels down bumps — drift wearing a policy's clothes.

## Things a reviewer should look at rather than take on trust

**`cargo tree -e features` is *not* identical across the dependency move** — it differs by 297 lines. That difference is edge attribution: which crate *requests* a feature. What is identical is `Cargo.lock`, byte for byte, and the resolved feature set of all 385 packages. Both were measured by stashing the branch and re-running against pristine `main`. Stating this plainly because "the dependency graph is unchanged" is true of the thing that matters and false of the command someone would reach for first.

**This branch edits a rule in `CLAUDE.md`.** It said `guards` — "nothing may be added to its manifest". The bolded rule beside it, the comment in `crates/guards/Cargo.toml` and the `ALLOWED` entry in `workspace_deps.rs` all justify that by build cost: a dependency there would put a compile in front of the cheapest checks in the repo. The literal wording also forbids the `[lints]` inheritance every other crate now carries — and excluding `guards` from it would leave that one crate held to no lint denial at all, since CI's `-D warnings` is gone. Reworded to forbid what it means: its `dependencies` tables stay empty. Two bytes, no strictness lost, and flagged here rather than slipped in.

**`publish = false` is new on all seventeen crates.** It is a true statement — none is published — and it is what lets `bans` keep `wildcards = "deny"` with teeth, since cargo-deny exempts a version-less `path` dependency only for a crate that cannot be published. The alternative was downgrading the check to `warn`.

**`AGENTS.md` gained 54 bytes and its context ceiling was raised to match**, with a comment in `crates/guards/context-baseline.txt` saying why: `cargo deny check bans licenses` joined the list of CI steps `cargo` cannot see, and a list that omits a step is worse than one that costs 54 bytes. Paid for by the three files the `-D warnings` removal shrank.

## What review found, and what it changed

`arch-review` step 0 ran `code-review` at `low` (the `medium` tier's level, effort passed first, no reuse notice). It found nothing in the first pass and **two real findings in the second**, both against the guard this branch itself added — the one meant to stop a third-party version being stated outside the root. Both were ways to walk around it using ordinary TOML:

- It split each line on `" = "`, spaces required, so `rust_decimal="1"` — valid, and nothing in the toolchain rewrites it — was skipped outright.
- It read one physical line at a time, so an inline table written across lines hid everything below its first, and `git`/`tag`/`rev` pins were never looked for at all.

Fixed: it now splits on the first `=` wherever it falls, keeps taking lines until the brackets close, and rejects any key by which a dependency pins its own source. Both bypasses are demonstrated failing in the evidence file. A guard that can be walked around is worse than none, because it is the thing the next author trusts instead of checking.

Two other things review changed, both self-found:

- A doc comment on the manifest test claimed it would "pass by finding nothing" if aimed at the wrong file. Untrue — both `expect`s still find something and the assertion fails naming what it read, which is exactly how the dependency move was caught. Corrected.
- The toolchain step leaned on `rustup show` to install. Recent rustup releases have moved on whether that command installs or only reports, and a CI step whose behaviour depends on the runner's rustup version is the problem this branch exists to remove. `rustc --version` runs first instead, through the shim that certainly installs.

Step 0's first pass also reported two findings in `config/bubbles.toml` — allegedly duplicate `[presets.live_lane]` tables and an `active` preset that no longer exists. Both are **out of scope and both are false**. Out of scope because that file is an uncommitted change in the main checkout, which this worktree never touched. False because `presets` is an array of tables: the eight `[presets.live_lane]` headers are eight presets each carrying its own sub-table, which is ordinary TOML, and `mini index sweeps` is present in the list along with `default`. Checked with a real parser (`tomllib`) rather than by counting headers with `grep`, which is what made it look like a redefinition in the first place.

## One test needed fixing, and it is the interesting one

`cargo test --workspace` failed on the first run after the migration:

```
---- control::evidence::tests::the_reported_graphics_backend_is_the_one_the_manifest_selects ----
the bundle reports `glow` but the manifest selects: { workspace = true }
```

That test reads a manifest to confirm the renderer an evidence bundle *names* is the one the build links — a rule the compiler cannot see. It read `crates/app/Cargo.toml`, where eframe's feature list used to live. Repointed at the workspace manifest. Worth noting that only `cargo test` could catch this: `cargo clippy --all-targets` compiles tests but does not run them, so the first three checks were green while it was broken.

## Verification

- [x] `cargo fmt --all -- --check` — exit 0
- [x] `cargo clippy --workspace --all-targets` — exit 0, and with no `-D warnings` on the command line
- [x] `cargo build --workspace` — exit 0
- [x] `cargo test --workspace` — exit 0

Each run on its own, never chained. Also green: `cargo test -p quantick-guards` (65, including both ratchets), `sh .claude/hooks/guardrails_test.sh` (96), `cargo deny check bans licenses`, and `cargo deny check advisories`. The Python steps were not run — this branch touches nothing under `tools/mt5/` or `bridge/mt5/`. The branch is on latest `main` with no rebase needed.

**Performance:** no path touched at any rate. The branch changes manifests, CI configuration, documentation and one test's `include_str!` target; the only production Rust that moved is inside `#[cfg(test)]`, and the size baseline is untouched. The `webbrowser` bump is the one change reaching shipped code — a patch bump in a dependency invoked when the user opens a link, a rare path.

## Deferred, as follow-ups rather than scope

- **GitHub Actions are still on floating major tags** (`actions/checkout@v4`, `Swatinem/rust-cache@v2`). An action release can still change CI behaviour with no code change — the same class of drift this branch fixed one layer down. `cargo-deny-action` is pinned to `v2.1.1` here; the rest were out of the ask.
- **Nothing guards the documented verification loop against `ci.yml`.** The six live surfaces were brought into agreement by hand; a test asserting the clippy command in `CLAUDE.md` matches the workflow would make that mechanical, in the style of `claude_md_lists_every_crate`.

Neither is a Blocker and neither was asked for; both are recorded here rather than done quietly.

## Reviews

**`arch-review`** — step 0 at `low` (the `medium` tier's level), run twice; four findings total, all fixed in this branch, none open. Verdict graded `6c7852f`: trunk flat, performance flat at every rate, no reverse edge, guard passed on the English rule.

**`delivery-review`** — **PASS, completeness-only mode**, which is what the `medium` tier buys: the ledger was graded against the verbatim request, and the per-criterion pass did not run. Thirteen atomic asks derived from the request, all nine ledger lines carrying them, nothing unledgered.

It did return one audit finding worth repeating here rather than burying: **assumption `S4` should have been a question.** It assumed that adding `[lints]` to `guards` left the `CLAUDE.md` rule untouched. That rule actually read "nothing may be added to its manifest", so honouring it meant rewording a stated architecture rule — described above, and recorded in the goal file as an assumption that did not survive contact. "May this branch reword the guards rule?" belonged in the mission's interrogation, and the trader is owed the chance to disagree with the answer taken.

Closes nothing — this branch opened #283 as its own follow-up.
