### PR TITLE
fix(tests): give every test a scratch directory it owns

### DIFF
--- a/.claude/GOAL-archive-tests-own-their-scratch.md
+++ b/.claude/GOAL-archive-tests-own-their-scratch.md
@@ -1,0 +1,240 @@
+# Mission: tests own their scratch
+
+**Objective** — Make every disk-writing test own a unique, self-removing
+scratch directory, so a red test means the change is wrong rather than that
+Windows reused a process id.
+
+**Why it matters** — `docs/agentic-development.md` §The gates rests on one
+property: a red means the change is wrong, so an agent can trust the signal
+instead of first proving the repository innocent. Two recorded flakes break it
+today, both rooted in a temp path keyed on `process::id()` alone and never
+removed: three `paper_trading` tests fail on a reused pid, and CI drops one app
+test at random on `main` too. The leak is also large — `%TEMP%` on the host
+held 450,227 `quantick-*` entries on 2026-09-04.
+
+**Tier:** `medium`. The work spans roughly forty call sites across five crates,
+which is past the `small` ceiling, and the criterion that actually matters —
+the suite leaves the temp directory as it found it — needs `delivery-review` to
+check it was *proved* rather than asserted. Not `high`: the change is
+mechanical once the helper exists, touches no trading logic, no UI and no hot
+path.
+
+## Request ledger
+
+| # | Ask |
+| --- | --- |
+| **R1** | Give each crate that needs it **one** scratch helper yielding a unique-per-run directory that **removes the tree on `Drop`** — verbatim, "a `ScratchDir` that builds `temp_dir()/quantick-<crate>-<pid>-<nanos-since-epoch>-<counter>` and removes the tree on `Drop`". `app` and the `mcp` tests need one; `replay` already has `src/scratch.rs`. |
+| **R2** | Add no new dependency unless the mission shows `std` cannot do it; a reach for `tempfile` goes through `[workspace.dependencies]` and runs `cargo deny check bans licenses`. |
+| **R3** | Route **every test-side temp path** through the helper — each site in evidence-ledger #4 that is test-side. |
+| **R4** | Leave the legitimate production sites of evidence-ledger #5 untouched: the `control-local` instance descriptor and client, the MCP link, the guards' own scratch. |
+| **R5** | Prove the suite is clean: count `quantick-*` entries in `temp_dir()` before and after the suite and assert the delta is zero. |
+| **R6** | A test that must leave a file for a later assertion keeps its `ScratchDir` alive until then — verbatim, "it keeps the `ScratchDir` alive until then". |
+| **R7** | Put **a one-line sweep in the PR body, not in code**, for the operator to clear the 450k leftovers once. The mission deletes nothing on the host. |
+| **R8** | Retire the two memory-level workarounds by pointing at the fix: the PR body says `paper-trading-tests-flake-on-pid-reuse` and `gateway-wait-for-change-ci-flake` no longer apply. |
+| **R9** | `grep -rn 'process::id()' crates --include=*.rs` returns only production sites, **each named in the PR body with why it is legitimate**. |
+| **R10** | The three tests of evidence-ledger #2 pass **ten consecutive runs** of `cargo test -p quantick-app paper_trading` on this host. |
+| **R11** | The temp-directory delta check exists, runs in the ordinary verification loop, and is green. |
+| **R12** | `cargo test --workspace` twice in a row from one shell leaves `ls $TEMP \| grep -c quantick-` unchanged between runs. |
+| **R13** | The four-check loop green, `cargo test -p quantick-guards` green, **no size ceiling raised** — helpers stay small and live in test modules or `tests/`. |
+| **R14** | Verify every claim in the brief's evidence ledger before acting, rather than trusting it. |
+| **R15** | Respect the parallel branches: nothing in `pane.rs` tests (`refactor/pane-tests-out`), nothing in `paper_trading.rs` beyond `test_scratch_dir` and its callers plus that file's own test module (`fix/generated-truth`), no dependence on `refactor/orderflow-crate`. |
+| **R16** | *(purpose, and the ask that judges the others)* A red means the change is wrong: the two recorded flakes stop happening, so an agent can trust the signal instead of proving the repository innocent. |
+
+## Decisions taken by the trader
+
+- **D1** *(answers the contradiction between the brief's scope 2 and its
+  criterion 1)* — The three test-only paths that live in **production files
+  behind `cfg!(test)`** are **in scope**: `store_home::test_path`
+  (`store_home.rs:281`), `paper_home::startup_home` (`paper_home.rs:107`) and
+  `paper_state::scratch_path` (`paper_state.rs:163`). They are test-side in
+  fact and are the largest leak — one cockpit home per app a test builds — and
+  criterion R9 cannot be met without them. Cleanup there needs an owner; a
+  test-only `Drop` on `QuantickApp` plus an explicit release in
+  `store_home::next_test_home` is the expected shape.
+- **D2** *(answers how R5 is proved, since no test inside the suite can observe
+  the state **after** the suite)* — Both halves: a **new static guard** in
+  `quantick-guards` that fails any raw `temp_dir()` in test-side code, so the
+  next regression is caught on every commit and in CI; **and** a measured
+  before/after count around `cargo test --workspace`, whose output goes in the
+  PR body. The guard covers the future, the measurement proves the present.
+
+## Assumptions
+
+- **S1** — The unique-per-run token is computed **once per process**
+  (`pid` + nanos since the epoch, in a `OnceLock`), not once per call. A
+  per-call nanos read would make two resolutions of a stable path disagree,
+  which is exactly what `store_home::test_path`'s comment forbids. The
+  per-call counter still distinguishes sibling directories within a run.
+- **S2** — The scratch helper stays `std`-only. `std::fs::remove_dir_all`,
+  `SystemTime::UNIX_EPOCH` and `AtomicU64` cover every requirement, so R2's
+  escape hatch is not taken and `cargo deny` is not needed. Recorded rather
+  than asked because R2 states the default and the code answers it.
+- **S3** — The helper is **per crate**, not a shared crate. A new workspace
+  crate for eight lines of test support would add a dependency edge from every
+  crate that tests to a new leaf, which `CLAUDE.md`'s dependency rule and the
+  context budget both argue against. `replay`'s existing `src/scratch.rs` is
+  the precedent the mission follows.
+- **S4** *(wanted to ask; the reading taken)* — The helper **never deletes a
+  directory it did not create**. A sweep of stale `quantick-*` entries at test
+  start would drain the host's 450k backlog automatically, but R7 says the
+  operator does that once, by hand, from the PR body; a helper that deletes
+  other runs' folders could also delete a live parallel run's. Unasked because
+  the brief's "the mission does not delete anything on the host" answers it,
+  and reversing it is a one-line change.
+- **S5** *(wanted to ask; the reading taken)* — A directory that a test
+  deliberately hands to a **spawned child process** or to the gateway keeps its
+  guard alive for the whole test body (R6), rather than being detached. If a
+  specific test turns out to need the directory to outlive the test, that test
+  is listed in the PR body as an exception with its reason.
+- **S7** *(supersedes D1's parenthetical about the cleanup owner)* — The
+  owner for the `cfg!(test)` paths is a **thread-local guard**, not a
+  test-only `Drop` on `QuantickApp`. libtest runs each test on a thread it
+  spawned, and a spawned thread runs its thread-local destructors on exit, so
+  the thread is an owner that already exists — where a `Drop` on `QuantickApp`
+  would have meant touching every test that moves out of an app, for the same
+  effect. The trader's decision was that the three paths are in scope; the
+  mechanism was mine. It leaks in `--test-threads=1`, where libtest uses the
+  main thread and the process exits without running its destructors: a bounded
+  handful of directories, in a mode neither CI nor an agent runs.
+- **S8** — The guard's rule is **"only a crate's own scratch module may ask
+  for the temporary directory"**, not "no `temp_dir()` inside `#[cfg(test)]`".
+  Deciding whether a line is test-side needs a Rust parser, and the guard crate
+  has no dependencies at all; the module-allowlist rule needs none, is
+  reviewable at a glance, and catches strictly more — including
+  `store_home::test_path` and its siblings, which are test-only paths in
+  production files that no `#[cfg(test)]` rule would have seen.
+- **S9** — **Five scratch modules, one per crate that needs one**, rather than
+  a shared crate. A shared one would be a new workspace crate that every crate
+  with tests depends on, which `CLAUDE.md`'s dependency rule argues against and
+  R2's "no new dependency" forbids outright; `guards` may depend on nothing at
+  all, and an `mcp` integration test links the crate as a dependency and cannot
+  see its `#[cfg(test)]` items, so `mcp` needs two. The guard names all five,
+  which is what keeps them from drifting.
+- **S10** — Two directories are deliberately **not created**: the gateway's
+  instances directory and `control-local`'s discovery directory. Discovery
+  refuses a descriptor folder whose ACL is not already private, and a folder
+  `ScratchDir` creates carries the default one. Found by `control-local`
+  failing outright, and it explains a gateway test that was dropping at random.
+- **S6** — "Removes the tree on `Drop`" is best-effort: `Drop` ignores I/O
+  errors, exactly as `replay`'s `Scratch` does today. A test binary killed
+  mid-run still leaks, and no `std` mechanism prevents that.
+
+## Acceptance criteria
+
+- [ ] **A1** — `crates/app` has exactly one scratch helper, a `ScratchDir`
+      building `temp_dir()/quantick-app-<pid>-<nanos>-<counter>` and removing
+      the tree on `Drop`; `crates/mcp`'s integration tests have one; `replay`'s
+      existing `Scratch` is aligned to the same unique-per-run token.
+      *Evidence:* the helper source, plus a unit test asserting two `ScratchDir`
+      values differ and that the path is gone after the value drops.
+      → the new `scratch` modules and their tests. *(R1)*
+- [ ] **A2** — No new workspace dependency; `Cargo.toml`'s
+      `[workspace.dependencies]` is unchanged.
+      *Evidence:* `git diff origin/main -- Cargo.toml Cargo.lock` empty.
+      → PR body. *(R2)*
+- [ ] **A3** — Every test-side temp path resolves through a helper: no raw
+      `std::env::temp_dir()` remains in test-side code across the workspace.
+      *Evidence:* the new guard's output, green.
+      → PR body. *(R3, R5)*
+- [ ] **A4** — The production sites of evidence-ledger #5 are untouched, and
+      `grep -rn 'process::id()' crates --include=*.rs` returns only production
+      sites, each named in the PR body with why it is legitimate.
+      *Evidence:* the grep output and the diff over those files.
+      → PR body. *(R4, R9)*
+- [ ] **A5** — A new `quantick-guards` check fails any raw `temp_dir()` in
+      test-side code, runs in `cargo test -p quantick-guards`, and is green on
+      this branch.
+      *Evidence:* the guard's name, its own unit tests, and the run output.
+      → PR body. *(R5, R11, D2)*
+- [ ] **A6** — The three tests of evidence-ledger #2 —
+      `an_in_session_rerun_opens_its_own_file`,
+      `the_ledger_never_lists_this_sessions_trades_twice_after_a_retarget`,
+      `a_close_refreshes_an_open_report_by_itself` — pass ten consecutive runs
+      of `cargo test -p quantick-app paper_trading`.
+      *Evidence:* the loop command and its ten results.
+      → PR body. *(R10, R16)*
+- [ ] **A7** — `cargo test --workspace` run twice from one shell leaves the
+      `quantick-*` count in `temp_dir()` unchanged between the two runs, and
+      the delta over the whole exercise is zero.
+      *Evidence:* the three counts (before, between, after).
+      → PR body. *(R5, R12, R16)*
+- [ ] **A8** — A test that must outlive its writer keeps its `ScratchDir`
+      alive; any test that genuinely cannot is listed as an exception with its
+      reason.
+      *Evidence:* the exception list, or the statement that there is none.
+      → PR body. *(R6)*
+- [ ] **A9** — The PR body carries the operator's one-line sweep for the 450k
+      leftovers, and states that
+      `paper-trading-tests-flake-on-pid-reuse` and
+      `gateway-wait-for-change-ci-flake` no longer apply.
+      *Evidence:* the PR body itself.
+      → PR body. *(R7, R8)*
+- [ ] **A10** — Every claim in the brief's evidence ledger was re-checked
+      against `origin/main` before acting, with the corrections stated.
+      *Evidence:* the verification table.
+      → PR body. *(R14)*
+- [ ] **A11** — The diff touches no `pane.rs` test, and nothing in
+      `paper_trading.rs` beyond `test_scratch_dir`, its callers and that file's
+      own test module.
+      *Evidence:* `git diff --stat origin/main...HEAD` and the per-file diff.
+      → PR body. *(R15)*
+- [ ] **G1** — Every artifact in English. *Evidence:* `arch-review` dimension 8
+      and `cargo test -p quantick-guards` (`language.rs`) green. → PR body.
+- [ ] **G2** — The four checks green after rebasing on latest `main`:
+      `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets`,
+      `cargo build --workspace`, `cargo test --workspace`; each run on its own,
+      never chained behind `||`. *Evidence:* the four outputs. → PR body.
+- [ ] **G3** — Performance impact declared. Every touched path is **test-side
+      or `cfg!(test)`-gated**: rate class *rare*, and none of it exists in a
+      release build. *Evidence:* this line, plus the diff showing no
+      production code path changed. → PR body.
+- [ ] **G4** — `cargo test -p quantick-guards` green, and **no size ceiling
+      raised** in `crates/guards/size-baseline.txt`. *Evidence:* the guards
+      output and an unchanged baseline. → PR body. *(R13)*
+- [ ] **G5** — `arch-review` run over `git diff origin/main...HEAD` with every
+      Blocker and Should-fix resolved, or deferred in the PR body with its
+      severity. *Evidence:* the verdict. → PR body.
+
+## Not applicable, and why
+
+- **Hot path** — nothing the diff touches runs in a release build; every edited
+  path is behind `#[cfg(test)]` or `cfg!(test)`. No `APP_HEALTH_SUMMARY` run
+  and no bench: there is no production code to measure. G3 records the
+  classification rather than a measurement.
+- **User-visible surfaces** — no surface changes, so `ui-harness`, `visual-qa`
+  and `trader-ux-review` do not apply. `QuantickApp` gains a `Drop` that exists
+  only in test builds.
+- **Adds a capability** — `new-extension` does not apply: nothing new docks,
+  and the scratch helpers are test support, not a registered capability.
+- **Something a trader does** — no new action, tool, trade or lock, so *The
+  second operator*'s act/read/discover criteria have nothing to grade.
+- **Engine / determinism** — no engine code. The new guard is nonetheless
+  written test-first, matching the repository's habit.
+- **Docs/skills only** — does not apply; this is a code change and takes the
+  full shape pass.
+
+## Closing steps
+
+- **C1** — `delivery-review` returns PASS.
+- **C2** — The PR is open, with the tier named beside the four verification
+  boxes.
+
+## The request as received
+
+Quoted verbatim, in the trader's own words, because the ledger above must not
+become its own source of truth — an ask dropped while writing the ledger is one
+no reviewer could find. This is the single attributed quotation `CLAUDE.md`'s
+English rule exempts; every other line of this file is English.
+
+> /mission medium fix/tests-own-their-scratch — every test that writes to disk
+> names its folder after the process id and never removes it, so Windows PID
+> reuse makes three paper-trading tests fail on stale files and CI drops one app
+> test at random. Give each crate one scratch helper that yields a
+> unique-per-run directory and removes it on drop, route every test-side temp
+> path through it, and prove the suite leaves the temp directory as it found it.
+> Read C:\src\mission-tests-own-their-scratch.md in full before anything else
+> and build the request ledger from it.
+
+The referenced brief, `C:\src\mission-tests-own-their-scratch.md`, is the
+mission's second source; its scope, evidence ledger, acceptance criteria and
+out-of-scope list are folded into R1–R16 above.

--- a/crates/app/src/app/tests/control_plane_tests.rs
+++ b/crates/app/src/app/tests/control_plane_tests.rs
@@ -10,9 +10,7 @@ use super::*;
 #[test]
 fn a_script_that_no_longer_reads_becomes_a_visible_error_slot() {
     let (mut app, _events, _commands, _book) = test_app();
-    let dir = std::env::temp_dir().join(format!("quantick-app-script-{}", std::process::id()));
-    let _ = std::fs::remove_dir_all(&dir);
-    std::fs::create_dir_all(&dir).expect("scratch dir");
+    let dir = crate::scratch::ScratchDir::new("app-script");
     let path = dir.join("vanishing.pine");
     std::fs::write(
         &path,
@@ -179,11 +177,7 @@ fn the_scripted_click_lands_on_the_pane_it_names() {
 #[test]
 fn the_scripted_replay_restart_seeks_once_the_trades_are_in() {
     let (mut app, evt_tx, mut cmd_rx, _book_tx) = test_app();
-    let dir = std::env::temp_dir().join(format!(
-        "quantick-replay-restart-hook-{}",
-        std::process::id()
-    ));
-    let _ = std::fs::remove_dir_all(&dir);
+    let dir = crate::scratch::ScratchDir::new("replay-restart-hook");
     let journal = dir.join("journal");
     app.active_tab_mut().paper.redirect_history_dir(journal);
     app.active_tab_mut().replay = Some(feed::ReplayLink::for_test(recording_at(&dir)));
@@ -1655,8 +1649,7 @@ fn observer_projects_each_pane_indicator_with_its_inputs_and_latest_reading() {
 
 #[test]
 fn observer_projects_the_replay_playhead_and_its_trace_sidecar() {
-    let dir = std::env::temp_dir().join(format!("quantick-observer-replay-{}", std::process::id()));
-    let _ = std::fs::remove_dir_all(&dir);
+    let dir = crate::scratch::ScratchDir::new("observer-replay");
     let (mut app, _commands) = app_with_history(4);
 
     // A live tab is not replaying, and says so rather than reporting a
@@ -3332,11 +3325,7 @@ fn gateway_journals_a_focus_change_the_human_made() {
 #[test]
 fn two_tabs_on_the_same_recording_share_one_trace_walk() {
     let ctx = egui::Context::default();
-    let dir = std::env::temp_dir().join(format!(
-        "quantick-control-trace-two-tabs-{}",
-        std::process::id()
-    ));
-    let _ = std::fs::remove_dir_all(&dir);
+    let dir = crate::scratch::ScratchDir::new("control-trace-two-tabs");
     let (mut app, _commands) = app_with_history(12);
     app.active_tab_mut().replay = Some(feed::ReplayLink::for_test(recording_at(&dir)));
     hover_bar(&mut app, &ctx, 6);

--- a/crates/app/src/app/tests/drawings_tests.rs
+++ b/crates/app/src/app/tests/drawings_tests.rs
@@ -457,12 +457,10 @@ fn a_rebuilt_timeline_does_not_stack_old_marks_on_its_edge() {
     let ctx = egui::Context::default();
     let screen = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(900.0, 600.0));
     let (mut app, evt_tx, _cmd_rx, _book_tx) = test_app();
-    let dir = std::env::temp_dir().join(format!(
-        "quantick-trade-paint-rebuild-{}",
-        std::process::id()
-    ));
-    let _ = std::fs::remove_dir_all(&dir);
-    app.active_tab_mut().paper.redirect_history_dir(dir.clone());
+    let dir = crate::scratch::ScratchDir::new("trade-paint-rebuild");
+    app.active_tab_mut()
+        .paper
+        .redirect_history_dir(dir.path().to_path_buf());
     // A round trip: bought on print 4, closed on print 6.
     evt_tx
         .try_send(FeedEvent::Backfilled(vec![trade(2)]))
@@ -1253,9 +1251,8 @@ fn the_coordinates_tab_offers_sharing_across_charts() {
 fn a_saved_default_style_reaches_the_next_drawing_and_only_that() {
     let (mut app, _commands) = app_with_history(200);
     let ctx = egui::Context::default();
-    app.drawing_presets = drawings::presets::PresetStore::load_from(std::env::temp_dir().join(
-        format!("quantick-default-style-{}.toml", std::process::id()),
-    ));
+    let presets = crate::scratch::ScratchFile::new("default-style", "presets.toml");
+    app.drawing_presets = drawings::presets::PresetStore::load_from(presets.path().to_path_buf());
     run_frame(&mut app, &ctx);
 
     arm_drawing_from_toolbox(&mut app, &ctx, "horizontal-line");
@@ -4171,11 +4168,7 @@ fn the_same_handler_places_the_traders_object_and_the_agents() {
 #[test]
 fn a_mark_during_replay_is_traced_and_replayed_at_the_same_logical_time() {
     let ctx = egui::Context::default();
-    let dir = std::env::temp_dir().join(format!(
-        "quantick-control-trace-replay-{}",
-        std::process::id()
-    ));
-    let _ = std::fs::remove_dir_all(&dir);
+    let dir = crate::scratch::ScratchDir::new("control-trace-replay");
     let session = recording_at(&dir);
     let trace_path = dir.join("20260316.csv.control-trace.jsonl");
 

--- a/crates/app/src/app/tests/indicators_tests.rs
+++ b/crates/app/src/app/tests/indicators_tests.rs
@@ -33,11 +33,7 @@ fn a_click_in_an_indicator_pane_draws_on_that_band() {
 #[test]
 fn opening_a_workspace_keeps_the_indicator_set_being_saved() {
     let (mut app, _evt, _cmd, _book) = test_app();
-    let file = std::env::temp_dir().join(format!(
-        "quantick-app-persist-{}-{:?}.qws.toml",
-        std::process::id(),
-        std::thread::current().id()
-    ));
+    let file = crate::scratch::ScratchFile::new("app-persist", "workspace.qws.toml");
     app.export_workspace_to(&file);
     // A market the live tab is not on, so the import replaces the strip.
     app.open_tab("binance".to_owned(), "OTHERUSDT".to_owned(), None);

--- a/crates/app/src/app/tests/layers_tests.rs
+++ b/crates/app/src/app/tests/layers_tests.rs
@@ -95,8 +95,7 @@ fn hiding_a_layer_never_stops_the_data_behind_it() {
 /// back the way it was left — through the same restore the constructor runs.
 #[test]
 fn layer_visibility_survives_a_restart() {
-    let dir = std::env::temp_dir().join(format!("quantick-app-layers-{}", std::process::id()));
-    std::fs::create_dir_all(&dir).expect("scratch dir");
+    let dir = crate::scratch::ScratchDir::new("app-layers");
     let path = dir.join("chart-layers.toml");
     let _ = std::fs::remove_file(&path);
 
@@ -161,8 +160,7 @@ fn layer_visibility_survives_a_restart() {
 /// second market is not a request to bring back hidden chrome.
 #[test]
 fn a_new_tab_opens_on_the_layers_the_user_left_showing() {
-    let dir = std::env::temp_dir().join(format!("quantick-app-newtab-{}", std::process::id()));
-    std::fs::create_dir_all(&dir).expect("scratch dir");
+    let dir = crate::scratch::ScratchDir::new("app-newtab");
     let path = dir.join("chart-layers.toml");
     let _ = std::fs::remove_file(&path);
 
@@ -239,8 +237,7 @@ fn the_time_pane_opens_on_the_same_layers_as_the_flow_pane() {
 /// own switches on the way past.
 #[test]
 fn a_new_tab_inherits_the_live_layers_not_the_startup_file() {
-    let dir = std::env::temp_dir().join(format!("quantick-app-live-{}", std::process::id()));
-    std::fs::create_dir_all(&dir).expect("scratch dir");
+    let dir = crate::scratch::ScratchDir::new("app-live");
     let path = dir.join("chart-layers.toml");
     let _ = std::fs::remove_file(&path);
 
@@ -288,8 +285,7 @@ crosshair = false
 /// checkbox hides the layer behind it.
 #[test]
 fn the_layer_menu_offers_every_layer_and_its_switches_work() {
-    let dir = std::env::temp_dir().join(format!("quantick-app-menu-{}", std::process::id()));
-    std::fs::create_dir_all(&dir).expect("scratch dir");
+    let dir = crate::scratch::ScratchDir::new("app-menu");
     let path = dir.join("chart-layers.toml");
     let _ = std::fs::remove_file(&path);
 
@@ -524,10 +520,10 @@ fn the_trade_paint_layer_switch_stops_the_marks() {
     let ctx = egui::Context::default();
     let screen = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(900.0, 600.0));
     let (mut app, evt_tx, _cmd_rx, _book_tx) = test_app();
-    let dir =
-        std::env::temp_dir().join(format!("quantick-trade-paint-gate-{}", std::process::id()));
-    let _ = std::fs::remove_dir_all(&dir);
-    app.active_tab_mut().paper.redirect_history_dir(dir.clone());
+    let dir = crate::scratch::ScratchDir::new("trade-paint-gate");
+    app.active_tab_mut()
+        .paper
+        .redirect_history_dir(dir.path().to_path_buf());
     evt_tx
         .try_send(FeedEvent::Backfilled(vec![trade(2)]))
         .unwrap();

--- a/crates/app/src/app/tests/mod.rs
+++ b/crates/app/src/app/tests/mod.rs
@@ -1202,12 +1202,14 @@ fn price_y(app: &QuantickApp, side: PaneSide, price: f64) -> f32 {
 }
 
 /// A scratch workspace path, so a test never writes the real cockpit.
+///
+/// `thread_dir` rather than a `ScratchDir`, because the path is handed to the
+/// app and the caller keeps nothing it could drop: every call site here reads
+/// `set_ui_state_path(scratch_ui_state(..))`, and a value dropped at the end
+/// of that statement would take the folder with it before the app ever wrote
+/// to it. The directory goes when the test's thread ends instead.
 fn scratch_ui_state(name: &str) -> std::path::PathBuf {
-    std::env::temp_dir().join(format!(
-        "quantick-app-ui-state-{name}-{}-{:?}.toml",
-        std::process::id(),
-        std::thread::current().id()
-    ))
+    crate::scratch::thread_dir("app-ui-state").join(format!("{name}.toml"))
 }
 
 /// A frame carrying the window's close request, which is the only signal
@@ -1584,13 +1586,11 @@ fn drain_load_older(commands: &mut mpsc::Receiver<FeedCommand>) -> Vec<usize> {
 
 // ---- adding a symbol from the picker (§11) ----
 
-/// A scratch sidecar path, so a test never touches the real one.
+/// A scratch sidecar path, so a test never touches the real one. Handed to
+/// the app, so it takes `thread_dir` for the reason [`scratch_ui_state`]
+/// gives.
 fn symbols_scratch(name: &str) -> std::path::PathBuf {
-    std::env::temp_dir().join(format!(
-        "quantick-symbols-app-{}-{}.toml",
-        name,
-        std::process::id()
-    ))
+    crate::scratch::thread_dir("symbols-app").join(format!("{name}.toml"))
 }
 
 /// A config with two MetaTrader feeds, one of them mapping a port — the
@@ -1772,12 +1772,16 @@ fn indicator_kinds(app: &QuantickApp) -> Vec<String> {
         .collect()
 }
 
+/// A gateway directory of this test's own, **not created**: the gateway makes
+/// its own instances directory, and handing it one that already exists is a
+/// different starting state than every one of these tests was written
+/// against. It sits inside this thread's scratch folder, which is removed
+/// when the test's thread ends.
 fn gateway_test_directory(name: &str) -> std::path::PathBuf {
     use std::sync::atomic::{AtomicU64, Ordering};
     static NEXT_DIRECTORY: AtomicU64 = AtomicU64::new(1);
-    std::env::temp_dir().join(format!(
-        "quantick-gateway-test-{}-{name}-{}",
-        std::process::id(),
+    crate::scratch::thread_dir("gateway-test").join(format!(
+        "{name}-{}",
         NEXT_DIRECTORY.fetch_add(1, Ordering::Relaxed)
     ))
 }

--- a/crates/app/src/app/tests/orderflow_tests.rs
+++ b/crates/app/src/app/tests/orderflow_tests.rs
@@ -253,8 +253,7 @@ fn the_tape_window_hook_reads_durations_and_refuses_nonsense() {
 /// only for the tape would take order entry and the drawing tools with it.
 #[test]
 fn a_right_click_on_the_tape_configures_the_tape_without_losing_the_chart() {
-    let dir = std::env::temp_dir().join(format!("quantick-tape-menu-{}", std::process::id()));
-    std::fs::create_dir_all(&dir).expect("scratch dir");
+    let dir = crate::scratch::ScratchDir::new("tape-menu");
     let path = dir.join("chart-layers.toml");
     let _ = std::fs::remove_file(&path);
 

--- a/crates/app/src/app/tests/paper_trading_tests.rs
+++ b/crates/app/src/app/tests/paper_trading_tests.rs
@@ -221,9 +221,10 @@ fn the_toolbar_close_action_exits_the_open_position() {
     let (mut app, evt_tx, _cmd_rx, _book_tx) = test_app();
     // The close journals; without this the test writes a real
     // `paper-trades/` folder into the crate's source tree.
-    let dir = std::env::temp_dir().join(format!("quantick-paper-app-close-{}", std::process::id()));
-    let _ = std::fs::remove_dir_all(&dir);
-    app.active_tab_mut().paper.redirect_history_dir(dir.clone());
+    let dir = crate::scratch::ScratchDir::new("paper-app-close");
+    app.active_tab_mut()
+        .paper
+        .redirect_history_dir(dir.path().to_path_buf());
     evt_tx
         .try_send(FeedEvent::Backfilled(vec![trade(2)]))
         .unwrap();
@@ -260,9 +261,10 @@ fn the_toolbar_close_action_exits_the_open_position() {
 #[test]
 fn a_source_reset_flattens_the_simulated_position_and_journals_it() {
     let (mut app, evt_tx, _cmd_rx, _book_tx) = test_app();
-    let dir = std::env::temp_dir().join(format!("quantick-paper-app-reset-{}", std::process::id()));
-    let _ = std::fs::remove_dir_all(&dir);
-    app.active_tab_mut().paper.redirect_history_dir(dir.clone());
+    let dir = crate::scratch::ScratchDir::new("paper-app-reset");
+    app.active_tab_mut()
+        .paper
+        .redirect_history_dir(dir.path().to_path_buf());
     // No `set_symbol` here: the tab's own drain syncs the journal to its
     // symbol before reading a single event, which is what makes the
     // folder assertion below a proof of that wiring too.
@@ -2134,11 +2136,7 @@ fn pulling_older_trades_re_trims_the_venue_prefix() {
 fn a_replay_switch_flattens_under_the_session_that_owned_the_position() {
     let ctx = egui::Context::default();
     let (mut app, _events, _commands) = history_app(&ctx);
-    let dir = std::env::temp_dir().join(format!(
-        "quantick-switch-source-test-{}",
-        std::process::id()
-    ));
-    let _ = std::fs::remove_dir_all(&dir);
+    let dir = crate::scratch::ScratchDir::new("switch-source-test");
     let print = |agg_id: u64, price: i64| quantick_engine::Trade {
         agg_id,
         timestamp_ms: i64::try_from(agg_id).expect("small ids") * 1000,
@@ -2148,7 +2146,7 @@ fn a_replay_switch_flattens_under_the_session_that_owned_the_position() {
     };
     {
         let paper = &mut app.active_tab_mut().paper;
-        paper.redirect_history_dir(dir.clone());
+        paper.redirect_history_dir(dir.path().to_path_buf());
         paper.set_symbol("SWITCHSRC");
         paper.seed(&print(0, 100));
         paper.market(quantick_engine::Side::Buy);
@@ -2275,13 +2273,10 @@ fn closing_a_tab_flattens_and_journals_its_simulated_position() {
     let ctx = egui::Context::default();
     let (mut app, _cmd_rx) = app_with_history(50);
     let ends = open_second_tab(&mut app, &ctx, "ETHUSDT");
-    let dir = std::env::temp_dir().join(format!(
-        "quantick-paper-tab-close-{}-{:?}",
-        std::process::id(),
-        std::thread::current().id()
-    ));
-    let _ = std::fs::remove_dir_all(&dir);
-    app.active_tab_mut().paper.redirect_history_dir(dir.clone());
+    let dir = crate::scratch::ScratchDir::new("paper-tab-close");
+    app.active_tab_mut()
+        .paper
+        .redirect_history_dir(dir.path().to_path_buf());
 
     // A filled position on the second tab: backfill seeds the mark, the
     // toolbar queues the order, the next live print fills it.

--- a/crates/app/src/app/tests/workspaces_tests.rs
+++ b/crates/app/src/app/tests/workspaces_tests.rs
@@ -16,11 +16,7 @@ fn a_cockpit_exported_from_the_app_comes_back_when_it_is_opened() {
     app.toolrail.set_favorites(&["measure".to_owned()]);
     app.save_workspace("test");
 
-    let file = std::env::temp_dir().join(format!(
-        "quantick-app-bundle-{}-{:?}.qws.toml",
-        std::process::id(),
-        std::thread::current().id()
-    ));
+    let file = crate::scratch::ScratchFile::new("app-bundle", "workspace.qws.toml");
     app.export_workspace_to(&file);
     assert!(file.is_file(), "the export reached the disk");
     assert_eq!(
@@ -110,11 +106,7 @@ fn opening_a_file_that_is_not_a_workspace_changes_nothing_on_screen() {
     app.toolrail.set_favorites(&["measure".to_owned()]);
     let before = app.starred_tool_ids();
 
-    let file = std::env::temp_dir().join(format!(
-        "quantick-app-bad-bundle-{}-{:?}.qws.toml",
-        std::process::id(),
-        std::thread::current().id()
-    ));
+    let file = crate::scratch::ScratchFile::new("app-bad-bundle", "workspace.qws.toml");
     std::fs::write(&file, "version = 99\nname = \"from tomorrow\"\n").unwrap();
     app.import_workspace_from(&file);
 
@@ -366,10 +358,8 @@ fn a_default_preset_shapes_new_fibs_and_leaves_existing_ones_alone() {
     assert_eq!(standard_levels, 7);
 
     // Save a compact custom preset and make it the default for new fibs.
-    let mut store = drawings::presets::PresetStore::load_from(std::env::temp_dir().join(format!(
-        "quantick-default-preset-test-{}.toml",
-        std::process::id()
-    )));
+    let presets = crate::scratch::ScratchFile::new("default-preset-test", "presets.toml");
+    let mut store = drawings::presets::PresetStore::load_from(presets.path().to_path_buf());
     let mut compact = FibPayload::new(drawings::fib::FibKind::Retracement);
     compact.apply_preset(&drawings::fib::RETRACEMENT_PRESETS[1]);
     let exported = compact.export_preset().expect("fib exports presets");

--- a/crates/app/src/chart_layers.rs
+++ b/crates/app/src/chart_layers.rs
@@ -631,10 +631,14 @@ crate::hooks::declare_hooks!["QUANTICK_CHART_LAYERS"];
 mod tests {
     use super::*;
 
+    /// A directory of this test's own thread. It used to be one fixed folder
+    /// shared by every test in this module *and* by every concurrent run on
+    /// the machine — two worktrees running the suite at once wrote each
+    /// other's fixtures. `thread_dir` rather than a `ScratchDir` because
+    /// every caller spells `temp_dir().join(..)` in a single statement, where
+    /// a value would be dropped before the file it names is written.
     fn temp_dir() -> PathBuf {
-        let dir = std::env::temp_dir().join("quantick-chart-layers-test");
-        std::fs::create_dir_all(&dir).unwrap();
-        dir
+        crate::scratch::thread_dir("chart-layers")
     }
 
     /// The words a trader actually reads, checked as words.

--- a/crates/app/src/chart_layers.rs
+++ b/crates/app/src/chart_layers.rs
@@ -635,9 +635,9 @@ mod tests {
     /// shared by every test in this module *and* by every concurrent run on
     /// the machine — two worktrees running the suite at once wrote each
     /// other's fixtures. `thread_dir` rather than a `ScratchDir` because
-    /// every caller spells `temp_dir().join(..)` in a single statement, where
+    /// every caller spells `scratch().join(..)` in a single statement, where
     /// a value would be dropped before the file it names is written.
-    fn temp_dir() -> PathBuf {
+    fn scratch() -> PathBuf {
         crate::scratch::thread_dir("chart-layers")
     }
 
@@ -682,7 +682,7 @@ mod tests {
 
     #[test]
     fn a_missing_file_opens_on_the_shipped_default() {
-        let fresh = load(&temp_dir().join("missing.toml"));
+        let fresh = load(&scratch().join("missing.toml"));
         assert_eq!(
             fresh,
             shipped_default(),
@@ -698,7 +698,7 @@ mod tests {
     /// worse than the bare chart this whole change is about.
     #[test]
     fn the_traders_own_choice_outranks_the_shipped_default() {
-        let path = temp_dir().join("trader-choice.toml");
+        let path = scratch().join("trader-choice.toml");
         assert_eq!(
             shipped_default().get(&ChartLayer::Heatmap),
             Some(&true),
@@ -742,7 +742,7 @@ mod tests {
     /// reporter's machine turned out to hold.
     #[test]
     fn a_file_from_before_the_defaults_still_opens_the_flow_layers() {
-        let path = temp_dir().join("pre-defaults.toml");
+        let path = scratch().join("pre-defaults.toml");
         std::fs::write(
             &path,
             "version = 1
@@ -841,7 +841,7 @@ mod tests {
 
     #[test]
     fn visibility_round_trips_through_disk() {
-        let path = temp_dir().join("round-trip.toml");
+        let path = scratch().join("round-trip.toml");
         let states = BTreeMap::from([
             (ChartLayer::Crosshair, false),
             (ChartLayer::Grid, false),
@@ -862,7 +862,7 @@ mod tests {
 
     #[test]
     fn preset_owned_layers_are_never_written_here() {
-        let path = temp_dir().join("preset-owned.toml");
+        let path = scratch().join("preset-owned.toml");
         save(
             &path,
             &BTreeMap::from([(ChartLayer::LaneMarks, false), (ChartLayer::Grid, false)]),
@@ -886,7 +886,7 @@ mod tests {
 
     #[test]
     fn unknown_versions_ids_and_garbage_degrade_instead_of_failing() {
-        let path = temp_dir().join("bad-layers.toml");
+        let path = scratch().join("bad-layers.toml");
         // A file this build cannot read means "we do not know what they
         // chose" — the same question a first launch asks, so it gets the same
         // answer rather than a second one.

--- a/crates/app/src/control/gateway.rs
+++ b/crates/app/src/control/gateway.rs
@@ -4145,11 +4145,13 @@ pub(crate) fn runtime_id_bytes() -> Result<[u8; CONTROL_RUNTIME_ID_BYTES], Contr
 mod tests {
     use super::*;
 
+    /// A directory that does not exist yet — the only caller asserts exactly
+    /// that — inside this thread's own scratch folder, which is removed when
+    /// the thread ends whether or not anything ever created it.
     fn unique_test_directory(name: &str) -> PathBuf {
         static NEXT_DIRECTORY: AtomicUsize = AtomicUsize::new(1);
-        std::env::temp_dir().join(format!(
-            "quantick-control-{name}-{}-{}",
-            std::process::id(),
+        crate::scratch::thread_dir("control-gateway").join(format!(
+            "{name}-{}",
             NEXT_DIRECTORY.fetch_add(1, Ordering::Relaxed)
         ))
     }

--- a/crates/app/src/control/trace.rs
+++ b/crates/app/src/control/trace.rs
@@ -252,12 +252,7 @@ mod tests {
 
     #[test]
     fn intents_and_results_pair_up_and_an_unfinished_intent_is_reported() {
-        let directory = std::env::temp_dir().join(format!(
-            "quantick-control-trace-{}-{}",
-            std::process::id(),
-            line!()
-        ));
-        std::fs::create_dir_all(&directory).unwrap();
+        let directory = crate::scratch::ScratchDir::new("control-trace");
         let session = directory.join("WINJ26-2026-03-16.csv");
         std::fs::write(&session, "# not read by the trace\n").unwrap();
 
@@ -303,12 +298,7 @@ mod tests {
 
     #[test]
     fn a_result_pairs_with_the_latest_intent_of_its_sequence() {
-        let directory = std::env::temp_dir().join(format!(
-            "quantick-control-trace-{}-{}",
-            std::process::id(),
-            line!()
-        ));
-        std::fs::create_dir_all(&directory).unwrap();
+        let directory = crate::scratch::ScratchDir::new("control-trace");
         let session = directory.join("WINJ26-2026-03-17.csv");
         std::fs::write(&session, "# not read by the trace\n").unwrap();
 

--- a/crates/app/src/drawings/presets.rs
+++ b/crates/app/src/drawings/presets.rs
@@ -274,14 +274,11 @@ crate::hooks::declare_hooks!["QUANTICK_DRAWING_PRESETS"];
 mod tests {
     use super::*;
 
+    /// A preset file of this test's own. `thread_dir` rather than a
+    /// `ScratchFile`, because a `PresetStore` outlives the expression that
+    /// built it and keeps writing to the path.
     fn scratch_path(name: &str) -> PathBuf {
-        let mut path = std::env::temp_dir();
-        path.push(format!(
-            "quantick-preset-test-{name}-{}.toml",
-            std::process::id()
-        ));
-        let _ = std::fs::remove_file(&path);
-        path
+        crate::scratch::thread_dir("preset-test").join(format!("{name}.toml"))
     }
 
     fn sample_value(marker: &str) -> toml::Value {

--- a/crates/app/src/feed/mt5_bridge.rs
+++ b/crates/app/src/feed/mt5_bridge.rs
@@ -573,18 +573,19 @@ async fn forward_bridge_line(line: &str, symbol: &str, notices: &mpsc::Sender<Fe
 mod tests {
     use super::*;
 
-    /// A throwaway directory tree, cleaned up when the test ends.
-    struct TempTree(PathBuf);
+    /// A throwaway directory tree, cleaned up when the test ends. The
+    /// `PathBuf` beside the scratch directory is the same path, kept owned
+    /// because `resolve_script` takes a `&[PathBuf]`.
+    struct TempTree(crate::scratch::ScratchDir, PathBuf);
 
     impl TempTree {
         fn new(tag: &str) -> Self {
-            // Unique per test without a temp-file crate: the process id keeps
-            // parallel runs apart, the tag keeps tests within one run apart.
-            let path =
-                std::env::temp_dir().join(format!("quantick-bridge-{}-{tag}", std::process::id()));
-            let _ = std::fs::remove_dir_all(&path);
-            std::fs::create_dir_all(&path).expect("create temp tree");
-            Self(path)
+            // The process id alone let a reused pid hand this tree to a later
+            // run; `ScratchDir` carries a run token no other run can produce
+            // and removes itself, which is what this type wanted all along.
+            let scratch = crate::scratch::ScratchDir::new(tag);
+            let path = scratch.path().to_path_buf();
+            Self(scratch, path)
         }
 
         fn file(&self, relative: &str) -> PathBuf {
@@ -595,12 +596,6 @@ mod tests {
         }
     }
 
-    impl Drop for TempTree {
-        fn drop(&mut self) {
-            let _ = std::fs::remove_dir_all(&self.0);
-        }
-    }
-
     #[test]
     fn the_script_is_found_in_the_working_directory() {
         let tree = TempTree::new("cwd");
@@ -608,7 +603,7 @@ mod tests {
         assert_eq!(
             resolve_script(
                 "bridge/mt5/quantick_bridge.py",
-                std::slice::from_ref(&tree.0)
+                std::slice::from_ref(&tree.1)
             ),
             Some(script)
         );
@@ -634,7 +629,7 @@ mod tests {
         assert_eq!(
             resolve_script(
                 "bridge/mt5/quantick_bridge.py",
-                std::slice::from_ref(&tree.0)
+                std::slice::from_ref(&tree.1)
             ),
             None
         );
@@ -652,7 +647,7 @@ mod tests {
         // ...and a wrong absolute path is a miss, not a search elsewhere.
         let wrong = tree.0.join("elsewhere/absent.py");
         assert_eq!(
-            resolve_script(&wrong.to_string_lossy(), std::slice::from_ref(&tree.0)),
+            resolve_script(&wrong.to_string_lossy(), std::slice::from_ref(&tree.1)),
             None
         );
     }
@@ -662,7 +657,7 @@ mod tests {
         let tree = TempTree::new("dir");
         std::fs::create_dir_all(tree.0.join("bridge/mt5")).expect("create dirs");
         assert_eq!(
-            resolve_script("bridge/mt5", std::slice::from_ref(&tree.0)),
+            resolve_script("bridge/mt5", std::slice::from_ref(&tree.1)),
             None
         );
     }

--- a/crates/app/src/feed/replay.rs
+++ b/crates/app/src/feed/replay.rs
@@ -994,21 +994,13 @@ mod tests {
         );
     }
 
-    /// A scratch directory of this test's own, emptied before it is used.
+    /// A scratch directory of this test's own, which removes itself.
     ///
-    /// Cleared up front rather than only at the end: an assertion that fails
-    /// leaves the old one behind, Windows recycles pids freely, and a later
-    /// run inheriting a populated directory is the stale-temp-dir flake this
-    /// repo has already been bitten by elsewhere.
-    fn scratch_dir(name: &str) -> PathBuf {
-        let dir = std::env::temp_dir().join(format!(
-            "quantick-replay-{name}-{}-{:?}",
-            std::process::id(),
-            std::thread::current().id()
-        ));
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).expect("scratch dir");
-        dir
+    /// The caller holds the value for as long as the files matter; see
+    /// [`crate::scratch`] for why the folder can no longer be inherited by a
+    /// later run that happens to draw the same process id.
+    fn scratch_dir(name: &str) -> crate::scratch::ScratchDir {
+        crate::scratch::ScratchDir::new(name)
     }
 
     /// `minutes` of broker candles in the hour before a tape starts — where a

--- a/crates/app/src/indicators/library.rs
+++ b/crates/app/src/indicators/library.rs
@@ -259,16 +259,9 @@ mod tests {
         }
     }
 
-    /// A private scratch folder, removed and recreated so two runs on one
-    /// machine cannot collide (the shape `drawings::presets` already uses).
-    fn scratch(tag: &str) -> PathBuf {
-        let dir = std::env::temp_dir().join(format!(
-            "quantick-script-library-{tag}-{}",
-            std::process::id()
-        ));
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).expect("scratch dir is creatable");
-        dir
+    /// A private scratch folder that removes itself when the test ends.
+    fn scratch(tag: &str) -> crate::scratch::ScratchDir {
+        crate::scratch::ScratchDir::new(tag)
     }
 
     #[test]
@@ -339,11 +332,9 @@ plot(high)
 
     #[test]
     fn an_unreadable_directory_degrades_to_embedded_only() {
-        let missing = std::env::temp_dir().join(format!(
-            "quantick-script-library-missing-{}",
-            std::process::id()
-        ));
-        let _ = std::fs::remove_dir_all(&missing);
+        // A folder that is not there: inside this thread's scratch directory,
+        // so nothing has to create it and nothing is left behind.
+        let missing = crate::scratch::thread_dir("script-library").join("missing");
         let library = ScriptLibrary::scan_dir(&missing);
         assert_eq!(
             library.entries().len(),

--- a/crates/app/src/indicators/state_file.rs
+++ b/crates/app/src/indicators/state_file.rs
@@ -303,8 +303,7 @@ mod tests {
 
     #[test]
     fn the_state_round_trips_through_disk() {
-        let dir = std::env::temp_dir().join("quantick-indicator-state-test");
-        std::fs::create_dir_all(&dir).unwrap();
+        let dir = crate::scratch::ScratchDir::new("indicator-state");
         let path = dir.join("indicators-state.toml");
         let saved = sample();
         save(&path, &saved);
@@ -318,8 +317,7 @@ mod tests {
     /// unknown shape and take the whole workspace with it.
     #[test]
     fn a_file_written_before_styles_existed_still_loads() {
-        let dir = std::env::temp_dir().join("quantick-indicator-state-test");
-        std::fs::create_dir_all(&dir).unwrap();
+        let dir = crate::scratch::ScratchDir::new("indicator-state");
         let path = dir.join("pre-style-state.toml");
         std::fs::write(
             &path,
@@ -342,8 +340,7 @@ mod tests {
     /// user had before this change is the file they have after it.
     #[test]
     fn an_unstyled_workspace_writes_no_style_tables() {
-        let dir = std::env::temp_dir().join("quantick-indicator-state-test");
-        std::fs::create_dir_all(&dir).unwrap();
+        let dir = crate::scratch::ScratchDir::new("indicator-state");
         let path = dir.join("unstyled-state.toml");
         save(
             &path,
@@ -408,8 +405,7 @@ mod tests {
 
     #[test]
     fn unknown_versions_and_garbage_start_empty() {
-        let dir = std::env::temp_dir().join("quantick-indicator-state-test");
-        std::fs::create_dir_all(&dir).unwrap();
+        let dir = crate::scratch::ScratchDir::new("indicator-state");
         let path = dir.join("bad-state.toml");
         std::fs::write(&path, "version = 99\n").unwrap();
         assert!(load(&path).is_empty(), "unknown version starts empty");

--- a/crates/app/src/layouts.rs
+++ b/crates/app/src/layouts.rs
@@ -925,13 +925,7 @@ mod tests {
 
     #[test]
     fn the_file_round_trips_and_refuses_what_it_cannot_read() {
-        let dir = std::env::temp_dir().join(format!(
-            "quantick-layouts-test-{}-{}",
-            std::process::id(),
-            line!()
-        ));
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).unwrap();
+        let dir = crate::scratch::ScratchDir::new("layouts");
         let path = dir.join(LAYOUTS_FILE);
         assert_eq!(load(&path), Loaded::Missing);
 

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -69,6 +69,7 @@ mod replay_home;
 mod replay_view;
 mod resample;
 mod risk_sizing;
+mod scratch;
 mod state;
 mod statusbar;
 mod store_home;

--- a/crates/app/src/pane/tests/mod.rs
+++ b/crates/app/src/pane/tests/mod.rs
@@ -1139,8 +1139,9 @@ fn drive_navigation(
     events: Vec<egui::Event>,
 ) -> Option<SlotId> {
     let mut toolrail = crate::toolrail::ToolRail::new();
-    let presets =
-        drawings::presets::PresetStore::load_from(std::env::temp_dir().join("no-such.toml"));
+    let presets = drawings::presets::PresetStore::load_from(
+        crate::scratch::thread_dir("pane-presets").join("no-such.toml"),
+    );
     let mut begin_text_edit = false;
     let style = crate::style::ChartStyle::default();
     let mut paper = crate::paper_trading::PaperTrading::new();
@@ -1190,8 +1191,9 @@ fn drive_navigation(
 fn with_chrome<R>(tool: Tool, body: impl FnOnce(&mut PaneChrome<'_>) -> R) -> R {
     let mut toolrail = crate::toolrail::ToolRail::new();
     toolrail.arm(tool);
-    let presets =
-        drawings::presets::PresetStore::load_from(std::env::temp_dir().join("no-such.toml"));
+    let presets = drawings::presets::PresetStore::load_from(
+        crate::scratch::thread_dir("pane-presets").join("no-such.toml"),
+    );
     let mut begin_text_edit = false;
     let style = crate::style::ChartStyle::default();
     let mut paper = crate::paper_trading::PaperTrading::new();

--- a/crates/app/src/paper_home.rs
+++ b/crates/app/src/paper_home.rs
@@ -101,12 +101,11 @@ pub(crate) fn startup_home(
     if cfg!(test) {
         // Tests must never scan, consolidate into, or journal under a
         // real documents folder — the same scratch discipline
-        // `PaperTrading::new` applies. Per process, like the old
-        // cwd-relative default the app tests already shared.
-        return (
-            std::env::temp_dir().join(format!("quantick-paper-home-{}", std::process::id())),
-            None,
-        );
+        // `PaperTrading::new` applies. Per test thread rather than per
+        // process, which is strictly more isolation than the shared folder
+        // this replaced, and is what lets the directory be removed when the
+        // thread ends instead of accumulating one per run for ever.
+        return (crate::scratch::thread_dir("paper-home"), None);
     }
     if let Some(env) = std::env::var_os(TRADES_DIR_ENV) {
         // An explicit per-run ask — a QA or autostart run must never
@@ -475,16 +474,15 @@ crate::hooks::declare_hooks!["QUANTICK_TRADES_DIR"];
 mod tests {
     use super::*;
 
+    /// A home path that does not exist yet: several of these tests assert on
+    /// what happens when the folder is missing, so it must not be created.
+    /// It sits inside this thread's own directory, which is removed when the
+    /// thread ends whether or not anything ever wrote there.
     fn scratch() -> PathBuf {
         use std::sync::atomic::{AtomicU64, Ordering};
         static NEXT: AtomicU64 = AtomicU64::new(0);
-        let dir = std::env::temp_dir().join(format!(
-            "quantick-paper-home-test-{}-{}",
-            std::process::id(),
-            NEXT.fetch_add(1, Ordering::Relaxed)
-        ));
-        let _ = std::fs::remove_dir_all(&dir);
-        dir
+        crate::scratch::thread_dir("paper-home-test")
+            .join(NEXT.fetch_add(1, Ordering::Relaxed).to_string())
     }
 
     fn write(path: &Path, text: &str) {

--- a/crates/app/src/paper_state.rs
+++ b/crates/app/src/paper_state.rs
@@ -158,11 +158,11 @@ pub(crate) fn validate(text: &str) -> Result<(), String> {
 fn scratch_path() -> PathBuf {
     use std::sync::atomic::{AtomicU64, Ordering};
     static NEXT: AtomicU64 = AtomicU64::new(0);
-    std::env::temp_dir().join(format!(
-        "quantick-paper-state-{}-{}.toml",
-        std::process::id(),
-        NEXT.fetch_add(1, Ordering::Relaxed)
-    ))
+    // Inside the thread's own directory rather than beside it: the file is
+    // then removed with the directory when the test's thread ends, and the
+    // counter only has to separate this thread's files from each other.
+    crate::scratch::thread_dir("paper-state")
+        .join(format!("{}.toml", NEXT.fetch_add(1, Ordering::Relaxed)))
 }
 
 /// The stored state; default (all `None`) when the file is missing,

--- a/crates/app/src/paper_trading.rs
+++ b/crates/app/src/paper_trading.rs
@@ -6250,11 +6250,11 @@ fn free_session_path(folder: &Path, stamp: &str) -> PathBuf {
 fn test_scratch_dir() -> PathBuf {
     use std::sync::atomic::{AtomicU64, Ordering};
     static NEXT: AtomicU64 = AtomicU64::new(0);
-    std::env::temp_dir().join(format!(
-        "quantick-paper-host-{}-{}",
-        std::process::id(),
-        NEXT.fetch_add(1, Ordering::Relaxed)
-    ))
+    // Under the thread's own directory, which removes the whole tree when the
+    // test's thread ends. Before this, the folder was named after the process
+    // id alone and never removed: a reused pid handed a later run the earlier
+    // run's journal, and three tests here failed on it.
+    crate::scratch::thread_dir("paper-host").join(NEXT.fetch_add(1, Ordering::Relaxed).to_string())
 }
 
 crate::hooks::declare_hooks![
@@ -9293,13 +9293,9 @@ mod tests {
 
     #[test]
     fn closed_trades_journal_to_one_session_file_and_reload() {
-        let dir = std::env::temp_dir().join(format!(
-            "quantick-paper-journal-test-{}",
-            std::process::id()
-        ));
-        let _ = std::fs::remove_dir_all(&dir);
+        let dir = crate::scratch::ScratchDir::new("paper-journal-test");
         let mut paper = PaperTrading::new();
-        paper.dir.clone_from(&dir);
+        paper.dir = dir.path().to_path_buf();
         paper.set_symbol("TESTUSDT");
         paper.seed(&print(0, 100));
         paper.market(Side::Buy);
@@ -9333,20 +9329,14 @@ mod tests {
         assert_eq!(report_from_history(&history).net_points, Decimal::from(7));
         assert_eq!(history.files, 1);
         assert_eq!(history.unreadable_files, 0);
-
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
     fn a_second_session_adds_a_file_and_never_touches_the_first() {
-        let dir = std::env::temp_dir().join(format!(
-            "quantick-paper-accumulate-test-{}",
-            std::process::id()
-        ));
-        let _ = std::fs::remove_dir_all(&dir);
+        let dir = crate::scratch::ScratchDir::new("paper-accumulate-test");
         // Session one: a round trip closing at t=2s.
         let mut first = PaperTrading::new();
-        first.dir.clone_from(&dir);
+        first.dir = dir.path().to_path_buf();
         first.set_symbol("ACCUM");
         first.seed(&print(0, 100));
         first.market(Side::Buy);
@@ -9365,7 +9355,7 @@ mod tests {
 
         // Session two: a fresh host — a restart — closing hours later.
         let mut second = PaperTrading::new();
-        second.dir.clone_from(&dir);
+        second.dir = dir.path().to_path_buf();
         second.set_symbol("ACCUM");
         second.seed(&print(10_000, 200));
         second.market(Side::Sell);
@@ -9387,17 +9377,13 @@ mod tests {
         let history = load_history(&dir, Some("ACCUM"), &[]);
         assert_eq!(history.files, 2);
         assert_eq!(history.rows.len(), 2, "both sessions' trades load");
-
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
     fn a_timeline_reset_journals_the_flatten_and_clears_the_form_state() {
-        let dir =
-            std::env::temp_dir().join(format!("quantick-paper-reset-test-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&dir);
+        let dir = crate::scratch::ScratchDir::new("paper-reset-test");
         let mut paper = PaperTrading::new();
-        paper.dir.clone_from(&dir);
+        paper.dir = dir.path().to_path_buf();
         paper.set_symbol("RESETX");
         paper.seed(&print(0, 100));
         paper.market(Side::Buy);
@@ -9420,7 +9406,6 @@ mod tests {
             1,
             "the reset exit is a real, journaled trade"
         );
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     // The stored-pick-vs-configured-base precedence now lives in
@@ -9431,14 +9416,10 @@ mod tests {
     /// and report re-read from it. Files already written stay put.
     #[test]
     fn switching_the_trades_dir_retargets_journal_ledger_and_report() {
-        let dir_a =
-            std::env::temp_dir().join(format!("quantick-paper-dir-a-{}", std::process::id()));
-        let dir_b =
-            std::env::temp_dir().join(format!("quantick-paper-dir-b-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&dir_a);
-        let _ = std::fs::remove_dir_all(&dir_b);
+        let dir_a = crate::scratch::ScratchDir::new("paper-dir-a");
+        let dir_b = crate::scratch::ScratchDir::new("paper-dir-b");
         let mut paper = PaperTrading::new();
-        paper.dir.clone_from(&dir_a);
+        paper.dir = dir_a.path().to_path_buf();
         paper.set_symbol("SWITCHX");
         paper.seed(&print(0, 100));
         paper.market(Side::Buy);
@@ -9453,8 +9434,8 @@ mod tests {
         };
         assert!(paper.report_state().saved_rows_loaded().is_some());
 
-        paper.set_trades_dir(dir_b.clone());
-        assert_eq!(paper.trades_dir(), dir_b.as_path());
+        paper.set_trades_dir(dir_b.path().to_path_buf());
+        assert_eq!(paper.trades_dir(), dir_b.path());
         assert!(
             paper.journal_path.is_none(),
             "the next close opens a new session file under B"
@@ -9468,8 +9449,6 @@ mod tests {
             dir_a.join("SWITCHX").exists(),
             "files already written stay where they are"
         );
-        let _ = std::fs::remove_dir_all(&dir_a);
-        let _ = std::fs::remove_dir_all(&dir_b);
     }
 
     /// The ledger's cache reads every saved file except the live session's
@@ -9477,11 +9456,9 @@ mod tests {
     /// symbol each row came from.
     #[test]
     fn the_ledger_cache_excludes_the_live_session_file() {
-        let dir =
-            std::env::temp_dir().join(format!("quantick-paper-ledger-test-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&dir);
+        let dir = crate::scratch::ScratchDir::new("paper-ledger-test");
         let mut paper = PaperTrading::new();
-        paper.dir.clone_from(&dir);
+        paper.dir = dir.path().to_path_buf();
         paper.set_symbol("LEDGX");
         paper.seed(&print(0, 100));
         paper.market(Side::Buy);
@@ -9524,19 +9501,16 @@ mod tests {
         assert_eq!(cache[0].symbol, "LEDGX");
         assert_eq!(cache[0].trade, trade);
         assert_eq!(cache[0].source, Some(history::SessionSource::Live));
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
     fn a_replay_rerun_lands_beside_its_first_run_never_inside_it() {
-        let dir =
-            std::env::temp_dir().join(format!("quantick-paper-rerun-test-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&dir);
+        let dir = crate::scratch::ScratchDir::new("paper-rerun-test");
         // The same recording replayed twice: identical prints, identical
         // venue times, so both sessions derive the same file stamp.
         for _ in 0..2 {
             let mut paper = PaperTrading::new();
-            paper.dir.clone_from(&dir);
+            paper.dir = dir.path().to_path_buf();
             paper.set_symbol("RERUN");
             paper.set_session_source(history::SessionSource::Replay);
             paper.seed(&print(0, 100));
@@ -9569,7 +9543,6 @@ mod tests {
                 .all(|row| row.source == Some(history::SessionSource::Replay)),
             "both files carry the replay source"
         );
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
@@ -9609,11 +9582,9 @@ mod tests {
     /// state it exists to photograph was unreachable.
     #[test]
     fn a_revealed_page_survives_the_ledgers_lazy_first_load() {
-        let dir =
-            std::env::temp_dir().join(format!("quantick-paper-pages-test-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&dir);
+        let dir = crate::scratch::ScratchDir::new("paper-pages-test");
         let mut paper = PaperTrading::new();
-        paper.dir.clone_from(&dir);
+        paper.dir = dir.path().to_path_buf();
         paper.set_symbol("PAGEX");
 
         paper.report_state_mut().autostart_ledger_pages(3);
@@ -9646,20 +9617,14 @@ mod tests {
             state.rescope_ledger(&env)
         };
         assert_eq!(paper.report_state().revealed_pages(), 1);
-
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
     fn the_report_scopes_by_symbol_folder_on_disk() {
-        let dir = std::env::temp_dir().join(format!(
-            "quantick-paper-symbols-test-{}",
-            std::process::id()
-        ));
-        let _ = std::fs::remove_dir_all(&dir);
+        let dir = crate::scratch::ScratchDir::new("paper-symbols-test");
         for (symbol, id0, price) in [("AAAUSDT", 0, 100), ("BBBUSDT", 100, 200)] {
             let mut paper = PaperTrading::new();
-            paper.dir.clone_from(&dir);
+            paper.dir = dir.path().to_path_buf();
             paper.set_symbol(symbol);
             paper.seed(&print(id0, price));
             paper.market(Side::Buy);
@@ -9681,8 +9646,6 @@ mod tests {
         let one = load_history(&dir, Some("BBBUSDT"), &[]);
         assert_eq!(one.rows.len(), 1, "a symbol scope reads only its folder");
         assert_eq!(one.rows[0].symbol, "BBBUSDT");
-
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/crates/app/src/replay_view.rs
+++ b/crates/app/src/replay_view.rs
@@ -1271,13 +1271,8 @@ mod tests {
     /// joined in front of it. Naming the day is what makes the other reachable.
     #[test]
     fn naming_a_day_selects_it_over_the_one_the_scan_lists_first() {
-        let folder = std::env::temp_dir().join(format!(
-            "quantick-replay-view-select-{}-{:?}",
-            std::process::id(),
-            std::thread::current().id()
-        ));
+        let folder = crate::scratch::ScratchDir::new("replay-view-select");
         let instrument = folder.join("WINJ26");
-        let _ = std::fs::remove_dir_all(&folder);
         std::fs::create_dir_all(&instrument).expect("scratch folder");
         for (name, day) in [
             ("20260313.csv", "2026-03-13"),

--- a/crates/app/src/scratch.rs
+++ b/crates/app/src/scratch.rs
@@ -109,8 +109,24 @@ impl Drop for OwnedDirs {
 /// A directory belonging to this test's thread, created if it is not there
 /// and removed when the thread ends.
 ///
-/// Stable: the same `label` on the same thread answers the same path every
-/// time, which is what the `cfg!(test)` paths in production modules need.
+/// **Stable per (run, thread), and only that.** The same `label` on the same
+/// thread answers the same path every time, which is what the `cfg!(test)`
+/// paths in production modules need — they are re-resolved on every call and
+/// two resolutions inside one test must agree. A *different* thread gets a
+/// different directory, deliberately: that is what stops two tests sharing a
+/// cockpit, and it is what `store_home::test_path` already keyed on before
+/// this module existed.
+///
+/// Two things follow, and both are the caller's to respect:
+///
+/// - **Do not hand a `thread_dir` path to anything that outlives the test's
+///   thread.** The directory goes when the thread does, so a writer still
+///   running afterwards writes into a tree nothing owns. Every caller here
+///   hands it to something the test itself owns and drops.
+/// - **Do not expect a spawned thread to resolve the same path.** A test that
+///   needs one directory across threads wants a [`ScratchDir`] it passes by
+///   path, not this.
+///
 /// Callers that can hold a value should hold a [`ScratchDir`] instead — its
 /// removal happens at the end of the test rather than the end of the thread.
 pub(crate) fn thread_dir(label: &str) -> PathBuf {
@@ -305,6 +321,22 @@ mod tests {
         let second = thread_dir("stable-label");
         assert_eq!(first, second);
         assert!(first.exists(), "it was created");
+    }
+
+    /// The per-thread contract, pinned rather than left to be discovered: a
+    /// spawned thread gets its *own* directory, not the spawning test's. It
+    /// is what keeps two tests out of one cockpit, and it is the reason a
+    /// path from here must not be handed across a thread boundary.
+    #[test]
+    fn another_thread_gets_its_own_directory_for_the_same_label() {
+        let here = thread_dir("shared-label");
+        let there = std::thread::spawn(|| thread_dir("shared-label"))
+            .join()
+            .expect("the thread finished");
+        assert_ne!(
+            here, there,
+            "two threads must not resolve one directory for one label"
+        );
     }
 
     #[test]

--- a/crates/app/src/scratch.rs
+++ b/crates/app/src/scratch.rs
@@ -1,0 +1,320 @@
+//! Scratch directories the tests own, rather than leak.
+//!
+//! Every test in this crate that touches a real disk used to spell its own
+//! temporary path, and every spelling keyed on `std::process::id()` alone.
+//! Two things follow from that, and both cost review rounds.
+//!
+//! A process id is *reused*. Windows hands one back within minutes, so a test
+//! whose folder is named after it opens the folder a previous run left behind
+//! and asserts on that run's files — the failure looks like the change under
+//! test and is not. Three `paper_trading` tests failed that way, and CI drops
+//! one app test at random for the same reason.
+//!
+//! And nothing removed any of it: the host that runs this suite daily held
+//! 450,227 `quantick-*` entries in `%TEMP%` on 2026-09-04.
+//!
+//! # The fix, in two halves
+//!
+//! **Unique per run.** Every path here carries [`run_token`] — the process id
+//! *and* the nanoseconds since the epoch at which this process first asked.
+//! A reused pid cannot reproduce the nanosecond, so no run can ever see
+//! another's leftovers, whatever the operating system does with pids.
+//!
+//! **Removed by an owner.** Two owners, because there are two shapes of
+//! caller. A test that can hold a value holds a [`ScratchDir`], which removes
+//! its tree on `Drop` — including when the test panics, since that unwinds.
+//! A path resolved *inside* production code under `cfg!(test)` —
+//! `store_home::test_path`, `paper_home::startup_home`,
+//! `paper_state::scratch_path`, `paper_trading`'s journal folder — has no such
+//! value: it is re-resolved on every call and must answer the same twice.
+//! Those take [`thread_dir`], which hands the directory to the test's own
+//! thread and removes it when that thread ends.
+//!
+//! The thread is the right owner because `libtest` runs each test on a thread
+//! it spawned, and a spawned thread runs its thread-local destructors on the
+//! way out. The exception is `--test-threads=1`, where libtest uses the main
+//! thread and the process exits without running its destructors; a serialized
+//! run therefore leaves one directory per label behind. That is the only mode
+//! that leaks, it leaks a bounded handful rather than one per test, and it is
+//! not the mode CI or an agent runs.
+
+use std::cell::RefCell;
+use std::fs;
+use std::path::PathBuf;
+use std::sync::OnceLock;
+
+// Only [`ScratchDir`] needs these, and it exists only in a test build.
+#[cfg(test)]
+use std::path::Path;
+#[cfg(test)]
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// The prefix every scratch path in this crate carries, so one `ls` finds
+/// them all and the guard has one string to look for.
+const PREFIX: &str = "quantick-app";
+
+/// A token no other run of this crate can produce: this process's id, and the
+/// nanoseconds since the epoch at which it first asked.
+///
+/// Read **once** per process, not once per call. A per-call read would make
+/// two resolutions of the same stable path disagree, which is precisely what
+/// `store_home::test_path` exists to prevent — the bundle would then write to
+/// a different file than the app is reading.
+pub(crate) fn run_token() -> &'static str {
+    static TOKEN: OnceLock<String> = OnceLock::new();
+    TOKEN.get_or_init(|| {
+        // A clock that refuses to answer is not a reason to fail a test run;
+        // the pid alone still separates concurrent runs, and only a reused
+        // pid on a broken clock could then collide.
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_or(0, |since| since.as_nanos());
+        format!("{}-{nanos}", std::process::id())
+    })
+}
+
+/// This thread, as a filename-safe tag. `ThreadId`'s `Debug` is the only way
+/// to name a thread on stable Rust, and it renders as `ThreadId(3)`, whose
+/// parentheses do not belong in a path.
+fn thread_tag() -> String {
+    let id = format!("{:?}", std::thread::current().id());
+    let digits: String = id.chars().filter(char::is_ascii_digit).collect();
+    if digits.is_empty() {
+        // No `ThreadId` has ever rendered without a number, but a tag that
+        // silently collapses to the empty string would make two threads share
+        // a directory, which is the failure this module exists to end.
+        format!("t{id}").replace(['(', ')'], "-")
+    } else {
+        format!("t{digits}")
+    }
+}
+
+thread_local! {
+    /// Directories this thread created that no value owns. Removed when the
+    /// thread ends — see the module docs for why the thread is the owner.
+    static OWNED: OwnedDirs = const { OwnedDirs(RefCell::new(Vec::new())) };
+}
+
+/// The thread's own directories, and their removal.
+struct OwnedDirs(RefCell<Vec<PathBuf>>);
+
+impl Drop for OwnedDirs {
+    fn drop(&mut self) {
+        for dir in self.0.borrow().iter() {
+            let _ = fs::remove_dir_all(dir);
+        }
+    }
+}
+
+/// A directory belonging to this test's thread, created if it is not there
+/// and removed when the thread ends.
+///
+/// Stable: the same `label` on the same thread answers the same path every
+/// time, which is what the `cfg!(test)` paths in production modules need.
+/// Callers that can hold a value should hold a [`ScratchDir`] instead — its
+/// removal happens at the end of the test rather than the end of the thread.
+pub(crate) fn thread_dir(label: &str) -> PathBuf {
+    let dir =
+        std::env::temp_dir().join(format!("{PREFIX}-{}-{label}-{}", run_token(), thread_tag()));
+    // Created here rather than by the caller: every caller wants it to exist,
+    // and a `create_dir_all` per resolution is a stat on a warm path.
+    let _ = fs::create_dir_all(&dir);
+    OWNED.with(|owned| {
+        let mut dirs = owned.0.borrow_mut();
+        if !dirs.contains(&dir) {
+            dirs.push(dir.clone());
+        }
+    });
+    dir
+}
+
+/// A directory of this test's own, removed with everything under it when the
+/// value is dropped — including on a panic, which unwinds.
+///
+/// Keep it alive for as long as the files matter. A test that hands the path
+/// to something that writes later must hold the `ScratchDir` until its last
+/// assertion, or the directory is gone before the assertion reads it.
+/// Gated on `test` because every caller is: the `cfg!(test)` paths in
+/// production modules take [`thread_dir`] instead, so nothing outside a test
+/// build has a use for this type and a release build should not compile it.
+#[cfg(test)]
+pub(crate) struct ScratchDir(PathBuf);
+
+#[cfg(test)]
+impl ScratchDir {
+    /// A fresh directory named `{PREFIX}-<pid>-<nanos>-<counter>-<label>`.
+    ///
+    /// The counter separates two directories the same test asks for; the run
+    /// token separates every run from every other.
+    pub(crate) fn new(label: &str) -> Self {
+        static NEXT: AtomicU64 = AtomicU64::new(0);
+        let dir = std::env::temp_dir().join(format!(
+            "{PREFIX}-{}-{}-{label}",
+            run_token(),
+            NEXT.fetch_add(1, Ordering::Relaxed)
+        ));
+        fs::create_dir_all(&dir).expect("a scratch directory is creatable");
+        Self(dir)
+    }
+
+    /// The directory itself.
+    pub(crate) fn path(&self) -> &Path {
+        &self.0
+    }
+
+    /// A path inside it. The file need not exist — a test asking what happens
+    /// to a missing file wants exactly this.
+    pub(crate) fn join(&self, relative: impl AsRef<Path>) -> PathBuf {
+        self.0.join(relative)
+    }
+
+    /// Write `contents` at `relative`, creating parent folders as needed.
+    pub(crate) fn write(&self, relative: impl AsRef<Path>, contents: &str) -> PathBuf {
+        let path = self.join(relative);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("a scratch parent is creatable");
+        }
+        fs::write(&path, contents).expect("a scratch file is writable");
+        path
+    }
+}
+
+/// So a `ScratchDir` can stand where a `&Path` is wanted, which is how the
+/// per-module `scratch()` helpers this replaced were used: `dir.join(..)`,
+/// `fs::write(&dir, ..)`, `load(&dir)`. Holding the value is still the
+/// caller's job — a `ScratchDir` dropped at the end of the statement that
+/// created it takes its files with it, and the test fails on the missing
+/// file, loudly, which is the right way for that mistake to surface.
+#[cfg(test)]
+impl std::ops::Deref for ScratchDir {
+    type Target = Path;
+
+    fn deref(&self) -> &Path {
+        &self.0
+    }
+}
+
+#[cfg(test)]
+impl AsRef<Path> for ScratchDir {
+    fn as_ref(&self) -> &Path {
+        &self.0
+    }
+}
+
+#[cfg(test)]
+impl Drop for ScratchDir {
+    fn drop(&mut self) {
+        // Best-effort, like `replay`'s. A file still held open by something
+        // the test spawned is not worth failing a green test over, and the
+        // run token means the leftover can never be mistaken for a later
+        // run's own directory.
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+
+/// One scratch *file*, in a directory of its own that removes itself.
+///
+/// The shape most of this crate's per-module helpers had before: they handed
+/// back a `PathBuf` naming a `.toml` and nothing ever removed it. A
+/// `ScratchFile` stands where that `&Path` stood — `fs::write(&file, ..)`,
+/// `load_from(&file)` — and takes its directory with it when the test ends.
+#[cfg(test)]
+pub(crate) struct ScratchFile {
+    /// Held only for its `Drop`: removing the directory removes the file.
+    _dir: ScratchDir,
+    path: PathBuf,
+}
+
+#[cfg(test)]
+impl ScratchFile {
+    /// `name` inside a fresh directory labelled `label`.
+    pub(crate) fn new(label: &str, name: &str) -> Self {
+        let dir = ScratchDir::new(label);
+        let path = dir.join(name);
+        Self { _dir: dir, path }
+    }
+
+    /// The file's path. It does not exist until something writes it.
+    pub(crate) fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+#[cfg(test)]
+impl std::ops::Deref for ScratchFile {
+    type Target = Path;
+
+    fn deref(&self) -> &Path {
+        &self.path
+    }
+}
+
+#[cfg(test)]
+impl AsRef<Path> for ScratchFile {
+    fn as_ref(&self) -> &Path {
+        &self.path
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn two_scratch_directories_never_share_a_path() {
+        let first = ScratchDir::new("same-label");
+        let second = ScratchDir::new("same-label");
+        assert_ne!(first.path(), second.path());
+    }
+
+    #[test]
+    fn a_scratch_directory_is_gone_once_it_is_dropped() {
+        let path = {
+            let scratch = ScratchDir::new("removed-on-drop");
+            scratch.write("nested/file.toml", "content");
+            assert!(scratch.path().exists(), "the directory was created");
+            scratch.path().to_path_buf()
+        };
+        assert!(!path.exists(), "the tree went with the value: {path:?}");
+    }
+
+    #[test]
+    fn the_run_token_carries_the_pid_and_is_stable_within_a_process() {
+        let token = run_token();
+        assert!(
+            token.starts_with(&format!("{}-", std::process::id())),
+            "the token opens with this process's id: {token}"
+        );
+        assert_eq!(token, run_token(), "the token is read once, not per call");
+    }
+
+    #[test]
+    fn a_scratch_file_goes_with_its_directory() {
+        let path = {
+            let file = ScratchFile::new("file-drop", "state.toml");
+            fs::write(&file, "x").expect("the scratch file is writable");
+            assert!(file.path().exists(), "the file was written");
+            file.path().to_path_buf()
+        };
+        assert!(!path.exists(), "the file went with its directory: {path:?}");
+    }
+
+    #[test]
+    fn a_thread_directory_answers_the_same_path_twice() {
+        let first = thread_dir("stable-label");
+        let second = thread_dir("stable-label");
+        assert_eq!(first, second);
+        assert!(first.exists(), "it was created");
+    }
+
+    #[test]
+    fn a_thread_directory_goes_when_its_thread_ends() {
+        let path = std::thread::spawn(|| thread_dir("ends-with-the-thread"))
+            .join()
+            .expect("the thread finished");
+        assert!(
+            !path.exists(),
+            "the thread's own directory went with it: {path:?}"
+        );
+    }
+}

--- a/crates/app/src/store_home.rs
+++ b/crates/app/src/store_home.rs
@@ -261,7 +261,7 @@ pub(crate) fn next_test_home() {
     TEST_HOME_EPOCH.with(|epoch| epoch.set(epoch.get() + 1));
 }
 
-/// A per-process scratch home for stores built by a test.
+/// A scratch home for stores built by a test, per thread and per epoch.
 ///
 /// Stable within a process and distinct per file, so a `default_path()` a
 /// test calls twice answers twice the same — and no test can reach the real
@@ -274,18 +274,15 @@ pub(crate) fn test_path(file: &str) -> PathBuf {
     // this replaced did give, and `--test-threads=1` would otherwise take
     // away, since libtest then runs every test on the same thread.
     //
-    // So: stable per (process, thread, epoch), where the epoch is bumped by
+    // So: stable per (run, thread, epoch), where the epoch is bumped by
     // `next_test_home` when a test builds an app.
-    let home = std::env::temp_dir().join(format!(
-        "quantick-test-home-{}-{:?}-{}",
-        std::process::id(),
-        std::thread::current().id(),
+    // `thread_dir` supplies the rest: a token no other run can reproduce, the
+    // thread, creation, and removal when the test's thread ends. The epoch is
+    // this module's own contribution to the label.
+    let home = crate::scratch::thread_dir(&format!(
+        "home-{}",
         TEST_HOME_EPOCH.with(std::cell::Cell::get)
     ));
-    // The real home is created by the startup rescue, which a test does not
-    // run; without this every store's first save would fail on a missing
-    // folder rather than on anything the test is about.
-    let _ = std::fs::create_dir_all(&home);
     home.join(file)
 }
 
@@ -484,15 +481,8 @@ fn write_marker(marker: &Path) {
 mod tests {
     use super::*;
 
-    fn scratch(name: &str) -> PathBuf {
-        let dir = std::env::temp_dir().join(format!(
-            "quantick-store-home-{name}-{}-{:?}",
-            std::process::id(),
-            std::thread::current().id()
-        ));
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).expect("scratch");
-        dir
+    fn scratch(name: &str) -> crate::scratch::ScratchDir {
+        crate::scratch::ScratchDir::new(name)
     }
 
     /// The whole point of the module: the answer does not depend on where the
@@ -501,7 +491,7 @@ mod tests {
     fn a_store_resolves_into_the_home_not_the_launch_directory() {
         let home = scratch("resolve");
         assert_eq!(
-            resolve_in(Some(home.clone()), "ui-state.toml"),
+            resolve_in(Some(home.path().to_path_buf()), "ui-state.toml"),
             home.join("ui-state.toml")
         );
     }

--- a/crates/app/src/strategy_presets.rs
+++ b/crates/app/src/strategy_presets.rs
@@ -625,10 +625,7 @@ mod tests {
     use super::*;
 
     fn scratch(name: &str) -> PathBuf {
-        std::env::temp_dir().join(format!(
-            "quantick-strategy-bank-{}-{name}.toml",
-            std::process::id()
-        ))
+        crate::scratch::thread_dir("strategy-bank").join(format!("{name}.toml"))
     }
 
     #[test]

--- a/crates/app/src/surfaces/drawing_chrome/mod.rs
+++ b/crates/app/src/surfaces/drawing_chrome/mod.rs
@@ -1156,17 +1156,12 @@ mod tests {
     /// Its own file every call. The store persists on every write, so two
     /// banks sharing a path would let the first call's save leak into the
     /// second and turn a free name into a taken one.
+    /// `thread_dir` rather than a `ScratchFile`: the store outlives the
+    /// expression that built it and keeps saving to this path, so nothing
+    /// here could hold a value that removed the file at the right moment.
     fn bank(tag: &str) -> crate::drawings::presets::PresetStore {
-        let mut store =
-            crate::drawings::presets::PresetStore::load_from(std::env::temp_dir().join(format!(
-                "quantick-drawing-chrome-{}-{:?}-{tag}.toml",
-                std::process::id(),
-                std::thread::current().id()
-            )));
-        // Start from a clean file even if an earlier run left one behind.
-        for name in store.custom_preset_names("fib") {
-            store.delete_custom_preset("fib", &name);
-        }
+        let path = crate::scratch::thread_dir("drawing-chrome").join(format!("{tag}.toml"));
+        let mut store = crate::drawings::presets::PresetStore::load_from(path);
         store.save_custom_preset("fib", "taken", toml::Value::Integer(1), false);
         store
     }

--- a/crates/app/src/symbols_file.rs
+++ b/crates/app/src/symbols_file.rs
@@ -214,11 +214,7 @@ mod tests {
     use super::*;
 
     fn scratch(name: &str) -> PathBuf {
-        std::env::temp_dir().join(format!(
-            "quantick-symbols-{}-{}.toml",
-            name,
-            std::process::id()
-        ))
+        crate::scratch::thread_dir("symbols").join(format!("{name}.toml"))
     }
 
     #[test]

--- a/crates/app/src/tab.rs
+++ b/crates/app/src/tab.rs
@@ -4499,10 +4499,11 @@ mod shared_routing_tests {
             // Its own directory, never the shared temp root: a tab opens a
             // paper-trading ledger, and pointing every test tab at one folder
             // makes them read each other's trades.
-            std::env::temp_dir().join(format!(
-                "quantick-tab-test-{context}-{}",
-                NEXT_TEST_DIR.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            )),
+            crate::scratch::thread_dir("tab-test").join(
+                NEXT_TEST_DIR
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+                    .to_string(),
+            ),
         );
         for slot in 0..context {
             tab.time_panes.push(ChartPane::time(
@@ -4694,10 +4695,11 @@ mod move_pane_tests {
                 commands: cmd_tx,
                 replay: None,
             },
-            std::env::temp_dir().join(format!(
-                "quantick-opening-test-{}",
-                NEXT_DIR.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            )),
+            crate::scratch::thread_dir("opening-test").join(
+                NEXT_DIR
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+                    .to_string(),
+            ),
         );
         (tab, evt_tx)
     }
@@ -4787,10 +4789,11 @@ mod move_pane_tests {
                 commands: cmd_tx,
                 replay: None,
             },
-            std::env::temp_dir().join(format!(
-                "quantick-move-test-{}",
-                NEXT_DIR.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            )),
+            crate::scratch::thread_dir("move-test").join(
+                NEXT_DIR
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+                    .to_string(),
+            ),
         );
         for slot in 0..context {
             tab.time_panes.push(ChartPane::time(
@@ -4921,10 +4924,11 @@ mod collapse_path_tests {
                 commands: cmd_tx,
                 replay: None,
             },
-            std::env::temp_dir().join(format!(
-                "quantick-collapse-test-{}",
-                NEXT_DIR.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            )),
+            crate::scratch::thread_dir("collapse-test").join(
+                NEXT_DIR
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+                    .to_string(),
+            ),
         )
     }
 

--- a/crates/app/src/ui_state.rs
+++ b/crates/app/src/ui_state.rs
@@ -1039,11 +1039,7 @@ mod tests {
     use super::*;
 
     fn temp_path(name: &str) -> PathBuf {
-        std::env::temp_dir().join(format!(
-            "quantick-ui-state-{name}-{}-{:?}.toml",
-            std::process::id(),
-            std::thread::current().id()
-        ))
+        crate::scratch::thread_dir("ui-state").join(format!("{name}.toml"))
     }
 
     fn sample() -> Workspace {

--- a/crates/app/src/workspace_bundle.rs
+++ b/crates/app/src/workspace_bundle.rs
@@ -407,15 +407,8 @@ mod tests {
     use super::*;
     use crate::store_home::COCKPIT_STORES;
 
-    fn scratch(name: &str) -> PathBuf {
-        let dir = std::env::temp_dir().join(format!(
-            "quantick-bundle-{name}-{}-{:?}",
-            std::process::id(),
-            std::thread::current().id()
-        ));
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).expect("scratch");
-        dir
+    fn scratch(name: &str) -> crate::scratch::ScratchDir {
+        crate::scratch::ScratchDir::new(name)
     }
 
     /// A cockpit on disk: one valid file per store, in a scratch folder.
@@ -474,7 +467,8 @@ mod tests {
             capture("scalp WIN manhã", COCKPIT_STORES, &paths_in(&source)).expect("capture");
         assert_eq!(bundle.len(), bundled(), "every store travels");
 
-        let file = scratch("round-trip-file").join(file_name_for(&bundle.name));
+        let files = scratch("round-trip-file");
+        let file = files.join(file_name_for(&bundle.name));
         write(&file, &bundle).expect("write");
         let reread = read(&file).expect("read");
         assert_eq!(reread, bundle, "the file is a faithful copy");
@@ -779,7 +773,8 @@ mod tests {
 
         let bundle = capture("fake", FAKE_REGISTRY, &paths_in(&source)).expect("capture");
         assert_eq!(bundle.len(), 1);
-        let file = scratch("fake-file").join(file_name_for("fake"));
+        let files = scratch("fake-file");
+        let file = files.join(file_name_for("fake"));
         write(&file, &bundle).expect("write");
         let reread = read(&file).expect("read");
         let written = apply(&reread, FAKE_REGISTRY, &paths_in(&live)).expect("apply");

--- a/crates/control-local/src/client.rs
+++ b/crates/control-local/src/client.rs
@@ -647,12 +647,12 @@ mod tests {
 
     #[test]
     fn an_empty_directory_discovers_nothing_and_creates_nothing() {
-        let directory = std::env::temp_dir().join(format!(
-            "quantick-control-local-empty-{}-{}",
-            std::process::id(),
-            line!()
-        ));
-        let _ = std::fs::remove_dir_all(&directory);
+        // A directory that does not exist, inside one that does: discovery
+        // refuses a descriptor directory whose ACL is not already private,
+        // and a folder `ScratchDir` created carries the default one. The
+        // scratch value is still what removes whatever discovery leaves.
+        let scratch = crate::scratch::ScratchDir::new("empty");
+        let directory = scratch.join("instances");
         let live = discover_in(&directory, &options()).unwrap();
         assert!(live.clients.is_empty());
         assert!(!live.next_steps.is_empty());

--- a/crates/control-local/src/discovery.rs
+++ b/crates/control-local/src/discovery.rs
@@ -1059,17 +1059,10 @@ mod tests {
         }
     }
 
-    fn scratch(name: &str) -> PathBuf {
-        let path = std::env::temp_dir().join(format!(
-            "quantick-control-discovery-{}-{name}",
-            std::process::id()
-        ));
-        if path.exists() {
-            fs::remove_dir_all(&path).unwrap();
-        }
-        fs::create_dir(&path).unwrap();
-        set_and_verify_private_directory(&path).unwrap();
-        path
+    fn scratch(name: &str) -> crate::scratch::ScratchDir {
+        let dir = crate::scratch::ScratchDir::new(name);
+        set_and_verify_private_directory(dir.path()).unwrap();
+        dir
     }
 
     #[test]

--- a/crates/control-local/src/lib.rs
+++ b/crates/control-local/src/lib.rs
@@ -19,3 +19,5 @@
 
 pub mod client;
 pub mod discovery;
+#[cfg(test)]
+mod scratch;

--- a/crates/control-local/src/scratch.rs
+++ b/crates/control-local/src/scratch.rs
@@ -1,0 +1,100 @@
+//! Scratch directories these tests own, rather than leak.
+//!
+//! Test-only. The same fix `crates/app/src/scratch.rs` documents at length,
+//! in the smallest form this crate needs: a temporary path keyed on
+//! `std::process::id()` alone is a path a later run can inherit populated,
+//! because the operating system reuses process ids — and nothing here ever
+//! removed one.
+//!
+//! Each crate carries its own copy rather than sharing one. A shared helper
+//! would be a new workspace crate that every crate with tests depends on,
+//! which this repository's dependency rule and its "no new dependency"
+//! constraint both argue against for eighty lines of `std`. The repository
+//! guard `crates/guards/src/scratch.rs` is what keeps the copies honest: it
+//! names each of them, and refuses the call anywhere else.
+
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// A token no other run of this crate can produce: this process's id, and the
+/// nanoseconds since the epoch at which it first asked. Read once per
+/// process, so two resolutions inside one test agree.
+fn run_token() -> &'static str {
+    static TOKEN: OnceLock<String> = OnceLock::new();
+    TOKEN.get_or_init(|| {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_or(0, |since| since.as_nanos());
+        format!("{}-{nanos}", std::process::id())
+    })
+}
+
+/// A directory of this test's own, removed with everything under it when the
+/// value is dropped — including on a panic, which unwinds.
+pub(crate) struct ScratchDir(PathBuf);
+
+impl ScratchDir {
+    /// A fresh directory named `quantick-control-local-<pid>-<nanos>-<counter>-<label>`.
+    /// Created, so a caller can write into it at once.
+    pub(crate) fn new(label: &str) -> Self {
+        static NEXT: AtomicU64 = AtomicU64::new(0);
+        let dir = std::env::temp_dir().join(format!(
+            "quantick-control-local-{}-{}-{label}",
+            run_token(),
+            NEXT.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::create_dir_all(&dir).expect("a scratch directory is creatable");
+        Self(dir)
+    }
+
+    /// The directory itself.
+    pub(crate) fn path(&self) -> &Path {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for ScratchDir {
+    type Target = Path;
+
+    fn deref(&self) -> &Path {
+        &self.0
+    }
+}
+
+impl AsRef<Path> for ScratchDir {
+    fn as_ref(&self) -> &Path {
+        &self.0
+    }
+}
+
+impl Drop for ScratchDir {
+    fn drop(&mut self) {
+        // Best-effort, like every other copy of this: a file something the
+        // test spawned still holds open is not worth failing a green test
+        // over, and the run token means no later run can inherit it.
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn two_scratch_directories_never_share_a_path() {
+        let first = ScratchDir::new("same-label");
+        let second = ScratchDir::new("same-label");
+        assert_ne!(first.path(), second.path());
+    }
+
+    #[test]
+    fn the_tree_goes_when_the_value_does() {
+        let path = {
+            let dir = ScratchDir::new("removed-on-drop");
+            std::fs::write(dir.join("file.txt"), "content").expect("the file is writable");
+            dir.path().to_path_buf()
+        };
+        assert!(!path.exists(), "the tree went with the value: {path:?}");
+    }
+}

--- a/crates/guards/src/context.rs
+++ b/crates/guards/src/context.rs
@@ -722,14 +722,8 @@ mod tests {
 
     /// A scratch workspace whose baseline names two skill files, so a raise on
     /// one can be paid for — or not — by the other.
-    fn scratch(test: &str, first: usize, second: usize, budget: usize) -> std::path::PathBuf {
-        // Process-unique, like `ratchet::tests::tempdir`: two worktrees running
-        // the suite at once — the workflow `CLAUDE.md` prescribes — would
-        // otherwise have one run `remove_dir_all` the other's fixture
-        // mid-test.
-        let root =
-            std::env::temp_dir().join(format!("quantick-context-{test}-{}", std::process::id()));
-        let _ = fs::remove_dir_all(&root);
+    fn scratch(test: &str, first: usize, second: usize, budget: usize) -> crate::tempdir::TempDir {
+        let root = crate::tempdir::TempDir::new(test);
         fs::create_dir_all(root.join("crates/guards")).expect("scratch dirs are creatable");
         fs::create_dir_all(root.join(".claude/skills/one")).expect("scratch dirs are creatable");
         fs::create_dir_all(root.join(".claude/skills/two")).expect("scratch dirs are creatable");

--- a/crates/guards/src/context.rs
+++ b/crates/guards/src/context.rs
@@ -722,8 +722,13 @@ mod tests {
 
     /// A scratch workspace whose baseline names two skill files, so a raise on
     /// one can be paid for — or not — by the other.
-    fn scratch(test: &str, first: usize, second: usize, budget: usize) -> crate::tempdir::TempDir {
-        let root = crate::tempdir::TempDir::new(test);
+    fn scratch(
+        test: &str,
+        first: usize,
+        second: usize,
+        budget: usize,
+    ) -> crate::scratch_dir::ScratchDir {
+        let root = crate::scratch_dir::ScratchDir::new(test);
         fs::create_dir_all(root.join("crates/guards")).expect("scratch dirs are creatable");
         fs::create_dir_all(root.join(".claude/skills/one")).expect("scratch dirs are creatable");
         fs::create_dir_all(root.join(".claude/skills/two")).expect("scratch dirs are creatable");

--- a/crates/guards/src/lib.rs
+++ b/crates/guards/src/lib.rs
@@ -1,12 +1,14 @@
 //! Repository guards for the things the compiler cannot see.
 //!
-//! Four rules hold in this repo that no amount of `cargo build` can check: a
+//! Five rules hold in this repo that no amount of `cargo build` can check: a
 //! file may not silently absorb a crate ([`size`]), a crate's modules may not
 //! weld themselves into a cycle ([`cycle`]), everything written into a
-//! tracked file is English ([`language`]), and sources are UTF-8 without a BOM
-//! and without welded doc comments ([`encoding`]). Each is a rule
-//! `CLAUDE.md` states and each fails invisibly — fmt, clippy, build and the
-//! whole suite stay green while it is broken.
+//! tracked file is English ([`language`]), sources are UTF-8 without a BOM
+//! and without welded doc comments ([`encoding`]), and a test's temporary
+//! directory is minted by its crate's scratch module rather than spelled by
+//! hand ([`scratch`]). Each is a rule `CLAUDE.md` states and each fails
+//! invisibly — fmt, clippy, build and the whole suite stay green while it is
+//! broken.
 //!
 //! # Why this is a crate rather than three test files
 //!
@@ -41,7 +43,10 @@ pub mod encoding;
 pub mod generated;
 pub mod language;
 pub mod ratchet;
+pub mod scratch;
 pub mod size;
+#[cfg(test)]
+pub mod tempdir;
 
 use std::path::{Path, PathBuf};
 
@@ -167,6 +172,12 @@ pub const GUARDS: &[Guard] = &[
             baseline_file: cycle::BASELINE_FILE,
             budget_slack: cycle::BUDGET_SLACK,
         }),
+    },
+    Guard {
+        name: "scratch",
+        check: scratch::check,
+        check_file: scratch::check_file,
+        ratchet: None,
     },
     Guard {
         name: "language",

--- a/crates/guards/src/lib.rs
+++ b/crates/guards/src/lib.rs
@@ -1,14 +1,18 @@
 //! Repository guards for the things the compiler cannot see.
 //!
-//! Five rules hold in this repo that no amount of `cargo build` can check: a
-//! file may not silently absorb a crate ([`size`]), a crate's modules may not
-//! weld themselves into a cycle ([`cycle`]), everything written into a
-//! tracked file is English ([`language`]), sources are UTF-8 without a BOM
-//! and without welded doc comments ([`encoding`]), and a test's temporary
-//! directory is minted by its crate's scratch module rather than spelled by
-//! hand ([`scratch`]). Each is a rule `CLAUDE.md` states and each fails
-//! invisibly — fmt, clippy, build and the whole suite stay green while it is
-//! broken.
+//! [`GUARDS`] is the list, and deliberately the only one: a file may not
+//! silently absorb a crate ([`size`]), the instructions a session loads may
+//! not either ([`context`]), a crate's modules may not weld themselves into a
+//! cycle ([`cycle`]), everything written into a tracked file is English
+//! ([`language`]), sources are UTF-8 without a BOM and without welded doc
+//! comments ([`encoding`]), the generated indexes still say what the code
+//! says ([`generated`]), and a test's temporary directory is minted by its
+//! crate's scratch module rather than spelled by hand ([`scratch`]).
+//!
+//! Each is a rule `CLAUDE.md` states and each fails invisibly — fmt, clippy,
+//! build and the whole suite stay green while it is broken. Counting them
+//! here was how this paragraph fell a rule behind twice; the registry
+//! counts.
 //!
 //! # Why this is a crate rather than three test files
 //!
@@ -44,9 +48,9 @@ pub mod generated;
 pub mod language;
 pub mod ratchet;
 pub mod scratch;
-pub mod size;
 #[cfg(test)]
-pub mod tempdir;
+pub mod scratch_dir;
+pub mod size;
 
 use std::path::{Path, PathBuf};
 

--- a/crates/guards/src/ratchet.rs
+++ b/crates/guards/src/ratchet.rs
@@ -446,8 +446,8 @@ mod tests {
     };
 
     /// A scratch workspace holding one baseline file.
-    fn workspace(baseline: &str) -> crate::tempdir::TempDir {
-        let dir = crate::tempdir::TempDir::new("ratchet");
+    fn workspace(baseline: &str) -> crate::scratch_dir::ScratchDir {
+        let dir = crate::scratch_dir::ScratchDir::new("ratchet");
         fs::write(dir.path().join("baseline.txt"), baseline).expect("baseline is writable");
         dir
     }

--- a/crates/guards/src/ratchet.rs
+++ b/crates/guards/src/ratchet.rs
@@ -446,44 +446,10 @@ mod tests {
     };
 
     /// A scratch workspace holding one baseline file.
-    fn workspace(baseline: &str) -> tempdir::TempDir {
-        let dir = tempdir::TempDir::new();
+    fn workspace(baseline: &str) -> crate::tempdir::TempDir {
+        let dir = crate::tempdir::TempDir::new("ratchet");
         fs::write(dir.path().join("baseline.txt"), baseline).expect("baseline is writable");
         dir
-    }
-
-    /// The smallest temporary directory that removes itself, so these tests
-    /// stay inside the no-dependency rule the whole crate is built on.
-    mod tempdir {
-        use std::path::{Path, PathBuf};
-        use std::sync::atomic::{AtomicUsize, Ordering};
-        use std::{fs, process};
-
-        pub struct TempDir(PathBuf);
-
-        static NEXT: AtomicUsize = AtomicUsize::new(0);
-
-        impl TempDir {
-            pub fn new() -> Self {
-                let path = std::env::temp_dir().join(format!(
-                    "quantick-ratchet-{}-{}",
-                    process::id(),
-                    NEXT.fetch_add(1, Ordering::Relaxed)
-                ));
-                fs::create_dir_all(&path).expect("temp dir is creatable");
-                Self(path)
-            }
-
-            pub fn path(&self) -> &Path {
-                &self.0
-            }
-        }
-
-        impl Drop for TempDir {
-            fn drop(&mut self) {
-                let _ = fs::remove_dir_all(&self.0);
-            }
-        }
     }
 
     #[test]

--- a/crates/guards/src/scratch.rs
+++ b/crates/guards/src/scratch.rs
@@ -40,7 +40,7 @@ use crate::Finding;
 const SCRATCH_MODULES: &[&str] = &[
     "crates/app/src/scratch.rs",
     "crates/control-local/src/scratch.rs",
-    "crates/guards/src/tempdir.rs",
+    "crates/guards/src/scratch_dir.rs",
     // `mcp` needs two: an integration test links the crate as a dependency
     // and cannot see its `#[cfg(test)]` items, so the unit tests and the
     // tests under `tests/` cannot share one module.
@@ -81,7 +81,18 @@ fn scan(dir: &Path, root: &Path, violations: &mut Vec<String>) {
         }
     };
     for entry in entries {
-        let path = entry.expect("dir entry is readable").path();
+        // Reported, not panicked on. A transient IO error on one entry would
+        // otherwise abort the whole scan mid-way, which reads as a crash
+        // rather than as the finding it is — and the `read_dir` failure just
+        // above is already handled that way.
+        let path = match entry {
+            Ok(entry) => entry.path(),
+            Err(e) => {
+                let relative = relative_to(dir, root);
+                violations.push(format!("{relative}/: an entry could not be read: {e}"));
+                continue;
+            }
+        };
         if path.is_dir() {
             if path.file_name().is_some_and(|name| name == "target") {
                 continue;
@@ -119,12 +130,29 @@ fn in_scope(relative: &str) -> bool {
 
 /// The per-file half of the scan, shared with [`check_file`].
 fn inspect(path: &Path, relative: &str, violations: &mut Vec<String>) {
-    let Ok(text) = fs::read_to_string(path) else {
-        return;
+    // A file that will not read is reported rather than skipped. Silence here
+    // would make `check_file` answer "clean" for a file the scan could not
+    // read, which breaks the one property the hook and the scan must share —
+    // and a guard that goes quiet over sources nobody opened is the failure
+    // this whole family exists to make impossible.
+    let text = match fs::read_to_string(path) {
+        Ok(text) => text,
+        Err(e) => {
+            violations.push(format!("{relative}: could not be read: {e}"));
+            return;
+        }
     };
     for (line_no, line) in text.lines().enumerate() {
-        // Comments are prose, and this guard's own documentation names the
-        // call it hunts for. A commented-out call leaks nothing either.
+        // A line comment is prose, and this guard's own documentation names
+        // the call it hunts for. A commented-out call leaks nothing either.
+        //
+        // Line comments only: a `temp_dir(` inside a `/* … */` block would
+        // still be a finding. That is a false positive on paper and none in
+        // practice — this workspace's Rust holds four block comments in
+        // total, none of them near a temporary path — and the alternative is
+        // tracking comment state across lines, which is a parser, in the
+        // crate that is allowed no dependencies. If one ever appears, the
+        // finding says which line and the fix is to reword it.
         if line.trim_start().starts_with("//") {
             continue;
         }
@@ -177,7 +205,7 @@ mod tests {
     /// exists to ask is not, and neither is a file that never asks.
     #[test]
     fn only_a_scratch_module_may_ask_for_the_temporary_directory() {
-        let root = crate::tempdir::TempDir::new("scratch-guard");
+        let root = crate::scratch_dir::ScratchDir::new("scratch-guard");
         fs::create_dir_all(root.join("crates/app/src")).expect("scratch dirs are creatable");
         fs::write(
             root.join("crates/app/src/scratch.rs"),
@@ -214,7 +242,7 @@ mod tests {
     /// exists to prevent could come back by changing an import.
     #[test]
     fn every_spelling_of_the_call_is_caught() {
-        let root = crate::tempdir::TempDir::new("scratch-guard-spellings");
+        let root = crate::scratch_dir::ScratchDir::new("scratch-guard-spellings");
         fs::create_dir_all(root.join("crates/app/src")).expect("scratch dirs are creatable");
         // Built from `NEEDLE` rather than spelled out: a fixture that names
         // the call literally makes this file its own first finding.
@@ -248,7 +276,7 @@ mod tests {
     /// reports what the suite does not is an advisory nobody can clear.
     #[test]
     fn check_file_agrees_with_the_scan_about_every_file() {
-        let root = crate::tempdir::TempDir::new("scratch-guard-agree");
+        let root = crate::scratch_dir::ScratchDir::new("scratch-guard-agree");
         fs::create_dir_all(root.join("crates/app/src")).expect("scratch dirs are creatable");
         for name in ["scratch.rs", "leaky.rs"] {
             fs::write(
@@ -269,6 +297,37 @@ mod tests {
                 "the hook and the scan disagree about {relative}"
             );
         }
+    }
+
+    /// A file the guard cannot read is a finding, and the hook says so too.
+    /// Silence there would let an unreadable source pass as clean — the one
+    /// outcome this guard family exists to make impossible — and would break
+    /// the hook/scan equivalence the test above only checks on readable
+    /// files.
+    #[test]
+    fn a_source_that_cannot_be_read_is_reported_by_both_the_scan_and_the_hook() {
+        let root = crate::scratch_dir::ScratchDir::new("scratch-guard-unreadable");
+        fs::create_dir_all(root.join("crates/app/src")).expect("scratch dirs are creatable");
+        let relative = "crates/app/src/undecodable.rs";
+        // Not UTF-8, so `read_to_string` fails the way a locked or corrupt
+        // file does, without needing platform-specific permissions.
+        fs::write(root.join(relative), [0x66, 0x6e, 0xff, 0xfe, 0x0a])
+            .expect("the fixture is writable");
+
+        let from_scan = check(root.path());
+        assert_eq!(from_scan.len(), 1, "the scan reports it: {from_scan:#?}");
+        assert!(
+            from_scan[0]
+                .line
+                .starts_with(&format!("{relative}: could not be read")),
+            "{}",
+            from_scan[0].line
+        );
+        assert_eq!(
+            check_file(root.path(), relative),
+            from_scan,
+            "the hook and the scan agree on the error path too"
+        );
     }
 
     /// The guard's own source names the call it hunts for, and must not

--- a/crates/guards/src/scratch.rs
+++ b/crates/guards/src/scratch.rs
@@ -55,9 +55,19 @@ const SCRATCH_MODULES: &[&str] = &[
 /// path it mints cannot leak and when the entry goes.
 const ALLOWED: &[&str] = &[];
 
-/// The call this guard hunts for. Written split so the guard's own source
-/// does not match it — the file would otherwise be its own first finding.
-const NEEDLE: &str = concat!("env::", "temp_dir()");
+/// The call this guard hunts for.
+///
+/// The bare call rather than `env::temp_dir()`, because the qualified spelling
+/// is only one of the ways to write it: `use std::env::temp_dir;` and a bare
+/// `temp_dir()`, or `std::env :: temp_dir()`, are the same call and were both
+/// invisible to a needle that insisted on the path. Matching the call itself
+/// costs one rule — no source outside a scratch module may name a function
+/// called `temp_dir` — which is why `chart_layers`'s local helper of that name
+/// was renamed rather than exempted.
+///
+/// Written split so the guard's own source does not match it; the file would
+/// otherwise be its own first finding.
+const NEEDLE: &str = concat!("temp_", "dir(");
 
 fn scan(dir: &Path, root: &Path, violations: &mut Vec<String>) {
     let entries = match fs::read_dir(dir) {
@@ -196,6 +206,41 @@ mod tests {
             "the finding names the file and the line: {}",
             findings[0].line
         );
+    }
+
+    /// The spelling does not save a leak. A qualified call, an imported bare
+    /// one, and a spaced-out path are the same call, and a needle that
+    /// insisted on `env::` saw only the first — so the regression this guard
+    /// exists to prevent could come back by changing an import.
+    #[test]
+    fn every_spelling_of_the_call_is_caught() {
+        let root = crate::tempdir::TempDir::new("scratch-guard-spellings");
+        fs::create_dir_all(root.join("crates/app/src")).expect("scratch dirs are creatable");
+        // Built from `NEEDLE` rather than spelled out: a fixture that names
+        // the call literally makes this file its own first finding.
+        fs::write(
+            root.join("crates/app/src/spellings.rs"),
+            format!(
+                "use std::env::temp_dir;
+                 fn a() {{ let _ = std::env::{NEEDLE}); }}
+                 fn b() {{ let _ = {NEEDLE}); }}
+                 fn c() {{ let _ = std::env :: {NEEDLE}); }}
+"
+            ),
+        )
+        .expect("the source is writable");
+
+        let lines: Vec<String> = check(root.path())
+            .into_iter()
+            .map(|finding| finding.line)
+            .collect();
+        assert_eq!(lines.len(), 3, "one per call, not per import: {lines:#?}");
+        for (index, line) in lines.iter().enumerate() {
+            assert!(
+                line.starts_with(&format!("crates/app/src/spellings.rs:{}:", index + 2)),
+                "the calls are on lines 2, 3 and 4: {line}"
+            );
+        }
     }
 
     /// The edit-time hook and the whole-repo scan answer the same for one

--- a/crates/guards/src/scratch.rs
+++ b/crates/guards/src/scratch.rs
@@ -1,0 +1,255 @@
+//! Grep guard for temporary directories nobody owns.
+//!
+//! A test that spells `std::env::temp_dir()` itself gets two things wrong that
+//! nothing else in the build can see.
+//!
+//! It names the folder after `std::process::id()`, because that is the only
+//! unique-looking number `std` offers for free. A process id is *reused* —
+//! Windows hands one back within minutes — so the folder a later run creates
+//! is the folder an earlier run left behind, and the test asserts on the
+//! previous run's files. The failure looks exactly like the change under
+//! test. Three `paper_trading` tests failed that way, and the same shape has
+//! taken app tests down in CI on `main`.
+//!
+//! And it removes nothing. `%TEMP%` on the host that runs this suite daily
+//! held 450,227 `quantick-*` entries on 2026-09-04.
+//!
+//! Neither is visible to fmt, clippy, build or the suite: the leak is silent
+//! by construction, and the collision only fires when the operating system
+//! happens to reuse a number. So the rule is mechanical instead — **only a
+//! crate's own scratch module may ask for the temporary directory**, and
+//! those modules carry a run token no other run can reproduce plus a `Drop`
+//! that removes the tree.
+//!
+//! # What this cannot see
+//!
+//! It reads text, not types: a helper that returns a path from an allowed
+//! module and never removes it passes. The guard makes the *one* place where
+//! temporary paths are minted explicit and reviewable, which is what makes
+//! the removal reviewable too — not a proof that every test cleans up.
+
+use std::fs;
+use std::path::Path;
+
+use crate::Finding;
+
+/// What a test-side path has to go through. Every entry is a module whose
+/// whole job is minting scratch paths that remove themselves; each carries
+/// its own run token, because a crate that cannot depend on another (the
+/// `guards` crate depends on nothing at all) cannot share one.
+const SCRATCH_MODULES: &[&str] = &[
+    "crates/app/src/scratch.rs",
+    "crates/control-local/src/scratch.rs",
+    "crates/guards/src/tempdir.rs",
+    // `mcp` needs two: an integration test links the crate as a dependency
+    // and cannot see its `#[cfg(test)]` items, so the unit tests and the
+    // tests under `tests/` cannot share one module.
+    "crates/mcp/src/scratch.rs",
+    "crates/mcp/tests/common/mod.rs",
+    "crates/replay/src/scratch.rs",
+];
+
+/// The one place outside a scratch module that legitimately reads the
+/// temporary directory, and why.
+///
+/// `pane.rs` names a path it never creates — `load_from(temp_dir().join(
+/// "no-such.toml"))`, twice, asking what a missing preset file does — so it
+/// leaks nothing. It is exempt rather than fixed because
+/// `refactor/pane-tests-out` is relocating that whole test module as this
+/// lands, and a two-line edit inside it buys a rebase conflict for no
+/// behaviour. Remove this entry once that branch has merged.
+const ALLOWED: &[&str] = &["crates/app/src/pane.rs"];
+
+/// The call this guard hunts for. Written split so the guard's own source
+/// does not match it — the file would otherwise be its own first finding.
+const NEEDLE: &str = concat!("env::", "temp_dir()");
+
+fn scan(dir: &Path, root: &Path, violations: &mut Vec<String>) {
+    let entries = match fs::read_dir(dir) {
+        Ok(entries) => entries,
+        // Reported, not skipped: a permission error or a locked tree must not
+        // produce a green verdict over sources nobody opened.
+        Err(e) => {
+            let relative = relative_to(dir, root);
+            violations.push(format!("{relative}/: directory could not be listed: {e}"));
+            return;
+        }
+    };
+    for entry in entries {
+        let path = entry.expect("dir entry is readable").path();
+        if path.is_dir() {
+            if path.file_name().is_some_and(|name| name == "target") {
+                continue;
+            }
+            scan(&path, root, violations);
+            continue;
+        }
+        let relative = relative_to(&path, root);
+        if !in_scope(&relative) {
+            continue;
+        }
+        inspect(&path, &relative, violations);
+    }
+}
+
+/// A workspace-relative path with forward slashes, so a finding reads the
+/// same on either platform.
+fn relative_to(path: &Path, root: &Path) -> String {
+    path.strip_prefix(root)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+/// Whether a workspace-relative path is one this guard reads. The single
+/// owner of that question, called by the walker and by [`check_file`], so the
+/// whole-repo run and the edit-time hook can never disagree about scope.
+fn in_scope(relative: &str) -> bool {
+    relative.starts_with("crates/")
+        && relative.ends_with(".rs")
+        && !relative.split('/').any(|part| part == "target")
+        && !SCRATCH_MODULES.contains(&relative)
+        && !ALLOWED.contains(&relative)
+}
+
+/// The per-file half of the scan, shared with [`check_file`].
+fn inspect(path: &Path, relative: &str, violations: &mut Vec<String>) {
+    let Ok(text) = fs::read_to_string(path) else {
+        return;
+    };
+    for (line_no, line) in text.lines().enumerate() {
+        // Comments are prose, and this guard's own documentation names the
+        // call it hunts for. A commented-out call leaks nothing either.
+        if line.trim_start().starts_with("//") {
+            continue;
+        }
+        if line.contains(NEEDLE) {
+            violations.push(format!(
+                "{relative}:{}: asks for the temporary directory directly",
+                line_no + 1,
+            ));
+        }
+    }
+}
+
+/// What the guard asks for beyond the list of violations.
+pub const REMEDY: &str = "A temporary path was minted outside its crate's scratch module. Take it \
+                          from that module instead — `ScratchDir`/`ScratchFile` where a test can \
+                          hold the value, `thread_dir` where the path is handed to something the \
+                          test does not own — so it carries a run token and is removed.";
+
+/// Every unowned temporary path found under `crates`.
+pub fn check(root: &Path) -> Vec<Finding> {
+    let mut violations = Vec::new();
+    scan(&root.join("crates"), root, &mut violations);
+    // One class of violation, one remedy.
+    violations
+        .into_iter()
+        .map(|v| Finding::new(v, REMEDY))
+        .collect()
+}
+
+/// The same check for one file. A path outside `crates/`, a scratch module,
+/// or a non-Rust file reports nothing.
+pub fn check_file(root: &Path, relative: &str) -> Vec<Finding> {
+    if !in_scope(relative) {
+        return Vec::new();
+    }
+    let mut violations = Vec::new();
+    inspect(&root.join(relative), relative, &mut violations);
+    violations
+        .into_iter()
+        .map(|v| Finding::new(v, REMEDY))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The whole rule, on a workspace of three files: an ordinary source that
+    /// asks for the temporary directory is a finding, the scratch module that
+    /// exists to ask is not, and neither is a file that never asks.
+    #[test]
+    fn only_a_scratch_module_may_ask_for_the_temporary_directory() {
+        let root = crate::tempdir::TempDir::new("scratch-guard");
+        fs::create_dir_all(root.join("crates/app/src")).expect("scratch dirs are creatable");
+        fs::write(
+            root.join("crates/app/src/scratch.rs"),
+            format!("fn dir() {{ std::{NEEDLE}; }}\n"),
+        )
+        .expect("the scratch module is writable");
+        fs::write(
+            root.join("crates/app/src/leaky.rs"),
+            format!("#[test]\nfn t() {{\n    let d = std::{NEEDLE}.join(\"x\");\n}}\n"),
+        )
+        .expect("the leaky test is writable");
+        fs::write(
+            root.join("crates/app/src/clean.rs"),
+            "fn t() { let d = crate::scratch::ScratchDir::new(\"x\"); }\n",
+        )
+        .expect("the clean test is writable");
+
+        let findings = check(root.path());
+        assert_eq!(
+            findings.len(),
+            1,
+            "one file asks and should not: {findings:#?}"
+        );
+        assert!(
+            findings[0].line.starts_with("crates/app/src/leaky.rs:3:"),
+            "the finding names the file and the line: {}",
+            findings[0].line
+        );
+    }
+
+    /// The edit-time hook and the whole-repo scan answer the same for one
+    /// file, including for a file the scan deliberately skips — a hook that
+    /// reports what the suite does not is an advisory nobody can clear.
+    #[test]
+    fn check_file_agrees_with_the_scan_about_every_file() {
+        let root = crate::tempdir::TempDir::new("scratch-guard-agree");
+        fs::create_dir_all(root.join("crates/app/src")).expect("scratch dirs are creatable");
+        for name in ["scratch.rs", "leaky.rs"] {
+            fs::write(
+                root.join(format!("crates/app/src/{name}")),
+                format!("fn dir() {{ std::{NEEDLE}; }}\n"),
+            )
+            .expect("the source is writable");
+        }
+        for name in ["scratch.rs", "leaky.rs"] {
+            let relative = format!("crates/app/src/{name}");
+            let from_scan: Vec<_> = check(root.path())
+                .into_iter()
+                .filter(|finding| finding.line.starts_with(&relative))
+                .collect();
+            assert_eq!(
+                check_file(root.path(), &relative),
+                from_scan,
+                "the hook and the scan disagree about {relative}"
+            );
+        }
+    }
+
+    /// The guard's own source names the call it hunts for, and must not
+    /// report itself for doing so.
+    #[test]
+    fn the_guard_does_not_find_itself() {
+        let findings = check(&crate::workspace_root());
+        assert!(
+            !findings
+                .iter()
+                .any(|finding| finding.line.starts_with("crates/guards/src/scratch.rs")),
+            "the guard reported its own source: {findings:#?}"
+        );
+    }
+
+    /// The rule as it actually stands in this repository: every temporary
+    /// path is minted in a scratch module. The guard is worth nothing if the
+    /// workspace it guards does not pass it.
+    #[test]
+    fn the_workspace_itself_is_clean() {
+        let findings = check(&crate::workspace_root());
+        assert!(findings.is_empty(), "{findings:#?}");
+    }
+}

--- a/crates/guards/src/scratch.rs
+++ b/crates/guards/src/scratch.rs
@@ -49,16 +49,11 @@ const SCRATCH_MODULES: &[&str] = &[
     "crates/replay/src/scratch.rs",
 ];
 
-/// The one place outside a scratch module that legitimately reads the
-/// temporary directory, and why.
-///
-/// `pane.rs` names a path it never creates — `load_from(temp_dir().join(
-/// "no-such.toml"))`, twice, asking what a missing preset file does — so it
-/// leaks nothing. It is exempt rather than fixed because
-/// `refactor/pane-tests-out` is relocating that whole test module as this
-/// lands, and a two-line edit inside it buys a rebase conflict for no
-/// behaviour. Remove this entry once that branch has merged.
-const ALLOWED: &[&str] = &["crates/app/src/pane.rs"];
+/// Files outside a scratch module that may still read the temporary
+/// directory. Empty, and meant to stay that way: an entry here is a place the
+/// rule does not reach, so each one needs a reason beside it saying why the
+/// path it mints cannot leak and when the entry goes.
+const ALLOWED: &[&str] = &[];
 
 /// The call this guard hunts for. Written split so the guard's own source
 /// does not match it — the file would otherwise be its own first finding.

--- a/crates/guards/src/scratch_dir.rs
+++ b/crates/guards/src/scratch_dir.rs
@@ -1,7 +1,7 @@
 //! The smallest temporary directory that removes itself, so these tests stay
 //! inside the no-dependency rule the whole crate is built on.
 //!
-//! It was three spellings before: `ratchet`'s own `TempDir`, `context`'s
+//! It was three spellings before: `ratchet`'s own `ScratchDir`, `context`'s
 //! process-id-keyed `scratch`, and `size`'s folder named after the *test*
 //! rather than after anything unique at all. The last is the interesting one
 //! — its comment records why it was written that way, "a reused pid leaves a
@@ -32,9 +32,9 @@ fn run_token() -> &'static str {
 }
 
 /// A directory that removes itself, with everything under it, when dropped.
-pub struct TempDir(PathBuf);
+pub struct ScratchDir(PathBuf);
 
-impl TempDir {
+impl ScratchDir {
     /// A fresh directory, unique to this run and this call.
     pub fn new(label: &str) -> Self {
         static NEXT: AtomicUsize = AtomicUsize::new(0);
@@ -53,9 +53,9 @@ impl TempDir {
     }
 }
 
-/// So a `TempDir` stands where the `PathBuf` roots these tests passed around
+/// So a `ScratchDir` stands where the `PathBuf` roots these tests passed around
 /// stood: `root.join(..)`, `check(&root)`.
-impl std::ops::Deref for TempDir {
+impl std::ops::Deref for ScratchDir {
     type Target = Path;
 
     fn deref(&self) -> &Path {
@@ -63,13 +63,13 @@ impl std::ops::Deref for TempDir {
     }
 }
 
-impl AsRef<Path> for TempDir {
+impl AsRef<Path> for ScratchDir {
     fn as_ref(&self) -> &Path {
         &self.0
     }
 }
 
-impl Drop for TempDir {
+impl Drop for ScratchDir {
     fn drop(&mut self) {
         let _ = fs::remove_dir_all(&self.0);
     }
@@ -81,15 +81,15 @@ mod tests {
 
     #[test]
     fn two_directories_with_one_label_never_share_a_path() {
-        let first = TempDir::new("same");
-        let second = TempDir::new("same");
+        let first = ScratchDir::new("same");
+        let second = ScratchDir::new("same");
         assert_ne!(first.path(), second.path());
     }
 
     #[test]
     fn the_tree_goes_when_the_value_does() {
         let path = {
-            let dir = TempDir::new("removed");
+            let dir = ScratchDir::new("removed");
             fs::create_dir_all(dir.join("nested")).expect("nested dirs are creatable");
             fs::write(dir.join("nested/file.txt"), "content").expect("the file is writable");
             dir.path().to_path_buf()

--- a/crates/guards/src/size.rs
+++ b/crates/guards/src/size.rs
@@ -612,10 +612,10 @@ mod tests {
     }
 
     /// A throwaway workspace: a baseline naming one source file, and that
-    /// file. See [`crate::tempdir`] for why the name carries a run token
+    /// file. See [`crate::scratch_dir`] for why the name carries a run token
     /// rather than the test's own name.
-    fn scratch(test: &str, ceiling: usize, lines: usize) -> crate::tempdir::TempDir {
-        let root = crate::tempdir::TempDir::new(test);
+    fn scratch(test: &str, ceiling: usize, lines: usize) -> crate::scratch_dir::ScratchDir {
+        let root = crate::scratch_dir::ScratchDir::new(test);
         fs::create_dir_all(root.join("crates/guards")).expect("scratch dirs are creatable");
         fs::create_dir_all(root.join("crates/probe/src")).expect("scratch dirs are creatable");
         fs::write(
@@ -778,7 +778,7 @@ mod tests {
     /// its own instructions.
     #[test]
     fn a_file_that_does_not_decode_is_not_reported_as_a_stale_entry() {
-        let root = crate::tempdir::TempDir::new("undecodable");
+        let root = crate::scratch_dir::ScratchDir::new("undecodable");
         fs::create_dir_all(root.join("crates/guards")).expect("scratch dirs are creatable");
         fs::create_dir_all(root.join("crates/probe/src")).expect("scratch dirs are creatable");
         fs::write(
@@ -812,7 +812,7 @@ mod tests {
     /// delete the entries — would switch the ratchet off repo-wide.
     #[test]
     fn a_missing_sources_directory_is_named_rather_than_read_as_stale_entries() {
-        let root = crate::tempdir::TempDir::new("missing-sources");
+        let root = crate::scratch_dir::ScratchDir::new("missing-sources");
         fs::create_dir_all(root.join("crates/guards")).expect("scratch dirs are creatable");
         fs::write(
             root.join(BASELINE_FILE),
@@ -839,8 +839,8 @@ mod tests {
         first: usize,
         second: usize,
         budget: usize,
-    ) -> crate::tempdir::TempDir {
-        let root = crate::tempdir::TempDir::new(test);
+    ) -> crate::scratch_dir::ScratchDir {
+        let root = crate::scratch_dir::ScratchDir::new(test);
         fs::create_dir_all(root.join("crates/guards")).expect("scratch dirs are creatable");
         fs::create_dir_all(root.join("crates/probe/src")).expect("scratch dirs are creatable");
         fs::write(

--- a/crates/guards/src/size.rs
+++ b/crates/guards/src/size.rs
@@ -612,12 +612,10 @@ mod tests {
     }
 
     /// A throwaway workspace: a baseline naming one source file, and that
-    /// file. Named after its test rather than after the process id, because
-    /// a reused pid leaves a populated directory behind and the test then
-    /// fails on the previous run's contents.
-    fn scratch(test: &str, ceiling: usize, lines: usize) -> std::path::PathBuf {
-        let root = std::env::temp_dir().join(format!("quantick-guards-{test}"));
-        let _ = fs::remove_dir_all(&root);
+    /// file. See [`crate::tempdir`] for why the name carries a run token
+    /// rather than the test's own name.
+    fn scratch(test: &str, ceiling: usize, lines: usize) -> crate::tempdir::TempDir {
+        let root = crate::tempdir::TempDir::new(test);
         fs::create_dir_all(root.join("crates/guards")).expect("scratch dirs are creatable");
         fs::create_dir_all(root.join("crates/probe/src")).expect("scratch dirs are creatable");
         fs::write(
@@ -780,8 +778,7 @@ mod tests {
     /// its own instructions.
     #[test]
     fn a_file_that_does_not_decode_is_not_reported_as_a_stale_entry() {
-        let root = std::env::temp_dir().join("quantick-guards-undecodable");
-        let _ = fs::remove_dir_all(&root);
+        let root = crate::tempdir::TempDir::new("undecodable");
         fs::create_dir_all(root.join("crates/guards")).expect("scratch dirs are creatable");
         fs::create_dir_all(root.join("crates/probe/src")).expect("scratch dirs are creatable");
         fs::write(
@@ -815,8 +812,7 @@ mod tests {
     /// delete the entries — would switch the ratchet off repo-wide.
     #[test]
     fn a_missing_sources_directory_is_named_rather_than_read_as_stale_entries() {
-        let root = std::env::temp_dir().join("quantick-guards-missing-sources");
-        let _ = fs::remove_dir_all(&root);
+        let root = crate::tempdir::TempDir::new("missing-sources");
         fs::create_dir_all(root.join("crates/guards")).expect("scratch dirs are creatable");
         fs::write(
             root.join(BASELINE_FILE),
@@ -838,9 +834,13 @@ mod tests {
     /// on one can be paid for — or not — by the other. The single-entry
     /// [`scratch`] cannot express pay-as-you-go at all: with one ceiling, the
     /// total and the ceiling are the same number and every raise is a raise.
-    fn scratch_pair(test: &str, first: usize, second: usize, budget: usize) -> std::path::PathBuf {
-        let root = std::env::temp_dir().join(format!("quantick-guards-{test}"));
-        let _ = fs::remove_dir_all(&root);
+    fn scratch_pair(
+        test: &str,
+        first: usize,
+        second: usize,
+        budget: usize,
+    ) -> crate::tempdir::TempDir {
+        let root = crate::tempdir::TempDir::new(test);
         fs::create_dir_all(root.join("crates/guards")).expect("scratch dirs are creatable");
         fs::create_dir_all(root.join("crates/probe/src")).expect("scratch dirs are creatable");
         fs::write(

--- a/crates/guards/src/tempdir.rs
+++ b/crates/guards/src/tempdir.rs
@@ -1,0 +1,99 @@
+//! The smallest temporary directory that removes itself, so these tests stay
+//! inside the no-dependency rule the whole crate is built on.
+//!
+//! It was three spellings before: `ratchet`'s own `TempDir`, `context`'s
+//! process-id-keyed `scratch`, and `size`'s folder named after the *test*
+//! rather than after anything unique at all. The last is the interesting one
+//! — its comment records why it was written that way, "a reused pid leaves a
+//! populated directory behind and the test then fails on the previous run's
+//! contents" — which trades one collision for a worse one: two worktrees
+//! running the suite at once, the workflow `CLAUDE.md` prescribes, then share
+//! a fixture directory and delete each other's files mid-test.
+//!
+//! [`run_token`] settles both. A pid *and* the nanosecond the process started
+//! cannot be reproduced by a later run or a concurrent one, so the name needs
+//! no help from the test's own name, and `Drop` means nothing is left to
+//! inherit.
+
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::{fs, process};
+
+/// A token no other run of this crate can produce. Read once per process.
+fn run_token() -> &'static str {
+    static TOKEN: OnceLock<String> = OnceLock::new();
+    TOKEN.get_or_init(|| {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_or(0, |since| since.as_nanos());
+        format!("{}-{nanos}", process::id())
+    })
+}
+
+/// A directory that removes itself, with everything under it, when dropped.
+pub struct TempDir(PathBuf);
+
+impl TempDir {
+    /// A fresh directory, unique to this run and this call.
+    pub fn new(label: &str) -> Self {
+        static NEXT: AtomicUsize = AtomicUsize::new(0);
+        let path = std::env::temp_dir().join(format!(
+            "quantick-guards-{}-{}-{label}",
+            run_token(),
+            NEXT.fetch_add(1, Ordering::Relaxed)
+        ));
+        fs::create_dir_all(&path).expect("temp dir is creatable");
+        Self(path)
+    }
+
+    /// The directory itself.
+    pub fn path(&self) -> &Path {
+        &self.0
+    }
+}
+
+/// So a `TempDir` stands where the `PathBuf` roots these tests passed around
+/// stood: `root.join(..)`, `check(&root)`.
+impl std::ops::Deref for TempDir {
+    type Target = Path;
+
+    fn deref(&self) -> &Path {
+        &self.0
+    }
+}
+
+impl AsRef<Path> for TempDir {
+    fn as_ref(&self) -> &Path {
+        &self.0
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn two_directories_with_one_label_never_share_a_path() {
+        let first = TempDir::new("same");
+        let second = TempDir::new("same");
+        assert_ne!(first.path(), second.path());
+    }
+
+    #[test]
+    fn the_tree_goes_when_the_value_does() {
+        let path = {
+            let dir = TempDir::new("removed");
+            fs::create_dir_all(dir.join("nested")).expect("nested dirs are creatable");
+            fs::write(dir.join("nested/file.txt"), "content").expect("the file is writable");
+            dir.path().to_path_buf()
+        };
+        assert!(!path.exists(), "the tree went with the value: {path:?}");
+    }
+}

--- a/crates/guards/tests/guards.rs
+++ b/crates/guards/tests/guards.rs
@@ -1,4 +1,4 @@
-//! The six repository guards, as the tests CI runs.
+//! The seven repository guards, as the tests CI runs.
 //!
 //! Each is a thin shell over the library: the logic, its rationale and its
 //! unit tests live in the module the failure names, and this file exists so
@@ -17,13 +17,14 @@ use quantick_guards::{GUARDS, remedies, workspace_root};
 /// instead of a green suite over a guard CI never runs — which is the failure
 /// the check exists to prevent, and which a hand-kept list of names invites by
 /// making "add the string" the obvious fix.
-const TESTED: [&str; 6] = [
+const TESTED: [&str; 7] = [
     "size",
     "language",
     "encoding",
     "context",
     "cycle",
     "generated",
+    "scratch",
 ];
 
 /// Run one named guard and fail with everything it found.
@@ -99,4 +100,13 @@ fn no_crate_grows_a_module_cycle_past_its_recorded_ceiling() {
 #[test]
 fn the_generated_indexes_match_the_code_they_describe() {
     assert_clean(TESTED[5]);
+}
+
+/// The one that keeps a red honest: a test naming its own temporary folder
+/// after a process id inherits a reused id's leftovers and fails on the
+/// previous run's files, while leaving the folder behind for ever. Neither
+/// half is visible to fmt, clippy, the build or the suite.
+#[test]
+fn no_test_mints_a_temporary_path_outside_its_scratch_module() {
+    assert_clean(TESTED[6]);
 }

--- a/crates/mcp/src/lib.rs
+++ b/crates/mcp/src/lib.rs
@@ -30,6 +30,8 @@ pub mod fake;
 pub mod jsonrpc;
 pub mod link;
 pub mod protocol;
+#[cfg(test)]
+mod scratch;
 pub mod server;
 pub mod setup;
 pub mod tools;

--- a/crates/mcp/src/link.rs
+++ b/crates/mcp/src/link.rs
@@ -252,18 +252,24 @@ mod tests {
 
     use super::*;
 
-    fn link(pinned: Option<InstanceId>) -> LocalLink {
-        LocalLink::new(
+    /// The scratch directory comes back with the link: built as a temporary
+    /// it would be dropped — and removed — at the end of this expression,
+    /// leaving the link holding a path whose owner is gone, and anything the
+    /// link wrote there afterwards leaking exactly as before.
+    fn link(pinned: Option<InstanceId>) -> (crate::scratch::ScratchDir, LocalLink) {
+        let directory = crate::scratch::ScratchDir::new("link");
+        let link = LocalLink::new(
             ConnectOptions::observer("test", "0", BTreeSet::new()),
-            Some(crate::scratch::ScratchDir::new("link").path().to_path_buf()),
+            Some(directory.path().to_path_buf()),
             pinned,
-        )
+        );
+        (directory, link)
     }
 
     #[test]
     fn a_pin_wins_and_a_contradicting_id_is_refused() {
         let pinned = InstanceId::from_bytes([1; 16]);
-        let link = link(Some(pinned.clone()));
+        let (_directory, link) = link(Some(pinned.clone()));
         assert_eq!(link.wanted(None).unwrap(), Some(pinned.clone()));
         assert_eq!(link.wanted(Some(&pinned)).unwrap(), Some(pinned));
         let other = InstanceId::from_bytes([2; 16]);
@@ -275,7 +281,7 @@ mod tests {
 
     #[test]
     fn an_empty_directory_lists_nothing_with_a_next_step_and_starts_nothing() {
-        let mut link = link(None);
+        let (_directory, mut link) = link(None);
         let directory = link.directory.clone().unwrap();
         let _ = std::fs::remove_dir_all(&directory);
         let instances = link.instances().unwrap();

--- a/crates/mcp/src/link.rs
+++ b/crates/mcp/src/link.rs
@@ -255,11 +255,7 @@ mod tests {
     fn link(pinned: Option<InstanceId>) -> LocalLink {
         LocalLink::new(
             ConnectOptions::observer("test", "0", BTreeSet::new()),
-            Some(std::env::temp_dir().join(format!(
-                "quantick-mcp-link-{}-{}",
-                std::process::id(),
-                line!()
-            ))),
+            Some(crate::scratch::ScratchDir::new("link").path().to_path_buf()),
             pinned,
         )
     }

--- a/crates/mcp/src/scratch.rs
+++ b/crates/mcp/src/scratch.rs
@@ -1,0 +1,100 @@
+//! Scratch directories these tests own, rather than leak.
+//!
+//! Test-only. The same fix `crates/app/src/scratch.rs` documents at length,
+//! in the smallest form this crate needs: a temporary path keyed on
+//! `std::process::id()` alone is a path a later run can inherit populated,
+//! because the operating system reuses process ids — and nothing here ever
+//! removed one.
+//!
+//! Each crate carries its own copy rather than sharing one. A shared helper
+//! would be a new workspace crate that every crate with tests depends on,
+//! which this repository's dependency rule and its "no new dependency"
+//! constraint both argue against for eighty lines of `std`. The repository
+//! guard `crates/guards/src/scratch.rs` is what keeps the copies honest: it
+//! names each of them, and refuses the call anywhere else.
+
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// A token no other run of this crate can produce: this process's id, and the
+/// nanoseconds since the epoch at which it first asked. Read once per
+/// process, so two resolutions inside one test agree.
+fn run_token() -> &'static str {
+    static TOKEN: OnceLock<String> = OnceLock::new();
+    TOKEN.get_or_init(|| {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_or(0, |since| since.as_nanos());
+        format!("{}-{nanos}", std::process::id())
+    })
+}
+
+/// A directory of this test's own, removed with everything under it when the
+/// value is dropped — including on a panic, which unwinds.
+pub(crate) struct ScratchDir(PathBuf);
+
+impl ScratchDir {
+    /// A fresh directory named `quantick-mcp-unit-<pid>-<nanos>-<counter>-<label>`.
+    /// Created, so a caller can write into it at once.
+    pub(crate) fn new(label: &str) -> Self {
+        static NEXT: AtomicU64 = AtomicU64::new(0);
+        let dir = std::env::temp_dir().join(format!(
+            "quantick-mcp-unit-{}-{}-{label}",
+            run_token(),
+            NEXT.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::create_dir_all(&dir).expect("a scratch directory is creatable");
+        Self(dir)
+    }
+
+    /// The directory itself.
+    pub(crate) fn path(&self) -> &Path {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for ScratchDir {
+    type Target = Path;
+
+    fn deref(&self) -> &Path {
+        &self.0
+    }
+}
+
+impl AsRef<Path> for ScratchDir {
+    fn as_ref(&self) -> &Path {
+        &self.0
+    }
+}
+
+impl Drop for ScratchDir {
+    fn drop(&mut self) {
+        // Best-effort, like every other copy of this: a file something the
+        // test spawned still holds open is not worth failing a green test
+        // over, and the run token means no later run can inherit it.
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn two_scratch_directories_never_share_a_path() {
+        let first = ScratchDir::new("same-label");
+        let second = ScratchDir::new("same-label");
+        assert_ne!(first.path(), second.path());
+    }
+
+    #[test]
+    fn the_tree_goes_when_the_value_does() {
+        let path = {
+            let dir = ScratchDir::new("removed-on-drop");
+            std::fs::write(dir.join("file.txt"), "content").expect("the file is writable");
+            dir.path().to_path_buf()
+        };
+        assert!(!path.exists(), "the tree went with the value: {path:?}");
+    }
+}

--- a/crates/mcp/tests/common/mod.rs
+++ b/crates/mcp/tests/common/mod.rs
@@ -1,0 +1,80 @@
+//! Scratch directories these integration tests own, rather than leak.
+//!
+//! Both test binaries here spelled their own temporary path, and both keyed
+//! it on `std::process::id()` alone: a reused process id — Windows hands one
+//! back within minutes — pointed a later run at an earlier run's descriptor
+//! directory, and nothing ever removed either. This module is the `mcp` half
+//! of the same fix `crates/app/src/scratch.rs` makes for the application.
+//!
+//! It lives under `tests/common/` rather than beside its callers because
+//! cargo compiles every file directly in `tests/` as a test binary of its
+//! own; a subdirectory module is shared support instead.
+
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// A token no other run can produce: this process's id, and the nanoseconds
+/// since the epoch at which it first asked. Read once per process.
+fn run_token() -> &'static str {
+    static TOKEN: OnceLock<String> = OnceLock::new();
+    TOKEN.get_or_init(|| {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_or(0, |since| since.as_nanos());
+        format!("{}-{nanos}", std::process::id())
+    })
+}
+
+/// A directory of this test's own, removed with everything under it when the
+/// value is dropped — including on a panic, which unwinds.
+///
+/// Hold it for as long as the files matter: the gateway and the adapter both
+/// keep writing into the directory for as long as they are alive.
+pub struct ScratchDir(PathBuf);
+
+impl ScratchDir {
+    /// A fresh directory named `quantick-mcp-<pid>-<nanos>-<counter>-<label>`.
+    ///
+    /// Not created: both callers hand the path to discovery as the instances
+    /// directory, and "no such directory" is the state they are testing — an
+    /// empty one that exists is a different answer. Whatever the adapter or
+    /// the gateway creates there is still removed on the way out.
+    pub fn new(label: &str) -> Self {
+        static NEXT: AtomicU64 = AtomicU64::new(0);
+        let dir = std::env::temp_dir().join(format!(
+            "quantick-mcp-{}-{}-{label}",
+            run_token(),
+            NEXT.fetch_add(1, Ordering::Relaxed)
+        ));
+        Self(dir)
+    }
+
+    /// The directory itself.
+    pub fn path(&self) -> &Path {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for ScratchDir {
+    type Target = Path;
+
+    fn deref(&self) -> &Path {
+        &self.0
+    }
+}
+
+impl AsRef<Path> for ScratchDir {
+    fn as_ref(&self) -> &Path {
+        &self.0
+    }
+}
+
+impl Drop for ScratchDir {
+    fn drop(&mut self) {
+        // Best-effort: a file a spawned adapter still holds open is not worth
+        // failing a green test over, and the run token means no later run can
+        // mistake the leftover for its own.
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}

--- a/crates/mcp/tests/fake_gateway.rs
+++ b/crates/mcp/tests/fake_gateway.rs
@@ -5,11 +5,13 @@
 //! discovery, the real `LocalClient`, the real `LocalLink` and the real
 //! `McpServer` run over it — only the application is replaced.
 
+mod common;
+
 use std::{
     collections::BTreeSet,
     io::Write as _,
     net::{Ipv4Addr, TcpListener, TcpStream},
-    path::{Path, PathBuf},
+    path::Path,
     sync::{
         Arc,
         atomic::{AtomicBool, Ordering},
@@ -206,14 +208,8 @@ fn answer(instance_id: &InstanceId, request: &RequestEnvelope) -> ResponseOutcom
     }
 }
 
-fn scratch_directory(name: &str) -> PathBuf {
-    let directory = std::env::temp_dir().join(format!(
-        "quantick-mcp-gateway-{name}-{}-{}",
-        std::process::id(),
-        line!()
-    ));
-    let _ = std::fs::remove_dir_all(&directory);
-    directory
+fn scratch_directory(name: &str) -> common::ScratchDir {
+    common::ScratchDir::new(name)
 }
 
 fn server_over(directory: &Path) -> McpServer {
@@ -388,7 +384,7 @@ fn a_pinned_adapter_lists_only_its_instance_and_fails_when_it_is_gone() {
     );
     let link = LocalLink::new(
         options,
-        Some(directory.clone()),
+        Some(directory.path().to_path_buf()),
         Some(first.instance_id.clone()),
     );
     let mut server = McpServer::new(Box::new(link), "observer");
@@ -431,7 +427,7 @@ fn a_pinned_adapter_refuses_a_contradicting_routing_id() {
     );
     let link = LocalLink::new(
         options,
-        Some(directory.clone()),
+        Some(directory.path().to_path_buf()),
         Some(gateway.instance_id.clone()),
     );
     let mut server = McpServer::new(Box::new(link), "observer");

--- a/crates/mcp/tests/stdio_smoke.rs
+++ b/crates/mcp/tests/stdio_smoke.rs
@@ -9,14 +9,10 @@ use std::{
 
 use serde_json::{Value, json};
 
-fn scratch_directory(name: &str) -> std::path::PathBuf {
-    let directory = std::env::temp_dir().join(format!(
-        "quantick-mcp-stdio-{name}-{}-{}",
-        std::process::id(),
-        line!()
-    ));
-    let _ = std::fs::remove_dir_all(&directory);
-    directory
+mod common;
+
+fn scratch_directory(name: &str) -> common::ScratchDir {
+    common::ScratchDir::new(name)
 }
 
 fn frames(stdout: &[u8]) -> Vec<Value> {
@@ -39,7 +35,7 @@ fn startup_errors_and_shutdown_emit_only_mcp_frames_on_stdout() {
     let directory = scratch_directory("smoke");
     let mut child = Command::new(env!("CARGO_BIN_EXE_quantick-mcp"))
         .arg("--instances-dir")
-        .arg(&directory)
+        .arg(directory.path())
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())

--- a/crates/replay/src/scratch.rs
+++ b/crates/replay/src/scratch.rs
@@ -5,21 +5,38 @@
 //! "make me a temp folder" is one more thing to keep in step.
 
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 use std::sync::atomic::{AtomicU32, Ordering};
+
+/// A token no other run of this crate can produce: this process's id, and the
+/// nanoseconds since the epoch at which it first asked. Read once per
+/// process.
+///
+/// The process id on its own was not enough. Windows reuses one within
+/// minutes, and a folder named after a reused id is a folder a later run can
+/// inherit populated — the flake `crates/app/src/scratch.rs` documents at
+/// length. This crate escaped it only because [`Scratch::new`] wipes the
+/// folder before using it; the token removes the hazard rather than papering
+/// over it, and keeps two concurrent runs apart into the bargain.
+fn run_token() -> &'static str {
+    static TOKEN: OnceLock<String> = OnceLock::new();
+    TOKEN.get_or_init(|| {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_or(0, |since| since.as_nanos());
+        format!("{}-{nanos}", std::process::id())
+    })
+}
 
 /// A temporary folder that removes itself when dropped.
 pub(crate) struct Scratch(PathBuf);
 
 impl Scratch {
-    /// A folder unique to this process, this test name and this call.
+    /// A folder unique to this run, this test name and this call.
     pub(crate) fn new(name: &str) -> Self {
         static COUNTER: AtomicU32 = AtomicU32::new(0);
         let id = COUNTER.fetch_add(1, Ordering::Relaxed);
-        let dir = std::env::temp_dir().join(format!(
-            "quantick-replay-{name}-{}-{id}",
-            std::process::id()
-        ));
-        let _ = std::fs::remove_dir_all(&dir);
+        let dir = std::env::temp_dir().join(format!("quantick-replay-{}-{id}-{name}", run_token()));
         std::fs::create_dir_all(&dir).unwrap();
         Self(dir)
     }


### PR DESCRIPTION
Make every disk-writing test own a unique, self-removing scratch directory, so
a red test means the change is wrong rather than that Windows reused a process
id.

**Tier: `medium`** — 50 files across five crates, and the criterion that
matters (the suite leaves the temp directory as it found it) had to be proved
rather than asserted, so `delivery-review` runs.

## The defect

A test that names its temporary folder after `std::process::id()` alone gets
two things wrong, and nothing in the build can see either.

A process id is **reused** — Windows hands one back within minutes — so the
folder a run creates is the folder an earlier run left behind, and the test
asserts on the previous run's files. The failure looks exactly like the change
under test. And **nothing removed any of it**: `%TEMP%` on this host held
**459,685** `quantick-*` entries when this branch started.

## The fix

Each crate that needs one has a single scratch module, and every test-side path
comes from it. Two shapes, because there are two shapes of caller:

- **`ScratchDir` / `ScratchFile`** where a test can hold the value — a
  directory carrying a run token no other run can reproduce, removed with its
  whole tree on `Drop`, including on a panic (which unwinds).
- **`thread_dir`** where the path is handed to something the test does not own:
  the `cfg!(test)` branches in `store_home`, `paper_home`, `paper_state` and
  `paper_trading`, which are re-resolved on every call and must answer the same
  twice, and every helper whose only call shape is
  `set_ui_state_path(scratch(..))` — a value dropped at the end of that
  statement takes the folder with it before the app ever writes. libtest runs
  each test on a thread it spawned, and a spawned thread runs its thread-local
  destructors on the way out, so the thread is an owner that already exists.

The **run token** is the process id *and* the nanosecond at which the process
first asked, read once per process so two resolutions of one stable path agree.
A reused pid cannot reproduce the nanosecond.

**A sixth repository guard keeps it fixed.** `crates/guards/src/scratch.rs`:
only a crate's own scratch module may ask for the temporary directory. It runs
in `cargo test -p quantick-guards` (about a second, no dependencies), in
`cargo test --workspace` and in CI, and it ships with **no exemptions**.

## Evidence

**The temp directory is left as it was found** — `cargo test --workspace` twice
from one shell, counting `ls $TEMP | grep -c quantick-`:

```
BEFORE=459685
BETWEEN=459685
AFTER=459685   DELTA=0
```

**The three tests that failed on a reused pid, ten consecutive runs** of
`cargo test -p quantick-app paper_trading` — `an_in_session_rerun_opens_its_own_file`,
`the_ledger_never_lists_this_sessions_trades_twice_after_a_retarget`,
`a_close_refreshes_an_open_report_by_itself` are all in the 146:

```
run  1..10: test result: ok. 146 passed; 0 failed; 0 ignored; 2050 filtered out
```

**The four checks**, each run on its own, after rebasing onto `origin/main`
(`d551813`):

- [x] `cargo fmt --all -- --check` — exit 0
- [x] `cargo clippy --workspace --all-targets` — exit 0
- [x] `cargo build --workspace` — exit 0
- [x] `cargo test --workspace` — exit 0
- [x] `cargo test -p quantick-guards` — 107 + 8 + 5 passed, 0 failed

**No new dependency, no ceiling raised.** `Cargo.toml`, `Cargo.lock`,
`size-baseline.txt` and `context-baseline.txt` are untouched in this diff —
`std` covers every requirement, so R2's `tempfile` escape hatch is not taken
and `cargo deny` is not needed.

**Performance:** every edited path is behind `#[cfg(test)]` or `cfg!(test)`.
Rate class *rare*, and none of it exists in a release build. No hot path is
touched, so there is nothing to measure.

## `process::id()` after the change, and why each site is legitimate

`grep -rn 'process::id()' crates --include=*.rs` returns 14 lines: 5 are prose
in module docs, and the 9 real ones are

| Site | Why it stays |
| --- | --- |
| `app/src/control/gateway.rs:2851` | The instance descriptor's `process_id` field — production, and the whole point of the field |
| `mcp/tests/fake_gateway.rs:66` | The same field in a fake gateway's descriptor fixture: data in a descriptor, not a path |
| `app/src/scratch.rs:72`, `control-local/src/scratch.rs:29`, `guards/src/scratch_dir.rs:30`, `mcp/src/scratch.rs:29`, `mcp/tests/common/mod.rs:25`, `replay/src/scratch.rs:27` | The run token itself — the one place a pid belongs, and each is paired with a nanosecond stamp so a reused id cannot collide |
| `app/src/scratch.rs:285` | The unit test asserting the token opens with this process's id |

## Corrections to the brief's evidence ledger

Each claim was re-checked against `origin/main` before acting. Four did not
hold:

1. **The count was 64, not 63.** Same for the leftovers: 459,685 entries on
   this host, not 450,227.
2. **Ledger #5 was wrong about which sites are production.** It listed
   `control-local/src/{client,discovery}.rs`, `mcp/src/link.rs` and
   `guards/src/{context,ratchet}.rs` as legitimate production uses that should
   stay. All five are inside `#[cfg(test)] mod tests` — they were test leaks,
   and all five are now routed through a scratch module. Only
   `gateway.rs:2851` was genuinely production.
3. **Ledger #3's shared pattern does not hold, and the random CI drop is not
   fixed by this branch.** See the section below — this is the one ask this PR
   does not discharge, and it is called out rather than quietly dropped.
4. **The brief's scope missed the biggest leaks.** Three test-only paths live
   in *production* files behind `cfg!(test)` (`store_home::test_path`,
   `paper_home::startup_home`, `paper_state::scratch_path`) — one cockpit home
   per app a test builds, and no `#[cfg(test)]` rule would have seen them. The
   trader ruled them in scope. Beyond the ledger entirely: `chart_layers.rs`,
   `indicators/state_file.rs` and `guards/src/size.rs` used **fixed** folder
   names shared by every concurrent run on the machine, and four `tab.rs` paths
   carried **no pid at all**.

Two more things the work turned up, both worth knowing:

- **A pre-created directory is not equivalent to an absent one.** Discovery
  refuses a descriptor folder whose ACL is not already private, and a folder
  `ScratchDir` creates carries the default one. `control-local` failed
  outright on it, and it explains a gateway test that was dropping at random
  mid-mission. Two directories are therefore deliberately left uncreated, with
  the reason at each site.
- **`refactor/pane-tests-out` merged mid-mission**, so the two `pane.rs` lines
  the brief put out of scope were fixed properly in their new home
  (`pane/tests/mod.rs`) and the guard ships with an empty exemption list.

## What this does *not* fix

**The random single-test drop is not this branch's, and is not fixed by it.**
The brief's ledger #3 assumed it shared the scratch-directory root cause. It
does not — it is load-dependent, and `main` has it just as badly.

Measured twice, `cargo test -p quantick-app` on this host. Quiet machine:

```
branch  1..12: ok. 2015 passed; 0 failed     (12/12 green)
main    1..12: ok. 2008 passed; 0 failed     (12/12 green)
```

Then with four other agent sessions compiling on the same cores — suite time
goes from ~9.5s to 15-35s, and both sides start dropping tests:

```
branch: 3 reds in 9 runs
main:   3 reds in 6 runs
```

Same victims on both sides, and none of them touch a scratch directory:
`gateway_a_client_that_never_reads_does_not_stall_another`,
`an_operator_cannot_detach_the_traders_own_indicator`,
`attaching_a_script_and_detaching_it_leaves_the_pane_as_it_was`,
`both_panes_group_the_ladders_at_the_market_bucket_even_with_the_layer_hidden`,
`feed::metatrader` paging. They are timing-dependent tests losing a race when
the CPU is oversubscribed. A separate defect, present on `main`, and it wants
its own issue.

One of those reds *was* mine and is fixed: a gateway test dropped because
`ScratchDir` pre-created a directory whose ACL discovery rejects — see the
uncreated-directory note above.

So of the two memory-level workarounds:

- **`paper-trading-tests-flake-on-pid-reuse` no longer applies** — that flake
  is fixed at the root, and ten consecutive runs prove it. The memory can go.
- **`gateway-wait-for-change-ci-flake` still applies.** Keep it: a single-test
  red on `main` is still worth a rerun rather than a diff hunt.

## For the operator: clearing the backlog

This branch deletes nothing on the host. To clear the 459,685 leftovers once,
from PowerShell (it takes a while — that is 459k entries):

```powershell
Get-ChildItem $env:TEMP -Filter 'quantick-*' | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
```

Nothing will replace them: from this branch on, the count is flat across runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SWHJkMu9DYm6ZnNDKjGYXi
