### PR TITLE
docs(control): link the MCP tool reference

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,7 @@ boundary and the evidence each delivery left behind.
 | Document | What it settles |
 | --- | --- |
 | [`control-plane/README.md`](control-plane/README.md) | The directory's own index, its precedence order and its change policy |
+| [`../crates/mcp/README.md`](../crates/mcp/README.md) | The MCP adapter's tool-by-tool reference, setup flow and evidence-bundle semantics |
 | [`mcp-control-plane-development-plan.md`](mcp-control-plane-development-plan.md) | Scope and delivery sequence — it owns ordering; the contract owns details |
 | [`control-plane/control-contract.md`](control-plane/control-contract.md) | Identifier, schema, revision, authority, limit, tool-surface, determinism and trade-annotation rules |
 | [`control-plane/adr-0001-local-transport-and-instance-discovery.md`](control-plane/adr-0001-local-transport-and-instance-discovery.md) | Why the transport is an authenticated loopback socket and how a client discovers a running instance |


### PR DESCRIPTION
## Summary

Add the MCP adapter's tool-by-tool reference to the documentation index so readers can reach setup, tool, and evidence-bundle details directly from the control-plane section.

Closes #320

## Verification loop

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets`
- [x] `cargo build --workspace`
- [x] `cargo test --workspace`

## Notes for the reviewer

Documentation-only change: one table row in `docs/README.md`; no runtime or contract behavior changes.

Arch review step 0: native correctness review at high (no mission tier; exact branch diff inspected), zero findings. Documentation shape dimensions were waived; language and the link target were checked.

Delivery review: PASS against issue #320; all three derived asks are covered and both acceptance criteria are delivered.
