### PR TITLE
chore: throwaway fixture for the ai-review thread mechanics

### DIFF
--- a/fixture/ai_review_probe.rs
+++ b/fixture/ai_review_probe.rs
@@ -1,0 +1,30 @@
+//! A throwaway probe for the ai-review thread mechanics. Not in the workspace.
+
+use std::collections::HashMap;
+
+/// The next alert kind means editing this enum and every match on it.
+pub enum AlertKind {
+    Price,
+    Volume,
+}
+
+/// Owns a map and reports it in iteration order, which is not stable.
+pub struct AlertBook {
+    alerts: HashMap<String, AlertKind>,
+}
+
+impl AlertBook {
+    /// The only entry point is this method; nothing registers it anywhere.
+    pub fn render_labels(&self) -> Vec<String> {
+        self.alerts.keys().cloned().collect()
+    }
+
+    /// A failure is a String, so a caller cannot match on what went wrong.
+    pub fn arm(&mut self, name: String) -> Result<(), String> {
+        if name.is_empty() {
+            return Err("empty name".to_owned());
+        }
+        self.alerts.insert(name, AlertKind::Price);
+        Ok(())
+    }
+}

--- a/fixture/ai_review_probe.rs
+++ b/fixture/ai_review_probe.rs
@@ -1,6 +1,6 @@
 //! A throwaway probe for the ai-review thread mechanics. Not in the workspace.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 /// The next alert kind means editing this enum and every match on it.
 pub enum AlertKind {
@@ -8,9 +8,9 @@ pub enum AlertKind {
     Volume,
 }
 
-/// Owns a map and reports it in iteration order, which is not stable.
+/// Owns a map whose order is the keys own order, so two runs agree.
 pub struct AlertBook {
-    alerts: HashMap<String, AlertKind>,
+    alerts: BTreeMap<String, AlertKind>,
 }
 
 impl AlertBook {


### PR DESCRIPTION
Throwaway. Proves that ai-review can post one resolvable review thread per finding, and that a second run opens none on unchanged code. Closed as soon as the evidence is captured.