### PR TITLE
test(app): force the frame the trade paint layer switch test asserts

### DIFF
--- a/.claude/GOAL-archive-layers-test-load-sensitive.md
+++ b/.claude/GOAL-archive-layers-test-load-sensitive.md
@@ -1,0 +1,129 @@
+# Mission — force the frame the trade paint layer switch test asserts
+
+**Objective:** make `app::tests::layers_tests::the_trade_paint_layer_switch_stops_the_marks`
+deterministic under CPU load by having the fixture establish the state its
+shape-count comparison depends on, so default-branch CI stops going red at
+random on an assertion the product never broke.
+
+**Tier:** `small`. Campaign child of #367 (task key Q8) for issue #403: one
+test in one test module, no production file, no contract, wire or financial
+rule in reach. Nothing here is the trader's call, so no interrogation and no
+`delivery-review` (the small-tier exemption).
+
+**Campaign base:** `origin/campaign/lean-a-plus` at `86bbe06a`. PR base is
+exactly `campaign/lean-a-plus`.
+
+## Request ledger
+
+- **R1** — find what the assertion at `layers_tests.rs:565` depends on that the
+  fixture does not force (a frame count, a worker publish, a shape cache) and
+  make the test establish it, the way #382 and #400 did.
+- **R2** — *"Weakening the assertion is not the fix"*: the property — switching
+  the trade paint layer off stops the marks — stays asserted, and the live
+  paper layer assertion stays.
+- **R3** — test-only: no production file changes.
+- **R4** — proof: 200 of 200 filtered runs pass while a concurrent
+  `cargo build --workspace` competes for CPU, with a before/after table in the
+  PR and on #403.
+- **R5** — merged into `campaign/lean-a-plus` through a PR whose base is exactly
+  that branch, with the merge read back (the coordinator's step).
+- **R6** — the closing purpose: A+ gate 3, default-branch CI green at the
+  assessed revision, no longer at the mercy of this test.
+
+## Decisions (from the coordinator, answering step 3)
+
+- **D1** — test-only; a production change that turns out to be required is
+  reported, not made.
+- **D2** — reproduce first (200 runs under a concurrent build, capture a
+  failing assertion), then make the test establish the missing state with a
+  bounded wait on the observable condition; the property stays asserted.
+- **D3** — the 200-run table before and after, in the PR body and on #403.
+- **D4** — tier `small`: `arch-review` with `code-review` at `low`;
+  `ai-review` completion; no delivery-review.
+- **D5** — `gh pr ready` once, Bash tool, `cd` prefix; never merge, never touch
+  main, never rebase.
+
+## Assumptions
+
+- **S1** — the failing CI assertion (run 34700339682, attempt 1: "the marks
+  kept painting with their layer off (309 vs 224)") is the order-flow worker
+  publishing a projection frame between the "on" and the "off" draw: the
+  "off" count is *larger*, which only something arriving between draws can
+  explain. Safe: confirmed or refuted by the reproduction before any edit.
+  *Outcome:* confirmed, and refined — convergence takes two worker round
+  trips, not one (the live lane waits for the published live edge). A first
+  fix forcing only one trip failed 118 of 200 under the pinned harness.
+- **S3** — the D2 harness (one process at a time beside a concurrent
+  `cargo build --workspace`) did not reproduce on this 12-core machine: 600 of
+  600 passed on the base. The reproduction adds contention of the kind the CI
+  runner has: 20 copies at a time, every copy pinned to one core
+  (`start /affinity 1`), still beside the concurrent build. Safe: it forces
+  the same interleaving harder and reproduced the CI assertion verbatim; both
+  harnesses are reported.
+- **S2** — the shared `mod.rs` helper is left alone unless a second test needs
+  the same settling. Safe: reversible in one edit.
+
+## Acceptance criteria
+
+- [x] **A1** — the root cause is named from a captured failure, not a guess.
+      *Evidence:* the failing run's assertion output under contention.
+      → the PR body's root-cause section. *(R1)*
+- [x] **A2** — the test passes 200 of 200 filtered runs under a concurrent
+      `cargo build --workspace`, against a before run on the base binary.
+      *Evidence:* the before/after table. → the PR body and a comment on #403.
+      *(R1, R4, R6)*
+- [x] **A3** — `marks_off < marks_on` and the live paper layer assertion are
+      still asserted, unweakened.
+      *Evidence:* the diff of `layers_tests.rs`. → the PR body. *(R2)*
+- [x] **A4** — no production file changes.
+      *Evidence:* `git diff --name-only origin/campaign/lean-a-plus...HEAD`.
+      → the PR body. *(R3)*
+- [ ] **A5** — the PR's base is exactly `campaign/lean-a-plus`.
+      *Evidence:* `gh pr view --json baseRefName`. → the handoff. *(R5)*
+- [ ] **G1** — every artifact in English; conventional commits.
+      *Evidence:* `cargo test -p quantick-guards` and the commit log. → the PR.
+- [ ] **G2** — the four checks green, run one at a time, and CI green at the
+      exact PR head. *Evidence:* command output; `gh pr checks`. → the PR.
+- [ ] **G3** — performance impact declared: every touched path is
+      `#[cfg(test)]`, rate "per test run". *Evidence:* the PR body's
+      performance section. → the PR.
+- [ ] **G4** — `arch-review` with every Blocker and Should-fix resolved or
+      deferred; `ai-review` completion recorded with zero open threads.
+      *Evidence:* review verdicts and markers. → the PR.
+
+## Closing steps
+
+- **C1** — the draft PR is open against `campaign/lean-a-plus` and marked
+  ready once reviews, markers and CI are green.
+- **C2** — the campaign merge and its read-back (R5) belong to the
+  coordinator.
+
+## Not applicable
+
+- *Touches a hot path*, *user-visible*, *adds a capability*, *adds something a
+  trader does*, *engine territory* — the diff is one `#[cfg(test)]` module.
+
+## The request as received
+
+> Attributed quotation: the coordinator's delegation for campaign #367, task Q8,
+> and issue #403's scope and acceptance criteria, verbatim.
+
+> You are executing campaign child mission **Q8** of campaign #367 (https://github.com/milocaetano/quantick/issues/367) for milocaetano/quantick: make the load-sensitive test `app::tests::layers_tests::the_trade_paint_layer_switch_stops_the_marks` deterministic. You are a subagent: you cannot ask the trader; decisions D1..Dn below answer the mission's step-3 questions. A doubt that would need a new decision is reported back, never guessed.
+>
+> ## Decisions
+> - D1: test-only. If you conclude a production change is genuinely required, stop, write the reasoning in your handoff, and do not make it.
+> - D2: first reproduce: run the filtered test 200 times while a concurrent `cargo build --workspace` (or `cargo test --workspace --no-run`) runs in another process, and capture a failing run's assertion output; then identify what the fixture does not force (a frame count, a worker publish, a shape cache refresh) and make the test establish it with a bounded wait on the observable condition, the shape #382/#400 used. The property under test (switching the trade paint layer off stops the marks) stays asserted.
+> - D3: proof: the 200-run table before and after, in the PR body and as a comment on #403.
+> - D4: tier `small`: `arch-review` with `code-review` at `low`; `ai-review` completion is still required; no delivery-review.
+> - D5: `gh pr ready` works with the cd-prefixed form from the Bash tool. Run it once after reviews, markers and green CI; if denied because the campaign tip moved, stop and report. **Never use the PowerShell tool for `gh pr` commands; never merge; never touch main.** Do not rebase; the coordinator does that at integration time.
+>
+> Issue #403, *Scope*:
+>
+> - Find what the assertion at `layers_tests.rs:565` depends on that the fixture does not force (frame count, a worker publish, a shape cache) and make the test establish it, the way #382 and #400 did for the gateway tests.
+> - Test-only change. Weakening the assertion is not the fix.
+>
+> Issue #403, *Acceptance criteria*:
+>
+> - [ ] A1: the test passes 200 of 200 filtered runs while a concurrent `cargo build --workspace` competes for CPU, before/after table in the PR; the property (switching the trade paint layer off stops the marks) is still asserted.
+> - [ ] A2: no production file changes.
+> - [ ] A3: merged into `campaign/lean-a-plus` through a PR whose base is exactly that branch, with the merge read back.

--- a/crates/app/src/app/tests/layers_tests.rs
+++ b/crates/app/src/app/tests/layers_tests.rs
@@ -557,11 +557,28 @@ fn the_trade_paint_layer_switch_stops_the_marks() {
             output.shapes.len()
         })
     };
+    // The two counts may differ only by the switch, so both are taken from
+    // a chart that has finished converging, and that takes two trips
+    // through the order-flow worker, each landing whenever its thread gets
+    // a core. The live lane is laid out only once the worker has published
+    // the newest print it recorded; and a draw paints the projection the
+    // draw *before* it asked for. Under load the "on" count caught the lane
+    // laid out over a projection requested without it, and the "off" count
+    // caught the finished chart — 224 shapes against 309 — so the marks
+    // looked as if they kept painting. The fixture's prints are in the
+    // worker before the first draw, and every count waits for the worker
+    // to publish what the draw before it asked for.
+    app.active_tab_mut().tape_mut().flush_for_test();
+    let settled = |app: &mut QuantickApp| {
+        let _ = shapes(app);
+        app.active_tab_mut().tape_mut().flush_for_test();
+        shapes(app)
+    };
     // One frame to settle the ranges a draw computes for the next one.
     let _ = shapes(&mut app);
-    let marks_on = shapes(&mut app);
+    let marks_on = settled(&mut app);
     switch_layer(&mut app, ChartLayer::TradePaint, false);
-    let marks_off = shapes(&mut app);
+    let marks_off = settled(&mut app);
     assert!(
         marks_off < marks_on,
         "the marks kept painting with their layer off ({marks_off} vs {marks_on})"


### PR DESCRIPTION
## Summary

Make `app::tests::layers_tests::the_trade_paint_layer_switch_stops_the_marks` deterministic under CPU load by forcing the frame its shape-count comparison depends on.

**Tier:** `small`. Campaign child of #367 (Q8); closes on integration: #403. Test-only: the diff is one `#[cfg(test)]` module and the mission archive. No production file changed.

### Root cause (captured, not guessed)

The CI failure (run 34700339682, attempt 1) was `the marks kept painting with their layer off (309 vs 224)`: the "off" count was **larger** than the "on" count. I reproduced that assertion verbatim on the base (table below), then instrumented the draws on a failing run:

```text
first=185 aggr=0 builds=0 live_end=None     <- worker has not recorded the prints yet
pre=185   aggr=0 builds=0 live_end=None
post=224  aggr=2 builds=1 live_end=Some(..) <- "on" count: lane laid out, projection requested without it
pre=174   aggr=2 builds=1
post=309  aggr=4 builds=2                   <- "off" count: the finished chart
```

On a quiet run the same chart settles at 359 on / 309 off.

The flow pane takes **two** trips through the order-flow worker to finish converging, and each trip lands whenever the worker thread gets a core:

1. `OrderflowView::live_lane` lays the live lane out only once the worker has published the newest print it recorded (`live_end_ms`). Until then the pane draws without a lane and asks for a projection with `lane: false`.
2. A draw paints the projection that the draw **before** it requested (`project_visible` returns the published frame, then sends the new request).

Under load, the "on" count caught the chart with the lane laid out but painting a projection requested without the lane (224 shapes). The "off" count came one round trip later and caught the finished chart (309). So the marks looked as if they kept painting. The product was behaving as designed. The fixture had assumed the worker is always one step ahead of the render thread.

A first fix that forced only the second trip (`draw → flush → draw` per count) made the test **worse**: 118 of 200 failed under the pinned harness, all with `309 vs 224`. That run is what exposed the first trip.

### The fix

- After the fixture's prints are drained, `tape_mut().flush_for_test()` waits until the worker has recorded them and published its live edge. The first draw then lays out the lane.
- Each count is taken as `draw → flush → draw`, so the measured draw paints the projection for the draw just before it.

`flush_for_test` is the existing bounded wait (`OrderflowWorker::flush`: a `Flush` ack with a 10 s `recv_timeout`) that the other order-flow tests already use. Neither step reads a clock. After step 1 no new data reaches the worker, so the `PROJECTION_INTERVAL` cadence in `project_at` cannot hold back a rebuild: a changed layout rebuilds immediately, and an unchanged one hits a clean cache.

Both assertions are unchanged: `marks_off < marks_on`, and the live paper layer is still visible after hiding closed-trade history.

### Before / after

Every run executes the filtered test with `--exact ... --test-threads=1`, one test per process. A loop of `cargo build --workspace` ran throughout in its own target dir, touching `crates/engine` each round. *Before* used the test binary built at the campaign base `86bbe06a`. *After* used the binary built at `5cc21dbf`.

| Harness | Build | Runs | Pass | Fail | Failure captured |
| --- | --- | ---: | ---: | ---: | --- |
| sequential, one process at a time (the issue's harness) | before | 600 | 600 | 0 | none: this 12-core machine never starved the worker |
| sequential, one process at a time | after | 200 | 200 | 0 | none |
| 20 processes at a time, all pinned to one core (`start /affinity 1`) | before | 200 | 190 | **10** | `layers_tests.rs:565`, `309 vs 224`, the CI assertion verbatim |
| same, repeated | before | 200 | 191 | **9** | same |
| same | first fix (second trip only) | 200 | 82 | **118** | same |
| same | **after** | 200 | **200** | **0** | none |
| same, extended | **after** | 1000 | **1000** | **0** | none |

The issue's harness alone does not reproduce the failure on this machine. The pinned harness recreates the contention of the two-core CI runner, and it reproduces the CI assertion exactly. Both are reported. The same table is posted on #403.

### Performance impact

Test-only, rate "once per test run". The only touched code is a `#[cfg(test)]` test body. It adds two worker flushes and two extra draws to one test, about 1 ms on a quiet machine. No per-trade, per-depth or per-frame production path is reached.

## Verification loop

Run locally at `5cc21dbf` (the code head), each command on its own, none chained:

- [x] `cargo fmt --all -- --check`: exit 0
- [x] `cargo clippy --workspace --all-targets`: exit 0, 0 warnings
- [x] `cargo build --workspace`: exit 0
- [x] `cargo test --workspace` (with `QUANTICK_BUBBLES` unset): exit 0; `quantick-app` 2000 passed, 0 failed, 7 ignored
- [x] `cargo test -p quantick-guards`: 164 passed

The archive commit `2e18b1be` is prose only; guards were rerun after it. Required CI at the final head is pending.

Changed files (`git diff --name-only origin/campaign/lean-a-plus...HEAD`): `crates/app/src/app/tests/layers_tests.rs`, `.claude/GOAL-archive-layers-test-load-sensitive.md`.

## Reviews

Graded at `2e18b1be` against `origin/campaign/lean-a-plus` at `f36cc022`, review key `11c116f8`.

**arch-review.** Step 0: `code-review` at `low` (level given as the first token, no reuse notice), 0 findings. Its `low` recipe skips test hunks, so the bug pass was also run here independently, as the skill provides for. That pass came back clean:

- The flush is the existing bounded `OrderflowWorker::flush` ack.
- The flow pane always has a tape, so `tape_mut` cannot panic here.
- Both assertions are unchanged.
- No clock-dependent cadence remains once the fixture's prints are in the worker.

The tier is `small`, so the shape pass read the dimensions the diff reaches: 2 (the declaration), 4 and 8. One Consider, not acted on: the pre-existing single settle draw is now partly redundant with `settled`'s first draw. It is harmless.

- **Correctness**: clean, nothing open.
- **Docking**: no port involved; the change is local to one test body.
- **Performance**: flat; the only touched path is a `#[cfg(test)]` test body, run once per test run.
- **Operability**: no surface.
- **Proof**: the test itself, measured: it fails 10 of 200 on the base under the pinned harness and passes 1200 of 1200 at this head. It is an app unit test.
- **Accumulation**: trunk flat; nothing tracked by the size ratchet moved.
- **Language**: the guard passed inside `cargo test --workspace`; the comments, branch name, commit messages and this body were read here and are English.

**ai-review**: 6 of 6 PASS, 0 findings, 0 threads. Report: https://github.com/milocaetano/quantick/pull/404#issuecomment-5646980800

**delivery-review**: not run, per the `small`-tier exemption (21 of 300 changed lines).

## Notes for the reviewer

- The campaign tip moved to `f36cc022` (#396, #391) after this branch was cut. Per D5 this branch is not rebased; the coordinator rebases at integration. The touched test module is disjoint from those merges.
- `a_hidden_layer_paints_nothing` in the same file solved the same class of problem another way: it hides every flow layer so the pipeline never starts. That was not an option here without changing what the chart under test looks like, so this test waits for the pipeline instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VdP84bYEGeyCg7KwsNb1X2
