### PR TITLE
fix(app): keep previous-day replay download alive

### DIFF
--- a/crates/app/src/replay_get_data.rs
+++ b/crates/app/src/replay_get_data.rs
@@ -424,7 +424,9 @@ impl GetDataPanel {
             if let Some(finished) = self.absorb(event) {
                 action = Some(finished);
                 ended = true;
-            } else if !matches!(self.phase, Phase::Probing | Phase::Running { .. }) {
+            } else if !matches!(self.day_before_stage, Some(DayBeforeStage::Running { .. }))
+                && !matches!(self.phase, Phase::Probing | Phase::Running { .. })
+            {
                 ended = true;
             }
         }
@@ -1776,6 +1778,38 @@ mod tests {
             !matches!(panel.phase, Phase::Failed { .. }),
             "the chosen day's download did not fail"
         );
+    }
+
+    /// The chosen day's phase stays finished while its optional predecessor is
+    /// fetched. Progress from that second worker must not make `poll` mistake
+    /// the finished first phase for the end of the still-running second job.
+    #[test]
+    fn day_before_progress_keeps_its_job_connected() {
+        let mut panel = panel_on("2026-08-31");
+        panel.phase = Phase::Finished {
+            ticks: 1_200,
+            sessions: 5,
+            complete: true,
+        };
+        panel.day_before_stage = Some(DayBeforeStage::Running {
+            day: "2026-08-28".to_string(),
+            ticks: 0,
+        });
+        let (sender, events) = std::sync::mpsc::channel();
+        sender
+            .send(DownloadEvent::Progress { ticks: 250_000 })
+            .expect("the live worker still owns its receiver");
+        panel.job = Some(DownloadJob::stopped_for_test(events));
+
+        let action = panel.poll();
+
+        assert!(action.is_none());
+        assert!(panel.job.is_some(), "the second worker is still running");
+        assert!(matches!(
+            panel.day_before_stage,
+            Some(DayBeforeStage::Running { ticks: 250_000, .. })
+        ));
+        drop(sender);
     }
 
     /// The caption under the tick and the tick itself are one statement. They


### PR DESCRIPTION
## Summary

- keep the chained previous-day replay download job connected while its progress events arrive
- prevent a finished primary-day phase from clearing the still-running predecessor job
- add a regression test for `Phase::Finished` together with `DayBeforeStage::Running`

Closes #312

## Verification loop

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets`
- [x] `cargo build --workspace`
- [x] `cargo test --workspace`

## Notes for the reviewer

- The selected day intentionally stays `Finished` while the optional preceding session is downloaded; the termination guard now considers both state machines.
- Existing completion, failure, disconnect, and cancellation paths remain unchanged and continue to consume the pending selected tape with `take()`.
- Architecture review of commit `271d38d`: native high-effort bug pass (the bundled code-review skill was unavailable in this Codex session), 0 findings; all nine shape dimensions reviewed, 0 Blockers and 0 Should-fix findings.
- Full delivery review used linked issue #312 and passed on round 2: 10/10 derived asks covered and 6/6 acceptance criteria delivered.
- No mission tier was recorded for this issue-started branch, so the full delivery review ran.
