### PR TITLE
test(app): force the interleavings the two load-sensitive tests assert

### DIFF
--- a/.claude/GOAL-archive-load-sensitive-tests.md
+++ b/.claude/GOAL-archive-load-sensitive-tests.md
@@ -1,0 +1,274 @@
+# Mission: force the interleavings the two load-sensitive tests assert
+
+Two tests make CI red at random: `delayed_producer_bookkeeping_does_not_block_real_flush_or_sample_recovery`
+(#361) pins one producer/worker interleaving that nothing in the fixture
+establishes, and `gateway_client_reads_the_running_application_and_wrong_tokens_fail_closed`
+(#364) asserts a refusal code where a loaded machine can instead produce a
+transport timeout. A+ gate 3 requires default-branch CI green at the assessed
+revision, and every child PR of campaign #367 inherits the exposure.
+
+**Tier:** `medium`. Campaign child Q1 of #367, assigned at `medium` by the
+coordinator: two independent test harnesses in two subsystems, each needing a
+design decision about where the ordering belongs, but no product change.
+
+## Request ledger
+
+- **R1** — #361: give the fixture a way to establish the delayed-producer
+  interleaving instead of hoping for it. Verbatim: *"so the delayed-producer
+  interleaving is established, not hoped for"*. Weakening the assertion to
+  `Some(1) | Some(2)` is forbidden. *(issue #361 "What a fix needs"; Q1
+  adoption comment, Scope bullet 1; D1, D3)*
+- **R2** — #364: assert the refusal reason separately from the transport
+  outcome, so a handshake that timed out under load reports as a timeout and
+  not as a wrong-code failure; or retry a transport-level failure a bounded
+  number of times before asserting the code. The test must still assert
+  `control.auth_failed` for each wrong credential. *(issue #364 "What a fix
+  probably needs"; Q1 adoption comment, Scope bullet 2; D1, D4)*
+- **R3** — No production change to worker-progress semantics, handshake
+  deadlines or authority, and no other tests touched. Verbatim: *"Out of
+  scope: any change to worker progress semantics, handshake deadlines in
+  production, or other tests."* *(Q1 adoption comment, Scope; D2)*
+- **R4** — `cargo test -p quantick-app delayed_producer_bookkeeping` passes
+  200 of 200 filtered runs under a concurrent `cargo build --workspace`, with
+  the property under test (sample recovery after a delayed producer) still
+  asserted. *(Q1 adoption comment, A1; D5)*
+- **R5** — `gateway_client_reads_the_running_application_and_wrong_tokens_fail_closed`
+  passes 200 of 200 runs under the same contention, still asserting
+  `control.auth_failed` for each wrong credential. *(Q1 adoption comment, A2;
+  D5)*
+- **R6** — Both issues' rate tables are extended with the after numbers, in
+  the PR body and as a comment on each issue. *(Q1 adoption comment, A3; D5)*
+- **R7** — The change ships through a PR whose base is exactly
+  `campaign/lean-a-plus`. *(Q1 adoption comment, A4; integration contract)*
+- **R8** — Purpose: default-branch CI stops going red at random on these two
+  tests, so gate 3 can be assessed. *(Q1 adoption comment, opening paragraph)*
+
+## Decisions (from the coordinator)
+
+- **D1** — Both tests are fixed in this one PR.
+- **D2** — No production change to worker-progress semantics, handshake
+  deadlines or authority. Only test/fixture/harness code changes. A genuinely
+  required production change stops the mission and is reported instead.
+- **D3** — #361 is fixed by giving the fixture a way to hold the producer's
+  sampling (the same shape `Gate::hold` gives the worker's phases), so the
+  delayed-producer interleaving is established. Weakening the assertion to
+  accept `Some(1) | Some(2)` is forbidden.
+- **D4** — #364 is fixed by asserting the refusal reason separately from the
+  transport outcome, or by retrying a transport-level failure a bounded number
+  of times before asserting the code; `control.auth_failed` stays asserted for
+  each wrong credential when the handshake completes.
+- **D5** — Proof of A1/A2: 200 filtered iterations of each test while a
+  concurrent `cargo build --workspace` competes for CPU, before and after the
+  fix; both tables recorded in the PR body and on both issues.
+- **D6** — Tier `medium`: `arch-review` with `code-review` at `low` and the
+  full shape pass; `delivery-review` completeness pass only, inline;
+  `ai-review` completion required.
+
+## Assumptions
+
+- **S1** — *Wanted to ask.* D3 asks for a hold on the producer's sampling. The
+  producer's sampling is `WorkerProgress::record_send`, which the fixture calls
+  on its own thread: its timing is already fully under the test's control, so a
+  producer-side hold cannot remove any interleaving. The unforced party is the
+  worker consumer, which reads the sample slot inside `SharedProgress::begin`
+  before it signals `Phase::Applying`, so no existing phase callback can fence
+  that read, and adding one would be the production change D2 forbids. The
+  fixture therefore establishes the interleaving with the mechanism D3 names —
+  `Gate::hold` — applied to the worker: the worker is parked in the `Phase::Idle`
+  callback that ends the previous cycle, so the producer's whole S2 step
+  completes before the worker can admit it. This is exactly the pattern the S3
+  step of the same schedule already uses; S2 was the one step that omitted it.
+  Safe to assume because it satisfies D3's operative requirement (the
+  interleaving is established, not hoped for) with no production change, and
+  because the alternative readings all require touching `worker_progress.rs`.
+- **S2** — *Wanted to ask.* Parking the worker in the `Phase::Idle` callback of
+  the S1 cycle moves the S1 flush acknowledgement after the producer's late
+  `record_send`, because the worker sends flush acknowledgements only after
+  `finish()` returns. The S1 property ("delayed producer bookkeeping does not
+  block the real flush") is preserved and strengthened by asserting, at the
+  parked point, that the worker completed the whole cycle — `Phase::Idle`,
+  `cycles == 1`, `mailbox_replacements == 1` — while the producer had still
+  recorded no acceptance at all. Safe to assume because the observable property
+  is stronger, not weaker.
+- **S3** — A handshake that misses its deadline surfaces as
+  `control.instance_gone` (`instance_gone_error()` in
+  `crates/control-local/src/client.rs`), which is the transport outcome D4
+  separates from the refusal reason. Read from the code, not from a captured
+  failure — #364 records that the failing assertion was never captured.
+- **S4** — The bounded retry count for a transport-level handshake failure is
+  four attempts. Nobody chose a number; four keeps a genuinely broken gateway
+  loud while absorbing a loaded machine, and the exhaustion message names the
+  transport outcome so it can never be read as a wrong-code failure.
+- **S5** — *Wanted to ask.* #364's presumed mechanism is disproved by the first
+  capture of its failure. Under this mission's contention the test failed at
+  `control_plane_tests.rs:852` — "the application frame must drain the queued
+  gateway request", left 1 right 0 — never at a handshake assertion. The drain
+  is bounded by `CONTROL_UI_BUDGET_US` (250 microseconds per frame), which a
+  loaded machine can spend before the drain starts. The evidence-driven repair
+  is therefore the one shipped; D4's hardening is also applied, because it
+  costs little and the handshake path carries the same class of exposure. Safe
+  to assume because A2 — 200 of 200 under contention, `control.auth_failed`
+  still asserted for each wrong credential — is met either way, and applying
+  only D4's reading would have left the test failing at the same rate.
+- **S6** — A third load-sensitive point in the same test, its teardown
+  (`disable_test_gateway`, "test gateway did not stop cleanly"), surfaced after
+  the first repair. Its waiters counted 400 sleep iterations rather than
+  elapsed time; they are now bounded by wall clock. These are shared harness
+  helpers rather than "other tests": no other test's asserted property changes,
+  only how long each waits, so this stays inside the scope line.
+- **S7** — Two sibling control-plane tests
+  (`a_retry_that_races_its_own_first_call_is_refused_rather_than_acted_on`,
+  `gateway_a_client_that_never_reads_does_not_stall_another`) carry the same
+  exposure and are explicitly out of scope. Measured at the same rate before
+  and after this diff (3 failures in 26 full-suite runs on each binary), so
+  nothing here regressed them; reported to the coordinator instead of fixed.
+
+## Acceptance criteria
+
+- [x] **A1** — The #361 schedule establishes the producer/worker interleaving
+      it asserts: the producer's ticket-2 acceptance is recorded before the
+      worker can admit it, and `last_sampled_ticket` is `Some(1)` by
+      construction rather than by luck. The assertion is not weakened.
+      *Evidence:* the diff of `crates/app/src/worker_progress/tests/protocol.rs`
+      plus the after table below. → PR body. *(R1, R3)*
+- [x] **A2** — `cargo test -p quantick-app delayed_producer_bookkeeping` passes
+      200 of 200 filtered runs under a concurrent `cargo build --workspace`.
+      *Evidence:* the before/after run table. → PR body and a comment on #361.
+      *(R4, R6)*
+- [x] **A3** — The #364 test separates the refusal reason from the transport
+      outcome: a handshake that fails at the transport level is retried a
+      bounded number of times and, if it never completes, reported as a
+      transport failure naming `control.instance_gone`, never as a wrong-code
+      failure. `control.auth_failed` stays asserted for the wrong bearer token,
+      the wrong instance id and the wrong process nonce.
+      *Evidence:* the diff of `crates/app/src/app/tests/control_plane_tests.rs`.
+      → PR body. *(R2, R3)*
+- [x] **A4** — `gateway_client_reads_the_running_application_and_wrong_tokens_fail_closed`
+      passes 200 of 200 runs under the same contention.
+      *Evidence:* the before/after run table. → PR body and a comment on #364.
+      *(R5, R6)*
+- [x] **A5** — No file outside the two test modules changes behaviour; nothing
+      under `crates/app/src/worker_progress.rs`, `crates/app/src/control/` or
+      `crates/control*/src/` is modified. *Evidence:* `git diff --stat` against
+      the campaign base. → PR body. *(R3)*
+- [ ] **A6** — The PR base is exactly `campaign/lean-a-plus` and the PR links
+      #361, #364 and campaign #367. *Evidence:* `gh pr view` base field. → PR.
+      *(R7)*
+
+## Injected gates
+
+- [x] **G1** — Every artifact in English; conventional commits.
+      *Evidence:* `cargo test -p quantick-guards` and the commit log. → PR body.
+- [x] **G2** — `cargo fmt --all -- --check`, `cargo clippy --workspace
+      --all-targets`, `cargo build --workspace`, `cargo test --workspace`, each
+      run on its own, green at the final head. *Evidence:* command exit codes.
+      → PR body.
+- [x] **G3** — Performance impact declared per touched path by rate.
+      *Evidence:* a paragraph in the PR body. Expected: test-only, rare path.
+      → PR body.
+- [ ] **G4** — `arch-review` over the exact diff against `origin/campaign/lean-a-plus`,
+      its step 0 bug pass included, every Blocker and Should-fix resolved or
+      deferred in the PR body; `ai-review` completion recorded;
+      `delivery-review` completeness pass. *Evidence:* review verdicts and the
+      recorded markers. → PR body.
+- [ ] **G5** — CI green at the final PR head. *Evidence:* `gh pr checks`.
+      → PR.
+
+## Not applicable
+
+- *Touches a hot path* — the diff is confined to `#[cfg(test)]` modules; no
+  per-trade, per-depth or per-frame path is touched.
+- *Touches anything user-visible* — no UI surface changes, so `ui-harness`,
+  `visual-qa` and `trader-ux-review` do not apply.
+- *Adds a capability* — nothing docks; no new feed, bar type, indicator, layer,
+  panel or crate.
+- *Adds something a trader does* — no new action, tool, trade or lock.
+- *Engine / determinism territory* — the change is itself a determinism repair
+  in a test harness; no engine code and no golden fixture changes.
+- *Docs/skills only* — this is a code change, so the full shape pass applies.
+
+## Measured evidence
+
+All runs on this machine, one filtered test per process, `--test-threads=1`,
+while a loop of `cargo build --workspace` over the whole workspace competed for
+all twelve cores.
+
+| Test | Binary | Runs | Failures | Failure seen |
+| --- | --- | ---: | ---: | --- |
+| #361 `delayed_producer_bookkeeping…` | before | 200 | 1 | `protocol.rs:92`, left `Some(2)` right `Some(1)` |
+| #361 `delayed_producer_bookkeeping…` | after | 200 | 0 | — |
+| #364 `gateway_client_reads…` | before | 200 | 1 | `control_plane_tests.rs:852`, "the application frame must drain the queued gateway request", left 1 right 0 |
+| #364 `gateway_client_reads…` | after, first repair | 200 | 1 | `mod.rs:1970`, "test gateway did not stop cleanly" |
+| #364 `gateway_client_reads…` | after, final | 200 | 0 | — |
+
+Whole `quantick-app` test binary, 26 runs of each binary, same machine:
+
+| Binary | Runs | Failures | Which tests |
+| --- | ---: | ---: | --- |
+| before | 26 | 3 | `a_retry_that_races_its_own_first_call_is_refused_rather_than_acted_on` ×3 |
+| after | 26 | 3 | `a_retry_that_races…` ×1, `gateway_a_client_that_never_reads_does_not_stall_another` ×2 |
+
+Neither in-scope test dropped in any of those 52 full-suite runs; the two
+sibling tests that did are explicitly out of scope (S7) and fail at the same
+rate on both binaries.
+
+## Closing steps
+
+- **C1** — `delivery-review` returns PASS (completeness pass, tier `medium`).
+- **C2** — The PR is open against `campaign/lean-a-plus` and marked ready.
+- **C3** — The after numbers are posted as a comment on #361 and on #364.
+
+## The request as received, verbatim
+
+> *Attributed quotation under `CLAUDE.md`'s language exemption; the campaign
+> task comment is reproduced as it stands on both issues.*
+
+### Q1 adoption comment (identical on #361 and #364)
+
+> <!-- campaign-task:milocaetano/quantick#367/Q1 -->
+> ## Campaign child: gate 3 reliability
+>
+> Campaign child of https://github.com/milocaetano/quantick/issues/367 (task key Q1). Base: `campaign/lean-a-plus`. Mission tier: medium. This comment adopts this issue and #364 together as one mission (it owns criterion SE5, scored 4 at this SHA for exactly these two tests): both are load-sensitive tests that make default-branch CI red at random (about one run in eighty under CPU contention; main run 34619523514 at `47004db5` failed on the #361 test and the rerun at `e8eb23e543dcc827c16c7c552478e7ebf2150a4f` passed). A+ gate 3 requires default-branch CI green at the assessed revision, and every child PR of this campaign inherits the exposure, so this mission dispatches first.
+>
+> ### Scope
+>
+> - #361: give the fixture a way to hold the producer's sampling the way `Gate::hold` holds the worker's phases, so "the producer's bookkeeping is still delayed" is a fact the test establishes. Weakening the assertion to `Some(1) | Some(2)` is not the fix.
+> - #364: assert the refusal reason separately from the transport outcome, so a handshake that timed out under load reports as a timeout, not as a wrong-code failure; or retry a transport failure before asserting, whichever the transport owner's reading supports. No product change to timeouts or authority.
+> - Out of scope: any change to worker progress semantics, handshake deadlines in production, or other tests.
+>
+> ### Acceptance criteria
+>
+> - [ ] A1: `cargo test -p quantick-app delayed_producer_bookkeeping` passes 200 of 200 filtered runs while a concurrent `cargo build --workspace` competes for CPU, and the property under test (sample recovery after a delayed producer) is still asserted.
+> - [ ] A2: `gateway_client_reads_the_running_application_and_wrong_tokens_fail_closed` passes 200 of 200 runs under the same contention, still asserting `control.auth_failed` for each wrong credential.
+> - [ ] A3: both issues' rate tables are extended with the after numbers in the PR.
+> - [ ] A4: merged into `campaign/lean-a-plus` through a PR whose base is exactly that branch, with the merge read back.
+>
+> ## Gates
+>
+> - G1: every artifact English; conventional commits.
+> - G2: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets`, `cargo build --workspace`, `cargo test --workspace` green on the final head, run one at a time.
+> - G3: `arch-review` over the exact diff against the campaign base, its step 0 bug pass included; every Blocker and Should-fix resolved or deferred in the PR body. `ai-review` completion recorded. `delivery-review` per tier.
+> - G4: performance impact declared per touched path by rate; no per-trade, per-depth or per-frame path grows with session length.
+>
+> ## Campaign assignment
+>
+> Parent: https://github.com/milocaetano/quantick/issues/367. Stable key: Q1. Class: autonomous. Priority: 1. Risk: low: test-only change in two test modules. Executor: opus - test harness design in two subsystems. Dependencies: none. Project item ID: null (Project writes pending token scope). Branch, worktree owner, PR URL/head: null until claimed in a parent checkpoint. Retry counters start at operation=0, repair=0 and persist by failure signature. Evidence destination: this issue's comments and the linked PR.
+> Validation plan: first row (tests changed): the two filtered tests under contention, then the full ordered loop before every commit, CI at the final head.
+
+### Issue #361 — "What fails"
+
+> `orderflow_worker::progress_tests::delayed_producer_bookkeeping_does_not_block_real_flush_or_sample_recovery`, at `crates/app/src/worker_progress/tests/protocol.rs:92`:
+>
+> ```text
+> assertion `left == right` failed
+>   left: Some(2)
+>  right: Some(1)
+> ```
+>
+> The second panic in the log, `fixture releases worker: Disconnected` at `crates/app/src/worker_progress/tests.rs:81`, is teardown unwinding after the first — not a separate defect.
+>
+> Observed in CI on [run 34528139191](https://github.com/milocaetano/quantick/actions/runs/34528139191/job/103041998612).
+
+### Issue #364 — "What fails"
+
+> `app::tests::control_plane_tests::gateway_client_reads_the_running_application_and_wrong_tokens_fail_closed`, during `cargo test --workspace`.

--- a/.claude/GOAL-archive-load-sensitive-tests.md
+++ b/.claude/GOAL-archive-load-sensitive-tests.md
@@ -219,6 +219,14 @@ rate on both binaries.
 - **C1** — `delivery-review` returns PASS (completeness pass, tier `medium`).
 - **C2** — The PR is open against `campaign/lean-a-plus` and marked ready.
 - **C3** — The after numbers are posted as a comment on #361 and on #364.
+- **C4** — The PR is merged into `campaign/lean-a-plus` and the merge is read
+  back (`mergedAt`, merge commit, campaign ref), then #361 and #364 are closed
+  explicitly. Owned by the campaign coordinator, not by this child: under
+  [the integration contract](../docs/campaign/integration.md) a child hands off
+  its reviewed PR and never merges. Recorded here because the Q1 comment's A4
+  asks for it — *"merged into `campaign/lean-a-plus` through a PR whose base is
+  exactly that branch, with the merge read back"* — and the half this child can
+  discharge (the PR and its base) is A6.
 
 ## The request as received, verbatim
 

--- a/.claude/GOAL-archive-load-sensitive-tests.md
+++ b/.claude/GOAL-archive-load-sensitive-tests.md
@@ -199,7 +199,9 @@ all twelve cores.
 | #361 `delayed_producer_bookkeeping…` | after | 200 | 0 | — |
 | #364 `gateway_client_reads…` | before | 200 | 1 | `control_plane_tests.rs:852`, "the application frame must drain the queued gateway request", left 1 right 0 |
 | #364 `gateway_client_reads…` | after, first repair | 200 | 1 | `mod.rs:1970`, "test gateway did not stop cleanly" |
-| #364 `gateway_client_reads…` | after, final | 200 | 0 | — |
+| #364 `gateway_client_reads…` | after, repaired | 200 | 0 | — |
+| #361 `delayed_producer_bookkeeping…` | final head | 200 | 0 | — |
+| #364 `gateway_client_reads…` | final head | 200 | 0 | — |
 
 Whole `quantick-app` test binary, 26 runs of each binary, same machine:
 

--- a/crates/app/src/app/tests/control_plane_tests.rs
+++ b/crates/app/src/app/tests/control_plane_tests.rs
@@ -782,6 +782,37 @@ fn a_new_generation_replaces_a_block_already_held() {
     );
 }
 
+/// Connect with a descriptor the gateway must refuse, and report the refusal
+/// code it answered with. A handshake that misses its deadline on a loaded
+/// machine fails at the transport level with `control.instance_gone`, which
+/// says nothing about the credential that was offered. That outcome is retried
+/// a bounded number of times and, if it never clears, reported as the transport
+/// failure it is — never as the wrong refusal code.
+fn refused_handshake_code(
+    credential: &str,
+    descriptor: &quantick_control::descriptor::InstanceDescriptor,
+    options: &quantick_control_local::client::ConnectOptions,
+) -> String {
+    use quantick_control::error::codes;
+    const ATTEMPTS: usize = 4;
+    for attempt in 1..=ATTEMPTS {
+        match quantick_control_local::client::LocalClient::connect(descriptor.clone(), options) {
+            Ok(_) => panic!("the gateway accepted {credential}, which it must refuse"),
+            Err(error) if error.code.as_str() == codes::INSTANCE_GONE => {
+                if attempt < ATTEMPTS {
+                    std::thread::sleep(std::time::Duration::from_millis(50));
+                }
+            }
+            Err(error) => return error.code.as_str().to_owned(),
+        }
+    }
+    panic!(
+        "the handshake offering {credential} never completed: all {ATTEMPTS} attempts failed at \
+         the transport level with {}, so the gateway never stated a refusal reason",
+        codes::INSTANCE_GONE
+    );
+}
+
 #[test]
 fn gateway_client_reads_the_running_application_and_wrong_tokens_fail_closed() {
     use quantick_control::{
@@ -807,37 +838,49 @@ fn gateway_client_reads_the_running_application_and_wrong_tokens_fail_closed() {
     let descriptor = client.descriptor().clone();
     let mut wrong_token = descriptor.clone();
     wrong_token.bearer_token = BearerToken::from_bytes([0xEE; 32]);
-    let error =
-        quantick_control_local::client::LocalClient::connect(wrong_token, &gateway_test_options())
-            .unwrap_err();
-    assert_eq!(error.code.as_str(), codes::AUTH_FAILED);
+    assert_eq!(
+        refused_handshake_code(
+            "a wrong bearer token",
+            &wrong_token,
+            &gateway_test_options()
+        ),
+        codes::AUTH_FAILED
+    );
 
     let mut wrong_instance = descriptor.clone();
     wrong_instance.instance_id = InstanceId::from_bytes([0xDD; 16]);
-    let error = quantick_control_local::client::LocalClient::connect(
-        wrong_instance,
-        &gateway_test_options(),
-    )
-    .unwrap_err();
-    assert_eq!(error.code.as_str(), codes::AUTH_FAILED);
+    assert_eq!(
+        refused_handshake_code(
+            "a wrong instance id",
+            &wrong_instance,
+            &gateway_test_options()
+        ),
+        codes::AUTH_FAILED
+    );
 
     let mut wrong_nonce = descriptor.clone();
     wrong_nonce.process_nonce = ProcessNonce::from_bytes([0xCC; 16]);
-    let error =
-        quantick_control_local::client::LocalClient::connect(wrong_nonce, &gateway_test_options())
-            .unwrap_err();
-    assert_eq!(error.code.as_str(), codes::AUTH_FAILED);
+    assert_eq!(
+        refused_handshake_code(
+            "a wrong process nonce",
+            &wrong_nonce,
+            &gateway_test_options()
+        ),
+        codes::AUTH_FAILED
+    );
 
     let mut non_overlapping_version = descriptor;
     non_overlapping_version.protocol_versions =
         ProtocolVersionRange::new(CURRENT_PROTOCOL_VERSION + 1, CURRENT_PROTOCOL_VERSION + 1)
             .unwrap();
-    let error = quantick_control_local::client::LocalClient::connect(
-        non_overlapping_version,
-        &gateway_test_options(),
-    )
-    .unwrap_err();
-    assert_eq!(error.code.as_str(), codes::VERSION_UNSUPPORTED);
+    assert_eq!(
+        refused_handshake_code(
+            "a protocol range this build does not speak",
+            &non_overlapping_version,
+            &gateway_test_options()
+        ),
+        codes::VERSION_UNSUPPORTED
+    );
 
     let request_id = client
         .send(
@@ -848,16 +891,10 @@ fn gateway_client_reads_the_running_application_and_wrong_tokens_fail_closed() {
         )
         .unwrap();
     wait_for_queued_gateway_requests(&app, 1);
-    run_frame(&mut app, &ctx);
-    assert_eq!(
-        app.control
-            .control_access
-            .as_ref()
-            .expect("control access is installed")
-            .queued_requests_for_test(),
-        0,
-        "the application frame must drain the queued gateway request"
-    );
+    // Application frames drain the queue; the socket thread never does. Under
+    // a 250-microsecond per-frame budget a loaded machine can need more than
+    // one frame, which is the budget working, not the drain failing.
+    drain_gateway_requests(&mut app, &ctx);
     let response = client.read().unwrap();
     assert_eq!(response.request_id, request_id);
     let first_revisions = response.module_revisions.clone();
@@ -887,7 +924,7 @@ fn gateway_client_reads_the_running_application_and_wrong_tokens_fail_closed() {
         )
         .unwrap();
     wait_for_queued_gateway_requests(&app, 1);
-    run_frame(&mut app, &ctx);
+    drain_gateway_requests(&mut app, &ctx);
     let repeated = client.read().unwrap();
     assert_eq!(repeated.request_id, again);
     assert_eq!(

--- a/crates/app/src/app/tests/control_plane_tests.rs
+++ b/crates/app/src/app/tests/control_plane_tests.rs
@@ -794,13 +794,18 @@ fn refused_handshake_code(
     options: &quantick_control_local::client::ConnectOptions,
 ) -> String {
     use quantick_control::error::codes;
+    /// Enough attempts that a machine busy for a moment still gets its answer,
+    /// few enough that a gateway which never answers stays loud.
     const ATTEMPTS: usize = 4;
+    /// Long enough to outlast the scheduling hiccup that cost the last attempt,
+    /// short enough that four of them do not dominate the test's runtime.
+    const BACKOFF: std::time::Duration = std::time::Duration::from_millis(50);
     for attempt in 1..=ATTEMPTS {
         match quantick_control_local::client::LocalClient::connect(descriptor.clone(), options) {
             Ok(_) => panic!("the gateway accepted {credential}, which it must refuse"),
             Err(error) if error.code.as_str() == codes::INSTANCE_GONE => {
                 if attempt < ATTEMPTS {
-                    std::thread::sleep(std::time::Duration::from_millis(50));
+                    std::thread::sleep(BACKOFF);
                 }
             }
             Err(error) => return error.code.as_str().to_owned(),

--- a/crates/app/src/app/tests/mod.rs
+++ b/crates/app/src/app/tests/mod.rs
@@ -1887,6 +1887,12 @@ fn enable_test_gateway_with_limits(
     wait_for_test_gateway_descriptor(app, ctx)
 }
 
+/// How long a test waits for another thread to reach a state. A fixed number
+/// of short sleeps is not a clock: on a loaded machine the iterations run out
+/// long before the work they are waiting for had its chance, and the wait then
+/// reports a defect where there is only contention.
+const GATEWAY_TEST_WAIT: std::time::Duration = std::time::Duration::from_secs(30);
+
 fn wait_for_test_gateway_descriptor(
     app: &mut QuantickApp,
     ctx: &egui::Context,
@@ -1910,12 +1916,6 @@ fn wait_for_test_gateway_descriptor(
     }
 }
 
-/// How long a test waits for another thread to reach a state. A fixed number
-/// of short sleeps is not a clock: on a loaded machine the iterations run out
-/// long before the work they are waiting for had its chance, and the wait then
-/// reports a defect where there is only contention.
-const GATEWAY_TEST_WAIT: std::time::Duration = std::time::Duration::from_secs(30);
-
 fn wait_for_queued_gateway_requests(app: &QuantickApp, expected: usize) {
     let deadline = std::time::Instant::now() + GATEWAY_TEST_WAIT;
     loop {
@@ -1937,15 +1937,14 @@ fn wait_for_queued_gateway_requests(app: &QuantickApp, expected: usize) {
     }
 }
 
-/// Run application frames until the gateway request queue is empty, and report
-/// how many frames that took. A frame admits up to
-/// `CONTROL_UI_MAX_REQUESTS_PER_FRAME` requests, but only inside
+/// Run application frames until the gateway request queue is empty. A frame
+/// admits up to `CONTROL_UI_MAX_REQUESTS_PER_FRAME` requests, but only inside
 /// `CONTROL_UI_BUDGET_US`; on a loaded machine the frame's other work can spend
 /// that budget before the drain even starts, and the queue then empties over
-/// several frames. The property a caller asserts is that application frames
-/// drain the queue — the socket thread never does — so how many frames the
-/// budget needed is reported rather than asserted.
-fn drain_gateway_requests(app: &mut QuantickApp, ctx: &egui::Context) -> usize {
+/// several frames. What a caller asserts by calling this is that application
+/// frames drain the queue — the socket thread never does — so how many frames
+/// the budget needed is reported only when the wait gives up.
+fn drain_gateway_requests(app: &mut QuantickApp, ctx: &egui::Context) {
     let deadline = std::time::Instant::now() + GATEWAY_TEST_WAIT;
     let mut frames = 0;
     loop {
@@ -1959,7 +1958,7 @@ fn drain_gateway_requests(app: &mut QuantickApp, ctx: &egui::Context) -> usize {
             .queued_requests_for_test()
             == 0
         {
-            return frames;
+            return;
         }
         assert!(
             std::time::Instant::now() < deadline,

--- a/crates/app/src/app/tests/mod.rs
+++ b/crates/app/src/app/tests/mod.rs
@@ -1891,7 +1891,8 @@ fn wait_for_test_gateway_descriptor(
     app: &mut QuantickApp,
     ctx: &egui::Context,
 ) -> std::path::PathBuf {
-    for _ in 0..400 {
+    let deadline = std::time::Instant::now() + GATEWAY_TEST_WAIT;
+    loop {
         run_frame(app, ctx);
         if let Some(path) = app
             .control
@@ -1901,13 +1902,23 @@ fn wait_for_test_gateway_descriptor(
         {
             return path;
         }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "test gateway did not publish discovery within {GATEWAY_TEST_WAIT:?}"
+        );
         std::thread::sleep(std::time::Duration::from_millis(5));
     }
-    panic!("test gateway did not publish discovery");
 }
 
+/// How long a test waits for another thread to reach a state. A fixed number
+/// of short sleeps is not a clock: on a loaded machine the iterations run out
+/// long before the work they are waiting for had its chance, and the wait then
+/// reports a defect where there is only contention.
+const GATEWAY_TEST_WAIT: std::time::Duration = std::time::Duration::from_secs(30);
+
 fn wait_for_queued_gateway_requests(app: &QuantickApp, expected: usize) {
-    for _ in 0..400 {
+    let deadline = std::time::Instant::now() + GATEWAY_TEST_WAIT;
+    loop {
         if app
             .control
             .control_access
@@ -1918,9 +1929,44 @@ fn wait_for_queued_gateway_requests(app: &QuantickApp, expected: usize) {
         {
             return;
         }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "gateway request queue did not reach {expected} within {GATEWAY_TEST_WAIT:?}"
+        );
         std::thread::sleep(std::time::Duration::from_millis(5));
     }
-    panic!("gateway request queue did not reach {expected}");
+}
+
+/// Run application frames until the gateway request queue is empty, and report
+/// how many frames that took. A frame admits up to
+/// `CONTROL_UI_MAX_REQUESTS_PER_FRAME` requests, but only inside
+/// `CONTROL_UI_BUDGET_US`; on a loaded machine the frame's other work can spend
+/// that budget before the drain even starts, and the queue then empties over
+/// several frames. The property a caller asserts is that application frames
+/// drain the queue — the socket thread never does — so how many frames the
+/// budget needed is reported rather than asserted.
+fn drain_gateway_requests(app: &mut QuantickApp, ctx: &egui::Context) -> usize {
+    let deadline = std::time::Instant::now() + GATEWAY_TEST_WAIT;
+    let mut frames = 0;
+    loop {
+        run_frame(app, ctx);
+        frames += 1;
+        if app
+            .control
+            .control_access
+            .as_ref()
+            .expect("control access is installed")
+            .queued_requests_for_test()
+            == 0
+        {
+            return frames;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "application frames did not drain the queued gateway requests within \
+             {GATEWAY_TEST_WAIT:?} ({frames} frames)"
+        );
+    }
 }
 
 fn disable_test_gateway(app: &mut QuantickApp, ctx: &egui::Context) {
@@ -1929,7 +1975,8 @@ fn disable_test_gateway(app: &mut QuantickApp, ctx: &egui::Context) {
         .as_mut()
         .expect("control access is installed")
         .disable_for_test();
-    for _ in 0..400 {
+    let deadline = std::time::Instant::now() + GATEWAY_TEST_WAIT;
+    loop {
         run_frame(app, ctx);
         if app
             .control
@@ -1940,9 +1987,12 @@ fn disable_test_gateway(app: &mut QuantickApp, ctx: &egui::Context) {
         {
             return;
         }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "test gateway did not stop cleanly within {GATEWAY_TEST_WAIT:?}"
+        );
         std::thread::sleep(std::time::Duration::from_millis(5));
     }
-    panic!("test gateway did not stop cleanly");
 }
 
 fn response_error(

--- a/crates/app/src/worker_progress/tests/protocol.rs
+++ b/crates/app/src/worker_progress/tests/protocol.rs
@@ -64,8 +64,32 @@ pub(crate) fn delayed_bookkeeping<T>(
     first.release();
     publication.reached();
     clock.at(180);
+    // Park the worker in the Idle callback that closes this cycle, before it
+    // can acknowledge the flush or receive anything else. Every send later in
+    // this schedule is made against a parked worker; S2 below was the one that
+    // was not, which left the producer's acceptance of ticket 2 racing the
+    // worker's admission of it and made `last_sampled_ticket` a coin flip.
+    let parked = clock.hold(Phase::Idle);
     publication.release();
-    acknowledge(a1); // Successful-send accounting is still delayed here.
+    parked.reached();
+    // The cycle is complete — applied, published, retired and counted — while
+    // the producer has recorded no acceptance at all: the real flush waits on
+    // nothing the producer still owes. The reader is momentarily incomplete
+    // for exactly that reason (one admitted command, zero accepted), so the
+    // core() invariants do not hold here and are not claimed.
+    let unaccounted = p.snapshot();
+    assert!(!unaccounted.valid);
+    assert_eq!(unaccounted.phase, Phase::Idle);
+    assert_eq!(unaccounted.counts.accepted, 0);
+    assert_eq!(unaccounted.counts.retired, 1);
+    assert_eq!(
+        (
+            unaccounted.counts.cycles,
+            unaccounted.counts.mailbox_replacements
+        ),
+        (1, 1)
+    );
+    evidence("S1-cycle-completed-unaccounted", &unaccounted);
     clock.at(200);
     commands.progress.record_send(true);
 
@@ -85,7 +109,14 @@ pub(crate) fn delayed_bookkeeping<T>(
     let idle = clock.hold(Phase::Idle);
     clock.at(260);
     let (tx, a2) = channel();
+    // The producer's whole ordinary send — enqueue then acceptance — completes
+    // while the worker is still parked above, so ticket 2 meets a slot that
+    // still holds the unobserved ticket 1 and is never sampled. Releasing the
+    // park afterwards is what lets the worker admit both under one ledger, and
+    // the acknowledgement the delayed accounting never blocked arrives with it.
     assert!(commands.send(flush(tx)).is_ok());
+    parked.release();
+    acknowledge(a1);
     second.reached();
     let s = p.snapshot();
     core(&s, instance, [2, 0, 1, 1, 0, 0]);


### PR DESCRIPTION
## Summary

Campaign child of #367 (Q1); closes on integration: #361, #364. Mission tier: **medium**.

Two tests made CI red at random, each by asserting an outcome that only holds when the machine is quiet. No production code changes: every hunk is inside a `#[cfg(test)]` module.

**#361 — the delayed-producer progress schedule.** The S2 step admitted ticket 2 on the worker thread while the producer was still recording its acceptance on the fixture thread. Whichever ran first decided whether the sample slot still held the unobserved ticket 1, so `last_sampled_ticket` came out `Some(1)` or `Some(2)` by luck. Every other send in that schedule is made against a worker parked in a phase hold; S2 was the one that was not. It now parks the worker in the `Phase::Idle` callback that closes the previous cycle, with `Gate::hold` — the mechanism the issue named.

A note on the reading. The issue asks for a hold on *the producer's* sampling, but the producer's sampling is `WorkerProgress::record_send`, which the fixture calls on its own thread and therefore already controls completely. The unforced party is the worker, and it reads the sample slot inside `SharedProgress::begin` *before* it signals `Phase::Applying`, so no existing callback can fence that read — and adding one would be the production change this mission was told not to make. Parking the worker establishes the same interleaving with no production change. The assertion is not weakened.

Parking there also lets the schedule state the S1 property outright instead of implying it: at the parked point the cycle has applied, published, retired and counted while the producer has recorded no acceptance at all.

**#364 — the gateway handshake test.** The failing assertion had never been captured; this mission captured it. It is **not** a handshake timeout:

```text
panicked at crates\app\src\app\tests\control_plane_tests.rs:852:5:
assertion `left == right` failed: the application frame must drain the queued gateway request
  left: 1
 right: 0
```

`drain_bounded_since` (`crates/app/src/control/gateway/server.rs:95`) stops the frame's drain once `CONTROL_UI_BUDGET_US` — 250 microseconds — has elapsed, and `begin_frame` spends part of that budget before the drain starts. On a loaded machine the prelude consumes the whole budget, the drain admits nothing, and the queue still holds the request. The product is behaving as designed; the test asserted that one frame is always enough. It now runs frames until the queue is empty, which still proves that application frames drain it and the socket thread never does.

A third point surfaced once that was repaired: `disable_test_gateway` ("test gateway did not stop cleanly") and its two sibling waiters counted 400 sleep iterations rather than elapsed time, so a loaded machine ran out of iterations before the gateway thread had its chance. They are bounded by wall-clock time now, and say so when they give up.

The issue's own recommendation is applied as well, because it costs little and the handshake path carries the same class of exposure: the refused handshakes report their refusal code through a helper that retries a transport-level failure (`control.instance_gone`) a bounded number of times and, if it never clears, reports the transport failure rather than a wrong refusal code. `control.auth_failed` is still asserted for the wrong bearer token, the wrong instance id and the wrong process nonce.

### Rate tables

One filtered test per process, `--test-threads=1`, while a loop of `cargo build --workspace` competed for all twelve cores.

| Test | Build | Runs | Failures | Failure captured |
| --- | --- | ---: | ---: | --- |
| #361 `delayed_producer_bookkeeping…` | before | 200 | **1** | `protocol.rs:92`, left `Some(2)` right `Some(1)` — the issue's own assertion |
| #361 `delayed_producer_bookkeeping…` | after | 200 | **0** | — |
| #364 `gateway_client_reads…` | before | 200 | **1** | `control_plane_tests.rs:852`, frame did not drain |
| #364 `gateway_client_reads…` | after the drain repair only | 200 | **1** | `mod.rs:1970`, "test gateway did not stop cleanly" |
| #364 `gateway_client_reads…` | after, final head | 200 | **0** | — |
| #361 `delayed_producer_bookkeeping…` | after, final head | 200 | **0** | — |

Whole `quantick-app` test binary, 26 runs of each build on the same machine: 3 failures each, none of them either of these two tests.

### Performance impact

Test-only, rare. Every touched loop is `#[cfg(test)]`: the drain helper runs per call site, the three waiters once per test setup or teardown, and `delayed_bookkeeping` once per test. No per-trade, per-depth or per-frame production path is reached and nothing grows with session length.

## Verification loop

Run locally at the code head, each command on its own, none chained:

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets`
- [x] `cargo build --workspace`
- [x] `cargo test --workspace` — 1983 passed, 0 failed in the `quantick-app` binary
- [x] `cargo test -p quantick-guards`, and `cargo run -p quantick-guards -- --report` with every ratchet at its recorded value

Plus the rate tables above (local), and required CI at the final head.

## Reviews

**arch-review — step 0: `code-review` at `low` (effort-first, no reuse notice), 0 findings, twice.** Both invocations declined the diff with "every hunk lands in test or goal-doc paths, which this level does not review", so the bug pass was run independently instead, as the skill provides for. That pass read `worker_progress.rs`, `worker_progress/tests.rs` and `orderflow_worker.rs::run` against the new schedule and returned **clean**: the `Phase::Idle` hold is pushed while the Gate's FIFO is empty and the worker is blocked inside the Publishing hold, so it cannot be missed; the parked worker holds no ledger, sample or mailbox lock, so no deadlock; the parked assertions are deterministic; moving `acknowledge(a1)` cannot hang because `run()` sends flush acknowledgements after `finish()` and before the next `recv()`; and S2 is forced more strongly than the comment claims, since `record_send`'s `pending` guard short-circuits before the slot is even locked.

Verdict at `01a001c7`:

- **Correctness** — clean; nothing open.
- **Docking** — no port involved; the change adds a helper beside the helpers it belongs with.
- **Performance** — flat. Every touched path is `#[cfg(test)]`.
- **Operability** — no surface; the change adds no user-facing capability.
- **Proof** — the two tests themselves, measured: each fails on the base under contention and passes 200 of 200 at this head.
- **Accumulation** — trunk flat. No ratchet-tracked file moved; `--report` shows the size and context ratchets at their recorded values, and goal files are excluded from the context ratchet by design.
- **Language** — the guard passed inside `cargo test --workspace`; the prose, the branch name, the commit messages and this body were read here and are English.

**ai-review** — 6 of 6 PASS, 0 findings, 0 threads. Report: https://github.com/milocaetano/quantick/pull/382#issuecomment-5642156391

**delivery-review** — completeness pass (tier `medium`), inline. One gap found and repaired in the record: the request's A4 asks for the campaign merge to be read back, which a child never performs, so it had no line on the mission's checklist. It is now closing step **C4**, owned by the coordinator. An independent follow-up graded that prose delta and returned CARRY FORWARD.

## Notes for the reviewer

**Out of scope, and reported rather than fixed.** Two sibling control-plane tests carry the same class of exposure, and this mission's scope line excludes other tests:

- `gateway_a_client_that_never_reads_does_not_stall_another` — `control_plane_tests.rs:2183`. Measured under contention at **4 failures in 100** filtered runs on the base build and **0 in 100** at this head, failing on the base at the same assertion CI hit. It is what made the first CI run on this PR red, and it is pre-existing.
- `a_retry_that_races_its_own_first_call_is_refused_rather_than_acted_on` — `control_plane_tests.rs:5255`, one `run_frame` then `client.read().unwrap()`. The same 250 µs mechanism as #364; the one-line repair is the `drain_gateway_requests` helper this PR adds. Measured at 3 failures in 26 whole-binary runs on the base build.

Neither was touched, because fixing them is a scope change the campaign has to grant. **CI on this PR is exposed to them**, so a red run whose only failure is one of those two is not a finding against this diff.

**A deliberate choice worth an eye.** `protocol.rs` now asserts `!unaccounted.valid` at the parked point — it enshrines a transient invalid ledger. It is deterministic today and the comment beside it says why, but if the ledger ever learns to represent "accounting outstanding" without flipping `valid`, this line fails for a good reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VdP84bYEGeyCg7KwsNb1X2
