### PR TITLE
docs(skills): add the ai-review skill

### DIFF
--- a/.agents/skills/ai-review/SKILL.md
+++ b/.agents/skills/ai-review/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: ai-review
+description: Review a Quantick diff as an AI engineer would - modular, decoupled, agent-ready, extensible, scalable.
+---
+
+Follow the [canonical workflow](../../../.claude/skills/ai-review/SKILL.md) with the [Codex mappings](../../references/codex-compatibility.md).

--- a/.claude/skills/ai-review/SKILL.md
+++ b/.claude/skills/ai-review/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: ai-review
+description: Review a diff the way an AI engineer would - modularity, decoupling, MCP and agent readiness, agent testability and legibility, extensibility, scalability. Use when the user types /ai-review, or asks whether code is modular, decoupled, agent-ready, extensible or scalable. Reports findings; never edits.
+---
+
+# AI engineer review
+
+Target: `git diff origin/main...HEAD` by default, or the path, branch or PR
+number given as argument. Read the code, not its description.
+
+Answer six questions. Each gets one verdict - PASS, WEAK or FAIL - and
+`file:line` evidence. No praise, no restating the diff.
+
+1. **Is it modular?** One responsibility per unit. A new capability lands as
+   a new file plus one registration line, not edits across the trunk.
+2. **Is it decoupled?** Dependencies point one way, no reverse edge, no module
+   cycle, no hidden shared state. A change here does not force a change there.
+3. **Is it ready for MCP and other AI use?** Every behaviour is reachable as a
+   named call with typed input and a readable result, so MCP, a bot or a
+   script drives it without the UI.
+4. **Can agents test it and understand it?** Deterministic and headless -
+   fixture in, expected out. Names and doc comments state intent, so an agent
+   finds and tests the unit without reading the whole crate.
+5. **Is it extensible?** The next variant - feed, bar type, indicator, tool -
+   is added, not patched in. No `match` every new case must grow.
+6. **Does it scale?** Cost grows with the data, not with the feature count.
+   No quadratic pass over trades or bars, no per-frame allocation, no
+   unbounded growth.
+
+## Report
+
+```
+## AI review - <target>
+1. Modular:      PASS|WEAK|FAIL - evidence
+2. Decoupled:    ...
+3. AI-ready:     ...
+4. Agent-tested: ...
+5. Extensible:   ...
+6. Scalable:     ...
+Top fix: the one change that raises the most verdicts
+```
+
+Findings only. The human decides; do not apply fixes.

--- a/.claude/skills/ai-review/SKILL.md
+++ b/.claude/skills/ai-review/SKILL.md
@@ -1,43 +1,55 @@
 ---
 name: ai-review
-description: Review a diff the way an AI engineer would - modularity, decoupling, MCP and agent readiness, agent testability and legibility, extensibility, scalability. Use when the user types /ai-review, or asks whether code is modular, decoupled, agent-ready, extensible or scalable. Reports findings; never edits.
+description: Review a diff the way an AI engineer would - modularity, decoupling, MCP and agent readiness, agent testability and legibility, extensibility, scalability. Use when the user types /ai-review. Reports findings; never edits, builds or posts.
 ---
 
 # AI engineer review
 
 Target: `git diff origin/main...HEAD` by default, or the path, branch or PR
-number given as argument. Read the code, not its description.
+number given as argument. Read the code, not its description. Read-only.
 
-Answer six questions. Each gets one verdict - PASS, WEAK or FAIL - and
-`file:line` evidence. No praise, no restating the diff.
+Answer six questions. Each gets one verdict and `file:line` evidence, PASS
+included. FAIL: the diff breaks the rule. WEAK: it holds today but the next
+variant breaks it - name that variant. PASS: cite the line that proves it,
+or say why the diff cannot reach the question.
 
-1. **Is it modular?** One responsibility per unit. A new capability lands as
-   a new file plus one registration line, not edits across the trunk.
-2. **Is it decoupled?** Dependencies point one way, no reverse edge, no module
-   cycle, no hidden shared state. A change here does not force a change there.
-3. **Is it ready for MCP and other AI use?** Every behaviour is reachable as a
-   named call with typed input and a readable result, so MCP, a bot or a
-   script drives it without the UI.
-4. **Can agents test it and understand it?** Deterministic and headless -
-   fixture in, expected out. Names and doc comments state intent, so an agent
-   finds and tests the unit without reading the whole crate.
+1. **Is it modular?** One responsibility per unit, and the file name says
+   which. Count the pre-existing files the diff edits and name the one with
+   the most edited lines: that is the blast radius.
+2. **Is it decoupled?** Judge what the compiler cannot: a consumer naming a
+   concrete producer where a trait bound would do; state owned by the caller
+   that the unit should own; a `pub` item nothing outside the crate calls.
+3. **Is it ready for MCP and other AI use?** Every behaviour the diff adds
+   is a named call with a typed request, a typed result and a typed error -
+   never a `String` standing in for a failure - and calling it twice is safe.
+   Evidence is the call site in the registry the UI reads; a click handler
+   as the only entry is FAIL.
+4. **Can agents test it and understand it?** Name the test that fails
+   without the diff, runnable alone with `cargo test -p <crate> <name>`,
+   below `app`, with an error-path fixture; an expectation derived from the
+   code under test is FAIL. Hunt: `SystemTime`, `Instant`, `HashMap`
+   iteration, `rand`, env reads, thread timing.
 5. **Is it extensible?** The next variant - feed, bar type, indicator, tool -
-   is added, not patched in. No `match` every new case must grow.
-6. **Does it scale?** Cost grows with the data, not with the feature count.
-   No quadratic pass over trades or bars, no per-frame allocation, no
-   unbounded growth.
+   is added, not patched in. A closed `enum` where the variants are the
+   domain; a trait object where the next variant is a capability. A registry
+   keyed by name appends; one keyed by position makes every branch edit the
+   same line.
+6. **Does it scale?** State the rate of every touched loop - per trade, per
+   depth update, per frame, rare. Per-event cost is independent of session
+   length: a new trade updates the open bar, never rescans history. No
+   buffer without a stated cap, no burst dropped in silence.
 
 ## Report
 
 ```
-## AI review - <target>
+## AI review - <target> @ <sha>
 1. Modular:      PASS|WEAK|FAIL - evidence
 2. Decoupled:    ...
 3. AI-ready:     ...
 4. Agent-tested: ...
 5. Extensible:   ...
-6. Scalable:     ...
-Top fix: the one change that raises the most verdicts
+6. Scalable:     ... - rate of the touched path
+Top fix: <file> - <change> - flips: <verdicts>
 ```
 
 Findings only. The human decides; do not apply fixes.

--- a/crates/guards/context-baseline.txt
+++ b/crates/guards/context-baseline.txt
@@ -140,4 +140,9 @@ AGENTS.md 13179
 # generated file only. Not one `Reaches` cell was shortened -- the long ones
 # say which class of defect is invisible without that hook, which is the most
 # valuable content in the harness and the thing a grep cannot supply.
-!budget 232885
+# +2,235 for `ai-review`, a new skill: 1,949 for the six-question checklist a
+# session loads on `/ai-review`, 286 for its Codex adapter. A raise, not a
+# trade: nothing left the tree. The skill is one screen by design - each
+# question is a sentence plus the test that decides it - so there was no
+# reference file to extract and no sibling prose this branch owned to cut.
+!budget 235120

--- a/crates/guards/context-baseline.txt
+++ b/crates/guards/context-baseline.txt
@@ -140,9 +140,11 @@ AGENTS.md 13179
 # generated file only. Not one `Reaches` cell was shortened -- the long ones
 # say which class of defect is invisible without that hook, which is the most
 # valuable content in the harness and the thing a grep cannot supply.
-# +2,235 for `ai-review`, a new skill: 1,949 for the six-question checklist a
+# +3,039 for `ai-review`, a new skill: 2,753 for the six-question checklist a
 # session loads on `/ai-review`, 286 for its Codex adapter. A raise, not a
 # trade: nothing left the tree. The skill is one screen by design - each
-# question is a sentence plus the test that decides it - so there was no
+# question names the rule and the evidence that decides it - so there was no
 # reference file to extract and no sibling prose this branch owned to cut.
-!budget 235120
+# The first cut was 1,949; ten independent reviews found none of its six
+# verdicts falsifiable, and the 804 bytes added are the falsifiers.
+!budget 235924


### PR DESCRIPTION
## What

A one-screen skill, `/ai-review`, that reviews a diff the way an AI engineer would. Six questions, each graded PASS, WEAK or FAIL with `file:line` evidence: is it modular, is it decoupled, is it ready for MCP and other AI use, can agents test and understand it, is it extensible, does it scale. It reports only; the human applies. Meant to be run on its own, separately from `arch-review`, so the trader can review the code himself against the verdicts.

The second commit is the answer to ten independent AI-engineering reviews of the first cut (MCP tool designer, agent-evals engineer, context-window economist, skeptical staff engineer, LLM-app reliability engineer, Rust systems architect, prompt minimalist, streaming-pipeline engineer, multi-agent orchestration lead, contrarian). Their shared verdict: the six questions were right and none could fail. So the verdicts are now defined (FAIL breaks the rule in the diff; WEAK names the next variant that breaks it; PASS cites the proving line), and each question carries the evidence that decides it: blast radius in pre-existing files, typed request/result/error and safe retry for the MCP surface, the named test below `app` that fails without the diff plus the determinism hunt list, enum-versus-trait-object and registry-by-name for extension, the rate of every touched loop with per-event cost independent of session length. The report carries the sha it graded. Recorded dissent: the contrarian measured four of the six questions as overlapping `arch-review` and would cut to two; kept at six because the skill's point is to stand alone.

Files:

- `.claude/skills/ai-review/SKILL.md` — the skill, 2,753 bytes.
- `.agents/skills/ai-review/SKILL.md` — the Codex adapter every other skill has, 286 bytes.
- `crates/guards/context-baseline.txt` — `!budget` raised by exactly those 3,039 bytes, signed. A raise, not a trade: `main` was already inside the budget's headroom, and the skill is one screen by design, so there was no reference file to extract and no sibling prose this branch owned to cut.

## Review

Tier `small` declared (70 changed lines). Docs/skills change: shape dimensions 1–7 and 9 waived, dimension 8 and step 0 graded. Two rounds run, one per commit.

step 0: code-review at low (effort-first, no reuse notice), 0 findings on 1c656ec and 0 findings on cbcf1e6. Verdict graded at cbcf1e6.

- **Correctness** — step 0 returned nothing in either round; the adapter's relative link resolves to the file this diff adds, and the budget arithmetic is exact. Nothing open.
- **Docking** — no code; a new skill docks as a new directory plus its Codex adapter, no existing skill edited.
- **Performance** — no runtime path touched. Context cost: +3,039 bytes loaded only when `/ai-review` is invoked.
- **Operability** — no surface; a skill is already a named call.
- **Proof** — `cargo test -p quantick-guards`: the context ratchet fails without the signed budget line, the language guard scans the new prose. Unit tests.
- **Accumulation** — trunk flat in code. Tracked context weight +3,039; the ceiling raised is the `!budget` line, with a justifying comment.
- **Language** — guard passed; I read the prose, the branch name and both commit messages myself. All English.

Four checks: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets`, `cargo build --workspace`, `cargo test --workspace` (1,894 app tests among them) ran green on 1c656ec in the worktree. cbcf1e6 changes no Rust source, so fmt, the guards crate (138 tests, both ratchets) and `guardrails_test.sh` (111) were re-run on it; CI runs the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Bt1TPaNH2iPqwvyWSxWsa
