### PR TITLE
feat(guards): leave the size baseline with no signed per-file exception

### DIFF
--- a/.claude/GOAL-archive-size-baseline-no-exceptions.md
+++ b/.claude/GOAL-archive-size-baseline-no-exceptions.md
@@ -1,0 +1,245 @@
+# Mission: leave the size baseline with no signed per-file exception
+
+**Objective.** Retire the last per-file entry in
+`crates/guards/size-baseline.txt` and set `!budget 0`, so that "no production
+file over 1,500 production lines" is a rule the size guard enforces rather
+than a state the tree happens to be in; and make the guards' report honest when
+a scan fails, instead of printing the most flattering number it has.
+
+**Tier:** `medium`. Campaign child S10 of #367 (issue #377), assigned at
+`medium` by the coordinator: a guard change whose failure mode is a guard that
+reports clean when it could not look, but with no runtime, money or UI path in
+reach. `medium` buys the full gate table, `code-review` at `low` inside
+`arch-review` with the full shape pass, and `delivery-review`'s completeness
+pass inline. Step 3's questions were answered by the coordinator as D1–D7.
+
+## Request ledger
+
+- **R1** — "the baseline holds no per-file entries and `!budget 0`"; "Remove
+  `crates/app/src/app.rs 769`". The mechanism for a future legitimate
+  exception stays: "a signed entry plus a budget raise in the same change is
+  still possible and still reviewed". *(A1, A2)*
+- **R2** — A file over 1,500 production lines fails the guard "without an
+  escape hatch other than an explicit, reasoned budget raise". *(A2, A3)*
+- **R3** — "a guard test that a fixture file of 1,501 production lines fails
+  and one of 1,500 passes with an empty baseline and `!budget 0`". *(A3)*
+- **R4** — "a test that a signed entry above the threshold without a matching
+  budget raise fails (if such a test does not already exist, add it; if it
+  exists, name it)". *(A4)*
+- **R5** — Rewrite the baseline header: "one accurate paragraph that states
+  the rule", then "a short, accurate history of how the file reached zero in
+  campaign #367" naming the twenty entries and the PRs that retired them,
+  "with no stale arithmetic"; fold the per-cut paragraphs in; recover S5's lost
+  rationale from `29bff61b` for the control-plane line; drop the stale 40,121,
+  1,297 and 5,891. *(A5)*
+- **R6** — `extension_boundary.rs` `measured()` "must not report a failed scan
+  as 0": propagate the error so `--report` prints the failure, with
+  `size::measured` and `context::measured` consistent; a test with an
+  unreadable or missing root. *(A6, A7)*
+- **R7** — `CLAUDE.md`: "at most one sentence in *Keeping the trunk small*"
+  saying the baseline is empty and every production file is at or under
+  1,500, its bytes paid in the context ratchet by trimming redundant prose in
+  the same section, or the exact overage reported. *(A8)*
+- **R8** — Purpose, the ask that judges the rest: "so that 'no production file
+  over 1,500 production lines' becomes a rule the guard enforces, and make the
+  guards report honest when a scan fails". *(A2, A6)*
+- **R9** — Write only in `crates/guards/*` and one sentence of `CLAUDE.md`
+  (plus this mission's own archive); never the sibling-owned control, worker,
+  state, health or layers-test files. *(A9)*
+
+Operational instructions (worktree, draft PR, reviews, markers, CI, one
+`gh pr ready`, never merge) map to G/C below, not to R/A.
+
+## Decisions (from the coordinator, answering step 3)
+
+- **D1** — No per-file entries, `!budget 0`; the exception mechanism stays.
+- **D2** — Header: one rule paragraph, then a short accurate history of the
+  twenty entries and PRs #383, #384, #388, #390, #391, #392, #395, #396, #399,
+  and app.rs retired here; S5's rationale recovered from `29bff61b`.
+- **D3** — Tests: 1,501 fails / 1,500 passes with an empty baseline and
+  `!budget 0`; a signed over-threshold entry without a budget raise fails.
+- **D4** — `measured()` propagates errors; `--report` prints the failure
+  consistently with `scan.unreadable`/`scan.blind`; size and context
+  consistent; a test with a missing or unreadable root.
+- **D5** — At most one `CLAUDE.md` sentence, paid in the context ratchet.
+- **D6** — Guard change: the delivery contract's first validation row;
+  `medium` review shape; at most three step-0 rounds.
+- **D7** — `gh pr ready` once, cd-prefixed, from the Bash tool; stop and
+  report if denied; never merge, never touch `main`.
+
+## Assumptions
+
+- **S1** — The issue body's "pure moves" scope and its A2/A3 (line multiset,
+  pinned tests unchanged) are the campaign's template for S1–S9. S10 moves no
+  production code, so A2's multiset has nothing to prove; A3's "no test
+  expectation edited" is honoured except for the one test that asserted the
+  `app.rs` entry exists (`baseline_parsing_ignores_comments`), which R1
+  retires by definition. Safe: the coordinator's brief and D1 name that entry
+  for removal, and the test's comment-parsing property is kept on a fixture.
+- **S2** — "Consistent" (D4) is read as: every `Ratchet::measured` returns a
+  `Result`, and a walk that could not see every tracked path — an unlistable
+  directory, an unreadable file, a file that does not decode — is a failed
+  measurement, not a smaller total. `cycle::measured` shares the registry
+  signature and is made consistent too. Safe: the alternative is a signature
+  that lets one ratchet keep the defect the issue names.
+- **S3** — `--report` on a failed scan keeps printing the whole table, with
+  `failed` in place of the number, a `scan.failed` count row beside
+  `scan.unreadable`/`scan.blind`, the reasons on stderr, and exit code 1. D4
+  offers "exits non-zero or prints an explicit `scan.failed` line"; doing both
+  costs nothing and a script checking the status is not misled. Reversible in
+  one edit.
+- **S4** — Budget and the BUDGET_SLACK: with an empty baseline, the recorded
+  total is 0 and `!budget 0` sits at it, so the slack rule is quiet. Code
+  comments that cite "eighteen entries recorded today" are updated only where
+  they state a current count as fact.
+
+## Acceptance criteria
+
+- [x] **A1** — `crates/guards/size-baseline.txt` has no `<path> <count>` line
+      and its only directive is `!budget 0`.
+      *Evidence:* `grep -vE '^(#|$)' crates/guards/size-baseline.txt` prints
+      exactly `!budget 0`; `--report` shows `ratchet.size.budget 0` and
+      `ratchet.size.recorded 0`. → PR body. *(R1)*
+- [x] **A2** — The guard passes on the real tree with that baseline, and
+      `cargo run -p quantick-guards -- --tighten` changes nothing.
+      *Evidence:* `cargo test -p quantick-guards` green;
+      `--tighten` output and a clean `git status`. → PR body. *(R1, R2, R8)*
+- [x] **A3** — A fixture file of 1,501 production lines fails the size guard
+      and one of 1,500 passes, both under an empty baseline with `!budget 0`.
+      *Evidence:* the named tests in `crates/guards/src/size.rs`. → PR body.
+      *(R2, R3)*
+- [x] **A4** — A signed entry above the threshold without a matching budget
+      raise fails, and the same entry with the budget raised passes.
+      *Evidence:* named tests in `size.rs` (existing and new). → PR body.
+      *(R4)*
+- [x] **A5** — The baseline header is one rule paragraph plus a history of
+      the twenty entries and the PRs that retired them, carrying S5's
+      recovered rationale and none of 40,121, 1,297 as current, or 5,891.
+      *Evidence:* the file's text and `grep -c` for those numbers. → PR body.
+      *(R5)*
+- [x] **A6** — `--report` over a root whose scan fails prints `failed`, not
+      `0`, for every affected ratchet, a non-zero `scan.failed`, the reasons
+      on stderr, and exits non-zero; on the real tree it still exits 0 with
+      `scan.failed 0`.
+      *Evidence:* an integration test in `crates/guards/tests/guards.rs`
+      running the binary against a missing root; the command's output. → PR
+      body. *(R6, R8)*
+- [x] **A7** — `extension_boundary::measured`, `size::measured`,
+      `context::measured` (and `cycle::measured`) return an error for a scan
+      that failed; each has a unit test over a missing or unreadable root.
+      *Evidence:* named tests. → PR body. *(R6)*
+- [x] **A8** — `CLAUDE.md` carries exactly one new sentence in *Keeping the
+      trunk small* with the rule, and `cargo test -p quantick-guards` passes
+      the context ratchet without raising `CLAUDE.md`'s ceiling or the
+      budget — or the exact overage is reported.
+      *Evidence:* the diff of `CLAUDE.md` and `context-baseline.txt`. → PR
+      body. *(R7)*
+- [x] **A9** — The diff touches only `crates/guards/*`, `CLAUDE.md` and this
+      mission's archive. *Evidence:* `git diff --stat` against the base. → PR
+      body. *(R9)*
+- [x] **G1** — Every artifact English; conventional commits with the session
+      trailers. *Evidence:* `arch-review` dimension 8; guards. → review report.
+- [ ] **G2** — `cargo fmt --all -- --check`, `cargo clippy --workspace
+      --all-targets`, `cargo build --workspace`,
+      `env -u QUANTICK_BUBBLES cargo test --workspace` green, run one at a
+      time, plus `sh .claude/hooks/guardrails_test.sh`; CI green at the exact
+      PR head. *Evidence:* outputs and the CI run URL. → PR body.
+- [x] **G3** — Performance impact declared: every touched path is the guards
+      binary or its tests (rate: rare, developer-time); no per-trade,
+      per-depth or per-frame path is touched. *Evidence:* PR body.
+- [ ] **G4** — `arch-review` over the diff against `origin/campaign/lean-a-plus`
+      with `code-review` at `low` and the full shape pass; every Blocker and
+      Should-fix resolved or deferred in the PR body; `ai-review` completion
+      recorded with zero unresolved threads. *Evidence:* review reports on the
+      PR. → PR comments.
+
+## Evidence at the implementation commit
+
+- A1: `grep -vE '^(#|$)' crates/guards/size-baseline.txt` prints `!budget 0`;
+  `--report` rows `ratchet.size.budget 0`, `ratchet.size.recorded 0`,
+  `ratchet.size.measured 184691`.
+- A2: `cargo test -p quantick-guards` green; `--tighten` printed "nothing to
+  tighten" for all four ratchets and left `git status` clean.
+- A3: `size::tests::a_file_one_line_over_the_threshold_fails_an_empty_baseline`,
+  `size::tests::a_file_at_the_threshold_passes_an_empty_baseline`.
+- A4: new `size::tests::a_signed_exception_without_a_budget_raise_fails` and
+  `size::tests::a_signed_exception_with_its_budget_raise_passes`; existing
+  `size::tests::a_raise_that_pays_for_nothing_is_over_budget`.
+  `size::tests::the_baseline_holds_no_exception_and_a_zero_budget` pins A1.
+- A5: `grep -cE "40,121|1,297|5,891" crates/guards/size-baseline.txt` is 0;
+  the header is the rule, the budget's reason, and the per-PR history.
+- A6: `tests/guards.rs::the_report_says_failed_rather_than_zero_when_a_scan_fails`
+  and `tests/extension_boundary.rs::a_failed_scan_is_not_measured_as_zero`;
+  the real tree's report carries `scan.failed 0` and exits 0
+  (`the_report_is_byte_identical_across_runs`).
+- A7: `tests/guards.rs::every_ratchet_fails_to_measure_a_tree_it_cannot_scan`
+  (all four through the registry), `size::tests::measured_is_a_failure_when_the_walk_missed_a_file`,
+  `context::tests::measured_is_a_failure_when_an_instruction_directory_is_missing`,
+  `ratchet::tests::a_walk_that_missed_a_path_has_no_total`.
+- A8: `CLAUDE.md` 9,551 -> 9,548 bytes, under its 9,551 ceiling; the context
+  baseline and budget unchanged.
+- A9: `git diff --stat origin/campaign/lean-a-plus...HEAD` lists only
+  `CLAUDE.md`, `crates/guards/*` and this archive.
+- G2 (local): fmt check, clippy, build and
+  `env -u QUANTICK_BUBBLES cargo test --workspace` (3,614 passed) each exit
+  0, run one at a time; `sh .claude/hooks/guardrails_test.sh` 227 passed.
+  CI at the PR head is recorded in the PR.
+
+## Not applicable
+
+- *Touches a hot path*, *user-visible*, *adds a capability*, *adds something
+  a trader does*, *engine/determinism*: the diff is the guards crate, its
+  baselines and one `CLAUDE.md` sentence — no app, engine or UI code.
+- *Docs/skills only*: tests and guard source change, so the full shape pass
+  and the first validation row apply.
+
+## Closing steps
+
+- **C1** — `delivery-review` completeness pass (inline, tier `medium`) returns
+  PASS and its marker is recorded with the campaign key.
+- **C2** — Draft PR against exactly `campaign/lean-a-plus`, then one
+  `gh pr ready` after reviews, markers and green CI; the coordinator merges.
+
+## The request as received
+
+The coordinator's delegated task request, quoted in full and verbatim:
+
+> You are executing campaign child mission **S10** of campaign #367 (https://github.com/milocaetano/quantick/issues/367) for milocaetano/quantick: leave the size baseline with no signed per-file exception, so that "no production file over 1,500 production lines" becomes a rule the guard enforces, and make the guards report honest when a scan fails. You are a subagent: you cannot ask the trader; decisions D1..Dn below answer the mission's step-3 questions. A doubt that would need a new decision is reported back, never guessed.
+>
+> ## Read first, in this order
+> 1. `C:\src\quantick\CLAUDE.md` (*Keeping the trunk small*: the size ratchet, teeth both ways, pay-as-you-go growth, the budget; *Keeping the instructions small*: the context ratchet covers CLAUDE.md, so any sentence you add is paid for there).
+> 2. `C:\src\quantick\.claude\skills\mission\SKILL.md` — you are a **campaign child at tier `medium`**; follow steps 1, 2, 4, 5, 7, 8, 9. Step 3 is answered below. Step 6 is done (worktree, `mission-base`, `mission-tier`, guards armed); still run `cargo check -p quantick-guards --all-targets` before the first edit.
+> 3. `C:\src\quantick\docs\campaign\integration.md` (base `origin/campaign/lean-a-plus`, PR base exactly `campaign/lean-a-plus`, review key from `sh .claude/hooks/campaign_context.sh key "$WT"`), `C:\src\quantick\docs\workflow\delivery.md`.
+> 4. The task: issue #377 (`gh issue view 377 --comments`): scope, acceptance criteria, and the two comments carrying inputs from the integrations (the lost S5 rationale paragraph recoverable from `git show 29bff61b:crates/guards/size-baseline.txt`; stale numbers in S1's block, 40,121, and S9's block, a 1,297 fall; S8's block closing on 5,891).
+> 5. Issue #365 item 3 (`gh issue view 365`): `crates/guards/src/extension_boundary.rs` `measured()` swallows inventory errors with `unwrap_or(0)`, so `cargo run -p quantick-guards -- --report` prints 0 when the scan fails.
+> 6. The guard: `crates/guards/src/size.rs` (THRESHOLD 1,500, `production_flags`, the baseline parser, `--tighten`, the budget rules and their tests), `crates/guards/size-baseline.txt` (header prose and the one remaining entry `crates/app/src/app.rs 769`, which is below the threshold and only exists as history), `crates/guards/src/context.rs` and `crates/guards/context-baseline.txt` (the context ratchet), `crates/guards/tests/guards.rs`.
+>
+> ## Worktree (the only place you write)
+> - `C:\src\quantick-worktrees\feat-size-baseline-no-exceptions` (Git Bash `/c/src/quantick-worktrees/feat-size-baseline-no-exceptions`), branch `feat/size-baseline-no-exceptions`, cut from `origin/campaign/lean-a-plus` at `f36cc022`. Every command starts with `cd /c/src/quantick-worktrees/feat-size-baseline-no-exceptions &&`. Never write to `C:\src\quantick` or other worktrees.
+> - You own `crates/guards/*` (sources, tests, baselines) and one sentence in `CLAUDE.md`. Siblings in flight own `crates/app/src/control/*` (Q2), worker/state/health files (Q3) and `crates/app/src/app/tests/layers_tests.rs` (Q8); do not edit those.
+>
+> ## Decisions
+> - D1: the baseline holds no per-file entries and `!budget 0`. The mechanism for a future legitimate exception stays (a signed entry plus a budget raise in the same change is still possible and still reviewed); only the current data goes to zero. Remove `crates/app/src/app.rs 769` (it is below the threshold).
+> - D2: rewrite the baseline header: one accurate paragraph that states the rule (every production file at or under 1,500 production lines; an exception needs a signed entry and a budget raise, and the budget only ever goes down on its own), followed by a short, accurate history of how the file reached zero in campaign #367 (the twenty entries and the PRs that retired them: #383 pane, #384 paper trading, #388 renderers, #390 drawings, #391 control plane, #392 chrome, #395 MT5 stream, #396 orderflow, #399 pine, and app.rs retired here), with no stale arithmetic. Fold the per-cut paragraphs into that history; keep what a reader needs (why an entry left, where to look) and drop what was only true on the day. Recover S5's lost rationale from `git show 29bff61b:crates/guards/size-baseline.txt` for the control-plane line.
+> - D3: tests: a guard test that a fixture file of 1,501 production lines fails and one of 1,500 passes with an empty baseline and `!budget 0`; a test that a signed entry above the threshold without a matching budget raise fails (if such a test does not already exist, add it; if it exists, name it). Keep every existing guard test green.
+> - D4: `extension_boundary.rs` `measured()` must not report a failed scan as 0: propagate the error so `--report` prints the failure (and exits non-zero or prints an explicit `scan.failed` line consistent with how `scan.unreadable`/`scan.blind` are reported today); make `size::measured` and `context::measured` consistent with that. Add a test with an unreadable or missing root.
+> - D5: `CLAUDE.md`: at most one sentence in *Keeping the trunk small* saying the baseline is empty and every production file is at or under 1,500 production lines; pay its bytes in `crates/guards/context-baseline.txt` by trimming an equivalent amount of redundant prose in the same section if the context ratchet requires it, or report the exact overage.
+> - D6: this is a guard change: the delivery contract's first row applies (tests changed). Tier `medium`: `arch-review` with `code-review` at `low`, full shape pass; `ai-review` completion; `delivery-review` completeness pass inline. At most three step-0 rounds.
+> - D7: `gh pr ready` works with the cd-prefixed form from the Bash tool. Run it once after reviews, markers and green CI; if denied because the campaign tip moved or the PR is DIRTY, stop and report; the coordinator rebases. **Never use the PowerShell tool for `gh pr` commands; never merge; never touch main.**
+>
+> ## Environment notes
+> - Use `python`, not `python3`. If `cargo fmt` is blocked, run `rustfmt` directly then `cargo fmt --all -- --check`. Run the four checks one at a time, never `||` or `| head`; read whole failures. Do not wait on background commands; foreground with an adequate timeout.
+> - `sh .claude/hooks/guardrails_test.sh` also reads the guards' outputs; run it before committing.
+> - If writing review markers into the git dir is denied by the permission classifier, put the exact `printf` lines in your handoff, marked pending.
+> - Commit trailers: `Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>` and `Claude-Session: https://claude.ai/code/session_01VdP84bYEGeyCg7KwsNb1X2`.
+> - Known CI load flake being fixed by Q8: `layers_tests::the_trade_paint_layer_switch_stops_the_marks`; report, rerun the job once at most.
+>
+> ## Delivery
+> 1. Implement with the verification loop (`cargo check -p quantick-guards`, `cargo test -p quantick-guards`, `cargo run -p quantick-guards -- --report`, `cargo run -p quantick-guards -- --tighten` changing nothing).
+> 2. Before every commit: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets`, `cargo build --workspace`, `env -u QUANTICK_BUBBLES cargo test --workspace`, each separately, plus `sh .claude/hooks/guardrails_test.sh`.
+> 3. Archive `GOAL.md` per mission step 8 (slug `size-baseline-no-exceptions`) as the last commit before reviews.
+> 4. Push; open a **draft** PR: `cd /c/src/quantick-worktrees/feat-size-baseline-no-exceptions && gh pr create --draft --base campaign/lean-a-plus --title "feat(guards): leave the size baseline with no signed per-file exception" --body-file -` with a heredoc body per the PR template: tier, "Campaign child of #367 (S10); closes on integration: #377; addresses #365 item 3", the before/after of the baseline, the new tests and what each proves, the `--report` output on a failed scan, local verification, then `🤖 Generated with [Claude Code](https://claude.com/claude-code)` and `https://claude.ai/code/session_01VdP84bYEGeyCg7KwsNb1X2`.
+> 5. `/arch-review`, `/ai-review`, `/delivery-review`; resolve Blockers/Should-fixes; record markers with the shared key per integration.md.
+> 6. Watch CI at the head (`gh pr checks <n> --watch`, bounded).
+> 7. `gh pr ready <n>` once (D7).
+> 8. Return a HANDOFF BLOCK: issue; branch; worktree; PR URL; head SHA; base tip; the final `--report` size lines; tests added; the context-ratchet outcome; review verdicts with URLs; markers yes/no; CI run URL and conclusion; findings closed/open; repair batches; ready accepted or denied; any human_decision; the coordinator's next action.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,9 +47,9 @@ Crates under `crates/`; `AGENTS.md` *The map* owns the descriptions and the grap
 
 - **A capability docks as a new file plus one registration line** — not a field, an init, a draw call and a hotkey in `QuantickApp`. No port to dock against? Build one: `.claude/skills/new-extension/SKILL.md`.
 - **A surface that moves out takes its tests with it.**
-- **The size ratchet enforces this** — `crates/guards/src/size.rs`, ceilings in `crates/guards/size-baseline.txt`. Production lines only, threshold 1,500; `tests/` untracked.
-- **Teeth both ways** — no growth past a ceiling, and no sitting more than 200 lines below one. `cargo run -p quantick-guards -- --tighten` writes the new number when a file shrinks.
-- **Growth is pay-as-you-go** — a raise must be signed in the baseline with a reason, and a budget caps the sum of all ceilings, so raising one means lowering another in the same change.
+- **The size ratchet enforces this** — `crates/guards/src/size.rs`, production lines only, `tests/` untracked. `crates/guards/size-baseline.txt` is empty: no production file exceeds 1,500 lines.
+- **Teeth both ways** — no growth past a ceiling, nor more than 200 lines below one. `cargo run -p quantick-guards -- --tighten` writes the new number when a file shrinks.
+- **Growth is pay-as-you-go** — an exception is a signed, reasoned entry, and a budget caps the sum of all ceilings, so raising one means lowering another in the same change.
 
 ## Keeping the instructions small
 

--- a/crates/guards/size-baseline.txt
+++ b/crates/guards/size-baseline.txt
@@ -1,385 +1,91 @@
-# The recorded ceiling, in production lines, for every file over the
-# threshold. One `path ceiling` pair per line; `#` starts a comment.
+# The size ratchet's exceptions: one `path ceiling` pair per line, plus the
+# one `!budget` directive capping their sum. `#` starts a comment.
 #
-# These are sizes, not targets: each entry is debt, and the only direction one
-# should ever move is down. `app.rs` at the top of the list is the reason the
-# guard exists.
+# ## The rule
 #
-# This is a data file rather than a Rust `const` for two reasons. Raising a
-# ceiling is then a data diff instead of an edit to a source file full of
-# prose, which is what two worktrees conflict over; and `--tighten` can
-# rewrite a line-oriented file safely, where rewriting a Rust array by machine
-# is the kind of clever nobody should have to review.
-
-# `app.rs` is the reason this guard exists. Tightened three times now. The
-# guard's own change took the agent popup, the acknowledgement toast and the
-# Save-as box out to `src/surfaces/`; the second batch took the
-# indicator-preview watermark, the appearance window, the footprint settings
-# window, the market dialog and the arming dialog with its alarm section -
-# 403 production lines and nine struct fields - and gave back the environment
-# the port hands them instead, plus the review's fixes and the
-# `QUANTICK_TOAST=paper` hook that photographs the converged acknowledgement
-# lane.
+# Every production source file is at or under 1,500 production lines, as
+# `crates/guards/src/size.rs` counts them (top-level `#[cfg(test)]` items and
+# `tests/` excluded). This file therefore holds no entry and `!budget 0`, and a
+# file that crosses the threshold fails `cargo test -p quantick-guards`. The
+# fix the failure asks for is to give the new code its own module, as
+# `new-extension` describes. An exception is still possible, and it is two
+# edits in the same change, both reviewed: a signed `path ceiling` entry with
+# a comment saying why, and a raise of the `!budget` line by as much. The
+# budget never goes up on its own: `--tighten` only lowers it, so every raise
+# is a number a person wrote and a reviewer can argue with.
 #
-# The third batch was the drawing chrome: the context bar, the on-chart note
-# editor, the inspector in both its hosts and the object manager, with the
-# title bar, the body, the placement rule and the action applier they share.
-# 1,548 production lines and twenty-one struct fields, out to
-# `src/surfaces/drawing_chrome/` as one member - they are one subsystem, and
-# four members would have left the state they share behind. The number below
-# is what that left, not a target: this file is still six times the threshold.
+# A data file rather than a Rust `const`, so that a raise is a one-line data
+# diff instead of an edit to a source file, and so that `--tighten` can
+# rewrite it line by line without eating the comments beside an entry.
 #
-# Raised again by the risk-per-trade work, for the three things only this file
-# can do: reading the sidecar into every tab on boot, the save-and-fan-out
-# when a ticket changes the risk, and handing a newly opened tab the settings
-# the one beside it is using. All three have the shapes
-# `persist_order_strategies` and `set_cmd_trading` beside them already have,
-# and none can move - they reach `self.tabs`, which is what this file is. The
-# last of them came out of that branch's own review: the toolbar's entry pair
-# reads the same lock the ticket does, because gating one and not the other
-# left a button lit while the order behind it was already refused.
-# Raised for the MT5 session-history branch: one window-level setting (the
-# `by time` reach's span) in the six places such settings live, plus the
-# `ScriptedMenu` registry that replaced a string equality so a capture can
-# open the history menu at all.
-# ## The debt budget
+# ## Why the budget exists
 #
-# The sum of every ceiling below may not exceed this number. Per-file ceilings
-# alone could not answer the question that matters -- is this repository's
-# largest code getting better or worse? -- because eighteen entries each raised
-# "for this branch" read as eighteen reasonable decisions and one lost trunk.
-# That is not hypothetical: the entry for `app.rs` went from 9,775 to 9,890 in
-# commit 2dcf062, on PR #271, signed, with nothing extracted in return.
+# Per-file ceilings alone could not answer whether the largest code was
+# getting better or worse: eighteen entries each raised "for this branch" read
+# as eighteen reasonable decisions and one lost trunk. The entry for `app.rs`
+# went from 9,775 to 9,890 in commit 2dcf062, on PR #271, signed, with nothing
+# extracted in return. So the budget caps the sum of every ceiling, and growth
+# is pay-as-you-go: raising one ceiling means lowering another, or raising
+# this line in plain view.
 #
-# So growth is pay-as-you-go. Raising a ceiling means lowering another by as
-# much, in the same change -- extract a surface into its own module and both
-# numbers fall on their own. Nothing is blocked: raising this line is still
-# allowed and is the escape hatch on purpose, because it is one number, in one
-# place, that a reviewer watches move.
+# ## How this file reached zero
 #
-# It only ever goes down on its own: `--tighten` lowers it to match the
-# ceilings and will never raise it, or the failure message would be
-# recommending its own bypass.
-# Raised by 458 for the report extraction below, and this is the whole of
-# that raise: `paper_trading.rs` fell 2,842 and `paper_report.rs` arrived
-# at 3,300. The difference is the seam - the environment the report is
-# handed, the response it answers with, the one state struct, and the
-# wrappers that keep every control-plane and harness name where its callers
-# already look. Paid here, in the one number a reviewer watches, rather
-# than hidden inside a signed entry: a reader of the budget alone should be
-# able to see that this branch cost 458 lines and ask whether the money
-# path being auditable was worth them.
-# Raised by 13 for the hook self-declaration, and this is the whole of that
-# raise: `paper_trading.rs` +11 and `footprint_render.rs` +2, one line per
-# hook those two files read plus one for the call. Every other owning module
-# absorbed its own within an existing ceiling.
+# `app.rs` is the reason the guard exists: it grew to over 36,000 lines in
+# five weeks, and the sprints before campaign #367 cut it to 769 production
+# lines by moving `impl QuantickApp` groups to siblings under
+# `crates/app/src/app/` and its 56 fields into six owner structs. The
+# reasoning behind each of those cuts, and behind the raises signed along the
+# way, is in this file's git history and in the PR bodies it cites.
 #
-# What the 13 lines buy is that the hook registry can no longer lie. It was a
-# hand-kept file that had drifted both ways -- six hooks the application reads
-# had no row, and one row named `QUANTICK_DRAWING_MANAGER`, which nothing has
-# ever read, so a capture run setting it got a window that simply did not open
-# and read as a defect in the surface. Each module now declares the hooks it
-# reads beside the reads, one `declare_hooks!` line, and the registry is
-# generated from those declarations fused with the prose. A hook read but not
-# described, or described but not read, fails `cargo test -p quantick-guards`.
+# Campaign #367 opened with twenty entries, 45,505 recorded lines under a
+# budget of 45,739, and closed with none. Each entry left the same way: its
+# file was split into owned siblings under its own directory by pure moves -
+# every body unchanged, the only widenings `pub(super)` marks - until the root
+# and every sibling sat under the threshold, and the entry was then removed
+# by hand, because a recorded ceiling on a file under 1,500 is a permission
+# nobody spends. Each PR body carries the statement-line multiset proving
+# nothing was lost or duplicated.
 #
-# Paid here rather than hidden in the two signed entries, because a reader of
-# the budget alone should be able to see that this branch cost 13 lines and ask
-# whether an index that cannot drift was worth them. Nothing was extracted in
-# return, and that is the honest shape of it: this is a raise, not a trade.
-#
-# Then lowered by 1,863 -- the whole of `app.rs`'s fall from 9,362 to 7,499 --
-# by `--tighten` after four `impl QuantickApp` groups moved to siblings under
-# `crates/app/src/app/`: the harness demo appliers, the drawing input, the
-# health summary and the workspace restore. None of the four files reaches
-# the 1,500-line threshold, so none of them takes an entry here and the fall
-# is a trade of nothing for 1,863: the lines still exist, they are simply no
-# longer in the file the ratchet was written for. The first cut of this
-# sprint that moves this number down rather than sideways.
-#
-# Then lowered by 2,153 more, the same way and for the same reason: `pane.rs`
-# fell from 7,771 to 5,618 when four `impl ChartPane` groups moved to siblings
-# under `crates/app/src/pane/` -- the context menus, the strategy badges and
-# their lifecycle, the drawing gestures, and the axes and chrome painters.
-# None of the four reaches the 1,500-line threshold, so again no new entry is
-# taken and the fall is a trade of nothing for 2,153. The two functions that
-# are the pane, `handle_navigation` and `draw_chart`, stayed put on purpose:
-# they are the next cut, and they need a shape rather than a new address.
-#
-# Then lowered by 2,149 more -- `app.rs` from 7,499 to 5,350 -- after the third
-# cut of the same sprint moved three `impl QuantickApp` groups to siblings
-# under `crates/app/src/app/`: the workspace store's write half, the indicator
-# manager and the chart-layer wiring. Same trade as the two cuts before it and
-# the same reason it costs nothing here: `workspace_save.rs` (1,124 lines),
-# `indicator_manager.rs` (835) and `chart_layers_wiring.rs` (270) are each
-# under the 1,500-line threshold, so none takes an entry. None of the three
-# carries a test module, so those are production counts entire.
-#
-# `--tighten` first wrote 5,339. The eleven lines between that and the number
-# above are `attach_surface` and the blank line above it, which the mission
-# brief listed with the workspace
-# store because it sits in the middle of that line range. It is a two-line
-# setter for the window handle, called once from `main`, and it has nothing to
-# do with saving a workspace; the pre-PR review sent it back to `app.rs` rather
-# than let `workspace_save.rs`'s name lie about what is in it. Recorded here
-# because a ceiling that moved for a reason should say the reason, even when
-# the reason made it ten lines worse.
-#
-# The budget arithmetic is done by hand, as the two briefs agreed it would be:
-# `pane.rs` and `app.rs` were cut in parallel, both lower this line, and the
-# second to land subtracts its own fall from the first's number rather than
-# from the one it measured against. 57,394 - 2,149 = 55,245.
-#
-# Then lowered by 3,456 -- `app.rs` from 5,388 to 1,932 -- by the final cut of
-# the same campaign, which moved the last seven `impl QuantickApp` groups to
-# siblings under `crates/app/src/app/`: the control host, the tab lifecycle,
-# the toolbar wiring, the menu bar, the drawing chrome, the replay/history/
-# alarm appliers and `draw_frame`. Same trade as the three cuts before it, and
-# it costs nothing here for the same reason: `menu_bar.rs` (778 production
-# lines), `frame.rs` (732), `replay_and_history.rs` (518), `control_host.rs`
-# (496), `drawing_chrome_wiring.rs` (430), `tabs.rs` (375) and
-# `toolbar_wiring.rs` (307) are each under the 1,500-line threshold, so none
-# takes an entry. They come to 3,636 against a fall of 3,456; the 180
-# difference is seven module headers, seven import blocks and the
-# `impl QuantickApp` wrappers -- the price of seven addresses, paid once.
-# 55,595 - 3,456 = 52,139.
-#
-# What is left in `app.rs` is the window's definition and nothing else: the
-# struct, `new`, `new_with_workspace`, the pickers and `persist_*`,
-# `adopt_tab`, `arm_strategy_instance`, `attach_surface`, the `eframe::App`
-# impl and `declare_hooks!`. Those stayed on purpose -- they are the regions
-# the paper-policy branch was editing in parallel, and moving them would have
-# turned that branch's edits into modify/delete conflicts. It has since landed,
-# so giving the constructor a shape is the next cut's job, not this one's.
-#
-# Then lowered by 1,143 -- `app.rs` from 1,932 to 789 -- by that next cut,
-# which took the two regions the paragraph above named. The 721-line launch-
-# hook sequence left `new_with_workspace` for `app/launch_hooks.rs` as
-# `apply_launch_hooks`, split into ten appliers by surface in the order they
-# were read; the paper wiring -- the trades-dir pickers, `persist_*`,
-# `adopt_tab` and `arm_strategy_instance` -- left for `app/paper_wiring.rs` as
-# a pure move. `declare_hooks!` followed the reads, because `hooks::OWNERS`
-# names the file a reader should open and the guard checks the two agree.
-# Same trade, same price: `launch_hooks.rs` (880 production lines) and
-# `paper_wiring.rs` (392) are both under the 1,500-line threshold, so neither
-# takes an entry. They come to 1,272 against a fall of 1,143; the 129
-# difference is two module headers, two import blocks and two
-# `impl QuantickApp` wrappers -- the price of two addresses, paid once.
-# 52,139 - 1,143 = 50,996.
-#
-# What is left in `app.rs` is now the window's definition and nothing else:
-# the struct, `new`, `new_with_workspace`, `attach_surface`, the `eframe::App`
-# impl and `mod tests`. The 56 fields are the next cut's job.
-#
-# Then lowered by 2,446 -- `control/gateway.rs` from 4,142 to 1,696 -- by
-# splitting it along the thread boundary it already had. The gateway thread's
-# free functions left for `control/gateway/server.rs`, the frame emitter and
-# its keys for `semantic.rs`, the parked screenshot arc for `screenshot.rs`,
-# the egui panel for `panel.rs`, and both test modules for `tests/mod.rs`.
-# Every body moved unchanged; the only widenings are the `pub(super)` marks a
-# child module needs to be called by its parent.
-# Same trade, same price: at 1,445, 591, 278 and 278 lines on disk the four
-# siblings are all under the 1,500-line threshold, so none takes an entry, and
-# the 450 lines of tests are untracked either way. `server.rs` is the one to
-# watch: 55 lines of headroom, spent partly on naming its imports instead of
-# globbing them. The connection session and the two dispatchers are where the
-# next cut goes rather than a signed raise.
-# 48,185 - 2,446 = 45,739.
-#
-# What is left in `gateway.rs` is the UI thread's half and nothing else: the
-# options and identities, the lifecycle, the local actions, and the frame
-# service the screenshot arc is armed against. `invoke_local_action` at 164
-# lines and `service_replay_trace` are the next cut's job.
-#
-# The 56 fields became 24: six owner structs, declared in the sidecar that
-# owns each, replacing 38 flat fields. `app.rs` falls 789 -> 625 production
-# lines, because every moved field took its doc comment with it. Nothing was
-# deleted -- the prose moved to `indicator_manager.rs`, `control_host.rs`, a
-# new `chrome.rs`, `tabs.rs`, `health.rs` and `replay_and_history.rs`, all of
-# them under the 1,500-line threshold, so none takes an entry.
-#
-# `layout_wiring.rs` is raised 1,557 -> 1,577 and `app.rs` lowered 789 -> 769
-# to pay for it, so the budget line does not move. The 20 lines are not new
-# code: `self.pending_styles` became `self.indicators.pending_styles`, and the
-# eleven longest of those reads now wrap where they used to fit. A path that
-# says which module owns a field costs a line where it crosses 100 columns --
-# the one price this regroup charges, paid by the file that shrank.
-#
-# Then lowered by 5,384 -- the whole of `pane.rs`'s entry -- by the cut the
-# note above promised: `handle_navigation` and `draw_chart` got a shape rather
-# than a new address. The input frame stays in `pane.rs` as the orchestrator
-# and its arms went to `pane/context_menu.rs` (the secondary click),
-# `pane/primary_button.rs` (paper's claim on the button, then the pointer
-# tool) and `pane/axes_and_panes.rs` (the axes, the lane divider and the
-# indicator panes' handles, with the `pane_*_gesture` helpers only they
-# call). The paint frame went whole to `pane/draw_chart.rs`, because the
-# slices of `self.state` it borrows for the frame forbid a `&mut self` arm,
-# and its read-only painters to `pane/layer_painters.rs` as `&self` methods
-# over one borrowed `DrawFrame`. The rest of the file left by owner:
-# `layers.rs`, `series.rs`, `shared_marks.rs`, `drawing_paint.rs`,
-# `pointer_hit.rs`, `tape_switch.rs` and `canvas_split.rs`, plus two impl
-# blocks appended to `context_menu.rs` and `strategies.rs`. Every body moved
-# at the same indentation; the multiset proof is in PR #383's body.
-#
-# `pane.rs` itself is 1,212 production lines and takes no entry: it is under
-# the threshold, and the largest new sibling (`draw_chart.rs`, 746) is under it
-# by a wider margin, as is the largest of all of them, the untouched
-# `drawing_gestures.rs` at 800. `--tighten` first wrote 1,256 and 41,377 (the
-# review's seam repairs then took it to 1,212); the entry is removed by hand
-# because a sub-threshold file with a recorded ceiling is a
-# permission nobody spends, and the budget follows it down by the same
-# 1,256. 45,739 - 5,384 = 40,355; what the guard measures the sum at today
-# is 40,121, and the line below is that sum, not the arithmetic.
-#
-# `toolrail.rs`, `tab.rs` and `layout_wiring.rs` left this file entirely.
-# Each was split into owned siblings under its own directory -- the rail's
-# state, favourites band and family flyout; the tab's pane addressing and its
-# layout/spec persistence; the layout wiring's indicator mirrors and its
-# layout strip -- by pure moves, so all three fell under the 1,500-line
-# threshold and stopped being tracked. The entry for `tab.rs` took the
-# `drain_feed` opening-block note with it: that arm is in `tab/feed.rs` and
-# was never what this entry paid for. Nothing was deleted; the budget falls
-# by the three ceilings.
-# +2: the `QUANTICK_FOOTPRINT_DEBUG` declaration. See the budget note above.
-#
-# `eval.rs` and `compile.rs` left this file entirely. The interpreter's
-# built-in families moved out of the evaluator core -- `eval/kernels.rs` (the
-# stateful `ta.*` kernels), `eval/pure.rs` (the pure math, colour and string
-# built-ins) and `eval/objects.rs` (`line.new` / `box.new` / `label.new`, the
-# argument coercions a drawing takes and the `handle.set_*` methods) -- and
-# the compiler's lowering passes out of the driver: `compile/declarations.rs`
-# (pass 1, the `indicator()` header, the plot registry and `fill()`),
-# `compile/fold.rs` (pass 4's constant folder with `Const` and the member
-# constants) and `compile/resolve.rs` (passes 2/3/5/6, the one resolved walk).
-# Pure moves, so both roots fell under the 1,500-line threshold and stopped
-# being tracked; the largest new sibling is `compile/resolve.rs` at 608.
-# `--tighten` first wrote 974 and 323; the two entries are removed by hand
-# because a sub-threshold file with a recorded ceiling is a permission nobody
-# spends, and the budget follows them down by the same 1,297. Nothing was
-# deleted; the multiset proof is in PR #399's body.
-# Raised for the same branch: an `Mt5Event::OpeningPage` variant and one
-# branch in the block state machine deciding whether a block settles a
-# request. The session loop is the only place that knows what a
-# `history_start` opened; the slicing itself lives in the bridge.
-#
-# `projection.rs` and `config.rs` in `crates/orderflow` left this file too.
-# The projection's read model, print tiers and budget fold went to
-# `projection/{model,tiers,fold}.rs`, the bubble and live-lane config
-# families to `config/{bubbles,lane}.rs`, by pure moves (the multiset proof
-# is in PR #396's body); the roots are 778 and 514 production lines, the
-# largest sibling 557, so none of the seven files is tracked. `--tighten`
-# lowered the two entries rather than removing them; they are removed by hand
-# for the reason `pane.rs`'s note gives, and the budget falls by the two
-# ceilings: 9,264 - 1,850 - 1,523 = 5,891, which is the sum below.
-!budget 769
-
-crates/app/src/app.rs 769
-
-# ## Three entries that no longer exist
-#
-# Everything from here to the note that closes this block is the history of
-# `paper_report.rs`, `paper_account.rs` and `paper_trading.rs` - the two
-# earlier cuts and the allowances they carried, including the `+11` for the
-# eight `QUANTICK_PAPER_*` hooks. None of it attaches to a live entry any
-# more: the third cut took all three under the threshold and their entries
-# are gone. It is kept because the reasoning still explains why the code is
-# shaped the way it is, and deleting it would leave the shape unexplained.
-#
-# The five entries below `pane.rs` were invisible to the first version of this
-# guard, which stopped counting at the first `#[cfg(test)]` of any kind:
-# `gateway.rs` scored 72 lines of its 4,142, `drawings/mod.rs` 221 of 2,283.
-# They are recorded at today's true size, not at a target. `paper_trading.rs`
-# came down two lines when its private toast - a second acknowledgement lane
-# in the same place on a different clock - was converged onto the window's
-# `ToastSurface`; what left was mostly drawing code, and what stayed is the
-# outbox that replaced it.
-#
-# Then raised by the risk-per-trade work. The capability itself docked as
-# `src/risk_sizing.rs` - the policy half of the arithmetic, the sentences, the
-# whole RISK block, the sidecar records and the launch hook, around 1,300
-# production lines that never entered this file. What is recorded here is the
-# seam that could not leave: the settings the ticket holds, the accessors the
-# control plane reads through, the three placement sites where the lock is
-# enforced, the quantity field turning derived, and one call that draws the
-# block. They reach this struct's private state - `aim_bracket`,
-# `quantity_preview`, `parse_quantity`, `show_toast`, `venue` - so moving them
-# would mean widening five private items to a sibling module, which trades a
-# number in this table for a hole in the type's encapsulation. The two-pass
-# sizing *did* move, behind a closure, once it was clear it was logic rather
-# than registration. Argue with these numbers rather than with their absence.
-# The performance report and the trades ledger came out of
-# `paper_trading.rs` as `paper_report.rs` - the reading half of paper
-# trading, split from the writing half. The point was not tidiness: that
-# file places orders, projects brackets, sizes risk against capital and
-# writes the trades journal, and every line of calendar tinting and
-# equity-curve plotting sitting in it was a line an auditor asking "was the
-# stop placed at the right price?" had to read past.
-#
-# 2,842 production lines and twenty-one struct fields left, against 3,300
-# arriving here - so the budget rises by 458 rather than falling, and that
-# is the honest number. What the difference bought: a `ReportEnv` the
-# report is *handed* instead of a host it reaches into, a `ReportResponse`
-# for what it cannot do itself, one `ReportState` in place of the
-# twenty-one fields, and the wrappers that keep every control-plane and
-# harness name exactly where its callers already look. The report's own
-# tests went with it, and the ten that drive a real journal stayed with the
-# host that writes one.
-#
-# The numbers are pinned, not merely moved: `the_report_numbers_are_fixed`
-# asserts a fixed journal's whole report byte for byte, across two cuts. It
-# was written against the old code in its old home and its expected text
-# did not change - same SHA-256 before and after.
-
-# +11: the eight `QUANTICK_PAPER_*` hooks this file reads, declared beside
-# them. See the budget note above.
-# The money path came out of `paper_trading.rs` as `paper_account.rs` - the
-# deciding half of paper trading, split from the drawing half, exactly as
-# `paper_report.rs` was the reading half. That file placed orders, projected
-# brackets, sized risk against capital and wrote the trades journal *and* drew
-# the ticket, and an auditor asking "was the stop placed at the right price?"
-# had to read through drawing code to answer.
-#
-# 1,818 production lines left, against 2,128 arriving here, plus 2 in `tab.rs`
-# and 38 in `app.rs` for the receivers the split moved to `account()` - a
-# `tab.paper.set_risk_settings(..)` becoming
-# `tab.paper.account_mut().set_risk_settings(..)` wraps where it used to fit.
-# So the sum of ceilings rises by 350.
-#
-# The mission allowed +300 and this is 50 over, granted by the trader with the
-# measurement in front of them. Its own two criteria pull against each other:
-# it asked for twenty-one named functions on the account AND a rise under 300,
-# and a function moved across a seam pays for its signature twice - once where
-# it lives, once where the ticket resolves its text before calling it. At
-# seventeen moved the rise was 297; the last four - `market`, `settle`,
-# `on_trade`, `set_symbol`, all named in the brief - cost the rest. Reverting
-# them would buy the number and lose the delivery.
-#
-# Eleven lines were already returned from real duplication the move exposed:
-# `push_toast` against `set_toast` (two doors into a one-slot outbox),
-# `has_toast` against `peek_toast`, and one explanation written into both
-# halves of `set_symbol`. What remains is signatures, and shaving a doc comment
-# to reach a round number would buy the number and lose the reason.
-#
-# It also closes the note below. The five private items that entry said would
-# have to be widened were why the risk seam stopped short; each has landed on
-# exactly one side. `aim_bracket` moved (arithmetic, and its only tie to the
-# ticket was the ruler, which now arrives as two resolved prices) and so did
-# `venue`; `show_toast`, `parse_quantity` and `quantity_preview` stayed,
-# because each reads a text box or writes the ticket's one-slot outbox.
-#
-# The numbers are pinned, not merely moved: `the_journal_bytes_are_fixed`
-# asserts a fixed tape's whole journal byte for byte over four round trips - a
-# manual long, a manual short, a stop-out and a target. It was written against
-# the old code in its old home and its expected text did not change - same
-# SHA-256 before and after,
-# ab74859479f2f1e471dfb5a1556a15d2891d440c7c119db49c0e2ad64be094d6.
-#
-# The three paper files came under the 1,500-line threshold in one cut, so
-# their entries are gone rather than lowered: `paper_trading.rs` gave the
-# ticket, the chart paint, the pointer, CMD entry, the ruler and the order
-# strategies their own modules; `paper_report.rs` gave the ledger, its rows,
-# the equity curve, the tables and the window theirs; `paper_account.rs` gave
-# risk sizing, order placement, import/export and the report seam theirs.
-# Pure moves, with `the_journal_bytes_are_fixed` and
-# `the_report_numbers_are_fixed` unchanged on both sides of it.
-
+# - #384: `paper_trading.rs`, `paper_account.rs` and `paper_report.rs`. The
+#   ticket, chart paint, pointer, CMD entry, ruler and order strategies; the
+#   ledger, equity curve and tables; risk sizing, placement and the report
+#   seam each got a module. `the_journal_bytes_are_fixed` and
+#   `the_report_numbers_are_fixed` kept their expected bytes across the cut.
+# - #383: `pane.rs`. `handle_navigation` and `draw_chart` got a shape rather
+#   than a new address: the input frame stayed as the orchestrator with its
+#   arms in `pane/context_menu.rs`, `pane/primary_button.rs` and
+#   `pane/axes_and_panes.rs`; the paint frame went whole to
+#   `pane/draw_chart.rs`, its painters to `pane/layer_painters.rs`.
+# - #388: `orderflow_render.rs`, `orderflow_view.rs` and
+#   `footprint_render.rs`, into `orderflow_render/` (bubbles, heatmap,
+#   layout, legend, preview), `orderflow_view/` (frame, settings) and
+#   `footprint_render/` (bar, heat).
+# - #390: `drawings/mod.rs`, into `drawings/collection.rs`,
+#   `drawings/placement.rs` and `drawings/tool.rs`.
+# - #391: the control plane, `control/gateway.rs`, `control/contract.rs` and
+#   `control/evidence.rs`, all at once and nothing raised in return. The
+#   action door (`invoke_local_action`, `invoke_local_read` and the local
+#   actor they mint) went to `gateway/local_action.rs` and the trace walk with
+#   `service_replay_trace` to `gateway/trace_replay.rs`; the contract's
+#   per-capability prepare handlers and the invocations they build went to
+#   `contract/reads.rs`, leaving the permission ceilings and the refusal
+#   sequence in the root; the evidence store with its grant-rechecking read
+#   went to `evidence/store.rs` and the screenshot encoding to
+#   `evidence/image.rs`.
+# - #392: the chrome, `toolrail.rs`, `tab.rs` and `app/layout_wiring.rs`: the
+#   rail's state, favourites band and family flyout; the tab's pane addressing
+#   and layout persistence; the layout wiring's indicator mirrors and strip.
+# - #395: `feed-mt5/src/stream.rs`, into `stream/` (blocks, connection,
+#   events, ports, publish, reader). The `Mt5Event::OpeningPage` decision
+#   the entry was once raised for now lives in `stream/connection.rs`.
+# - #399: `pine/src/eval.rs` and `pine/src/compile.rs`: the built-in families
+#   into `eval/kernels.rs`, `eval/pure.rs` and `eval/objects.rs`; the lowering
+#   passes into `compile/declarations.rs`, `compile/fold.rs` and
+#   `compile/resolve.rs`.
+# - #396: `orderflow/src/projection.rs` and `orderflow/src/config.rs`: the
+#   read model, print tiers and budget fold into `projection/`, the bubble and
+#   live-lane config families into `config/`.
+# - #377: `app.rs` itself, whose 769 had been under the threshold since the
+#   field regroup and was kept only as history. Its entry was retired with the
+#   rest and the budget set to 0.
+!budget 0

--- a/crates/guards/src/context.rs
+++ b/crates/guards/src/context.rs
@@ -288,8 +288,20 @@ fn relative_to(root: &Path, path: &Path) -> String {
 /// What every tracked path measures today, summed, for
 /// [`crate::report`]. The *how* is [`ratchet::total`]; this only names the
 /// walk it sums, which is the one thing that differs per guard.
-pub fn measured(root: &Path) -> usize {
-    ratchet::total(&measure(root).counts)
+///
+/// An error rather than a smaller total when the walk missed anything. That
+/// includes an instruction directory that is not there at all, which
+/// [`measure`] skips in silence: [`check`] and [`tighten`] both refuse that
+/// tree, and a report that summed it anyway would print the flattering half.
+pub fn measured(root: &Path) -> Result<usize, String> {
+    let mut missed: Vec<String> = INSTRUCTION_DIRS
+        .iter()
+        .filter(|directory| !root.join(directory).is_dir())
+        .map(|directory| format!("  {directory}: not a readable directory"))
+        .collect();
+    let found = measure(root);
+    missed.extend(found.unreadable);
+    ratchet::complete_total(&found.counts, &missed)
 }
 
 /// Byte counts for every context file, sorted by path.
@@ -780,6 +792,21 @@ mod tests {
         fs::write(&note, "x".repeat(3_000)).expect("scratch reference is writable");
         assert!(!check(&root).is_empty(), "3,000 bytes is not churn");
         let _ = fs::remove_dir_all(&root);
+    }
+
+    /// A tree missing an instruction directory measures as less, silently —
+    /// `measure` skips an absent directory — so the total is refused rather
+    /// than reported, for the reason `check` and `tighten` refuse the tree.
+    #[test]
+    fn measured_is_a_failure_when_an_instruction_directory_is_missing() {
+        let root = scratch("measured-missing-dir", 12_000, 10_000, 22_000);
+        assert_eq!(measured(&root), Ok(22_000));
+        fs::remove_dir_all(root.join("docs/workflow")).expect("scratch dir is removable");
+        let failure = measured(&root).expect_err("a missing directory is not zero bytes");
+        assert!(
+            failure.contains("  docs/workflow/: not a readable"),
+            "{failure}"
+        );
     }
 
     /// A scratch workspace whose baseline names two skill files, so a raise on

--- a/crates/guards/src/context.rs
+++ b/crates/guards/src/context.rs
@@ -293,7 +293,7 @@ fn relative_to(root: &Path, path: &Path) -> String {
 /// includes an instruction directory that is not there at all, which
 /// [`measure`] skips in silence: [`check`] and [`tighten`] both refuse that
 /// tree, and a report that summed it anyway would print the flattering half.
-pub fn measured(root: &Path) -> Result<usize, String> {
+pub fn measured(root: &Path) -> Result<usize, ratchet::Unmeasured> {
     let mut missed: Vec<String> = INSTRUCTION_DIRS
         .iter()
         .filter(|directory| !root.join(directory).is_dir())
@@ -803,9 +803,9 @@ mod tests {
         assert_eq!(measured(&root), Ok(22_000));
         fs::remove_dir_all(root.join("docs/workflow")).expect("scratch dir is removable");
         let failure = measured(&root).expect_err("a missing directory is not zero bytes");
-        assert!(
-            failure.contains("  docs/workflow/: not a readable"),
-            "{failure}"
+        assert_eq!(
+            failure.missed,
+            vec!["  docs/workflow/: not a readable directory".to_owned()]
         );
     }
 

--- a/crates/guards/src/cycle.rs
+++ b/crates/guards/src/cycle.rs
@@ -457,8 +457,12 @@ fn collect_sources(
 /// What every tracked path measures today, summed, for
 /// [`crate::report`]. The *how* is [`ratchet::total`]; this only names the
 /// walk it sums, which is the one thing that differs per guard.
-pub fn measured(root: &Path) -> usize {
-    ratchet::total(&measure(root).counts)
+///
+/// An error rather than a smaller total when the walk missed anything, as
+/// for the other ratchets.
+pub fn measured(root: &Path) -> Result<usize, String> {
+    let found = measure(root);
+    ratchet::complete_total(&found.counts, &found.unreadable)
 }
 
 /// Cycle counts for every crate in the workspace, sorted by crate path.
@@ -468,8 +472,16 @@ pub fn measure(root: &Path) -> Measured {
         cycles: BTreeMap::new(),
         unreadable: Vec::new(),
     };
-    let Ok(entries) = fs::read_dir(root.join("crates")) else {
-        return found;
+    let entries = match fs::read_dir(root.join("crates")) {
+        Ok(entries) => entries,
+        // Named rather than returned empty: an empty measurement is zero
+        // cycles, which is the best number this ratchet can print.
+        Err(e) => {
+            found
+                .unreadable
+                .push(format!("  crates/: directory could not be listed: {e}"));
+            return found;
+        }
     };
     let mut dirs: Vec<_> = entries.flatten().map(|entry| entry.path()).collect();
     dirs.sort();

--- a/crates/guards/src/cycle.rs
+++ b/crates/guards/src/cycle.rs
@@ -460,7 +460,7 @@ fn collect_sources(
 ///
 /// An error rather than a smaller total when the walk missed anything, as
 /// for the other ratchets.
-pub fn measured(root: &Path) -> Result<usize, String> {
+pub fn measured(root: &Path) -> Result<usize, ratchet::Unmeasured> {
     let found = measure(root);
     ratchet::complete_total(&found.counts, &found.unreadable)
 }

--- a/crates/guards/src/extension_boundary.rs
+++ b/crates/guards/src/extension_boundary.rs
@@ -218,8 +218,14 @@ pub fn check_file(root: &Path, relative: &str) -> Vec<Finding> {
 /// The root production lines today, or why the scan could not count them.
 /// Never `0` for a failed scan (#365): zero is the best number this ratchet
 /// can print, and a failure has to read as one.
-pub fn measured(root: &Path) -> Result<usize, String> {
-    inventory(root).map(|inventory| crate::ratchet::total(&inventory.counts))
+pub fn measured(root: &Path) -> Result<usize, crate::ratchet::Unmeasured> {
+    match inventory(root) {
+        Ok(inventory) => Ok(crate::ratchet::total(&inventory.counts)),
+        // The inventory stops at its first failure, so it names one path.
+        Err(reason) => Err(crate::ratchet::Unmeasured {
+            missed: vec![format!("  {reason}")],
+        }),
+    }
 }
 
 pub fn tighten(root: &Path) -> Result<Vec<String>, String> {

--- a/crates/guards/src/extension_boundary.rs
+++ b/crates/guards/src/extension_boundary.rs
@@ -215,10 +215,11 @@ pub fn check_file(root: &Path, relative: &str) -> Vec<Finding> {
     }
 }
 
-pub fn measured(root: &Path) -> usize {
-    inventory(root)
-        .map(|inventory| inventory.counts.iter().map(|(_, count)| count).sum())
-        .unwrap_or(0)
+/// The root production lines today, or why the scan could not count them.
+/// Never `0` for a failed scan (#365): zero is the best number this ratchet
+/// can print, and a failure has to read as one.
+pub fn measured(root: &Path) -> Result<usize, String> {
+    inventory(root).map(|inventory| crate::ratchet::total(&inventory.counts))
 }
 
 pub fn tighten(root: &Path) -> Result<Vec<String>, String> {

--- a/crates/guards/src/lib.rs
+++ b/crates/guards/src/lib.rs
@@ -158,7 +158,7 @@ pub struct Ratchet {
     ///
     /// An error when the walk could not measure every path it tracks, never a
     /// smaller number: see [`ratchet::complete_total`].
-    pub measured: fn(&Path) -> Result<usize, String>,
+    pub measured: fn(&Path) -> Result<usize, ratchet::Unmeasured>,
 }
 
 /// One guard, so the binary and the tests name the same things in the same

--- a/crates/guards/src/lib.rs
+++ b/crates/guards/src/lib.rs
@@ -155,7 +155,10 @@ pub struct Ratchet {
     /// the recorded ceilings to show the debt still to be written off, and
     /// asking the registry for it is what keeps a fourth ratchet from
     /// appearing in `--tighten` and nowhere else.
-    pub measured: fn(&Path) -> usize,
+    ///
+    /// An error when the walk could not measure every path it tracks, never a
+    /// smaller number: see [`ratchet::complete_total`].
+    pub measured: fn(&Path) -> Result<usize, String>,
 }
 
 /// One guard, so the binary and the tests name the same things in the same

--- a/crates/guards/src/main.rs
+++ b/crates/guards/src/main.rs
@@ -76,7 +76,9 @@ usage: quantick-guards (--file <path> | --tighten | --report | --blast-radius)
 
 The four modes are alternatives; they cannot be combined.
 Exit code 1 means a guard found something. --report and --blast-radius exit 0:
-they measure, they do not judge.";
+they measure, they do not judge. The one exception is a --report measurement
+that could not be taken: its row reads `failed`, the reason goes to stderr,
+and the exit code is 1.";
 
 fn main() -> ExitCode {
     // A set-but-empty variable is not a root. `var_os` hands back
@@ -92,13 +94,22 @@ fn main() -> ExitCode {
     match args.first().map(String::as_str) {
         None => run_guards(&root, None),
         Some("--tighten") if args.len() == 1 => tighten(&root),
-        // Printed rather than returned as findings, and always exit 0. These
-        // numbers describe the tree; none of them is ratcheted, and a
-        // measurement that can fail a build is one people negotiate with
-        // instead of reading.
+        // Printed rather than returned as findings. These numbers describe
+        // the tree; none of them is ratcheted, and a measurement that can
+        // fail a build is one people negotiate with instead of reading. A
+        // measurement that could not be *taken* is different: the report is
+        // then not describing the tree, and a script trusting exit 0 would
+        // read `failed` rows as a clean run (#365).
         Some("--report") if args.len() == 1 => {
-            print!("{}", report::render(&root));
-            ExitCode::SUCCESS
+            let rendered = report::render(&root);
+            print!("{}", rendered.table);
+            if rendered.failures.is_empty() {
+                return ExitCode::SUCCESS;
+            }
+            for failure in &rendered.failures {
+                eprintln!("{failure}");
+            }
+            ExitCode::FAILURE
         }
         // Report-only for the same reason `--report` is, and it reads its
         // subject from stdin rather than measuring the tree: the diff a

--- a/crates/guards/src/ratchet.rs
+++ b/crates/guards/src/ratchet.rs
@@ -37,12 +37,12 @@ pub const BUDGET_DIRECTIVE: &str = "!budget";
 
 /// What a guard's own walk measured, summed.
 ///
-/// One owner for the arithmetic, three one-line callers that each name their
-/// own `measure`. The three copies this replaces were byte-identical, in a
-/// change that elsewhere removed a duplicated constant for exactly this
-/// reason — and the failure they invited is quiet: a guard summing its counts
-/// differently from its siblings makes [`crate::report`] print three totals
-/// that are not comparable, with nothing to fail.
+/// One owner for the arithmetic; each guard's `measured` reaches it through
+/// [`complete_total`] over its own `measure`. The copies this replaced were
+/// byte-identical, in a change that elsewhere removed a duplicated constant
+/// for exactly this reason — and the failure they invited is quiet: a guard
+/// summing its counts differently from its siblings makes [`crate::report`]
+/// print totals that are not comparable, with nothing to fail.
 ///
 /// Deliberately the *measurement* and not [`Baseline::recorded`]. The budget
 /// caps what the repository has signed for; this is what its files actually

--- a/crates/guards/src/ratchet.rs
+++ b/crates/guards/src/ratchet.rs
@@ -60,15 +60,36 @@ pub fn total(counts: &[(String, usize)]) -> usize {
 /// "excellent" and cannot be told apart from "measured nothing". Each line of
 /// `missed` names one path or directory the walk could not measure; any at
 /// all turns the total into a failure the caller has to print as one.
-pub fn complete_total(counts: &[(String, usize)], missed: &[String]) -> Result<usize, String> {
+pub fn complete_total(counts: &[(String, usize)], missed: &[String]) -> Result<usize, Unmeasured> {
     if missed.is_empty() {
         return Ok(total(counts));
     }
-    Err(format!(
-        "{} path(s) could not be measured:\n{}",
-        missed.len(),
-        missed.join("\n")
-    ))
+    Err(Unmeasured {
+        missed: missed.to_vec(),
+    })
+}
+
+/// A measurement that could not be taken, and why.
+///
+/// Typed rather than a message so a caller can enumerate what was missed —
+/// tell a missing root from one unreadable file — without parsing prose;
+/// [`Display`](std::fmt::Display) gives the sentence `--report` prints.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Unmeasured {
+    /// One `"  <path>: <reason>"` line per path or directory the walk could
+    /// not measure, in the order the walk met them.
+    pub missed: Vec<String>,
+}
+
+impl std::fmt::Display for Unmeasured {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{} path(s) could not be measured:\n{}",
+            self.missed.len(),
+            self.missed.join("\n")
+        )
+    }
 }
 
 /// One recorded ceiling, with the position that lets [`Policy::tighten`]
@@ -690,9 +711,15 @@ mod tests {
         assert_eq!(complete_total(&counts, &[]), Ok(12));
         let missed = ["  src/c.md: could not be read: denied".to_owned()];
         let failure = complete_total(&counts, &missed).expect_err("a missed path is a failure");
-        assert!(
-            failure.contains("1 path(s)") && failure.contains("src/c.md"),
-            "the failure names what was missed: {failure}"
+        assert_eq!(
+            failure.missed,
+            missed.to_vec(),
+            "the failure lists what was missed"
+        );
+        assert_eq!(
+            failure.to_string(),
+            "1 path(s) could not be measured:
+  src/c.md: could not be read: denied"
         );
     }
 }

--- a/crates/guards/src/ratchet.rs
+++ b/crates/guards/src/ratchet.rs
@@ -52,6 +52,25 @@ pub fn total(counts: &[(String, usize)]) -> usize {
     counts.iter().map(|(_, count)| count).sum()
 }
 
+/// [`total`], refused when the walk did not measure every path it tracks.
+///
+/// A sum over a walk that skipped something is smaller than the tree, and
+/// smaller is the flattering direction: `--report` printed 0 root lines for
+/// the extension boundary whenever its scan failed (#365), which reads as
+/// "excellent" and cannot be told apart from "measured nothing". Each line of
+/// `missed` names one path or directory the walk could not measure; any at
+/// all turns the total into a failure the caller has to print as one.
+pub fn complete_total(counts: &[(String, usize)], missed: &[String]) -> Result<usize, String> {
+    if missed.is_empty() {
+        return Ok(total(counts));
+    }
+    Err(format!(
+        "{} path(s) could not be measured:\n{}",
+        missed.len(),
+        missed.join("\n")
+    ))
+}
+
 /// One recorded ceiling, with the position that lets [`Policy::tighten`]
 /// rewrite it.
 #[derive(Debug)]
@@ -660,5 +679,20 @@ mod tests {
         let text = fs::read_to_string(dir.path().join("baseline.txt")).expect("readable");
         // 10 measured plus the 10 the vanished entry still holds.
         assert!(text.contains("!budget 20"), "{text}");
+    }
+
+    /// A walk that missed a path has no total. The sum of what it did see is
+    /// the flattering number, and returning it is how `--report` came to print
+    /// 0 for a scan that had failed outright.
+    #[test]
+    fn a_walk_that_missed_a_path_has_no_total() {
+        let counts = [("src/a.md".to_owned(), 7), ("src/b.md".to_owned(), 5)];
+        assert_eq!(complete_total(&counts, &[]), Ok(12));
+        let missed = ["  src/c.md: could not be read: denied".to_owned()];
+        let failure = complete_total(&counts, &missed).expect_err("a missed path is a failure");
+        assert!(
+            failure.contains("1 path(s)") && failure.contains("src/c.md"),
+            "the failure names what was missed: {failure}"
+        );
     }
 }

--- a/crates/guards/src/report.rs
+++ b/crates/guards/src/report.rs
@@ -125,7 +125,7 @@ const TRUNK_CRATE: &str = "app";
 /// reads a clock, an environment variable or a random number. Two calls
 /// against the same tree return equal strings, which is the property
 /// `report_is_byte_identical_across_runs` pins.
-pub fn render(root: &Path) -> String {
+pub fn render(root: &Path) -> Rendered {
     let sizes = size::measure(root);
     let scanned = Scan::of(root, &sizes.counts);
 
@@ -133,7 +133,7 @@ pub fn render(root: &Path) -> String {
     crates_section(&mut out, &sizes.counts);
     largest_files_section(&mut out, &sizes.counts);
     wide_structs_section(&mut out, &scanned);
-    ratchets_section(&mut out, root);
+    let failures = ratchets_section(&mut out, root);
     sites_section(&mut out, &scanned);
     row(
         &mut out,
@@ -149,7 +149,23 @@ pub fn render(root: &Path) -> String {
     row(&mut out, "scan.unreadable", sizes.unreadable.len());
     row(&mut out, "scan.undecodable", sizes.undecodable.len());
     row(&mut out, "scan.blind", sizes.blind.len());
-    out
+    row(&mut out, "scan.failed", failures.len());
+    Rendered {
+        table: out,
+        failures,
+    }
+}
+
+/// The report, and every ratchet measurement it could not take.
+pub struct Rendered {
+    /// The `label<TAB>value` table.
+    pub table: String,
+    /// One reason per ratchet whose walk failed, in registry order, each
+    /// opening with the ratchet's name. Kept out of the table because a
+    /// reason carries operating-system text and absolute paths, which would
+    /// break the byte-identical property; the table carries the count, as
+    /// `scan.failed`, and `failed` in place of each missing number.
+    pub failures: Vec<String>,
 }
 
 /// One `label<TAB>value` line. The single owner of the report's shape, so a
@@ -230,7 +246,12 @@ fn wide_structs_section(out: &mut String, scanned: &Scan) {
 /// The registry is the only list. A ratchet added to [`GUARDS`] appears here
 /// without an edit, which is the property that stopped the cycle ratchet from
 /// being invisible to `--tighten` when it was added.
-fn ratchets_section(out: &mut String, root: &Path) {
+///
+/// Returns the reason for every measurement that failed. Such a row reads
+/// `failed`, never a number: the first version printed `0` for a failed
+/// extension-boundary scan, the one value that looks best (#365).
+fn ratchets_section(out: &mut String, root: &Path) -> Vec<String> {
+    let mut failures = Vec::new();
     for guard in GUARDS {
         let Some(ratchet) = &guard.ratchet else {
             continue;
@@ -256,12 +277,16 @@ fn ratchets_section(out: &mut String, root: &Path) {
                 row(out, format!("ratchet.{name}.recorded"), "unparsed");
             }
         }
-        row(
-            out,
-            format!("ratchet.{name}.measured"),
-            (ratchet.measured)(root),
-        );
+        let label = format!("ratchet.{name}.measured");
+        match (ratchet.measured)(root) {
+            Ok(total) => row(out, label, total),
+            Err(reason) => {
+                row(out, label, "failed");
+                failures.push(format!("{name}: {reason}"));
+            }
+        }
     }
+    failures
 }
 
 /// The counted sites, in the fixed order [`SITES`] lists them.

--- a/crates/guards/src/report.rs
+++ b/crates/guards/src/report.rs
@@ -123,7 +123,7 @@ const TRUNK_CRATE: &str = "app";
 /// Deterministic by construction: every section sorts before it prints, the
 /// only paths are workspace-relative with forward slashes, and nothing here
 /// reads a clock, an environment variable or a random number. Two calls
-/// against the same tree return equal strings, which is the property
+/// against the same tree return equal tables, which is the property
 /// `report_is_byte_identical_across_runs` pins.
 pub fn render(root: &Path) -> Rendered {
     let sizes = size::measure(root);

--- a/crates/guards/src/size.rs
+++ b/crates/guards/src/size.rs
@@ -412,7 +412,7 @@ fn scan(dir: &Path, root: &Path, found: &mut Measured) {
 /// An error rather than a smaller total when the walk missed anything: an
 /// unlistable directory (a missing `crates/` included), an unreadable file,
 /// or one that does not decode and so carries no count.
-pub fn measured(root: &Path) -> Result<usize, String> {
+pub fn measured(root: &Path) -> Result<usize, ratchet::Unmeasured> {
     let found = measure(root);
     let mut missed = found.unreadable;
     missed.extend(
@@ -1296,13 +1296,20 @@ mod tests {
         fs::write(root.join("crates/probe/src/latin.rs"), b"// caf\xe9\n")
             .expect("scratch source is writable");
         let failure = measured(&root).expect_err("an undecodable file is a missed one");
-        assert!(
-            failure.contains("crates/probe/src/latin.rs"),
-            "the failure names the file: {failure}"
+        assert_eq!(
+            failure.missed,
+            vec!["  crates/probe/src/latin.rs: does not decode as UTF-8".to_owned()],
+            "the failure names the file"
         );
 
         let missing = crate::scratch_dir::ScratchDir::new("measured-missing-sources");
         let failure = measured(&missing).expect_err("a missing crates/ is not zero lines");
-        assert!(failure.contains("crates/"), "{failure}");
+        assert!(
+            failure
+                .missed
+                .iter()
+                .all(|line| line.starts_with("  crates/: ")),
+            "{failure}"
+        );
     }
 }

--- a/crates/guards/src/size.rs
+++ b/crates/guards/src/size.rs
@@ -55,6 +55,11 @@
 //! to be bigger now" and can argue with it, which is precisely what a silent
 //! +400 lines inside a 36,000-line file never let anyone do.
 //!
+//! Campaign #367 left the baseline with no entry and a budget of 0, so every
+//! production file is at or under [`THRESHOLD`] and an exception is now two
+//! edits in one change: the signed entry, and the budget raise that pays for
+//! it. The mechanism below is unchanged; only its data went to zero.
+//!
 //! # And the total is capped, because signed raises still lose ground
 //!
 //! A signed raise is arguable, and it was still not enough. One branch raised
@@ -112,8 +117,10 @@ pub const BASELINE_FILE: &str = "crates/guards/size-baseline.txt";
 /// is not. [`Baseline::recorded`] sums *ceilings*, not measured counts, so
 /// every tracked file may also sit up to [`SLACK`] under its own entry without
 /// moving the total at all. The real hidden headroom is therefore
-/// `BUDGET_SLACK + entries × SLACK` — with the eighteen entries recorded
-/// today, about 4,100 production lines rather than 500.
+/// `BUDGET_SLACK + entries × SLACK` — eighteen entries once made that about
+/// 4,100 production lines rather than 500. With the baseline empty and the
+/// budget at 0 it is nothing, and each exception signed in later adds back
+/// its own [`SLACK`].
 ///
 /// That is stated rather than fixed, because the alternative is worse. Summing
 /// measured counts would move the budget on every ordinary edit, so a branch
@@ -145,9 +152,11 @@ pub const REMEDY: &str = "A file over its ceiling means a capability docked by e
                           instead of by adding a module. The fix asked for is the one in the \
                           new-extension skill: give the capability its own file and a port to \
                           dock into, so the edit here is a registration line rather than a body. \
-                          Raising a ceiling on purpose is still allowed — change the number in \
-                          crates/guards/size-baseline.txt and say why in a comment, so a reviewer \
-                          argues with a visible decision instead of missing an invisible one. A \
+                          An exception on purpose is still allowed — record the file and its \
+                          ceiling in crates/guards/size-baseline.txt with a comment saying why, \
+                          and raise its !budget line by as much in the same change, so a \
+                          reviewer argues with a visible decision instead of missing an \
+                          invisible one. A \
                           file that shrank needs no argument at all: `cargo run -p \
                           quantick-guards -- --tighten` writes the new number.";
 
@@ -399,8 +408,20 @@ fn scan(dir: &Path, root: &Path, found: &mut Measured) {
 /// What every tracked path measures today, summed, for
 /// [`crate::report`]. The *how* is [`ratchet::total`]; this only names the
 /// walk it sums, which is the one thing that differs per guard.
-pub fn measured(root: &Path) -> usize {
-    ratchet::total(&measure(root).counts)
+///
+/// An error rather than a smaller total when the walk missed anything: an
+/// unlistable directory (a missing `crates/` included), an unreadable file,
+/// or one that does not decode and so carries no count.
+pub fn measured(root: &Path) -> Result<usize, String> {
+    let found = measure(root);
+    let mut missed = found.unreadable;
+    missed.extend(
+        found
+            .undecodable
+            .iter()
+            .map(|path| format!("  {path}: does not decode as UTF-8")),
+    );
+    ratchet::complete_total(&found.counts, &missed)
 }
 
 /// Production-line counts for every scanned file, sorted by path.
@@ -612,19 +633,39 @@ mod tests {
 
     /// The parse the data file bought, and the two ways it could go wrong: a
     /// comment read as an entry, or a trailing comment read into the count.
+    /// Over a fixture, because the real baseline no longer holds an entry to
+    /// read a comment beside.
     #[test]
     fn baseline_parsing_ignores_comments() {
-        let entries = baseline(&workspace_root())
-            .expect("the baseline file parses")
-            .entries;
-        assert!(
-            entries.iter().any(|e| e.path == "crates/app/src/app.rs"),
-            "app.rs is the entry the guard was written for"
+        let root = scratch("parse-comments", 1_600, 1_600);
+        let parsed = baseline(&root).expect("the scratch baseline parses");
+        let entries: Vec<(&str, usize)> = parsed
+            .entries
+            .iter()
+            .map(|e| (e.path.as_str(), e.ceiling))
+            .collect();
+        assert_eq!(
+            entries,
+            vec![("crates/probe/src/big.rs", 1_600)],
+            "a comment was read as an entry or into a count"
         );
+        assert_eq!(parsed.budget.map(|b| b.allowed), Some(1_600));
+    }
+
+    /// The rule this file now states: no production file over the threshold,
+    /// so no exception recorded and nothing for a budget to cap. A signed
+    /// entry is still possible, but it arrives with a budget raise, and this
+    /// test is where a reviewer sees the two land together.
+    #[test]
+    fn the_baseline_holds_no_exception_and_a_zero_budget() {
+        let parsed = baseline(&workspace_root()).expect("the baseline file parses");
+        let entries: Vec<&str> = parsed.entries.iter().map(|e| e.path.as_str()).collect();
         assert!(
-            entries.iter().all(|e| !e.path.starts_with('#')),
-            "a comment line was read as an entry"
+            entries.is_empty(),
+            "every production file is at or under {THRESHOLD} lines; these carry an exception: \
+             {entries:?}"
         );
+        assert_eq!(parsed.budget.map(|b| b.allowed), Some(0));
     }
 
     #[test]
@@ -1159,5 +1200,109 @@ mod tests {
             "a mixed run must explain both, file first: {findings:?}"
         );
         let _ = fs::remove_dir_all(&root);
+    }
+
+    /// A throwaway workspace with the given baseline text and one probe file
+    /// of `lines` production lines, followed by a test module that must not
+    /// count — so the fixture is measured the way a real source file is.
+    fn scratch_with(test: &str, baseline: &str, lines: usize) -> crate::scratch_dir::ScratchDir {
+        let root = crate::scratch_dir::ScratchDir::new(test);
+        fs::create_dir_all(root.join("crates/guards")).expect("scratch dirs are creatable");
+        fs::create_dir_all(root.join("crates/probe/src")).expect("scratch dirs are creatable");
+        fs::write(root.join(BASELINE_FILE), baseline).expect("scratch baseline is writable");
+        let source = format!(
+            "{}\n#[cfg(test)]\nmod tests {{\n    fn t() {{}}\n}}\n",
+            "x\n".repeat(lines).trim_end()
+        );
+        assert_eq!(
+            production_lines(&source),
+            lines,
+            "the fixture counts as meant"
+        );
+        fs::write(root.join("crates/probe/src/big.rs"), source)
+            .expect("scratch source is writable");
+        root
+    }
+
+    /// The rule with no exception left to hide behind: one line over the
+    /// threshold fails an empty baseline, in both surfaces, and is sent to
+    /// carve a module rather than to raise a number.
+    #[test]
+    fn a_file_one_line_over_the_threshold_fails_an_empty_baseline() {
+        let root = scratch_with("threshold-over", "!budget 0\n", THRESHOLD + 1);
+        let findings = check(&root);
+        assert_eq!(findings.len(), 1, "expected one finding: {findings:?}");
+        assert!(
+            findings[0]
+                .line
+                .starts_with("  crates/probe/src/big.rs: 1501 production lines, over the 1500"),
+            "the finding names the file, its size and the threshold: {findings:?}"
+        );
+        assert_eq!(findings[0].remedy, REMEDY);
+        assert_eq!(check_file(&root, "crates/probe/src/big.rs"), findings);
+    }
+
+    /// The boundary is inclusive: a file of exactly the threshold is inside
+    /// the rule, and an empty baseline with a zero budget is a clean tree.
+    #[test]
+    fn a_file_at_the_threshold_passes_an_empty_baseline() {
+        let root = scratch_with("threshold-at", "!budget 0\n", THRESHOLD);
+        assert_eq!(check(&root), Vec::new());
+        assert_eq!(check_file(&root, "crates/probe/src/big.rs"), Vec::new());
+        assert_eq!(check_file(&root, BASELINE_FILE), Vec::new());
+    }
+
+    /// The one way past the threshold that stays, and why it is two edits: a
+    /// signed entry alone is a raise nobody paid for, because an empty
+    /// baseline's budget is 0. The older `a_raise_that_pays_for_nothing_is_
+    /// over_budget` proves the same rule between two existing entries; this
+    /// is the case the zero budget makes the only one.
+    #[test]
+    fn a_signed_exception_without_a_budget_raise_fails() {
+        let root = scratch_with(
+            "exception-unpaid",
+            "!budget 0\ncrates/probe/src/big.rs 1501  # signed, and unpaid\n",
+            THRESHOLD + 1,
+        );
+        let findings = check(&root);
+        assert_eq!(findings.len(), 1, "expected only the budget: {findings:?}");
+        assert!(
+            findings[0].line.contains("+1501"),
+            "the finding names the whole unpaid raise: {findings:?}"
+        );
+        assert_eq!(findings[0].remedy, BUDGET_REMEDY);
+        assert_eq!(check_file(&root, BASELINE_FILE), findings);
+    }
+
+    /// The same exception with the budget raised by as much in the same
+    /// change: allowed, because both numbers are now in front of a reviewer.
+    #[test]
+    fn a_signed_exception_with_its_budget_raise_passes() {
+        let root = scratch_with(
+            "exception-paid",
+            "!budget 1501\ncrates/probe/src/big.rs 1501  # signed, budget raised with it\n",
+            THRESHOLD + 1,
+        );
+        assert_eq!(check(&root), Vec::new());
+    }
+
+    /// A walk that could not see a file has no total to report, and the
+    /// undecodable file is the quiet case: present, seen, and carrying no
+    /// count, so summing the rest would print a smaller tree than there is.
+    #[test]
+    fn measured_is_a_failure_when_the_walk_missed_a_file() {
+        let root = scratch_with("measured-undecodable", "!budget 0\n", 10);
+        assert_eq!(measured(&root), Ok(10));
+        fs::write(root.join("crates/probe/src/latin.rs"), b"// caf\xe9\n")
+            .expect("scratch source is writable");
+        let failure = measured(&root).expect_err("an undecodable file is a missed one");
+        assert!(
+            failure.contains("crates/probe/src/latin.rs"),
+            "the failure names the file: {failure}"
+        );
+
+        let missing = crate::scratch_dir::ScratchDir::new("measured-missing-sources");
+        let failure = measured(&missing).expect_err("a missing crates/ is not zero lines");
+        assert!(failure.contains("crates/"), "{failure}");
     }
 }

--- a/crates/guards/tests/extension_boundary.rs
+++ b/crates/guards/tests/extension_boundary.rs
@@ -449,3 +449,44 @@ fn corrupt_or_unreadable_inputs_are_findings() {
             .any(|f| f.line.contains("unreadable source directory"))
     );
 }
+
+/// #365 item 3: a scan that fails is reported as a failure, not as 0 root
+/// lines. The fixture measures its literal caps; a source that does not
+/// decode, or a root with no source at all, has no measurement, and
+/// `--report` prints `failed` with the scan's own reason.
+#[test]
+fn a_failed_scan_is_not_measured_as_zero() {
+    let root = fixture();
+    assert_eq!(boundary::measured(&root), Ok(8));
+
+    fs::write(root.join("crates/app/src/app.rs"), b"\xff").unwrap();
+    let failure = boundary::measured(&root).expect_err("an unreadable source has no count");
+    assert!(failure.contains("unreadable source"), "{failure}");
+    let output = Command::new(env!("CARGO_BIN_EXE_quantick-guards"))
+        .env("QUANTICK_GUARDS_ROOT", root.path())
+        .arg("--report")
+        .output()
+        .unwrap();
+    let table = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        table
+            .lines()
+            .any(|line| line == "ratchet.extension-boundary.measured\tfailed"),
+        "{table}"
+    );
+    assert!(
+        !table
+            .lines()
+            .any(|line| line == "ratchet.extension-boundary.measured\t0")
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("extension-boundary: crates/app/src/app.rs: unreadable source"),
+        "{stderr}"
+    );
+    assert!(!output.status.success());
+
+    let missing = ScratchDir::new("extension-measured-missing-root");
+    let failure = boundary::measured(&missing).expect_err("no source is not zero lines");
+    assert!(failure.contains("unreadable source directory"), "{failure}");
+}

--- a/crates/guards/tests/extension_boundary.rs
+++ b/crates/guards/tests/extension_boundary.rs
@@ -461,7 +461,11 @@ fn a_failed_scan_is_not_measured_as_zero() {
 
     fs::write(root.join("crates/app/src/app.rs"), b"\xff").unwrap();
     let failure = boundary::measured(&root).expect_err("an unreadable source has no count");
-    assert!(failure.contains("unreadable source"), "{failure}");
+    assert_eq!(failure.missed.len(), 1, "{failure}");
+    assert!(
+        failure.missed[0].starts_with("  crates/app/src/app.rs: unreadable source"),
+        "{failure}"
+    );
     let output = Command::new(env!("CARGO_BIN_EXE_quantick-guards"))
         .env("QUANTICK_GUARDS_ROOT", root.path())
         .arg("--report")
@@ -481,12 +485,18 @@ fn a_failed_scan_is_not_measured_as_zero() {
     );
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("extension-boundary: crates/app/src/app.rs: unreadable source"),
+        stderr.contains(
+            "extension-boundary: 1 path(s) could not be measured:
+  crates/app/src/app.rs: unreadable source"
+        ),
         "{stderr}"
     );
     assert!(!output.status.success());
 
     let missing = ScratchDir::new("extension-measured-missing-root");
     let failure = boundary::measured(&missing).expect_err("no source is not zero lines");
-    assert!(failure.contains("unreadable source directory"), "{failure}");
+    assert!(
+        failure.missed[0].contains("unreadable source directory"),
+        "{failure}"
+    );
 }

--- a/crates/guards/tests/guards.rs
+++ b/crates/guards/tests/guards.rs
@@ -277,6 +277,10 @@ fn the_report_is_byte_identical_across_runs() {
         first.lines().all(|line| line.matches('\t').count() == 1),
         "every row is one label, one tab, one value"
     );
+    assert!(
+        first.lines().any(|line| line == "scan.failed\t0"),
+        "every measurement of this repository was taken"
+    );
 }
 
 /// The modes are alternatives. `--report` with anything beside it is refused
@@ -302,6 +306,75 @@ fn the_report_mode_refuses_extra_arguments() {
         complaint.contains("--report"),
         "the usage string offers the mode that was asked for: {complaint}"
     );
+}
+
+#[path = "../src/scratch_dir.rs"]
+mod scratch_dir;
+
+/// Every registered ratchet measures this repository, and refuses to measure
+/// a tree it cannot scan instead of reporting the zero it found there. Walked
+/// through the registry, so a ratchet added later is held to it without an
+/// edit here: the extension boundary printed 0 for a failed scan (#365)
+/// because nothing asked this of it.
+#[test]
+fn every_ratchet_fails_to_measure_a_tree_it_cannot_scan() {
+    let missing = scratch_dir::ScratchDir::new("report-missing-root");
+    for guard in GUARDS {
+        let Some(ratchet) = &guard.ratchet else {
+            continue;
+        };
+        let name = guard.name;
+        let real = (ratchet.measured)(&workspace_root());
+        assert!(
+            real.is_ok(),
+            "{name} could not measure this repository: {real:?}"
+        );
+        let failed = (ratchet.measured)(missing.path());
+        assert!(
+            failed.is_err(),
+            "{name} measured {failed:?} over an empty tree instead of failing"
+        );
+    }
+}
+
+/// The same property through the command, which is where a reader meets it:
+/// `failed` where the number would be, a `scan.failed` count beside the
+/// other scan rows, the reasons on stderr, and a non-zero exit, so neither a
+/// reader nor a script can take the table for a clean measurement.
+#[test]
+fn the_report_says_failed_rather_than_zero_when_a_scan_fails() {
+    let missing = scratch_dir::ScratchDir::new("report-failed-scan");
+    let output = Command::new(env!("CARGO_BIN_EXE_quantick-guards"))
+        .env("QUANTICK_GUARDS_ROOT", missing.path())
+        .arg("--report")
+        .output()
+        .expect("the guards binary runs");
+    let table = String::from_utf8_lossy(&output.stdout);
+    let reasons = String::from_utf8_lossy(&output.stderr);
+    let ratchets: Vec<&str> = GUARDS
+        .iter()
+        .filter(|guard| guard.ratchet.is_some())
+        .map(|guard| guard.name)
+        .collect();
+    for name in &ratchets {
+        let row = format!("ratchet.{name}.measured\tfailed");
+        assert!(
+            table.lines().any(|line| line == row),
+            "no `{row}` in:\n{table}"
+        );
+        assert!(
+            reasons
+                .lines()
+                .any(|line| line.starts_with(&format!("{name}: "))),
+            "stderr gives no reason for {name}:\n{reasons}"
+        );
+    }
+    let count = format!("scan.failed\t{}", ratchets.len());
+    assert!(
+        table.lines().any(|line| line == count),
+        "no `{count}` in:\n{table}"
+    );
+    assert!(!output.status.success(), "a failed scan must not exit 0");
 }
 
 /// `--blast-radius` measures; it never judges, so it exits 0 whatever it is


### PR DESCRIPTION
## Summary

Leave `crates/guards/size-baseline.txt` with no signed per-file exception, so that "no production file over 1,500 production lines" is a rule the size guard enforces, and make the guards' report honest when a scan fails.

**Tier:** `medium`. Campaign child of #367 (S10); closes on integration: #377; addresses #365 item 3.

### The baseline, before and after

| | before (`f36cc022`) | after |
| --- | --- | --- |
| entries | `crates/app/src/app.rs 769` (under the threshold, kept as history) | none |
| `!budget` | 769 | 0 |
| header | 385 lines of per-cut notes, some stale (40,121 as current, a 1,297 fall, a sum of 5,891) and missing S5's control-plane paragraph | the rule, the budget's reason, and one history of the twenty entries campaign #367 retired, per PR (#384, #383, #388, #390, #391 with S5's rationale recovered from `29bff61b`, #392, #395, #399, #396, and app.rs here) |

`grep -cE "40,121|1,297|5,891" crates/guards/size-baseline.txt` → `0`. An exception is still possible: a signed entry and a budget raise by as much, in the same change.

### A failed scan is no longer reported as zero (#365 item 3)

`Ratchet::measured` now returns `Result<usize, ratchet::Unmeasured>`, whose `missed` lists every path the walk could not measure. `ratchet::complete_total` refuses a total whenever the walk missed a path; `extension_boundary::measured` propagates the inventory error instead of `unwrap_or(0)`; `size`, `context` and `cycle` report an unlistable directory, an unreadable or undecodable file, or a missing instruction directory as a failure (`cycle::measure` used to return empty for an unlistable `crates/`). `--report` prints `failed` in place of the number, adds a `scan.failed` count beside `scan.unreadable`/`scan.blind`, writes each reason to stderr and exits 1. On the real tree it still exits 0, with `scan.failed 0`.

`--report` over an empty root, before → after:

```text
before (exit 0)                               after (exit 1)
ratchet.extension-boundary.measured	0         ratchet.extension-boundary.measured	failed
ratchet.size.measured	0                       ratchet.size.measured	failed
ratchet.context.measured	0                    ratchet.context.measured	failed
ratchet.cycle.measured	0                      ratchet.cycle.measured	failed
                                              scan.failed	4

stderr after:
extension-boundary: crates/app/src: unreadable source directory: <os error 3>
size: 1 path(s) could not be measured:
  crates/: directory could not be listed: <os error 3>
context: 4 path(s) could not be measured:
  .claude/skills/: not a readable directory
  .agents/: not a readable directory
  docs/campaign/: not a readable directory
  docs/workflow/: not a readable directory
cycle: 1 path(s) could not be measured:
  crates/: directory could not be listed: <os error 3>
```

### Tests and what each proves

- `size::a_file_one_line_over_the_threshold_fails_an_empty_baseline` — 1,501 production lines (plus a test module that must not count) under `!budget 0` fails, in `check` and `check_file`, with the carve-a-module remedy.
- `size::a_file_at_the_threshold_passes_an_empty_baseline` — 1,500 passes; the boundary is inclusive.
- `size::a_signed_exception_without_a_budget_raise_fails` — a signed 1,501 entry under `!budget 0` fails the budget (+1501). The existing `a_raise_that_pays_for_nothing_is_over_budget` proves the same rule between two entries.
- `size::a_signed_exception_with_its_budget_raise_passes` — the same entry with `!budget 1501` is clean: the mechanism stays.
- `size::the_baseline_holds_no_exception_and_a_zero_budget` — the real baseline has no entry and `!budget 0`.
- `size::baseline_parsing_ignores_comments` — moved onto a fixture; it asserted the `app.rs` entry this PR retires (the only changed expectation).
- `size::measured_is_a_failure_when_the_walk_missed_a_file`, `context::measured_is_a_failure_when_an_instruction_directory_is_missing`, `ratchet::a_walk_that_missed_a_path_has_no_total` — each walk's failure is an error, not a smaller sum.
- `tests/guards.rs::every_ratchet_fails_to_measure_a_tree_it_cannot_scan` — every registered ratchet measures this repository and refuses an empty root; walked through the registry, so a future ratchet is held to it.
- `tests/guards.rs::the_report_says_failed_rather_than_zero_when_a_scan_fails` — the binary prints `failed` per ratchet, `scan.failed 4`, a reason per ratchet on stderr, and exits non-zero.
- `tests/extension_boundary.rs::a_failed_scan_is_not_measured_as_zero` — the #365 shape exactly: an otherwise valid tree whose source does not decode reports `ratchet.extension-boundary.measured failed` with the scan's reason.
- `the_report_is_byte_identical_across_runs` now also asserts `scan.failed 0` on the real tree.

### CLAUDE.md and the context ratchet

One sentence in *Keeping the trunk small*: "`crates/guards/size-baseline.txt` is empty: no production file exceeds 1,500 lines." Paid for in the same section (the ratchet bullet lost "ceilings in … threshold 1,500"; *Teeth both ways* and *pay-as-you-go* were tightened). `CLAUDE.md` 9,551 → 9,548 bytes, under its 9,551 ceiling; `context-baseline.txt` and the budget are unchanged.

### Scope notes

- The issue's "pure moves" template (its A2 line multiset, A3 pinned tests unchanged) has nothing to apply to: no production code moved (goal S1).
- Performance: every touched path is the guards crate (a developer-time tool, rate: rare). No per-trade, per-depth or per-frame path is touched. `--report` walks what it walked before.

## Reviews

- **arch-review** — round one: step 0 code-review at low (effort-first, no reuse notice), 0 findings; full shape pass at `74628b0d`, no Blocker or Should-fix, one Consider (two stale doc comments) closed in `0e4a84e2` (https://github.com/milocaetano/quantick/pull/406#issuecomment-5647098938). Round two, delta follow-up at `25b5b409`: step 0 at low on PR #406, 0 findings; clean (https://github.com/milocaetano/quantick/pull/406#issuecomment-5647193593).
- **ai-review** — round one: 1 WEAK (AI-ready: a failed measurement was a prose `String`), thread `PRRT_kwDOTfuoRs6hxli3` (https://github.com/milocaetano/quantick/pull/406#issuecomment-5647107402). Fixed in `25b5b409` with a typed `ratchet::Unmeasured { missed }`; thread resolved; round two all PASS (https://github.com/milocaetano/quantick/pull/406#issuecomment-5647191852). Repair batches: 1 of 3.
- **delivery-review** — completeness pass only (tier `medium`, inline): PASS, nothing unledgered (https://github.com/milocaetano/quantick/pull/406#issuecomment-5647099060); follow-up PASS at `25b5b409` (https://github.com/milocaetano/quantick/pull/406#issuecomment-5647193683).
- Markers (`arch-review-ok`, `delivery-review-ok`, `ai-review-complete`) recorded with the campaign key `58ba8cbf` for `25b5b409` on base `6de991c3`. No deferrals.

## Verification loop

Local, run at `25b5b409` (the final head, rebased on `6de991c3`), one at a time:

- [x] `cargo fmt --all -- --check` — exit 0
- [x] `cargo clippy --workspace --all-targets` — exit 0, no warnings
- [x] `cargo build --workspace` — exit 0
- [x] `env -u QUANTICK_BUBBLES cargo test --workspace` — exit 0, 3,614 passed
- [x] `sh .claude/hooks/guardrails_test.sh` — 227 passed, 0 failed
- [x] `cargo run -p quantick-guards -- --tighten` — "nothing to tighten" in all four ratchets; `git status` clean
- [x] `cargo run -p quantick-guards -- --report` — `ratchet.size.budget 0`, `ratchet.size.recorded 0`, `ratchet.size.measured 184718`, `scan.failed 0`; largest file `control/gateway/server.rs` at exactly 1,500

Final-head CI at `25b5b409`: green — `ci` pass (6m17s), `windows` pass (8m2s), https://github.com/milocaetano/quantick/actions/runs/34705404052.

## Notes for the reviewer

- `--report` exiting 1 on a failed measurement changes its documented "always exit 0". The usage string and the comment in `main.rs` say why: the table then does not describe the tree, and a script trusting exit 0 would read `failed` rows as clean. The table stays byte-deterministic; OS error text goes to stderr only.
- `cycle::measured` was made consistent too, since the registry signature is shared and its walk had the same silent-empty case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VdP84bYEGeyCg7KwsNb1X2

