### PR TITLE
refactor: break the paper module cycle, and guard against the next one

### DIFF
--- a/.claude/GOAL-archive-no-module-cycles.md
+++ b/.claude/GOAL-archive-no-module-cycles.md
@@ -1,0 +1,234 @@
+# Mission — break the paper module cycle, and guard against the next one
+
+Break the app crate's remaining module cycle (`paper_report` ↔ `paper_trading`)
+by moving the shared presentation vocabulary into a neutral module below both,
+then add a cycle guard to `crates/guards` as a third instance of the ratchet
+`Policy`, so the next refactor that welds two modules together fails the build
+instead of being found by hand months later.
+
+**Why it matters.** This is the second module cycle in the app crate in three
+days. The first was broken by hand (PR #285); this one was *introduced* by
+PR #282, a well-reviewed refactor, and nothing in the repository saw it.
+Reviews caught neither. A rule enforced only by review is a rule that drifts —
+`CLAUDE.md` already says so about worktrees, and `size`, `language` and
+`encoding` are the repo's answer. Cycles get the same answer.
+
+**Tier:** `medium`. Two crates change, one of them headless-adjacent; the diff
+is a module extraction plus a new guard with its own baseline, which is more
+than a `small` mission's exemption is meant to cover, and `delivery-review`'s
+completeness pass is worth running over a request with nine distinct asks. It
+is not `high`: behaviour is unchanged by construction, no UI surface moves, and
+the acceptance evidence is all mechanical (tests, guard exit codes).
+
+## Request ledger
+
+- **R1** — Break the app crate's remaining dependency cycle: `paper_report`
+  imports thirteen items from `paper_trading` while `paper_trading` re-exports
+  three back.
+- **R2** — Move the shared helpers down into a neutral module below both, the
+  way PR #285 moved the plot geometry into `plot_area`, so *"`paper_report`
+  stops importing `paper_trading` at all"*. The thirteen: `PositionSummary`,
+  `caption`, `fmt_decimal`, `fmt_duration_ms`, `fmt_offset_minute`,
+  `fmt_points`, `fmt_signed_points`, `list_symbol_folders`, `pill_toggle`,
+  `points_color`, `position_word`, `sanitize_symbol`, `today`.
+- **R3** — The `HistoryRow` / `LedgerAction` / `LedgerScope` re-export in
+  `paper_trading` *"may stay, since it is a deliberate facade with callers in
+  app.rs and dock.rs and it is one-directional once the other edge is gone"*.
+- **R4** — Behaviour unchanged.
+- **R5** — *"tests travel with the items they cover"*.
+- **R6** — Add a cycle guard to `crates/guards` as *"a third instance of the
+  ratchet Policy that size and context already share"*.
+- **R7** — It *"reads the `use crate::` edges of a crate's modules, reports any
+  strongly connected component larger than one"*.
+- **R8** — …*"and records the count in a baseline that starts at zero"*.
+  Amended by **D1**: the baseline records what exists, signed.
+- **R9** — *(purpose; judges the others)* *"So that a refactor that welds two
+  modules together fails the build instead of being found by someone measuring
+  months later."*
+
+## Decisions taken by the trader
+
+- **D1 — The baseline records what exists, signed, rather than starting at
+  zero.** Measured before any code was written: the repository has three
+  production `use crate::` cycles today, not one — `app`
+  [`paper_report`, `paper_trading`], `app` [`app`, `surfaces`, `control`]
+  (`app.rs` → `surfaces::MarketRequest` → `control::AgentPopup` →
+  `app::QuantickApp`), and `trading` [`events`, `position`]. A baseline
+  literally starting at zero would require breaking all three, which reaches
+  into the app/control/surfaces architecture and into a headless crate nobody
+  asked to touch. So the baseline is an entry per crate, signed with its
+  reason, exactly like `size-baseline.txt` and `context-baseline.txt`: this
+  branch drives `crates/app` from 2 to 1, `crates/trading` stays at a signed 1,
+  every other crate is 0, and a new cycle anywhere fails the build — which is
+  R9. `--tighten` writes the lower number when a signed cycle is later broken.
+
+## Assumptions
+
+- **S1 — Production edges only; `#[cfg(test)]` modules and `*/tests/*` files
+  are not measured.** The size guard already rations production lines only and
+  leaves `tests/` untracked, for a stated reason; a cycle guard that counted
+  test edges would fire on `paper_report`'s own test module reaching for
+  `PaperTrading` to build a fixture, which is not the defect being guarded.
+  Safe to assume rather than ask: the repo has already made this exact call
+  once, in writing.
+- **S2 — Nodes are a crate's top-level modules.** `control::contract` counts as
+  `control`. It is what R7's "a crate's modules" reads as against a crate root
+  that declares its modules in one list, it is the granularity the cycle in the
+  request is stated at, and a finer one would need parent/child edges invented
+  to be meaningful.
+- **S3 — Only `use crate::` statements are edges, not inline `crate::foo::bar`
+  paths.** R7 says so explicitly, and measuring inline paths as well was tried
+  in the prototype: it reports the `guards` crate itself as a three-way cycle
+  purely from `[`size`](crate::size)` doc-comment links, which is a false
+  positive that would make the guard untrustworthy on day one.
+- **S4 — The new module is `crates/app/src/paper_chrome.rs`.** Naming and file
+  placement have a conventional default here. "Chrome" is already the word
+  `PositionSummary`'s own doc comment uses for the surfaces that share these
+  items.
+- **S5 — Every caller of a moved helper is repointed at its new home; no
+  helper is re-exported from `paper_trading`.** R3 grants the facade to the
+  three ledger types by name and by reason; extending it to the helpers would
+  leave `paper_calendar` and `paper_home` still naming `paper_trading` for a
+  formatter, which is the edge the mission exists to delete.
+- **S6 — `--tighten` covers the cycle baseline too.** `main.rs` runs both
+  existing ratchets and says in its own doc comment why tightening only one is
+  a trap; a third that silently stayed stale would be that trap.
+- **S7 — Wanted to ask, went with a reading:** whether the guard should also
+  fail on a *new* signed entry appearing (a crate gaining its first cycle) as
+  opposed to an existing count rising. Reading taken: both fail, because the
+  ratchet's untracked-file rule already works this way — a file with no entry
+  is capped at the threshold, and here the threshold is 0.
+- **S8 — `fmt_offset_minute` and `today` land in `paper_calendar`, not in
+  `paper_chrome`.** Both need `CivilDate` and `civil_utc`, which
+  `paper_calendar` owns, while `paper_calendar` paints its day cells with
+  `points_color` and `fmt_signed_points`. Putting all thirteen in one module
+  would therefore have made `paper_chrome` and `paper_calendar` import each
+  other — trading the cycle the mission removes for an identical one, in the
+  module built to prevent it. `paper_calendar` is itself a neutral module
+  below both halves, and these two are date law, so R2 is satisfied by both
+  homes. Recorded rather than asked because it was discovered while writing
+  the code, after step 3 had closed, and no reading of the request makes the
+  new cycle acceptable.
+- **S9 — A fourth cycle, `crates/control`, is signed alongside the two D1
+  names.** The guard found `error` ↔ `wire` on its first run; the throwaway
+  prototype that measured the repository before D1 was asked had missed it,
+  because both imports are written as grouped `use crate::{...}` trees and
+  the prototype read only the first segment after `crate::`. D1's answer —
+  record what exists, signed — decides this one too, so it is an assumption
+  rather than a second question.
+
+## Acceptance criteria
+
+- [ ] **A1** — `crates/app/src/paper_report.rs` names `paper_trading` nowhere
+      in its production code: no `use crate::paper_trading`, no inline
+      `crate::paper_trading::` path.
+      *Evidence:* `grep -n 'paper_trading' crates/app/src/paper_report.rs`
+      returns only lines inside the `#[cfg(test)]` module, quoted in the PR.
+      → PR body. *(R1, R2)*
+- [ ] **A2** — Eleven of the thirteen named items live in
+      `crates/app/src/paper_chrome.rs`, which imports neither `paper_trading`
+      nor `paper_report`; `fmt_offset_minute` and `today` land in
+      `paper_calendar` instead, per **S8**. Both homes are neutral modules
+      below `paper_report` and `paper_trading`, which is what R2 asks for.
+      *Evidence:* each file's `use crate::` block, quoted; `grep` for each of
+      the thirteen showing its definition at the new address.
+      → PR body. *(R2)*
+- [ ] **A3** — `paper_trading`'s `pub(crate) use crate::paper_report::{HistoryRow,
+      LedgerAction, LedgerScope}` survives unchanged, with its comment.
+      *Evidence:* the line, quoted from the branch. → PR body. *(R3)*
+- [ ] **A4** — Behaviour unchanged: `cargo test --workspace` green, and
+      `the_report_numbers_are_fixed` — the byte-for-byte pin on a fixed
+      journal's whole report — passes untouched.
+      *Evidence:* the test run's summary lines, and the diff showing that test
+      unedited. → PR body. *(R4)*
+- [ ] **A5** — Every test covering a moved item moved with it: no test naming
+      only `paper_chrome` items is left behind in `paper_trading`.
+      *Evidence:* the moved test names listed with their new file.
+      → PR body. *(R5)*
+- [ ] **A6** — `crates/guards/src/cycle.rs` is a third `ratchet::Policy` — it
+      reuses the shared baseline parser, `!budget` and `tighten` rather than
+      copying them — and is registered in `GUARDS` and in `main.rs`'s tighten
+      list.
+      *Evidence:* the `Policy` construction quoted, plus the two registration
+      lines. → PR body. *(R6)*
+- [ ] **A7** — The guard reads production `use crate::` edges over a crate's
+      top-level modules and reports every strongly connected component larger
+      than one, naming the modules and the edges that close the loop.
+      *Evidence:* unit tests over synthetic sources, named in the PR; plus the
+      guard's real output on `origin/main`, which must name both app cycles. → PR body. *(R7)*
+- [ ] **A8** — `crates/guards/cycle-baseline.txt` carries a signed entry per
+      crate with a cycle (`crates/app` 1, `crates/control` 1, `crates/trading` 1)
+      and a `!budget`; every other crate is capped at 0 with no entry.
+      *Evidence:* the baseline file, quoted whole. → PR body. *(R8, D1)*
+- [ ] **A9** — `cargo run -p quantick-guards` exits 0 on this branch, and would
+      have exited 1 on `origin/main`.
+      *Evidence:* both exit codes and both outputs. → PR body. *(R9)*
+- [ ] **A10** — A test proves the guard catches the exact defect PR #282 landed:
+      a two-module `use crate::` cycle raises a finding rather than passing.
+      *Evidence:* the test name and its assertion. → PR body. *(R9)*
+- [ ] **G1** — `cargo fmt --all -- --check`, `cargo clippy --workspace
+      --all-targets`, `cargo build --workspace`, `cargo test --workspace` all
+      green after rebasing on latest `main`, each run on its own.
+      *Evidence:* the four commands' output. → PR body.
+- [ ] **G2** — Performance impact declared: every touched path classified by
+      rate (per-trade / per-depth / per-frame / rare).
+      *Evidence:* the classification. → PR body.
+- [ ] **G3** — `arch-review` run over `git diff origin/main...HEAD`, step 0
+      included, every Blocker and Should-fix resolved or deferred with its
+      severity.
+      *Evidence:* the verdict and the deferral list. → PR body.
+- [ ] **G4** — Every artifact English, per `CLAUDE.md`.
+      *Evidence:* `arch-review` dimension 8 and `quantick-guards`' language
+      guard, both clean. → PR body.
+- [ ] **G5** — The new guard docks per `new-extension`: port named (`GUARDS` and
+      `ratchet::Policy`), registration-only edits to existing files, and the
+      third `Policy` instance is itself the proof that the abstraction holds a
+      second implementation.
+      *Evidence:* the diff of `lib.rs` and `main.rs`, which must be additions
+      to a list and nothing else. → PR body.
+
+### Not applicable, and why
+
+- **Hot path** — nothing here runs per trade, per depth update or per frame.
+  The moved helpers are the same functions at a new address, called from the
+  same places; the guard runs in `cargo test`, never in the app.
+- **User-visible surfaces** (`ui-harness`, `visual-qa`, `trader-ux-review`) —
+  no surface is added, removed or changed. The moved items render exactly what
+  they rendered, which is what A4 pins.
+- **Something a trader *does*** — no action, tool, trade or lock is added.
+- **Engine / determinism** — no crate below `app` changes behaviour; the
+  `trading` crate is only *measured* by the new guard, not edited.
+- **Docs/skills only** — this is code, so no shape dimension is waived.
+
+### Closing steps
+
+- **C1** — `delivery-review` returns PASS.
+- **C2** — The PR is open.
+
+## The request as received
+
+Quoted verbatim and untranslated: this is the marked, attributed quotation
+`CLAUDE.md`'s English rule exempts, and the ledger above is the operative
+English statement of it. It is preserved so no reviewer has to trust the
+ledger as its own source of truth.
+
+> /mission medium Break the app crate's remaining dependency cycle, and stop the
+> next one from landing unseen. `paper_report` imports thirteen items from
+> `paper_trading` — PositionSummary plus the presentation helpers caption,
+> fmt_decimal, fmt_duration_ms, fmt_offset_minute, fmt_points, fmt_signed_points,
+> list_symbol_folders, pill_toggle, points_color, position_word, sanitize_symbol
+> and today — while `paper_trading` re-exports HistoryRow, LedgerAction and
+> LedgerScope back, so the two form a cycle. Move the shared helpers down into a
+> neutral module below both, the way PR #285 moved the plot geometry into
+> plot_area, so `paper_report` stops importing `paper_trading` at all; the
+> re-export may stay, since it is a deliberate facade with callers in app.rs and
+> dock.rs and it is one-directional once the other edge is gone. Behaviour
+> unchanged, tests travel with the items they cover. Then add a cycle guard to
+> crates/guards as a third instance of the ratchet Policy that size and context
+> already share: it reads the `use crate::` edges of a crate's modules, reports
+> any strongly connected component larger than one, and records the count in a
+> baseline that starts at zero. This cycle was introduced by PR #282, a
+> well-reviewed refactor, and nothing in the repository saw it — the previous
+> cycle was broken by hand three days ago and this is the second. So that a
+> refactor that welds two modules together fails the build instead of being found
+> by someone measuring months later.

--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -21,7 +21,7 @@ Wired in `.claude/settings.json`, implemented in `guardrails.sh` (POSIX sh, no
 
 The other three modes are gates. This one is a courier.
 
-The repository guards — the size and context ratchets, the language scan, the encoding
+The repository guards — the size, context and cycle ratchets, the language scan, the encoding
 check — are the cheapest checks in the codebase and used to be the slowest to
 consult, because they lived under `crates/app/tests/` and cargo built the
 largest crate in the repo before it could answer. Four minutes of link for

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,7 +166,7 @@ graph TD
 | `mcp` | The MCP adapter. A leaf: it depends on `control` and `control-local` only, never on `app`, and its stdout carries MCP frames only. |
 | `feed-*` | Binance, Hyperliquid and MetaTrader 5 sources. They produce trades and never link the script language. |
 | `backtest` | The headless harness: recorded sessions in, performance out, over the exact engine and indicator path the chart draws. |
-| `guards` | The repository guards the compiler cannot see: the size and context ratchets, the English scan, the encoding check. No dependencies, so asking them costs a second rather than a full build of `app`. |
+| `guards` | The guards the compiler cannot see: the size, context and cycle ratchets, the English scan, the encoding check. No dependencies, so asking them costs a second, not a full build of `app`. |
 | `app` | The desktop chart (egui). A consumer of the engine, never the other way around. |
 
 Market replay is a **source**, not a chart mode: it releases a recorded

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ CI runs those four plus what cargo cannot see — `sh .claude/hooks/guardrails_t
 
 Crates under `crates/`; `AGENTS.md` *The map* owns the descriptions and the graph. The invariants:
 
-- **Dependency direction is one-way; never add a reverse edge.** `app` → `pine` → `indicators` → `engine`; `sim` → `trading` → `engine`; `control-local` → `control`.
+- **Dependency direction is one-way; never add a reverse edge.** `app` → `pine` → `indicators` → `engine`; `sim` → `trading` → `engine`; `control-local` → `control`. Inside a crate too: cargo cannot see a module cycle, so `guards/src/cycle.rs` fails the build on a new one.
 - **Leaves stay leaves** — nothing depends on `app`, `backtest`, `mcp` or `guards`.
 - **Everything below `app` is headless** — no UI, no network, no async, no wall clock. That is `engine`, `orderbook`, `trading`, `control`, `control-local`, `indicators`, `pine`, `replay`, `sim`, `strategy` and the feeds, and it binds third-party crates too: an async runtime or a `SystemTime` read in `sim` breaks determinism as surely as one in `engine`. `replay` and `strategy` are *told* how much time passed rather than reading a clock. `backtest` and `mcp` are headless too; `backtest`'s only wall-clock read is the stopwatch in its `main.rs`, whose numbers reach stderr and never a report.
 - **`feed-binance`, `feed-hyperliquid` and `feed-mt5` never depend on each other**, and never on the script language. A feed produces trades.

--- a/crates/app/src/control/session.rs
+++ b/crates/app/src/control/session.rs
@@ -14,7 +14,7 @@ use quantick_sim::{ClosedTrade, Order};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::{app::QuantickApp, paper_trading::PositionSummary, tab::Tab};
+use crate::{app::QuantickApp, paper_chrome::PositionSummary, tab::Tab};
 
 use super::{
     registry::{CaptureContext, ProjectionRegistry, ProjectionRegistryError},

--- a/crates/app/src/dock.rs
+++ b/crates/app/src/dock.rs
@@ -14,9 +14,8 @@ use quantick_engine::Side;
 
 use crate::feed::ReplayLink;
 use crate::orderflow_view::OrderflowView;
-use crate::paper_trading::{
-    LedgerAction, PaperTrading, TradingTabAction, fmt_decimal, position_word,
-};
+use crate::paper_chrome::{fmt_decimal, position_word};
+use crate::paper_trading::{LedgerAction, PaperTrading, TradingTabAction};
 use crate::replay_view::{ReplayAction, ReplayView};
 use crate::theme;
 use crate::timezone::TzOffset;

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -54,6 +54,7 @@ mod orderflow_view;
 mod orderflow_worker;
 mod pane;
 mod paper_calendar;
+mod paper_chrome;
 mod paper_home;
 mod paper_hud;
 mod paper_report;

--- a/crates/app/src/paper_calendar.rs
+++ b/crates/app/src/paper_calendar.rs
@@ -22,6 +22,7 @@ use egui_phosphor::regular as icons;
 use quantick_sim::ClosedTrade;
 use rust_decimal::Decimal;
 
+use crate::paper_chrome::{fmt_signed_points, points_color};
 use crate::theme;
 use crate::timezone::TzOffset;
 
@@ -198,6 +199,32 @@ impl CivilDate {
         let (other_year, other_month, _) = other.ymd();
         (year, month) == (other_year, other_month)
     }
+}
+
+/// `YYYY-MM-DD HH:MM` in the display timezone — the equity curve's hover
+/// stamp, on the same clock as every trade row beneath it.
+///
+/// Here rather than beside the report's other formatters because it is
+/// civil-date arithmetic, and this module is where that law lives; a copy
+/// in `paper_chrome` would have had to import `civil_utc` from here while
+/// this module imports colours from there, which is the cycle the split
+/// exists to prevent.
+pub(crate) fn fmt_offset_minute(timestamp_ms: i64, tz: TzOffset) -> String {
+    let (year, month, day, hour, minute, _) =
+        civil_utc(timestamp_ms.saturating_add(tz.offset_ms()));
+    format!("{year:04}-{month:02}-{day:02} {hour:02}:{minute:02}")
+}
+
+/// Today's civil date on the display clock. The app layer may read a wall
+/// clock — the engine and the pure modules may not — and this is the one
+/// place it does so for a date: the calendar's fallback when no saved
+/// trade names a month to open on.
+pub(crate) fn today(tz: TzOffset) -> CivilDate {
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|elapsed| i64::try_from(elapsed.as_millis()).unwrap_or(0))
+        .unwrap_or(0);
+    CivilDate::from_ms(now_ms, tz)
 }
 
 /// `Jan`…`Dec`; anything outside 1..=12 is a bug upstream, and `???` says
@@ -600,7 +627,7 @@ fn draw_day_cell(
         // a single number is. A day that netted exactly zero is neither —
         // the same verdict `points_color` gives it everywhere else, and
         // painting a scratch green would be the optimistic lie.
-        let base = crate::paper_trading::points_color(stat.net);
+        let base = points_color(stat.net);
         ui.painter().rect_filled(
             body,
             egui::Rounding::same(3.0),
@@ -651,7 +678,7 @@ fn draw_day_cell(
                 "{} · {} trade(s) · {} pts · {} win",
                 date.iso(),
                 stat.trades,
-                crate::paper_trading::fmt_signed_points(stat.net),
+                fmt_signed_points(stat.net),
                 stat.wins,
             ),
             None => format!("{} · no trades", date.iso()),
@@ -679,6 +706,22 @@ mod tests {
     /// shows up here first.
     fn sao_paulo() -> TzOffset {
         TzOffset::new(-180)
+    }
+
+    /// Travelled here with `fmt_offset_minute`: the curve's hover stamp
+    /// and the ledger's rows must read on one clock, and that clock is
+    /// this module's.
+    #[test]
+    fn display_stamps_read_on_the_display_clock() {
+        assert_eq!(
+            fmt_offset_minute(1_773_666_068_000, utc()),
+            "2026-03-16 13:01"
+        );
+        assert_eq!(
+            fmt_offset_minute(1_773_666_068_000, sao_paulo()),
+            "2026-03-16 10:01",
+            "the curve's stamp reads on the display clock"
+        );
     }
 
     fn trade(closed_ms: i64, pnl: i64) -> ClosedTrade {

--- a/crates/app/src/paper_chrome.rs
+++ b/crates/app/src/paper_chrome.rs
@@ -1,7 +1,7 @@
 //! The vocabulary every paper-trading surface shares: how a simulated
 //! number, label, colour and journal folder are spelled.
 //!
-//! This module exists because two modules above it needed the same twelve
+//! This module exists because two modules above it needed the same eleven
 //! items and reached for each other to get them. `paper_report` — the
 //! reading half — imported them from `paper_trading` — the writing half —
 //! while `paper_trading` re-exported the ledger's own types back, and the
@@ -14,11 +14,13 @@
 //! - **It never reaches up.** Nothing here names `PaperTrading`,
 //!   `ReportState` or any surface that draws. The imports below are the
 //!   proof, and they are meant to stay that short.
-//! - **It never reaches sideways either.** `paper_calendar` owns the date
-//!   law and paints day cells in these colours, so it sits *below* this
-//!   module and the two date formatters that need `CivilDate` live there
-//!   rather than here. Hosting them here would have traded one cycle for
-//!   another.
+//! - **It never reaches sideways either.** `theme` is the only module of
+//!   this crate it imports. `paper_calendar` sits *above* it, painting its
+//!   day cells with `points_color` and `fmt_signed_points` — which is
+//!   exactly why `fmt_offset_minute` and `today` live there rather than
+//!   here. Both need `CivilDate`, and hosting them here would have pointed
+//!   this module back at the calendar that imports it: one cycle traded for
+//!   another, in the module built to prevent it.
 //! - **Presentation only.** Nothing here holds session state, opens a
 //!   file picker, places an order or reads a clock. [`PositionSummary`] is
 //!   the one type, and it is a read-only snapshot the host hands out.

--- a/crates/app/src/paper_chrome.rs
+++ b/crates/app/src/paper_chrome.rs
@@ -1,0 +1,189 @@
+//! The vocabulary every paper-trading surface shares: how a simulated
+//! number, label, colour and journal folder are spelled.
+//!
+//! This module exists because two modules above it needed the same twelve
+//! items and reached for each other to get them. `paper_report` — the
+//! reading half — imported them from `paper_trading` — the writing half —
+//! while `paper_trading` re-exported the ledger's own types back, and the
+//! two became a cycle: neither could be read, moved or tested without the
+//! other. The same shape `plot_area` was carved out of `pane` to fix.
+//!
+//! So the rule here is the one `paper_calendar` and `plot_area` already
+//! follow, and it is the whole reason the module is worth its own file:
+//!
+//! - **It never reaches up.** Nothing here names `PaperTrading`,
+//!   `ReportState` or any surface that draws. The imports below are the
+//!   proof, and they are meant to stay that short.
+//! - **It never reaches sideways either.** `paper_calendar` owns the date
+//!   law and paints day cells in these colours, so it sits *below* this
+//!   module and the two date formatters that need `CivilDate` live there
+//!   rather than here. Hosting them here would have traded one cycle for
+//!   another.
+//! - **Presentation only.** Nothing here holds session state, opens a
+//!   file picker, places an order or reads a clock. [`PositionSummary`] is
+//!   the one type, and it is a read-only snapshot the host hands out.
+//!
+//! `crates/guards/src/cycle.rs` now fails the build if a future edit
+//! points one of these modules back at another, which is what stops the
+//! third cycle from being found by hand like the first two.
+
+use std::path::Path;
+
+use eframe::egui;
+use quantick_engine::Side;
+use rust_decimal::Decimal;
+
+use crate::theme;
+
+/// The open position, read-only, as every chrome surface reports it — the
+/// HUD, the dock badge and the status cell all describe the same trade.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PositionSummary {
+    /// Which way the position points.
+    pub side: Side,
+    /// Contracts/units held.
+    pub quantity: Decimal,
+    /// Average entry price.
+    pub avg_price: Decimal,
+    /// Open profit at the current mark; `None` before any mark exists.
+    pub open_points: Option<Decimal>,
+}
+
+/// Uppercase section caption — the ledger's group labels and column header.
+pub(crate) fn caption(text: &str) -> egui::RichText {
+    egui::RichText::new(text)
+        .size(10.0)
+        .color(theme::TEXT_FAINT)
+}
+
+/// A pill-shaped toggle chip: accent fill while on, quiet control while off.
+pub(crate) fn pill_toggle(ui: &mut egui::Ui, label: &str, on: bool, hover: &str) -> egui::Response {
+    let (fill, ink, stroke) = if on {
+        (theme::ACCENT, theme::CHIP_INK, egui::Stroke::NONE)
+    } else {
+        (
+            theme::CONTROL,
+            theme::TEXT_MUTED,
+            egui::Stroke::new(1.0_f32, theme::BORDER),
+        )
+    };
+    ui.add(
+        egui::Button::new(egui::RichText::new(label).color(ink).small())
+            .fill(fill)
+            .stroke(stroke)
+            .rounding(egui::Rounding::same(9.0)),
+    )
+    .on_hover_text(hover)
+}
+
+/// `38s`, `4m 18s`, `1h 02m` — a trade's age in venue time.
+pub(crate) fn fmt_duration_ms(ms: i64) -> String {
+    let seconds = (ms / 1000).max(0);
+    if seconds < 60 {
+        format!("{seconds}s")
+    } else if seconds < 3600 {
+        format!("{}m {:02}s", seconds / 60, seconds % 60)
+    } else {
+        format!("{}h {:02}m", seconds / 3600, (seconds % 3600) / 60)
+    }
+}
+
+/// `LONG`/`SHORT` — shared with the HUD so every surface uses one register.
+pub(crate) fn position_word(side: Side) -> &'static str {
+    match side {
+        Side::Buy => "LONG",
+        Side::Sell => "SHORT",
+    }
+}
+
+/// Green gains, red losses, muted zero — shared with the HUD.
+pub(crate) fn points_color(points: Decimal) -> egui::Color32 {
+    match points.cmp(&Decimal::ZERO) {
+        std::cmp::Ordering::Greater => theme::BUY,
+        std::cmp::Ordering::Less => theme::SELL,
+        std::cmp::Ordering::Equal => theme::TEXT_MUTED,
+    }
+}
+
+/// Exact value, trailing zeros stripped — prices and quantities.
+pub(crate) fn fmt_decimal(value: Decimal) -> String {
+    value.normalize().to_string()
+}
+
+/// Points rounded to two places for display (the stored value stays exact).
+pub(crate) fn fmt_points(value: Decimal) -> String {
+    value.round_dp(2).normalize().to_string()
+}
+
+/// Signed points: an explicit `+` on gains so a green `12` can never be
+/// misread as a count.
+pub(crate) fn fmt_signed_points(value: Decimal) -> String {
+    if value > Decimal::ZERO {
+        format!("+{}", fmt_points(value))
+    } else {
+        fmt_points(value)
+    }
+}
+
+/// Keep the characters real venue symbols use (`WDO$`, `WIN@N`… stay
+/// recognizable); anything else becomes `_` so a symbol can never traverse
+/// paths.
+pub(crate) fn sanitize_symbol(symbol: &str) -> String {
+    let cleaned: String = symbol
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() || "-_.$#".contains(character) {
+                character
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    if cleaned.is_empty() {
+        "_".to_owned()
+    } else {
+        cleaned
+    }
+}
+
+/// The symbol folders under the history dir, for the report's combo box.
+pub(crate) fn list_symbol_folders(dir: &Path) -> Vec<String> {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    let mut folders: Vec<String> = entries
+        .flatten()
+        .filter(|entry| entry.path().is_dir())
+        .filter_map(|entry| entry.file_name().to_str().map(str::to_owned))
+        .collect();
+    folders.sort();
+    folders
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn symbols_sanitize_without_losing_venue_spellings() {
+        assert_eq!(sanitize_symbol("WDO$"), "WDO$");
+        assert_eq!(sanitize_symbol("BTCUSDT"), "BTCUSDT");
+        assert_eq!(sanitize_symbol("../evil"), ".._evil");
+        assert_eq!(sanitize_symbol(""), "_");
+    }
+
+    #[test]
+    fn signed_points_always_carry_their_sign() {
+        assert_eq!(fmt_signed_points(Decimal::from(12)), "+12");
+        assert_eq!(fmt_signed_points(Decimal::from(-3)), "-3");
+        assert_eq!(fmt_signed_points(Decimal::ZERO), "0");
+    }
+
+    #[test]
+    fn durations_format_by_magnitude() {
+        assert_eq!(fmt_duration_ms(38_000), "38s");
+        assert_eq!(fmt_duration_ms(258_000), "4m 18s");
+        assert_eq!(fmt_duration_ms(3_720_000), "1h 02m");
+        assert_eq!(fmt_duration_ms(-5), "0s", "clock skew never explodes");
+    }
+}

--- a/crates/app/src/paper_home.rs
+++ b/crates/app/src/paper_home.rs
@@ -364,7 +364,7 @@ fn copy_loose_file(path: &Path, dest: &Path, summary: &mut ImportSummary) {
         .and_then(|parsed| parsed.symbol);
     match symbol {
         Some(symbol) => {
-            let folder = dest.join(crate::paper_trading::sanitize_symbol(&symbol));
+            let folder = dest.join(crate::paper_chrome::sanitize_symbol(&symbol));
             copy_one(path, &folder, summary);
         }
         None => {

--- a/crates/app/src/paper_hud.rs
+++ b/crates/app/src/paper_hud.rs
@@ -17,9 +17,10 @@ use quantick_engine::Side;
 use rust_decimal::prelude::ToPrimitive;
 
 use crate::chart::PriceScale;
-use crate::paper_trading::{
-    PaperTrading, PositionSummary, fmt_decimal, fmt_signed_points, points_color, position_word,
+use crate::paper_chrome::{
+    PositionSummary, fmt_decimal, fmt_signed_points, points_color, position_word,
 };
+use crate::paper_trading::PaperTrading;
 use crate::theme;
 
 /// Gap between the pane's corner and the HUD card, in pixels.

--- a/crates/app/src/paper_report.rs
+++ b/crates/app/src/paper_report.rs
@@ -49,11 +49,11 @@ use rust_decimal::prelude::ToPrimitive;
 // One date law for every trade surface - see `paper_calendar`.
 use crate::paper_calendar::{
     CalendarAction, CalendarState, CivilDate, DAY_MS, DateRange, DayIndex, DaySelection,
+    fmt_offset_minute, today,
 };
-use crate::paper_trading::{
-    PositionSummary, caption, fmt_decimal, fmt_duration_ms, fmt_offset_minute, fmt_points,
-    fmt_signed_points, list_symbol_folders, pill_toggle, points_color, position_word,
-    sanitize_symbol, today,
+use crate::paper_chrome::{
+    PositionSummary, caption, fmt_decimal, fmt_duration_ms, fmt_points, fmt_signed_points,
+    list_symbol_folders, pill_toggle, points_color, position_word, sanitize_symbol,
 };
 use crate::theme;
 use crate::timezone::TzOffset;

--- a/crates/app/src/paper_trading.rs
+++ b/crates/app/src/paper_trading.rs
@@ -26,7 +26,11 @@ use rust_decimal::prelude::ToPrimitive;
 
 use crate::chart::PriceScale;
 // One date law for every trade surface - see `paper_calendar`.
-use crate::paper_calendar::{CivilDate, DaySelection, civil_utc};
+use crate::paper_calendar::{DaySelection, civil_utc};
+use crate::paper_chrome::{
+    PositionSummary, caption, fmt_decimal, fmt_points, fmt_signed_points, pill_toggle,
+    points_color, position_word, sanitize_symbol,
+};
 use crate::theme;
 use crate::timezone::TzOffset;
 
@@ -255,20 +259,6 @@ const CHIP_CLEAR_PX: f32 = 16.0;
 pub struct ArmedPlacement {
     side: Side,
     kind: EntryKind,
-}
-
-/// The open position, read-only, as every chrome surface reports it — the
-/// HUD, the dock badge and the status cell all describe the same trade.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct PositionSummary {
-    /// Which way the position points.
-    pub side: Side,
-    /// Contracts/units held.
-    pub quantity: Decimal,
-    /// Average entry price.
-    pub avg_price: Decimal,
-    /// Open profit at the current mark; `None` before any mark exists.
-    pub open_points: Option<Decimal>,
 }
 
 /// Which simulated line the pointer is dragging.
@@ -5986,45 +5976,6 @@ fn kind_short(kind: EntryKind) -> &'static str {
     }
 }
 
-/// Uppercase section caption — the ledger's group labels and column header.
-pub(crate) fn caption(text: &str) -> egui::RichText {
-    egui::RichText::new(text)
-        .size(10.0)
-        .color(theme::TEXT_FAINT)
-}
-
-/// A pill-shaped toggle chip: accent fill while on, quiet control while off.
-pub(crate) fn pill_toggle(ui: &mut egui::Ui, label: &str, on: bool, hover: &str) -> egui::Response {
-    let (fill, ink, stroke) = if on {
-        (theme::ACCENT, theme::CHIP_INK, egui::Stroke::NONE)
-    } else {
-        (
-            theme::CONTROL,
-            theme::TEXT_MUTED,
-            egui::Stroke::new(1.0_f32, theme::BORDER),
-        )
-    };
-    ui.add(
-        egui::Button::new(egui::RichText::new(label).color(ink).small())
-            .fill(fill)
-            .stroke(stroke)
-            .rounding(egui::Rounding::same(9.0)),
-    )
-    .on_hover_text(hover)
-}
-
-/// `38s`, `4m 18s`, `1h 02m` — a trade's age in venue time.
-pub(crate) fn fmt_duration_ms(ms: i64) -> String {
-    let seconds = (ms / 1000).max(0);
-    if seconds < 60 {
-        format!("{seconds}s")
-    } else if seconds < 3600 {
-        format!("{}m {:02}s", seconds / 60, seconds % 60)
-    } else {
-        format!("{}h {:02}m", seconds / 3600, (seconds % 3600) / 60)
-    }
-}
-
 /// Keep a gutter chip legible when it would land on the last-price chip:
 /// push it just clear of the reserved row, towards its own side of the
 /// price, clamped into the pane. At the exact fill price (no distance at
@@ -6074,69 +6025,11 @@ fn side_word_upper(side: Side) -> &'static str {
     }
 }
 
-/// `LONG`/`SHORT` — shared with the HUD so every surface uses one register.
-pub(crate) fn position_word(side: Side) -> &'static str {
-    match side {
-        Side::Buy => "LONG",
-        Side::Sell => "SHORT",
-    }
-}
-
 fn kind_word(kind: EntryKind) -> &'static str {
     match kind {
         EntryKind::Market => "market",
         EntryKind::Limit => "limit",
         EntryKind::Stop => "stop",
-    }
-}
-
-/// Green gains, red losses, muted zero — shared with the HUD.
-pub(crate) fn points_color(points: Decimal) -> egui::Color32 {
-    match points.cmp(&Decimal::ZERO) {
-        std::cmp::Ordering::Greater => theme::BUY,
-        std::cmp::Ordering::Less => theme::SELL,
-        std::cmp::Ordering::Equal => theme::TEXT_MUTED,
-    }
-}
-
-/// Exact value, trailing zeros stripped — prices and quantities.
-pub(crate) fn fmt_decimal(value: Decimal) -> String {
-    value.normalize().to_string()
-}
-
-/// Points rounded to two places for display (the stored value stays exact).
-pub(crate) fn fmt_points(value: Decimal) -> String {
-    value.round_dp(2).normalize().to_string()
-}
-
-/// Signed points: an explicit `+` on gains so a green `12` can never be
-/// misread as a count.
-pub(crate) fn fmt_signed_points(value: Decimal) -> String {
-    if value > Decimal::ZERO {
-        format!("+{}", fmt_points(value))
-    } else {
-        fmt_points(value)
-    }
-}
-
-/// Keep the characters real venue symbols use (`WDO$`, `WIN@N`… stay
-/// recognizable); anything else becomes `_` so a symbol can never traverse
-/// paths.
-pub(crate) fn sanitize_symbol(symbol: &str) -> String {
-    let cleaned: String = symbol
-        .chars()
-        .map(|character| {
-            if character.is_ascii_alphanumeric() || "-_.$#".contains(character) {
-                character
-            } else {
-                '_'
-            }
-        })
-        .collect();
-    if cleaned.is_empty() {
-        "_".to_owned()
-    } else {
-        cleaned
     }
 }
 
@@ -6152,26 +6045,6 @@ fn utc_compact(timestamp_ms: i64) -> String {
 fn fmt_utc_date(timestamp_ms: i64) -> String {
     let (year, month, day, ..) = civil_utc(timestamp_ms);
     format!("{year:04}-{month:02}-{day:02}")
-}
-
-/// `YYYY-MM-DD HH:MM` in the display timezone — the equity curve's hover
-/// stamp, on the same clock as every trade row beneath it.
-pub(crate) fn fmt_offset_minute(timestamp_ms: i64, tz: TzOffset) -> String {
-    let (year, month, day, hour, minute, _) =
-        civil_utc(timestamp_ms.saturating_add(tz.offset_ms()));
-    format!("{year:04}-{month:02}-{day:02} {hour:02}:{minute:02}")
-}
-
-/// Today's civil date on the display clock. The app layer may read a wall
-/// clock — the engine and the pure modules may not — and this is the one
-/// place it does so for a date: the calendar's fallback when no saved
-/// trade names a month to open on.
-pub(crate) fn today(tz: TzOffset) -> CivilDate {
-    let now_ms = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|elapsed| i64::try_from(elapsed.as_millis()).unwrap_or(0))
-        .unwrap_or(0);
-    CivilDate::from_ms(now_ms, tz)
 }
 
 /// A protective price the ticket's offset away from the average entry:
@@ -6384,20 +6257,6 @@ fn test_scratch_dir() -> PathBuf {
     ))
 }
 
-/// The symbol folders under the history dir, for the report's combo box.
-pub(crate) fn list_symbol_folders(dir: &Path) -> Vec<String> {
-    let Ok(entries) = std::fs::read_dir(dir) else {
-        return Vec::new();
-    };
-    let mut folders: Vec<String> = entries
-        .flatten()
-        .filter(|entry| entry.path().is_dir())
-        .filter_map(|entry| entry.file_name().to_str().map(str::to_owned))
-        .collect();
-    folders.sort();
-    folders
-}
-
 #[cfg(test)]
 mod risk_tests {
     use super::*;
@@ -6590,6 +6449,9 @@ mod risk_tests {
 #[cfg(test)]
 mod tests {
     use super::*;
+    // Journalling tests read back the folders the writer created; the
+    // helper that lists them lives with the rest of the shared chrome.
+    use crate::paper_chrome::list_symbol_folders;
     use crate::paper_report::{load_history, report_from_history};
 
     /// One journal row: the trade, the folder it came from, the source its
@@ -6618,29 +6480,6 @@ mod tests {
         assert_eq!(utc_compact(1_773_666_068_000), "20260316-130108");
         // The epoch itself.
         assert_eq!(utc_compact(0), "19700101-000000");
-    }
-
-    #[test]
-    fn symbols_sanitize_without_losing_venue_spellings() {
-        assert_eq!(sanitize_symbol("WDO$"), "WDO$");
-        assert_eq!(sanitize_symbol("BTCUSDT"), "BTCUSDT");
-        assert_eq!(sanitize_symbol("../evil"), ".._evil");
-        assert_eq!(sanitize_symbol(""), "_");
-    }
-
-    #[test]
-    fn signed_points_always_carry_their_sign() {
-        assert_eq!(fmt_signed_points(Decimal::from(12)), "+12");
-        assert_eq!(fmt_signed_points(Decimal::from(-3)), "-3");
-        assert_eq!(fmt_signed_points(Decimal::ZERO), "0");
-    }
-
-    #[test]
-    fn durations_format_by_magnitude() {
-        assert_eq!(fmt_duration_ms(38_000), "38s");
-        assert_eq!(fmt_duration_ms(258_000), "4m 18s");
-        assert_eq!(fmt_duration_ms(3_720_000), "1h 02m");
-        assert_eq!(fmt_duration_ms(-5), "0s", "clock skew never explodes");
     }
 
     #[test]
@@ -6750,15 +6589,6 @@ mod tests {
     #[test]
     fn utc_dates_format_from_the_same_civil_math() {
         assert_eq!(fmt_utc_date(1_773_666_068_000), "2026-03-16");
-        assert_eq!(
-            fmt_offset_minute(1_773_666_068_000, TzOffset::new(0)),
-            "2026-03-16 13:01"
-        );
-        assert_eq!(
-            fmt_offset_minute(1_773_666_068_000, TzOffset::new(-180)),
-            "2026-03-16 10:01",
-            "the curve's stamp reads on the display clock"
-        );
     }
 
     #[test]

--- a/crates/app/src/risk_sizing.rs
+++ b/crates/app/src/risk_sizing.rs
@@ -871,7 +871,7 @@ pub(crate) struct RiskBlock<'a> {
 pub(crate) fn draw_risk_block(ui: &mut eframe::egui::Ui, block: RiskBlock<'_>) -> bool {
     use eframe::egui;
 
-    use crate::paper_trading::{caption, pill_toggle};
+    use crate::paper_chrome::{caption, pill_toggle};
     use crate::theme;
 
     let mut changed = false;

--- a/crates/app/src/trade_paint.rs
+++ b/crates/app/src/trade_paint.rs
@@ -33,7 +33,7 @@ use quantick_sim::ClosedTrade;
 use rust_decimal::prelude::ToPrimitive;
 
 use crate::chart::PriceScale;
-use crate::paper_trading::{
+use crate::paper_chrome::{
     fmt_decimal, fmt_duration_ms, fmt_signed_points, points_color, position_word,
 };
 use crate::theme;

--- a/crates/guards/cycle-baseline.txt
+++ b/crates/guards/cycle-baseline.txt
@@ -1,0 +1,45 @@
+# The recorded ceiling, in module cycles, for every crate that has one. One
+# `path ceiling` pair per line; `#` starts a comment.
+#
+# A module cycle is two or more of a crate's top-level modules that import
+# each other, directly or the long way round. Cargo forbids this between
+# crates and permits it inside one, so nothing in a green build says it has
+# happened — which is how the repository acquired the three below without
+# anyone deciding to.
+#
+# Every crate not listed here is capped at zero. That is the point of the
+# file: a new cycle anywhere fails the build in the change that introduces
+# it, instead of being found by hand months later.
+#
+# These are defects, not budgets. The only direction an entry should ever
+# move is down, and `cargo run -p quantick-guards -- --tighten` writes the
+# lower number once a cycle is actually broken.
+
+# `app.rs` defines `QuantickApp`, which every control-plane call operates on;
+# `QuantickApp` draws `surfaces`; and `surfaces/agent_popup.rs` reaches back
+# into `control` for the popup's own state. So `app -> surfaces -> control ->
+# app`. Untouched by the branch that introduced this guard: the fix is a
+# port for the control plane to hold its own surface state behind, which is
+# a design change, not a move. Recorded so it cannot grow while it waits.
+crates/app 1
+
+# `wire.rs` names `error::ControlError` and `error.rs` names
+# `wire::ModuleRevision` — an error type that carries a wire value, and a wire
+# type that returns errors. Found by this guard rather than by anyone reading
+# the crate: the prototype that measured the repository before the guard was
+# written used a regular expression and missed it, because both imports are
+# written as grouped `use crate::{...}` trees. That miss is why the parser is
+# written by hand.
+crates/control 1
+
+# `events.rs` names `position::ClosedTrade` and `position.rs` names
+# `events::ExitReason` — two type definitions that reference each other
+# across a module boundary. Pre-existing, in a headless crate this branch had
+# no reason to open. Breaking it means one more module below both, the same
+# shape as `paper_chrome`.
+crates/trading 1
+
+# The whole tracked weight: every signed cycle, plus any in a crate with no
+# entry (there are none, and the threshold of zero is what keeps it that
+# way). Paying for a new cycle means breaking an old one in the same change.
+!budget 3

--- a/crates/guards/src/cycle.rs
+++ b/crates/guards/src/cycle.rs
@@ -177,48 +177,82 @@ pub fn module_of(relative: &str) -> Option<String> {
 /// The first path segment of every `use crate::…` statement in a source
 /// file, in order, with duplicates kept so a caller can count them.
 ///
-/// A statement, not a substring: the scan starts only where a line *begins*
-/// a `use` (after an optional visibility), so `crate::` inside a doc
-/// comment or a string is never mistaken for an import. From there it reads
-/// the use-tree across however many lines it spans, which is why the parse
-/// is written by hand rather than by line.
+/// A statement, not a substring: a scan position is only ever the start of
+/// a statement — the beginning of a line, or whatever follows a `;` on one
+/// that already began with a `use` — so `crate::` inside a doc comment or a
+/// string is never mistaken for an import. From there it reads the use-tree
+/// across however many lines it spans, which is why the parse is written by
+/// hand rather than by line.
 ///
 /// Grouped imports are the whole reason it is not a regular expression:
 /// `use crate::{app::QuantickApp, tab::Tab};` is two edges, and
 /// `use crate::pane::{Pane, Split};` is one. The parser tracks, per brace
 /// level, whether the next identifier is still the head of its path.
+///
+/// Two statements on one line are two edges. `rustfmt` splits them and
+/// `cargo fmt --check` gates CI, so the repository has none today — but a
+/// guard that reads only the first is silently wrong, and being silently
+/// wrong is the one thing this guard may not be. Its whole claim is that a
+/// clean run means clean.
 pub fn use_targets(source: &str) -> Vec<String> {
     let lines: Vec<&str> = source.lines().collect();
     let mut targets = Vec::new();
     for (index, line) in lines.iter().enumerate() {
-        let trimmed = line.trim_start();
-        let head = trimmed
-            .strip_prefix("pub(crate) ")
-            .or_else(|| trimmed.strip_prefix("pub(super) "))
-            .or_else(|| trimmed.strip_prefix("pub "))
-            .unwrap_or(trimmed);
-        let Some(rest) = head.strip_prefix("use crate::") else {
-            continue;
-        };
-        // A use tree may span lines. Rebuilding the tail from the line list
-        // rather than indexing into `source` keeps the parse correct on a
-        // file with CRLF endings, where `str::lines` has already dropped a
-        // byte the offsets would still have counted.
-        let mut tail = String::from(rest);
-        let mut next = index + 1;
-        while !tail.contains(';') && next < lines.len() {
-            tail.push('\n');
-            tail.push_str(lines[next]);
-            next += 1;
+        let mut cursor = code(line);
+        while let Some(rest) = statement(cursor) {
+            // A use tree may span lines. Rebuilding the tail from the line
+            // list rather than indexing into `source` keeps the parse
+            // correct on a file with CRLF endings, where `str::lines` has
+            // already dropped a byte the offsets would still have counted.
+            let mut tail = String::from(rest);
+            let mut next = index + 1;
+            while !tail.contains(';') && next < lines.len() {
+                tail.push('\n');
+                tail.push_str(code(lines[next]));
+                next += 1;
+            }
+            let consumed = read_use_tree(&tail, &mut targets);
+            // Past the end of this line means the statement ran on into the
+            // ones already folded into `tail`; there is nothing left here.
+            // Otherwise step over the `;` the parser stopped on and look for
+            // another statement beside it.
+            let Some(remainder) = rest.get(consumed + 1..) else {
+                break;
+            };
+            cursor = remainder;
         }
-        read_use_tree(&tail, &mut targets);
     }
     targets
 }
 
+/// The part of a line that is code: everything before a `//`.
+///
+/// A `use` path can never contain `//`, so this cannot truncate a real
+/// import. It exists so that a comment beside or inside a use tree —
+/// `use crate::{a, // b, c` — cannot contribute `b` as a module.
+fn code(line: &str) -> &str {
+    line.split("//").next().unwrap_or(line)
+}
+
+/// Whatever follows `use crate::` at the head of `text`, or `None` when
+/// `text` does not begin a `use crate::` statement.
+fn statement(text: &str) -> Option<&str> {
+    let trimmed = text.trim_start();
+    let head = trimmed
+        .strip_prefix("pub(crate) ")
+        .or_else(|| trimmed.strip_prefix("pub(super) "))
+        .or_else(|| trimmed.strip_prefix("pub "))
+        .unwrap_or(trimmed);
+    head.strip_prefix("use crate::")
+}
+
 /// Read one use-tree, starting immediately after `crate::`, pushing the
 /// head segment of every path it names.
-fn read_use_tree(rest: &str, targets: &mut Vec<String>) {
+///
+/// Returns the byte offset it stopped at — the terminating `;`, or the end
+/// of the text — so the caller can look for a second statement beside the
+/// first.
+fn read_use_tree(rest: &str, targets: &mut Vec<String>) -> usize {
     // Per brace level: whether identifiers at this level are path heads
     // (`crate::{a, b}` — yes; `a::{X, Y}` — no), and whether the next
     // identifier is still the first of its path.
@@ -265,6 +299,7 @@ fn read_use_tree(rest: &str, targets: &mut Vec<String>) {
             _ => index += 1,
         }
     }
+    index
 }
 
 /// Every strongly connected component larger than one module, sorted.
@@ -769,6 +804,47 @@ mod tests {
                       /// The remedy mentions crate::ratchet too.\n\
                       let name = \"use crate::pane\";\n";
         assert!(use_targets(source).is_empty(), "{:?}", use_targets(source));
+    }
+
+    /// The false negative round 2 of the review found: a second statement
+    /// beside the first was never read, and a missed edge is a missed
+    /// cycle — the one way this guard may not be wrong.
+    #[test]
+    fn two_statements_on_one_line_are_two_edges() {
+        assert_eq!(
+            use_targets(
+                "use crate::a::X; use crate::b::Y;
+"
+            ),
+            vec!["a", "b"]
+        );
+    }
+
+    /// And the hole that reading past the first  would have opened if
+    /// comments were not cut first.
+    #[test]
+    fn a_comment_beside_a_use_names_no_module() {
+        assert_eq!(
+            use_targets(
+                "use crate::a::X; // like use crate::b::Y;
+"
+            ),
+            vec!["a"]
+        );
+    }
+
+    #[test]
+    fn a_comment_inside_a_use_tree_names_no_module() {
+        assert_eq!(
+            use_targets(
+                "use crate::{
+    a, // b, c
+    d,
+};
+"
+            ),
+            vec!["a", "d"]
+        );
     }
 
     #[test]

--- a/crates/guards/src/cycle.rs
+++ b/crates/guards/src/cycle.rs
@@ -1,0 +1,814 @@
+//! Ratchet guard for module cycles inside a crate.
+//!
+//! `CLAUDE.md` states the dependency rule one level up — `app` → `pine` →
+//! `indicators` → `engine`, never a reverse edge — and cargo enforces it,
+//! because a cycle between crates does not compile. Inside a crate nothing
+//! enforces anything: `paper_report` may import from `paper_trading` while
+//! `paper_trading` imports back, and the build is green.
+//!
+//! It happened twice in three days. PR #285 broke an `app`/`pane`/`tab`
+//! cycle by hand. PR #282 — a well-reviewed refactor that split the paper
+//! surfaces in two — welded `paper_report` and `paper_trading` together in
+//! the same week, and nothing in the repository saw it: not fmt, not
+//! clippy, not the build, not the suite, not two rounds of review. It was
+//! found by someone drawing the graph months after the fact, which is the
+//! most expensive moment to find it and the reason this file exists.
+//!
+//! # What a cycle costs
+//!
+//! Two modules in a cycle are one module with a comment between them. They
+//! cannot be read apart, moved apart, or tested apart — a fixture for one
+//! links the other — and the trunk-shrinking work `size` rations depends
+//! on being able to lift a surface out to its own file. A cycle is the
+//! edit that quietly makes the next extraction impossible.
+//!
+//! # What is measured
+//!
+//! One node per **top-level module** of a crate: `control::gateway` counts
+//! as `control`, because that is the granularity a crate root declares its
+//! modules at and the granularity the rule is stated at.
+//!
+//! One edge per **`use crate::` statement** in production code, from the
+//! module the file belongs to, to the first path segment after `crate::`.
+//! Deliberately not every inline `crate::foo::bar` path: a doc comment
+//! linking `[`size`](crate::size)` is not a dependency, and counting those
+//! reports this very crate as a three-way cycle on the day it ships. A
+//! guard whose first output is a false positive is a guard that gets
+//! switched off.
+//!
+//! Test code is not measured, for [`crate::size`]'s reason and through
+//! [`crate::size::production_source`], the same function: a test module
+//! reaching for a fixture is not the defect, and a guard that fired on one
+//! would teach authors to write fewer tests.
+//!
+//! Root files (`lib.rs`, `main.rs`) are skipped. A `crate::` path always
+//! begins with a top-level module name, so the root has no incoming edges
+//! and can never sit inside a cycle.
+//!
+//! # Why the baseline does not start at zero
+//!
+//! Because the repository does not. When this guard was written it found
+//! three cycles, not the one that prompted it: the `paper` pair that this
+//! branch removed, `app`/`surfaces`/`control` (the control plane operates
+//! on `QuantickApp`, which draws the surfaces that open the control
+//! plane's popup), and `events`/`position` in `quantick-trading`. Starting
+//! at zero would have meant rewriting two architectures nobody asked to
+//! touch, in the branch that adds the guard.
+//!
+//! So the honest start is the ratchet's own answer, the one `size` gives
+//! for `app.rs`: record what exists, signed, and forbid it from growing.
+//! Every crate not listed is capped at zero — the [`THRESHOLD`] — so a new
+//! cycle anywhere fails the build, which is the whole point, and the two
+//! signed entries can only ever move down.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::Path;
+
+use crate::Finding;
+use crate::ratchet::Policy;
+use crate::size::production_source;
+
+/// The number of cycles a crate may have without a signed baseline entry.
+///
+/// Zero, unlike its sibling ratchets, and the difference is the point: a
+/// large file is a cost to weigh, while a cycle is a defect to fix. There
+/// is no size below which one is acceptable.
+pub const THRESHOLD: usize = 0;
+
+/// How far below its ceiling a crate may sit before the entry must be
+/// tightened. Zero: breaking a cycle is a whole event, not a gradual
+/// shrink, and an entry left at 2 after one was broken is permission
+/// nobody re-earned to weld the pair back together.
+pub const SLACK: usize = 0;
+
+/// The recorded ceilings, workspace-relative.
+pub const BASELINE_FILE: &str = "crates/guards/cycle-baseline.txt";
+
+/// Both budget tolerances are zero for [`SLACK`]'s reason: this total
+/// counts defects, and every movement in it is deliberate.
+pub const BUDGET_SLACK: usize = 0;
+
+/// See [`BUDGET_SLACK`].
+pub const BUDGET_HEADROOM: usize = 0;
+
+pub const REMEDY: &str = "A module cycle is two modules welded into one: neither can be read, moved or tested \
+     without the other, and the next extraction out of the trunk is blocked by it. Break it \
+     by moving what they share *down* into a module below both — `plot_area` came out of \
+     `pane`, `paper_chrome` out of `paper_trading` — and not by re-exporting one from the \
+     other, which hides the edge without removing it. If the cycle is genuinely deliberate, \
+     raise the crate's entry in crates/guards/cycle-baseline.txt with the reason written \
+     beside it, and lower another entry in the same change.";
+
+pub const BUDGET_REMEDY: &str = "The cycle budget is every welded module pair this repository has signed for. It is the \
+     one number that says whether the codebase is getting easier or harder to take apart, so \
+     a new cycle is paid for by breaking an old one in the same change — not by raising the \
+     cap.";
+
+pub const BUDGET_SLACK_REMEDY: &str = "A signed cycle has been broken and the budget still reserves room for it. Good news with \
+     the number already computed: run `cargo run -p quantick-guards -- --tighten`, which only \
+     ever moves these numbers down.";
+
+pub const BASELINE_REMEDY: &str = "The cycle baseline could not be read as data, so no crate was checked at all — this is a \
+     syntax error in a data file, not a design problem. Each line is `path ceiling`, `#` \
+     starts a comment, and exactly one `!budget <total>` caps the sum.";
+
+pub const POLICY: Policy = Policy {
+    baseline_file: BASELINE_FILE,
+    threshold: THRESHOLD,
+    slack: SLACK,
+    budget_slack: BUDGET_SLACK,
+    budget_headroom: BUDGET_HEADROOM,
+    unit: "module cycles",
+    remedy: REMEDY,
+    budget_remedy: BUDGET_REMEDY,
+    budget_slack_remedy: BUDGET_SLACK_REMEDY,
+    baseline_remedy: BASELINE_REMEDY,
+};
+
+/// One strongly connected component larger than a single module: the
+/// modules welded together, and the `use crate::` statements that weld
+/// them.
+#[derive(Debug, PartialEq, Eq)]
+pub struct Cycle {
+    /// The modules in the component, sorted.
+    pub modules: Vec<String>,
+    /// One `from -> to  (file, and N more)` line per edge inside the
+    /// component, sorted. The finding names these rather than only the
+    /// modules: "app, control and surfaces are a cycle" is a fact, and
+    /// "control -> app  (control/actions.rs, and 20 more)" is the line to
+    /// open.
+    pub edges: Vec<String>,
+}
+
+/// What a walk of `crates/` found.
+pub struct Measured {
+    /// Cycle counts by crate path (`crates/app`), sorted.
+    pub counts: Vec<(String, usize)>,
+    /// The components behind those counts, by the same crate path.
+    pub cycles: BTreeMap<String, Vec<Cycle>>,
+    /// Files that exist and could not be read. Reported rather than
+    /// skipped, for [`crate::size`]'s reason: a file the guard could not
+    /// open is not a file it has cleared, and an edge it never saw is a
+    /// cycle it never found.
+    pub unreadable: Vec<String>,
+}
+
+/// The module a source file belongs to, given its path relative to the
+/// crate's `src/`, or `None` for a file this guard does not measure.
+///
+/// `None` covers the crate root, whose modules cannot be named from
+/// `crate::`, and test trees, which are not production code.
+pub fn module_of(relative: &str) -> Option<String> {
+    if relative == "lib.rs" || relative == "main.rs" {
+        return None;
+    }
+    let mut segments = relative.split('/');
+    let head = segments.next()?;
+    // A `tests/` directory anywhere below `src/`, and the `*_tests.rs`
+    // files this repo splits large suites into. Both are `#[cfg(test)]`
+    // modules; neither ships.
+    if relative.split('/').any(|segment| segment == "tests") || relative.ends_with("_tests.rs") {
+        return None;
+    }
+    Some(head.strip_suffix(".rs").unwrap_or(head).to_owned())
+}
+
+/// The first path segment of every `use crate::…` statement in a source
+/// file, in order, with duplicates kept so a caller can count them.
+///
+/// A statement, not a substring: the scan starts only where a line *begins*
+/// a `use` (after an optional visibility), so `crate::` inside a doc
+/// comment or a string is never mistaken for an import. From there it reads
+/// the use-tree across however many lines it spans, which is why the parse
+/// is written by hand rather than by line.
+///
+/// Grouped imports are the whole reason it is not a regular expression:
+/// `use crate::{app::QuantickApp, tab::Tab};` is two edges, and
+/// `use crate::pane::{Pane, Split};` is one. The parser tracks, per brace
+/// level, whether the next identifier is still the head of its path.
+pub fn use_targets(source: &str) -> Vec<String> {
+    let lines: Vec<&str> = source.lines().collect();
+    let mut targets = Vec::new();
+    for (index, line) in lines.iter().enumerate() {
+        let trimmed = line.trim_start();
+        let head = trimmed
+            .strip_prefix("pub(crate) ")
+            .or_else(|| trimmed.strip_prefix("pub(super) "))
+            .or_else(|| trimmed.strip_prefix("pub "))
+            .unwrap_or(trimmed);
+        let Some(rest) = head.strip_prefix("use crate::") else {
+            continue;
+        };
+        // A use tree may span lines. Rebuilding the tail from the line list
+        // rather than indexing into `source` keeps the parse correct on a
+        // file with CRLF endings, where `str::lines` has already dropped a
+        // byte the offsets would still have counted.
+        let mut tail = String::from(rest);
+        let mut next = index + 1;
+        while !tail.contains(';') && next < lines.len() {
+            tail.push('\n');
+            tail.push_str(lines[next]);
+            next += 1;
+        }
+        read_use_tree(&tail, &mut targets);
+    }
+    targets
+}
+
+/// Read one use-tree, starting immediately after `crate::`, pushing the
+/// head segment of every path it names.
+fn read_use_tree(rest: &str, targets: &mut Vec<String>) {
+    // Per brace level: whether identifiers at this level are path heads
+    // (`crate::{a, b}` — yes; `a::{X, Y}` — no), and whether the next
+    // identifier is still the first of its path.
+    let mut heads = vec![true];
+    let mut pending = vec![true];
+    let bytes = rest.as_bytes();
+    let mut index = 0;
+    while index < bytes.len() {
+        let depth = heads.len() - 1;
+        match bytes[index] {
+            b'{' => {
+                heads.push(heads[depth] && pending[depth]);
+                pending.push(true);
+                pending[depth] = false;
+                index += 1;
+            }
+            b'}' => {
+                if depth == 0 {
+                    break;
+                }
+                heads.pop();
+                pending.pop();
+                index += 1;
+            }
+            b',' => {
+                pending[depth] = true;
+                index += 1;
+            }
+            b';' => break,
+            byte if byte.is_ascii_alphanumeric() || byte == b'_' => {
+                let from = index;
+                while index < bytes.len()
+                    && (bytes[index].is_ascii_alphanumeric() || bytes[index] == b'_')
+                {
+                    index += 1;
+                }
+                if pending[depth] {
+                    pending[depth] = false;
+                    if heads[depth] {
+                        targets.push(rest[from..index].to_owned());
+                    }
+                }
+            }
+            _ => index += 1,
+        }
+    }
+}
+
+/// Every strongly connected component larger than one module, sorted.
+///
+/// `edges` is `module -> (target, file)`, already restricted to modules the
+/// crate actually has.
+///
+/// The components come from a reachability closure rather than from
+/// Tarjan's algorithm, and that is a deliberate trade. A crate here has at
+/// most a hundred modules, so the closure is a few million bit operations —
+/// unmeasurable beside reading the files — and in exchange the grouping is
+/// three obvious loops that a reviewer can check by reading, in a guard
+/// whose whole value is that its findings are believed.
+pub fn components(edges: &BTreeMap<String, BTreeSet<(String, String)>>) -> Vec<Cycle> {
+    let modules: Vec<&String> = edges.keys().collect();
+    let mut reaches: BTreeMap<&String, BTreeSet<&String>> = modules
+        .iter()
+        .map(|module| {
+            let direct = edges[*module]
+                .iter()
+                .filter_map(|(target, _)| edges.get_key_value(target).map(|(key, _)| key))
+                .collect();
+            (*module, direct)
+        })
+        .collect();
+    // Warshall: `via` is the module a path is allowed to pass through.
+    for via in &modules {
+        for from in &modules {
+            if !reaches[*from].contains(*via) {
+                continue;
+            }
+            let through: Vec<&String> = reaches[*via].iter().copied().collect();
+            reaches.get_mut(*from).expect("module").extend(through);
+        }
+    }
+
+    let mut grouped: Vec<Cycle> = Vec::new();
+    let mut placed: BTreeSet<&String> = BTreeSet::new();
+    for module in &modules {
+        if placed.contains(*module) {
+            continue;
+        }
+        let mutual: Vec<&String> = modules
+            .iter()
+            .copied()
+            .filter(|other| {
+                other == module
+                    || (reaches[*module].contains(*other) && reaches[*other].contains(*module))
+            })
+            .collect();
+        if mutual.len() < 2 {
+            continue;
+        }
+        let names: BTreeSet<&String> = mutual.iter().copied().collect();
+        placed.extend(names.iter().copied());
+        // One line per *edge of the graph*, not per import statement. The
+        // `app`/`surfaces`/`control` component has twenty-one files naming
+        // `crate::app`, and printing all of them buries the two edges that
+        // actually close the loop under a list of the obvious one. The
+        // representative file is the first in path order, with the rest
+        // counted so nobody reads the line as "this is the only place".
+        let mut pairs: BTreeMap<(&String, &String), Vec<&String>> = BTreeMap::new();
+        for member in &names {
+            for (target, file) in &edges[*member] {
+                if let Some(target) = names.get(target) {
+                    pairs.entry((*member, *target)).or_default().push(file);
+                }
+            }
+        }
+        let inner: Vec<String> = pairs
+            .into_iter()
+            .map(|((from, to), mut files)| {
+                files.sort();
+                let more = match files.len() {
+                    1 => String::new(),
+                    n => format!(", and {} more", n - 1),
+                };
+                format!("{from} -> {to}  ({}{more})", files[0])
+            })
+            .collect();
+        grouped.push(Cycle {
+            modules: names.iter().map(|name| (*name).to_owned()).collect(),
+            edges: inner,
+        });
+    }
+    grouped
+}
+
+/// The cycles in one crate, given its directory.
+fn measure_crate(crate_dir: &Path, crate_path: &str, unreadable: &mut Vec<String>) -> Vec<Cycle> {
+    let src = crate_dir.join("src");
+    let mut edges: BTreeMap<String, BTreeSet<(String, String)>> = BTreeMap::new();
+    let mut files: Vec<(String, String)> = Vec::new();
+    collect_sources(&src, &src, &mut files, crate_path, unreadable);
+    for (relative, source) in &files {
+        let Some(module) = module_of(relative) else {
+            continue;
+        };
+        edges.entry(module.clone()).or_default();
+        let production = production_source(source).join("\n");
+        for target in use_targets(&production) {
+            if target == module {
+                continue;
+            }
+            edges
+                .entry(module.clone())
+                .or_default()
+                .insert((target, format!("{crate_path}/src/{relative}")));
+        }
+    }
+    components(&edges)
+}
+
+/// Every `.rs` file under `src`, as `(path relative to src, contents)`.
+fn collect_sources(
+    src: &Path,
+    dir: &Path,
+    out: &mut Vec<(String, String)>,
+    crate_path: &str,
+    unreadable: &mut Vec<String>,
+) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        // A directory the guard cannot list is edges it never saw. Named
+        // rather than skipped: silence here is indistinguishable from clean.
+        unreadable.push(format!(
+            "  {crate_path}: {} could not be listed — edges inside it were not measured",
+            dir.display()
+        ));
+        return;
+    };
+    let mut paths: Vec<_> = entries.flatten().map(|entry| entry.path()).collect();
+    paths.sort();
+    for path in paths {
+        if path.is_dir() {
+            collect_sources(src, &path, out, crate_path, unreadable);
+            continue;
+        }
+        if path.extension().and_then(|ext| ext.to_str()) != Some("rs") {
+            continue;
+        }
+        let Ok(relative) = path.strip_prefix(src) else {
+            continue;
+        };
+        let relative = relative.to_string_lossy().replace('\\', "/");
+        match fs::read_to_string(&path) {
+            Ok(source) => out.push((relative, source)),
+            // Not valid UTF-8 is the encoding guard's finding, not this
+            // one's; unreadable for any other reason is still an unseen
+            // edge, and both are named here rather than passed over.
+            Err(e) => unreadable.push(format!("  {crate_path}/src/{relative}: unreadable: {e}")),
+        }
+    }
+}
+
+/// Cycle counts for every crate in the workspace, sorted by crate path.
+pub fn measure(root: &Path) -> Measured {
+    let mut found = Measured {
+        counts: Vec::new(),
+        cycles: BTreeMap::new(),
+        unreadable: Vec::new(),
+    };
+    let Ok(entries) = fs::read_dir(root.join("crates")) else {
+        return found;
+    };
+    let mut dirs: Vec<_> = entries.flatten().map(|entry| entry.path()).collect();
+    dirs.sort();
+    for dir in dirs {
+        if !dir.join("src").is_dir() {
+            continue;
+        }
+        let name = dir.file_name().unwrap_or_default().to_string_lossy();
+        let crate_path = format!("crates/{name}");
+        let cycles = measure_crate(&dir, &crate_path, &mut found.unreadable);
+        found.counts.push((crate_path.clone(), cycles.len()));
+        found.cycles.insert(crate_path, cycles);
+    }
+    found.counts.sort();
+    found
+}
+
+/// The findings for one crate: the ratchet's verdict, and — whenever there
+/// is one — the components behind the number.
+///
+/// The detail lines carry the same remedy as the verdict, so
+/// [`crate::remedies`] prints the instruction once however many cycles a
+/// crate has.
+fn detailed(found: &Measured, path: &str, verdict: Option<Finding>) -> Vec<Finding> {
+    let Some(verdict) = verdict else {
+        return Vec::new();
+    };
+    let remedy = verdict.remedy;
+    let mut out = vec![verdict];
+    for cycle in found.cycles.get(path).into_iter().flatten() {
+        out.push(Finding::new(
+            format!("    {}", cycle.modules.join(" <-> ")),
+            remedy,
+        ));
+        out.extend(
+            cycle
+                .edges
+                .iter()
+                .map(|edge| Finding::new(format!("      {edge}"), remedy)),
+        );
+    }
+    out
+}
+
+/// What every crate carries that its baseline entry does not.
+fn unrecorded(recorded: &crate::ratchet::Baseline, found: &Measured) -> usize {
+    found
+        .counts
+        .iter()
+        .filter(|(path, _)| recorded.entry(path).is_none())
+        .map(|(_, count)| *count)
+        .sum()
+}
+
+/// Every way the recorded baseline and the module graph disagree.
+pub fn check(root: &Path) -> Vec<Finding> {
+    let sources = root.join("crates");
+    if !sources.is_dir() {
+        // For [`crate::size::check`]'s reason: an unreadable `crates/`
+        // measures as empty, which reports every entry stale — and the
+        // stated remedy for a stale entry is to delete it.
+        return vec![Finding::new(
+            format!(
+                "  {} is not a readable directory — there is nothing to measure, and every \
+                 baseline entry would otherwise be reported stale",
+                sources.display()
+            ),
+            BASELINE_REMEDY,
+        )];
+    }
+    let recorded = match POLICY.baseline(root) {
+        Ok(recorded) => recorded,
+        Err(problem) => return vec![POLICY.unparsed(&problem)],
+    };
+    let found = measure(root);
+    let mut violations: Vec<Finding> = found
+        .unreadable
+        .iter()
+        .map(|line| Finding::new(line.clone(), BASELINE_REMEDY))
+        .collect();
+    for (path, count) in &found.counts {
+        violations.extend(detailed(
+            &found,
+            path,
+            POLICY.verdict(recorded.entry(path), path, *count),
+        ));
+    }
+    violations.extend(POLICY.budget_verdict(&recorded, unrecorded(&recorded, &found)));
+    violations.extend(
+        recorded
+            .entries
+            .iter()
+            .filter(|entry| !found.counts.iter().any(|(path, _)| path == &entry.path))
+            .map(|entry| POLICY.stale(&entry.path)),
+    );
+    violations
+}
+
+/// The same verdict for the crate one edited file belongs to — what the
+/// edit-time hook calls after a write.
+///
+/// A single file cannot answer this question the way it answers a line
+/// count: a cycle is a property of the graph, and the edge an edit adds
+/// closes a loop through modules the file never mentions. So the unit here
+/// is the crate, which is a few dozen small reads rather than a walk of the
+/// workspace.
+pub fn check_file(root: &Path, relative: &str) -> Vec<Finding> {
+    if relative == BASELINE_FILE {
+        return match POLICY.baseline(root) {
+            Ok(recorded) => {
+                let found = measure(root);
+                POLICY
+                    .budget_verdict(&recorded, unrecorded(&recorded, &found))
+                    .into_iter()
+                    .collect()
+            }
+            Err(problem) => vec![POLICY.unparsed(&problem)],
+        };
+    }
+    let Some(crate_name) = crate_of(relative) else {
+        return Vec::new();
+    };
+    let recorded = match POLICY.baseline(root) {
+        Ok(recorded) => recorded,
+        Err(problem) => return vec![POLICY.unparsed(&problem)],
+    };
+    let crate_path = format!("crates/{crate_name}");
+    let mut found = Measured {
+        counts: Vec::new(),
+        cycles: BTreeMap::new(),
+        unreadable: Vec::new(),
+    };
+    let cycles = measure_crate(
+        &root.join("crates").join(&crate_name),
+        &crate_path,
+        &mut found.unreadable,
+    );
+    let count = cycles.len();
+    found.cycles.insert(crate_path.clone(), cycles);
+    let mut violations: Vec<Finding> = found
+        .unreadable
+        .iter()
+        .map(|line| Finding::new(line.clone(), BASELINE_REMEDY))
+        .collect();
+    violations.extend(detailed(
+        &found,
+        &crate_path,
+        POLICY.verdict(recorded.entry(&crate_path), &crate_path, count),
+    ));
+    violations
+}
+
+/// The crate a workspace-relative path belongs to, if it is Rust source
+/// this guard measures.
+fn crate_of(relative: &str) -> Option<String> {
+    let rest = relative.strip_prefix("crates/")?;
+    let (name, inside) = rest.split_once('/')?;
+    let inside = inside.strip_prefix("src/")?;
+    if !inside.ends_with(".rs") {
+        return None;
+    }
+    Some(name.to_owned())
+}
+
+/// Lower any entry whose crate now has fewer cycles than it is signed for.
+/// Down only, like every other ratchet here.
+pub fn tighten(root: &Path) -> Result<Vec<String>, String> {
+    let recorded = POLICY.baseline(root)?;
+    let found = measure(root);
+    let unrecorded = unrecorded(&recorded, &found);
+    POLICY.tighten(root, &found.counts, unrecorded)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn edges(pairs: &[(&str, &str)]) -> BTreeMap<String, BTreeSet<(String, String)>> {
+        let mut map: BTreeMap<String, BTreeSet<(String, String)>> = BTreeMap::new();
+        for (from, to) in pairs {
+            map.entry((*from).to_owned()).or_default();
+            map.entry((*to).to_owned()).or_default();
+            map.entry((*from).to_owned())
+                .or_default()
+                .insert(((*to).to_owned(), format!("{from}.rs")));
+        }
+        map
+    }
+
+    /// The defect PR #282 landed, in miniature: two modules importing each
+    /// other. This is the case the guard exists for, and it must be a
+    /// finding rather than a pass.
+    #[test]
+    fn a_two_module_cycle_is_found() {
+        let found = components(&edges(&[
+            ("paper_report", "paper_trading"),
+            ("paper_trading", "paper_report"),
+        ]));
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].modules, vec!["paper_report", "paper_trading"]);
+        assert_eq!(
+            found[0].edges,
+            vec![
+                "paper_report -> paper_trading  (paper_report.rs)",
+                "paper_trading -> paper_report  (paper_trading.rs)",
+            ]
+        );
+    }
+
+    /// Twenty-one files in the `app` crate name `crate::app`, and they are
+    /// one edge, not twenty-one findings. The count still says so, because
+    /// a line reading like the only site would send an author to fix one
+    /// file and call the cycle broken.
+    #[test]
+    fn many_files_on_one_edge_collapse_to_one_line() {
+        let mut map = edges(&[("control", "app"), ("app", "control")]);
+        for file in ["control/gateway.rs", "control/trade.rs"] {
+            map.get_mut("control")
+                .expect("control")
+                .insert(("app".to_owned(), file.to_owned()));
+        }
+        let found = components(&map);
+        assert_eq!(found.len(), 1);
+        assert_eq!(
+            found[0].edges,
+            vec![
+                "app -> control  (app.rs)",
+                "control -> app  (control.rs, and 2 more)",
+            ]
+        );
+    }
+
+    /// The shape this branch left behind: one module below two others,
+    /// imported by both, importing neither. It must be clean, or the fix
+    /// the guard recommends would itself be a finding.
+    #[test]
+    fn a_shared_module_below_two_others_is_not_a_cycle() {
+        let found = components(&edges(&[
+            ("paper_report", "paper_chrome"),
+            ("paper_trading", "paper_chrome"),
+            ("paper_trading", "paper_report"),
+        ]));
+        assert!(found.is_empty(), "{found:?}");
+    }
+
+    /// Three modules closing a loop the long way round — the
+    /// `app`/`surfaces`/`control` shape. A guard that only looked at pairs
+    /// would call this clean.
+    #[test]
+    fn a_cycle_through_a_third_module_is_found() {
+        let found = components(&edges(&[
+            ("app", "surfaces"),
+            ("surfaces", "control"),
+            ("control", "app"),
+        ]));
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].modules, vec!["app", "control", "surfaces"]);
+    }
+
+    /// Two independent cycles in one crate count as two, not one: the
+    /// baseline number is what a reviewer reads to know how much is left
+    /// to untangle.
+    #[test]
+    fn independent_cycles_are_counted_separately() {
+        let found = components(&edges(&[
+            ("a", "b"),
+            ("b", "a"),
+            ("c", "d"),
+            ("d", "c"),
+            ("a", "c"),
+        ]));
+        assert_eq!(found.len(), 2);
+        assert_eq!(found[0].modules, vec!["a", "b"]);
+        assert_eq!(found[1].modules, vec!["c", "d"]);
+    }
+
+    /// An edge to something the crate has no module for — a re-export of a
+    /// dependency, say — is not an edge inside the crate.
+    #[test]
+    fn an_edge_to_an_unknown_module_is_dropped() {
+        let mut map = edges(&[("a", "b"), ("b", "a")]);
+        map.get_mut("a")
+            .expect("a")
+            .insert(("nowhere".to_owned(), "a.rs".to_owned()));
+        let found = components(&map);
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].modules, vec!["a", "b"]);
+    }
+
+    #[test]
+    fn a_plain_import_names_one_module() {
+        assert_eq!(use_targets("use crate::pane::Pane;\n"), vec!["pane"]);
+    }
+
+    /// The grouped form `control/session.rs` uses. A scan that only read
+    /// the first segment after `crate::` would see no edge here at all,
+    /// and the `app`/`surfaces`/`control` cycle would go unreported.
+    #[test]
+    fn a_grouped_import_names_every_module_in_the_group() {
+        assert_eq!(
+            use_targets(
+                "use crate::{app::QuantickApp, paper_chrome::PositionSummary, tab::Tab};\n"
+            ),
+            vec!["app", "paper_chrome", "tab"]
+        );
+    }
+
+    /// A nested group names items, not modules: only the head counts.
+    #[test]
+    fn a_nested_group_does_not_promote_items_to_modules() {
+        assert_eq!(
+            use_targets("use crate::{drawings::{Drawing, Kind}, theme};\n"),
+            vec!["drawings", "theme"]
+        );
+    }
+
+    #[test]
+    fn a_use_tree_may_span_lines() {
+        assert_eq!(
+            use_targets("use crate::paper_chrome::{\n    caption,\n    pill_toggle,\n};\n"),
+            vec!["paper_chrome"]
+        );
+    }
+
+    #[test]
+    fn a_re_export_is_an_edge_like_any_other() {
+        assert_eq!(
+            use_targets("pub(crate) use crate::paper_report::{HistoryRow, LedgerScope};\n"),
+            vec!["paper_report"]
+        );
+    }
+
+    /// The false positive that would have made the guard untrustworthy on
+    /// its first run: this crate's own doc comments link their siblings
+    /// with `crate::` paths, and none of them is a dependency.
+    #[test]
+    fn a_crate_path_in_prose_is_not_an_edge() {
+        let source = "//! See [`size`](crate::size) — it does not `use crate::size` here.\n\
+                      /// The remedy mentions crate::ratchet too.\n\
+                      let name = \"use crate::pane\";\n";
+        assert!(use_targets(source).is_empty(), "{:?}", use_targets(source));
+    }
+
+    #[test]
+    fn a_renamed_import_still_names_its_module() {
+        assert_eq!(use_targets("use crate::theme as colours;\n"), vec!["theme"]);
+    }
+
+    #[test]
+    fn the_crate_root_is_not_a_module() {
+        assert_eq!(module_of("lib.rs"), None);
+        assert_eq!(module_of("main.rs"), None);
+    }
+
+    #[test]
+    fn a_nested_file_belongs_to_its_top_level_module() {
+        assert_eq!(module_of("control/gateway.rs").as_deref(), Some("control"));
+        assert_eq!(module_of("pane.rs").as_deref(), Some("pane"));
+        assert_eq!(
+            module_of("surfaces/drawing_chrome/mod.rs").as_deref(),
+            Some("surfaces")
+        );
+    }
+
+    /// Test trees are not measured, in both spellings this repo uses.
+    #[test]
+    fn test_trees_are_not_measured() {
+        assert_eq!(module_of("app/tests/mod.rs"), None);
+        assert_eq!(module_of("app/tests/paper_trading_tests.rs"), None);
+        assert_eq!(module_of("resample_tests.rs"), None);
+    }
+
+    #[test]
+    fn only_rust_sources_inside_a_crate_are_routed_to_a_crate() {
+        assert_eq!(crate_of("crates/app/src/pane.rs").as_deref(), Some("app"));
+        assert_eq!(
+            crate_of("crates/guards/src/cycle.rs").as_deref(),
+            Some("guards")
+        );
+        assert_eq!(crate_of("crates/app/Cargo.toml"), None);
+        assert_eq!(crate_of("crates/app/tests/guards.rs"), None);
+        assert_eq!(crate_of("docs/README.md"), None);
+    }
+}

--- a/crates/guards/src/cycle.rs
+++ b/crates/guards/src/cycle.rs
@@ -472,15 +472,21 @@ fn detailed(found: &Measured, path: &str, verdict: Option<Finding>) -> Vec<Findi
     out
 }
 
-/// What every crate carries that its baseline entry does not.
-fn unrecorded(recorded: &crate::ratchet::Baseline, found: &Measured) -> usize {
-    found
-        .counts
-        .iter()
-        .filter(|(path, _)| recorded.entry(path).is_none())
-        .map(|(_, count)| *count)
-        .sum()
-}
+/// What the budget counts outside the baseline: nothing.
+///
+/// [`crate::context`] passes a real sum here because a tracked file can be
+/// split into sub-threshold pieces whose weight the ceilings stop seeing.
+/// Nothing can hide below a threshold of zero, so this ratchet passes `0`
+/// like [`crate::size`] does, and the budget stays a pure statement of
+/// signed permissions.
+///
+/// Written as a named constant rather than a literal at the two call sites
+/// because the first version summed the unrecorded counts, and every new
+/// cycle in an unlisted crate then reported *twice* — once as a crate over
+/// its threshold, once as a repository over budget, each with a different
+/// remedy. Two instructions for one defect is how an author ends up
+/// following the wrong one.
+const UNRECORDED: usize = 0;
 
 /// Every way the recorded baseline and the module graph disagree.
 pub fn check(root: &Path) -> Vec<Finding> {
@@ -515,7 +521,7 @@ pub fn check(root: &Path) -> Vec<Finding> {
             POLICY.verdict(recorded.entry(path), path, *count),
         ));
     }
-    violations.extend(POLICY.budget_verdict(&recorded, unrecorded(&recorded, &found)));
+    violations.extend(POLICY.budget_verdict(&recorded, UNRECORDED));
     violations.extend(
         recorded
             .entries
@@ -535,17 +541,13 @@ pub fn check(root: &Path) -> Vec<Finding> {
 /// is the crate, which is a few dozen small reads rather than a walk of the
 /// workspace.
 pub fn check_file(root: &Path, relative: &str) -> Vec<Finding> {
+    // The whole scan, not just the budget: with a threshold of zero every
+    // entry in this baseline is load-bearing, so *lowering* one below its
+    // crate's real count is the edit that matters here — and a hook that
+    // answered only the budget would have called that edit clean and left
+    // the suite to find it. The scan is a few hundred small reads.
     if relative == BASELINE_FILE {
-        return match POLICY.baseline(root) {
-            Ok(recorded) => {
-                let found = measure(root);
-                POLICY
-                    .budget_verdict(&recorded, unrecorded(&recorded, &found))
-                    .into_iter()
-                    .collect()
-            }
-            Err(problem) => vec![POLICY.unparsed(&problem)],
-        };
+        return check(root);
     }
     let Some(crate_name) = crate_of(relative) else {
         return Vec::new();
@@ -595,10 +597,8 @@ fn crate_of(relative: &str) -> Option<String> {
 /// Lower any entry whose crate now has fewer cycles than it is signed for.
 /// Down only, like every other ratchet here.
 pub fn tighten(root: &Path) -> Result<Vec<String>, String> {
-    let recorded = POLICY.baseline(root)?;
     let found = measure(root);
-    let unrecorded = unrecorded(&recorded, &found);
-    POLICY.tighten(root, &found.counts, unrecorded)
+    POLICY.tighten(root, &found.counts, UNRECORDED)
 }
 
 #[cfg(test)]
@@ -798,6 +798,41 @@ mod tests {
         assert_eq!(module_of("app/tests/mod.rs"), None);
         assert_eq!(module_of("app/tests/paper_trading_tests.rs"), None);
         assert_eq!(module_of("resample_tests.rs"), None);
+    }
+
+    /// The hook and the suite must say the same thing about the same
+    /// crate. Both sibling ratchets pin this, and the failure it forbids is
+    /// the worst one a guard has: an author edits, is told nothing, and
+    /// finds the violation in CI.
+    #[test]
+    fn check_file_agrees_with_the_whole_repo_scan() {
+        let root = crate::workspace_root();
+        let scan = check(&root);
+        let whole: Vec<&str> = scan.iter().map(|f| f.line.as_str()).collect();
+        for (crate_path, _) in measure(&root).counts {
+            let source = ["src/lib.rs", "src/main.rs"]
+                .into_iter()
+                .map(|tail| format!("{crate_path}/{tail}"))
+                .find(|candidate| root.join(candidate).is_file())
+                .unwrap_or_else(|| panic!("{crate_path} has a crate root"));
+            let single = check_file(&root, &source);
+            let prefix = format!("  {crate_path}: ");
+            assert_eq!(
+                single
+                    .iter()
+                    .filter(|f| f.line.starts_with(&prefix))
+                    .count(),
+                whole.iter().filter(|l| l.starts_with(&prefix)).count(),
+                "the two surfaces disagree about whether {crate_path} has a verdict"
+            );
+            for finding in &single {
+                assert!(
+                    whole.contains(&finding.line.as_str()),
+                    "the hook reports `{}` for {crate_path} and the scan does not",
+                    finding.line
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/guards/src/lib.rs
+++ b/crates/guards/src/lib.rs
@@ -102,6 +102,25 @@ pub fn remedies(findings: &[Finding]) -> Vec<&'static str> {
     out
 }
 
+/// The half of a guard that rations a measurable quantity and can therefore
+/// lower its own recorded numbers.
+///
+/// Carried on the [`Guard`] rather than listed a second time in the binary.
+/// The first version of the cycle ratchet was registered in three places —
+/// [`GUARDS`], the tighten list in `main.rs`, and the CI test file — and only
+/// the third had a drift check. A ratchet added to the registry and forgotten
+/// in the binary tightens nothing, silently, which is the failure shape this
+/// crate exists to remove.
+pub struct Ratchet {
+    /// Lower every entry whose measurement has fallen, and the budget with
+    /// them. One line per entry rewritten.
+    pub tighten: fn(&Path) -> Result<Vec<String>, String>,
+    /// The baseline it rewrites, workspace-relative, for the success line.
+    pub baseline_file: &'static str,
+    /// The gap below the budget it tolerates, for the nothing-to-do line.
+    pub budget_slack: usize,
+}
+
 /// One guard, so the binary and the tests name the same things in the same
 /// order.
 pub struct Guard {
@@ -111,6 +130,9 @@ pub struct Guard {
     pub check: fn(&Path) -> Vec<Finding>,
     /// Every violation in one file, for the edit-time hook.
     pub check_file: fn(&Path, &str) -> Vec<Finding>,
+    /// Present only for a guard built on [`ratchet::Policy`]. `None` for the
+    /// scans — [`language`] and [`encoding`] have no numbers to lower.
+    pub ratchet: Option<Ratchet>,
 }
 
 /// Every guard this crate runs.
@@ -119,25 +141,42 @@ pub const GUARDS: &[Guard] = &[
         name: "size",
         check: size::check,
         check_file: size::check_file,
+        ratchet: Some(Ratchet {
+            tighten: size::tighten,
+            baseline_file: size::BASELINE_FILE,
+            budget_slack: size::BUDGET_SLACK,
+        }),
     },
     Guard {
         name: "context",
         check: context::check,
         check_file: context::check_file,
+        ratchet: Some(Ratchet {
+            tighten: context::tighten,
+            baseline_file: context::BASELINE_FILE,
+            budget_slack: context::BUDGET_SLACK,
+        }),
     },
     Guard {
         name: "cycle",
         check: cycle::check,
         check_file: cycle::check_file,
+        ratchet: Some(Ratchet {
+            tighten: cycle::tighten,
+            baseline_file: cycle::BASELINE_FILE,
+            budget_slack: cycle::BUDGET_SLACK,
+        }),
     },
     Guard {
         name: "language",
         check: language::check,
         check_file: language::check_file,
+        ratchet: None,
     },
     Guard {
         name: "encoding",
         check: encoding::check,
         check_file: encoding::check_file,
+        ratchet: None,
     },
 ];

--- a/crates/guards/src/lib.rs
+++ b/crates/guards/src/lib.rs
@@ -1,7 +1,8 @@
 //! Repository guards for the things the compiler cannot see.
 //!
-//! Three rules hold in this repo that no amount of `cargo build` can check: a
-//! file may not silently absorb a crate ([`size`]), everything written into a
+//! Four rules hold in this repo that no amount of `cargo build` can check: a
+//! file may not silently absorb a crate ([`size`]), a crate's modules may not
+//! weld themselves into a cycle ([`cycle`]), everything written into a
 //! tracked file is English ([`language`]), and sources are UTF-8 without a BOM
 //! and without welded doc comments ([`encoding`]). Each is a rule
 //! `CLAUDE.md` states and each fails invisibly — fmt, clippy, build and the
@@ -35,6 +36,7 @@
 //! was born inside.
 
 pub mod context;
+pub mod cycle;
 pub mod encoding;
 pub mod language;
 pub mod ratchet;
@@ -122,6 +124,11 @@ pub const GUARDS: &[Guard] = &[
         name: "context",
         check: context::check,
         check_file: context::check_file,
+    },
+    Guard {
+        name: "cycle",
+        check: cycle::check,
+        check_file: cycle::check_file,
     },
     Guard {
         name: "language",

--- a/crates/guards/src/main.rs
+++ b/crates/guards/src/main.rs
@@ -18,7 +18,7 @@
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
-use quantick_guards::{GUARDS, context, cycle, ratchet, remedies, size, workspace_root};
+use quantick_guards::{GUARDS, ratchet, remedies, workspace_root};
 
 /// Turn whatever the caller typed into the workspace-relative spelling with
 /// forward slashes that every guard is keyed on.
@@ -144,37 +144,26 @@ fn report(root: &std::path::Path, only: Option<String>) -> ExitCode {
 /// Lower every baseline entry whose file has shrunk past the slack, and the
 /// `!budget` total with it. Both directions are down only.
 ///
-/// Every ratchet runs. A command that tightened code and quietly left the
-/// context or cycle ceilings stale would report the good news it happened to
-/// know about, and the author would find the other half as a failing test
-/// later — which is exactly the shape of surprise this flag exists to
-/// remove.
+/// Every ratchet in the registry runs, and the registry is the only list —
+/// a ratchet named here as well would be one somebody could add to `GUARDS`
+/// and forget, after which it tightens nothing and says so nowhere. A
+/// command that tightened code and quietly left the context or cycle
+/// ceilings stale would report the good news it happened to know about, and
+/// the author would find the other half as a failing test later, which is
+/// exactly the shape of surprise this flag exists to remove.
 fn tighten(root: &std::path::Path) -> ExitCode {
     let mut failed = false;
-    for outcome in [
-        tighten_one(
+    for guard in GUARDS {
+        let Some(ratchet) = &guard.ratchet else {
+            continue;
+        };
+        failed |= tighten_one(
             root,
-            "size",
-            size::tighten(root),
-            size::BASELINE_FILE,
-            size::BUDGET_SLACK,
-        ),
-        tighten_one(
-            root,
-            "context",
-            context::tighten(root),
-            context::BASELINE_FILE,
-            context::BUDGET_SLACK,
-        ),
-        tighten_one(
-            root,
-            "cycle",
-            cycle::tighten(root),
-            cycle::BASELINE_FILE,
-            cycle::BUDGET_SLACK,
-        ),
-    ] {
-        failed |= outcome;
+            guard.name,
+            (ratchet.tighten)(root),
+            ratchet.baseline_file,
+            ratchet.budget_slack,
+        );
     }
     if failed {
         ExitCode::FAILURE

--- a/crates/guards/src/main.rs
+++ b/crates/guards/src/main.rs
@@ -18,7 +18,7 @@
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
-use quantick_guards::{GUARDS, context, ratchet, remedies, size, workspace_root};
+use quantick_guards::{GUARDS, context, cycle, ratchet, remedies, size, workspace_root};
 
 /// Turn whatever the caller typed into the workspace-relative spelling with
 /// forward slashes that every guard is keyed on.
@@ -144,10 +144,11 @@ fn report(root: &std::path::Path, only: Option<String>) -> ExitCode {
 /// Lower every baseline entry whose file has shrunk past the slack, and the
 /// `!budget` total with it. Both directions are down only.
 ///
-/// Both ratchets run. A command that tightened code and quietly left the
-/// context ceilings stale would report the good news it happened to know
-/// about, and the author would find the other half as a failing test later —
-/// which is exactly the shape of surprise this flag exists to remove.
+/// Every ratchet runs. A command that tightened code and quietly left the
+/// context or cycle ceilings stale would report the good news it happened to
+/// know about, and the author would find the other half as a failing test
+/// later — which is exactly the shape of surprise this flag exists to
+/// remove.
 fn tighten(root: &std::path::Path) -> ExitCode {
     let mut failed = false;
     for outcome in [
@@ -164,6 +165,13 @@ fn tighten(root: &std::path::Path) -> ExitCode {
             context::tighten(root),
             context::BASELINE_FILE,
             context::BUDGET_SLACK,
+        ),
+        tighten_one(
+            root,
+            "cycle",
+            cycle::tighten(root),
+            cycle::BASELINE_FILE,
+            cycle::BUDGET_SLACK,
         ),
     ] {
         failed |= outcome;

--- a/crates/guards/src/size.rs
+++ b/crates/guards/src/size.rs
@@ -216,12 +216,24 @@ fn baseline(root: &Path) -> Result<Baseline, String> {
 /// Test code above the module therefore costs nothing, and production code
 /// below it is counted — which is the direction a ratchet should err in.
 pub fn production_lines(source: &str) -> usize {
+    production_source(source).len()
+}
+
+/// The production lines themselves, in file order — the same law as
+/// [`production_lines`], which is now a count of what this returns.
+///
+/// Split out for [`crate::cycle`], which reads `use crate::` statements and
+/// must not see the ones a test module writes to reach a fixture. Two copies
+/// of "where does the test code start?" would drift, and the first symptom
+/// would be a cycle guard that fires on a test import — the false positive
+/// that gets a guard switched off.
+pub fn production_source(source: &str) -> Vec<&str> {
     let lines: Vec<&str> = source.lines().collect();
-    let mut production = 0;
+    let mut production = Vec::new();
     let mut index = 0;
     while index < lines.len() {
         if lines[index] != "#[cfg(test)]" {
-            production += 1;
+            production.push(lines[index]);
             index += 1;
             continue;
         }

--- a/crates/guards/tests/guards.rs
+++ b/crates/guards/tests/guards.rs
@@ -1,4 +1,4 @@
-//! The four repository guards, as the tests CI runs.
+//! The five repository guards, as the tests CI runs.
 //!
 //! Each is a thin shell over the library: the logic, its rationale and its
 //! unit tests live in the module the failure names, and this file exists so
@@ -17,7 +17,7 @@ use quantick_guards::{GUARDS, remedies, workspace_root};
 /// instead of a green suite over a guard CI never runs — which is the failure
 /// the check exists to prevent, and which a hand-kept list of names invites by
 /// making "add the string" the obvious fix.
-const TESTED: [&str; 4] = ["size", "language", "encoding", "context"];
+const TESTED: [&str; 5] = ["size", "language", "encoding", "context", "cycle"];
 
 /// Run one named guard and fail with everything it found.
 fn assert_clean(name: &str) {
@@ -75,4 +75,12 @@ fn every_guard_in_the_registry_has_a_test_here() {
 #[test]
 fn no_context_file_grows_past_its_recorded_ceiling() {
     assert_clean(TESTED[3]);
+}
+
+/// The one this repository learned the hard way twice: a refactor that
+/// welds two modules into a cycle leaves fmt, clippy, the build and the
+/// whole suite green. This is the test that stops being green.
+#[test]
+fn no_crate_grows_a_module_cycle_past_its_recorded_ceiling() {
+    assert_clean(TESTED[4]);
 }


### PR DESCRIPTION
Break the app crate's remaining module cycle (`paper_report` ↔ `paper_trading`)
by moving the shared presentation vocabulary into a neutral module below both,
then add a cycle guard to `crates/guards` so the next refactor that welds two
modules together fails the build instead of being found by hand months later.

**Mission tier: `medium`.** Goal file, request ledger and criteria:
`.claude/GOAL-archive-no-module-cycles.md`.

## Why

This is the second module cycle in the app crate in three days. PR #285 broke an
`app`/`pane`/`tab` cycle by hand; PR #282 — a well-reviewed refactor that split
the paper surfaces in two — introduced this one in the same week, and nothing in
the repository saw it. Not fmt, not clippy, not the build, not the suite, not two
rounds of review. Cargo forbids a dependency cycle *between* crates and permits
one *inside* a crate, so a green build says nothing at all about it.

## The cycle, gone

`paper_report` imported thirteen items from `paper_trading` while `paper_trading`
re-exported `HistoryRow`, `LedgerAction` and `LedgerScope` back. Eleven of the
thirteen move down into `paper_chrome`, a new module whose entire set of
crate-internal imports is:

```rust
use crate::theme;
```

`fmt_offset_minute` and `today` land in `paper_calendar` instead. Both need
`CivilDate` and `civil_utc`, which `paper_calendar` owns, and `paper_calendar`
paints its day cells with `points_color` and `fmt_signed_points`. Hosting all
thirteen in one module would have pointed the new module back at the calendar
that imports it — one cycle traded for another, in the module built to prevent
it. Both homes are neutral modules below `paper_report` and `paper_trading`,
which is what the request asked for; the split is recorded as **S8** in the goal
file.

`paper_report` now names `paper_trading` nowhere in production code:

```
$ grep -n 'paper_trading' crates/app/src/paper_report.rs
5://! from `paper_trading` because the writing half — placing orders,
787:    /// with `paper_trading` because they drive a real journal on disk. They
3312:    use crate::paper_trading::PaperTrading;   <- inside `#[cfg(test)] mod tests` (line 3308)
```

The facade stays, unchanged, exactly as the request allowed — it is
one-directional now that the other edge is gone:

```rust
pub(crate) use crate::paper_report::{HistoryRow, LedgerAction, LedgerScope};
```

Every caller of a moved helper is repointed at its new home, so `paper_calendar`
and `paper_home` no longer reach into `paper_trading` for a formatter either.
Tests travelled with their items: `symbols_sanitize_without_losing_venue_spellings`,
`signed_points_always_carry_their_sign` and `durations_format_by_magnitude` to
`paper_chrome`; the `fmt_offset_minute` half of
`utc_dates_format_from_the_same_civil_math` to `paper_calendar` as
`display_stamps_read_on_the_display_clock`. Behaviour is unchanged, and
`the_report_numbers_are_fixed` — the byte-for-byte pin on a whole report — is
untouched and green.

## The guard

`crates/guards/src/cycle.rs` is a third instance of the `ratchet::Policy` that
`size` and `context` already share: same baseline parser, same `!budget`, same
`--tighten`. It reads the `use crate::` statements of a crate's **production**
modules — test code excluded through `size::production_source`, split out of
`production_lines` so the two guards share one answer to "where does the test
code start?" — groups top-level modules into strongly connected components, and
reports every component larger than one with the edges that close it.

Inline `crate::foo` paths are deliberately not edges. Counting them reports the
guards crate itself as a three-way cycle purely from ``[`size`](crate::size)``
doc links, and a guard whose first output is a false positive is a guard that
gets switched off. Grouped `use crate::{a::X, b::Y}` trees *are* parsed, by hand
rather than by regular expression — which is how the guard found a cycle the
throwaway prototype had missed.

### The baseline does not start at zero, and here is why

The request asked for a baseline starting at zero. It cannot: the repository has
more than one cycle. Measured before any code was written, and confirmed by the
guard itself on its first run, there are three this branch had no mandate to
touch. The trader chose to sign what exists rather than rewrite two
architectures in the branch that adds the guard (**D1**), so every crate not
listed is capped at zero — the threshold — and a new cycle anywhere fails.

```
crates/app 1        # app -> surfaces -> control -> app
crates/control 1    # error <-> wire
crates/trading 1    # events <-> position
!budget 3
```

`crates/control` was found by the guard, not by anyone reading the crate: both
imports there are grouped `use crate::{...}` trees, which the prototype's
regular expression could not see. That miss is why the parser is written by
hand, and it is recorded as **S9**.

### Proof it would have caught PR #282

On `origin/main`, with this baseline, the guard exits 1 and names the defect:

```
$ QUANTICK_GUARDS_ROOT=<origin/main worktree> quantick-guards ; echo $?
cycle: 8 finding(s)
  crates/app: 2 module cycles, ceiling 1 (+1)
    app <-> control <-> surfaces
      app -> surfaces  (crates/app/src/app.rs)
      control -> app  (crates/app/src/control/actions.rs, and 19 more)
      surfaces -> control  (crates/app/src/surfaces/agent_popup.rs)
    paper_report <-> paper_trading
      paper_report -> paper_trading  (crates/app/src/paper_report.rs)
      paper_trading -> paper_report  (crates/app/src/paper_trading.rs)
1
```

On this branch it exits 0. `--tighten` drives the cycle baseline down and never
up, verified by setting `crates/app 2` / `!budget 4` and watching it rewrite
both back to 1 and 3.

## Review

**step 0: code-review at `low` (effort-first, no reuse notice) — round 1: 3
findings, 3 confirmed; round 2: 1, confirmed; round 3: 1, confirmed.** The level
is one notch below the `medium` tier per the skill's table; the tier was read
from the branch's `mission-tier` file and agrees with the goal file's
`**Tier:**` line.

**The round budget is spent, and the shape is worth stating.** Findings went
3 → 1 → 1, and round 3's finding sits inside round 2's own fix. That is the
"flat, and in the last round's code" pattern: the hand-written comment handling
in `use_targets` is accreting special cases one review at a time. It is not a
Blocker, so it defers rather than holding the branch.

Fixed in `a578dcf`:

1. **Should-fix — `crates/guards/src/cycle.rs` `check_file`.** A write to
   `cycle-baseline.txt` ran only the budget verdict, so *lowering* an entry
   below its crate's real count passed the edit-time hook silently. With a
   threshold of zero every entry is load-bearing; it now runs the whole scan.
2. **Should-fix — `crates/guards/src/cycle.rs` `check`.** The budget was passed
   the unrecorded cycle total, copied from the context ratchet, where a file
   really can be split into sub-threshold pieces the ceilings stop seeing.
   Nothing hides below a threshold of zero, so one new cycle in an unlisted
   crate reported *twice* with two different remedies. Now passes zero, like the
   size ratchet.
3. **Should-fix — `crates/app/src/paper_chrome.rs`.** The module doc had the
   layering upside down: it claimed `paper_calendar` sits below the new module
   while the same branch has the calendar importing from it.
4. **Should-fix — `crates/guards/src/main.rs`.** Registering the ratchet took
   three edits, and only `tests/guards.rs` had a drift check; a fourth ratchet
   added to `GUARDS` and forgotten in the binary would have tightened nothing
   and said so nowhere. `--tighten` is now driven from `GUARDS`, with the
   tighten half on the `Guard` as an `Option<Ratchet>`, so the next one is a
   registration and not three.
5. **Should-fix — `crates/guards/src/cycle.rs` tests.** No
   `check_file_agrees_with_the_whole_repo_scan`, which both siblings carry.

Fixed in `0749040`:

6. **Should-fix — `use_targets`.** The scan stopped at the first `;`, so
   `use crate::a::X; use crate::b::Y;` was one edge instead of two. A missed
   edge is a missed cycle, and a guard whose claim is "clean means clean" may
   not lean on `cargo fmt --check` for that claim. The scan now continues past
   the `;`, and cuts each line at `//` first — without which reading further
   would have let a comment beside or inside a use tree invent modules. Three
   tests, one per case.

### Deferred — Should-fix, follow-up

7. **`crates/guards/src/cycle.rs` `fn code` — block comments are not stripped.**
   The comment cutter handles `//` only, so `use crate::foo::Bar;` inside a
   `/* … */` block would parse as a real statement and contribute a phantom
   edge — a build failure on commented-out code, the exact false positive the
   module doc forbids. **Unreachable today**: the Rust tree contains zero block
   comments (all three `/*` matches are glob patterns inside doc comments). The
   fix is not a third special case in `fn code` but one comment-stripping pass
   that handles both forms; it is deferred because the three-round review budget
   is spent and this is not a Blocker.

**delivery-review: PASS**, completeness pass only, as `medium` prescribes — no
criteria pass ran. Twelve atomic asks derived from the verbatim request, all
twelve carried by the ledger, nothing `UNLEDGERED`. Two premises were checked
rather than waved through: the request's word "*remaining*" (singular) is false
— `crates/app` had two cycles and keeps one, which `D1` records the trader
deciding to sign — and "fails the build", which this guard does through
`cargo test --workspace` exactly as `size`, `context`, `language` and `encoding`
do, which is the standing the request itself asked for.

## Verification

- [x] `cargo fmt --all -- --check` — exit 0
- [x] `cargo clippy --workspace --all-targets` — exit 0
- [x] `cargo build --workspace` — exit 0
- [x] `cargo test --workspace` — exit 0, 90 suites, 0 failed
- [x] `sh .claude/hooks/guardrails_test.sh` — 96 passed, 0 failed

**Performance.** No path runs per trade, per depth update or per frame. The
moved helpers are the same functions at a new address, called from the same
places. The guard runs in `cargo test` and in the edit-time hook, never in the
app: the whole-repo scan reads every `.rs` under `crates/` once and does an
O(V³) closure per crate over at most ~100 modules, landing inside the guards
suite's 0.4 s; the hook path measures one crate. `production_lines` now
allocates the `Vec` it counts — rare path, unmeasurable.

**Accumulation.** Trunk shrank: `paper_trading.rs` is 176 production lines
lighter. No size or context ceiling was raised — the `CLAUDE.md` and `AGENTS.md`
additions were trimmed to fit under the existing ones rather than paid for.
`paper_chrome.rs` and `cycle.rs` are both well under the 1,500-line threshold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H17SAchmAL3E8VwbFXPf61
