### PR TITLE
refactor(indicators): a native docks as a new file plus one line, in app too

### DIFF
--- a/.claude/GOAL-archive-native-indicator-docking.md
+++ b/.claude/GOAL-archive-native-indicator-docking.md
@@ -1,0 +1,274 @@
+# Mission: a native indicator docks as a new file plus one line — in `app` too
+
+Replace the per-indicator native variants in `crates/app` with a catalog the
+app iterates, so that adding a fourth native touches the `indicators` crate
+only, while existing state and preset files still load and every hook, control
+call and toolbar entry keeps its name.
+
+**Why it matters.** `CLAUDE.md` *Keeping the trunk small* promises that a
+capability docks as a new file plus one registration line. For native
+indicators that promise holds below `app` and fails inside it: the same native
+is a variant in two enums, a toolbar action, and match arms in the worker, the
+app and the layout wiring. The audit behind PR #287 counted this as one of four
+falsified recipes and fixed the prose; this mission fixes the code so the prose
+can say what it originally promised. The cost is paid on every indicator
+addition and on every review of one.
+
+**Tier:** `medium`. The change is behaviour-preserving, but it rewrites the
+on-disk vocabulary of the trader's workspace file and redraws a trader-facing
+menu, so `delivery-review` runs in full and the toolbar rows get a
+`trader-ux-review` pass. It is not `small`: the diff spans six production files
+plus a serde compatibility path, and D1 below is a one-way change to a file the
+trader owns.
+
+## Request ledger
+
+Derived from `C:\src\mission-native-indicator-docking.md`, read in full before
+any work started. Every claim in its evidence table was re-verified against
+`origin/main` at `d551813` before this file was written; the three corrections
+are recorded as `S` lines.
+
+### The catalog
+
+- **R1** — Add a native catalog to `crates/indicators/src/native/mod.rs`: one
+  entry per native carrying a stable id (`native.ema`, `native.cvd`), a display
+  label, default inputs and a constructor `fn() -> Box<dyn Indicator>`. The
+  existing `pub use` lines stay; the catalog entry is *"the one registration
+  line the recipe promises"*.
+- **R2** — Anchored VWAP is **not** re-docked: it is a drawing today and stays
+  one. Out of scope, and the branch must not touch `avwap` docking.
+
+### Collapsing the app-side variants
+
+- **R3** — `SavedKind::Native { id }` replaces `NativeEma` / `NativeCvd`.
+- **R4** — `IndicatorSource::Native { id, values }` replaces the two worker
+  variants.
+- **R5** — `ToolbarAction::AddNative(id)` replaces `AddEmaIndicator` and
+  `AddCvdIndicator`.
+- **R6** — The toolbar indicator rows are drawn by iterating the catalog, not
+  written out one per native.
+- **R7** — `add_native_indicator` (`app.rs`) and the layout wiring
+  (`layout_wiring.rs`) look the id up in the catalog instead of matching on a
+  variant.
+- **R8** — The `_ =>` arm that today silently turns any unknown kind into an
+  EMA becomes an error path. *Verbatim:* "becomes an error path, never a silent
+  EMA."
+
+### Compatibility and names
+
+- **R9** — The state file and the preset file still load a workspace saved by
+  today's code, covered by a test that loads a fixture written in today's
+  on-disk spelling.
+- **R10** — Every `QUANTICK_*` hook, control capability id, harness registry
+  row and toolbar label that mentions EMA or CVD keeps its **exact** string.
+- **R11** — The recipe row in `.claude/skills/new-extension/SKILL.md` (the
+  table row and the *"The indicator port is only half a port"* section it
+  points at) is rewritten to the new truth and names the one file and one line
+  a fourth native touches.
+
+### The proof, and the checks
+
+- **R12** — A fourth native costs exactly one new file under
+  `crates/indicators/src/native/` and one line in `native/mod.rs`, and from
+  those two edits alone it appears in the toolbar, saves and restores through a
+  layout. *(Proof shape set by D2 — a permanent test-only fake native, not the
+  throwaway SMA the brief proposed.)*
+- **R13** — `grep -rn 'NativeEma\|NativeCvd' crates/app/src` returns only the
+  compatibility path and its test.
+- **R14** — Every existing test in `indicators_tests.rs`, `state_file.rs`,
+  `preset_file.rs`, `layouts.rs` and `indicator_worker.rs` is green, unchanged
+  except for the variant spelling.
+- **R15** — No hook, capability id, registry row or UI string changed: the
+  generated hook registry and the capability inventory show an empty diff.
+- **R16** — The four-check loop and `cargo test -p quantick-guards` are green,
+  and the size baseline is tightened where `app.rs` and `layout_wiring.rs`
+  shrank.
+- **R18** — Respect the parallel branches: `refactor/feed-crate` (touches
+  `app.rs` and `toolbar.rs` at `use` lines only) and
+  `fix/tests-own-their-scratch` (edits `app/tests/*.rs` scratch helpers,
+  `indicators_tests.rs` among them) — this mission's changes to
+  `indicators_tests.rs` stay limited to variant spelling.
+
+### The judging ask
+
+- **R17** — *Verbatim:* "so that adding a fourth native touches the indicators
+  crate only, existing state and preset files still load, and every hook,
+  control call and toolbar entry keeps its name." Three conditions, all three
+  required; R17 is the ask that judges the rest.
+
+## Decisions taken by the trader
+
+- **D1** — After the change the app **writes the new format**
+  (`native = { id = "native.ema" }`); reading the old spelling keeps working
+  permanently. Accepted consequence: a workspace file saved by this build is
+  not readable by a build older than this PR — a one-way migration.
+- **D2** — The proof that a fourth native costs one file plus one line is a
+  **permanent fake native registered behind `#[cfg(test)]`**, exercising
+  catalog, toolbar, save and restore. The brief's throwaway SMA is **not**
+  added: the fake is the "second implementation tested" that `new-extension`
+  already asks for, and unlike a quoted diff it is re-run by every CI.
+
+## Assumptions
+
+- **S1** — *Correction to the brief's ledger #9.* `SavedKind` carries
+  `#[serde(rename_all = "snake_case")]`, so the on-disk spelling is
+  `native_ema` / `native_cvd`, not `NativeEma` / `NativeCvd`. The compatibility
+  path in R9 is written against the real spelling, and the fixture is generated
+  by today's serializer rather than hand-typed. Safe to assume: it is a fact
+  the code states, not a choice.
+- **S2** — *Correction to the brief's ledger #7.* `preset_file.rs` (13
+  matches) and `layouts.rs` (2 matches) mention the variants **only in their
+  test modules**; their production cost is zero. Their production code is
+  generic over `SavedKind` and needs no change beyond compiling. Scope is
+  therefore narrower than the brief stated, not wider.
+- **S3** — *Correction to the brief's ledger #7.* `app.rs` has 11 matching
+  sites and `state_file.rs` 7, not the 8 and 5 the brief counted. No design
+  consequence; recorded so the count is not re-derived.
+- **S4** — `IndicatorSource::Native { id, values }` carries the EMA's `len` and
+  `source` as `values: Vec<InputValue>`, not as typed fields, with an empty
+  `values` meaning "declared defaults". This is already how the settings path
+  binds them (`rebind`, brief ledger #8), so no second mechanism is invented.
+  Conventional default; not a trader-facing call.
+- **S5** — The toolbar keeps the literal strings "Add EMA(9) on close" and
+  "Add CVD pane" by storing each native's full menu label in its catalog entry,
+  rather than composing `"Add " + label`. R10 demands the exact string, and
+  composition is what silently changes one.
+- **S6** — `.claude/evidence/generated-truth/recipes.md` records what PR #287
+  *measured* and is a historical artifact, so its body is not rewritten; a
+  single "superseded by" pointer line is added so a later reader is not misled
+  by a claim this branch falsifies. *Wanted to ask* — the `medium` budget of
+  two questions went to D1 and D2, which cost more if wrong.
+- **S7** — The catalog lives in `crates/indicators/src/native/mod.rs` as the
+  brief says, and `app` consumes it through the crate's public surface. The
+  catalog returns `Box<dyn Indicator>`; it does not know about `SavedKind`,
+  `IndicatorSource` or egui, so no reverse dependency edge is created.
+  Conventional; the dependency direction rule in `CLAUDE.md` decides it.
+
+## Acceptance criteria
+
+- [ ] **A1** — `crates/indicators/src/native/mod.rs` exposes a catalog of
+      native entries, each with a stable id, a display label, default inputs
+      and a `fn() -> Box<dyn Indicator>` constructor; the two existing
+      `pub use` lines are still there.
+      *Evidence:* the catalog quoted, plus a test in the `indicators` crate
+      asserting the catalog's ids are exactly `native.ema` and `native.cvd`.
+      → `crates/indicators/src/native/mod.rs` tests. *(R1)*
+- [ ] **A2** — Anchored VWAP is untouched: no change to `avwap.rs`, to the
+      drawing-tool path, or to how AVWAP docks.
+      *Evidence:* `git diff origin/main...HEAD --stat` naming no `avwap` file.
+      → PR body. *(R2)*
+- [ ] **A3** — `SavedKind::Native { id }`, `IndicatorSource::Native { id,
+      values }` and `ToolbarAction::AddNative(id)` each replace their two
+      per-native variants, and no per-native variant remains in any of the
+      three enums.
+      *Evidence:* the three enum definitions quoted from the branch.
+      → PR body. *(R3, R4, R5)*
+- [ ] **A4** — The toolbar's native rows are produced by iterating the catalog:
+      one loop, no per-native `if ui.button(...)`.
+      *Evidence:* the `draw_indicators_menu` diff quoted. → PR body. *(R6)*
+- [ ] **A5** — `add_native_indicator` and `add_indicator_at` resolve a native
+      by catalog lookup, and an id no catalog knows produces a visible error
+      slot rather than an EMA.
+      *Evidence:* a test that asks both paths for an unknown id and asserts an
+      error, not an EMA. → `crates/app/src/app/tests/indicators_tests.rs`.
+      *(R7, R8)*
+- [ ] **A6** — A workspace state file and a preset file written in today's
+      `native_ema` / `native_cvd` spelling still load and restore both natives
+      on the branch's code.
+      *Evidence:* a test loading a fixture in the old spelling, asserting both
+      indicators come back. → `crates/app/src/indicators/state_file.rs` and
+      `preset_file.rs` tests. *(R9, D1)*
+- [ ] **A7** — Files this build writes use the new spelling
+      (`native = { id = "native.ema" }`).
+      *Evidence:* a round-trip test asserting the serialized text.
+      → `crates/app/src/indicators/state_file.rs` tests. *(D1)*
+- [ ] **A8** — Every `QUANTICK_*` hook name, control capability id, harness
+      registry row and toolbar label mentioning EMA or CVD is byte-identical to
+      `origin/main`.
+      *Evidence:* `git diff origin/main...HEAD` over the hook registry and the
+      capability inventory is empty, and the two menu strings are grepped from
+      the branch. → PR body. *(R10, R15)*
+- [ ] **A9** — A fake native registered behind `#[cfg(test)]` reaches the
+      toolbar, saves and restores through a layout, with its registration being
+      one catalog line and its implementation one file.
+      *Evidence:* the test and the line count of its two edits, quoted.
+      → `crates/indicators/src/native/` + an app test. *(R12, D2)*
+- [ ] **A10** — `grep -rn 'NativeEma\|NativeCvd' crates/app/src` returns only
+      the compatibility path and its test.
+      *Evidence:* the command's full output. → PR body. *(R13)*
+- [ ] **A11** — The existing tests in `indicators_tests.rs`, `state_file.rs`,
+      `preset_file.rs`, `layouts.rs` and `indicator_worker.rs` are green with
+      no change beyond variant spelling, and the `indicators_tests.rs` diff
+      contains nothing but spelling plus the new tests A5 and A9 name.
+      *Evidence:* the per-file diff and the test run. → PR body. *(R14, R18)*
+- [ ] **A12** — The `new-extension` recipe row and its *"only half a port"*
+      section state the new truth and name the one file and one line, and the
+      section does not grow the context budget.
+      *Evidence:* the diff, plus `cargo test -p quantick-guards` green on the
+      context ratchet. → PR body. *(R11)*
+- [ ] **A13** — The size baseline is tightened wherever `app.rs`,
+      `layout_wiring.rs`, `indicator_worker.rs` or `toolbar.rs` shrank.
+      *Evidence:* the `size-baseline.txt` diff, and guards green.
+      → PR body. *(R16)*
+- [ ] **A14** — All three conditions of the judging ask hold together: a fourth
+      native touches the `indicators` crate only, old state and preset files
+      still load, and no hook, control call or toolbar entry changed name.
+      *Evidence:* A9, A6 and A8 cited together. → PR body. *(R17)*
+
+### Injected gates
+
+- [ ] **G1** — Every artifact this branch authors is in English, per
+      `CLAUDE.md`.
+      *Evidence:* `arch-review` dimension 8 with no finding, and
+      `cargo test -p quantick-guards` green. → arch-review verdict.
+- [ ] **G2** — The four checks are green after rebasing on latest `main`:
+      `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets`,
+      `cargo build --workspace`, `cargo test --workspace`, each run on its own.
+      *Evidence:* the four exit codes, pasted separately. → PR body. *(also R16)*
+- [ ] **G3** — Performance impact declared: every touched path classified by
+      rate (per-trade / per-depth / per-frame / rare).
+      *Evidence:* the classification table. → PR body.
+- [ ] **G4** — `arch-review` run over `git diff origin/main...HEAD`, every
+      Blocker and Should-fix resolved or deferred in the PR body.
+      *Evidence:* the verdict and the `arch-review-ok` marker.
+      → PR body.
+- [ ] **G5** — The catalog is a docking port per `new-extension`: port named,
+      registration-only edits, defaults preserving today's behaviour, a fake
+      second implementation tested (A9), blast radius stated.
+      *Evidence:* the `new-extension` checklist answered. → PR body.
+- [ ] **G6** — The redrawn indicator menu passes `trader-ux-review` with no
+      unresolved Blocker, and the surface stays reachable through the existing
+      `QUANTICK_INDICATORS_AUTOSTART` hook with no new hook needed.
+      *Evidence:* the review verdict and a `visual-qa` capture of the menu.
+      → PR body.
+
+### Not applicable, and why
+
+- **Hot path evidence** — the catalog is consulted when an indicator is
+  *added* or *restored*, never per trade, per depth update or per frame. The
+  per-frame toolbar loop iterates two entries where it previously ran two
+  `if`s. G3 declares this; a benchmark would measure nothing.
+- **Engine / determinism territory** — nothing under `crates/engine` is
+  touched, and no bar-building code changes. The `indicators` crate change is
+  additive and does not alter any kernel.
+- **`ui-harness` new-hook rule** — no new UI surface appears. The menu that
+  changes is already reachable through `QUANTICK_INDICATORS_AUTOSTART`, and R10
+  forbids adding or renaming a hook. G6 covers the surface that exists.
+- **Docs/skills waiver** — not claimed. The branch is code first, so the full
+  `arch-review` shape pass applies to all of it, `SKILL.md` included.
+
+## Closing steps
+
+- [ ] **C1** — `delivery-review` returns PASS over the branch as shipped.
+- [ ] **C2** — The PR is open, naming the `medium` tier beside the four
+      verification boxes.
+
+## The request as received
+
+Quoted verbatim and untranslated: this is the marked, attributed quotation
+`CLAUDE.md`'s English rule exempts, kept word-for-word because the ledger above
+must remain auditable against the words that produced it. The request arrived
+in English; the brief it points at is reproduced in the branch's history rather
+than here.
+
+> medium refactor/native-indicator-docking — `crates/indicators/src/native/mod.rs` promises that a third native indicator is "a new file plus one line", and inside that crate it is; in `crates/app` the same indicator is a variant in two enums, a toolbar action, and match arms in the worker, the app and the layout wiring, across six files. Replace the per-indicator variants with a native catalog the app iterates — one entry per native (id, label, constructor) — so that adding a fourth native touches the indicators crate only, existing state and preset files still load, and every hook, control call and toolbar entry keeps its name. Read C:\src\mission-native-indicator-docking.md in full before anything else and build the request ledger from it.

--- a/.claude/evidence/generated-truth/recipes.md
+++ b/.claude/evidence/generated-truth/recipes.md
@@ -29,6 +29,12 @@ One `SavedKind` variant plus 14 call sites across four files. The
 half and omitted the `app` half. Corrected in `new-extension/SKILL.md`, which
 now names all fifteen sites and points at the `.pine` route first.
 
+**Superseded.** The measurement above stands as what was true when it was
+taken; the code no longer is. `refactor/native-indicator-docking` replaced the
+per-native variants with a catalog in `crates/indicators/src/native/mod.rs`,
+so the fifteen sites are gone and a native really is a new file plus one line —
+in `app` too. `new-extension/SKILL.md` states the new truth.
+
 ## 2. The feeds clause in CLAUDE.md's headless bullet (R15)
 
 **Claim:** the feeds are among the crates with "no UI, no network, no async, no

--- a/.claude/skills/new-extension/SKILL.md
+++ b/.claude/skills/new-extension/SKILL.md
@@ -18,28 +18,22 @@ repo's existing ports:
 | --- | --- | --- |
 | Market data source | `FeedEvent` channel + `FeedCapabilities` | new `feed-*` crate; config entry in `crates/app/config/feeds.toml` |
 | Bar/aggregation type | engine aggregator trait | new module in `engine`, one registration |
-| Indicator / kernel | `Indicator` trait (commit/preview + rollback) | a `.pine` script is data only. A **native** is a new file plus one `pub use` in `indicators` — and then 15 edits in `app`. See *The indicator port is only half a port* below |
+| Indicator / kernel | `Indicator` trait (commit/preview + rollback) | a `.pine` script is data only. A **native** is a new file in `crates/indicators/src/native/` plus one `NATIVES` entry beside it — and nothing at all in `app` |
 | Chart layer / overlay | chart layer registry (`QUANTICK_CHART_LAYERS` set) | new layer module in `app` |
 | Panel / dock tab | dock tab set | new module in `app`, one tab registration |
 | Floating UI surface (popup, toast, overlay box) | `Surface` trait + `SurfaceEnv`/`SurfaceResponse` | new module in `app/src/surfaces/`, one field on `Surfaces` |
 | Look / preset | config file (`bubbles.toml`, drawing presets) | data only — no code |
 | Sim/backtest behaviour | `sim` fill model + metrics | `sim` crate, consumed by chart and runner alike |
 
-**The indicator port is only half a port**, and the table used to hide it.
-`crates/indicators/src/native/mod.rs` says "a third native is a new file plus
-one line", which is true *of that crate* and is where the claim came from. It
-is not true of adding an indicator. Measured against `NativeCvd`, the newest
-native, the `app` side costs a `SavedKind` variant in
-`indicators/state_file.rs` and **14 further call sites**: nine in
-`indicator_worker.rs`, three in `app.rs`, one in `app/layout_wiring.rs`.
-Adding a fourth native means visiting all fifteen.
-
-So: a `.pine` script is the real extension point and costs no code at all —
-prefer it. If a native is genuinely required (performance, or a kernel the
-dialect cannot express), the honest plan says fifteen sites, and carving
-`SavedKind` into a registry keyed by a string — the shape
-`indicators/library.rs` already uses for scripts — is a legitimate first
-slice of that goal rather than scope creep.
+**A native costs two edits, and the second is one line.** Write the kernel as
+its own file under `crates/indicators/src/native/`, then register it in
+`native/mod.rs`: one `pub use`, and one `NATIVES` entry giving its stable id
+(`native.sma`), the menu label the toolbar prints verbatim, and a
+`fn() -> Box<dyn Indicator>`. Nothing in `app` changes — the toolbar draws the
+catalog, the workspace file stores the id, and the worker resolves it. An id
+no build ships becomes an error slot naming it, never a substitute indicator.
+Prefer a `.pine` script anyway where the dialect can express the kernel: that
+costs no code at all.
 
 **No port fits?** Then the goal has two parts: first carve the port (a
 trait, a registry, a capability flag) as its own reviewable slice, then

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -70,6 +70,15 @@ rodio = { workspace = true }
 # without one reports that instead of pretending (see `audio/platform.rs`).
 windows-sys = { workspace = true }
 
+[dev-dependencies]
+# The same crate the `[dependencies]` table already carries, asking for the
+# throwaway native the docking port is tested through. Feature resolution
+# keeps a dev-dependency's features out of the normal build, so the binary
+# `cargo build --workspace` produces ships the two real natives and nothing
+# else — while the tests get a third one to prove the app never learned their
+# names. See `crates/indicators/src/native/fake.rs`.
+quantick-indicators = { path = "../indicators", features = ["fake-native"] }
+
 [target.'cfg(windows)'.build-dependencies]
 winresource = { workspace = true }
 

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -103,8 +103,6 @@ const DEMO_FALLBACK_BAND_FRACTION: f64 = 0.004;
 /// mark. Any distance the tab cannot possibly hold would do; an hour is
 /// unambiguous at every timeframe the chart offers.
 const DEMO_OFF_SERIES_LEAD_MS: i64 = 3_600_000;
-/// Length of the EMA the toolbar's hardcoded M1 entry adds (the settings UI
-/// generated from `InputSpec` replaces this in M4).
 /// The natives `QUANTICK_INDICATORS_AUTOSTART` opens with: the overlay and
 /// the pane, so a scripted run photographs both shapes. Named by catalog id
 /// rather than "all of them", because the hook's contract is a fixed,

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -105,7 +105,12 @@ const DEMO_FALLBACK_BAND_FRACTION: f64 = 0.004;
 const DEMO_OFF_SERIES_LEAD_MS: i64 = 3_600_000;
 /// Length of the EMA the toolbar's hardcoded M1 entry adds (the settings UI
 /// generated from `InputSpec` replaces this in M4).
-const DEFAULT_EMA_LEN: usize = 9;
+/// The natives `QUANTICK_INDICATORS_AUTOSTART` opens with: the overlay and
+/// the pane, so a scripted run photographs both shapes. Named by catalog id
+/// rather than "all of them", because the hook's contract is a fixed,
+/// deterministic pair — a native added later must not silently change what
+/// every existing capture shows.
+const AUTOSTART_NATIVES: &[&str] = &["native.ema", "native.cvd"];
 /// How often the hot-reload poll checks script files for changes.
 const SCRIPT_RELOAD_POLL_INTERVAL: Duration = Duration::from_millis(1_000);
 /// Horizontal offset of a duplicated drawing, so the copy is visibly a copy.
@@ -1089,11 +1094,12 @@ impl QuantickApp {
         // menu takes, so a scripted validation run needs no clicks.
         if std::env::var("QUANTICK_INDICATORS_AUTOSTART").is_ok_and(|value| value == "1") {
             let pane = &mut app.active_tab_mut().flow_pane;
-            pane.add_indicator(IndicatorSource::NativeEma {
-                len: DEFAULT_EMA_LEN,
-                source: quantick_indicators::SourceId::Close,
-            });
-            pane.add_indicator(IndicatorSource::NativeCvd);
+            for id in AUTOSTART_NATIVES {
+                pane.add_indicator(IndicatorSource::Native {
+                    id: (*id).to_owned(),
+                    values: Vec::new(),
+                });
+            }
         }
         // The folded legend, reachable from a clean launch: without it the
         // collapsed state is un-photographable by an agent, and a surface no
@@ -2782,13 +2788,9 @@ impl QuantickApp {
             // path, the trader's own, and not in `ChartPane::add_indicator`,
             // which the workspace restore and the harness hooks also travel —
             // there it would erase the fold on every launch.
-            ToolbarAction::AddEmaIndicator => {
+            ToolbarAction::AddNative(id) => {
                 self.set_focused_legend_collapsed(false);
-                self.add_native_indicator(SavedKind::NativeEma);
-            }
-            ToolbarAction::AddCvdIndicator => {
-                self.set_focused_legend_collapsed(false);
-                self.add_native_indicator(SavedKind::NativeCvd);
+                self.add_native_indicator(id);
             }
             ToolbarAction::ToggleIndicatorHidden(slot) => {
                 let target = self.target_slot(SlotId(slot));
@@ -3512,15 +3514,16 @@ impl QuantickApp {
 
     /// Add one of the built-in indicators to the focused pane and register how
     /// it restores.
-    fn add_native_indicator(&mut self, kind: SavedKind) -> SlotId {
-        let source = match kind {
-            SavedKind::NativeCvd => IndicatorSource::NativeCvd,
-            // Every other kind is a script, which comes through
-            // `add_script_indicator`; EMA is the remaining native.
-            _ => IndicatorSource::NativeEma {
-                len: DEFAULT_EMA_LEN,
-                source: quantick_indicators::SourceId::Close,
-            },
+    ///
+    /// The kind travels to the worker as-is: an id no build ships becomes an
+    /// error slot naming it, which is why there is no fallback arm here. The
+    /// one this replaced turned every unrecognised kind into an EMA, so a
+    /// mistyped id put an indicator on the chart that nobody had asked for.
+    fn add_native_indicator(&mut self, id: &str) -> SlotId {
+        let kind = SavedKind::native(id);
+        let source = IndicatorSource::Native {
+            id: id.to_owned(),
+            values: Vec::new(),
         };
         let slot = self.focused_pane_mut().add_indicator(source);
         let owner = self.target_slot(slot);

--- a/crates/app/src/app/layout_wiring.rs
+++ b/crates/app/src/app/layout_wiring.rs
@@ -50,7 +50,7 @@ use crate::indicators::state_file::{SavedIndicator, SavedInput, SavedKind, Saved
 use crate::layouts::{self, DrawingKey, LayoutBook, LayoutError, LayoutId, Loaded, SavedDrawing};
 use crate::pane::{ChartPane, DrawingDrag, PaneIndex, PaneSide};
 
-use super::{DEFAULT_EMA_LEN, QuantickApp, TabSlot};
+use super::{QuantickApp, TabSlot};
 use crate::workspace_store::LayoutSave;
 
 /// The feed half of a drawing key while a tab plays a recording.
@@ -632,10 +632,11 @@ impl QuantickApp {
         kind: &SavedKind,
     ) -> Option<SlotId> {
         let source = match kind {
-            SavedKind::NativeCvd => IndicatorSource::NativeCvd,
-            SavedKind::NativeEma => IndicatorSource::NativeEma {
-                len: DEFAULT_EMA_LEN,
-                source: quantick_indicators::SourceId::Close,
+            // Unresolved on purpose: the worker owns the catalog, and an id
+            // it does not know becomes an error slot naming it.
+            SavedKind::Native { id } => IndicatorSource::Native {
+                id: id.clone(),
+                values: Vec::new(),
             },
             SavedKind::Script { name } => {
                 let index = self

--- a/crates/app/src/app/tests/drawings_tests.rs
+++ b/crates/app/src/app/tests/drawings_tests.rs
@@ -3466,7 +3466,7 @@ fn apply_keeps_the_settings_dialog_open_and_lands_the_draft() {
     let (mut app, _commands) = split_app(&ctx, 200);
     let point = pane_point(&app, PaneSide::Flow);
     click_chart(&mut app, &ctx, point);
-    app.apply_toolbar_action(ToolbarAction::AddEmaIndicator);
+    app.apply_toolbar_action(ToolbarAction::AddNative("native.ema"));
     settle_indicators(&mut app);
     let slot = app.active_tab().flow_pane.indicators.all()[0].slot;
     app.apply_toolbar_action(ToolbarAction::OpenIndicatorSettings(slot.0));
@@ -3756,7 +3756,7 @@ fn moving_a_context_chart_moves_its_drawings_and_slots_with_it() {
         .set_layout(CanvasLayout::TimeTimeAndFlow);
     run_frame(&mut app, &ctx);
     run_frame(&mut app, &ctx);
-    app.apply_toolbar_action(ToolbarAction::AddEmaIndicator);
+    app.apply_toolbar_action(ToolbarAction::AddNative("native.ema"));
     settle_indicators(&mut app);
     place_level(&mut app, PaneSide::Time(0), 100.0);
     run_frame(&mut app, &ctx);

--- a/crates/app/src/app/tests/indicators_tests.rs
+++ b/crates/app/src/app/tests/indicators_tests.rs
@@ -73,13 +73,13 @@ fn the_indicator_set_restores_from_disk_and_saves_back() {
         &path,
         &[
             SavedIndicator {
-                kind: SavedKind::NativeEma,
+                kind: SavedKind::native("native.ema"),
                 hidden: false,
                 inputs: vec![SavedInput::Int(21), SavedInput::Source("close".to_owned())],
                 plot_styles: Vec::new(),
             },
             SavedIndicator {
-                kind: SavedKind::NativeCvd,
+                kind: SavedKind::native("native.cvd"),
                 hidden: true,
                 inputs: Vec::new(),
                 plot_styles: Vec::new(),
@@ -106,8 +106,8 @@ fn the_indicator_set_restores_from_disk_and_saves_back() {
         3,
         "a script the library lacks takes an error slot saying so, keeping the layout's positions aligned"
     );
-    assert_eq!(app.slot_kinds[0].1, SavedKind::NativeEma);
-    assert_eq!(app.slot_kinds[1].1, SavedKind::NativeCvd);
+    assert_eq!(app.slot_kinds[0].1, SavedKind::native("native.ema"));
+    assert_eq!(app.slot_kinds[1].1, SavedKind::native("native.cvd"));
     assert_eq!(app.pending_hidden.len(), 1, "the hidden flag survived");
     assert!(
         !app.workspace.layouts().is_dirty(),
@@ -227,7 +227,7 @@ fn an_indicator_added_on_one_pane_appears_on_every_pane() {
         "clicking a pane focuses it"
     );
 
-    app.apply_toolbar_action(ToolbarAction::AddEmaIndicator);
+    app.apply_toolbar_action(ToolbarAction::AddNative("native.ema"));
     settle_indicators(&mut app);
 
     for side in [PaneSide::Time(0), PaneSide::Flow] {
@@ -266,7 +266,7 @@ fn an_indicator_added_on_one_pane_appears_on_every_pane() {
     assert_eq!(app.layouts().active().indicators.len(), 1);
     assert_eq!(
         app.layouts().active().indicators[0].kind,
-        crate::indicators::state_file::SavedKind::NativeEma
+        crate::indicators::state_file::SavedKind::native("native.ema")
     );
 }
 
@@ -281,7 +281,7 @@ fn a_pane_gesture_opens_the_dialog_once_on_the_indicator_it_named() {
     let (mut app, _commands) = split_app(&ctx, 200);
     let point = pane_point(&app, PaneSide::Flow);
     click_chart(&mut app, &ctx, point);
-    app.apply_toolbar_action(ToolbarAction::AddEmaIndicator);
+    app.apply_toolbar_action(ToolbarAction::AddNative("native.ema"));
     settle_indicators(&mut app);
     let slot = app.active_tab().flow_pane.indicators.all()[0].slot;
 
@@ -315,7 +315,7 @@ fn a_restyled_plot_comes_back_after_a_restart() {
     let (mut app, _commands) = split_app(&ctx, 200);
     let point = pane_point(&app, PaneSide::Flow);
     click_chart(&mut app, &ctx, point);
-    app.apply_toolbar_action(ToolbarAction::AddEmaIndicator);
+    app.apply_toolbar_action(ToolbarAction::AddNative("native.ema"));
     settle_indicators(&mut app);
     let slot = app.active_tab().flow_pane.indicators.all()[0].slot;
     app.active_tab_mut()
@@ -372,7 +372,7 @@ fn the_settings_hook_finds_indicators_on_the_flow_pane_while_the_time_pane_has_f
     // Indicators on the flow pane...
     let point = pane_point(&app, PaneSide::Flow);
     click_chart(&mut app, &ctx, point);
-    app.apply_toolbar_action(ToolbarAction::AddEmaIndicator);
+    app.apply_toolbar_action(ToolbarAction::AddNative("native.ema"));
     settle_indicators(&mut app);
     // ...mirrored onto the time pane by the layout; the hook's index names
     // the same indicator on whichever pane has focus.
@@ -418,7 +418,7 @@ fn legend_actions_land_on_their_own_pane_not_the_focused_one() {
     // An EMA on the time pane...
     let point = pane_point(&app, PaneSide::Time(0));
     click_chart(&mut app, &ctx, point);
-    app.apply_toolbar_action(ToolbarAction::AddEmaIndicator);
+    app.apply_toolbar_action(ToolbarAction::AddNative("native.ema"));
     settle_indicators(&mut app);
     let slot = app
         .active_tab()
@@ -517,7 +517,7 @@ fn the_second_context_pane_takes_focus_bars_and_indicators() {
         "and the top chart kept its own"
     );
 
-    app.apply_toolbar_action(ToolbarAction::AddEmaIndicator);
+    app.apply_toolbar_action(ToolbarAction::AddNative("native.ema"));
     settle_indicators(&mut app);
     assert_eq!(
         app.active_tab()
@@ -565,7 +565,7 @@ fn the_indicator_rebuild_covers_the_venue_prefix() {
     let (mut app, events, _commands) = history_app(&ctx);
     let point = pane_point(&app, PaneSide::Time(0));
     click_chart(&mut app, &ctx, point);
-    app.apply_toolbar_action(ToolbarAction::AddEmaIndicator);
+    app.apply_toolbar_action(ToolbarAction::AddNative("native.ema"));
     settle_indicators(&mut app);
 
     events
@@ -598,4 +598,124 @@ fn the_indicator_rebuild_covers_the_venue_prefix() {
         inside.is_some(),
         "and the average is finite over the venue history"
     );
+}
+
+/// The whole point of the native catalog: the application handles a native it
+/// has never heard of.
+///
+/// Driven by iterating the catalog rather than by naming EMA and CVD, so a
+/// native added to `quantick-indicators` is covered here the moment it is
+/// registered — and the `fake-native` feature puts one in the catalog that
+/// this crate demonstrably does not know, so the test is not merely a
+/// restatement of the two it does.
+#[test]
+fn every_native_in_the_catalog_adds_and_registers_without_being_named_here() {
+    assert!(
+        quantick_indicators::native::native("native.fake").is_some(),
+        "the throwaway native is registered under test, or this test proves \
+         only that the two shipped natives work"
+    );
+
+    for entry in quantick_indicators::native::NATIVES {
+        let (mut app, _commands) = app_with_history(200);
+        app.apply_toolbar_action(ToolbarAction::AddNative(entry.id));
+        settle_indicators(&mut app);
+
+        let views = app.active_tab().flow_pane.indicators.all();
+        assert_eq!(views.len(), 1, "{} added exactly one indicator", entry.id);
+        assert!(
+            views[0].error.is_none(),
+            "{} built cleanly: {:?}",
+            entry.id,
+            views[0].error
+        );
+        assert_eq!(
+            views[0].kind.as_ref(),
+            entry.id,
+            "the slot is keyed by the catalog id, which is what a drawing \
+             anchors to and what the control plane reports"
+        );
+
+        app.maintain_indicator_state();
+        assert_eq!(
+            app.layouts().active().indicators[0].kind,
+            crate::indicators::state_file::SavedKind::native(entry.id),
+            "{} registered how it restores",
+            entry.id
+        );
+    }
+}
+
+/// A native the catalog does not have is an error slot naming it — never a
+/// different indicator.
+///
+/// The arm this replaces mapped every unrecognised kind to the EMA, so a
+/// workspace naming a withdrawn native put an EMA on the chart and said
+/// nothing. A trader reading that line would have been reading a moving
+/// average while believing it was something else.
+#[test]
+fn an_unknown_native_id_is_an_error_slot_rather_than_a_silent_ema() {
+    let (mut app, _commands) = app_with_history(200);
+    app.apply_toolbar_action(ToolbarAction::AddNative("native.nonesuch"));
+    settle_indicators(&mut app);
+
+    let views = app.active_tab().flow_pane.indicators.all();
+    assert_eq!(
+        views.len(),
+        1,
+        "the slot is kept, so positions stay aligned"
+    );
+    assert!(
+        views[0].error.is_some(),
+        "the slot says it could not build: {:?}",
+        views[0].label()
+    );
+    assert!(
+        !views[0].label().contains("EMA"),
+        "and it is emphatically not an EMA: {}",
+        views[0].label()
+    );
+}
+
+/// The same for the restore path, which reaches natives through the layout
+/// rather than through the menu: a workspace naming a native this build does
+/// not ship keeps its slot and says so.
+#[test]
+fn a_workspace_naming_a_native_this_build_lacks_restores_an_error_slot() {
+    use crate::indicators::state_file::{SavedIndicator, SavedKind};
+
+    let (mut app, _events, _commands, _book) = test_app();
+    let path = crate::indicators::state_file::default_path();
+    let layouts_path = crate::layouts::default_path();
+    let _ = std::fs::remove_file(&path);
+    let _ = std::fs::remove_file(&layouts_path);
+    app.workspace.set_layouts_path(layouts_path.clone());
+
+    crate::indicators::state_file::save(
+        &path,
+        &[SavedIndicator {
+            kind: SavedKind::native("native.from.the.future"),
+            hidden: false,
+            inputs: Vec::new(),
+            plot_styles: Vec::new(),
+        }],
+    );
+    app.reload_layouts(&[]);
+    settle_indicators(&mut app);
+
+    assert_eq!(
+        app.slot_kinds.len(),
+        1,
+        "the slot is kept so the layout's positions stay aligned"
+    );
+    let views = app.active_tab().flow_pane.indicators.all();
+    assert_eq!(views.len(), 1);
+    assert!(
+        views[0].error.is_some(),
+        "it reports rather than substitutes: {}",
+        views[0].label()
+    );
+    assert!(!views[0].label().contains("EMA"), "{}", views[0].label());
+    let _ = std::fs::remove_file(&path);
+    let _ = std::fs::remove_file(&layouts_path);
 }

--- a/crates/app/src/app/tests/panes_layout_tests.rs
+++ b/crates/app/src/app/tests/panes_layout_tests.rs
@@ -1901,7 +1901,7 @@ fn the_status_bar_follows_the_focused_pane() {
 fn two_panes_show_two_layouts_side_by_side() {
     let ctx = egui::Context::default();
     let (mut app, _commands) = split_app(&ctx, 200);
-    app.apply_toolbar_action(ToolbarAction::AddEmaIndicator);
+    app.apply_toolbar_action(ToolbarAction::AddNative("native.ema"));
     settle_indicators(&mut app);
     let first = app.layouts().active_id();
     assert_eq!(app.layouts().get(first).unwrap().indicators.len(), 1);
@@ -1936,7 +1936,7 @@ fn two_panes_show_two_layouts_side_by_side() {
     );
 
     // An edit on the time pane reaches layout 2 only.
-    app.apply_toolbar_action(ToolbarAction::AddCvdIndicator);
+    app.apply_toolbar_action(ToolbarAction::AddNative("native.cvd"));
     settle_indicators(&mut app);
     assert_eq!(
         app.active_tab()
@@ -1954,7 +1954,7 @@ fn two_panes_show_two_layouts_side_by_side() {
     assert_eq!(app.layouts().get(second).unwrap().indicators.len(), 1);
     assert_eq!(
         app.layouts().get(second).unwrap().indicators[0].kind,
-        crate::indicators::state_file::SavedKind::NativeCvd
+        crate::indicators::state_file::SavedKind::native("native.cvd")
     );
     assert_eq!(app.layouts().get(first).unwrap().indicators.len(), 1);
     assert_eq!(
@@ -2019,7 +2019,7 @@ fn per_pane_layouts_are_recorded_and_restored() {
     let point = pane_point(&app, PaneSide::Time(0));
     click_chart(&mut app, &ctx, point);
     let second = app.create_layout(Some("levels")).expect("second");
-    app.apply_toolbar_action(ToolbarAction::AddCvdIndicator);
+    app.apply_toolbar_action(ToolbarAction::AddNative("native.cvd"));
     settle_indicators(&mut app);
     app.flush_layouts();
 
@@ -2065,7 +2065,7 @@ fn per_pane_layouts_are_recorded_and_restored() {
 fn layouts_come_back_after_a_restart() {
     let ctx = egui::Context::default();
     let (mut app, _commands) = split_app(&ctx, 200);
-    app.apply_toolbar_action(ToolbarAction::AddEmaIndicator);
+    app.apply_toolbar_action(ToolbarAction::AddNative("native.ema"));
     settle_indicators(&mut app);
     app.maintain_indicator_state();
     place_level(&mut app, PaneSide::Time(0), 100.0);
@@ -2115,7 +2115,7 @@ fn layouts_come_back_after_a_restart() {
 fn a_previewed_input_never_reaches_the_layout() {
     let ctx = egui::Context::default();
     let (mut app, _commands) = split_app(&ctx, 200);
-    app.apply_toolbar_action(ToolbarAction::AddEmaIndicator);
+    app.apply_toolbar_action(ToolbarAction::AddNative("native.ema"));
     settle_indicators(&mut app);
     let slot = app.active_tab().flow_pane.indicators.all()[0].slot;
     let target = TabSlot {
@@ -2819,7 +2819,7 @@ fn closing_a_tab_activates_a_neighbour_and_drops_its_market() {
     let second = app.active_tab().id;
     // Register a slot on the tab about to close, so the bookkeeping has
     // something to lose with it.
-    app.apply_toolbar_action(ToolbarAction::AddCvdIndicator);
+    app.apply_toolbar_action(ToolbarAction::AddNative("native.cvd"));
     assert!(app.slot_kinds.iter().any(|(owner, _)| owner.tab == second));
 
     app.apply_tab_action(TabAction::Close(1));

--- a/crates/app/src/app/tests/paper_trading_tests.rs
+++ b/crates/app/src/app/tests/paper_trading_tests.rs
@@ -2002,8 +2002,8 @@ fn removing_a_slot_on_one_pane_removes_its_layout_position_everywhere() {
 
     let point = pane_point(&app, PaneSide::Flow);
     click_chart(&mut app, &ctx, point);
-    app.apply_toolbar_action(ToolbarAction::AddEmaIndicator);
-    app.apply_toolbar_action(ToolbarAction::AddCvdIndicator);
+    app.apply_toolbar_action(ToolbarAction::AddNative("native.ema"));
+    app.apply_toolbar_action(ToolbarAction::AddNative("native.cvd"));
     settle_indicators(&mut app);
     assert_eq!(
         app.slot_kinds.len(),

--- a/crates/app/src/indicator_worker.rs
+++ b/crates/app/src/indicator_worker.rs
@@ -131,7 +131,15 @@ impl IndicatorSource {
                 // values back is generated too, via the trait, so a new
                 // native's settings cannot be silently ignored for want of a
                 // match arm here.
-                Ok(entry.build_with(values.unwrap_or(saved)))
+                // An empty set means "never given one" — the same reading
+                // the script arm below takes — so it falls back to the values
+                // this source was restored with rather than silently
+                // resetting a tuned native to its declared defaults.
+                let bind = match values {
+                    Some(values) if !values.is_empty() => values,
+                    _ => saved,
+                };
+                Ok(entry.build_with(bind))
             }
             IndicatorSource::Script { name, text } => match quantick_pine::compile(text, name) {
                 Ok(compiled) => Ok(Box::new(match values {
@@ -1492,6 +1500,37 @@ mod set_inputs_tests {
     use super::*;
     use crate::indicators::IndicatorViews;
     use quantick_indicators::{IndicatorHost, PlotId, SourceId, native::Ema};
+
+    /// An empty value set is a slot that was never given one, not an
+    /// instruction to forget the values it holds.
+    ///
+    /// The two readings are indistinguishable at the call site and differ
+    /// only when a native has been tuned: taking "empty" literally rebuilds
+    /// it at its declared defaults, which a trader reads as their period
+    /// resetting itself. The script arm has always made this distinction;
+    /// this asserts the native arm makes the same one.
+    #[test]
+    fn an_empty_value_set_keeps_a_natives_restored_values() {
+        let source = IndicatorSource::Native {
+            id: "native.ema".to_owned(),
+            values: vec![InputValue::Int(21), InputValue::Source(SourceId::Delta)],
+        };
+
+        let built = source
+            .build_with(Some(&[]))
+            .expect("the EMA is in the catalog");
+        assert_eq!(
+            built.descriptor().title,
+            "EMA(21, delta)",
+            "an empty set falls back to what the source carries"
+        );
+
+        // And a real set still wins over the carried one.
+        let rebound = source
+            .build_with(Some(&[InputValue::Int(5)]))
+            .expect("the EMA is in the catalog");
+        assert_eq!(rebound.descriptor().title, "EMA(5)");
+    }
 
     /// Applying settings = construct anew + replace + replay: the columns
     /// The second implementer of the input port: a script's bound values must

--- a/crates/app/src/indicator_worker.rs
+++ b/crates/app/src/indicator_worker.rs
@@ -19,8 +19,7 @@ use std::sync::mpsc::{Receiver, Sender, channel};
 use quantick_engine::{Bar, Trade};
 use quantick_indicators::{
     EvalError, Indicator, IndicatorDescriptor, IndicatorHost, InputValue, InstanceId,
-    ObjectSnapshot, PreviewFrame, Rgba8, SourceId,
-    native::{Cvd, Ema},
+    ObjectSnapshot, PreviewFrame, Rgba8, native::native,
 };
 
 /// Most rungs a lane ladder is ever walked with.
@@ -82,10 +81,18 @@ pub(crate) struct SlotId(pub u64);
 /// What to instantiate behind a slot.
 #[derive(Debug, Clone)]
 pub(crate) enum IndicatorSource {
-    /// Native EMA over a selectable source series.
-    NativeEma { len: usize, source: SourceId },
-    /// Native cumulative volume delta pane.
-    NativeCvd,
+    /// A native, by its catalog id, with the input values it was restored
+    /// with — empty meaning "whatever the native declares".
+    ///
+    /// One variant for every native there will ever be: the worker resolves
+    /// the id against [`quantick_indicators::native`] and never learns which
+    /// natives exist.
+    Native {
+        /// Stable catalog id (`native.ema`).
+        id: String,
+        /// Saved input values, in binding order.
+        values: Vec<InputValue>,
+    },
     /// A Quantick Pine script: display name + source text (the UI owns
     /// files; the worker only ever sees text).
     Script { name: String, text: String },
@@ -113,18 +120,19 @@ impl IndicatorSource {
     /// falls back to its default rather than panicking the worker.
     fn build_with(&self, values: Option<&[InputValue]>) -> Result<Box<dyn Indicator>, String> {
         match self {
-            IndicatorSource::NativeEma { len, source } => {
-                let base = Ema::new(*len, *source);
-                // The panel is generated from `InputSpec`; binding the values
-                // back is generated too, via the trait, so a future native
-                // cannot forget to extend a match here and have its settings
-                // silently ignored.
-                Ok(match values.and_then(|values| base.rebind(values)) {
-                    Some(bound) => bound,
-                    None => Box::new(base),
-                })
+            IndicatorSource::Native { id, values: saved } => {
+                // An id this build does not ship is an error slot saying so,
+                // never a substitute indicator: silently building a different
+                // native than the workspace named is how a trader ends up
+                // reading an EMA and believing it is something else.
+                let entry = native(id)
+                    .ok_or_else(|| format!("`{id}` is not a native indicator this build ships"))?;
+                // The panel is generated from `InputSpec` and binding the
+                // values back is generated too, via the trait, so a new
+                // native's settings cannot be silently ignored for want of a
+                // match arm here.
+                Ok(entry.build_with(values.unwrap_or(saved)))
             }
-            IndicatorSource::NativeCvd => Ok(Box::new(Cvd::new())),
             IndicatorSource::Script { name, text } => match quantick_pine::compile(text, name) {
                 Ok(compiled) => Ok(Box::new(match values {
                     // An empty set is a slot that has never been given one:
@@ -205,8 +213,7 @@ impl IndicatorSource {
     /// series, not which pane the trader was annotating.
     pub(crate) fn kind_id(&self) -> String {
         match self {
-            IndicatorSource::NativeEma { .. } => "native.ema".to_owned(),
-            IndicatorSource::NativeCvd => "native.cvd".to_owned(),
+            IndicatorSource::Native { id, .. } => id.clone(),
             IndicatorSource::Script { name, .. } => format!("script.{name}"),
         }
     }
@@ -215,8 +222,12 @@ impl IndicatorSource {
     /// instance's title comes from its descriptor).
     fn fallback_title(&self) -> String {
         match self {
-            IndicatorSource::NativeEma { len, .. } => format!("EMA({len})"),
-            IndicatorSource::NativeCvd => "CVD".to_owned(),
+            IndicatorSource::Native { id, values } => native(id).map_or_else(
+                // Nothing shipped under this id, so the id itself is the most
+                // useful thing the error row can say.
+                || id.clone(),
+                |entry| entry.build_with(values).descriptor().title.clone(),
+            ),
             IndicatorSource::Script { name, .. } => name.clone(),
         }
     }
@@ -901,7 +912,7 @@ mod tests {
     use super::*;
     use crate::indicators::IndicatorViews;
     use quantick_engine::{BarBuilder as _, Side, TickBarBuilder, Trade, golden as engine_golden};
-    use quantick_indicators::{PlotId, native::Ema};
+    use quantick_indicators::{PlotId, SourceId, native::Ema};
     use rust_decimal::Decimal;
 
     pub(super) fn trade(i: u64) -> Trade {
@@ -1053,9 +1064,9 @@ mod tests {
         let slot = views.allocate_slot("test.indicator");
         worker.send(IndicatorCommand::Add {
             slot,
-            source: IndicatorSource::NativeEma {
-                len: 3,
-                source: SourceId::Close,
+            source: IndicatorSource::Native {
+                id: "native.ema".to_owned(),
+                values: vec![InputValue::Int(3), InputValue::Source(SourceId::Close)],
             },
         });
         worker.send(IndicatorCommand::Backfilled(bars[..split].to_vec()));
@@ -1105,7 +1116,10 @@ mod tests {
         let slot = views.allocate_slot("test.indicator");
         worker.send(IndicatorCommand::Add {
             slot,
-            source: IndicatorSource::NativeCvd,
+            source: IndicatorSource::Native {
+                id: "native.cvd".to_owned(),
+                values: Vec::new(),
+            },
         });
         worker.send(IndicatorCommand::Backfilled(coarse));
         worker.send(IndicatorCommand::Rebuild(
@@ -1138,8 +1152,20 @@ mod tests {
         let doomed = views.allocate_slot("test.indicator");
         let survivor = views.allocate_slot("test.indicator");
         for (slot, source) in [
-            (doomed, IndicatorSource::NativeCvd),
-            (survivor, IndicatorSource::NativeCvd),
+            (
+                doomed,
+                IndicatorSource::Native {
+                    id: "native.cvd".to_owned(),
+                    values: Vec::new(),
+                },
+            ),
+            (
+                survivor,
+                IndicatorSource::Native {
+                    id: "native.cvd".to_owned(),
+                    values: Vec::new(),
+                },
+            ),
         ] {
             worker.send(IndicatorCommand::Add { slot, source });
         }
@@ -1228,7 +1254,10 @@ mod tests {
         let slot = views.allocate_slot("test.indicator");
         worker.send(IndicatorCommand::Add {
             slot,
-            source: IndicatorSource::NativeCvd,
+            source: IndicatorSource::Native {
+                id: "native.cvd".to_owned(),
+                values: Vec::new(),
+            },
         });
         worker.send(IndicatorCommand::Backfilled(bars.clone()));
         worker.send(IndicatorCommand::PartialUpdated {
@@ -1284,7 +1313,10 @@ mod tests {
         let slot = views.allocate_slot("test.indicator");
         worker.send(IndicatorCommand::Add {
             slot,
-            source: IndicatorSource::NativeCvd,
+            source: IndicatorSource::Native {
+                id: "native.cvd".to_owned(),
+                values: Vec::new(),
+            },
         });
         worker.send(IndicatorCommand::Backfilled(bars.clone()));
         worker.send(IndicatorCommand::PartialUpdated {
@@ -1459,7 +1491,7 @@ mod object_event_tests {
 mod set_inputs_tests {
     use super::*;
     use crate::indicators::IndicatorViews;
-    use quantick_indicators::{IndicatorHost, PlotId, native::Ema};
+    use quantick_indicators::{IndicatorHost, PlotId, SourceId, native::Ema};
 
     /// Applying settings = construct anew + replace + replay: the columns
     /// The second implementer of the input port: a script's bound values must
@@ -1522,9 +1554,9 @@ plot(close * k)
         let slot = views.allocate_slot("test.indicator");
         worker.send(IndicatorCommand::Add {
             slot,
-            source: IndicatorSource::NativeEma {
-                len: 3,
-                source: SourceId::Close,
+            source: IndicatorSource::Native {
+                id: "native.ema".to_owned(),
+                values: vec![InputValue::Int(3), InputValue::Source(SourceId::Close)],
             },
         });
         worker.send(IndicatorCommand::Backfilled(bars.clone()));

--- a/crates/app/src/indicators/preset_file.rs
+++ b/crates/app/src/indicators/preset_file.rs
@@ -239,7 +239,11 @@ mod tests {
         let path = default_path();
         let mut store = PresetStore::default();
         assert!(store.insert(&copilot(), "choppy day", choppy()));
-        assert!(store.insert(&SavedKind::NativeEma, "fast", vec![SavedInput::Int(9)]));
+        assert!(store.insert(
+            &SavedKind::native("native.ema"),
+            "fast",
+            vec![SavedInput::Int(9)]
+        ));
         store.save(&path);
 
         let loaded = PresetStore::load(&path);
@@ -250,8 +254,56 @@ mod tests {
         );
         assert_eq!(loaded.get(&copilot(), "choppy day"), Some(&choppy()[..]));
         assert_eq!(
-            loaded.get(&SavedKind::NativeEma, "fast"),
+            loaded.get(&SavedKind::native("native.ema"), "fast"),
             Some(&[SavedInput::Int(9)][..])
+        );
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// The presets a trader saved for their EMA are addressed by kind, and
+    /// before the native catalog that kind was spelled `native_ema` in the
+    /// file. Losing the mapping would not error — it would quietly show an
+    /// empty preset menu on an indicator that has presets, which is worse.
+    #[test]
+    fn presets_saved_before_the_catalog_still_belong_to_their_native() {
+        let path = default_path();
+        std::fs::write(
+            &path,
+            "version = 1
+
+             [[presets]]
+kind = \"native_ema\"
+name = \"fast\"
+
+             [[presets.inputs]]
+type = \"int\"
+value = 9
+
+             [[presets]]
+kind = \"native_cvd\"
+name = \"plain\"
+inputs = []
+",
+        )
+        .unwrap();
+
+        let loaded = PresetStore::load(&path);
+        assert_eq!(
+            loaded
+                .names_for(&SavedKind::native("native.ema"))
+                .collect::<Vec<_>>(),
+            ["fast"],
+            "the old spelling names the catalog's EMA"
+        );
+        assert_eq!(
+            loaded.get(&SavedKind::native("native.ema"), "fast"),
+            Some(&[SavedInput::Int(9)][..])
+        );
+        assert_eq!(
+            loaded
+                .names_for(&SavedKind::native("native.cvd"))
+                .collect::<Vec<_>>(),
+            ["plain"]
         );
         std::fs::remove_file(&path).ok();
     }
@@ -296,7 +348,11 @@ mod tests {
             "overwriting an existing name still works when full"
         );
         assert!(
-            store.insert(&SavedKind::NativeEma, "ema", vec![SavedInput::Int(9)]),
+            store.insert(
+                &SavedKind::native("native.ema"),
+                "ema",
+                vec![SavedInput::Int(9)]
+            ),
             "another kind's shelf is not full"
         );
         assert!(store.remove(&copilot(), "p0"));

--- a/crates/app/src/indicators/state_file.rs
+++ b/crates/app/src/indicators/state_file.rs
@@ -26,18 +26,96 @@ pub(crate) const STATE_FILE: &str = "indicators-state.toml";
 const FORMAT_VERSION: u32 = 1;
 
 /// Which constructor an entry restores through.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+///
+/// Natives are named by their catalog id rather than by a variant of their
+/// own: the file then survives a native being added or withdrawn, and nothing
+/// in this crate has to learn which natives exist. See
+/// [`quantick_indicators::native`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum SavedKind {
-    /// The native EMA.
-    NativeEma,
-    /// The native CVD pane.
-    NativeCvd,
+    /// A native, by its stable catalog id (`native.ema`).
+    Native {
+        /// The catalog id. An id this build does not ship restores as an
+        /// error slot, never as a different indicator.
+        id: String,
+    },
     /// A library script, by its menu name (`zigzag.pine`).
     Script {
         /// The library entry name.
         name: String,
     },
+}
+
+impl SavedKind {
+    /// A native entry for a catalog id.
+    pub(crate) fn native(id: &str) -> Self {
+        SavedKind::Native { id: id.to_owned() }
+    }
+}
+
+/// The catalog ids the two pre-catalog variants meant. Kept here rather than
+/// read from the catalog: this is a statement about what old *files* say, and
+/// it must stay true even if one of those natives is one day withdrawn.
+const LEGACY_EMA_ID: &str = "native.ema";
+/// See [`LEGACY_EMA_ID`].
+const LEGACY_CVD_ID: &str = "native.cvd";
+
+/// The spelling written by builds before the native catalog: a bare string,
+/// `kind = "native_ema"`, from the unit variants `SavedKind` used to carry.
+///
+/// Read-only, and permanently so — a workspace saved years ago still opens.
+/// This build writes [`SavedKind::Native`] instead, so a file converts the
+/// first time it is saved.
+#[derive(Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum LegacyNativeKind {
+    /// Became `native.ema`.
+    NativeEma,
+    /// Became `native.cvd`.
+    NativeCvd,
+}
+
+/// The current spelling, derived so [`SavedKind`]'s own `Deserialize` can be
+/// hand-written without recursing into itself.
+#[derive(Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum CurrentKind {
+    /// `native = { id = "native.ema" }`
+    Native {
+        /// The catalog id.
+        id: String,
+    },
+    /// `script = { name = "zigzag.pine" }`
+    Script {
+        /// The library entry name.
+        name: String,
+    },
+}
+
+/// Either spelling, discriminated by shape: the legacy one is a string, the
+/// current one a table, so `untagged` cannot confuse them.
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum SavedKindWire {
+    /// Pre-catalog.
+    Legacy(LegacyNativeKind),
+    /// This build's.
+    Current(CurrentKind),
+}
+
+impl<'de> Deserialize<'de> for SavedKind {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Ok(match SavedKindWire::deserialize(deserializer)? {
+            SavedKindWire::Legacy(LegacyNativeKind::NativeEma) => SavedKind::native(LEGACY_EMA_ID),
+            SavedKindWire::Legacy(LegacyNativeKind::NativeCvd) => SavedKind::native(LEGACY_CVD_ID),
+            SavedKindWire::Current(CurrentKind::Native { id }) => SavedKind::Native { id },
+            SavedKindWire::Current(CurrentKind::Script { name }) => SavedKind::Script { name },
+        })
+    }
 }
 
 /// One persisted input value. Sources are stored by name so the file stays
@@ -281,7 +359,7 @@ mod tests {
     fn sample() -> Vec<SavedIndicator> {
         vec![
             SavedIndicator {
-                kind: SavedKind::NativeEma,
+                kind: SavedKind::native("native.ema"),
                 hidden: false,
                 inputs: vec![SavedInput::Int(21), SavedInput::Source("delta".to_owned())],
                 plot_styles: Vec::new(),
@@ -299,6 +377,129 @@ mod tests {
                 }],
             },
         ]
+    }
+
+    /// A workspace saved by any build before the native catalog names its
+    /// natives with the unit-variant spelling `native_ema` / `native_cvd`.
+    /// Those files are on traders' disks and must open forever: the fixture
+    /// here is the exact text today's serializer produced for that set.
+    #[test]
+    fn a_workspace_saved_before_the_catalog_still_restores_both_natives() {
+        let dir = crate::scratch::ScratchDir::new("indicator-state");
+        let path = dir.join("pre-catalog-state.toml");
+        std::fs::write(
+            &path,
+            "version = 1
+
+             [[indicators]]
+kind = \"native_ema\"
+hidden = false
+
+             [[indicators.inputs]]
+type = \"int\"
+value = 21
+
+             [[indicators.inputs]]
+type = \"source\"
+value = \"delta\"
+
+             [[indicators]]
+kind = \"native_cvd\"
+hidden = true
+
+             [[indicators]]
+hidden = false
+
+             [indicators.kind.script]
+name = \"zigzag.pine\"
+",
+        )
+        .unwrap();
+
+        let loaded = load(&path);
+        assert_eq!(loaded.len(), 3, "every entry survived: {loaded:?}");
+        assert_eq!(
+            loaded[0].kind,
+            SavedKind::native("native.ema"),
+            "the old EMA spelling names the catalog's EMA"
+        );
+        assert_eq!(
+            loaded[0].inputs,
+            vec![SavedInput::Int(21), SavedInput::Source("delta".to_owned())],
+            "a tuned length and source come back with it"
+        );
+        assert_eq!(loaded[1].kind, SavedKind::native("native.cvd"));
+        assert!(
+            loaded[1].hidden,
+            "the hidden flag is unrelated and survived"
+        );
+        assert_eq!(
+            loaded[2].kind,
+            SavedKind::Script {
+                name: "zigzag.pine".to_owned()
+            },
+            "scripts never had a spelling change and must not have acquired one"
+        );
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// The migration is read-side and one-way, on purpose: this build writes
+    /// the catalog spelling, so a file converts the first time it is saved.
+    /// Asserted on the text rather than on a round trip, because a round trip
+    /// would pass just as well if nothing had changed.
+    #[test]
+    fn this_build_writes_the_catalog_spelling() {
+        let dir = crate::scratch::ScratchDir::new("indicator-state");
+        let path = dir.join("catalog-spelling-state.toml");
+        save(
+            &path,
+            &[SavedIndicator {
+                kind: SavedKind::native("native.ema"),
+                hidden: false,
+                inputs: Vec::new(),
+                plot_styles: Vec::new(),
+            }],
+        );
+        let text = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            text.contains("native.ema"),
+            "the id is what identifies the native now: {text}"
+        );
+        assert!(
+            !text.contains("native_ema"),
+            "the pre-catalog spelling is read, never written: {text}"
+        );
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// An id no build ships is carried, not corrected. A workspace written by
+    /// a newer build, or one naming a withdrawn native, must reach the worker
+    /// intact so it can say what is missing — the loader silently rewriting it
+    /// to a native that does exist is the failure this whole change removes.
+    #[test]
+    fn an_unknown_native_id_survives_the_file_unchanged() {
+        let dir = crate::scratch::ScratchDir::new("indicator-state");
+        let path = dir.join("unknown-native-state.toml");
+        std::fs::write(
+            &path,
+            "version = 1
+
+[[indicators]]
+hidden = false
+
+             [indicators.kind.native]
+id = \"native.from.the.future\"
+",
+        )
+        .unwrap();
+
+        let loaded = load(&path);
+        assert_eq!(
+            loaded.first().map(|entry| &entry.kind),
+            Some(&SavedKind::native("native.from.the.future")),
+            "loaded: {loaded:?}"
+        );
+        std::fs::remove_file(&path).ok();
     }
 
     #[test]
@@ -345,7 +546,7 @@ mod tests {
         save(
             &path,
             &[SavedIndicator {
-                kind: SavedKind::NativeEma,
+                kind: SavedKind::native("native.ema"),
                 hidden: false,
                 inputs: vec![SavedInput::Int(21)],
                 plot_styles: Vec::new(),

--- a/crates/app/src/layouts.rs
+++ b/crates/app/src/layouts.rs
@@ -723,7 +723,7 @@ mod tests {
 
     fn ema() -> SavedIndicator {
         SavedIndicator {
-            kind: SavedKind::NativeEma,
+            kind: SavedKind::native("native.ema"),
             hidden: false,
             inputs: vec![SavedInput::Int(20), SavedInput::Source("close".to_owned())],
             plot_styles: Vec::new(),

--- a/crates/app/src/toolbar.rs
+++ b/crates/app/src/toolbar.rs
@@ -385,11 +385,11 @@ pub enum ToolbarAction {
     ToggleDock,
     /// Open or close the appearance dialog.
     ToggleAppearance,
-    /// Add the native EMA overlay (M1's hardcoded entry; the script library
-    /// browser replaces this menu in M2).
-    AddEmaIndicator,
-    /// Add the native CVD pane.
-    AddCvdIndicator,
+    /// Add a native indicator, by its catalog id
+    /// (`quantick_indicators::native`). One variant for every native there
+    /// will ever be — the menu is drawn from the catalog, so the toolbar
+    /// never learns which natives exist.
+    AddNative(&'static str),
     /// Flip an indicator's render-side eye toggle (no recompute).
     ToggleIndicatorHidden(u64),
     /// Remove an indicator.
@@ -1235,9 +1235,14 @@ fn draw_layers(ui: &mut egui::Ui, model: &ToolbarModel, actions: &mut Vec<Toolba
     }
 }
 
-/// INDICATORS: add the M1 native indicators and manage the active ones —
-/// status dot, eye toggle, remove. M2 swaps the two hardcoded add entries
-/// for the script library browser; the entry list stays.
+/// INDICATORS: add the native indicators and manage the active ones —
+/// status dot, eye toggle, remove.
+///
+/// The native entries are the catalog in menu order, not a hand-written list:
+/// a native added to `quantick-indicators` appears here with no edit to this
+/// file. Each entry prints its own `menu_label` verbatim rather than a label
+/// this function assembles, so the strings a trader reads are owned in one
+/// place.
 fn draw_indicators_menu(ui: &mut egui::Ui, model: &ToolbarModel, actions: &mut Vec<ToolbarAction>) {
     let any_active = !model.indicators.is_empty();
     let icon = egui::RichText::new(LAYER_INDICATORS_ICON)
@@ -1248,16 +1253,14 @@ fn draw_indicators_menu(ui: &mut egui::Ui, model: &ToolbarModel, actions: &mut V
             theme::TEXT_MUTED
         });
     ui.menu_button(icon, |ui| {
-        if ui
-            .button(format!("{} Add EMA(9) on close", icons::PLUS))
-            .clicked()
-        {
-            actions.push(ToolbarAction::AddEmaIndicator);
-            ui.close_menu();
-        }
-        if ui.button(format!("{} Add CVD pane", icons::PLUS)).clicked() {
-            actions.push(ToolbarAction::AddCvdIndicator);
-            ui.close_menu();
+        for entry in quantick_indicators::native::NATIVES {
+            if ui
+                .button(format!("{} {}", icons::PLUS, entry.menu_label))
+                .clicked()
+            {
+                actions.push(ToolbarAction::AddNative(entry.id));
+                ui.close_menu();
+            }
         }
         if !model.scripts.is_empty() {
             ui.separator();

--- a/crates/indicators/Cargo.toml
+++ b/crates/indicators/Cargo.toml
@@ -13,6 +13,12 @@ rust_decimal = { workspace = true }
 # pow/exp/ln/log10 (see src/fmath.rs and the grep-guard test).
 libm = { workspace = true }
 
+[features]
+# A native that exists only so the docking port can be driven end to end by a
+# test: `quantick-app` turns it on in its `[dev-dependencies]` and nowhere
+# else, so `cargo build --workspace` never ships it. Not for `--all-features`.
+fake-native = []
+
 [[bench]]
 name = "eval"
 harness = false

--- a/crates/indicators/src/native/fake.rs
+++ b/crates/indicators/src/native/fake.rs
@@ -1,0 +1,116 @@
+//! A native that exists only to prove the port, behind the `fake-native`
+//! feature.
+//!
+//! This file is the *whole* cost of a new native, and it is here to keep that
+//! claim honest: it was written by copying `cvd.rs`, and it reaches the
+//! toolbar, the workspace file and the layout restore through one entry in
+//! [`super::NATIVES`] and nothing else. A test that drives it end to end is
+//! therefore a test that a fourth *real* native needs no edit above this
+//! crate. Delete the entry and this file and the port is unchanged.
+//!
+//! The feature is enabled by `quantick-app` in its `[dev-dependencies]` only,
+//! so `cargo build --workspace` never ships it. Do not enable it anywhere a
+//! trader can reach; `--all-features` would.
+
+use super::{CVD_COLOR, PLOT_WIDTH_PT};
+use crate::bar::IndicatorBar;
+use crate::indicator::{Ctx, EvalError, Indicator, IndicatorDescriptor};
+use crate::input::{InputSpec, InputValue};
+use crate::output::{PlotBuffer, PlotId, PlotSpec, PlotStyle, PreviewFrame};
+
+/// Plots the bar's close scaled by one integer input.
+///
+/// Declares an input on purpose: a native with none would not exercise the
+/// save-and-restore of input values, which is half of what the port has to
+/// carry.
+pub struct Fake {
+    descriptor: IndicatorDescriptor,
+    plots: PlotBuffer,
+    factor: i64,
+}
+
+impl Fake {
+    /// A fake native with the given multiplier.
+    #[must_use]
+    pub fn new(factor: i64) -> Self {
+        Self {
+            descriptor: IndicatorDescriptor {
+                title: format!("FAKE({factor})"),
+                short_title: None,
+                overlay: true,
+                plots: vec![PlotSpec {
+                    id: PlotId::new(0),
+                    title: "fake".to_owned(),
+                    style: PlotStyle::Line,
+                    base_color: CVD_COLOR,
+                    width: PLOT_WIDTH_PT,
+                    offset: 0,
+                    marker: None,
+                }],
+                fills: Vec::new(),
+                inputs: vec![InputSpec::Int {
+                    name: "factor".to_owned(),
+                    title: "Factor".to_owned(),
+                    default: 2,
+                    min: Some(1),
+                    max: None,
+                    step: None,
+                    options: Vec::new(),
+                }],
+            },
+            plots: PlotBuffer::new(1),
+            factor,
+        }
+    }
+
+    /// The value this indicator commits for a bar.
+    fn value(&self, bar: &IndicatorBar) -> f64 {
+        #[allow(clippy::cast_precision_loss)]
+        let factor = self.factor as f64;
+        bar.close * factor
+    }
+}
+
+impl Default for Fake {
+    /// `FAKE(2)` — the multiplier the input spec declares.
+    fn default() -> Self {
+        Self::new(2)
+    }
+}
+
+impl Indicator for Fake {
+    fn descriptor(&self) -> &IndicatorDescriptor {
+        &self.descriptor
+    }
+
+    fn plots(&self) -> &PlotBuffer {
+        &self.plots
+    }
+
+    fn on_close(&mut self, bar: &IndicatorBar, _ctx: &mut Ctx<'_>) -> Result<(), EvalError> {
+        let value = self.value(bar);
+        self.plots.push_row(&[value]);
+        Ok(())
+    }
+
+    fn preview(
+        &mut self,
+        partial: &IndicatorBar,
+        _ctx: &mut Ctx<'_>,
+    ) -> Result<PreviewFrame, EvalError> {
+        // No state of our own advances, so nothing needs snapshotting.
+        Ok(PreviewFrame::new(vec![self.value(partial)]))
+    }
+
+    fn rebind(&self, values: &[InputValue]) -> Option<Box<dyn Indicator>> {
+        let factor = match values.first() {
+            Some(InputValue::Int(value)) => *value,
+            _ => self.factor,
+        };
+        Some(Box::new(Self::new(factor)))
+    }
+
+    fn reset(&mut self) {
+        self.plots.clear();
+    }
+}

--- a/crates/indicators/src/native/mod.rs
+++ b/crates/indicators/src/native/mod.rs
@@ -6,21 +6,121 @@
 //! performance reference a scripted equivalent is benchmarked against, and
 //! they double as living documentation of how an indicator is written.
 //!
-//! Each lives in its own file and is registered here with one `pub use`, so
-//! a third native is a new file plus one line rather than an edit to the
-//! behaviour of the two that already ship. Both follow the preview
-//! discipline the trait demands: kernels are cloned for the preview push so
-//! committed state never advances inside a forming bar.
+//! Each lives in its own file and is registered here with one `pub use` and
+//! one [`NATIVES`] entry, so a fourth native is a new file plus one line —
+//! and that line is the whole registration, in this crate and above it. The
+//! application iterates the catalog; it never learns a native's name. Both
+//! shipped natives follow the preview discipline the trait demands: kernels
+//! are cloned for the preview push so committed state never advances inside a
+//! forming bar.
 
 mod avwap;
 mod cvd;
 mod ema;
+#[cfg(feature = "fake-native")]
+mod fake;
 
 pub use avwap::{AVWAP_BAND_PAIRS, AVWAP_PLOT_COUNT, AnchoredVwap};
 pub use cvd::Cvd;
 pub use ema::Ema;
+#[cfg(feature = "fake-native")]
+pub use fake::Fake;
 
+use crate::indicator::Indicator;
+use crate::input::{InputSpec, InputValue};
 use crate::output::Rgba8;
+
+/// One native indicator, as everything above this crate sees it: a stable id
+/// that outlives any rename, the exact label a menu prints, and the
+/// constructor that yields a fresh instance at its declared defaults.
+///
+/// This struct is the docking port. Nothing above `indicators` names a
+/// particular native — the application iterates [`NATIVES`] and looks entries
+/// up by [`Native::id`], so a new native reaches the toolbar, the workspace
+/// file and the layout restore without a single edit outside this crate.
+pub struct Native {
+    /// Stable identity, serialised into the workspace and reported by the
+    /// control plane. Never change one: a saved workspace names it.
+    pub id: &'static str,
+    /// The menu entry a chart toolbar prints, verbatim. Held whole rather
+    /// than composed from a shorter name, so a caller cannot alter a
+    /// trader-facing string by changing how it assembles one.
+    pub menu_label: &'static str,
+    /// Builds a fresh instance at its declared defaults.
+    construct: fn() -> Box<dyn Indicator>,
+}
+
+impl Native {
+    /// A fresh instance at its declared defaults.
+    #[must_use]
+    pub fn build(&self) -> Box<dyn Indicator> {
+        (self.construct)()
+    }
+
+    /// An instance with saved values bound, falling back to the declared
+    /// defaults for anything the values do not cover.
+    ///
+    /// Binding runs through [`Indicator::rebind`], which is generated from the
+    /// input spec, so a native that declares an input cannot forget to accept
+    /// it back — and one that declares none (the CVD) needs no arm here.
+    #[must_use]
+    pub fn build_with(&self, values: &[InputValue]) -> Box<dyn Indicator> {
+        let base = self.build();
+        match base.rebind(values) {
+            Some(bound) => bound,
+            None => base,
+        }
+    }
+
+    /// The inputs a fresh instance declares, in binding order.
+    ///
+    /// Read off the constructor rather than restated in the entry: a second
+    /// copy of the defaults is a second thing to keep in step, and the
+    /// descriptor is already the one the settings panel is generated from.
+    #[must_use]
+    pub fn default_inputs(&self) -> Vec<InputSpec> {
+        self.build().descriptor().inputs.to_vec()
+    }
+}
+
+/// Every native this build ships, in the order a menu offers them.
+///
+/// The one registration line. Adding a native is its own file beside
+/// `ema.rs`, its `pub use` above, and one entry here — **appended**, never
+/// inserted: this order is the order of the chart's indicator menu, and a
+/// trader who reaches for the second entry without reading it should keep
+/// getting the CVD.
+pub static NATIVES: &[Native] = &[
+    Native {
+        id: "native.ema",
+        menu_label: "Add EMA(9) on close",
+        construct: || Box::new(Ema::default()),
+    },
+    Native {
+        id: "native.cvd",
+        menu_label: "Add CVD pane",
+        construct: || Box::new(Cvd::new()),
+    },
+    // The whole registration of a native, and the reason the port can be
+    // tested rather than merely asserted. Feature-gated, never in a build a
+    // trader runs — see `fake.rs`.
+    #[cfg(feature = "fake-native")]
+    Native {
+        id: "native.fake",
+        menu_label: "Add FAKE(2)",
+        construct: || Box::new(Fake::default()),
+    },
+];
+
+/// The native with this id, or `None` for an id no build ships.
+///
+/// `None` is a real answer, not a shrug: a workspace saved by a newer build,
+/// or one naming a native that was withdrawn. Callers report it; none of them
+/// substitutes a different indicator for the one that was asked for.
+#[must_use]
+pub fn native(id: &str) -> Option<&'static Native> {
+    NATIVES.iter().find(|native| native.id == id)
+}
 
 /// Stroke width of a native's plot, in points (`PlotSpec::width`'s unit).
 pub(crate) const PLOT_WIDTH_PT: f32 = 1.5;
@@ -63,7 +163,7 @@ pub const AVWAP_BAND_MULTS: [f64; 3] = [1.0, 2.0, 3.0];
 mod tests {
     use super::*;
     use crate::indicator::Indicator;
-    use crate::input::SourceId;
+    use crate::input::{InputValue, SourceId};
 
     #[test]
     fn ema_overlay_follows_the_source_scale() {
@@ -83,6 +183,97 @@ mod tests {
             Ema::new(21, SourceId::Delta).descriptor().title,
             "EMA(21, delta)"
         );
+    }
+
+    #[test]
+    fn the_catalog_ships_the_shipped_natives() {
+        let ids: Vec<&str> = NATIVES
+            .iter()
+            .map(|native| native.id)
+            .filter(|id| !id.starts_with("native.fake"))
+            .collect();
+        assert_eq!(
+            ids,
+            ["native.ema", "native.cvd"],
+            "the ids are serialised into a trader's workspace; changing one              orphans every saved indicator that names it"
+        );
+    }
+
+    /// The menu a trader reads, pinned.
+    ///
+    /// These strings moved here from the toolbar when the menu became a loop
+    /// over this catalog. A loop is exactly the kind of change that quietly
+    /// rewords an entry — composing `"Add " + title` would have turned "Add
+    /// CVD pane" into "Add CVD" — so the labels are asserted whole, in menu
+    /// order, where they are now owned.
+    #[test]
+    fn the_menu_reads_exactly_as_it_did() {
+        let labels: Vec<&str> = NATIVES
+            .iter()
+            .filter(|entry| !entry.id.starts_with("native.fake"))
+            .map(|entry| entry.menu_label)
+            .collect();
+        assert_eq!(labels, ["Add EMA(9) on close", "Add CVD pane"]);
+    }
+
+    #[test]
+    fn every_entry_builds_and_is_uniquely_addressable() {
+        for entry in NATIVES {
+            assert!(
+                !entry.menu_label.is_empty(),
+                "{} has no menu label",
+                entry.id
+            );
+            assert_eq!(
+                native(entry.id).map(|found| found.id),
+                Some(entry.id),
+                "{} is in the catalog but not findable by its own id",
+                entry.id
+            );
+            // Building is the whole contract the app depends on; a native
+            // that panics here would take the toolbar down with it.
+            assert!(!entry.build().descriptor().title.is_empty());
+        }
+    }
+
+    #[test]
+    fn an_unknown_id_is_none_rather_than_a_substitute() {
+        assert!(native("native.nonesuch").is_none());
+        assert!(native("").is_none());
+        assert!(
+            native("NATIVE.EMA").is_none(),
+            "ids are matched exactly; a near miss is a different indicator"
+        );
+    }
+
+    #[test]
+    fn default_inputs_come_from_the_constructor() {
+        let ema = native("native.ema").expect("the EMA is in the catalog");
+        let inputs = ema.default_inputs();
+        assert_eq!(inputs.len(), 2);
+        assert_eq!(inputs[0].name(), "len");
+        assert!(
+            native("native.cvd")
+                .expect("the CVD is in the catalog")
+                .default_inputs()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn build_with_binds_saved_values_and_falls_back_to_defaults() {
+        let ema = native("native.ema").expect("the EMA is in the catalog");
+        assert_eq!(ema.build().descriptor().title, "EMA(9)");
+        assert_eq!(
+            ema.build_with(&[InputValue::Int(21), InputValue::Source(SourceId::Delta)])
+                .descriptor()
+                .title,
+            "EMA(21, delta)"
+        );
+        // A native that declares no inputs has no `rebind`, and must still
+        // come back as itself rather than as nothing.
+        let cvd = native("native.cvd").expect("the CVD is in the catalog");
+        assert_eq!(cvd.build_with(&[]).descriptor().title, "CVD");
     }
 
     #[test]


### PR DESCRIPTION
Replace the per-indicator native variants in `crates/app` with a catalog the
app iterates, so adding a fourth native touches the `indicators` crate only.

**Tier: `medium`.** Behaviour-preserving, but it rewrites the on-disk
vocabulary of the trader's workspace file and redraws a trader-facing menu, so
`delivery-review` and a `trader-ux-review` on the toolbar rows both ran.

## The problem

`crates/indicators/src/native/mod.rs` promised a third native was "a new file
plus one line". Inside that crate it was; in `crates/app` the same native was a
variant in two enums, a toolbar action, and match arms in the worker, the app
and the layout wiring. The audit behind #287 counted this as one of four
falsified recipes and fixed the prose; this fixes the code so the prose can say
what it promised.

## What changed

- `NATIVES` in `crates/indicators/src/native/mod.rs` — one entry per native:
  stable id, the menu label a toolbar prints verbatim, and a
  `fn() -> Box<dyn Indicator>`. Default inputs are read off the constructor
  rather than restated, so there is no second copy to keep in step.
- `SavedKind::Native { id }`, `IndicatorSource::Native { id, values }` and
  `ToolbarAction::AddNative(id)` replace their per-native pairs. The menu is a
  loop over the catalog.
- **The `_ =>` arm is gone.** It turned any unrecognised kind into an EMA, so a
  workspace naming a withdrawn native put a moving average on the chart and
  said nothing. An unknown id is now an error slot naming it — the same
  mechanism a `.pine` script that fails to compile already uses.

## Compatibility

Workspace and preset files written with the old `native_ema` / `native_cvd`
spelling load permanently, through a read-side migration; this build writes the
catalog id. **One-way, by the trader's decision (`D1`):** a file saved by this
build will not open on a build older than this PR.

Note the brief's evidence ledger said those files contain `NativeEma` /
`NativeCvd`. They do not — `SavedKind` carries `rename_all = "snake_case"`, so
the on-disk spelling is `native_ema`. The compatibility path is written against
the real spelling. Two other ledger counts were also off and are recorded as
`S2`/`S3` in the goal file; both made the scope smaller.

## Proof that a fourth native costs one crate

A fake native behind the `fake-native` feature, which `quantick-app` enables in
its `[dev-dependencies]` alone. The app's tests then drive a native the app has
demonstrably never heard of, because
`every_native_in_the_catalog_adds_and_registers_without_being_named_here`
iterates `NATIVES` instead of naming EMA and CVD.

It cannot reach a trader. Verified against the built binary rather than
asserted:

```
$ grep -a -c 'native.fake' target/debug/quantick-app.exe   → 0
$ grep -a -o -m1 'Add CVD pane' target/debug/quantick-app.exe → Add CVD pane
```

**Stated precisely:** a real fourth native is one new file plus a three-line
registration in `native/mod.rs` (`mod`, `pub use`, the `NATIVES` entry) — the
ordinary Rust module cost. The claim that holds exactly is the one that
mattered: **nothing in `app` changes.**

## Names kept

Hook registry and capability inventory diffs are empty. `Add EMA(9) on close`
and `Add CVD pane` are byte-identical, now pinned by a test — a loop is exactly
the change that quietly rewords an entry.

```
$ grep -rn 'NativeEma\|NativeCvd' crates/app/src
state_file.rs:74,76,113,114   ← the legacy read path and nothing else
```

## Performance

| Path | Rate | Change |
| --- | --- | --- |
| Catalog lookup (add, restore, rebuild, settings apply) | rare | 2-entry linear scan |
| Indicator menu loop | per frame **while the menu is open** | 2 iterations replacing 2 `if`s |
| `fallback_title` builds an instance | error path only | unreachable for a healthy native |

No per-trade, per-depth or per-frame path is touched.

## Verification

- [x] `cargo fmt --all -- --check` — exit 0
- [x] `cargo clippy --workspace --all-targets` — exit 0
- [x] `cargo build --workspace` — exit 0
- [x] `cargo test --workspace` — exit 0

Each run separately. `cargo test -p quantick-guards` green.

**Trunk, honestly:** it did not shrink. `app.rs` +1, `layout_wiring.rs` +1,
`toolbar.rs` +3, `indicator_worker.rs` +68, `state_file.rs` +182 production
lines. The 15 per-native call sites are gone, but the compatibility path and
the tests spent the lines back. No ceiling raised; `--tighten` reported nothing
to tighten. The win is that a fourth native reads one crate, not six files —
not a smaller trunk.

## Reviews

- **arch-review** — step 0 (`code-review` at `low`, effort-first, no reuse
  notice) returned 2 findings, both confirmed and **fixed in `617107c`**: an
  empty value set silently reset a tuned native to defaults, and an orphaned
  doc comment. The first has a regression test measured failing without the fix
  (`EMA(9)` instead of `EMA(21, delta)`).
- **trader-ux-review** — no Blockers. One Consider fixed inline: catalog order
  is menu order, now documented as append-only so a fourth native cannot move
  the entry a trader reaches for without looking.
- **delivery-review** — PASS, completeness-only mode (tier `medium`). Nothing
  unledgered.

### Deferred

- **arch-review dimension 7 (Should-fix)** — natives are still attachable only
  from the click handler. `indicator.script.attach` exists; there is no native
  equivalent, and no capability enumerates the catalog. **Verified
  pre-existing** on `origin/main`. Deferred because `A8`/`R10` require an empty
  capability-inventory diff, so adding one is new scope. This change makes it
  cheap: `NATIVES` is exactly the registry the *discover* half needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AdxEUdGrhkoLXHaxAy3xfc
