### PR TITLE
feat(guards): add a --report mode that measures the repository

### DIFF
--- a/.claude/GOAL-archive-guards-report.md
+++ b/.claude/GOAL-archive-guards-report.md
@@ -1,0 +1,260 @@
+# Mission: `quantick-guards --report`
+
+## Objective
+
+Add a `--report` mode to `quantick-guards` that prints, deterministically and
+with no dependency, the repository health numbers this refactor sprint is being
+judged on, as one stable text table with one line per number, so a session can
+quote it before and after a merge instead of re-deriving twelve numbers by hand
+with `wc`, `grep` and `awk` at open-judgement rates.
+
+**Tier:** `medium`. A new CLI mode with its own measurement code, new tests and
+a `CLAUDE.md` line is past the `small` diff ceiling, and the mode's output is a
+public artifact the sprint will quote — it earns a completeness pass. It is not
+`high`: nothing here is user-visible, nothing touches the engine, and the whole
+change lives inside a leaf crate with no dependants.
+
+## Request ledger
+
+| # | Ask | Verbatim fragment where the wording carries it |
+| --- | --- | --- |
+| R1 | Add `--report` as a third mode beside `--file <path>` and `--tighten`, and update the hand-written usage string. | "a third mode beside the two in ledger #1, with the usage string updated" |
+| R2 | Output is plain text, one `label<TAB>value` line per number, in a fixed sort order, with no timestamps and no paths outside the workspace. | "one `label<TAB>value` line per number, sorted by a fixed order, no timestamps, no paths outside the workspace" |
+| R3 | Two runs on the same tree are byte-identical, so `diff` between two commits is the report of what a merge changed. | "two runs on the same tree are byte-identical and `diff` between two commits is the report of what a merge changed" |
+| R4 | Report production lines per crate (via `size::production_lines`), the workspace total, and `app` as a percentage. | "production lines per crate […] the workspace total, and `app` as a percentage" |
+| R5 | Report the eight largest production files. | "the eight largest production files" |
+| R6 | Report every `pub struct` in `crates/*/src` with 30 or more fields, by name and field count, where a field is a `name:` line at one indent inside the struct body. | "a field is a `name:` line at one indent inside the struct body" |
+| R7 | Report each ratchet's recorded `!budget` against the total it caps. | "both ratchets: recorded `!budget` and the measured total it caps" |
+| R8 | Report counts in production source of `#[allow(`, `process::id()` and `#[cfg(test)]` outside `tests/` directories and `tests.rs` files. | "counts in production source of `#[allow(`, `process::id()`, and `#[cfg(test)]` outside `tests/` directories and `tests.rs` files" |
+| R9 | Report lines in `crates/app/src` production files that contain no `egui` identifier, as the remaining extraction headroom. | "as the remaining extraction headroom" |
+| R10 | Test the struct-field counter and the production-only counting on fixture strings, in `crates/guards/tests/guards.rs`. | "Tests for the struct-field counter and the production-only counting on fixture strings" |
+| R11 | Test that `--report` run twice on the real tree produces identical output. | "one test that runs `--report` twice on the real tree and asserts the outputs are identical" |
+| R12 | Add one sentence to `CLAUDE.md`'s verification-loop paragraph naming the mode, paid for inside the existing context budget by finding the bytes elsewhere in the same change. | "paid for inside the context budget (find the bytes elsewhere in the same change; the guard will say if you did not)" |
+| R13 | Record today's report in this goal file, so the sprint's "before" is in the archive. | "so the sprint's 'before' is in the archive" |
+| R14 | `--report` completes in under two seconds on a warm build. | "completes in under two seconds on a warm build" |
+| R15 | The report's numbers agree with the brief's hand measurements to the line, or the PR body explains each difference as a rule chosen differently, never a bug. | "or the PR body explains each difference (a rule chosen differently, never a bug)" |
+| R16 | `crates/guards/Cargo.toml` `[dependencies]` stays empty. | "stays empty" |
+| R17 | Do not ratchet any of the new numbers; no JSON, history or plotting; no change to `size.rs` / `context.rs` behaviour beyond reuse. | "Out of scope, deliberately" |
+| R18 | Purpose: a session can quote the same numbers before and after a merge, so "did it improve?" is answered by a number rather than re-derived by hand each mission. | "so that a session can quote it before and after a merge" |
+
+## Decisions taken by the trader
+
+- **D1** — The report iterates the `GUARDS` registry and prints a line per
+  ratchet it finds, not only the two the brief named. The tree has three today
+  (`size`, `context`, `cycle`); a fourth appears in the report without an edit.
+  This widens R7 from "both ratchets" to "every ratchet".
+- **D2** — Each ratchet prints three numbers: the signed `!budget`, the
+  `recorded` total of its ceilings (which is what the budget actually caps),
+  and the `measured` total its files weigh today. The slack between `recorded`
+  and `measured` is the debt the sprint is paying down, and showing it is the
+  point of diffing two reports.
+
+## Assumptions
+
+- **S1** — `--report` exits 0 whenever it could read the tree, regardless of
+  what any guard would find. It is a measurement mode, not a check; making it
+  exit non-zero would make it unusable inside a `diff` pipeline. Safe to
+  assume: the brief calls it a report, and the existing modes already own the
+  pass/fail question.
+- **S2** — "Production" throughout means `size::production_source` over the
+  files `size`'s own `tracked()` accepts (`crates/**/*.rs`, excluding any
+  `tests/` or `target/` path segment), reusing the existing definition rather
+  than writing a second one. Safe to assume: R17 asks for reuse, and two
+  definitions of "production" drifting apart is the defect this repository
+  files against its own code.
+- **S3** — "Per crate" means the directory immediately under `crates/`, which
+  is how both baselines already spell paths. Conventional default.
+- **S4** — The `#[cfg(test)]` count in R8 counts occurrences in tracked files
+  that are not under a `tests/` directory and are not named `tests.rs`, over
+  the *whole* file text rather than over production-only text — counting
+  `#[cfg(test)]` inside production-only text would score zero by construction,
+  since stripping exactly those items is what `production_source` does. Safe
+  to assume: the ask is meaningless under the other reading.
+- **S5** — Struct field counting (R6) is a line-shaped rule, as the brief
+  spells it: a `name:` line at one indent inside a `pub struct` body. It is
+  not a Rust parser, and the tests pin the rule rather than a parse. Safe to
+  assume: the brief states the rule.
+- **S6** — Row labels are stable identifiers, and rows whose *set* is
+  data-driven (per crate, largest files, wide structs) sort by a fixed key, so
+  a crate appearing or a file shrinking moves exactly the lines it should.
+  Conventional default for a diffable report.
+- **S7** *(wanted to ask; the `medium` question budget was spent on D1 and
+  D2)* — The new measurement code lands in a new module
+  `crates/guards/src/report.rs` rather than growing `main.rs` or `size.rs`.
+  Reading chosen: `CLAUDE.md`'s "a capability docks as a new file plus one
+  registration line". Reversible in one move if the trader wants it elsewhere.
+- **S8** *(wanted to ask)* — The percentage in R4 is printed as an integer
+  percent, computed with integer arithmetic. A fractional percent invites a
+  formatting decision that can differ between float paths; an integer is
+  byte-stable by construction.
+
+## Acceptance criteria
+
+- [ ] **A1** — `cargo run -q -p quantick-guards -- --report` exits 0 and
+      prints a `label<TAB>value` table covering every number in R4–R9.
+      *Evidence:* the captured output, quoted in full.
+      → the PR body, and the baseline section of this file. *(R1, R2, R4, R5,
+      R6, R7, R8, R9)*
+- [ ] **A2** — The usage string names three modes and still says they are
+      alternatives; `--report` with extra arguments is refused, not ignored.
+      *Evidence:* the usage text, and a test asserting the refusal.
+      → `crates/guards/tests/guards.rs`, quoted in the PR body. *(R1)*
+- [ ] **A3** — Two consecutive `--report` runs on the same tree produce
+      byte-identical output. *Evidence:* an empty `diff` between two captured
+      runs, plus a test that runs the report twice and asserts equality.
+      → `crates/guards/tests/guards.rs`, `diff` output in the PR body.
+      *(R3, R11)*
+- [ ] **A4** — Every ratchet in `GUARDS` prints its `!budget`, its `recorded`
+      total and its `measured` total. *Evidence:* three lines per ratchet in
+      the output, for all three ratchets present today.
+      → the PR body. *(R7, D1, D2)*
+- [ ] **A5** — The struct-field counter and the production-only counting are
+      each tested on fixture strings, including the cases the rule turns on: a
+      nested type at deeper indent, a `#[cfg(test)]` item above a test module,
+      a non-`pub` struct. *Evidence:* named tests, green.
+      → `crates/guards/tests/guards.rs`. *(R6, R10)*
+- [ ] **A6** — `--report` on a warm build completes in under two seconds.
+      *Evidence:* a timed run's wall clock.
+      → the PR body. *(R14)*
+- [ ] **A7** — Each number in the brief's hand measurements is placed
+      side-by-side with the report's number, and every difference is explained
+      as a rule chosen differently. *Evidence:* the side-by-side table.
+      → the PR body. *(R15)*
+- [ ] **A8** — `crates/guards/Cargo.toml` `[dependencies]` is still empty.
+      *Evidence:* the file, quoted. → the PR body. *(R16)*
+- [ ] **A9** — `CLAUDE.md`'s verification-loop paragraph names `--report` in
+      one sentence, and the context ratchet is green without its `!budget`
+      being raised. *Evidence:* `cargo test -p quantick-guards` green, and the
+      `CLAUDE.md` diff showing the bytes paid for elsewhere.
+      → the PR body. *(R12)*
+- [ ] **A10** — Today's report is pasted verbatim into this file's baseline
+      section before it is archived. *Evidence:* the archived
+      `GOAL-archive-guards-report.md`. *(R13, R18)*
+- [ ] **A11** — Nothing new is ratcheted, no JSON, history or plotting is
+      added, and `size.rs` / `context.rs` behaviour is unchanged beyond new
+      reuse. *Evidence:* the diff of those two files carries no behaviour
+      change. → the PR body. *(R17)*
+- [ ] **G1** — Every artifact in the change is English.
+- [ ] **G2** — The four checks green after rebasing on latest `main`:
+      `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets`,
+      `cargo build --workspace`, `cargo test --workspace`, each run on its own.
+      *Evidence:* each command's output. → the PR body.
+- [ ] **G3** — Performance impact declared: every touched path classified by
+      rate. *Evidence:* the classification. → the PR body.
+- [ ] **G4** — `arch-review` run over `git diff origin/main...HEAD`, with
+      every Blocker and Should-fix resolved or deferred in the PR body.
+      *Evidence:* the review verdict. → the PR body.
+
+## Not applicable, and why
+
+- **Hot path** — nothing here runs per trade, per depth update or per frame.
+  `--report` is a rare, operator-invoked tree walk; A6 bounds it anyway.
+- **User-visible surface** — no UI is touched, so `ui-harness`, `visual-qa`
+  and `trader-ux-review` have no surface to reach. The mode's only output is
+  stdout text.
+- **`new-extension`** — this adds a CLI mode to a leaf binary, not a feed, bar
+  type, indicator, layer, panel or crate. The registry it docks against is the
+  existing `main.rs` mode dispatch and the existing `GUARDS` list.
+- **Second operator** — the capability *is* a named call with a readable
+  result; there is no mouse path to build an alternative to.
+- **Engine / determinism** — no engine code is touched. Determinism is
+  nonetheless a first-class ask here (R3), tested by A3.
+- **Docs/skills-only waiver** — does not apply. This change ships Rust, so the
+  full shape pass is owed despite the one-line `CLAUDE.md` edit.
+
+## Closing steps
+
+- **C1** — `delivery-review` returns PASS.
+- **C2** — The PR is open, naming the tier beside the four verification boxes.
+
+## The sprint baseline
+
+`cargo run -q -p quantick-guards -- --report` on this branch, rebased onto
+`origin/main` at `6d3e792` on 2026-09-04. This is the sprint's "before": a
+later session runs the same command and diffs the two.
+
+The branch was cut at `d551813` and rebased once, which the report itself
+recorded: `site.process_id` read 7 at `d551813` and reads 11 here, because
+PR #290 landed production scratch-directory helpers in `guards` and
+`replay` in between. That is the mode working — four new sites, named by one
+diffed line, with nobody re-deriving anything by hand.
+
+```
+crate.lines.app	114392
+crate.lines.backtest	2400
+crate.lines.control	5184
+crate.lines.control-local	1612
+crate.lines.engine	3375
+crate.lines.feed-binance	2914
+crate.lines.feed-hyperliquid	1773
+crate.lines.feed-mt5	4594
+crate.lines.guards	4393
+crate.lines.indicators	3878
+crate.lines.mcp	2422
+crate.lines.orderbook	1022
+crate.lines.orderflow	7701
+crate.lines.pine	6123
+crate.lines.replay	3787
+crate.lines.sim	2279
+crate.lines.strategy	1879
+crate.lines.trading	1789
+crate.lines.total	171517
+crate.lines.app_percent	66
+file.largest.crates/app/src/app.rs	9232
+file.largest.crates/app/src/control/gateway.rs	4142
+file.largest.crates/app/src/orderflow_render.rs	3075
+file.largest.crates/app/src/orderflow_view.rs	2485
+file.largest.crates/app/src/pane.rs	7771
+file.largest.crates/app/src/paper_report.rs	3300
+file.largest.crates/app/src/paper_trading.rs	6265
+file.largest.crates/app/src/tab.rs	4468
+struct.wide.app::ChartPane	77
+struct.wide.app::PaperTrading	55
+struct.wide.app::QuantickApp	56
+struct.wide.app::Tab	62
+struct.wide.app::ToolRail	32
+struct.wide.app::ToolbarModel	31
+struct.wide.orderflow::BookEngine	31
+struct.wide.orderflow::BubbleStyle	30
+struct.wide.orderflow::HeatmapConfig	34
+struct.wide.orderflow::OrderflowHealth	32
+struct.wide.sim::PerformanceReport	36
+ratchet.size.budget	61410
+ratchet.size.recorded	61410
+ratchet.size.measured	171517
+ratchet.context.budget	232885
+ratchet.context.recorded	166099
+ratchet.context.measured	233820
+ratchet.cycle.budget	3
+ratchet.cycle.recorded	3
+ratchet.cycle.measured	3
+site.allow	88
+site.process_id	11
+site.cfg_test	598
+app.lines.without_egui	110701
+scan.unreadable	0
+scan.undecodable	0
+scan.blind	0
+```
+
+## The request as received
+
+Quoted in full and verbatim, in the language it was written in, because the
+ledger above must be auditable against the original words rather than against
+its own paraphrase. Everything else in this file is English.
+
+> /mission medium feat/guards-report — add a `--report` mode to quantick-guards
+> that prints, deterministically and with no dependency, the repository health
+> numbers this refactor sprint is being judged on: production lines per crate
+> and the app's share of the workspace, the largest production files, the
+> widest structs, the two ratchet budgets against their measured totals, and
+> the counts of `#[allow(`, `process::id()` and `#[cfg(test)]` sites in
+> production files. One stable text table, one line per number, so that a
+> session can quote it before and after a merge. Read
+> C:\src\mission-guards-report.md in full before anything else and build the
+> request ledger from it.
+
+The brief that invocation points at is `C:\src\mission-guards-report.md`,
+outside the repository. Its scope, acceptance criteria, out-of-scope list and
+parallel-work note are the source of R1–R18 above; the fragments quoted in the
+ledger's third column are its words.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,9 @@ cargo build --workspace
 cargo test --workspace
 ```
 
-`cargo test -p quantick-guards` runs the repository guards in about a second — that crate has no dependencies to build, so ask it after a batch of edits rather than at the end of a suite run. A `PostToolUse` hook runs the same binary over each edited file, but a fresh worktree has no `target/`, so it reports nothing at all — not "clean", *nothing* — until `cargo build -p quantick-guards` has run there. Advisory; gates nothing.
+`cargo test -p quantick-guards` runs the guards in about a second — no dependencies to build, so ask it after a batch of edits, not at the end of a suite. The `PostToolUse` hook runs the same binary per edited file; advisory, gates nothing, and in a fresh worktree reports nothing at all — not "clean", *nothing* — until `cargo build -p quantick-guards` has run there.
+
+`cargo run -p quantick-guards -- --report` prints the numbers a refactor is judged on — lines per crate, largest files, widest structs, each ratchet against its budget — deterministically, so two runs diff into what a merge changed.
 
 CI runs those four plus what cargo cannot see — `sh .claude/hooks/guardrails_test.sh`, `ruff check --select F` over `tools/mt5/` and `bridge/mt5/`, `python3 tools/mt5/test_export_session.py`, `python3 bridge/mt5/tests/test_*.py`. Run the ones your change touches, watch with `gh pr checks <n> --watch`; red CI never merges.
 
@@ -51,7 +53,7 @@ Crates under `crates/`; `AGENTS.md` *The map* owns the descriptions and the grap
 
 ## Keeping the instructions small
 
-The same ratchet over the other tree — `crates/guards/src/context.rs`, ceilings in `context-baseline.txt`, mechanism shared with the size guard in `ratchet.rs`. It counts **bytes** (prose wrapped at 80 columns makes a line count meaningless) of what a session loads: this file, `AGENTS.md`, every `.md` under `.claude/skills/`. Goal files are out of scope on purpose.
+The same ratchet over the other tree — `crates/guards/src/context.rs`, ceilings in `context-baseline.txt`, mechanism shared with `size` in `ratchet.rs`. It counts **bytes** of what a session loads: this file, `AGENTS.md`, every `.md` under `.claude/skills/`. Goal files are out of scope on purpose.
 
 - **A `SKILL.md` states every rule that decides an outcome, once, operatively.** Reasoning, histories and per-dimension detail go to `references/` beside it, read on demand — a waived dimension then costs nothing. A working rule's reasoning goes to `docs/agentic-development.md`.
 - **The budget is the whole tracked weight**, not just the ceilings: files over 10,000 bytes carry a signed entry, and every smaller one still counts. So splitting prose into sub-threshold files buys nothing — only deleting it does.
@@ -70,7 +72,7 @@ The same ratchet over the other tree — `crates/guards/src/context.rs`, ceiling
 
   After the merge, from the main checkout: `git worktree remove ../quantick-worktrees/<prefix>-<slug>` then `git branch -d <prefix>/<slug>`.
 - **One mission, one tier** — `/mission` takes `small` (the default), `medium`, `high` or `max`, scaling the ceremony and whether `delivery-review` runs. `small` is the only tier the hooks see; the skill owns the table.
-- **Arch-review before PR** — over `git diff origin/main...HEAD` (the remote ref deliberately: `main...HEAD` in a worktree credits other branches' merged work to this one). Its step 0 runs `code-review` on the same diff. Resolve every Blocker and Should-fix; note deferrals in the PR body. A docs/skills change waives shape dimensions 1–7 and 9, never 8 and never step 0.
+- **Arch-review before PR** — over `git diff origin/main...HEAD`. Its step 0 runs `code-review` on the same diff. Resolve every Blocker and Should-fix; note deferrals in the PR body. A docs/skills change waives shape dimensions 1–7 and 9, never 8 and never step 0.
 - **Delivery-review before PR** — arch-review asks whether the branch is well built, never whether it is what was asked for. Runs last, over the branch as shipped, grading every ask in the goal file (`.claude/GOAL.md` or its `GOAL-archive-<slug>.md`, committed before either review) and every criterion as DELIVERED / PARTIAL / MISSING / UNPROVEN, from a fresh-context subagent. Passes only when nothing is unmet. A `small` mission is exempt, bounded by a diff-size ceiling that revokes the exemption if the branch grows. A branch not from `/mission` is graded against its issue's criteria, and the verdict says so.
 - **The review chain has a budget: three rounds per branch**, then the remainder ships as recorded PR follow-ups. A round is one pass by everything that owes the branch a review — arch-review's bug pass and shape pass, then delivery-review — plus the commit answering them; not three per skill, since a fix commit stales both markers and re-runs both. Nothing is discarded to fit: findings defer into the PR body with their severity. An open Blocker never defers, and if it runs the budget out the branch goes to the trader. On reaching it, say the shape — findings shrinking is convergence, findings flat or climbing into the last round's code is a design problem.
 - **Subagents are routed by model, named at the call** — retrieval `haiku`, applying someone else's checklist `sonnet`, open judgement (bugs, docking, design) the default strong model. Omitting the field inherits the caller's and bills retrieval at open-judgement rates. `delivery-review`'s criteria pass is the standard the next routed site meets.

--- a/crates/guards/src/context.rs
+++ b/crates/guards/src/context.rs
@@ -47,7 +47,7 @@ use std::fs;
 use std::path::Path;
 
 use crate::Finding;
-use crate::ratchet::{Baseline, Policy};
+use crate::ratchet::{self, Baseline, Policy};
 
 /// Bytes above which a context file must carry a baseline entry.
 ///
@@ -268,6 +268,13 @@ fn relative_to(root: &Path, path: &Path) -> String {
         .unwrap_or(path)
         .to_string_lossy()
         .replace('\\', "/")
+}
+
+/// What every tracked path measures today, summed, for
+/// [`crate::report`]. The *how* is [`ratchet::total`]; this only names the
+/// walk it sums, which is the one thing that differs per guard.
+pub fn measured(root: &Path) -> usize {
+    ratchet::total(&measure(root).counts)
 }
 
 /// Byte counts for every context file, sorted by path.

--- a/crates/guards/src/cycle.rs
+++ b/crates/guards/src/cycle.rs
@@ -66,7 +66,7 @@ use std::fs;
 use std::path::Path;
 
 use crate::Finding;
-use crate::ratchet::Policy;
+use crate::ratchet::{self, Policy};
 use crate::size::production_source;
 
 /// The number of cycles a crate may have without a signed baseline entry.
@@ -452,6 +452,13 @@ fn collect_sources(
             Err(e) => unreadable.push(format!("  {crate_path}/src/{relative}: unreadable: {e}")),
         }
     }
+}
+
+/// What every tracked path measures today, summed, for
+/// [`crate::report`]. The *how* is [`ratchet::total`]; this only names the
+/// walk it sums, which is the one thing that differs per guard.
+pub fn measured(root: &Path) -> usize {
+    ratchet::total(&measure(root).counts)
 }
 
 /// Cycle counts for every crate in the workspace, sorted by crate path.

--- a/crates/guards/src/lib.rs
+++ b/crates/guards/src/lib.rs
@@ -47,6 +47,7 @@ pub mod encoding;
 pub mod generated;
 pub mod language;
 pub mod ratchet;
+pub mod report;
 pub mod scratch;
 #[cfg(test)]
 pub mod scratch_dir;
@@ -125,10 +126,28 @@ pub struct Ratchet {
     /// Lower every entry whose measurement has fallen, and the budget with
     /// them. One line per entry rewritten.
     pub tighten: fn(&Path) -> Result<Vec<String>, String>,
-    /// The baseline it rewrites, workspace-relative, for the success line.
-    pub baseline_file: &'static str,
-    /// The gap below the budget it tolerates, for the nothing-to-do line.
-    pub budget_slack: usize,
+    /// The numbers and wordings this ratchet runs on — the baseline it
+    /// rewrites, the gap below budget it tolerates, and everything else the
+    /// guard rations by.
+    ///
+    /// A borrow of the guard's own [`ratchet::Policy`] rather than a copy of
+    /// two of its fields. The copy was here first, and it was the duplicated
+    /// constant this crate files findings about: `baseline_file` and
+    /// `budget_slack` were stated once in the policy and again in this
+    /// registry, with nothing to fail if the two ever drifted apart — a
+    /// `--tighten` success line naming a file it did not rewrite, or a
+    /// nothing-to-do line quoting a slack the guard does not use.
+    pub policy: &'static ratchet::Policy,
+    /// What the files this ratchet tracks measure today, summed.
+    ///
+    /// Deliberately not derivable from [`Ratchet::policy`]: a policy owns the
+    /// rationing, and each guard measures its own tree — production lines of
+    /// Rust, bytes of markdown and module cycles per crate have nothing in
+    /// common but the number they end at. [`report`] needs that number beside
+    /// the recorded ceilings to show the debt still to be written off, and
+    /// asking the registry for it is what keeps a fourth ratchet from
+    /// appearing in `--tighten` and nowhere else.
+    pub measured: fn(&Path) -> usize,
 }
 
 /// One guard, so the binary and the tests name the same things in the same
@@ -153,8 +172,8 @@ pub const GUARDS: &[Guard] = &[
         check_file: size::check_file,
         ratchet: Some(Ratchet {
             tighten: size::tighten,
-            baseline_file: size::BASELINE_FILE,
-            budget_slack: size::BUDGET_SLACK,
+            policy: &size::POLICY,
+            measured: size::measured,
         }),
     },
     Guard {
@@ -163,8 +182,8 @@ pub const GUARDS: &[Guard] = &[
         check_file: context::check_file,
         ratchet: Some(Ratchet {
             tighten: context::tighten,
-            baseline_file: context::BASELINE_FILE,
-            budget_slack: context::BUDGET_SLACK,
+            policy: &context::POLICY,
+            measured: context::measured,
         }),
     },
     Guard {
@@ -173,8 +192,8 @@ pub const GUARDS: &[Guard] = &[
         check_file: cycle::check_file,
         ratchet: Some(Ratchet {
             tighten: cycle::tighten,
-            baseline_file: cycle::BASELINE_FILE,
-            budget_slack: cycle::BUDGET_SLACK,
+            policy: &cycle::POLICY,
+            measured: cycle::measured,
         }),
     },
     Guard {

--- a/crates/guards/src/main.rs
+++ b/crates/guards/src/main.rs
@@ -18,7 +18,7 @@
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
-use quantick_guards::{GUARDS, ratchet, remedies, workspace_root};
+use quantick_guards::{GUARDS, ratchet, remedies, report, workspace_root};
 
 /// Turn whatever the caller typed into the workspace-relative spelling with
 /// forward slashes that every guard is keyed on.
@@ -57,15 +57,19 @@ fn relative_to(root: &Path, argument: &str) -> Result<String, String> {
 // would do both, while only the first argument was ever honoured — a mistyped
 // invocation exiting 0 having done half of what was asked.
 const USAGE: &str = "\
-usage: quantick-guards (--file <path> | --tighten)
+usage: quantick-guards (--file <path> | --tighten | --report)
 
   (no arguments)   run every guard over the repository
   --file <path>    run every guard over one workspace-relative path
-  --tighten        lower any baseline entry whose file has shrunk, in both
-                   ratchets, and the !budget totals to match -- only downward
+  --tighten        lower any baseline entry whose file has shrunk, in every
+                   ratchet, and the !budget totals to match -- only downward
+  --report         print the repository's health numbers as a label<TAB>value
+                   table; deterministic, so a diff between two runs is the
+                   report of what changed between them
 
-The two modes are alternatives; they cannot be combined.
-Exit code 1 means a guard found something.";
+The three modes are alternatives; they cannot be combined.
+Exit code 1 means a guard found something. --report exits 0: it measures the
+tree, it does not judge it.";
 
 fn main() -> ExitCode {
     // A set-but-empty variable is not a root. `var_os` hands back
@@ -79,10 +83,18 @@ fn main() -> ExitCode {
     let args: Vec<String> = std::env::args().skip(1).collect();
 
     match args.first().map(String::as_str) {
-        None => report(&root, None),
+        None => run_guards(&root, None),
         Some("--tighten") if args.len() == 1 => tighten(&root),
+        // Printed rather than returned as findings, and always exit 0. These
+        // numbers describe the tree; none of them is ratcheted, and a
+        // measurement that can fail a build is one people negotiate with
+        // instead of reading.
+        Some("--report") if args.len() == 1 => {
+            print!("{}", report::render(&root));
+            ExitCode::SUCCESS
+        }
         Some("--file") if args.len() == 2 => match relative_to(&root, &args[1]) {
-            Ok(relative) => report(&root, Some(relative)),
+            Ok(relative) => run_guards(&root, Some(relative)),
             Err(problem) => {
                 eprintln!("{problem}\n\n{USAGE}");
                 ExitCode::FAILURE
@@ -95,8 +107,8 @@ fn main() -> ExitCode {
         // Everything left over is refused rather than ignored. Silently
         // dropping a trailing argument is how a caller ends up trusting a
         // clean exit for a run that never did what they asked.
-        Some(mode @ ("--file" | "--tighten")) => {
-            // `--file` consumes the path beside it; `--tighten` consumes
+        Some(mode @ ("--file" | "--tighten" | "--report")) => {
+            // `--file` consumes the path beside it; the other two consume
             // nothing. Naming only what is actually unconsumed keeps the
             // message from accusing the caller of the argument they got right.
             let consumed = if mode == "--file" { 2 } else { 1 };
@@ -115,7 +127,7 @@ fn main() -> ExitCode {
 
 /// Run every guard, over the whole repository or over one file, and print
 /// what each found.
-fn report(root: &std::path::Path, only: Option<String>) -> ExitCode {
+fn run_guards(root: &std::path::Path, only: Option<String>) -> ExitCode {
     let mut clean = true;
     for guard in GUARDS {
         let violations = match &only {
@@ -161,8 +173,8 @@ fn tighten(root: &std::path::Path) -> ExitCode {
             root,
             guard.name,
             (ratchet.tighten)(root),
-            ratchet.baseline_file,
-            ratchet.budget_slack,
+            ratchet.policy.baseline_file,
+            ratchet.policy.budget_slack,
         );
     }
     if failed {

--- a/crates/guards/src/ratchet.rs
+++ b/crates/guards/src/ratchet.rs
@@ -35,6 +35,23 @@ use crate::Finding;
 /// somebody reflows the file.
 pub const BUDGET_DIRECTIVE: &str = "!budget";
 
+/// What a guard's own walk measured, summed.
+///
+/// One owner for the arithmetic, three one-line callers that each name their
+/// own `measure`. The three copies this replaces were byte-identical, in a
+/// change that elsewhere removed a duplicated constant for exactly this
+/// reason — and the failure they invited is quiet: a guard summing its counts
+/// differently from its siblings makes [`crate::report`] print three totals
+/// that are not comparable, with nothing to fail.
+///
+/// Deliberately the *measurement* and not [`Baseline::recorded`]. The budget
+/// caps what the repository has signed for; this is what its files actually
+/// weigh, and the gap between the two is the debt `--tighten` has yet to
+/// write off.
+pub fn total(counts: &[(String, usize)]) -> usize {
+    counts.iter().map(|(_, count)| count).sum()
+}
+
 /// One recorded ceiling, with the position that lets [`Policy::tighten`]
 /// rewrite it.
 #[derive(Debug)]

--- a/crates/guards/src/report.rs
+++ b/crates/guards/src/report.rs
@@ -1,0 +1,418 @@
+//! The repository's health numbers, as one stable text table.
+//!
+//! Every mission of the refactor sprint has been graded on the same dozen
+//! numbers — how much of the workspace is `app`, which files are still the
+//! largest, how wide the widest structs are, what the two ratchets have signed
+//! for against what the tree actually weighs — and each grading re-derived
+//! them by hand from ad-hoc `wc`, `grep` and `awk` runs. Re-derivation is not
+//! free and it is not reproducible: two sessions counting "production lines"
+//! with two different `grep` invocations produce two different answers, and
+//! neither can be diffed against the other.
+//!
+//! So the crate that already owns the measurements answers the question
+//! itself. [`render`] returns a `label<TAB>value` table with one line per
+//! number, in a fixed order, with no timestamps and no absolute paths — which
+//! makes `diff` between a report taken before a merge and one taken after
+//! *the report of what the merge changed*.
+//!
+//! # Why the rules here are the size guard's rules
+//!
+//! Nothing in this module decides for itself what "production" means. It
+//! walks with [`size::measure`] and strips test items with
+//! [`size::production_source`], because a second definition of production
+//! source is the duplicated-constant defect this repository files against its
+//! own code — and the first symptom would be a report whose per-crate totals
+//! disagree with the ratchet that rations them, with no way to tell which of
+//! the two is lying.
+//!
+//! # Why this measures and enforces nothing
+//!
+//! Not one of these numbers is ratcheted. The mode exists to make "did it
+//! improve?" answerable, and a number that fails a build is a number people
+//! negotiate with rather than read. Deciding which of them earns a ceiling is
+//! a later decision, taken with a few weeks of reports to look at.
+
+use std::fmt::Write as _;
+use std::fs;
+use std::path::Path;
+
+use crate::{GUARDS, size};
+
+/// How many of the largest production files the report names.
+///
+/// Eight because that is roughly where this repository's tail flattens: the
+/// files above it are the extraction targets a sprint argues about, and the
+/// ones below are ordinary. A longer list would move more lines per diff
+/// without adding a decision to take.
+pub const LARGEST_FILES: usize = 8;
+
+/// How many fields a `pub struct` must carry to be called wide.
+///
+/// A struct this size is the same defect the size ratchet exists for, one
+/// level down: a type that absorbed a subsystem instead of docking against
+/// it. Thirty is deliberately far above anything ordinary — the report is
+/// meant to name four or five types, not audit every record in the tree.
+pub const WIDE_STRUCT_FIELDS: usize = 30;
+
+/// One indent of Rust, in spaces. A field of a struct sits at exactly one;
+/// anything deeper belongs to a nested type or a generic bound.
+const INDENT: usize = 4;
+
+/// The substrings counted per production line, each with the label it is
+/// reported under.
+///
+/// A table rather than three counters because the three questions are the
+/// same question — how many sites of a thing the tree still carries — and
+/// three hand-written loops is how one of them silently starts counting over
+/// a different set of files than the other two.
+///
+/// Each needle is spelled in two halves so this table cannot match itself.
+/// The scan walks every production file in the workspace, this one included,
+/// and a whole literal here would add a phantom site to its own count — a
+/// number wrong by construction, in the direction that makes the tree look
+/// worse than it is, and wrong again the day somebody splits the module.
+pub const SITES: [(&str, &str); 2] = [
+    ("site.allow", concat!("#[all", "ow(")),
+    ("site.process_id", concat!("process:", ":id()")),
+];
+
+/// How many times each entry of [`SITES`] occurs in one file's production
+/// source, in that order.
+///
+/// Public so a fixture can pin the one property that is easy to get wrong and
+/// impossible to notice: these counts see production source only, so a
+/// `process::id()` a test module opens a scratch directory with is *not* a
+/// site the repository still carries. Counting it would score the branch that
+/// moved tests out of a production file as no improvement at all.
+pub fn site_counts(production: &[&str]) -> Vec<usize> {
+    SITES
+        .iter()
+        .map(|(_, needle)| {
+            production
+                .iter()
+                .map(|line| line.matches(needle).count())
+                .sum()
+        })
+        .collect()
+}
+
+/// The site counted over the *whole* file rather than over production source.
+///
+/// `#[cfg(test)]` is exactly what [`size::production_source`] strips, so
+/// counting it in production source would score zero by construction and the
+/// row would be a lie that never moves. What the sprint wants to know is how
+/// many production files still carry their tests inside them, which is a
+/// count over the file as written.
+///
+/// Spelled in halves for the reason [`SITES`] gives.
+const TEST_MODULE_SITE: &str = concat!("#[cfg(te", "st)]");
+
+/// The identifier whose absence marks a line as portable out of `app`.
+///
+/// `app` is the only crate allowed to know about the UI toolkit, so a
+/// production line in it that never names `egui` is a line some other crate
+/// could hold. The count is headroom, not a defect list: plenty of those
+/// lines are genuinely app glue.
+const UI_IDENTIFIER: &str = "egui";
+
+/// The crate whose share of the workspace the sprint is trying to shrink.
+const TRUNK_CRATE: &str = "app";
+
+/// The whole report, ready to print.
+///
+/// Deterministic by construction: every section sorts before it prints, the
+/// only paths are workspace-relative with forward slashes, and nothing here
+/// reads a clock, an environment variable or a random number. Two calls
+/// against the same tree return equal strings, which is the property
+/// `report_is_byte_identical_across_runs` pins.
+pub fn render(root: &Path) -> String {
+    let sizes = size::measure(root);
+    let scanned = Scan::of(root, &sizes.counts);
+
+    let mut out = String::new();
+    crates_section(&mut out, &sizes.counts);
+    largest_files_section(&mut out, &sizes.counts);
+    wide_structs_section(&mut out, &scanned);
+    ratchets_section(&mut out, root);
+    sites_section(&mut out, &scanned);
+    row(
+        &mut out,
+        format!("{TRUNK_CRATE}.lines.without_{UI_IDENTIFIER}"),
+        scanned.portable_trunk_lines,
+    );
+    row(&mut out, "scan.unreadable", sizes.unreadable.len());
+    row(&mut out, "scan.undecodable", sizes.undecodable.len());
+    row(&mut out, "scan.blind", sizes.blind.len());
+    out
+}
+
+/// One `label<TAB>value` line. The single owner of the report's shape, so a
+/// section cannot invent a second one.
+fn row(out: &mut String, label: impl AsRef<str>, value: impl std::fmt::Display) {
+    let _ = writeln!(out, "{}\t{value}", label.as_ref());
+}
+
+/// The crate a workspace-relative path belongs to: the directory immediately
+/// under `crates/`, which is how both baselines already spell paths.
+fn crate_of(path: &str) -> Option<&str> {
+    path.strip_prefix("crates/")?.split('/').next()
+}
+
+/// Production lines per crate, the workspace total, and the trunk's share.
+///
+/// The percentage is integer arithmetic on purpose. A fractional percent
+/// invites a formatting decision that can differ between float paths, and a
+/// report whose last digit wobbles is one nobody can diff.
+fn crates_section(out: &mut String, counts: &[(String, usize)]) {
+    let mut per_crate: Vec<(&str, usize)> = Vec::new();
+    for (path, lines) in counts {
+        let Some(name) = crate_of(path) else { continue };
+        match per_crate.iter_mut().find(|(known, _)| *known == name) {
+            Some((_, total)) => *total += lines,
+            None => per_crate.push((name, *lines)),
+        }
+    }
+    per_crate.sort();
+    for (name, lines) in &per_crate {
+        row(out, format!("crate.lines.{name}"), lines);
+    }
+    let total: usize = per_crate.iter().map(|(_, lines)| lines).sum();
+    let trunk = per_crate
+        .iter()
+        .find(|(name, _)| *name == TRUNK_CRATE)
+        .map_or(0, |(_, lines)| *lines);
+    row(out, "crate.lines.total", total);
+    // A zero total is an unreadable `crates/`, which `render` also reports as
+    // `scan.blind`. Printing 0 rather than dividing keeps the report from
+    // panicking on the one tree it most needs to describe.
+    let share = (trunk * 100).checked_div(total).unwrap_or(0);
+    row(out, format!("crate.lines.{TRUNK_CRATE}_percent"), share);
+}
+
+/// The [`LARGEST_FILES`] biggest production files.
+///
+/// Selected by line count, then printed by path. Printing them in rank order
+/// would make one file overtaking another rewrite every line between them;
+/// sorting the output by path means a diff shows the files that actually
+/// changed and nothing else.
+fn largest_files_section(out: &mut String, counts: &[(String, usize)]) {
+    let mut ranked: Vec<&(String, usize)> = counts.iter().collect();
+    ranked.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+    let mut largest: Vec<&(String, usize)> = ranked.into_iter().take(LARGEST_FILES).collect();
+    largest.sort();
+    for (path, lines) in largest {
+        row(out, format!("file.largest.{path}"), lines);
+    }
+}
+
+/// Every wide struct the scan found, by crate-qualified name.
+fn wide_structs_section(out: &mut String, scanned: &Scan) {
+    for (name, fields) in &scanned.wide_structs {
+        row(out, format!("struct.wide.{name}"), fields);
+    }
+}
+
+/// Each ratchet's signed `!budget`, the recorded ceilings it caps, and what
+/// the files it tracks weigh today.
+///
+/// Three numbers rather than the two the mission asked for, because the
+/// budget caps the *recorded* total and not the measured one. The slack
+/// between recorded and measured is the debt a sprint pays down before
+/// `--tighten` writes it off, and it is the number that moves first when a
+/// refactor lands.
+///
+/// The registry is the only list. A ratchet added to [`GUARDS`] appears here
+/// without an edit, which is the property that stopped the cycle ratchet from
+/// being invisible to `--tighten` when it was added.
+fn ratchets_section(out: &mut String, root: &Path) {
+    for guard in GUARDS {
+        let Some(ratchet) = &guard.ratchet else {
+            continue;
+        };
+        let name = guard.name;
+        match ratchet.policy.baseline(root) {
+            Ok(baseline) => {
+                match &baseline.budget {
+                    Some(budget) => row(out, format!("ratchet.{name}.budget"), budget.allowed),
+                    // Not silently zero. A missing directive is a cap that
+                    // stopped existing, and a `0` here would read as a
+                    // ratchet holding the line perfectly.
+                    None => row(out, format!("ratchet.{name}.budget"), "absent"),
+                }
+                row(out, format!("ratchet.{name}.recorded"), baseline.recorded());
+            }
+            // The report describes the tree; it does not fail on it. The
+            // guards themselves already turn an unparsable baseline into a
+            // finding with a remedy, and duplicating that here would give the
+            // sprint two voices on the same problem.
+            Err(_) => {
+                row(out, format!("ratchet.{name}.budget"), "unparsed");
+                row(out, format!("ratchet.{name}.recorded"), "unparsed");
+            }
+        }
+        row(
+            out,
+            format!("ratchet.{name}.measured"),
+            (ratchet.measured)(root),
+        );
+    }
+}
+
+/// The counted sites, in the fixed order [`SITES`] lists them.
+fn sites_section(out: &mut String, scanned: &Scan) {
+    for ((label, _), count) in SITES.iter().zip(&scanned.sites) {
+        row(out, *label, count);
+    }
+    row(out, "site.cfg_test", scanned.test_modules);
+}
+
+/// Everything the report reads out of file *contents*, gathered in one pass.
+///
+/// The paths come from [`size::measure`], so this never decides for itself
+/// which files are in scope; it only re-reads what that walk already found
+/// and asks four more questions of each one.
+struct Scan {
+    /// Wide structs by crate-qualified name, sorted.
+    wide_structs: Vec<(String, usize)>,
+    /// One count per entry of [`SITES`], in the same order.
+    sites: Vec<usize>,
+    /// `#[cfg(test)]` occurrences in files that are not themselves test files.
+    test_modules: usize,
+    /// Production lines in the trunk crate that never name the UI toolkit.
+    portable_trunk_lines: usize,
+}
+
+impl Scan {
+    fn of(root: &Path, counts: &[(String, usize)]) -> Self {
+        let mut scan = Scan {
+            wide_structs: Vec::new(),
+            sites: vec![0; SITES.len()],
+            test_modules: 0,
+            portable_trunk_lines: 0,
+        };
+        let trunk = format!("crates/{TRUNK_CRATE}/src/");
+        for (path, _) in counts {
+            // A file the walk measured and this pass cannot read is left out
+            // rather than guessed at; `size::measure` is the surface that
+            // reports it, and `render` prints its count as `scan.unreadable`.
+            let Ok(source) = fs::read_to_string(root.join(path)) else {
+                continue;
+            };
+            if !is_test_file(path) {
+                scan.test_modules += source.matches(TEST_MODULE_SITE).count();
+            }
+            let production = size::production_source(&source);
+            for (total, found) in scan.sites.iter_mut().zip(site_counts(&production)) {
+                *total += found;
+            }
+            if path.starts_with(&trunk) {
+                scan.portable_trunk_lines += production
+                    .iter()
+                    .filter(|line| !line.contains(UI_IDENTIFIER))
+                    .count();
+            }
+            if let Some(name) = crate_of(path) {
+                scan.wide_structs.extend(
+                    wide_structs(&production)
+                        .into_iter()
+                        .map(|(struct_name, fields)| (format!("{name}::{struct_name}"), fields)),
+                );
+            }
+        }
+        scan.wide_structs.sort();
+        scan
+    }
+}
+
+/// Whether a path is test code by its own name.
+///
+/// `size`'s walk already refuses any path with a `tests/` segment, so the
+/// only test files left in scope are the `tests.rs` siblings a module split
+/// leaves behind. Counting their `#[cfg(test)]` would score the extraction
+/// that moved tests *out* of a production file as no improvement at all.
+fn is_test_file(path: &str) -> bool {
+    path.rsplit('/')
+        .next()
+        .is_some_and(|file| file == "tests.rs")
+}
+
+/// Every `pub struct` in this production source with at least
+/// [`WIDE_STRUCT_FIELDS`] fields, by name.
+///
+/// A line rule rather than a parse: a `pub struct Name … {` at column zero
+/// opens a body, a line at exactly one [`INDENT`] naming a field closes over
+/// it, and a `}` back at column zero ends it. That is the rule the mission
+/// stated, and it is the rule `rustfmt` guarantees over this repository —
+/// every source here is formatted, so the indent carries the structure.
+/// Writing a real parser would be a larger and less predictable thing than
+/// the number is worth, and the fixture tests pin the rule rather than a
+/// parse tree.
+pub fn wide_structs(production: &[&str]) -> Vec<(String, usize)> {
+    let mut found = Vec::new();
+    let mut index = 0;
+    while index < production.len() {
+        let Some(name) = struct_name(production[index]) else {
+            index += 1;
+            continue;
+        };
+        index += 1;
+        let mut fields = 0;
+        while index < production.len() && production[index] != "}" {
+            if is_field(production[index]) {
+                fields += 1;
+            }
+            index += 1;
+        }
+        if fields >= WIDE_STRUCT_FIELDS {
+            found.push((name.to_owned(), fields));
+        }
+    }
+    found
+}
+
+/// The name of the `pub struct` this line opens a body for, if it does.
+///
+/// Only a brace-bodied struct at column zero qualifies. A tuple struct and a
+/// unit struct end on their own line with `;` and have no fields of the shape
+/// this counts, and an indented `struct` is nested inside something that is
+/// already being counted.
+fn struct_name(line: &str) -> Option<&str> {
+    let rest = line.strip_prefix("pub struct ")?;
+    if !rest.ends_with('{') {
+        return None;
+    }
+    let name = rest
+        .split(|c: char| c == '<' || c == '{' || c == '(' || c.is_whitespace())
+        .next()?;
+    if name.is_empty() { None } else { Some(name) }
+}
+
+/// Whether a line inside a struct body declares a field.
+///
+/// Exactly one indent, then an optional visibility, then an identifier and a
+/// colon. The indent test is what keeps a nested type's own fields, a
+/// multi-line generic bound and a `where` clause out of the count; the colon
+/// is what keeps attributes, doc comments and blank lines out.
+fn is_field(line: &str) -> bool {
+    let Some(rest) = line.strip_prefix(&" ".repeat(INDENT)) else {
+        return false;
+    };
+    if rest.starts_with(' ') {
+        return false;
+    }
+    let rest = match rest.strip_prefix("pub") {
+        // `pub name:` and `pub(crate) name:` both declare a field; `public: u8`
+        // is a field called `public` and must not lose its own prefix.
+        Some(after) => after
+            .strip_prefix(' ')
+            .or_else(|| after.split_once(") ").map(|(_, tail)| tail))
+            .unwrap_or(rest),
+        None => rest,
+    };
+    let Some((name, _)) = rest.split_once(':') else {
+        return false;
+    };
+    !name.is_empty()
+        && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+        && !name.starts_with(|c: char| c.is_ascii_digit())
+}

--- a/crates/guards/src/size.rs
+++ b/crates/guards/src/size.rs
@@ -83,7 +83,7 @@ use std::fs;
 use std::path::Path;
 
 use crate::Finding;
-use crate::ratchet::{Baseline, Policy};
+use crate::ratchet::{self, Baseline, Policy};
 
 /// Production lines above which a file must carry a baseline entry. Files
 /// below it are not the problem this guard exists for, and tracking them
@@ -369,6 +369,13 @@ fn scan(dir: &Path, root: &Path, found: &mut Measured) {
                 .push(format!("  {relative}: could not be read: {e}")),
         }
     }
+}
+
+/// What every tracked path measures today, summed, for
+/// [`crate::report`]. The *how* is [`ratchet::total`]; this only names the
+/// walk it sums, which is the one thing that differs per guard.
+pub fn measured(root: &Path) -> usize {
+    ratchet::total(&measure(root).counts)
 }
 
 /// Production-line counts for every scanned file, sorted by path.

--- a/crates/guards/tests/guards.rs
+++ b/crates/guards/tests/guards.rs
@@ -110,3 +110,208 @@ fn the_generated_indexes_match_the_code_they_describe() {
 fn no_test_mints_a_temporary_path_outside_its_scratch_module() {
     assert_clean(TESTED[6]);
 }
+
+// --- `--report`, the mode that measures rather than judges -------------------
+//
+// The guard tests above ask whether the repository is within its ceilings.
+// These ask whether the report describing it can be trusted to say the same
+// thing twice, and whether its two hand-written counting rules — a struct's
+// fields, and a site that survives into production source — count what the
+// mission said they should.
+
+use std::process::Command;
+
+use quantick_guards::{report, size};
+
+/// One `pub struct` whose fields sit at one indent, wrapped in the things
+/// that have to be ignored around them: a doc comment, an attribute, a
+/// generic parameter on the header, a nested type whose own fields sit
+/// deeper, and a trailing item after the closing brace.
+fn fixture_struct(fields: usize) -> String {
+    let mut source = String::from(
+        "//! A module.\n\
+         \n\
+         /// A type.\n\
+         #[derive(Debug)]\n\
+         pub struct Wide<T> {\n\
+         \x20   /// The first one, documented.\n\
+         \x20   pub kind: T,\n\
+         \x20   pub(crate) shared: usize,\n",
+    );
+    for index in 0..fields {
+        source.push_str(&format!("    field_{index}: usize,\n"));
+    }
+    source.push_str(
+        "    nested: Inner,\n\
+         }\n\
+         \n\
+         struct Inner {\n\
+         \x20   deep: usize,\n\
+         }\n",
+    );
+    source
+}
+
+/// The rule the mission stated: a field is a `name:` line at one indent
+/// inside a `pub struct` body. Everything at another indent, and everything
+/// without a colon, is not a field.
+#[test]
+fn a_struct_is_as_wide_as_its_fields_at_one_indent() {
+    let source = fixture_struct(report::WIDE_STRUCT_FIELDS);
+    let production = size::production_source(&source);
+    // Three hand-written fields — `kind`, `shared` and `nested` — plus the
+    // generated ones. The doc comment, the attribute, the generic header, the
+    // closing braces and the private `Inner` all count for nothing.
+    assert_eq!(
+        report::wide_structs(&production),
+        vec![("Wide".to_owned(), report::WIDE_STRUCT_FIELDS + 3)]
+    );
+}
+
+/// The threshold is a threshold. A struct one field short of it is ordinary,
+/// and an ordinary struct on this list would bury the four types the sprint
+/// is actually arguing about.
+#[test]
+fn a_struct_below_the_field_threshold_is_not_wide() {
+    let source = fixture_struct(report::WIDE_STRUCT_FIELDS - 4);
+    let production = size::production_source(&source);
+    assert!(report::wide_structs(&size::production_source(&source)).is_empty());
+    // …and the counting itself still ran, rather than the fixture being
+    // malformed in a way that would pass this test for the wrong reason.
+    assert!(production.iter().any(|line| line.contains("field_0")));
+}
+
+/// A struct that is not `pub`, and a struct with no brace-delimited body, are
+/// both outside the rule — the first because a private type is not a surface,
+/// the second because a tuple or unit struct has no fields of this shape.
+#[test]
+fn only_a_public_brace_bodied_struct_declares_fields() {
+    let mut source = String::from("struct Private {\n");
+    for index in 0..report::WIDE_STRUCT_FIELDS {
+        source.push_str(&format!("    field_{index}: usize,\n"));
+    }
+    source.push_str("}\n\npub struct Tuple(usize, usize);\npub struct Unit;\n");
+    let production = size::production_source(&source);
+    assert!(report::wide_structs(&production).is_empty());
+}
+
+/// The property the whole report rests on: a site inside a test module is not
+/// a site the repository still carries. Counting it would score the branch
+/// that moved tests out of a production file as no improvement at all.
+#[test]
+fn a_site_inside_a_test_module_is_not_counted() {
+    let allow_index = report::SITES
+        .iter()
+        .position(|(label, _)| *label == "site.allow")
+        .expect("the allow site is registered");
+    let process_index = report::SITES
+        .iter()
+        .position(|(label, _)| *label == "site.process_id")
+        .expect("the process-id site is registered");
+
+    let source = "\
+#[allow(dead_code)]
+pub fn live() -> u32 {
+    std::process::id()
+}
+
+#[cfg(test)]
+mod tests {
+    #[allow(unused)]
+    fn scratch() -> String {
+        format!(\"{}\", std::process::id())
+    }
+}
+";
+    let production = size::production_source(source);
+    let counts = report::site_counts(&production);
+    assert_eq!(counts[allow_index], 1, "only the production `allow` counts");
+    assert_eq!(
+        counts[process_index], 1,
+        "only the production `process::id()` counts"
+    );
+
+    // The same file with its test module deleted must count identically —
+    // which is what makes the number a measure of production code rather than
+    // of how a file happens to be laid out.
+    let without_tests: String = source
+        .lines()
+        .take_while(|line| !line.starts_with("#[cfg(test)]"))
+        .map(|line| format!("{line}\n"))
+        .collect();
+    assert_eq!(
+        report::site_counts(&size::production_source(&without_tests)),
+        counts
+    );
+}
+
+/// The mode's whole point. Two runs over the same tree must produce the same
+/// bytes, or a diff between a report taken before a merge and one taken after
+/// describes the reporter rather than the merge.
+///
+/// Run as the command rather than as [`report::render`], because the wiring
+/// between the two is part of what has to hold: a mode that printed a summary
+/// line or a path from the build machine would pass a library-level check and
+/// fail the one use the report has.
+#[test]
+fn the_report_is_byte_identical_across_runs() {
+    let first = run_report();
+    let second = run_report();
+    assert_eq!(
+        first, second,
+        "two --report runs over the same tree disagreed"
+    );
+    // A report of nothing is byte-identical too, and would pass the check
+    // above while saying nothing at all.
+    assert!(
+        first.lines().count() > 20,
+        "the report printed {} line(s); it should carry one per number",
+        first.lines().count()
+    );
+    assert!(
+        first.lines().all(|line| line.matches('\t').count() == 1),
+        "every row is one label, one tab, one value"
+    );
+}
+
+/// The modes are alternatives. `--report` with anything beside it is refused
+/// rather than ignored, because a mistyped invocation that exits 0 having
+/// done half of what was asked is the failure the usage string was rewritten
+/// to prevent.
+#[test]
+fn the_report_mode_refuses_extra_arguments() {
+    let output = Command::new(env!("CARGO_BIN_EXE_quantick-guards"))
+        .args(["--report", "--tighten"])
+        .output()
+        .expect("the guards binary runs");
+    assert!(
+        !output.status.success(),
+        "an extra argument must not exit 0"
+    );
+    let complaint = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        complaint.contains("--tighten"),
+        "the refusal names the unconsumed argument: {complaint}"
+    );
+    assert!(
+        complaint.contains("--report"),
+        "the usage string offers the mode that was asked for: {complaint}"
+    );
+}
+
+/// Run the command and hand back its stdout, failing loudly on a non-zero
+/// exit — `--report` measures the tree and never judges it, so the only way
+/// it can fail is by not working.
+fn run_report() -> String {
+    let output = Command::new(env!("CARGO_BIN_EXE_quantick-guards"))
+        .arg("--report")
+        .output()
+        .expect("the guards binary runs");
+    assert!(
+        output.status.success(),
+        "--report exited {:?}: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout).expect("the report is UTF-8")
+}


### PR DESCRIPTION
Add a `--report` mode to `quantick-guards` that prints, deterministically and with no dependency, the repository health numbers this refactor sprint is being judged on — one stable `label<TAB>value` table, one line per number, so a session can quote it before and after a merge instead of re-deriving twelve numbers by hand.

**Tier: `medium`.**

## Why

Every mission of the sprint has been graded from ad-hoc `wc`, `grep` and `awk` runs — the same twelve numbers, re-derived each time, by an agent, at open-judgement rates. Re-derivation is neither free nor reproducible: two sessions counting "production lines" with two different `grep` invocations get two different answers, and neither can be diffed against the other. The guards crate already owns the numbers that are ratcheted and already parses production source. The rest were one file walk away, and the crate builds in a second.

## What it prints

```
crate.lines.<crate>          production lines, per crate, plus the workspace total and app's share
file.largest.<path>          the eight largest production files
struct.wide.<crate>::<Name>  every pub struct with 30+ fields
ratchet.<name>.budget        the signed !budget
ratchet.<name>.recorded      the ceilings it caps
ratchet.<name>.measured      what those files weigh today
site.allow                   #[allow( in production source
site.process_id              process::id() in production source
site.cfg_test                #[cfg(test)] in production files (excluding tests.rs)
app.lines.without_egui       extraction headroom in the trunk
scan.*                       files the walk could not read, decode or list
```

Selection is by count; **print order is by path**, so one file overtaking another does not rewrite every line between them and a `diff` shows only what actually changed.

## Two decisions the trader took

- **Every ratchet, not the two named.** The report iterates `GUARDS`, so `cycle` appears for free and a fourth ratchet appears without an edit here.
- **Three numbers per ratchet.** The `!budget` caps the *recorded* ceilings, not the measured total. The gap between recorded and measured is the debt a refactor pays down before `--tighten` writes it off, and it is the number that moves first when work lands.

## The report against the brief's hand measurements

Every difference is a rule chosen differently, and each is reproduced independently below. The report column is the run at `d551813`, the commit the hand numbers were taken at.

| Number | By hand | `--report` | Why they differ |
|---|---|---|---|
| `app` lines / workspace | 182,739 / 263,767 (69%) | 114,223 / 170,859 (66%) | Hand counted raw `wc -l`; the report counts **production lines** — test items stripped, `tests/` directories excluded. Confirmed: raw `wc -l` over `crates/app` at that commit is **182,751**, twelve lines from the hand figure. |
| `app.rs` | 9,234 | 9,232 | Exactly the `#[cfg(test)]` + `mod tests;` pair that `production_source` steps over. |
| `pane.rs` | 7,773 | 7,771 | The same two lines. |
| `paper_trading.rs` | 9,718 | 6,265 | Its test module is **inline**, so production-only counting removes all of it. |
| `tab.rs` | 5,149 | 4,468 | The same. |
| `ChartPane` / `Tab` / `QuantickApp` / `PaperTrading` | 77 / 62 / 56 / 55 | **77 / 62 / 56 / 55** | Exact, to the field. |
| size `!budget` | 61,410 | **61,410** | Exact. |
| context `!budget` | 232,885 | **232,885** | Exact. |
| `#[allow(` | 66 (app) | 88 (workspace production) | A different scope *and* production-only. Independent recount: 60 raw in `crates/app`, 56 in app production, 88 workspace-wide production. |
| `process::id()` | 64 (workspace, raw) | 7 (workspace production) | Independent recount: 65 raw, of which 27 sit in `tests/` directories and 31 inside test modules within production files. The 7 survivors were each located and listed. |
| `#[cfg(test)]` | 238 (top-level app files) | 578 (workspace, non-`tests.rs`) | A different scope. Independent recount of the hand scope: **237**. |

**The mode demonstrating its own point.** The branch was cut at `d551813` and rebased onto `6d3e792` when PR #290 merged. `site.process_id` moved 7 → 11 and `site.cfg_test` 578 → 598, because that PR landed production scratch-directory helpers in `guards` and `replay`. Four new sites, named by one diffed line, with nobody re-deriving anything.

## Verification

- [x] `cargo fmt --all -- --check` — exit 0
- [x] `cargo clippy --workspace --all-targets` — exit 0
- [x] `cargo build --workspace` — exit 0
- [x] `cargo test --workspace` — exit 0

Each run separately on the shipped head `432fbf9`. `cargo run -p quantick-guards -- --report` completes in **289 ms** warm against a two-second budget, and two consecutive runs `diff` empty. `crates/guards/Cargo.toml` `[dependencies]` is still empty.

**Performance impact.** Every touched path is **rare**: `--report` and `--tighten` are operator-invoked, and nothing here is reachable from the app. No per-trade, per-depth or per-frame path is touched. The report walks `crates/` twice — once in `render`, once via the size ratchet's own `measured` — which is stated rather than special-cased, because eliminating it means lifting one ratchet out of a registry-driven loop for about 100 ms on a rare path. `cargo test -p quantick-guards` stays at about a second; the guards test file went 0.36 s → 0.74 s, the cost of running the binary twice to prove determinism honestly.

**Proof.** `the_report_is_byte_identical_across_runs` fails if determinism regresses; `a_site_inside_a_test_module_is_not_counted` fails if the production rule drifts; three fixture tests pin the struct-field rule against a nested type, a non-`pub` struct and a tuple struct; `the_report_mode_refuses_extra_arguments` pins the alternatives grammar.

**Trunk.** Flat. No baseline file is touched and no ceiling raised. `CLAUDE.md` gained one sentence naming the mode and lands back on its ceiling at exactly 10,118 bytes, paid for by moving two reasoning clauses to where this repository already keeps reasoning.

## Reviews

**`arch-review`** — step 0 ran `code-review` at `low` (effort-first, no reuse notice). It was invoked twice: the first pass came back scoped over PR #290's files this branch never touched, so the main checkout was fast-forwarded and it was re-invoked once per the scope rule. The second returned **one finding, fixed in this branch**: `measured()` was byte-identical in three modules, the duplicated-constant defect this same diff removes elsewhere. `ratchet::total` now owns the arithmetic and each guard keeps a one-line adapter naming only its own walk. No Blockers, no deferrals.

One defect was found and fixed before review: the `SITES` needles matched their own source, adding a phantom site to each of the report's own counts. They are now spelled in halves, and the corrected counts reproduce under a separate implementation.

**`delivery-review`** — PASS, completeness pass only, which is the `medium` mode. Every ask in the verbatim request is carried by the ledger. Two notes against the checklist rather than the branch: the brief's own "four checks green, context budget not raised" is discharged by `G2`/`A9` rather than by an `R` line, and its "reads and never writes the baselines" is read as R17's intent — satisfied either way, since no `*-baseline.txt` appears in the diff.

## Out of scope, deliberately

None of the new numbers is ratcheted; no JSON, history or plotting; no change to `size.rs` / `context.rs` behaviour beyond reuse. The mode measures — a later change may decide what to enforce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012PAG3aADwXyEpNZGCiPXik
