### PR TITLE
test(app): force the interleavings two more load-sensitive gateway tests assert

### DIFF
--- a/.claude/GOAL-archive-gateway-load-sensitive-tests.md
+++ b/.claude/GOAL-archive-gateway-load-sensitive-tests.md
@@ -1,0 +1,127 @@
+# Mission: make two more load-sensitive gateway tests deterministic
+
+Force the interleavings that `gateway_a_client_that_never_reads_does_not_stall_another`
+and `a_retry_that_races_its_own_first_call_is_refused_rather_than_acted_on` assert,
+so neither test depends on a single application frame winning a race against
+machine load. Both are pre-existing flakes on `campaign/lean-a-plus`; they make
+every child PR's CI, and the campaign's own green-CI gate, load-sensitive.
+
+**Tier:** `small` — test-only change in one test module, reusing the helper and
+the shape PR #382 already established and reviewed; no production file, no new
+design decision. Campaign child Q6 of #367, issue #385.
+
+## Request ledger
+
+- **R1** — Make `gateway_a_client_that_never_reads_does_not_stall_another`
+  deterministic under load. *(A1, A2)*
+- **R2** — Make `a_retry_that_races_its_own_first_call_is_refused_rather_than_acted_on`
+  deterministic under load. *(A1, A2)*
+- **R3** — Keep the property each test asserts: a non-reading client does not
+  stall another; a retry racing its own first call is refused, not acted on.
+  "Weakening an assertion is forbidden." *(A2)*
+- **R4** — No production change: not to the gateway, its UI budget, its
+  timeouts or its authority. *(A3)*
+- **R5** — Prove it: each test 200 of 200 filtered runs under a concurrent
+  `cargo build --workspace`, before and after, tables in the PR body and on
+  issue #385. *(A1)*
+- **R6** — So that the campaign base and every child PR stop inheriting a
+  CI-red coin flip. *(A1)*
+
+## Decisions (from the coordinator)
+
+- **D1** — Both tests ship in one PR.
+- **D2** — No production change. If one were genuinely required: stop and report.
+- **D3** — Fix shape is #382's: drain the gateway with `drain_gateway_requests`
+  (or the same shape) until the expected effect is observed within a bounded
+  budget, instead of asserting after one frame.
+- **D4** — Proof shape: 200 filtered runs per test, before and after, under a
+  concurrent workspace build; both tables in the PR body and on #385.
+- **D5** — Tier `small`: `arch-review` with `code-review` at `low`; `ai-review`
+  completion required; no `delivery-review`.
+- **D6** — `gh pr ready` once, cd-prefixed, from the Bash tool; never merge.
+
+## Assumptions
+
+- **S1** — The first test's premature break (`iteration >= 10 && queued == 0`)
+  is the load exposure: under contention the live client's request has not yet
+  reached the queue at 50 ms, the loop breaks on an empty queue, and the
+  subsequent `read()` has nothing to read. Waiting for the request to be queued
+  before draining removes the guess. Safe to assume: it is read off the test's
+  own code, and the after-table measures it.
+- **S2** — The expected queue depth at that point is
+  `CONTROL_MAX_IN_FLIGHT_PER_CONNECTION + 1` (8 stalled snapshot requests plus
+  the live one), under the test's queue capacity of 16, because no frame runs
+  between the sends and the wait and the worker-side `describe` never queues.
+  Safe to assume: both constants are in the test's own scope, and the wait
+  fails loudly with the count if it is wrong.
+
+## Acceptance criteria
+
+- [ ] **A1** — Each of the two tests passes 200 of 200 filtered runs while a
+      concurrent `cargo build --workspace` competes for CPU, and the before
+      table shows the failures the fix removes.
+      *Evidence:* before/after run tables. → PR body and a comment on #385. *(R1, R2, R5, R6)*
+- [ ] **A2** — Every assertion each test made before the change is still made
+      after it; only the waiting shape changed.
+      *Evidence:* the diff, read in `arch-review`. → PR diff and review verdict. *(R1, R2, R3)*
+- [ ] **A3** — No production file in the diff; the changed paths are the test
+      module(s) only.
+      *Evidence:* `git diff --stat` against the campaign base. → PR body. *(R4)*
+- [ ] **G1** — Every artifact English; conventional commits.
+      *Evidence:* the commits and the PR body. → PR.
+- [ ] **G2** — `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets`,
+      `cargo build --workspace`, `cargo test --workspace` green on the final
+      head, run one at a time; `cargo test -p quantick-guards` after edits.
+      *Evidence:* command output, plus CI at the head. → PR body and the CI run.
+- [ ] **G3** — `arch-review` over the exact diff against `campaign/lean-a-plus`
+      with its step 0 bug pass; `ai-review` completion recorded.
+      *Evidence:* review verdicts and the marker files. → PR threads and the git dir.
+
+## Performance impact
+
+None on any production path: the diff is test-only. The changed code runs at
+test rate, and the new waiting shape runs fewer frames on an idle machine than
+the fixed 400-iteration loop it replaces.
+
+## Not applicable
+
+- Hot path, user-visible surface, new capability, trader action, engine
+  determinism: the diff changes no production code and no UI surface.
+- `delivery-review`: tier `small` (D5).
+- `guardrails_test.sh`: no hook changes.
+
+## Closing steps
+
+- **C1** — Draft PR open against `campaign/lean-a-plus`, reviews and markers
+  recorded, CI green at the head, `gh pr ready` run once.
+- **C2** — Handoff block returned to the campaign coordinator.
+
+## The request as received (verbatim)
+
+> You are executing campaign child mission **Q6** of campaign #367
+> (https://github.com/milocaetano/quantick/issues/367) for milocaetano/quantick:
+> make two more load-sensitive gateway tests deterministic. You are a subagent:
+> you cannot ask the trader; decisions D1..Dn below answer the mission's step-3
+> questions. A doubt that would need a new decision is reported back, never
+> guessed.
+>
+> [...] D1: both tests in one PR:
+> `gateway_a_client_that_never_reads_does_not_stall_another` and
+> `a_retry_that_races_its_own_first_call_is_refused_rather_than_acted_on`.
+> D2: no production change to the gateway, its UI budget, timeouts or authority.
+> If you conclude a production change is genuinely required, stop, write the
+> reasoning in your handoff, and do not make it.
+> D3: the fix shape is the one #382 established: drain the gateway with the
+> helper (or the same shape) until the expected effect is observed within a
+> bounded budget, instead of asserting after one frame; the property under test
+> stays asserted (a non-reading client does not stall another; a retry racing
+> its own first call is refused, not acted on). Weakening an assertion is
+> forbidden.
+> D4: proof of A1: run each filtered test 200 times while a concurrent
+> `cargo build --workspace` (or `cargo test --workspace --no-run`) runs in
+> another process, before and after the fix; record both tables in the PR body
+> and as a comment on #385.
+> D5: tier `small`: `arch-review` with `code-review` at `low`; `ai-review`
+> completion is still required (every tier); no delivery-review.
+> D6: `gh pr ready` works with the cd-prefixed form from the Bash tool. Never
+> use the PowerShell tool for `gh pr` commands; never merge; never touch main.

--- a/crates/app/src/app/tests/control_plane_tests.rs
+++ b/crates/app/src/app/tests/control_plane_tests.rs
@@ -2116,6 +2116,18 @@ fn gateway_revoking_one_client_closes_it_and_keeps_serving_others() {
     std::fs::remove_dir_all(directory).unwrap();
 }
 
+/// Whether the gateway answered "the buffered-response budget is busy". That
+/// refusal is about a budget every connection shares, and production marks it
+/// retryable: it never means the client that asked was stalled.
+fn is_retryable_backpressure(outcome: &quantick_control::wire::ResponseOutcome) -> bool {
+    match outcome {
+        quantick_control::wire::ResponseOutcome::Failure { error } => {
+            error.code.as_str() == quantick_control::error::codes::BACKPRESSURE && error.retryable
+        }
+        quantick_control::wire::ResponseOutcome::Success { .. } => false,
+    }
+}
+
 /// Ask the gateway for a worker-side read and return the outcome it answered
 /// with, once the buffered-response slots the previous requests held have been
 /// released.
@@ -2142,13 +2154,7 @@ fn worker_side_read_past_the_unread_replies(
             )
             .unwrap()
             .outcome;
-        let busy = match &outcome {
-            quantick_control::wire::ResponseOutcome::Failure { error } => {
-                error.code.as_str() == quantick_control::error::codes::BACKPRESSURE
-            }
-            quantick_control::wire::ResponseOutcome::Success { .. } => false,
-        };
-        if !busy {
+        if !is_retryable_backpressure(&outcome) {
             return outcome;
         }
         assert!(
@@ -2185,14 +2191,35 @@ fn gateway_a_client_that_never_reads_does_not_stall_another() {
             )
             .unwrap();
     }
-    // Answer every one of them first, so what stalls the gateway from here on
-    // is the thing this test is named after: replies sitting unread in a
-    // client's socket. Leaving them queued instead would stall the gateway for
-    // a different and uninteresting reason — a connection may hold as many
-    // in-flight requests as the whole buffered-response budget has slots, so
-    // whether any other client is served at that moment is a race the test
-    // neither establishes nor is about.
-    wait_for_queued_gateway_requests(&app, CONTROL_MAX_IN_FLIGHT_PER_CONNECTION);
+    // Wait for the whole backlog to be queued before asking anything else of
+    // the gateway, so the interleaving below is established rather than raced:
+    // asking first could take the buffered-response slot one of these requests
+    // needs, and then the backlog never reaches its own depth.
+    wait_for_at_least_queued_gateway_requests(&app, CONTROL_MAX_IN_FLIGHT_PER_CONNECTION);
+    // With that backlog queued and unanswered, the other client is answered
+    // either way: served if the shared buffered-response budget still has a
+    // slot, refused retryably if the backlog took them all. A connection may
+    // hold as many in-flight requests as that budget has slots, so which of the
+    // two happens is not the test's to pin — being left to wait on a client
+    // that never reads is, and it is not among the outcomes.
+    let under_backlog = live
+        .invoke(
+            crate::control::DESCRIBE_CAPABILITY_ID,
+            serde_json::json!({}),
+        )
+        .unwrap()
+        .outcome;
+    assert!(
+        matches!(
+            under_backlog,
+            quantick_control::wire::ResponseOutcome::Success { .. }
+        ) || is_retryable_backpressure(&under_backlog),
+        "a queued backlog answers the live client, with a read or with a retryable refusal: \
+         {under_backlog:?}"
+    );
+    // Answer the backlog, so that what stalls the gateway from here on is the
+    // thing this test is named after: replies sitting unread in a client's
+    // socket, rather than requests still waiting to be served.
     drain_gateway_requests(&mut app, &ctx);
     // A worker-side read is answered without the frame loop and without
     // the stalled client's replies ever being read.

--- a/crates/app/src/app/tests/control_plane_tests.rs
+++ b/crates/app/src/app/tests/control_plane_tests.rs
@@ -2116,6 +2116,50 @@ fn gateway_revoking_one_client_closes_it_and_keeps_serving_others() {
     std::fs::remove_dir_all(directory).unwrap();
 }
 
+/// Ask the gateway for a worker-side read and return the outcome it answered
+/// with, once the buffered-response slots the previous requests held have been
+/// released.
+///
+/// A response thread releases its global slot after it has written its reply,
+/// which is a moment later than the application frame that answered it. A read
+/// that lands inside that moment is refused with `control.backpressure`, which
+/// production itself marks retryable: it says "the budget is busy", never "this
+/// client is stalled". Asking again inside a bounded budget is therefore a
+/// wait, not a softened assertion — a gateway a stalled client really did stall
+/// never clears, and the caller still asserts a success.
+fn worker_side_read_past_the_unread_replies(
+    client: &mut quantick_control_local::client::LocalClient,
+) -> quantick_control::wire::ResponseOutcome {
+    /// Long enough to outlast the write and the slot release that cost the
+    /// last attempt, short enough not to dominate the test's runtime.
+    const BACKOFF: std::time::Duration = std::time::Duration::from_millis(5);
+    let deadline = std::time::Instant::now() + GATEWAY_TEST_WAIT;
+    loop {
+        let outcome = client
+            .invoke(
+                crate::control::DESCRIBE_CAPABILITY_ID,
+                serde_json::json!({}),
+            )
+            .unwrap()
+            .outcome;
+        let busy = match &outcome {
+            quantick_control::wire::ResponseOutcome::Failure { error } => {
+                error.code.as_str() == quantick_control::error::codes::BACKPRESSURE
+            }
+            quantick_control::wire::ResponseOutcome::Success { .. } => false,
+        };
+        if !busy {
+            return outcome;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "the buffered-response budget never freed a slot for a worker-side read within \
+             {GATEWAY_TEST_WAIT:?}: {outcome:?}"
+        );
+        std::thread::sleep(BACKOFF);
+    }
+}
+
 #[test]
 fn gateway_a_client_that_never_reads_does_not_stall_another() {
     use quantick_control::limits::CONTROL_MAX_IN_FLIGHT_PER_CONNECTION;
@@ -2141,15 +2185,18 @@ fn gateway_a_client_that_never_reads_does_not_stall_another() {
             )
             .unwrap();
     }
+    // Answer every one of them first, so what stalls the gateway from here on
+    // is the thing this test is named after: replies sitting unread in a
+    // client's socket. Leaving them queued instead would stall the gateway for
+    // a different and uninteresting reason — a connection may hold as many
+    // in-flight requests as the whole buffered-response budget has slots, so
+    // whether any other client is served at that moment is a race the test
+    // neither establishes nor is about.
+    wait_for_queued_gateway_requests(&app, CONTROL_MAX_IN_FLIGHT_PER_CONNECTION);
+    drain_gateway_requests(&mut app, &ctx);
     // A worker-side read is answered without the frame loop and without
     // the stalled client's replies ever being read.
-    let outcome = live
-        .invoke(
-            crate::control::DESCRIBE_CAPABILITY_ID,
-            serde_json::json!({}),
-        )
-        .unwrap()
-        .outcome;
+    let outcome = worker_side_read_past_the_unread_replies(&mut live);
     assert!(
         matches!(
             outcome,
@@ -2165,19 +2212,10 @@ fn gateway_a_client_that_never_reads_does_not_stall_another() {
             serde_json::json!({ "scopes": ["system.info"] }),
         )
         .unwrap();
-    for iteration in 0..400 {
-        run_frame(&mut app, &ctx);
-        let queued = app
-            .control
-            .control_access
-            .as_ref()
-            .expect("control access is installed")
-            .queued_requests_for_test();
-        if iteration >= 10 && queued == 0 {
-            break;
-        }
-        std::thread::sleep(std::time::Duration::from_millis(5));
-    }
+    // Wait for the request to reach the queue before asking the frames to
+    // empty it: an empty queue means nothing until the request is in it.
+    wait_for_queued_gateway_requests(&app, 1);
+    drain_gateway_requests(&mut app, &ctx);
     let response = live.read().unwrap();
     assert_eq!(response.request_id, request_id);
     assert!(matches!(
@@ -5257,7 +5295,12 @@ fn a_retry_that_races_its_own_first_call_is_refused_rather_than_acted_on() {
         "the caller is told to ask again once the first has answered"
     );
 
-    run_frame(&mut app, &ctx);
+    // The refusal above was answered before any frame ran, which is the race
+    // this test is about. Serving the first call is not: a frame admits the
+    // queue only inside `CONTROL_UI_BUDGET_US`, and on a loaded machine the
+    // frame's other work can spend that budget before the drain starts, so the
+    // first call is served over as many frames as the budget needs.
+    drain_gateway_requests(&mut app, &ctx);
     let served = client.read().unwrap();
     assert_eq!(served.request_id, first);
     assert!(matches!(

--- a/crates/app/src/app/tests/mod.rs
+++ b/crates/app/src/app/tests/mod.rs
@@ -1917,21 +1917,38 @@ fn wait_for_test_gateway_descriptor(
 }
 
 fn wait_for_queued_gateway_requests(app: &QuantickApp, expected: usize) {
+    wait_for_queue_depth(app, &format!("reach {expected}"), |queued| {
+        queued == expected
+    });
+}
+
+/// [`wait_for_queued_gateway_requests`] for a caller that only needs the
+/// requests to have arrived, not to be the only ones there. Exact equality is
+/// a trap once more than one request is outstanding: the queue can also shrink
+/// on its own — the response worker answers a request that missed its deadline
+/// without any frame running — and a wait that insists on the peak then never
+/// sees it and reports a defect where there is only a slow machine.
+fn wait_for_at_least_queued_gateway_requests(app: &QuantickApp, expected: usize) {
+    wait_for_queue_depth(app, &format!("reach {expected} or more"), |queued| {
+        queued >= expected
+    });
+}
+
+fn wait_for_queue_depth(app: &QuantickApp, wanted: &str, reached: impl Fn(usize) -> bool) {
     let deadline = std::time::Instant::now() + GATEWAY_TEST_WAIT;
     loop {
-        if app
+        let queued = app
             .control
             .control_access
             .as_ref()
             .expect("control access is installed")
-            .queued_requests_for_test()
-            == expected
-        {
+            .queued_requests_for_test();
+        if reached(queued) {
             return;
         }
         assert!(
             std::time::Instant::now() < deadline,
-            "gateway request queue did not reach {expected} within {GATEWAY_TEST_WAIT:?}"
+            "gateway request queue did not {wanted} within {GATEWAY_TEST_WAIT:?} (queued {queued})"
         );
         std::thread::sleep(std::time::Duration::from_millis(5));
     }

--- a/crates/app/src/app/tests/mod.rs
+++ b/crates/app/src/app/tests/mod.rs
@@ -1924,10 +1924,15 @@ fn wait_for_queued_gateway_requests(app: &QuantickApp, expected: usize) {
 
 /// [`wait_for_queued_gateway_requests`] for a caller that only needs the
 /// requests to have arrived, not to be the only ones there. Exact equality is
-/// a trap once more than one request is outstanding: the queue can also shrink
-/// on its own — the response worker answers a request that missed its deadline
-/// without any frame running — and a wait that insists on the peak then never
-/// sees it and reports a defect where there is only a slow machine.
+/// a trap once anything else can be in flight: one extra request from another
+/// connection, or one left over from an earlier step, and a wait that insists
+/// on its own number never sees it.
+///
+/// What it does not buy: tolerance of the queue shrinking under the caller.
+/// The response worker answers a request that missed its deadline without any
+/// frame running, and a set that loses one of its own members never reaches
+/// its depth under either comparison. A caller that waits for a whole backlog
+/// is relying on that deadline being far away, not on this spelling.
 fn wait_for_at_least_queued_gateway_requests(app: &QuantickApp, expected: usize) {
     wait_for_queue_depth(app, &format!("reach {expected} or more"), |queued| {
         queued >= expected


### PR DESCRIPTION
**Tier:** `small`. Campaign child of #367 (Q6); closes on integration: #385.

Two control-plane tests on `campaign/lean-a-plus` assert an outcome that one
application frame, or one lucky ordering between two client connections, has to
produce. Under CPU load neither is guaranteed, and each made CI red at random —
`gateway_a_client_that_never_reads_does_not_stall_another` reddened the first CI
run of #382. This forces both interleavings. No production file is touched; the
diff is the two test modules.

## What changed

**`gateway_a_client_that_never_reads_does_not_stall_another`** had two load
exposures, only one of which the issue named:

1. The stalled client filled its whole per-connection in-flight budget
   (`CONTROL_MAX_IN_FLIGHT_PER_CONNECTION`, 8) and the test then asked another
   client for a worker-side read *while those eight sat queued*. A connection
   may hold as many in-flight requests as the global buffered-response budget
   has slots (`CONTROL_MAX_BUFFERED_RESPONSE_SLOTS`, also 8), so whether the
   other client got a slot at that instant was a race nothing in the test
   established. The captured failure is exactly that:
   `control.backpressure` / "global buffered response capacity is full".

   The test now establishes both halves instead of racing them. It waits for
   the whole backlog to be queued, then asserts the half of the old claim that
   *is* deterministic under a full budget: the live client is **answered** —
   with its read, or with a refusal it is told to retry — and is never left
   waiting on a client that never reads. It then answers the backlog, which is
   what this test is named after: replies sitting **unread in a client's
   socket**, rather than requests still waiting to be served. The Success-only
   assertion runs there, once the slots those replies held are released; the
   wait for that release retries only `control.backpressure`, the refusal
   production itself marks retryable, inside the shared 30 s test budget, and
   any other outcome fails the assertion immediately.
2. Its drain loop broke on an empty queue after ten iterations — 50 ms — which
   on a loaded machine can be before the request it was waiting for had even
   reached the queue. It now waits for the request to be queued, then drains
   with `drain_gateway_requests` (the helper #382 added).

**`a_retry_that_races_its_own_first_call_is_refused_rather_than_acted_on`**
asserted its first call was served after exactly one `run_frame`. A frame
admits the queue only inside `CONTROL_UI_BUDGET_US` (250 us), which a loaded
frame can spend before the drain starts; the read then waits out the 5 s
request timeout and the success assertion fails. It now drains over as many
frames as the budget needs. The refusal the test is really about is still
asserted **before any frame runs**, unchanged.

**Shared harness.** `wait_for_queued_gateway_requests` compared the queue depth
for equality, which only fits a single-sender caller. A backlog wait needs
`wait_for_at_least_queued_gateway_requests`; both spellings now delegate to one
`wait_for_queue_depth` loop that names the depth it saw when it gives up.

Every assertion both tests made is still made. Nothing was weakened.

## Before / after

200 filtered runs per test, one test per process, while a loop of
`cargo build --workspace` over the whole workspace (touching `crates/engine`
each round) competed for every core on this machine.

| Test | Before | After |
| --- | --- | --- |
| `gateway_a_client_that_never_reads_does_not_stall_another` | 199/200 pass, **1 failure** (`control.backpressure`, "global buffered response capacity is full", at the live client's worker-side read) | **200/200 pass** |
| `a_retry_that_races_its_own_first_call_is_refused_rather_than_acted_on` | 199/200 pass, **1 failure** (`served.outcome` not `Success`; the run took 5.09 s, the request timeout, because the frame never drained the queue) | **200/200 pass** |

The before runs used the test binary built from the campaign base
(`216010ef`); the after runs used the binary built from this branch, and were
repeated after the review repairs — 200/200 both times. Both tables are also
posted on #385.

## Reviews

`arch-review` at tier `small`, step 0 = the bundled `code-review` at `low`
(effort-first, no reuse notice) over the exact diff against
`origin/campaign/lean-a-plus`. Two findings, both Should-fix, both **resolved
in `2efa9f64`**, plus one doc correction resolved in `0b49035a`:

- *Coverage reduction* — draining the backlog before the live client's read
  dropped the "another client is answered while a backlog is still queued"
  case. Repaired by asserting that case explicitly, at its deterministic half
  (answered, either way), before the drain.
- *Exact-equality wait* — waiting for the queue to equal 8 is the wrong
  comparison for a backlog. Repaired with the `at_least` spelling.
- *Doc overclaim* — the new wait's doc claimed `>=` guards against the queue
  shrinking. It does not: a set that loses a member never reaches its depth
  under either comparison. Reworded to say what it does and does not cover.

Nothing deferred. Delta follow-up over `4481f5af..2efa9f64` returned no new
finding and no objection to shipping.

## Verification (local, this head)

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets` — clean
- `cargo build --workspace` — clean
- `env -u QUANTICK_BUBBLES cargo test --workspace` — exit 0, 96 test binaries ok, 0 failures
- `cargo test -p quantick-guards` — 206 passed, 0 failed

Each check run on its own, with the contention loop stopped.

## Performance impact

None on any production path. The diff is confined to `#[cfg(test)]` code: rate
class *rare* (test-only). On an idle machine the new waits run fewer frames
than the fixed 400-iteration loop they replace.

## Scope

`git diff --stat` against `origin/campaign/lean-a-plus`:
`crates/app/src/app/tests/control_plane_tests.rs` and
`crates/app/src/app/tests/mod.rs` (the shared gateway test harness #382 added),
plus the archived mission goal file. No production file, no other test's
asserted property.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VdP84bYEGeyCg7KwsNb1X2
