### PR TITLE
docs(campaign): route each child to a model and record the choice

### DIFF
--- a/.agents/references/codex-compatibility.md
+++ b/.agents/references/codex-compatibility.md
@@ -8,6 +8,8 @@ done. Translate only these host mechanics:
 - A mission authorizes the Codex goal facility; otherwise use `GOAL.md`.
 - `/code-review` means native review or direct inspection of the named diff.
 - Give a fresh subagent only its dossier; use fast models for retrieval,
-  balanced for checklists and the strongest for judgment.
+  balanced for checklists and the strongest for judgment. A campaign
+  `executor:` line maps the same way: `haiku` fast, `sonnet` balanced, `opus`
+  the default coding model, `fable` the strongest.
 - Translate POSIX examples without changing order, worktree, markers or failure.
 - `.codex/hooks.json` runs shared guardrails without adding permissions.

--- a/.claude/GOAL-archive-campaign-model-routing.md
+++ b/.claude/GOAL-archive-campaign-model-routing.md
@@ -1,0 +1,59 @@
+# Mission: campaign model routing
+
+Add a Routing section to `docs/campaign/workflow.md` so the campaign
+coordinator chooses, records and honours the model that executes each child
+task — on resume and under Codex alike.
+
+**Tier:** small — one prose section in a normative contract plus two one-line
+agreements (`state.md` field list, Codex role mapping) and a signed ratchet
+raise. No code, no UI, no trader call among the asks: the trader dictated every
+rule, so there was nothing to interrogate.
+
+## Request ledger
+
+- **R1** — A "Routing" section in `docs/campaign/workflow.md` lets the coordinator choose, per child task, which model executes it.
+- **R2** — The choice is recorded so resume and Codex honour it (purpose; judges the rest).
+- **R3** — Rules are stated by role so Codex can map them via `.agents/references/codex-compatibility.md`.
+- **R4** — The coordinator runs on the strongest model (Fable).
+- **R5** — A child mission defaults to the strong implementation model (Opus, `Agent` with model "opus").
+- **R6** — Escalate a child to the strongest model when it is tier high or max, designs a new port or crate boundary, breaks a module cycle, or touches engine determinism or a hot path.
+- **R7** — Escalate when an Opus child came back from two review rounds with findings "flat rather than shrinking".
+- **R8** — Retrieval and measurement go to haiku, checklist application to sonnet, as `CLAUDE.md` says.
+- **R9** — The coordinator writes `executor: <model> — <reason>` into each child issue before dispatch.
+- **R10** — A resumed campaign reads the executor line rather than re-deciding.
+- **R11** — The coordinator runs the child's interrogation (mission step 3) before dispatch and passes the answers in the brief as decisions.
+- **R12** — A doubt the child meets later becomes a human-task, never a guess.
+- **R13** — State only rules that decide an outcome; keep the section short (context ratchet).
+
+## Assumptions
+
+- **S1** — The Codex mapping gains one sentence mapping each `executor:` model name to a role. Without it "Codex honours it" has no mapping for the implementation role, which the existing three-role bullet lacks. Safe: additive, one edit to reverse.
+- **S2** — `state.md`'s child field list gains `executor`, so the two campaign contracts agree on what a child issue carries. Safe: one word, within that file's ceiling.
+- **S3** — "Escalate after two flat rounds" reads as re-dispatching the remaining work at *strongest*, and every escalation appends a new executor line; the latest line wins. Safe: the only reading that keeps R10 decidable.
+- **S4** — A child that raises its own tier to high or max after dispatch returns to the coordinator for re-routing; otherwise R6's tier trigger could be dodged by a late raise. Safe: mirrors mission's "a tier goes up, never down".
+- **S5** — "A doubt the child meets later" means a doubt that would have earned a mission step 3 question; items mission already settles as `S` assumptions (conventional defaults) stay assumptions. Safe: the reading that does not contradict mission step 3.
+- **S6** — The ~1,281-byte growth is a signed ceiling raise paid from the budget's unused room, `!budget` unchanged — the precedent `ai-review` set. Safe: the guard enforces the total either way.
+
+## Acceptance criteria
+
+- [x] **A1** — `docs/campaign/workflow.md` has a `## Routing` section, linked from run-loop step 3, that names a model per child. *Evidence:* quoted section. → PR body. *(R1, R2)*
+- [x] **A2** — Rules are phrased by role (*strongest*, *implementation*, *checklist*, *retrieval*), and the Codex mapping maps each executor model to a Codex role. *Evidence:* quoted section and `codex-compatibility.md` diff. → PR body. *(R3, R2)*
+- [x] **A3** — Coordinator at *strongest*; children at *implementation* via `Agent` `model: "opus"`; the five escalation triggers; retrieval/measurement at haiku and checklists at sonnet. *Evidence:* quoted section. → PR body. *(R4, R5, R6, R7, R8)*
+- [x] **A4** — The executor line is written before dispatch and resume/Codex read it, never re-decide. *Evidence:* quoted section, `state.md` field. → PR body. *(R9, R10, R2)*
+- [x] **A5** — The coordinator runs the child's step 3 and passes decisions in the brief; later doubts become human tasks. *Evidence:* quoted section. → PR body. *(R11, R12)*
+- [x] **A6** — The section holds operative rules only and the growth is signed in the context baseline. *Evidence:* byte count and `context-baseline.txt` diff; `cargo test -p quantick-guards` green. → PR body. *(R13)*
+- [x] **G1** — Every authored artifact is English, bar this file's verbatim request. *Evidence:* `crates/guards/src/language.rs` via `cargo test`; arch-review dimension 8. → PR body.
+- [x] **G2** — fmt, clippy, build and test green on latest `origin/main`; performance impact declared: none (prose and a baseline number, no runtime path). *Evidence:* the four exit codes. → PR body.
+- [ ] **G3** — `arch-review` (docs change: step 0 plus dimension 8) run, every Blocker/Should-fix resolved or deferred. *Evidence:* review verdict. → PR body.
+
+Not applicable: hot path, UI, capability, trader action and engine gates — the diff is prose plus one baseline number.
+
+## Closing steps
+
+- **C1** — PR open, naming the tier.
+
+## Request as received
+
+> Add model routing to the campaign coordinator. In docs/campaign/workflow.md, add a "Routing" section that lets the coordinator choose, per child task, which model executes it, and records that choice so resume and Codex honour it. Rules, stated by role so Codex can map them (.agents/references/codex-compatibility.md): the coordinator runs on the strongest model (Fable); a child mission defaults to the strong implementation model (Opus, via Agent with model "opus"); the coordinator escalates a child to the strongest model when the child is tier high or max, designs a new port or crate boundary, breaks a module cycle, touches engine determinism or a hot path, or when an Opus child came back from two review rounds with its findings flat rather than shrinking; retrieval and measurement go to haiku and checklist application to sonnet, as CLAUDE.md already says. The coordinator writes "executor: <model> — <reason>" into each child issue before dispatch, and a resumed campaign reads it from there rather than re-deciding. Because a subagent cannot ask the trader anything, the coordinator runs the child's interrogation (mission step 3) itself before dispatching and passes the answers in the child's brief as decisions; a doubt the child meets later becomes a human-task, never a guess. State only rules that decide an outcome; keep the section short, since the context ratchet counts skill prose.
+>
+> — the trader, `/mission small`, 2026-09-11

--- a/crates/guards/context-baseline.txt
+++ b/crates/guards/context-baseline.txt
@@ -188,7 +188,12 @@ AGENTS.md 13179
 # owns review source reconciliation and bounded repair. Sub-threshold contract
 # files contribute their full measured bytes to the budget as usual.
 docs/campaign/state.md 14602
-docs/campaign/workflow.md 10297
+# +1,281 for the campaign's Routing section: which model runs each child, the
+# `executor:` line resume and Codex honour, and the coordinator running the
+# child's interrogation because a subagent cannot ask the trader. A raise, not
+# a trade: the tracked total stays under the unchanged budget. Every line of
+# it decides a dispatch, so there was no reasoning to move out.
+docs/campaign/workflow.md 11578
 # Authorized continuation: standing process delegation and finite stall
 # allowances add 445 bytes. Paid by condensing duplicated initial validation
 # commentary; its original evaluator responses remain intact. Budget unchanged.

--- a/crates/guards/context-baseline.txt
+++ b/crates/guards/context-baseline.txt
@@ -188,12 +188,12 @@ AGENTS.md 13179
 # owns review source reconciliation and bounded repair. Sub-threshold contract
 # files contribute their full measured bytes to the budget as usual.
 docs/campaign/state.md 14602
-# +1,281 for the campaign's Routing section: which model runs each child, the
+# +1,277 for the campaign's Routing section: which model runs each child, the
 # `executor:` line resume and Codex honour, and the coordinator running the
 # child's interrogation because a subagent cannot ask the trader. A raise, not
 # a trade: the tracked total stays under the unchanged budget. Every line of
 # it decides a dispatch, so there was no reasoning to move out.
-docs/campaign/workflow.md 11578
+docs/campaign/workflow.md 11574
 # Authorized continuation: standing process delegation and finite stall
 # allowances add 445 bytes. Paid by condensing duplicated initial validation
 # commentary; its original evaluator responses remain intact. Budget unchanged.

--- a/docs/campaign/state.md
+++ b/docs/campaign/state.md
@@ -19,8 +19,8 @@ index, decision log links, and latest checkpoint link. Add marker
 `<!-- quantick-campaign:v1 -->` for discovery.
 
 Each child has a stable task key, parent URL, reviewable outcome, criteria and
-evidence destinations, priority, risk/validation plan, owner class, dependency
-keys with satisfaction conditions, issue URL/ID, Project item ID, branch,
+evidence destinations, priority, risk/validation plan, owner class, executor,
+dependency keys with satisfaction conditions, issue URL/ID, Project item ID, branch,
 worktree owner, PR URL/head/base and checkpoint links. Unknown IDs are null,
 never guessed. Use native parent/sub-issue and dependency relationships where
 available; the explicit issue links and conditions remain the portable record.

--- a/docs/campaign/state.md
+++ b/docs/campaign/state.md
@@ -20,8 +20,8 @@ index, decision log links, and latest checkpoint link. Add marker
 
 Each child has a stable task key, parent URL, reviewable outcome, criteria and
 evidence destinations, priority, risk/validation plan, owner class, executor,
-dependency keys with satisfaction conditions, issue URL/ID, Project item ID, branch,
-worktree owner, PR URL/head/base and checkpoint links. Unknown IDs are null,
+dependency keys with satisfaction conditions, issue URL/ID, Project item ID,
+branch, worktree owner, PR URL/head/base and checkpoint links. Unknown IDs are null,
 never guessed. Use native parent/sub-issue and dependency relationships where
 available; the explicit issue links and conditions remain the portable record.
 

--- a/docs/campaign/workflow.md
+++ b/docs/campaign/workflow.md
@@ -84,8 +84,8 @@ For each cycle:
    priority and stable task keys.
    An unresolved human task blocks only its dependents. If no implementation
    is ready, monitor active CI/reviews or perform other authorized reconciliation.
-3. Claim the task and persist the intended action before mutating. `new-task`
-   owns duplicate checks and the isolated worktree from the integration base. `mission`
+3. Claim the task, [route it](#routing) and persist the intended action
+   before mutating. `new-task` owns duplicate checks and the isolated worktree from the integration base. `mission`
    owns the task ledger and gates: one child mission per implementation/PR,
    never one giant mission/worktree for the campaign. Reuse an existing branch
    only after checking its owner and cleanliness; never reset another writer.
@@ -104,6 +104,28 @@ For each cycle:
    task when safe, synchronize Project items, and continue. An issue closed
    without acceptance evidence remains blocked in the campaign; reopen or
    repair only within granted issue-management authority.
+
+## Routing
+
+Roles, mapped per host by [Codex compatibility](../../.agents/references/codex-compatibility.md):
+*strongest* (`fable`), *implementation* (`opus`), *checklist* (`sonnet`),
+*retrieval* (`haiku`). The coordinator runs at *strongest*.
+
+- A child mission runs at *implementation* (`Agent` with `model: "opus"`),
+  or at *strongest* when it is tier `high` or `max`, designs a new port or
+  crate boundary, breaks a module cycle, or touches engine determinism or a
+  hot path. A child that raises its tier to `high` or `max` returns for
+  re-routing.
+- An *implementation* child back from two review rounds with its findings
+  flat rather than shrinking is re-dispatched at *strongest*.
+- Retrieval and measurement run at *retrieval*, checklist application at
+  *checklist*, per `CLAUDE.md`.
+- Before each dispatch, append `executor: <model> — <reason>` to the child
+  issue. Resume and Codex run the latest line; they never re-decide it.
+- A subagent cannot ask the trader. The coordinator runs the child's `mission`
+  step 3 itself before dispatch and passes the answers in the brief as
+  decisions `D1`…`Dn`. A later doubt that would earn a step 3 question becomes
+  a `human_decision` [human task](state.md#human-task-template), never a guess.
 
 ## Validation
 

--- a/docs/campaign/workflow.md
+++ b/docs/campaign/workflow.md
@@ -85,9 +85,10 @@ For each cycle:
    An unresolved human task blocks only its dependents. If no implementation
    is ready, monitor active CI/reviews or perform other authorized reconciliation.
 3. Claim the task, [route it](#routing) and persist the intended action
-   before mutating. `new-task` owns duplicate checks and the isolated worktree from the integration base. `mission`
-   owns the task ledger and gates: one child mission per implementation/PR,
-   never one giant mission/worktree for the campaign. Reuse an existing branch
+   before mutating. `new-task` owns duplicate checks and the isolated
+   worktree from the integration base. `mission` owns the task ledger and
+   gates: one child mission per implementation/PR, never one giant
+   mission/worktree for the campaign. Reuse an existing branch
    only after checking its owner and cleanliness; never reset another writer.
 4. Implement and validate according to affected behavior. `ship` owns commits,
    PR creation, checks and repairs; `arch-review`, `delivery-review` and
@@ -123,7 +124,7 @@ Roles, mapped per host by [Codex compatibility](../../.agents/references/codex-c
 - Before each dispatch, append `executor: <model> — <reason>` to the child
   issue. Resume and Codex run the latest line; they never re-decide it.
 - A subagent cannot ask the trader. The coordinator runs the child's `mission`
-  step 3 itself before dispatch and passes the answers in the brief as
+  step 3 before dispatch and passes the answers in the brief as
   decisions `D1`…`Dn`. A later doubt that would earn a step 3 question becomes
   a `human_decision` [human task](state.md#human-task-template), never a guess.
 


### PR DESCRIPTION
Add a Routing section to `docs/campaign/workflow.md` so the campaign coordinator chooses, records and honours the model that executes each child task — on resume and under Codex alike.

**Mission tier: `small`** — prose in two campaign contracts, one Codex mapping sentence, one signed baseline number. `delivery-review` not owed (48 of 300 changed lines); `arch-review` run. Mission record: `.claude/GOAL-archive-campaign-model-routing.md`.

## What changed

- **`docs/campaign/workflow.md` — `## Routing`**, linked from run-loop step 3 ("Claim the task, route it and persist…"):
  - Roles: *strongest* (`fable`), *implementation* (`opus`), *checklist* (`sonnet`), *retrieval* (`haiku`); the coordinator runs at *strongest*.
  - A child runs at *implementation* (`Agent` with `model: "opus"`), or at *strongest* when it is tier `high`/`max`, designs a new port or crate boundary, breaks a module cycle, or touches engine determinism or a hot path. A child that raises its own tier to `high`/`max` comes back to be routed again.
  - An *implementation* child whose findings stayed flat, not shrinking, over two review rounds is re-dispatched at *strongest*.
  - Retrieval and measurement run at *retrieval*; checklist application runs at *checklist*, per `CLAUDE.md`.
  - Before each dispatch, the coordinator appends `executor: <model> — <reason>` to the child issue. Resume and Codex run the latest line and never re-decide it.
  - The coordinator runs the child's `mission` step 3 before dispatch and passes the answers in the brief as `D1`…`Dn`. A later doubt that would earn a step 3 question becomes a `human_decision` human task, never a guess.
- **`.agents/references/codex-compatibility.md`** — an `executor:` line maps by role: `haiku` fast, `sonnet` balanced, `opus` the default coding model, `fable` the strongest.
- **`docs/campaign/state.md`** — `executor` joins the fields every child issue carries, so both contracts list the same fields.
- **`crates/guards/context-baseline.txt`** — `workflow.md` ceiling 10,297 → 11,574 (+1,277), signed in the file. The `!budget` line is unchanged: the tracked total is 293,799 against 295,668.

## Assumptions (from the mission record)

- S3: escalating after two flat rounds re-dispatches the remaining work, and each escalation adds a new executor line; the latest line wins.
- S4: a child that raises its tier after dispatch comes back to be routed again. Otherwise it could raise its tier late and never trigger the escalation.
- S5: "a doubt the child meets later" means one that would have earned a step 3 question. Conventional defaults that mission already records as `S` assumptions stay assumptions.
- S6: the growth is a signed raise paid from budget headroom, the precedent `ai-review` set, rather than a cut elsewhere.

## Verification

- [x] `cargo fmt --all -- --check` — exit 0
- [x] `cargo clippy --workspace --all-targets` — exit 0
- [x] `cargo build --workspace` — exit 0
- [x] `cargo test --workspace` — exit 0, 96 suites ok. Run with `QUANTICK_BUBBLES` unset: the local shell points it at the live `bubbles.toml`, and with it set two `orderflow_view` tests fail for environmental reasons. This diff touches no code.

Performance impact: none. The diff is prose plus one baseline number and touches no runtime path.

## arch-review (graded at `6bedbce9`)

step 0: code-review at low (effort-first, no reuse notice), 0 findings. Scoped to `origin/main...HEAD`. The first round, at `f590b8fb`, also returned 0 and asked for two cross-references to be checked; both hold (`state.md` `## Human task template`, owner class `human_decision`). Docs-only change, so shape dimensions 1–7 and 9 are waived; 8 was graded.

- **Correctness** — 0 findings in both step 0 rounds; nothing open.
- **Docking** — no surface; a prose contract.
- **Performance** — flat; no runtime path.
- **Operability** — no surface. The executor line is plain text in the issue, readable by any operator.
- **Proof** — `quantick-guards` context ratchet and language scan (`cargo test --workspace`).
- **Accumulation** — `docs/campaign/workflow.md` +1,277 bytes, ceiling raised with a signed comment; `state.md` +10, within its ceiling; budget unchanged.
- **Language** — the guard passed; I read the prose, the branch name and all three commit messages myself: English.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FjrPkGDiZnhjs29CdkKs5Y
