### PR TITLE
chore(campaign): synchronize main 57767f25 into campaign/lean-a-plus

### DIFF
--- a/.claude/GOAL-archive-campaign-gate-cd-prefix.md
+++ b/.claude/GOAL-archive-campaign-gate-cd-prefix.md
@@ -124,6 +124,12 @@ pass at `low`, and a `delivery-review` completeness pass.
   `README.md` / `integration.md` paid for by trimming prose in the same files
   rather than raising a ceiling, or the raise named explicitly.
   *Evidence:* the guards report and, if raised, the signed baseline entry.
+- **G5** — the branch writes only inside its own worktree, and only the files
+  this child owns: `.claude/hooks/guardrails.sh`, the two hook test scripts,
+  `.claude/hooks/README.md`, `docs/campaign/integration.md`, plus the goal
+  archive the mission's step 8 mandates. Three sibling missions run in
+  parallel. *(Added by the completeness pass.)*
+  *Evidence:* `git diff origin/campaign/lean-a-plus...HEAD --stat`.
 
 ### Not applicable, and why
 
@@ -135,6 +141,13 @@ pass at `low`, and a `delivery-review` completeness pass.
 - **Something a trader does** — the gate is an agent-facing guardrail, not a
   trader action.
 - **Engine / determinism** — no engine code is touched.
+- **Issue #386's A4** — "merged into `campaign/lean-a-plus` through a PR whose
+  base is exactly that branch, with the merge read back". The PR's base is that
+  branch, which is this mission's half; the merge itself is not. The campaign
+  integration contract gives the merge to the coordinator, and this mission is
+  instructed never to merge, so A4 stays **pending with the coordinator** and
+  is not gradeable here. *(Named by the completeness pass, which found it in
+  the retained request with no line behind it.)*
 
 ## Closing steps
 

--- a/.claude/GOAL-archive-campaign-gate-cd-prefix.md
+++ b/.claude/GOAL-archive-campaign-gate-cd-prefix.md
@@ -1,0 +1,189 @@
+# Mission: let the campaign merge and ready gate accept a cd-prefixed command
+
+Make `pr-gate` in `.claude/hooks/guardrails.sh` accept exactly one leading
+`cd <worktree> &&` before the otherwise bare, head-pinned campaign
+`gh pr merge` / `gh pr ready` statement, so the documented campaign integration
+commands are reachable from a Bash tool whose working directory resets between
+calls.
+
+**Why it matters.** Claude Code's Bash tool resets `cwd` between calls, so a
+campaign child reaches its worktree only through a leading `cd <dir> &&`.
+`effective_dir` already reads the worktree from that prefix, but the merge and
+campaign-ready form checks then require the whole command to equal the bare
+statement. The result, observed on 2026-09-11 while integrating PR #382, is a
+gate no honest agent can satisfy: the cd-prefixed form is denied as a compound
+command, and the bare form resolves to the main checkout and is denied as a
+merge to main. A gate that cannot be satisfied is a gate that invites a route
+around it.
+
+**Tier:** `medium`. The change is one small, well-bounded shell function plus
+its call sites, but it moves a security-shaped gate, so it takes the full
+request ledger, the full injected gate table, `arch-review` with its step 0 bug
+pass at `low`, and a `delivery-review` completeness pass.
+
+## Request ledger
+
+- **R1** — `pr-gate` accepts, for the campaign `merge` and `ready` forms,
+  exactly one leading `cd <dir> &&` before the otherwise bare statement, where
+  `<dir>` is the string `effective_dir` already extracts, quoted or not, and the
+  remainder equals today's exact pinned form. *(issue #386 Scope, bullet 1)*
+- **R2** — every other spelling stays denied with the existing messages: a
+  second `&&`, a `;`, a `||`, a trailing statement, `--auto`, `--admin`, `-R` /
+  `--repo`, merge-queue shortcuts. *(issue #386 Scope, bullet 1;
+  "still reject any other statement")*
+- **R3** — what the gate *checks* does not change at all: markers, AI
+  completion, open threads, head pin, base advance, draft state.
+  *(issue #386, "Out of scope")*
+- **R4** — the bare forms stay accepted where they already were. *(D1)*
+- **R5** — `docs/campaign/integration.md` and `.claude/hooks/README.md` show the
+  accepted form and say why it exists, and state that the PowerShell tool is
+  outside the `Bash` matcher and must never be used to route around the gate;
+  a denial is reported to the coordinator. *(issue #386 Scope, bullet 2; D2)*
+- **R6** — the hook suites carry positive and negative cases for the new form.
+  *(issue #386 Scope, bullet 2; A1; D3)*
+
+## Decisions
+
+- **D1** — the accepted forms on a campaign base become exactly
+  `cd <dir> && gh pr merge N --merge|--squash --match-head-commit <HEAD>` and
+  `cd <dir> && gh pr ready N`; the bare forms stay accepted; everything else is
+  denied with the existing messages; what the gate checks does not change.
+- **D2** — the documented reason is the Bash tool's `cwd` reset, with the
+  2026-09-11 PR #382 observation; both documents also state the PowerShell
+  prohibition.
+- **D3** — the tests live where the merge/ready form cases live today
+  (`campaign_context_test.sh`), with the main-base cases in
+  `guardrails_test.sh`: cd-prefixed merge accepted; cd-prefixed merge plus a
+  trailing statement denied; two `cd`s denied; cd-prefixed ready accepted; bare
+  merge from a main-based worktree still denied as a merge to main.
+- **D4** — validation is the delivery contract's second row plus behavioural
+  proof, and the shell script and test changes additionally take the first row
+  once.
+- **D5** — tier `medium` review set: `arch-review` with `code-review` at `low`,
+  `ai-review` completion, `delivery-review` completeness pass inline.
+
+## Assumptions
+
+- **S1** — the new form check is expressed as one helper that strips a single
+  leading `cd <dir> &&` and leaves everything else in place, so the existing
+  string-equality comparisons keep doing the rejecting. Safe to assume: it adds
+  no new accept path, and any spelling the helper does not understand survives
+  the strip and fails the same equality check as today. *(Conventional in this
+  file, which already parses by narrow, documented patterns.)*
+- **S2** — the helper mirrors `effective_dir`'s directory pattern rather than
+  inventing a second one, so the directory the gate *judges* and the directory
+  it *strips* can never disagree. Safe: a divergence between the two would be
+  the only way a prefix could smuggle something past the check.
+- **S3** — the denial messages are unchanged, because they already describe the
+  rejected shapes correctly and the campaign contract quotes them.
+
+## Acceptance criteria
+
+- [ ] **A1** — `sh .claude/hooks/guardrails_test.sh` and
+      `sh .claude/hooks/campaign_context_test.sh` pass, with the new cases and
+      every existing case green.
+      *Evidence:* both suites' final counts, before and after.
+      → the PR body. *(R1, R2, R4, R6)*
+- [ ] **A2** — from a campaign child worktree,
+      `cd <worktree> && gh pr merge N --merge --match-head-commit <HEAD>` passes
+      the gate when every other check holds, and the same command followed by
+      `&& echo x`, or preceded by a second `cd`, is denied.
+      *Evidence:* named cases in `campaign_context_test.sh`.
+      → the PR body. *(R1, R2)*
+- [ ] **A3** — bare `gh pr merge N …` from a main-based worktree is still denied
+      as a merge to main, and a cd-prefixed one is too.
+      *Evidence:* named cases in `guardrails_test.sh`.
+      → the PR body. *(R2, R3)*
+- [ ] **A4** — `docs/campaign/integration.md` and `.claude/hooks/README.md` show
+      the accepted cd-prefixed form, give the reason, and carry the PowerShell
+      prohibition.
+      *Evidence:* the quoted sections in the diff.
+      → the PR body. *(R5)*
+- [ ] **A5** — the set of checks the gate performs is unchanged: no marker, AI
+      completion, thread, head-pin, base-advance or draft-state condition is
+      added, removed or relaxed.
+      *Evidence:* the diff touches only the two form comparisons plus the new
+      helper; every pre-existing gate case stays green.
+      → the PR body. *(R3)*
+
+## Injected gates
+
+- **G1** — every artifact in English; conventional English commits.
+  *Evidence:* `arch-review` dimension 8, `cargo test -p quantick-guards`.
+- **G2** — `cargo fmt --all -- --check`, `cargo clippy --workspace
+  --all-targets`, `cargo build --workspace`, `cargo test --workspace`, each run
+  separately on the final head, plus both hook suites.
+  *Evidence:* command output in the PR body.
+- **G3** — `arch-review` over the exact diff against `origin/campaign/lean-a-plus`
+  with its step 0 bug pass at `low`, every Blocker and Should-fix resolved or
+  deferred in the PR body; `ai-review` completion recorded; `delivery-review`
+  completeness pass.
+  *Evidence:* review verdicts and the markers at the shared campaign key.
+- **G4** — the context ratchet stays satisfied: `cargo run -p quantick-guards --
+  --report` unchanged except for context bytes, and any growth in
+  `README.md` / `integration.md` paid for by trimming prose in the same files
+  rather than raising a ceiling, or the raise named explicitly.
+  *Evidence:* the guards report and, if raised, the signed baseline entry.
+
+### Not applicable, and why
+
+- **Hot path** — the change is a shell hook, not a per-trade, per-depth or
+  per-frame code path. No cargo runtime behaviour changes.
+- **User-visible surface** — no UI; `ui-harness`, `visual-qa` and
+  `trader-ux-review` do not apply.
+- **Adds a capability** — nothing docks; `new-extension` does not apply.
+- **Something a trader does** — the gate is an agent-facing guardrail, not a
+  trader action.
+- **Engine / determinism** — no engine code is touched.
+
+## Closing steps
+
+- **C1** — `delivery-review` returns PASS (completeness pass at `medium`).
+- **C2** — the draft PR is open against `campaign/lean-a-plus`, with the
+  evidence in its body.
+
+## The request as received
+
+> You are executing campaign child mission **Q7** of campaign #367
+> (https://github.com/milocaetano/quantick/issues/367) for milocaetano/quantick:
+> make the `pr-gate` hook accept exactly one leading `cd <worktree> &&` before
+> the otherwise bare, head-pinned campaign `gh pr merge` / `gh pr ready`
+> statement. You are a subagent: you cannot ask the trader; decisions D1..Dn
+> below answer the mission's step-3 questions. A doubt that would need a new
+> decision is reported back, never guessed.
+>
+> ## Decisions
+>
+> - D1: accepted forms on a campaign base become exactly
+>   `cd <dir> && gh pr merge N --merge|--squash --match-head-commit <HEAD>` and
+>   `cd <dir> && gh pr ready N`, where `<dir>` is the string `effective_dir`
+>   extracts (quoted or not) and the remainder equals today's exact bare form;
+>   the bare forms stay accepted. Anything else (a second `&&`, `;`, `||`, a
+>   trailing statement, `--auto`, `--admin`, `-R`, merge queue) is denied with
+>   the existing messages. What the gate checks (markers at the shared key, AI
+>   completion, zero open threads, head pin, base advance, draft state) does not
+>   change at all.
+> - D2: the reason, for the docs: Claude Code's Bash tool resets `cwd` between
+>   calls (observed 2026-09-11 while integrating PR #382:
+>   `cd <wt> && gh pr merge 382 --merge --match-head-commit 01a001c7...` denied
+>   as compound; a bare command would resolve to the main checkout and be denied
+>   as a merge to main). Say in README and integration.md that the PowerShell
+>   tool is outside the `Bash` matcher and must never be used to route around
+>   the gate; a denial is reported to the coordinator.
+> - D3: tests: add to `guardrails_test.sh` (or `campaign_context_test.sh`,
+>   whichever owns the merge/ready form cases today) at least: cd-prefixed merge
+>   accepted when all other checks hold; cd-prefixed merge followed by
+>   `&& echo x` denied; `cd a && cd b && gh pr merge ...` denied; cd-prefixed
+>   ready accepted; bare merge from a main-based dir still denied as merge to
+>   main. Keep every existing case green.
+> - D4: this is a workflow/gate change: the delivery contract's second row plus
+>   behavioural proof applies (`sh .claude/hooks/guardrails_test.sh`,
+>   `sh .claude/hooks/campaign_context_test.sh`, `cargo test -p quantick-guards`,
+>   `cargo run -p quantick-guards -- --report` unchanged except context bytes;
+>   the context ratchet in `crates/guards/context-baseline.txt` may need its
+>   number if README/integration.md grow, pay for it by trimming prose in the
+>   same files rather than raising unless impossible, and say which).
+> - D5: tier `medium`: `arch-review` with `code-review` at `low` (step 0
+>   applies; shape dimensions 1-7 and 9 waived for prose but NOT for the shell
+>   script and tests, which take the full pass; dimension 8 always); `ai-review`
+>   completion; `delivery-review` completeness pass inline.

--- a/.claude/GOAL-archive-campaign-gate-cd-prefix.md
+++ b/.claude/GOAL-archive-campaign-gate-cd-prefix.md
@@ -141,6 +141,16 @@ pass at `low`, and a `delivery-review` completeness pass.
 - **C1** — `delivery-review` returns PASS (completeness pass at `medium`).
 - **C2** — the draft PR is open against `campaign/lean-a-plus`, with the
   evidence in its body.
+- **C3** — `gh pr ready <n>` is attempted once from the worktree through the
+  Bash tool, and its outcome — accepted or denied — is reported rather than
+  worked around. The hook that runs is the main checkout's, so a denial is the
+  expected result until this branch merges. The gated commands are never run
+  through the PowerShell tool. *(Added by the completeness pass: an operational
+  obligation of this mission that the first map carried no `C` line for.)*
+- **C4** — the coordinator receives the handoff block: issue, branch, worktree,
+  PR URL, head SHA, base tip, review verdicts, markers, CI, suite results,
+  findings closed/open, the `gh pr ready` outcome and the next action.
+  *(Added by the completeness pass, same reason.)*
 
 ## The request as received
 

--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -159,7 +159,11 @@ reading the directory with the pattern `effective_dir` already uses — the
 directory the gate judges and the directory it strips can never disagree. Only
 the prefix is forgiven. A second `cd`, a `;`, a `||`, a trailing `&& echo x`,
 `--auto`, `--admin` and `--repo` all survive the strip and fail the same
-equality check they failed before, each with the message it had before.
+equality check they failed before, each with the message it had before. A
+directory containing a space is outside that pattern in both functions, so the
+honest form would be denied there — the worktrees this workflow creates under
+`../quantick-worktrees/` never carry one, and widening the pattern is a change
+with its own review.
 
 **A gate you cannot satisfy is a gate with a hole behind it**, and that is the
 whole reason this is worth a change rather than a workaround. The `Bash`

--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -137,6 +137,37 @@ and "nobody knows whether it has any" are different answers, and a gate that
 prints the same nothing for both has taught its reader that silence means
 clean.
 
+### The one prefix the pinned forms allow
+
+A campaign merge and a campaign `gh pr ready` are pinned by string equality —
+the explicit PR number, `--merge` or `--squash`, `--match-head-commit` with the
+reviewed HEAD, and nothing else — so that no second statement can ride on the
+first's authorization. That pin wanted the command bare, and the agent shell
+cannot send it bare.
+
+Claude Code's `Bash` tool resets its working directory between calls. Every
+command therefore reaches its task worktree through a leading `cd <dir> &&`,
+which is why `effective_dir` reads the directory from exactly there. Both
+spellings were denied, and the gate was unsatisfiable in both directions: on
+2026-09-11, integrating PR #382, `cd <wt> && gh pr merge 382 --merge
+--match-head-commit 01a001c7…` was denied as a compound command, while the bare
+form would have been judged against the main checkout and denied as a merge to
+main.
+
+So `bare_statement` strips **one** leading `cd <dir> &&` before the comparison,
+reading the directory with the pattern `effective_dir` already uses — the
+directory the gate judges and the directory it strips can never disagree. Only
+the prefix is forgiven. A second `cd`, a `;`, a `||`, a trailing `&& echo x`,
+`--auto`, `--admin` and `--repo` all survive the strip and fail the same
+equality check they failed before, each with the message it had before.
+
+**A gate you cannot satisfy is a gate with a hole behind it**, and that is the
+whole reason this is worth a change rather than a workaround. The `Bash`
+matcher does not cover Claude Code's PowerShell tool, so an agent that finds
+the honest command denied is one keystroke from a spelling nothing inspects.
+Running `gh pr merge` or `gh pr ready` through that tool is prohibited: a
+denial is reported to the coordinator, never routed around.
+
 ## Recording the two reviews
 
 `pr-gate` reads two files in the worktree's git dir, each holding a hash of

--- a/.claude/hooks/campaign_context_test.sh
+++ b/.claude/hooks/campaign_context_test.sh
@@ -154,6 +154,26 @@ for client in Bash exec_command; do
     allow "$client retarget before merge denied" gate "$client" "gh pr edit 42 --base main && gh pr merge 42 --merge --match-head-commit $head" deny
     allow "$client ready cannot borrow another repository" gate "$client" 'gh pr ready 42 --repo other/repo' deny
     allow "$client campaign ready accepts exact target" gate "$client" 'gh pr ready 42' allow
+    # The agent's Bash tool resets its working directory between calls, so the
+    # pinned statement reaches the task worktree only behind a single
+    # `cd <dir> &&`. One prefix is accepted; anything beside the statement is
+    # not, because a second statement would share the first's authorization.
+    allow "$client cd-prefixed campaign merge" \
+        gate "$client" "cd $fixture/repo && gh pr merge 42 --merge --match-head-commit $head" allow
+    allow "$client cd-prefixed campaign ready" \
+        gate "$client" "cd $fixture/repo && gh pr ready 42" allow
+    allow "$client cd-prefixed merge cannot carry a second statement" \
+        gate "$client" "cd $fixture/repo && gh pr merge 42 --merge --match-head-commit $head && echo x" deny
+    allow "$client only one cd prefix is stripped" \
+        gate "$client" "cd $fixture/hooks && cd $fixture/repo && gh pr merge 42 --merge --match-head-commit $head" deny
+    allow "$client a cd prefix on a semicolon is not the accepted form" \
+        gate "$client" "cd $fixture/repo ; gh pr merge 42 --merge --match-head-commit $head" deny
+    allow "$client cd-prefixed ready cannot carry a second statement" \
+        gate "$client" "cd $fixture/repo && gh pr ready 42 && gh pr merge 99 --merge" deny
+    allow "$client a cd prefix does not excuse an alternate repository" \
+        gate "$client" "cd $fixture/repo && gh pr merge 42 --merge --match-head-commit $head --repo other/repo" deny
+    allow "$client a cd prefix does not excuse auto-merge" \
+        gate "$client" "cd $fixture/repo && gh pr merge 42 --auto" deny
     printf 'feat/child small\n' > "$git_dir/mission-tier"
     printf '1\n' > "$fixture/hooks/threads"
     allow "$client small tier cannot skip open threads" gate "$client" 'gh pr ready 42' deny

--- a/.claude/hooks/guardrails.sh
+++ b/.claude/hooks/guardrails.sh
@@ -240,6 +240,31 @@ effective_dir() {
     printf '%s' "$2"
 }
 
+# The command with its single leading `cd <dir> &&` removed, trimmed at both
+# ends. Everything else is left exactly as written.
+#
+# The campaign statements below are pinned by string equality, and the function
+# above says why every agent command carries that prefix: the payload's `cwd`
+# is the session's and resets between calls, so the bare form the pin asks for
+# would be judged against the main checkout and denied as a merge to main. The
+# pinned form was therefore unreachable from the Bash tool in both directions.
+# The prefix is read with the pattern `effective_dir` uses, so the directory
+# the gate judges and the directory it strips can never disagree.
+#
+# Exactly one prefix, and only across `&&`. A second `cd`, a `;`, a `||` or any
+# trailing statement survives the strip and fails the equality check that
+# follows, so nothing beside the first statement can share its authorization.
+bare_statement() {
+    bare_command=$(printf '%s' "$1" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')
+    bare_rest=$(printf '%s' "$bare_command" |
+        sed -n 's|^cd[[:space:]][[:space:]]*"\{0,1\}[^"[:space:];&|]\{1,\}"\{0,1\}[[:space:]]*&&[[:space:]]*||p')
+    if [ -n "$bare_rest" ]; then
+        printf '%s' "$bare_rest"
+        return 0
+    fi
+    printf '%s' "$bare_command"
+}
+
 # Empty when the git dir cannot be resolved, so the caller can fail open
 # rather than build a path rooted at `/` and hand back a remedy telling an
 # agent to write the marker at the filesystem root.
@@ -769,10 +794,12 @@ pr_gate() {
 
     if [ "$gate_action" = merge ]; then
         [ "$gate_base" != "origin/$MAIN_BRANCH" ] || deny '"Merge to main is reserved exclusively for the user; do not enable auto-merge or enqueue it."'
-        # Only this explicit, head-pinned form is supported. This also rejects
-        # --admin, --auto, alternate repositories and merge-queue shortcuts.
+        # Only this explicit, head-pinned form is supported, bare or behind the
+        # single `cd <worktree> &&` that reaches the task worktree. This also
+        # rejects --admin, --auto, alternate repositories and merge-queue
+        # shortcuts.
         gate_merge=$(gh_statement "$command" "gh pr merge" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')
-        gate_whole=$(printf '%s' "$command" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')
+        gate_whole=$(bare_statement "$command")
         [ "$gate_merge" = "$gate_whole" ] || deny '"Run one campaign merge command from the task worktree; compound commands cannot share an authorization check."'
         gate_head=$(git -C "$dir" rev-parse HEAD)
         case "$gate_merge" in
@@ -782,7 +809,7 @@ pr_gate() {
     fi
     if [ "$gate_base" != "origin/$MAIN_BRANCH" ]; then
         if [ "$gate_action" = ready ]; then
-            gate_ready=$(printf '%s' "$command" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')
+            gate_ready=$(bare_statement "$command")
             [ "$gate_ready" = "gh pr ready $gate_pr" ] || deny '"Run one explicit campaign ready command in the task worktree, without repository overrides or compound commands."'
         fi
         if ! sh "$(dirname "$0")/campaign_context.sh" check-pr "$dir" "$gate_pr" "$gate_action" >/dev/null 2>&1; then

--- a/.claude/hooks/guardrails_test.sh
+++ b/.claude/hooks/guardrails_test.sh
@@ -676,6 +676,15 @@ run "all required reviews and no open thread makes the branch ready" \
 run "even reviewed main merges remain exclusively human" \
     pr-gate "$(json_bash "$root/wt" "gh pr merge 42 --squash")" deny "reserved exclusively"
 
+# The `cd <worktree> &&` prefix an agent needs to reach its worktree is read for
+# the campaign form pins only. On a main-based branch it changes nothing: the
+# ready case still passes on its markers, and the merge is still the user's.
+run "a cd prefix leaves a main-based ready where it was" \
+    pr-gate "$(json_bash "$root/wt" "cd $root/wt && gh pr ready 42")" silent
+
+run "a cd prefix does not make a main merge the agent's" \
+    pr-gate "$(json_bash "$root/wt" "cd $root/wt && gh pr merge 42 --squash")" deny "reserved exclusively"
+
 set_threads 2
 run "gh pr ready is denied while an ai-review thread is open" \
     pr-gate "$(json_bash "$root/wt" "gh pr ready 42")" deny "PR #42 has 2"

--- a/docs/campaign/integration.md
+++ b/docs/campaign/integration.md
@@ -139,13 +139,19 @@ by the gate are (substitute the explicit PR number and full reviewed HEAD):
 ```text
 gh pr merge 42 --merge --match-head-commit FULL_HEAD_SHA
 gh pr merge 42 --squash --match-head-commit FULL_HEAD_SHA
+cd /absolute/task/worktree && gh pr merge 42 --merge --match-head-commit FULL_HEAD_SHA
 ```
 
 No `--auto`, `--admin`, alternate repository or queue shortcut is accepted.
-Run that command alone from the task worktree; compound commands are rejected
-so a second merge or retarget cannot share the first command's authorization.
-Campaign readiness likewise uses a single `gh pr ready NUMBER` command in the
-task worktree, with no repository override or other statement.
+Exactly one leading `cd <worktree> &&` may precede the statement, and nothing
+may follow it. An agent shell whose working directory resets between calls
+reaches the task worktree only that way; a second `cd`, a `;`, a `||` or any
+trailing statement is still rejected, so no second statement can share the
+first's authorization. Campaign readiness likewise uses a single
+`gh pr ready NUMBER`, bare or behind that same one prefix, in the task
+worktree, with no repository override or other statement. A host tool outside
+the gate's matcher — Claude Code's PowerShell tool, for one — must never run
+these commands: a denial is reported to the coordinator, never routed around.
 The helper verifies the live base/head and clean, non-draft, same-repository PR
 with passing checks, and rejects a remote base that advanced since fetch.
 The existing hook's documented command-detection limits still apply: this is


### PR DESCRIPTION
## Summary

**Tier:** `medium`. Campaign synchronization PR for #367 (task key X1), per `docs/campaign/integration.md` step 6 and the delivery contract's "Adopt changes in an existing campaign".

Merges `origin/main` at `57767f25` into `campaign/lean-a-plus` (tip `caa2adb4`) with a merge commit, preserving campaign history. The only main work since the campaign's cut point is PR #387, `fix(agentic): let the campaign merge and ready gate accept a cd-prefixed command`, which the user merged to `main` on 2026-09-12 (default-branch CI green: run 34674376706). The merge touches no campaign file; the diff against the campaign tip is exactly #387's diff (6 files, +317/-8).

## Why now

The campaign's own merges run the hook from the main checkout, so #387 had to land on `main` first (decision D10 on #367). This PR carries it into the campaign branch so the campaign's CI and its worktrees run the same hook and hook tests as `main`, and so the final campaign-to-main PR carries no reverse delta on these files.

## Verification

- Delta classification (delivery contract): hook script, hook tests and prose already verified and reviewed on `main` at this exact content; reused from `main` `57767f25` (run 34674376706: ci pass, windows pass, guardrails 225/0). Local: `sh .claude/hooks/guardrails_test.sh` and `sh .claude/hooks/campaign_context_test.sh` at this head, `cargo test -p quantick-guards`; CI at this PR head is the run-at evidence for the merged tree.
- Reviews: follow-up carry-forward of #387's arch-review, ai-review and delivery-review at the campaign key, with the merge's identity to #387's diff proven in the follow-up comment.

Campaign child of #367 (X1); no issue to close on integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VdP84bYEGeyCg7KwsNb1X2
