### PR TITLE
Add Codex adapters for agent workflows

### DIFF
--- a/.agents/references/codex-compatibility.md
+++ b/.agents/references/codex-compatibility.md
@@ -1,0 +1,19 @@
+# Codex compatibility
+
+The linked Claude skill is canonical. Preserve its outcomes, gates, evidence,
+markers, and authority boundaries while mapping host mechanics:
+
+- `/name` or `Skill(name)` means the matching Codex `$name` skill.
+- Map `AskUserQuestion` to the available Codex user-input mechanism, still
+  obeying the session interaction policy.
+- A mission request authorizes the available Codex goal facility. Use it
+  instead of printing Claude's `/goal`; otherwise execute from `GOAL.md`.
+- Map `/code-review` to native review, or inspect the requested diff directly.
+- A required fresh subagent receives only the stated dossier. Map models by
+  role: fast for retrieval, balanced for checklists, strongest for judgment.
+- Translate POSIX shell examples to the active shell without changing their
+  ordering, target worktree, marker contents, or failure behavior.
+- `.codex/hooks.json` runs the shared guardrails. Trusting it never expands
+  command permissions.
+
+These mappings change mechanisms only; the canonical workflow decides done.

--- a/.agents/skills/arch-review/SKILL.md
+++ b/.agents/skills/arch-review/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: arch-review
+description: Review a Quantick diff for bugs and architecture before shipping.
+---
+
+Follow the [canonical workflow](../../../.claude/skills/arch-review/SKILL.md) with the [Codex mappings](../../references/codex-compatibility.md).

--- a/.agents/skills/delivery-review/SKILL.md
+++ b/.agents/skills/delivery-review/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: delivery-review
+description: Grade a Quantick branch against its request and criteria before its PR.
+---
+
+Follow the [canonical workflow](../../../.claude/skills/delivery-review/SKILL.md) with the [Codex mappings](../../references/codex-compatibility.md).

--- a/.agents/skills/issue/SKILL.md
+++ b/.agents/skills/issue/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: issue
+description: Turn an idea into a fully classified Quantick GitHub issue.
+---
+
+Follow the [canonical workflow](../../../.claude/skills/issue/SKILL.md) with the [Codex mappings](../../references/codex-compatibility.md).

--- a/.agents/skills/mission/SKILL.md
+++ b/.agents/skills/mission/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: mission
+description: Define and enforce a traceable, tiered Quantick development mission.
+---
+
+Follow the [canonical workflow](../../../.claude/skills/mission/SKILL.md) with the [Codex mappings](../../references/codex-compatibility.md).

--- a/.agents/skills/new-extension/SKILL.md
+++ b/.agents/skills/new-extension/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: new-extension
+description: Add a Quantick capability through an explicit port and registration point.
+---
+
+Follow the [canonical workflow](../../../.claude/skills/new-extension/SKILL.md) with the [Codex mappings](../../references/codex-compatibility.md).

--- a/.agents/skills/new-task/SKILL.md
+++ b/.agents/skills/new-task/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: new-task
+description: Start a Quantick GitHub issue in its required branch and worktree.
+---
+
+Follow the [canonical workflow](../../../.claude/skills/new-task/SKILL.md) with the [Codex mappings](../../references/codex-compatibility.md).

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: ship
+description: Verify, review, and deliver a Quantick pull request through green CI.
+---
+
+Follow the [canonical workflow](../../../.claude/skills/ship/SKILL.md) with the [Codex mappings](../../references/codex-compatibility.md).

--- a/.agents/skills/trader-ux-review/SKILL.md
+++ b/.agents/skills/trader-ux-review/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: trader-ux-review
+description: Review a Quantick flow through trader personas and order-flow usability.
+---
+
+Follow the [canonical workflow](../../../.claude/skills/trader-ux-review/SKILL.md) with the [Codex mappings](../../references/codex-compatibility.md).

--- a/.agents/skills/ui-harness/SKILL.md
+++ b/.agents/skills/ui-harness/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: ui-harness
+description: Drive and observe Quantick UI surfaces through hooks and screenshots.
+---
+
+Follow the [canonical workflow](../../../.claude/skills/ui-harness/SKILL.md) with the [Codex mappings](../../references/codex-compatibility.md).

--- a/.agents/skills/visual-qa/SKILL.md
+++ b/.agents/skills/visual-qa/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: visual-qa
+description: Run visual QA over changed Quantick UI states with screenshot evidence.
+---
+
+Follow the [canonical workflow](../../../.claude/skills/visual-qa/SKILL.md) with the [Codex mappings](../../references/codex-compatibility.md).

--- a/.claude/GOAL-archive-codex-skill-compatibility.md
+++ b/.claude/GOAL-archive-codex-skill-compatibility.md
@@ -1,0 +1,89 @@
+# Make Quantick's agent workflows equally available to Claude Code and Codex
+
+Quantick's repository-specific development workflows must be discoverable and
+usable from Codex without creating a second copy that can drift from the Claude
+Code workflow.
+
+**Tier:** medium — this touches the complete agent workflow surface and its
+enforcement hooks, so it needs the normal completeness review.
+
+## Request ledger
+
+- **R1** — Import the repository skills currently exposed to Claude Code into
+  Codex.
+- **R2** — Include workflows such as `mission`, not merely one isolated skill.
+- **R3** — Preserve equivalent development behavior in Claude Code and Codex.
+
+## Assumptions
+
+- **S1** — "Skills such as mission" means every tracked repository workflow
+  under `.claude/skills`, because importing only `mission` would leave the
+  orchestrated review and shipping skills unavailable. This is safe because
+  adapters are small and remain scoped to the existing workflow set.
+- **S2** — The existing `.claude/skills` files remain the canonical workflow
+  definitions. This avoids duplicated process rules and follows the request
+  for equal behavior.
+- **S3** — Codex-native invocation uses `$skill-name`; Claude Code keeps its
+  existing `/skill-name` spelling. Each product's documented syntax is used.
+
+## Acceptance criteria
+
+- [x] **A1** — Every tracked top-level workflow under `.claude/skills` has a
+      valid, discoverable Codex skill with the same name under
+      `.agents/skills`.
+      *Evidence:* parity check and skill validator outputs in
+      `.claude/evidence/codex-skill-compatibility/verification.md`. *(R1, R2)*
+- [x] **A2** — Codex adapters load the existing Claude workflow as their
+      canonical instruction source instead of duplicating its body.
+      *Evidence:* adapter structure and parity test in
+      `.claude/evidence/codex-skill-compatibility/verification.md`. *(R3)*
+- [x] **A3** — A shared compatibility contract translates Claude-specific
+      invocation, question, review, subagent, goal, shell, and tool concepts
+      into Codex-native behavior without weakening user authority.
+      *Evidence:* compatibility contract inspection and focused guard tests in
+      `.claude/evidence/codex-skill-compatibility/verification.md`. *(R1, R3)*
+- [x] **A4** — Codex project hooks invoke the repository's existing worktree,
+      PR, commit, and guard-watch policies through the same canonical script.
+      *Evidence:* hook configuration tests in
+      `.claude/evidence/codex-skill-compatibility/verification.md`. *(R3)*
+- [x] **A5** — An automated repository guard fails when the Claude and Codex
+      workflow inventories diverge or an adapter stops pointing to its
+      canonical workflow.
+      *Evidence:* positive and negative tests in
+      `.claude/evidence/codex-skill-compatibility/verification.md`. *(R1, R3)*
+- [x] **G1** — Every authored repository artifact is in English.
+      *Evidence:* `cargo test -p quantick-guards` and architecture-review
+      dimension 8 in `.claude/evidence/codex-skill-compatibility/verification.md`.
+- [x] **G2** — `cargo fmt --all -- --check`,
+      `cargo clippy --workspace --all-targets`, `cargo build --workspace`, and
+      `cargo test --workspace` pass after comparison with current
+      `origin/main`. Runtime performance impact is none: only agent lifecycle
+      discovery and hook execution are touched.
+      *Evidence:* command results in
+      `.claude/evidence/codex-skill-compatibility/verification.md`.
+- [x] **G3** — Arch-review reports no unresolved Blocker or Should-fix finding.
+      *Evidence:* verdict in
+      `.claude/evidence/codex-skill-compatibility/verification.md`.
+
+## Not applicable
+
+- Visual QA, trader UX review, and UI harness coverage are not applicable: no
+  Quantick UI or trader-facing runtime surface changes.
+- New-extension review is not applicable: this adds repository agent metadata,
+  not a Quantick runtime capability or crate.
+- Hot-path measurement is not applicable: no per-trade, per-depth, or per-frame
+  production path changes.
+- Engine golden tests are not applicable: no engine or deterministic market
+  computation changes.
+
+## Closing steps
+
+- **C1** — Delivery-review returns PASS.
+- **C2** — The pull request is open and CI is green.
+
+## Request as received
+
+The following is retained verbatim as an attributed quotation because it is
+the source request; all operative repository text above is in English.
+
+> consegue importar os kills como /mission do claude para codex para gnt conseguir desenvovler igual tnato para claude quanto para codex?

--- a/.claude/evidence/codex-skill-compatibility/verification.md
+++ b/.claude/evidence/codex-skill-compatibility/verification.md
@@ -1,0 +1,54 @@
+# Codex skill compatibility verification
+
+## Delivered surface
+
+- All ten canonical workflows have same-named Codex adapters:
+  `arch-review`, `delivery-review`, `issue`, `mission`, `new-extension`,
+  `new-task`, `ship`, `trader-ux-review`, `ui-harness`, and `visual-qa`.
+- Every adapter links to its matching `.claude/skills/<name>/SKILL.md` and to
+  `.agents/references/codex-compatibility.md`; no workflow body is duplicated.
+- `.codex/hooks.json` delegates worktree, PR, commit, and edit-watch policy to
+  `.claude/hooks/guardrails.sh` on both POSIX and Windows hosts.
+- `crates/guards/src/context.rs` charges both instruction surfaces to the
+  context budget. The mission workflow was shortened without changing an
+  operative outcome, and its ceiling was tightened from 22,007 to 18,664
+  bytes; no context budget was raised.
+
+## Focused verification
+
+- Codex skill validator: PASS for all 10 adapters.
+- `.claude/hooks/guardrails_test.sh`: PASS, 111 passed and 0 failed. This
+  includes positive and negative inventory parity, canonical-link checks,
+  Codex hook configuration checks, and `apply_patch` coverage for relative,
+  multi-file, and move-destination paths.
+- `.codex/hooks.json`: PASS through JSON parsing and direct Windows hook-command
+  execution; the PR gate returned the expected denial without a review marker.
+- `cargo test -p quantick-guards`: PASS, including 107 unit tests, 14 guard
+  integration tests, and 5 session-agreement tests.
+- `git diff --check`: PASS.
+
+## Mandatory verification
+
+- `cargo fmt --all -- --check`: PASS.
+- `cargo clippy --workspace --all-targets`: PASS.
+- `cargo build --workspace`: PASS.
+- `cargo test --workspace`: PASS.
+- Base freshness: `HEAD` and `origin/main` both resolved to
+  `900f88286d34695863a00d7e618c587dc890f00a` immediately before verification.
+
+Runtime performance impact is none: the change affects repository skill
+discovery, development hooks, and repository guards only. It does not touch a
+trade, depth, frame, or application runtime path.
+
+## Reviews
+
+- Preliminary architecture review: PASS. Native bug inspection found no
+  unresolved Blocker or Should-fix. Dimensions 1-9 found no dependency,
+  determinism, hardcoding, testing, standardisation, operability, language, or
+  registration problem. The final SHA marker is recorded after the archive
+  commit is reviewed.
+- Medium-tier completeness review: PASS. R1 is delivered by the full adapter
+  inventory, R2 includes `mission` and every orchestrated workflow, and R3 is
+  delivered by canonical links, host mappings, shared hooks, and parity guards.
+  A1-A5 and G1-G3 have concrete evidence above; no ask is partial, missing, or
+  unproven.

--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -6,16 +6,18 @@ work happens in a worktree, `arch-review` runs before the PR, and
 instruction in markdown is advice a long session can drift away from. A hook
 is a wall. These make the harness enforce all three.
 
-Wired in `.claude/settings.json`, implemented in `guardrails.sh` (POSIX sh, no
-`jq`, so it runs under Git Bash on Windows and dash in CI) and covered by
-`guardrails_test.sh`.
+Wired for Claude Code in `.claude/settings.json` and for Codex in
+`.codex/hooks.json`; both call `guardrails.sh` (POSIX sh, no `jq`) and are
+covered by `guardrails_test.sh`. Codex project hooks require one-time trust in
+its `/hooks` screen, as required by the
+[Codex hooks contract](https://learn.chatgpt.com/docs/hooks).
 
 | Mode | Event | Acts on | Effect |
 | --- | --- | --- | --- |
-| `worktree-guard` | `PreToolUse` | `Edit`, `Write`, `NotebookEdit` | Denies the write when it lands in the main checkout while that checkout is on `main`. |
+| `worktree-guard` | `PreToolUse` | `Edit`, `Write`, `NotebookEdit`, `apply_patch` | Denies the write when it lands in the main checkout while that checkout is on `main`. |
 | `pr-gate` | `PreToolUse` | `Bash` | Denies `gh pr create` until **both** `arch-review-ok` and `delivery-review-ok` record the exact **change** being shipped. A branch that declared the `small` mission tier needs only the first, while it stays under the ceiling. |
 | `commit-reminder` | `PostToolUse` | `Bash` | Cannot block (the commit already landed). After a `git commit` on a branch ahead of `origin/main`, says the gate is coming and names the markers that branch's tier actually owes. |
-| `guard-watch` | `PostToolUse` | `Edit`, `Write` | Cannot block, and is not meant to. Runs the already-built `quantick-guards` binary over the file just written and reports what the repository guards found. Silent when nothing was found, when the binary has not been built, or when the file is outside a repository. |
+| `guard-watch` | `PostToolUse` | `Edit`, `Write`, `apply_patch` | Cannot block, and is not meant to. Runs the already-built `quantick-guards` binary over each file just written and reports what the repository guards found. Silent when nothing was found, when the binary has not been built, or when the file is outside a repository. |
 
 ## Why `guard-watch` never blocks and never builds
 
@@ -125,16 +127,12 @@ prove the latter from outside the review. What it does remove is the failure
 this repo actually hits: forgetting entirely, or reviewing and then pushing
 three more commits.
 
-### The gate runs from the main checkout
+### The gate runs from the session checkout
 
-`.claude/settings.json` invokes the hook as
-`${CLAUDE_PROJECT_DIR}/.claude/hooks/guardrails.sh`, and that variable points
-at the session's project directory — the main checkout — not at whichever
-worktree a command runs in. So a branch that *edits* `guardrails.sh` is still
-gated by the copy on `main`: the change takes effect for sessions started after
-it merges. Nothing about the gated branch is special; it just cannot test its
-own gate through the hook, which is why `guardrails_test.sh` runs the script
-directly.
+Both host configurations resolve `guardrails.sh` from the git root where the
+session started, not from a worktree named inside a later command. A branch
+editing the script therefore tests it directly with `guardrails_test.sh`; the
+hook behavior changes for sessions started from that branch or after it merges.
 
 ## Why the filtering lives in the script
 
@@ -174,38 +172,25 @@ and then pushing three more commits.
 
 ### What worktree-guard does not see
 
-It matches `Edit|Write|NotebookEdit`, so it guards writes made through the file
-tools. A write driven from a shell — `Set-Content`, `sed -i`, `python` editing
-a file in place, a heredoc redirect — reaches the main checkout unguarded, and
-this repo's own notes make scripted edits routine. Same reasoning as above:
-deciding "does this command write a file, and where" from a command string is a
-larger version of the problem that would not converge for one named program.
+It guards Claude file tools and Codex `apply_patch`; for the latter it reads
+every Add, Update, Delete, or Move destination header from
+`tool_input.command`. A write driven from a shell — `Set-Content`, `sed -i`, a
+script, or a redirect — remains unguarded because reliably deriving its targets
+requires parsing the shell.
 
 ## Fail-open by design
 
-Anything `guardrails.sh` cannot determine exits 0 and the normal permission
-flow applies: no `file_path` in the payload, a path outside a git repo, a
-`git` invocation that errors. A guardrail that blocks the session over its own
-bugs would be worse than no guardrail, and the rules it protects are also
-written down in CLAUDE.md.
+Anything `guardrails.sh` cannot determine exits 0 and normal permissions apply:
+no edit path or patch header, a path outside a repository, or a failed `git`
+query. The rules it protects are also written in `CLAUDE.md`.
 
 ## Overrides
 
 - `QUANTICK_ALLOW_MAIN_WRITES=1` in the environment before launching disables
   `worktree-guard`, for the rare deliberate edit on the main checkout.
-- Paths under `.claude/` are always allowed on the main checkout, even while
-  it sits on `main`: the goal file, its archives and the skills live there by
-  design, and blocking them would break the workflow the guard exists to
-  protect.
-
-  **This is the guard's broadest hole and it is worth naming.** The exemption
-  covers `.claude/hooks/guardrails.sh` and `.claude/settings.json` — the two
-  files that arm every session — so a single `Edit` on the main checkout
-  disarms both gates for every branch, with no worktree, no branch and no
-  review. Narrowing it was tried on this branch and reverted: the carve-out
-  guarded the script but not `settings.json`, and the version that guarded
-  both still could not see a shell-driven write. It is documented rather than
-  half-closed, which is the same call made about `runs_command` above.
+- `.claude/GOAL.md` is always allowed because it is untracked working state.
+  Archives, skills, settings, and hooks are tracked artifacts and receive the
+  normal worktree protection.
 
 - `pr-gate` has **no override**, and that is a real cost rather than a design
   boast. `runs_command` matches the gated command at the start of *any*

--- a/.claude/hooks/guardrails.sh
+++ b/.claude/hooks/guardrails.sh
@@ -133,6 +133,39 @@ normalize_path() {
     printf '%s' "$1" | sed 's|\\\\|/|g; s|\\|/|g'
 }
 
+# Every file an edit tool targets. Claude's Write/Edit payloads carry one
+# `file_path`; Codex's apply_patch payload carries the patch in `command`.
+# Keep the translation here so both hosts reach the same policy functions.
+edit_paths() {
+    edit_file=$(json_string_field file_path)
+    if [ -n "$edit_file" ]; then
+        printf '%s\n' "$edit_file"
+        return 0
+    fi
+
+    edit_patch=$(json_string_field command)
+    [ -n "$edit_patch" ] || return 0
+    printf '%s' "$edit_patch" |
+        sed 's/\\r\\n/\
+/g; s/\\n/\
+/g' |
+        sed -n 's/^\*\*\* \(Add\|Update\|Delete\) File: //p; s/^\*\*\* Move to: //p'
+}
+
+# Codex patch headers may be relative to the hook's cwd; Claude normally sends
+# absolute file paths. Resolve both into the spelling the existing checks use.
+absolute_edit_path() {
+    edit_path=$(normalize_path "$1")
+    case "$edit_path" in
+        /* | ?:/*) printf '%s' "$edit_path" ;;
+        *)
+            edit_cwd=$(normalize_path "$(json_string_field cwd)")
+            [ -d "$edit_cwd" ] || edit_cwd=$(normalize_path "$(pwd -P)")
+            printf '%s/%s' "${edit_cwd%/}" "$edit_path"
+            ;;
+    esac
+}
+
 # Walk up to the first directory that exists: a Write targets a file that does
 # not exist yet, and may create its parents too.
 nearest_existing_dir() {
@@ -391,30 +424,37 @@ worktree_guard() {
         exit 0
     fi
 
-    raw=$(json_string_field file_path)
-    [ -n "$raw" ] || exit 0
-    path=$(normalize_path "$raw")
+    paths=$(edit_paths)
+    [ -n "$paths" ] || exit 0
+    old_ifs=$IFS
+    IFS='
+'
+    for raw in $paths; do
+        path=$(absolute_edit_path "$raw")
 
-    # Agent working files live in the main checkout by design: the goal file,
-    # its archives, the skills, these hooks. Blocking them would break the
-    # very workflow this guard protects.
-    case "$path" in
-        */.claude/*) exit 0 ;;
-    esac
+        # The live goal is agent working state and is deliberately written
+        # before the branch artifact exists. Tracked skills and hooks are not
+        # exempt: they belong in the worktree like every other repository edit.
+        case "$path" in
+            */.claude/GOAL.md) continue ;;
+        esac
 
-    dir=$(nearest_existing_dir "$path") || exit 0
+        dir=$(nearest_existing_dir "$path") || continue
 
-    git_dir=$(git -C "$dir" rev-parse --absolute-git-dir 2>/dev/null) || exit 0
-    common_dir=$(git -C "$dir" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || exit 0
+        git_dir=$(git -C "$dir" rev-parse --absolute-git-dir 2>/dev/null) || continue
+        common_dir=$(git -C "$dir" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || continue
 
-    # In a linked worktree these differ (<common>/worktrees/<name> vs
-    # <common>). Equal means the write lands in the main checkout.
-    [ "$git_dir" = "$common_dir" ] || exit 0
+        # In a linked worktree these differ (<common>/worktrees/<name> vs
+        # <common>). Equal means the write lands in the main checkout.
+        [ "$git_dir" = "$common_dir" ] || continue
 
-    branch=$(git -C "$dir" rev-parse --abbrev-ref HEAD 2>/dev/null) || exit 0
-    [ "$branch" = "$MAIN_BRANCH" ] || exit 0
+        branch=$(git -C "$dir" rev-parse --abbrev-ref HEAD 2>/dev/null) || continue
+        [ "$branch" = "$MAIN_BRANCH" ] || continue
 
-    deny "\"CLAUDE.md: one goal, one worktree. This write lands in the main checkout while it is on \`$MAIN_BRANCH\`. Create the worktree first:\n\n  git fetch origin\n  git worktree add -b <prefix>/<slug> ../quantick-worktrees/<prefix>-<slug> origin/$MAIN_BRANCH\n\nthen work inside that directory. Set QUANTICK_ALLOW_MAIN_WRITES=1 to override deliberately.\""
+        deny "\"CLAUDE.md: one goal, one worktree. This write lands in the main checkout while it is on \`$MAIN_BRANCH\`. Create the worktree first:\n\n  git fetch origin\n  git worktree add -b <prefix>/<slug> ../quantick-worktrees/<prefix>-<slug> origin/$MAIN_BRANCH\n\nthen work inside that directory. Set QUANTICK_ALLOW_MAIN_WRITES=1 to override deliberately.\""
+    done
+    IFS=$old_ifs
+    exit 0
 }
 
 # --- pr-gate ----------------------------------------------------------------
@@ -543,10 +583,8 @@ commit_reminder() {
 #   It reads one file. `--file` checks that path against the baseline instead
 #   of walking the repo, which is milliseconds rather than the seconds a full
 #   scan costs.
-guard_watch() {
-    file=$(normalize_path "$(json_string_field file_path)")
-    [ -n "$file" ] || exit 0
-
+guard_watch_one() {
+    file=$(absolute_edit_path "$1")
     # No extension filter here on purpose. One lived here and was a third
     # hand-kept copy of a list the two Rust guards already own; adding an
     # extension there while forgetting it here would have left the suite
@@ -561,18 +599,18 @@ guard_watch() {
     # while the file they did edit went unchecked.
     case "$file" in
         /* | ?:/*) ;;
-        *) exit 0 ;;
+        *) return 0 ;;
     esac
 
     dir=$(dirname "$file")
-    [ -d "$dir" ] || exit 0
+    [ -d "$dir" ] || return 0
 
     # Both answers from one process. `--show-toplevel` and `--show-prefix`
     # were two spawns for what one call prints on two lines, and on Windows a
     # spawn costs tens of milliseconds — against a binary that answers in 27.
     # This mode fires on every write in the session, so the shell plumbing had
     # become the dominant cost of the thing built to be cheap.
-    location=$(git -C "$dir" rev-parse --show-toplevel --show-prefix 2>/dev/null) || exit 0
+    location=$(git -C "$dir" rev-parse --show-toplevel --show-prefix 2>/dev/null) || return 0
     root=$(normalize_path "$(printf '%s\n' "$location" | sed -n '1p')")
     prefix=$(printf '%s\n' "$location" | sed -n '2p')
 
@@ -581,7 +619,7 @@ guard_watch() {
     # is the correct answer to it.
     binary="$root/target/debug/quantick-guards"
     [ -x "$binary" ] || binary="$binary.exe"
-    [ -x "$binary" ] || exit 0
+    [ -x "$binary" ] || return 0
 
     # Workspace-relative, forward slashes: the spelling the baseline uses.
     # `$prefix` above comes from git rather than from subtracting the root out
@@ -595,8 +633,8 @@ guard_watch() {
 
     # The binary is told which root to read, because the one compiled into it
     # is whichever worktree happened to build it.
-    findings=$(QUANTICK_GUARDS_ROOT="$root" "$binary" --file "$relative" 2>&1) && exit 0
-    [ -n "$findings" ] || exit 0
+    findings=$(QUANTICK_GUARDS_ROOT="$root" "$binary" --file "$relative" 2>&1) && return 0
+    [ -n "$findings" ] || return 0
 
     # JSON-escape by hand, because there is no jq here. Separate `-e` scripts
     # and a `|` delimiter: a `;`-joined script with a `/` delimiter is what
@@ -614,6 +652,19 @@ guard_watch() {
     # path.
     escaped_path=$(printf '%s' "$relative" | sed -e 's|\\|\\\\|g' -e 's|"|\\"|g')
     context "\"Repository guards on \`$escaped_path\`:\n$escaped\n\nThis is advisory and blocks nothing; \`cargo test --workspace\` is still the gate. Fix it now while the edit is in hand, or run \`cargo run -p quantick-guards -- --tighten\` if a baseline entry only needs lowering.\""
+}
+
+guard_watch() {
+    paths=$(edit_paths)
+    [ -n "$paths" ] || exit 0
+    old_ifs=$IFS
+    IFS='
+'
+    for file in $paths; do
+        guard_watch_one "$file"
+    done
+    IFS=$old_ifs
+    exit 0
 }
 
 case "$mode" in

--- a/.claude/hooks/guardrails_test.sh
+++ b/.claude/hooks/guardrails_test.sh
@@ -303,6 +303,24 @@ set_tier() {
 
 json_path() { printf '{"tool_name":"Write","tool_input":{"file_path":"%s"}}' "$1"; }
 json_bash() { printf '{"tool_name":"Bash","cwd":"%s","tool_input":{"command":"%s"}}' "$1" "$2"; }
+json_patch() {
+    printf '%s%s%s%s%s' \
+        '{"tool_name":"apply_patch","cwd":"' "$1" \
+        '","tool_input":{"command":"*** Begin Patch\n*** Update File: ' "$2" \
+        '\n*** End Patch"}}'
+}
+json_patch_two() {
+    printf '%s%s%s%s%s%s%s' \
+        '{"tool_name":"apply_patch","cwd":"' "$1" \
+        '","tool_input":{"command":"*** Begin Patch\n*** Update File: ' "$2" \
+        '\n*** Update File: ' "$3" '\n*** End Patch"}}'
+}
+json_patch_move() {
+    printf '%s%s%s%s%s' \
+        '{"tool_name":"apply_patch","cwd":"' "$1" \
+        '","tool_input":{"command":"*** Begin Patch\n*** Update File: ' "$2" \
+        '\n*** Move to: ' "$3" '\n*** End Patch"}}'
+}
 
 # --- worktree-guard ---------------------------------------------------------
 
@@ -317,6 +335,18 @@ run "agent working files under .claude are allowed" \
 
 run "write into a linked worktree is allowed" \
     worktree-guard "$(json_path "$root/wt/src/a.txt")" silent
+
+run "a Codex patch into the main checkout is denied" \
+    worktree-guard "$(json_patch "$root/mainco" "src/a.txt")" deny
+
+run "a Codex patch into a linked worktree is allowed" \
+    worktree-guard "$(json_patch "$root/wt" "src/a.txt")" silent
+
+run "every file in a multi-file Codex patch is guarded" \
+    worktree-guard "$(json_patch_two "$root/wt" "$root/wt/src/a.txt" "$root/mainco/src/a.txt")" deny
+
+run "a Codex patch move destination is guarded" \
+    worktree-guard "$(json_patch_move "$root/wt" "$root/wt/src/a.txt" "$root/mainco/src/a.txt")" deny
 
 run "a payload without file_path fails open" \
     worktree-guard '{"tool_name":"Bash","tool_input":{"command":"ls"}}' silent
@@ -726,6 +756,9 @@ run "guard-watch: reports what the binary found" \
 run "guard-watch: passes a workspace-relative path" \
     guard-watch "$(json_path "$root/wt/src/a.rs")" context "src/a.rs"
 
+run "guard-watch: reads the edited path from a Codex patch" \
+    guard-watch "$(json_patch "$root/wt" "src/a.rs")" context "src/a.rs"
+
 # A quotation mark in the report has to survive into the JSON string. The
 # harness already rejects a payload that is not a parseable one-line object,
 # so this case fails loudly if the escaping regresses — which it did once,
@@ -762,6 +795,9 @@ run "guard-watch: reports when the binary exits non-zero" \
 # not because the stub is silent for everything.
 run "guard-watch: silent for a file no guard reads" \
     guard-watch "$(json_path "$root/wt/src/a.txt")" silent
+
+run "guard-watch: reaches a later file in a multi-file Codex patch" \
+    guard-watch "$(json_patch_two "$root/wt" "src/a.txt" "src/a.rs")" context "src/a.rs"
 
 # A relative `file_path` would make `dirname` answer `.`, and the git queries
 # would then resolve against the hook's own working directory — reporting on
@@ -825,6 +861,120 @@ run "a cd to a path that does not exist falls back to the session cwd" \
 
 repo_root=$(CDPATH='' cd -- "$script_dir/../.." && pwd)
 markers=$(sed -n 's/^[A-Z_]*MARKER_NAME="\([^"]*\)".*/\1/p' "$GUARDRAILS")
+
+# --- Claude and Codex must expose the same repository workflows ------------
+
+skill_parity() {
+    parity_root=$1
+    [ -d "$parity_root/.claude/skills" ] || return 1
+    [ -d "$parity_root/.agents/skills" ] || return 1
+
+    claude_skills=$(
+        for skill_file in "$parity_root"/.claude/skills/*/SKILL.md; do
+            [ -f "$skill_file" ] || continue
+            basename "$(dirname "$skill_file")"
+        done | sort
+    )
+    codex_skills=$(
+        for skill_file in "$parity_root"/.agents/skills/*/SKILL.md; do
+            [ -f "$skill_file" ] || continue
+            basename "$(dirname "$skill_file")"
+        done | sort
+    )
+    [ "$claude_skills" = "$codex_skills" ] || return 1
+
+    for skill in $claude_skills; do
+        adapter="$parity_root/.agents/skills/$skill/SKILL.md"
+        grep -qF -- "../../../.claude/skills/$skill/SKILL.md" "$adapter" || return 1
+        grep -qF -- "../../references/codex-compatibility.md" "$adapter" || return 1
+        grep -qE -- "^name:[[:space:]]*$skill$" "$adapter" || return 1
+    done
+}
+
+if skill_parity "$repo_root"; then
+    passed=$((passed + 1))
+else
+    printf 'FAIL .claude/skills and .agents/skills do not expose the same canonical workflows\n'
+    failed=$((failed + 1))
+fi
+
+# Pin the failure direction too. A comparison that accidentally ignored one
+# tree would report the real repository green and this deliberately incomplete
+# fixture green as well.
+parity_fixture="$root/parity"
+mkdir -p "$parity_fixture/.claude/skills/one" \
+    "$parity_fixture/.agents/skills/one" \
+    "$parity_fixture/.agents/references"
+printf '%s\n' '---' 'name: one' 'description: fixture' '---' \
+    > "$parity_fixture/.claude/skills/one/SKILL.md"
+printf '%s\n' '---' 'name: one' 'description: fixture' '---' \
+    '../../../.claude/skills/one/SKILL.md' \
+    '../../references/codex-compatibility.md' \
+    > "$parity_fixture/.agents/skills/one/SKILL.md"
+if skill_parity "$parity_fixture"; then
+    passed=$((passed + 1))
+else
+    printf 'FAIL the complete skill-parity fixture was rejected\n'
+    failed=$((failed + 1))
+fi
+mkdir -p "$parity_fixture/.claude/skills/two"
+printf '%s\n' '---' 'name: two' 'description: missing from Codex' '---' \
+    > "$parity_fixture/.claude/skills/two/SKILL.md"
+if skill_parity "$parity_fixture"; then
+    printf 'FAIL skill parity accepted a Claude workflow with no Codex adapter\n'
+    failed=$((failed + 1))
+else
+    passed=$((passed + 1))
+fi
+
+# The lifecycle configuration must keep delegating every mode to the one
+# canonical script. The hook runner validates the JSON when the project layer
+# is trusted; this test owns the repository-specific agreement.
+codex_hooks="$repo_root/.codex/hooks.json"
+if [ ! -f "$codex_hooks" ]; then
+    printf 'FAIL .codex/hooks.json does not exist\n'
+    failed=$((failed + 1))
+else
+    validate_json() {
+        if command -v python3 >/dev/null 2>&1 && python3 --version >/dev/null 2>&1; then
+            python3 -m json.tool "$1" >/dev/null
+        elif command -v python >/dev/null 2>&1 && python --version >/dev/null 2>&1; then
+            python -m json.tool "$1" >/dev/null
+        elif command -v py >/dev/null 2>&1 && py -3 --version >/dev/null 2>&1; then
+            py -3 -m json.tool "$1" >/dev/null
+        else
+            return 2
+        fi
+    }
+    validate_json "$codex_hooks"
+    json_status=$?
+    case "$json_status" in
+        0) passed=$((passed + 1)) ;;
+        2) ;;
+        *)
+            printf 'FAIL .codex/hooks.json is not valid JSON\n'
+            failed=$((failed + 1))
+            ;;
+    esac
+
+    windows_commands=$(grep -c -- '"commandWindows"' "$codex_hooks")
+    if [ "$windows_commands" -eq 4 ]; then
+        passed=$((passed + 1))
+    else
+        printf 'FAIL Codex hooks define %s Windows commands, expected 4\n' "$windows_commands"
+        failed=$((failed + 1))
+    fi
+
+    for mode in worktree-guard pr-gate commit-reminder guard-watch; do
+        if grep -qF -- '.claude/hooks/guardrails.sh' "$codex_hooks" &&
+            grep -qF -- "$mode" "$codex_hooks"; then
+            passed=$((passed + 1))
+        else
+            printf 'FAIL Codex hooks do not delegate %s to guardrails.sh\n' "$mode"
+            failed=$((failed + 1))
+        fi
+    done
+fi
 
 # Every file the gate reads out of a worktree's git dir, not only the review
 # markers: the tier file is written by the same kind of prose snippet and read

--- a/.claude/skills/mission/SKILL.md
+++ b/.claude/skills/mission/SKILL.md
@@ -14,11 +14,8 @@ before doing anything else.
 same instruction. Anything else is objective text and the objective keeps every
 word of it. With no tier given, the mission runs at **`small`**.
 
-The bare form misreads an objective that genuinely opens with one of those
-words (`/mission small fonts are unreadable`). Two things hold it, and neither
-pretends to be a parser: step 1's echo names **what the tier drops**, not
-merely the word it read, and the flagged form exists for exactly the sentence a
-bare word guesses wrong on. Use it when the tier word reads as an adjective.
+An objective that genuinely starts with a tier word uses the flagged form so
+the adjective is not parsed as a tier; step 1's echo exposes any misparse.
 
 The mission is the orchestrator: it decides which other skills are part of
 *done* so the user never has to list them. One session, one mission, one
@@ -60,15 +57,10 @@ than it looked, and rewrite the tier file from step 6 when you do. Lowering one
 mid-mission cannot be told apart from dodging a review that was about to fail,
 so it is not available.
 
-**What `small` costs at the gate.** It is the only tier `pr-gate` can see: a
-`small` branch opens its PR on `arch-review-ok` alone. That hole is bounded
-rather than trusted — the exemption lapses once the branch exceeds
-`SMALL_TIER_MAX_CHANGED_LINES` in `guardrails.sh` (insertions plus deletions
-against `origin/main`), and past it the branch pays in full whatever the tier
-file says. So the word has to be true when the branch *ships*: a `small`
-mission that grows either raises its tier and runs `delivery-review`, or splits
-until a branch really is small. Shrinking a diff to get under a review is the
-dishonest third option. `.claude/hooks/README.md` owns the mechanism.
+`pr-gate` exempts `small` from `delivery-review` only while insertions plus
+deletions against `origin/main` stay within `SMALL_TIER_MAX_CHANGED_LINES`.
+Past it, raise the tier or split the work; never shrink a diff to evade review.
+`.claude/hooks/README.md` owns the mechanism.
 
 ## Steps
 
@@ -100,9 +92,6 @@ dishonest third option. `.claude/hooks/README.md` owns the mechanism.
      for `cargo clippy` to pass. Step 4's table is their provenance.
    - Numbers are stable for the life of the mission. Never renumber. A
      withdrawn ask stays on the ledger, struck through, with the reason.
-
-   The ledger is what turns "they only did part of it" from a feeling into a
-   detectable event.
 
 3. **Interrogate — once, before any work starts.** Raise everything that
    qualifies in a single `AskUserQuestion` call (at most four questions,
@@ -141,11 +130,8 @@ dishonest third option. `.claude/hooks/README.md` owns the mechanism.
    trader**. A decision recorded there is settled: re-opening one is a scope
    change.
 
-   **When more than four things qualify**, rank by the cost of being wrong —
-   how much work a wrong guess throws away, and how hard it is to reverse — ask
-   the top four, and record every one you did not ask as an `S` marked *wanted
-   to ask*. Dropping the fifth ambiguity in silence is the same failure as
-   dropping the fifth ask.
+   **When more than four things qualify**, ask the four costliest to get wrong
+   and record every omitted one as an `S` marked *wanted to ask*.
 
    If nothing qualifies, say so in one line. Legitimate, but stated, never
    silent. After this round the mission runs on its own: a later doubt becomes
@@ -173,9 +159,7 @@ dishonest third option. `.claude/hooks/README.md` owns the mechanism.
    | Engine / determinism territory | test-first: fixture + expected output written before the code; golden test guards determinism |
    | Docs/skills only | four checks still run; `arch-review`'s shape dimensions 1–7 and 9 waived — **dimension 8 is not**, and neither is step 0; `pr-gate` wants whichever markers the tier owes. The waiver covers prose: a shell script, a config file or a test shipping alongside it takes the full shape pass |
 
-   Write down what is **not applicable and why**. A gate silently omitted and
-   one deliberately excluded look identical to the next reader, and only one of
-   them is honest.
+   Write down every non-applicable gate and why it does not apply.
 
    ### Closing steps are not criteria
 
@@ -184,12 +168,7 @@ dishonest third option. `.claude/hooks/README.md` owns the mechanism.
    under **Closing steps**. **At `small` the first is not listed at all** — a
    closing step the mission is exempt from is not one it owes, and writing it
    down leaves the archive recording an obligation nothing will discharge.
-   Archiving `GOAL.md` is *not* among them: step 8 puts it before the reviews.
-
-   They are not criteria because they cannot be graded when the grading
-   happens — `delivery-review`'s own verdict does not exist while it is being
-   written, so written as criteria they come back UNPROVEN on every mission and
-   burn the fix loop on gaps no edit can close.
+   Archiving `GOAL.md` is not among them: step 8 puts it before the reviews.
 
    Present the merged checklist to the user before starting work.
 
@@ -206,23 +185,12 @@ dishonest third option. `.claude/hooks/README.md` owns the mechanism.
    acceptance criteria; what is not applicable and why; and last, **the request
    as received, quoted in full and verbatim**.
 
-   The tier line is not bookkeeping: `delivery-review` reads this file and
-   nothing else, so a branch declaring `small` needs the file to say why the
-   exemption was earned. At `small` the file may drop the decisions and the
-   not-applicable sections when both are empty, and keeps everything else.
-
-   The verbatim request is not optional. Without it the ledger becomes its own
-   source of truth, and an ask dropped while *writing* the ledger is one no
-   reviewer can ever find — `delivery-review` refuses to grade a goal file that
-   lacks it. On the language rule this is **one marked, attributed
-   quotation**, the shape `CLAUDE.md`'s exemption describes; say in the
-   section's preamble why the words are not translated, and keep every other
-   line English.
+   At `small`, the tier line says why the exemption was earned; empty decisions
+   and not-applicable sections may be omitted. `delivery-review` refuses a file
+   without the verbatim request. Mark it as an attributed quotation under
+   `CLAUDE.md`'s language exemption; keep every other line English.
 
    ### The checklist format
-
-   A contract, not a style preference: `delivery-review` reads it, and a
-   criterion it cannot grade is a criterion nobody grades.
 
    ```markdown
    - [ ] **A3** — <one observable outcome, stated so two readers would agree
@@ -232,15 +200,9 @@ dishonest third option. `.claude/hooks/README.md` owns the mechanism.
          → <path where that evidence will be written>. *(R3, R4)*
    ```
 
-   - **Stable ID.** `A1`…`An` mission-specific, `G1`…`Gn` injected gates. Never
-     renumbered.
-   - **One observable outcome.** Not "the ledger works well" — "every ask
-     appears as a numbered line mapped to a criterion". If you cannot say how
-     an outsider would check it, the criterion is not finished being written.
-   - **Evidence kind, and the path it lands at.** Naming the path in advance is
-     what stops evidence from being remembered instead of recorded. Evidence
-     that exists only as a claim in the transcript comes back **UNPROVEN**.
-   - **Ledger back-reference.** The `(R…)` tail, on `A` lines only.
+   Each item has a stable ID (`A` mission-specific, `G` injected), one
+   observable outcome, an evidence kind and destination path, and an `(R…)`
+   tail on `A` lines only. Never renumber. Transcript-only claims are UNPROVEN.
 
    Assumptions get their own list, `S1`…`Sn`, each with the reason it was safe
    to assume rather than ask. `delivery-review` audits that list: an assumption
@@ -251,10 +213,8 @@ dishonest third option. `.claude/hooks/README.md` owns the mechanism.
    main checkout, and check the worktree for a live writer before the first
    write. The `worktree-guard` hook denies the write if this step is skipped.
 
-   **Arm the worktree before the first edit**, with both commands, in the new
-   worktree. Both assignments are inside the fence on purpose: `WT` does not
-   survive between tool calls, and an unquoted `<placeholder>` is not a
-   placeholder to `sh` — it is two redirections.
+   **Arm the worktree before the first edit** with both commands. Keep the
+   assignments inside the same shell call and replace every placeholder.
 
    ```sh
    WT=/path/to/worktree
@@ -264,9 +224,7 @@ dishonest third option. `.claude/hooks/README.md` owns the mechanism.
      cargo check -p "$CRATE" --all-targets
    ```
 
-   `CLAUDE.md`'s *Verification loop* owns why. What belongs here is only that
-   the two commands run **before the first edit**: a guard armed afterwards has
-   already missed the edit worth reporting.
+   Both commands run **before the first edit**.
 
    **Record the tier here**, before the first line of work, beside the two
    review markers in that worktree's own git dir — per-branch, never committed:
@@ -279,15 +237,8 @@ dishonest third option. `.claude/hooks/README.md` owns the mechanism.
        > "$(git rev-parse --absolute-git-dir)/mission-tier"
    ```
 
-   **The branch name is half the record.** A bare tier word would outlive the
-   mission that wrote it, and the next branch checked out in that worktree
-   would inherit an exemption it never asked for. `guardrails.sh` refuses a
-   declaration naming any other branch, and refuses the one-field format
-   outright rather than guessing.
-
-   `pr-gate` reads that file and nothing else: a tier declared only in
-   `GOAL.md` changes nothing at the gate. Rewrite the file with the same
-   command whenever the tier is raised.
+   `guardrails.sh` accepts only `<current-branch> <tier>`; `pr-gate` reads that
+   file, not `GOAL.md`. Rewrite it whenever the tier is raised.
 
 7. **Stay on track**: refuse scope creep. A necessary detour is stated
    explicitly and tied back to the mission, or taken to the user. Keep the
@@ -332,13 +283,8 @@ dishonest third option. `.claude/hooks/README.md` owns the mechanism.
    and it is written anyway — the file is the only record of what the branch
    was for.
 
-   The order is the whole point. Archive *after* recording the markers and that
-   commit moves `HEAD`, both markers go stale, `pr-gate` denies — and the
-   cheapest way out is to re-stamp both without re-running either review, which
-   destroys the one property a sha-based marker exists to give. If either
-   review sends you back to the code, you commit again and both markers are
-   stale by design: re-run the review that owns each one before re-recording
-   it.
+   If either review changes the branch, commit and re-run both reviews before
+   recording their now-stale markers again.
 
 9. **Hand over the `/goal` condition.** Skipped at `small`. At every other
    tier, right after step 4, print the built-in command for the user to paste:

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,57 @@
+{
+  "description": "Quantick repository guardrails shared with Claude Code.",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -lc 'root=$(git rev-parse --show-toplevel) || exit 0; exec sh \"$root/.claude/hooks/guardrails.sh\" worktree-guard'",
+            "commandWindows": "powershell.exe -NoProfile -Command \"$root = git rev-parse --show-toplevel; $gitRoot = Split-Path (Split-Path (Get-Command git).Source); $sh = Join-Path $gitRoot 'bin\\sh.exe'; [Console]::In.ReadToEnd() | & $sh (Join-Path $root '.claude/hooks/guardrails.sh') worktree-guard\"",
+            "timeout": 10,
+            "statusMessage": "Checking the Quantick worktree policy"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -lc 'root=$(git rev-parse --show-toplevel) || exit 0; exec sh \"$root/.claude/hooks/guardrails.sh\" pr-gate'",
+            "commandWindows": "powershell.exe -NoProfile -Command \"$root = git rev-parse --show-toplevel; $gitRoot = Split-Path (Split-Path (Get-Command git).Source); $sh = Join-Path $gitRoot 'bin\\sh.exe'; [Console]::In.ReadToEnd() | & $sh (Join-Path $root '.claude/hooks/guardrails.sh') pr-gate\"",
+            "timeout": 10,
+            "statusMessage": "Checking the Quantick PR gate"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -lc 'root=$(git rev-parse --show-toplevel) || exit 0; exec sh \"$root/.claude/hooks/guardrails.sh\" commit-reminder'",
+            "commandWindows": "powershell.exe -NoProfile -Command \"$root = git rev-parse --show-toplevel; $gitRoot = Split-Path (Split-Path (Get-Command git).Source); $sh = Join-Path $gitRoot 'bin\\sh.exe'; [Console]::In.ReadToEnd() | & $sh (Join-Path $root '.claude/hooks/guardrails.sh') commit-reminder\"",
+            "timeout": 10,
+            "statusMessage": "Checking Quantick delivery state"
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -lc 'root=$(git rev-parse --show-toplevel) || exit 0; exec sh \"$root/.claude/hooks/guardrails.sh\" guard-watch'",
+            "commandWindows": "powershell.exe -NoProfile -Command \"$root = git rev-parse --show-toplevel; $gitRoot = Split-Path (Split-Path (Get-Command git).Source); $sh = Join-Path $gitRoot 'bin\\sh.exe'; [Console]::In.ReadToEnd() | & $sh (Join-Path $root '.claude/hooks/guardrails.sh') guard-watch\"",
+            "timeout": 10,
+            "statusMessage": "Running Quantick repository guards"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ Crates under `crates/`; `AGENTS.md` *The map* owns the descriptions and the grap
 
 ## Keeping the instructions small
 
-The same ratchet over the other tree — `crates/guards/src/context.rs`, ceilings in `context-baseline.txt`, mechanism shared with `size` in `ratchet.rs`. It counts **bytes** of what a session loads: this file, `AGENTS.md`, every `.md` under `.claude/skills/`. Goal files are out of scope on purpose.
+The context ratchet covers this file, `AGENTS.md`, and Markdown under `.claude/skills/` or `.agents/`; goal files are excluded. Its ceilings are in `context-baseline.txt`, using the mechanism shared with `size` in `ratchet.rs`.
 
 - **A `SKILL.md` states every rule that decides an outcome, once, operatively.** Reasoning, histories and per-dimension detail go to `references/` beside it, read on demand — a waived dimension then costs nothing. A working rule's reasoning goes to `docs/agentic-development.md`.
 - **The budget is the whole tracked weight**, not just the ceilings: files over 10,000 bytes carry a signed entry, and every smaller one still counts. So splitting prose into sub-threshold files buys nothing — only deleting it does.
@@ -71,7 +71,7 @@ The same ratchet over the other tree — `crates/guards/src/context.rs`, ceiling
   ```
 
   After the merge, from the main checkout: `git worktree remove ../quantick-worktrees/<prefix>-<slug>` then `git branch -d <prefix>/<slug>`.
-- **One mission, one tier** — `/mission` takes `small` (the default), `medium`, `high` or `max`, scaling the ceremony and whether `delivery-review` runs. `small` is the only tier the hooks see; the skill owns the table.
+- **One mission, one tier** — `/mission` in Claude Code or `$mission` in Codex takes `small` (the default), `medium`, `high` or `max`, scaling the ceremony and whether `delivery-review` runs. `small` is the only tier the hooks see; the skill owns the table.
 - **Arch-review before PR** — over `git diff origin/main...HEAD`. Its step 0 runs `code-review` on the same diff. Resolve every Blocker and Should-fix; note deferrals in the PR body. A docs/skills change waives shape dimensions 1–7 and 9, never 8 and never step 0.
 - **Delivery-review before PR** — arch-review asks whether the branch is well built, never whether it is what was asked for. Runs last, over the branch as shipped, grading every ask in the goal file (`.claude/GOAL.md` or its `GOAL-archive-<slug>.md`, committed before either review) and every criterion as DELIVERED / PARTIAL / MISSING / UNPROVEN, from a fresh-context subagent. Passes only when nothing is unmet. A `small` mission is exempt, bounded by a diff-size ceiling that revokes the exemption if the branch grows. A branch not from `/mission` is graded against its issue's criteria, and the verdict says so.
 - **The review chain has a budget: three rounds per branch**, then the remainder ships as recorded PR follow-ups. A round is one pass by everything that owes the branch a review — arch-review's bug pass and shape pass, then delivery-review — plus the commit answering them; not three per skill, since a fix commit stales both markers and re-runs both. Nothing is discarded to fit: findings defer into the PR body with their severity. An open Blocker never defers, and if it runs the budget out the branch goes to the trader. On reaching it, say the shape — findings shrinking is convergence, findings flat or climbing into the last round's code is a design problem.

--- a/crates/guards/context-baseline.txt
+++ b/crates/guards/context-baseline.txt
@@ -1,5 +1,5 @@
 # The recorded ceiling, in bytes, for every context file over the threshold —
-# the files a Claude session loads before it reads any code. One
+# the files a Claude Code or Codex session loads before it reads any code. One
 # `path ceiling` pair per line; `#` starts a comment.
 #
 # These are costs, not targets. Every byte here is paid on every turn of every
@@ -18,7 +18,7 @@
 # `references/` beside each skill, which a run reads only when it reaches that
 # dimension. Each of these three is still the single largest thing a session
 # loads when it invokes the skill, so each is debt, not a target.
-.claude/skills/mission/SKILL.md 22007
+.claude/skills/mission/SKILL.md 18664
 .claude/skills/arch-review/SKILL.md 19573
 .claude/skills/delivery-review/SKILL.md 18087
 

--- a/crates/guards/src/context.rs
+++ b/crates/guards/src/context.rs
@@ -1,7 +1,7 @@
-//! A ratchet for the files that are injected into a Claude session.
+//! A ratchet for the files that are injected into an agent session.
 //!
-//! `CLAUDE.md` is read at the start of every session; a skill's `SKILL.md` is
-//! read whole the moment that skill is invoked. Those bytes are paid for on
+//! `CLAUDE.md` and `AGENTS.md` are session instructions; a skill's `SKILL.md`
+//! is read whole the moment that skill is invoked. Those bytes are paid for on
 //! every turn that follows, before a single line of the repository has been
 //! looked at — and unlike the code, nothing has ever rationed them.
 //!
@@ -38,9 +38,9 @@
 //!
 //! Exactly the files a session loads: `CLAUDE.md`, `AGENTS.md` (which
 //! `CLAUDE.md` delegates the crate map to, so a cut that moves weight there
-//! must still be paid for), and every `.md` under `.claude/skills/`. The goal
-//! files under `.claude/` are not in scope — a `GOAL.md` is a record of one
-//! mission, read deliberately and never at start-up, and rationing it would
+//! must still be paid for), and every `.md` under the Claude and Codex
+//! instruction trees. Goal files are not in scope — a `GOAL.md` is a record
+//! of one mission, read deliberately and never at start-up. Rationing it would
 //! push authors to write down less of what they were asked for.
 
 use std::fs;
@@ -90,14 +90,14 @@ pub const BUDGET_SLACK: usize = 4_000;
 /// `--tighten` pulls the number back down whenever prose leaves.
 pub const BUDGET_HEADROOM: usize = 2_000;
 
-/// The directory every skill lives under.
+/// The directories that carry agent instructions.
 ///
 /// Carries its trailing slash so a prefix test is a directory test. Without
 /// it, `.claude/skills-old/notes.md` starts with `.claude/skills` and would be
 /// rationed as a skill — and, worse, an entry recorded for such a file would
 /// never be found by [`measure`], which walks the real directory, so the
 /// guard would report its own scan as a stale entry.
-const SKILLS: &str = ".claude/skills/";
+const INSTRUCTION_DIRS: [&str; 2] = [".claude/skills/", ".agents/"];
 
 /// The context files that are not skills, relative to the workspace root.
 const ROOT_FILES: [&str; 2] = ["CLAUDE.md", "AGENTS.md"];
@@ -163,7 +163,11 @@ pub const POLICY: Policy = Policy {
 /// [`check_file`], because those are the two surfaces the edit-time hook
 /// trusts to say the same thing.
 pub fn tracked(relative: &str) -> bool {
-    ROOT_FILES.contains(&relative) || (relative.starts_with(SKILLS) && relative.ends_with(".md"))
+    ROOT_FILES.contains(&relative)
+        || (INSTRUCTION_DIRS
+            .iter()
+            .any(|directory| relative.starts_with(directory))
+            && relative.ends_with(".md"))
 }
 
 /// What a walk of the context tree found.
@@ -299,9 +303,11 @@ pub fn measure(root: &Path) -> Measured {
                 .push(format!("  {name}: could not be read: {e}")),
         }
     }
-    let skills = root.join(SKILLS);
-    if skills.is_dir() {
-        walk(&skills, root, &mut found);
+    for directory in INSTRUCTION_DIRS {
+        let path = root.join(directory);
+        if path.is_dir() {
+            walk(&path, root, &mut found);
+        }
     }
     found.counts.sort();
     found
@@ -334,16 +340,18 @@ pub fn check(root: &Path) -> Vec<Finding> {
     // measures as *empty* — and an empty measurement makes every baseline
     // entry look stale, whose stated remedy is to delete it. That one edit
     // switches the ratchet off for every instruction file at once.
-    let skills = root.join(SKILLS);
-    if !skills.is_dir() {
-        return vec![Finding::new(
-            format!(
-                "  {} is not a readable directory — there is nothing to measure, and every \
-                 baseline entry would otherwise be reported stale",
-                skills.display()
-            ),
-            BASELINE_REMEDY,
-        )];
+    for directory in INSTRUCTION_DIRS {
+        let path = root.join(directory);
+        if !path.is_dir() {
+            return vec![Finding::new(
+                format!(
+                    "  {} is not a readable directory — there is nothing to measure, and every \
+                     baseline entry would otherwise be reported stale",
+                    path.display()
+                ),
+                BASELINE_REMEDY,
+            )];
+        }
     }
     let recorded = match POLICY.baseline(root) {
         Ok(recorded) => recorded,
@@ -438,13 +446,15 @@ pub fn check_file(root: &Path, relative: &str) -> Vec<Finding> {
 /// delete prose nobody had added. `check` already refuses the same
 /// conditions; this is the surface that *writes*, so it refuses harder.
 pub fn tighten(root: &Path) -> Result<Vec<String>, String> {
-    let skills = root.join(SKILLS);
-    if !skills.is_dir() {
-        return Err(format!(
-            "{} is not a readable directory — refusing to tighten from a scan that measured \
-             nothing, which would write a budget missing every skill",
-            skills.display()
-        ));
+    for directory in INSTRUCTION_DIRS {
+        let path = root.join(directory);
+        if !path.is_dir() {
+            return Err(format!(
+                "{} is not a readable directory — refusing to tighten from a scan that measured \
+                 nothing, which would write a budget missing agent instructions",
+                path.display()
+            ));
+        }
     }
     let found = measure(root);
     if !found.unreadable.is_empty() {
@@ -510,6 +520,8 @@ mod tests {
         assert!(tracked(
             ".claude/skills/ui-harness/references/hook-registry.md"
         ));
+        assert!(tracked(".agents/skills/mission/SKILL.md"));
+        assert!(tracked(".agents/references/codex-compatibility.md"));
     }
 
     #[test]
@@ -524,6 +536,7 @@ mod tests {
         // the walk would never reach reports as a stale entry for ever.
         assert!(!tracked(".claude/skills-old/notes.md"));
         assert!(!tracked(".claude/skillsets.md"));
+        assert!(!tracked(".agents-old/skills/mission/SKILL.md"));
     }
 
     #[test]
@@ -534,7 +547,7 @@ mod tests {
     }
 
     #[test]
-    fn the_scan_finds_claude_md_and_every_skill() {
+    fn the_scan_finds_root_instructions_and_both_skill_surfaces() {
         let found = measure(&workspace_root());
         assert!(
             found.counts.iter().any(|(path, _)| path == "CLAUDE.md"),
@@ -545,7 +558,7 @@ mod tests {
             .iter()
             .filter(|(path, _)| path.ends_with("/SKILL.md"))
             .count();
-        assert!(skills >= 8, "found only {skills} skills");
+        assert!(skills >= 16, "found only {skills} skills across both hosts");
     }
 
     #[test]
@@ -739,6 +752,7 @@ mod tests {
         fs::create_dir_all(root.join("crates/guards")).expect("scratch dirs are creatable");
         fs::create_dir_all(root.join(".claude/skills/one")).expect("scratch dirs are creatable");
         fs::create_dir_all(root.join(".claude/skills/two")).expect("scratch dirs are creatable");
+        fs::create_dir_all(root.join(".agents/skills")).expect("scratch dirs are creatable");
         fs::write(
             root.join(BASELINE_FILE),
             format!(

--- a/docs/agentic-development.md
+++ b/docs/agentic-development.md
@@ -26,9 +26,16 @@ loadable procedure with its own acceptance criteria, invoked by name.
 
 ## The skills
 
-Each is a directory under `.claude/skills/` with a `SKILL.md`. The agent loads
+Each canonical workflow is a directory under `.claude/skills/` with a
+`SKILL.md`. Claude Code invokes it as `/name`. Codex discovers the thin adapter
+with the same name under `.agents/skills/` and invokes it as `$name`; the
+adapter reads the canonical workflow and the shared host mappings, so the two
+agents do not own competing copies. The agent loads
 one when the task matches its description, or when the maintainer types its
 name as a slash command.
+
+The adapter location and `$name` spelling follow the
+[Codex skill discovery contract](https://developers.openai.com/codex/skills).
 
 | Skill | What it owns |
 | --- | --- |


### PR DESCRIPTION
## Summary

- expose all ten repository workflows to Codex through thin .agents/skills adapters
- keep .claude/skills canonical through a shared host-compatibility contract and parity guard
- run the existing worktree, PR, commit, and edit-watch policies from Codex hooks on Windows and POSIX
- include Codex instructions in the context-size ratchet without raising its budget

## Verification

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets
- cargo build --workspace
- cargo test --workspace
- .claude/hooks/guardrails_test.sh (111 passed, 0 failed)
- all 10 Codex adapters pass the skill validator

## Reviews

- arch-review: PASS; no Blocker or Should-fix findings
- delivery-review: PASS; R1-R3 and A1-A5/G1-G3 delivered

Runtime performance impact: none; only repository agent lifecycle paths change.