### PR TITLE
ci: run the app tests under CPU contention

### DIFF
--- a/.claude/GOAL-archive-app-tests-under-contention.md
+++ b/.claude/GOAL-archive-app-tests-under-contention.md
@@ -1,0 +1,221 @@
+# Mission: run the app tests under CPU contention in CI
+
+Add a Linux CI step that runs the already-built `quantick-app` test binary as
+many concurrent copies pinned to fewer cores, so a load-sensitive test fails in
+the pull request that introduces it rather than later, on an unrelated one.
+Four such tests (#361, #364, #385, #403) surfaced in sixteen hours of campaign
+#367, each only when somebody else's CI went red; the interim assessment keeps
+rubric criterion SE5 at 4 until a committed contention step exists.
+
+**Tier:** `medium`. Campaign child Q9 of #367, assigned at `medium` by the
+coordinator: a CI workflow change with a runtime cost to bound and a proof to
+produce against a historical revision, but no Rust source change.
+
+## Request ledger
+
+- **R1** — A CI step on Linux runs the `quantick-app` test binary under
+  deliberate CPU contention — N concurrent copies restricted with `taskset` to
+  K cores, N clearly larger than K — on every pull request and push, and fails
+  the check when any copy fails. *(#407 Scope bullet 1, A1; D1)*
+- **R2** — The step reuses the binary the main test step builds: no second full
+  build. *(#407 Scope bullet 2; D1)*
+- **R3** — The log names which copy failed and which test failed in it, and the
+  failing copy's output is kept (log or artifact). Verbatim: *"printing which
+  test failed in which copy"*. *(#407 Scope bullet 1, A1; D1)*
+- **R4** — The added wall-clock is bounded and stated: target under five
+  minutes, measured on the PR's own CI runs, capped by a `timeout-minutes`, and
+  the chosen N and K are explained. *(#407 Scope bullet 2, A3; D2)*
+- **R5** — Proof the step catches the class: it fails against a revision where
+  a known load-sensitive test is still unfixed, naming the test, and passes at
+  the campaign tip; both outputs are recorded in the PR. *(#407 A2; D3)*
+- **R6** — The step is documented in `ci.yml` comments, and in `CLAUDE.md`'s CI
+  list only if the context ratchet allows, otherwise under `docs/`. *(#407
+  Scope bullet 3)*
+- **R7** — Out of scope: fixing any newly found load-sensitive test (each is
+  filed as an issue with the failing copy's output and reported to the
+  coordinator), and Windows. *(#407 Scope "Out of scope"; D4)*
+- **R8** — Green at the final PR head. *(#407 A3)*
+- **R9** — Delivered through a PR whose base is exactly `campaign/lean-a-plus`;
+  the merge is the coordinator's and is read back by it. *(#407 A4;
+  integration contract)*
+- **R10** — Purpose: a load-sensitive test fails in the PR that introduces it,
+  which is the assessor's observable condition for SE5's next point.
+  *(#407 Context; the dispatch's opening paragraph)*
+
+## Decisions (from the coordinator)
+
+- **D1** — Linux only. Reuse the test binary the existing test step builds;
+  no second full build. N concurrent copies, all restricted with `taskset` to
+  K cores, N clearly larger than K (start from #404's 20 copies on one core;
+  scale to the runner's cores and the time budget), `--test-threads` left at
+  the default. Fail if any copy fails; print which copy and which test; keep
+  each copy's output on failure.
+- **D2** — Bound the added wall-clock: state the measured added time on the
+  PR's own CI runs; target under five minutes; cap the step with
+  `timeout-minutes`.
+- **D3** — Proof by running the same script against a revision where a known
+  flaky test is unfixed (the parent of #404's fix, or of #382's merge), showing
+  it fails there naming the test and passes at the campaign tip. A throwaway
+  branch is deleted afterwards and never targets `campaign/lean-a-plus` or
+  `main`.
+- **D4** — A new load-sensitive test found at the campaign tip is not fixed
+  here: file an issue with the failing copy's output, report it in the
+  handoff, and let the coordinator decide whether the step's first landing
+  must pass.
+- **D5** — Tier `medium`: `arch-review` with `code-review` at `low`, shape pass
+  on the touched dimensions (CI, operability, English); `ai-review`
+  completion; `delivery-review` completeness pass inline. At most three step-0
+  rounds.
+- **D14** — (coordinator decision, SendMessage to this child after the D4
+  question, 2026-09-12) Option (a): land the contention step blocking, with a
+  known-issue skip list that applies to the contention copies only. (1) The
+  list lives in one committed file, one exact test name per line, each line
+  citing its issue number; the step fails if a line lacks an issue. (2) The
+  normal `Test` step is unchanged and still runs every test. (3) One issue per
+  test found, with the failing copy output and the config that reproduced it,
+  labelled `area:app` `type:fix`, milestone "v0.1 - Engine core", with the
+  body line "Found by campaign #367 child Q9 (#407); a fix PR must remove the
+  test's line from the contention skip list." (4) The skip list and the issue
+  links are stated in the PR body and in the doc. (5) Recorded here with the
+  coordinator's message as its source. No test source is edited.
+- **D6** — `gh pr ready` once, cd-prefixed from the Bash tool, after reviews,
+  markers and green CI. Never merge; never touch `main`.
+
+## Assumptions
+
+- **S1** — libtest's default `--test-threads` is
+  `std::thread::available_parallelism()`, which on Linux honours the affinity
+  mask `taskset` sets. So "left at the default" means each copy runs K test
+  threads, not the runner's full core count. Safe to assume: it is what D1
+  asks for, and it is the property that makes every copy's own worker threads
+  compete for the same K cores.
+- **S2** — The proof runs on a throwaway CI branch whose own workflow adds its
+  name to the `push` trigger, so the real script runs on the real runner
+  shape; no PR is opened for it. Safe to assume: D3 allows a throwaway branch,
+  and a push trigger on that branch targets neither `campaign/lean-a-plus` nor
+  `main`.
+- **S3** — The helper script lives at `tools/ci/contention.sh` (POSIX sh),
+  its skip list beside it, and the longer prose (calibration table, cost, the
+  skip list at landing) at `docs/quality/app-tests-under-contention.md`, which
+  the context ratchet does not track. `CLAUDE.md` is not touched: its own
+  ceiling is 9,551 bytes and it measures 9,548, so a 118-byte pointer line
+  failed `the_repository_is_within_its_context_budget` (+115). #407 says "only
+  if the context ratchet allows; otherwise in `docs/`", so the ratchet did not
+  allow and the prose went to `docs/`. Conventional placement; reversible in
+  one edit.
+- **S4** — N = 24, K = 4. D1 says start from #404's 20 copies on one core and
+  scale to the runner and the budget. Measured on the 4-vCPU runner, 20 on 1
+  core and every 2- and 3-core config caught nothing, and only 24 copies on 4
+  cores caught #403's test before its fix. K = 4 is every vCPU the runner has,
+  so `taskset` there only states the mask; N = 24 > K keeps D1's shape, and a
+  larger runner is still pinned to 4. Safe to assume: D1 delegates the scaling,
+  and the table is in the doc.
+
+## Acceptance criteria
+
+- [ ] **A1** — `.github/workflows/ci.yml` has a step in the Linux job, after
+      `Test`, that runs the helper over the `quantick-app` test binary with N
+      copies pinned to K cores (N > K), on every `pull_request` and `push` to
+      `main`, and exits non-zero when any copy fails.
+      *Evidence:* the step's text in the diff; the throwaway run where it
+      failed. → PR body, "Proof". *(R1)*
+- [ ] **A2** — The binary is located from the `Test` step's build
+      (`cargo test --workspace --no-run --message-format=json`, the `Test`
+      step's own invocation, which compiles nothing new), not rebuilt.
+      *Evidence:* the step's log shows no `Compiling` line; the step's text.
+      → PR body, "Design". *(R2)*
+- [ ] **A3** — On failure the log names each failing copy and each failing
+      test in it, prints the copy's failure section, and the copies' logs are
+      uploaded as an artifact.
+      *Evidence:* the failing throwaway run's log excerpt and artifact. → PR
+      body, "Proof". *(R3)*
+- [ ] **A4** — The step carries `timeout-minutes`, N and K are explained in the
+      workflow comment, and the added wall-clock measured on this PR's own CI
+      run is stated and is under five minutes.
+      *Evidence:* the step's duration from `gh run view` at the final head.
+      → PR body, "Cost". *(R4)*
+- [ ] **A5** — The step, with the final script and skip list, fails on a
+      revision where #403's test is unfixed (`f36cc022`, the parent of #404's
+      fix `635f8936`), naming `the_trade_paint_layer_switch_stops_the_marks`,
+      and passes at the campaign tip.
+      *Evidence:* both runs' URLs and excerpts. → PR body, "Proof". *(R5, R10)*
+- [ ] **A6** — The step is documented in `ci.yml` comments and in
+      `docs/quality/app-tests-under-contention.md` (the ratchet refused a
+      `CLAUDE.md` line; see S3).
+      *Evidence:* the diff. → PR body. *(R6)*
+- [ ] **A7** — No Rust source or test is changed; a new load-sensitive test
+      found at the tip is filed as an issue and reported, not fixed; no
+      Windows step is added.
+      *Evidence:* `git diff --name-only` against the base; issue URL if any.
+      → PR body, handoff. *(R7)*
+- [ ] **A10** — Per D14: `tools/ci/contention-known-issues.txt` holds one
+      exact test name and one issue per line; the script stops on a line with
+      no issue or a name the binary does not have; the `Test` step is
+      unchanged; one issue per found test is filed as D14 specifies; the list
+      and issue links are in the PR body and the doc.
+      *Evidence:* the file; the script's shim exercise (no-issue, stale,
+      missing list); `git diff` of the `Test` step (none); issue URLs.
+      → PR body. *(R7, R8)*
+- [ ] **A8** — Every required check is green at the final PR head, the new
+      step included.
+      *Evidence:* `gh pr checks` at the head. → PR body, handoff. *(R8, R10)*
+- [ ] **A9** — The PR's base is exactly `campaign/lean-a-plus`.
+      *Evidence:* `gh pr view --json baseRefName`. → handoff. *(R9)*
+
+## Gates
+
+- [ ] **G1** — Every artifact in English (`CLAUDE.md`). *Evidence:* guards
+      `language` check; arch-review dimension 8. → PR body.
+- [ ] **G2** — Validation for a workflow/script change: YAML parses;
+      `sh .claude/hooks/guardrails_test.sh` green; `cargo test -p
+      quantick-guards` green; the four checks at the final head in CI (no Rust
+      input changes, so the local fmt/clippy/build/test loop is run once on
+      the final tree). *Evidence:* command exit codes. → PR body.
+- [ ] **G3** — Performance impact declared: CI-only; no per-trade, per-depth or
+      per-frame production path is touched; the cost is CI wall-clock, stated
+      in A4. → PR body.
+- [ ] **G4** — `arch-review` (step 0 `code-review` at `low`) with every
+      Blocker/Should-fix resolved or deferred in the PR body; `ai-review`
+      completion with zero unresolved threads. → PR body/comments.
+
+## Closing steps
+
+- **C1** — `delivery-review` completeness pass, inline, returns PASS.
+- **C2** — The PR is open, reviewed, green and marked ready (D6).
+- **C3** — The coordinator merges into `campaign/lean-a-plus` and reads the
+  merge back (A4 of #407); not this child's step.
+
+## Not applicable
+
+- Hot path, user-visible surface, capability, trader action, engine
+  determinism: the diff touches no Rust source, no UI and no engine.
+
+## The request as received
+
+The coordinator's dispatch, quoted verbatim (attributed quotation):
+
+> You are executing campaign child mission **Q9** of campaign #367 (https://github.com/milocaetano/quantick/issues/367) for milocaetano/quantick: add a CI step that runs the app test binary under deliberate CPU contention, so a load-sensitive test fails in the PR that introduces it instead of later on an unrelated PR. This earns rubric criterion SE5's next point (4 → 5) by the observable condition an independent assessor named. You are a subagent: you cannot ask the trader; decisions D1..Dn below answer the mission's step-3 questions. A doubt that would need a new decision is reported back, never guessed.
+>
+> ## Decisions
+> - D1: Linux only. Reuse the test binary the existing test step builds (locate it with `cargo test -p quantick-app --no-run --message-format=json` or the path cargo prints); do not add a second full build. Run N concurrent copies of that binary, all restricted with `taskset` to K cores where N is clearly larger than K (start from #404's 20 copies on 1 core; scale to the runner's cores and your time budget), each with `--test-threads` left at the default so the binary itself is parallel. Fail the step if any copy fails; print which copy and which test failed; keep each copy's output as an artifact or in the log on failure.
+> - D2: bound the added wall-clock: state the measured added time on the PR's own CI runs; target under 5 minutes; cap the step with a `timeout-minutes`.
+> - D3: proof (A2): demonstrate the step catches the class. Preferred: run the same script locally or in a throwaway CI branch against a revision where a known flaky test is still unfixed (for example the parent of #404's fix commit, `git log --oneline 86bbe06a..470e7e47` shows it; or the parent of #382's merge for #361), show it fails there naming the test, and show it passes at the campaign tip. A throwaway branch must be deleted afterwards and must not target `campaign/lean-a-plus` or `main`. Record both outputs in the PR body.
+> - D4: if the step finds a NEW load-sensitive test at the campaign tip, do not fix it here: file an issue with the failing copy output, report it in the handoff, and make the step's first landing pass only if the coordinator decides (report as a human_decision-free coordinator question in the handoff).
+> - D5: tier `medium`: `arch-review` with `code-review` at `low`, shape pass on the touched dimensions (CI, operability, English); `ai-review` completion; `delivery-review` completeness pass inline. At most three step-0 rounds.
+> - D6: `gh pr ready` works with the cd-prefixed form from the Bash tool. Run it once after reviews, markers and green CI; if denied because the campaign tip moved or the PR is DIRTY, stop and report. **Never use the PowerShell tool for `gh pr` commands; never merge; never touch main.**
+
+The task issue #407, quoted verbatim (attributed quotation):
+
+> ## Scope
+>
+> - Add a CI step (or a separate job) on Linux that runs the `quantick-app` test binary under deliberate CPU contention, for example N parallel copies of the already-built test binary restricted with `taskset` to fewer cores than copies, with a bounded total time, failing the check on any test failure and printing which test failed in which copy.
+> - Reuse the binary the main test step builds (no second full build); keep the added wall-clock bounded (state the number, target under 5 minutes) and explain the chosen N and core count.
+> - Document the step in `.github/workflows/ci.yml` comments and in `CLAUDE.md`'s CI list only if the context ratchet allows; otherwise in `docs/`.
+> - Out of scope: fixing any newly found flaky test in this PR (file each as an issue with the copy/test that failed); Windows.
+>
+> ## Acceptance criteria
+>
+> - [ ] A1: the contention step runs on every PR and push, uses the built test binary, and fails the check when a test fails in any copy; its logs name the test.
+> - [ ] A2: proof it catches the class: run it against the pre-fix revision of one of the four fixed tests (for example the parent of #404's fix commit) in a throwaway branch or a local reproduction, and show the step fails there and passes at the campaign tip; record both outputs in the PR.
+> - [ ] A3: green at the final PR head, with the added CI time stated.
+> - [ ] A4: merged into `campaign/lean-a-plus` through a PR whose base is exactly that branch, with the merge read back.

--- a/.claude/GOAL-archive-app-tests-under-contention.md
+++ b/.claude/GOAL-archive-app-tests-under-contention.md
@@ -78,6 +78,10 @@ produce against a historical revision, but no Rust source change.
   test's line from the contention skip list." (4) The skip list and the issue
   links are stated in the PR body and in the doc. (5) Recorded here with the
   coordinator's message as its source. No test source is edited.
+  Applied to every test the calibration and proof runs found: #408, #409,
+  #410, #411, #413, #415, #416, #417. The residual red rate at the tip (about
+  one run in five, falling) was reported back to the coordinator before
+  readiness.
 - **D6** — `gh pr ready` once, cd-prefixed from the Bash tool, after reviews,
   markers and green CI. Never merge; never touch `main`.
 
@@ -108,8 +112,8 @@ produce against a historical revision, but no Rust source change.
   core and every 2- and 3-core config caught nothing; on 4 cores, 24 copies
   caught #403's test before its fix in 3 of 9 runs and 20 copies in 1 of 3.
   24 is kept for the heavier contention per run; its step took 2:34 to 5:00
-  over eighteen runs, 20's 2:06 to 3:54, the measured fallback. K = 4 is every vCPU the runner has,
-  so `taskset` there only states the mask; N = 24 > K keeps D1's shape, and a
+  over twenty-four runs, 20's 2:06 to 3:54, the measured fallback. K = 4 is
+  every vCPU the runner has, so `taskset` there only states the mask; N = 24 > K keeps D1's shape, and a
   larger runner is still pinned to 4. Safe to assume: D1 delegates the scaling,
   and the table is in the doc.
 

--- a/.claude/GOAL-archive-app-tests-under-contention.md
+++ b/.claude/GOAL-archive-app-tests-under-contention.md
@@ -105,8 +105,10 @@ produce against a historical revision, but no Rust source change.
   one edit.
 - **S4** — N = 24, K = 4. D1 says start from #404's 20 copies on one core and
   scale to the runner and the budget. Measured on the 4-vCPU runner, 20 on 1
-  core and every 2- and 3-core config caught nothing, and only 24 copies on 4
-  cores caught #403's test before its fix. K = 4 is every vCPU the runner has,
+  core and every 2- and 3-core config caught nothing; on 4 cores, 24 copies
+  caught #403's test before its fix in 3 of 9 runs and 20 copies in 1 of 3.
+  24 is kept for the heavier contention per run; its step took 2:34 to 5:00
+  over eighteen runs, 20's 2:06 to 3:54, the measured fallback. K = 4 is every vCPU the runner has,
   so `taskset` there only states the mask; N = 24 > K keeps D1's shape, and a
   larger runner is still pinned to 4. Safe to assume: D1 delegates the scaling,
   and the table is in the doc.

--- a/.claude/GOAL-archive-app-tests-under-contention.md
+++ b/.claude/GOAL-archive-app-tests-under-contention.md
@@ -82,6 +82,20 @@ produce against a historical revision, but no Rust source change.
   #410, #411, #413, #415, #416, #417. The residual red rate at the tip (about
   one run in five, falling) was reported back to the coordinator before
   readiness.
+- **D19** — (coordinator decision, SendMessage to this child after the
+  residual-rate report, 2026-09-12; refines D14) Keep D14's design. (1) Stop
+  hunting after #417: add its line, no more exploratory batches. (2) Finish
+  reviews, markers and CI at the final head, run `gh pr ready` once, and hand
+  off. (3) The PR body and the doc state the measured residual rate (about one
+  run in five red on a pre-existing unlisted test at `2452e577`) and the
+  landing condition. (4) Landing condition, enforced by the coordinator: after
+  a follow-up mission (Q10) fixes #408–#417 and removes their lines, the
+  branch is rebased and shows 10 consecutive green contention runs at the tip
+  before the merge; this child makes that cheap and says how
+  (`CONTENTION_ROUNDS`). (5) #413, #416 and #417 say plainly that a Null
+  `capture_revision` under load may be a product race in the evidence
+  bundle, so the fix mission investigates the product path first. No test
+  source is edited.
 - **D6** — `gh pr ready` once, cd-prefixed from the Bash tool, after reviews,
   markers and green CI. Never merge; never touch `main`.
 
@@ -162,6 +176,13 @@ produce against a historical revision, but no Rust source change.
       *Evidence:* the file; the script's shim exercise (no-issue, stale,
       missing list); `git diff` of the `Test` step (none); issue URLs.
       → PR body. *(R7, R8)*
+- [ ] **A11** — Per D19: `CONTENTION_ROUNDS` runs the batch back to back and
+      stops at the first red round; the doc and PR body state the residual
+      rate and the landing condition, with the ten-round command; #413, #416
+      and #417 say plainly that the Null `capture_revision` may be a product
+      race.
+      *Evidence:* `tools/ci/contention_test.sh` rounds cases; the doc's
+      *Landing condition*; the three issue bodies. → PR body. *(R7, R10)*
 - [ ] **A8** — Every required check is green at the final PR head, the new
       step included.
       *Evidence:* `gh pr checks` at the head. → PR body, handoff. *(R8, R10)*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,41 @@ jobs:
         run: cargo build --workspace
       - name: Test
         run: cargo test --workspace
+      - name: App tests under CPU contention
+        # `Test` runs every test once on an idle runner. A test that quietly
+        # assumes a worker thread keeps up with the thread asserting on it
+        # passes there, merges, and goes red later on somebody else's pull
+        # request: #361, #364, #385 and #403 arrived that way within sixteen
+        # hours. Each reproduced only when many copies of the test binary
+        # shared the cores, so this step runs exactly that, on the binary
+        # `Test` just ran: `tools/ci/contention.sh` finds it with the same
+        # `cargo test --workspace` plus `--no-run`, which compiles nothing here.
+        #
+        # The script's defaults: 24 copies sharing 4 cores, each copy at
+        # libtest's default thread count, which follows the affinity mask, so
+        # 96 test threads and their workers on 4 vCPUs. Against the tree
+        # before #403's fix it named that test in 3 of 5 runs; 2 or 3 cores,
+        # and #404's 20 copies on 1 core, never did. The step took 3 to 5
+        # minutes over ten runs; `timeout-minutes` caps it at 8.
+        # The table is in `docs/quality/app-tests-under-contention.md`.
+        #
+        # Tests already known to fail under load are skipped by the copies
+        # only, one per line in `tools/ci/contention-known-issues.txt`, each
+        # naming its issue; `Test` above still runs them. A red step names
+        # each failing test and the copy it failed in, and the next step keeps
+        # every copy's log. Reproduce on Linux with `sh tools/ci/contention.sh`.
+        id: contention
+        timeout-minutes: 8
+        env:
+          CONTENTION_LOGS: ${{ runner.temp }}/contention
+        run: sh tools/ci/contention.sh quantick-app
+      - name: Keep the contention logs
+        if: failure() && steps.contention.outcome == 'failure'
+        uses: actions/upload-artifact@v4
+        with:
+          name: contention-logs
+          path: ${{ runner.temp }}/contention/
+          retention-days: 14
 
   # The second operating system the README is allowed to claim. It exists so
   # that sentence is backed by a workflow file rather than by memory: the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,13 @@ jobs:
             python3 "$suite" || failed=1
           done
           exit "$failed"
+      - name: Contention harness tests
+        # The harness the `App tests under CPU contention` step runs refuses a
+        # skip-list line with no issue and a name the binary no longer has, and
+        # names every failing copy and test. Nothing else would notice if an
+        # edit broke that: the step would just stay green. Shims stand in for
+        # cargo and the test binary, so this takes seconds and runs early.
+        run: sh tools/ci/contention_test.sh
       - name: Supply chain (bans, licenses)
         # Deliberately not `advisories`. These two checks are pure functions of
         # the committed `Cargo.lock`: they can only change when a commit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         # The script's defaults: 24 copies sharing 4 cores, each copy at
         # libtest's default thread count, which follows the affinity mask, so
         # 96 test threads and their workers on 4 vCPUs. Against the tree
-        # before #403's fix it named that test in 3 of 5 runs; 2 or 3 cores,
+        # before #403's fix it named that test in 3 of 9 runs; 2 or 3 cores,
         # and #404's 20 copies on 1 core, never did. The step took 3 to 5
         # minutes over ten runs; `timeout-minutes` caps it at 8.
         # The table is in `docs/quality/app-tests-under-contention.md`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -56,6 +56,7 @@ not a claim that those features have shipped.
 | [`agentic-development.md`](agentic-development.md) | The skills, the review gates and the hooks that enforce them — how work actually moves from objective to merged PR here |
 | [`campaign/workflow.md`](campaign/workflow.md) | Multi-issue campaigns, durable GitHub checkpoints, human tasks and recovery across agents |
 | [`quality/quantick-score-rubric.md`](quality/quantick-score-rubric.md) | The versioned evidence and scoring rules for sustainable growth, scalability and AI readiness |
+| [`quality/app-tests-under-contention.md`](quality/app-tests-under-contention.md) | The CI step that reruns the app tests as many copies on few cores, why 24 on 4, its skip list, and what to do when it goes red |
 | [`../CLAUDE.md`](../CLAUDE.md) | The working rules, authoritative for any agent changing this repository |
 | [`../.claude/hooks/README.md`](../.claude/hooks/README.md) | The guardrail hooks — the four modes, which three are gates and which one only reports, why they fail open, and how to override them |
 

--- a/docs/quality/app-tests-under-contention.md
+++ b/docs/quality/app-tests-under-contention.md
@@ -42,8 +42,15 @@ CONTENTION_COPIES=12 CONTENTION_CORES=2 sh tools/ci/contention.sh
 ```
 
 Other knobs: `CONTENTION_TIMEOUT` and `CONTENTION_LOGS`, plus
-`CONTENTION_KNOWN_ISSUES` to point at another skip list. Exit status is 0 when
-every copy passed, 1 when any copy failed, and 2 when the harness could not run.
+`CONTENTION_KNOWN_ISSUES` to point at another skip list. A package with more
+than one test target (a crate with `tests/*.rs` binaries) takes the target's
+name as a second argument: `sh tools/ci/contention.sh quantick-engine
+golden_tick`. Exit status is 0 when every copy passed, 1 when any copy failed,
+and 2 when the harness could not run.
+
+`tools/ci/contention_test.sh` tests every one of those exit paths with shims
+for cargo, `taskset` and the test binary. CI runs it early, in the
+`Contention harness tests` step.
 
 ## Choosing 24 copies on 4 cores
 

--- a/docs/quality/app-tests-under-contention.md
+++ b/docs/quality/app-tests-under-contention.md
@@ -1,0 +1,124 @@
+# App tests under CPU contention
+
+The Linux CI job runs the `quantick-app` test binary a second time, as many
+concurrent copies sharing a few cores, right after `Test`. The step is
+`App tests under CPU contention` in `.github/workflows/ci.yml`; the harness is
+`tools/ci/contention.sh`. Issue #407 added it (campaign #367, child Q9).
+
+## Why
+
+`Test` runs every test once on an idle runner. A test that assumes a worker
+thread keeps up with the thread asserting on it passes there, merges, and goes
+red later on an unrelated pull request. Four such tests (#361, #364, #385,
+#403) arrived that way in sixteen hours. Each fix reproduced its failure the
+same way: many copies of the test binary sharing one or two cores. This step
+runs that harness in the pull request that adds the test.
+
+## What it does
+
+1. Finds the binary with `cargo test --workspace --no-run
+   --message-format=json`: the `Test` step's own invocation. After that step
+   it compiles nothing. A single-package selection (`-p quantick-app`) could
+   resolve different features and rebuild.
+2. Reads `tools/ci/contention-known-issues.txt` and turns each line into a
+   `--skip <name>` under `--exact`.
+3. Starts 24 copies at once, each under `taskset -c 0-3` and a 360-second
+   `timeout`, from the package root (where cargo runs a test binary).
+4. Fails if any copy exits non-zero, times out, or ends without a passing
+   summary. For each failed copy it prints the copy number, the failing test
+   names, and libtest's failure report. Then it prints a count of copies per
+   failing test and one GitHub annotation per test. The next step uploads
+   every copy's log as the `contention-logs` artifact.
+
+Each copy keeps libtest's default `--test-threads`. The default is the size of
+the affinity mask, so each copy runs 4 tests at once: 96 test threads, plus
+their worker threads, on 4 vCPUs.
+
+Reproduce on Linux from the repository root, after a `cargo test --workspace`:
+
+```sh
+sh tools/ci/contention.sh                      # 24 copies on 4 cores
+CONTENTION_COPIES=12 CONTENTION_CORES=2 sh tools/ci/contention.sh
+```
+
+Other knobs: `CONTENTION_TIMEOUT` and `CONTENTION_LOGS`, plus
+`CONTENTION_KNOWN_ISSUES` to point at another skip list. Exit status is 0 when
+every copy passed, 1 when any copy failed, and 2 when the harness could not run.
+
+## Choosing 24 copies on 4 cores
+
+All figures come from the 4-vCPU `ubuntu-latest` runner, on throwaway
+push-only branches (`tmp/q9-proof-*`, deleted afterwards). *Before* is
+`f36cc022`, the parent of #404's fix, where #403's
+`the_trade_paint_layer_switch_stops_the_marks` is still unfixed. *Tip* is the
+campaign tip `52e35a1b`. The two trees differ in the app only in that test.
+
+| Copies × cores | Runs (before / tip) | #403's test caught before its fix | Copies' wall time |
+| --- | --- | --- | --- |
+| 20 × 1 (#404's harness, 1 test thread per copy) | 1 / 1 | 0 of 1 | 329–450 s |
+| 8 × 2 | 1 / 1 | 0 of 1 | 96–131 s |
+| 12 × 2 | 1 / 1 | 0 of 1 | 145–198 s |
+| 16 × 3 | 1 / 1 | 0 of 1 | 201–224 s |
+| 24 × 3 | 2 / 2 | 0 of 2 | 305–337 s |
+| 16 × 4 | 2 / 2 | 0 of 2 | 100–199 s |
+| 20 × 4 | 3 / 3 | 1 of 3 | 125–234 s |
+| **24 × 4** | **5 / 5** | **3 of 5** | **182–300 s** |
+
+So the harness needs every copy to be parallel as well as outnumbered. One
+test thread per copy (20 × 1) never caught it, and neither did 2 or 3 cores.
+With 4 cores, 24 copies was the only setting that caught it in most runs.
+`CONTENTION_CORES` is 4 because that is all the runner has, so there `taskset`
+only states the mask. On a larger machine the copies are still held to 4
+cores. Over ten runs, each whole step at 24 × 4 took 3 min 2 s to 5 min 0 s:
+at the five-minute target, not comfortably under it. 20 × 4 took 2 min 6 s
+to 3 min 54 s but caught #403's test in only 1 of 3 runs, so the extra copies
+earn the minute. `timeout-minutes: 8` caps the step.
+
+It catches most, not all. One green run is not proof that a test is immune to
+load. The step raises the odds that a load-sensitive test fails in its own pull
+request, where before it only failed later, on an unrelated one.
+
+The proof runs (final script and skip list, #403's test not skipped):
+
+- Before, https://github.com/milocaetano/quantick/actions/runs/34710577586:
+  red in 1 of 3 jobs at 24 × 4. It named
+  `app::tests::layers_tests::the_trade_paint_layer_switch_stops_the_marks`
+  at `layers_tests.rs:565`, the CI assertion #403 recorded. It was also red in
+  1 of 3 jobs at 20 × 4.
+- Tip, https://github.com/milocaetano/quantick/actions/runs/34710578514: that
+  test passed in every job. One job failed on a fifth test found by the step
+  itself, now #413 (below).
+
+## The skip list
+
+Calibration found five more load-sensitive tests. Their sources are identical
+at the campaign tip. Fixing them is outside #407, so the copies skip them.
+**`Test` still runs every one**, so nothing leaves the ordinary suite. Each
+line in `tools/ci/contention-known-issues.txt` is an exact name and its issue.
+The harness refuses a line without an issue, and a name the binary no longer
+has. The PR that fixes a test removes its line.
+
+At landing the list held:
+
+| Test | Issue | Reproduced at |
+| --- | --- | --- |
+| `control_plane_tests::gateway_client_reads_the_running_application_and_wrong_tokens_fail_closed` (`:935`, observer-read revisions) | #408 | 24 × 4 and 16 × 4 |
+| `control_plane_tests::attaching_a_script_and_detaching_it_leaves_the_pane_as_it_was` (`:3135`) | #409 | 16 × 4 |
+| `control_plane_tests::a_keyed_call_that_expired_before_the_application_saw_it_leaves_its_key_free` (`:5435`) | #410 | 24 × 4, and locally on Windows |
+| `control_plane_tests::gateway_rejects_a_duplicate_request_id_while_a_wait_is_parked` (`:2702`) | #411 | 24 × 4, and locally on Windows |
+| `screenshot_evidence_tests::synthetic_fractional_geometry_round_trips_original_png_and_clipped_regions` (`:92`) | #413 | 24 × 4 |
+
+The file is the current list; this table is only the landing record.
+
+## When the step goes red
+
+- **A test your PR added or changed:** it probably assumes an ordering that
+  load breaks. Make it force the ordering (a hold, a flush, or a wait for the
+  state it asserts), as #382, #400 and #404 did. Do not add it to the skip
+  list.
+- **A test your PR did not touch:** the step has found another test from
+  before this step existed. File an issue with the copy's output and tell the
+  reviewer. The skip-list line citing that issue is a reviewed change, never a
+  way to turn one run green.
+- **A copy timed out:** the log shows tests libtest reported as running for
+  over 60 seconds. Treat it like a failure.

--- a/docs/quality/app-tests-under-contention.md
+++ b/docs/quality/app-tests-under-contention.md
@@ -62,23 +62,27 @@ campaign tip `52e35a1b`. The two trees differ in the app only in that test.
 | 24 × 3 | 2 / 2 | 0 of 2 | 305–337 s |
 | 16 × 4 | 2 / 2 | 0 of 2 | 100–199 s |
 | 20 × 4 | 3 / 3 | 1 of 3 | 125–234 s |
-| **24 × 4** | **5 / 5** | **3 of 5** | **182–300 s** |
+| **24 × 4** | **9 / 9** | **3 of 9** | **154–300 s** |
 
 So the harness needs every copy to be parallel as well as outnumbered. One
 test thread per copy (20 × 1) never caught it, and neither did 2 or 3 cores.
-With 4 cores, 24 copies was the only setting that caught it in most runs.
+With 4 cores, 24 copies caught it in 3 of 9 runs and 20 copies in 1 of 3,
+about the same rate on samples this small.
 `CONTENTION_CORES` is 4 because that is all the runner has, so there `taskset`
 only states the mask. On a larger machine the copies are still held to 4
-cores. Over ten runs, each whole step at 24 × 4 took 3 min 2 s to 5 min 0 s:
+cores. Over eighteen runs, each whole step at 24 × 4 took 2 min 34 s to 5 min 0 s:
 at the five-minute target, not comfortably under it. 20 × 4 took 2 min 6 s
-to 3 min 54 s but caught #403's test in only 1 of 3 runs, so the extra copies
-earn the minute. `timeout-minutes: 8` caps the step.
+to 3 min 54 s. The step keeps 24 because more copies is more contention on
+every run, and because the extra minute stayed within the target in all
+eighteen; if the target tightens, 20 is the measured fallback.
+`timeout-minutes: 8` caps the step.
 
-It catches most, not all. One green run is not proof that a test is immune to
-load. The step raises the odds that a load-sensitive test fails in its own pull
-request, where before it only failed later, on an unrelated one.
+It catches a load-sensitive test often, not always: about one run in three
+for #403's. One green run is not proof that a test is immune to load. The step
+raises the odds that such a test fails in its own pull request, where before it
+only failed later, on an unrelated one, and every run that does fail names it.
 
-The proof runs (final script and skip list, #403's test not skipped):
+The proof runs (the skip-list logic, #403's test never skipped):
 
 - Before, https://github.com/milocaetano/quantick/actions/runs/34710577586:
   red in 1 of 3 jobs at 24 × 4. It named
@@ -86,12 +90,18 @@ The proof runs (final script and skip list, #403's test not skipped):
   at `layers_tests.rs:565`, the CI assertion #403 recorded. It was also red in
   1 of 3 jobs at 20 × 4.
 - Tip, https://github.com/milocaetano/quantick/actions/runs/34710578514: that
-  test passed in every job. One job failed on a fifth test found by the step
-  itself, now #413 (below).
+  test passed in every job. One job failed on a test found by the step itself,
+  now #413 (below).
+- The committed script with its CI defaults, four jobs each:
+  before, https://github.com/milocaetano/quantick/actions/runs/34712034171,
+  and tip, https://github.com/milocaetano/quantick/actions/runs/34712035367.
+  #403's test did not fail in these four, and each revision had one job red on
+  a further new test, now #415 and #416. The failing job's
+  `contention-logs-2` artifact holds all 24 copies' logs.
 
 ## The skip list
 
-Calibration found five more load-sensitive tests. Their sources are identical
+Calibration found seven more load-sensitive tests. Their sources are identical
 at the campaign tip. Fixing them is outside #407, so the copies skip them.
 **`Test` still runs every one**, so nothing leaves the ordinary suite. Each
 line in `tools/ci/contention-known-issues.txt` is an exact name and its issue.
@@ -107,6 +117,8 @@ At landing the list held:
 | `control_plane_tests::a_keyed_call_that_expired_before_the_application_saw_it_leaves_its_key_free` (`:5435`) | #410 | 24 × 4, and locally on Windows |
 | `control_plane_tests::gateway_rejects_a_duplicate_request_id_while_a_wait_is_parked` (`:2702`) | #411 | 24 × 4, and locally on Windows |
 | `screenshot_evidence_tests::synthetic_fractional_geometry_round_trips_original_png_and_clipped_regions` (`:92`) | #413 | 24 × 4 |
+| `control_plane_tests::an_operator_cannot_detach_the_traders_own_indicator` (`:2910`) | #415 | 24 × 4 |
+| `control_plane_tests::a_bundle_with_a_screenshot_maps_every_named_control_to_a_region_of_the_image` (`:4231`) | #416 | 24 × 4 |
 
 The file is the current list; this table is only the landing record.
 

--- a/docs/quality/app-tests-under-contention.md
+++ b/docs/quality/app-tests-under-contention.md
@@ -77,11 +77,11 @@ With 4 cores, 24 copies caught it in 3 of 9 runs and 20 copies in 1 of 3,
 about the same rate on samples this small.
 `CONTENTION_CORES` is 4 because that is all the runner has, so there `taskset`
 only states the mask. On a larger machine the copies are still held to 4
-cores. Over eighteen runs, each whole step at 24 × 4 took 2 min 34 s to 5 min 0 s:
+cores. Over twenty-four runs, each whole step at 24 × 4 took 2 min 34 s to 5 min 0 s:
 at the five-minute target, not comfortably under it. 20 × 4 took 2 min 6 s
 to 3 min 54 s. The step keeps 24 because more copies is more contention on
 every run, and because the extra minute stayed within the target in all
-eighteen; if the target tightens, 20 is the measured fallback.
+twenty-four; if the target tightens, 20 is the measured fallback.
 `timeout-minutes: 8` caps the step.
 
 It catches a load-sensitive test often, not always: about one run in three
@@ -108,7 +108,7 @@ The proof runs (the skip-list logic, #403's test never skipped):
 
 ## The skip list
 
-Calibration found seven more load-sensitive tests. Their sources are identical
+Calibration found eight more load-sensitive tests. Their sources are identical
 at the campaign tip. Fixing them is outside #407, so the copies skip them.
 **`Test` still runs every one**, so nothing leaves the ordinary suite. Each
 line in `tools/ci/contention-known-issues.txt` is an exact name and its issue.
@@ -126,8 +126,16 @@ At landing the list held:
 | `screenshot_evidence_tests::synthetic_fractional_geometry_round_trips_original_png_and_clipped_regions` (`:92`) | #413 | 24 × 4 |
 | `control_plane_tests::an_operator_cannot_detach_the_traders_own_indicator` (`:2910`) | #415 | 24 × 4 |
 | `control_plane_tests::a_bundle_with_a_screenshot_maps_every_named_control_to_a_region_of_the_image` (`:4231`) | #416 | 24 × 4 |
+| `control_plane_tests::a_capture_that_wants_an_image_waits_for_the_frame_instead_of_answering_blind` (`:4628`) | #417 | 24 × 4 |
 
 The file is the current list; this table is only the landing record.
+
+The list had not converged at landing. Each batch of runs at the campaign tip
+found one more test: 1 of 3 jobs red with five tests skipped, 1 of 4 with five,
+1 of 6 with seven. Expect roughly one run in five to go red on a test that was
+already there, until the list stops growing or its issues are fixed. #413,
+#416 and #417 share one symptom, an evidence bundle whose `capture_revision` is
+missing under load, which may be one cause rather than three.
 
 ## When the step goes red
 

--- a/docs/quality/app-tests-under-contention.md
+++ b/docs/quality/app-tests-under-contention.md
@@ -41,7 +41,8 @@ sh tools/ci/contention.sh                      # 24 copies on 4 cores
 CONTENTION_COPIES=12 CONTENTION_CORES=2 sh tools/ci/contention.sh
 ```
 
-Other knobs: `CONTENTION_TIMEOUT` and `CONTENTION_LOGS`, plus
+Other knobs: `CONTENTION_TIMEOUT`, `CONTENTION_LOGS`, `CONTENTION_ROUNDS`
+(see *Landing condition*), plus
 `CONTENTION_KNOWN_ISSUES` to point at another skip list. A package with more
 than one test target (a crate with `tests/*.rs` binaries) takes the target's
 name as a second argument: `sh tools/ci/contention.sh quantick-engine
@@ -136,6 +137,36 @@ found one more test: 1 of 3 jobs red with five tests skipped, 1 of 4 with five,
 already there, until the list stops growing or its issues are fixed. #413,
 #416 and #417 share one symptom, an evidence bundle whose `capture_revision` is
 missing under load, which may be one cause rather than three.
+
+## Landing condition
+
+The coordinator of campaign #367 (decision D19) holds this step's merge into
+`campaign/lean-a-plus` until it is expected green on unrelated pull requests.
+At `2452e577`, with seven tests skipped, 1 run in 6 was still red on a test
+that was already there (earlier batches: 1 in 4 and 1 in 3 with five
+skipped). That is about one run in five. The test it found, #417, is now
+skipped too, and the rate with all eight skipped has not been measured. The
+condition:
+
+1. A follow-up mission fixes #408–#411 and #413, #415–#417, removing each
+   test's line from the skip list.
+2. This branch is rebased onto that tip.
+3. The contention harness shows 10 consecutive green runs there.
+
+`CONTENTION_ROUNDS` makes the third step one command. It runs the batch that
+many times back to back, stops at the first red round, and says which round
+it was:
+
+```sh
+cargo test --workspace && CONTENTION_ROUNDS=10 sh tools/ci/contention.sh
+```
+
+On the CI runner shape, push the rebased tip to a throwaway branch that
+carries a push-triggered workflow running the same command, with
+`timeout-minutes: 60`: at the measured 154–300 seconds a round, ten rounds
+take 26–50 minutes. Delete the branch afterwards. The proof branches for
+#407 (`tmp/q9-proof-*`) were built that way. The regular `ci.yml` step stays
+at one round, since it runs on every push.
 
 ## When the step goes red
 

--- a/tools/ci/contention-known-issues.txt
+++ b/tools/ci/contention-known-issues.txt
@@ -1,0 +1,15 @@
+# Tests the contention step's copies skip because they are already known to
+# fail under CPU load. Read by tools/ci/contention.sh.
+#
+# One exact libtest name per line, then the issue tracking its fix. A line
+# without an issue number, or a name the test binary no longer has, fails the
+# step. The normal `Test` step still runs every test listed here; only the
+# contention copies skip them. The PR that fixes a test removes its line.
+#
+# All five were found by the step's own calibration (campaign #367, child Q9,
+# #407) at test sources identical to the campaign tip 52e35a1b.
+app::tests::control_plane_tests::gateway_client_reads_the_running_application_and_wrong_tokens_fail_closed #408
+app::tests::control_plane_tests::attaching_a_script_and_detaching_it_leaves_the_pane_as_it_was #409
+app::tests::control_plane_tests::a_keyed_call_that_expired_before_the_application_saw_it_leaves_its_key_free #410
+app::tests::control_plane_tests::gateway_rejects_a_duplicate_request_id_while_a_wait_is_parked #411
+app::tests::screenshot_evidence_tests::synthetic_fractional_geometry_round_trips_original_png_and_clipped_regions #413

--- a/tools/ci/contention-known-issues.txt
+++ b/tools/ci/contention-known-issues.txt
@@ -6,7 +6,7 @@
 # step. The normal `Test` step still runs every test listed here; only the
 # contention copies skip them. The PR that fixes a test removes its line.
 #
-# All seven were found by the step's own calibration (campaign #367, child
+# All eight were found by the step's own calibration (campaign #367, child
 # Q9, #407) at test sources identical to the campaign tip.
 app::tests::control_plane_tests::gateway_client_reads_the_running_application_and_wrong_tokens_fail_closed #408
 app::tests::control_plane_tests::attaching_a_script_and_detaching_it_leaves_the_pane_as_it_was #409
@@ -15,3 +15,4 @@ app::tests::control_plane_tests::gateway_rejects_a_duplicate_request_id_while_a_
 app::tests::screenshot_evidence_tests::synthetic_fractional_geometry_round_trips_original_png_and_clipped_regions #413
 app::tests::control_plane_tests::an_operator_cannot_detach_the_traders_own_indicator #415
 app::tests::control_plane_tests::a_bundle_with_a_screenshot_maps_every_named_control_to_a_region_of_the_image #416
+app::tests::control_plane_tests::a_capture_that_wants_an_image_waits_for_the_frame_instead_of_answering_blind #417

--- a/tools/ci/contention-known-issues.txt
+++ b/tools/ci/contention-known-issues.txt
@@ -6,10 +6,12 @@
 # step. The normal `Test` step still runs every test listed here; only the
 # contention copies skip them. The PR that fixes a test removes its line.
 #
-# All five were found by the step's own calibration (campaign #367, child Q9,
-# #407) at test sources identical to the campaign tip 52e35a1b.
+# All seven were found by the step's own calibration (campaign #367, child
+# Q9, #407) at test sources identical to the campaign tip.
 app::tests::control_plane_tests::gateway_client_reads_the_running_application_and_wrong_tokens_fail_closed #408
 app::tests::control_plane_tests::attaching_a_script_and_detaching_it_leaves_the_pane_as_it_was #409
 app::tests::control_plane_tests::a_keyed_call_that_expired_before_the_application_saw_it_leaves_its_key_free #410
 app::tests::control_plane_tests::gateway_rejects_a_duplicate_request_id_while_a_wait_is_parked #411
 app::tests::screenshot_evidence_tests::synthetic_fractional_geometry_round_trips_original_png_and_clipped_regions #413
+app::tests::control_plane_tests::an_operator_cannot_detach_the_traders_own_indicator #415
+app::tests::control_plane_tests::a_bundle_with_a_screenshot_maps_every_named_control_to_a_region_of_the_image #416

--- a/tools/ci/contention.sh
+++ b/tools/ci/contention.sh
@@ -1,0 +1,170 @@
+#!/bin/sh
+# Run one crate's already-built test binary as many concurrent copies pinned to
+# fewer cores than copies, and fail if any copy fails.
+#
+#   sh tools/ci/contention.sh [package]        # default: quantick-app
+#
+# Why: a test that assumes a worker thread keeps up with the thread asserting
+# on it passes on a quiet machine and fails on a loaded one. CI's `Test` step
+# runs every binary once, on an idle runner, so such a test ships green and
+# goes red later on an unrelated pull request. Every one found so far (#361,
+# #364, #385, #403) reproduced the same way: many copies of the binary sharing
+# one or two cores. This script is that harness, run where the test is added.
+#
+# Linux only: pinning uses `taskset`. Knobs, all optional; the defaults are
+# what CI runs, and `docs/quality/app-tests-under-contention.md` says why:
+#
+#   CONTENTION_COPIES   concurrent copies               (default 24)
+#   CONTENTION_CORES    cores they share, from core 0   (default 4)
+#   CONTENTION_TIMEOUT  seconds before a copy is killed (default 360)
+#   CONTENTION_LOGS     where each copy's output goes   (default target/contention)
+#   CONTENTION_KNOWN_ISSUES  the skip list              (default: beside this script)
+#
+# The skip list, `contention-known-issues.txt`, names tests already known to
+# fail under contention: one exact test name per line, then the issue that
+# tracks its fix (`app::tests::x::y #123`). The copies skip them, and only the
+# copies: the `Test` step still runs every one. A line without an issue, or a
+# name the binary no longer has, stops the harness, so the list can neither
+# grow silently nor outlive the test it excuses. A fix removes its line.
+#
+# Each copy keeps libtest's default `--test-threads`, which is the size of the
+# affinity mask, so every copy runs CONTENTION_CORES tests at once and all of
+# their worker threads compete for the same cores.
+#
+# The binary is located with the exact `cargo test --workspace` invocation the
+# CI `Test` step runs, plus `--no-run`: after that step it compiles nothing, so
+# the copies run the very binary the step just tested. A single-package
+# selection could resolve different features and rebuild.
+#
+# Exit status: 0 when every copy passed, 1 when any copy failed or timed out,
+# 2 when the harness itself could not run.
+
+set -u
+
+package=${1:-quantick-app}
+copies=${CONTENTION_COPIES:-24}
+cores=${CONTENTION_CORES:-4}
+limit=${CONTENTION_TIMEOUT:-360}
+logs=${CONTENTION_LOGS:-target/contention}
+known=${CONTENTION_KNOWN_ISSUES:-$(dirname "$0")/contention-known-issues.txt}
+
+die() {
+    echo "contention: $*" >&2
+    exit 2
+}
+
+command -v taskset >/dev/null 2>&1 || die "taskset not found (util-linux); this harness is Linux only"
+command -v timeout >/dev/null 2>&1 || die "timeout not found (coreutils)"
+[ "$copies" -gt "$cores" ] 2>/dev/null || die "CONTENTION_COPIES ($copies) must exceed CONTENTION_CORES ($cores), or nothing contends"
+[ "$cores" -ge 1 ] || die "CONTENTION_CORES must be at least 1"
+online=$(nproc)
+[ "$cores" -le "$online" ] || die "CONTENTION_CORES ($cores) exceeds the $online online cores"
+
+# One JSON object per line. The package's test executables are the artifacts
+# whose package id names it — `.../dir#<package>@<version>`, or
+# `.../<package>#<version>` when the directory already carries the name — and
+# whose `executable` is a path rather than null.
+artifacts=$(cargo test --workspace --no-run --message-format=json) || die "cargo test --no-run failed"
+matches=$(printf '%s\n' "$artifacts" | grep "\"reason\":\"compiler-artifact\"" | grep -E "(#$package@|/$package#)" | grep '"executable":"')
+count=$(printf '%s\n' "$matches" | grep -c '"executable":"')
+[ "$count" -eq 1 ] || die "expected exactly one test executable for $package, found $count"
+binary=$(printf '%s\n' "$matches" | sed 's/.*"executable":"\([^"]*\)".*/\1/')
+manifest=$(printf '%s\n' "$matches" | sed 's/.*"manifest_path":"\([^"]*\)".*/\1/')
+[ -x "$binary" ] || die "not executable: $binary"
+# cargo runs a test binary from its package root; tests that read fixtures by
+# relative path depend on that, so the copies do too.
+workdir=$(dirname "$manifest")
+
+# The skip list becomes libtest arguments: `--exact` makes every `--skip`
+# match one whole test name rather than any name containing it.
+[ -r "$known" ] || die "cannot read the skip list $known"
+listed=$(cd "$workdir" && "$binary" --list 2>/dev/null | sed -n 's/: test$//p') || die "cannot list the tests in $binary"
+set -- --exact
+skipped=0
+cr=$(printf '\r')
+while IFS= read -r line || [ -n "$line" ]; do
+    line=${line%"$cr"}
+    case "$line" in
+        '' | '#'*) continue ;;
+    esac
+    printf '%s\n' "$line" | grep -Eq '^[A-Za-z0-9_:]+[[:space:]]+#[0-9]+$' ||
+        die "$known: every line is '<exact test name> #<issue>': $line"
+    name=${line%%[[:space:]]*}
+    printf '%s\n' "$listed" | grep -Fxq "$name" ||
+        die "$known: no test named $name in $binary; remove its line"
+    set -- "$@" --skip "$name"
+    skipped=$((skipped + 1))
+    echo "contention: skipping $line"
+done <"$known"
+
+rm -rf "$logs"
+mkdir -p "$logs" || die "cannot create $logs"
+logs=$(cd "$logs" && pwd)
+
+last=$((cores - 1))
+echo "contention: $copies copies of $binary on cores 0-$last of $online, ${limit}s limit each, $skipped known issue(s) skipped"
+echo "contention: logs in $logs"
+
+started=$(date +%s)
+i=1
+while [ "$i" -le "$copies" ]; do
+    (
+        cd "$workdir" &&
+            exec timeout --kill-after=10 "$limit" taskset -c "0-$last" "$binary" "$@"
+    ) >"$logs/copy-$i.log" 2>&1 &
+    eval "pid_$i=$!"
+    i=$((i + 1))
+done
+
+failed=0
+i=1
+while [ "$i" -le "$copies" ]; do
+    eval "pid=\$pid_$i"
+    wait "$pid"
+    status=$?
+    log="$logs/copy-$i.log"
+    if [ "$status" -eq 0 ] && grep -q '^test result: ok\.' "$log"; then
+        i=$((i + 1))
+        continue
+    fi
+    failed=$((failed + 1))
+    echo
+    case "$status" in
+        124 | 137) echo "== copy $i of $copies: TIMED OUT after ${limit}s (exit $status)" ;;
+        0) echo "== copy $i of $copies: exited 0 without a passing test summary" ;;
+        *) echo "== copy $i of $copies: FAILED (exit $status)" ;;
+    esac
+    # The names, one per line, as libtest prints them while running.
+    grep -E '^test .* \.\.\. FAILED$' "$log" | sed 's/^test \(.*\) \.\.\. FAILED$/   failed: \1/'
+    # A hung test is announced but never finishes.
+    grep -E 'has been running for over' "$log" | sed 's/^/   /'
+    # libtest's own failure report: every failing test's captured output and
+    # panic message, then the list of names.
+    sed -n '/^failures:$/,/^test result:/p' "$log"
+    if [ "$status" -eq 124 ] || [ "$status" -eq 137 ]; then
+        tail -n 20 "$log"
+    fi
+    i=$((i + 1))
+done
+
+elapsed=$(($(date +%s) - started))
+echo
+if [ "$failed" -eq 0 ]; then
+    echo "contention: all $copies copies passed on $cores core(s) in ${elapsed}s"
+    exit 0
+fi
+
+echo "contention: $failed of $copies copies failed on $cores core(s) in ${elapsed}s"
+names=$(cat "$logs"/copy-*.log | grep -E '^test .* \.\.\. FAILED$' |
+    sed 's/^test \(.*\) \.\.\. FAILED$/\1/')
+if [ -z "$names" ]; then
+    echo "contention: no test reported FAILED; see the copies above that timed out or ended early"
+    exit 1
+fi
+echo "contention: failing tests, by the number of copies each failed in:"
+printf '%s\n' "$names" | sort | uniq -c | sort -rn
+if [ -n "${GITHUB_ACTIONS:-}" ]; then
+    # One annotation per distinct test, on the run's summary page.
+    printf '%s\n' "$names" | sort -u | sed 's/^/::error title=Failed under CPU contention::/'
+fi
+exit 1

--- a/tools/ci/contention.sh
+++ b/tools/ci/contention.sh
@@ -78,7 +78,11 @@ workdir=$(dirname "$manifest")
 # The skip list becomes libtest arguments: `--exact` makes every `--skip`
 # match one whole test name rather than any name containing it.
 [ -r "$known" ] || die "cannot read the skip list $known"
-listed=$(cd "$workdir" && "$binary" --list 2>/dev/null | sed -n 's/: test$//p') || die "cannot list the tests in $binary"
+# Two steps, so a binary that cannot list is reported as that, rather than as
+# a skip-list line naming a test that no longer exists.
+listing=$(cd "$workdir" && "$binary" --list 2>/dev/null) || die "cannot list the tests in $binary"
+listed=$(printf '%s\n' "$listing" | sed -n 's/: test$//p')
+[ -n "$listed" ] || die "$binary --list named no tests"
 set -- --exact
 skipped=0
 cr=$(printf '\r')

--- a/tools/ci/contention.sh
+++ b/tools/ci/contention.sh
@@ -2,7 +2,10 @@
 # Run one crate's already-built test binary as many concurrent copies pinned to
 # fewer cores than copies, and fail if any copy fails.
 #
-#   sh tools/ci/contention.sh [package]        # default: quantick-app
+#   sh tools/ci/contention.sh [package [target]]   # default: quantick-app
+#
+# `target` names one test target when the package has several (a crate with
+# `tests/*.rs` binaries); without it the package must have exactly one.
 #
 # Why: a test that assumes a worker thread keeps up with the thread asserting
 # on it passes on a quiet machine and fails on a loaded one. CI's `Test` step
@@ -42,6 +45,7 @@
 set -u
 
 package=${1:-quantick-app}
+target=${2:-}
 copies=${CONTENTION_COPIES:-24}
 cores=${CONTENTION_CORES:-4}
 limit=${CONTENTION_TIMEOUT:-360}
@@ -66,8 +70,13 @@ online=$(nproc)
 # whose `executable` is a path rather than null.
 artifacts=$(cargo test --workspace --no-run --message-format=json) || die "cargo test --no-run failed"
 matches=$(printf '%s\n' "$artifacts" | grep "\"reason\":\"compiler-artifact\"" | grep -E "(#$package@|/$package#)" | grep '"executable":"')
+if [ -n "$target" ]; then
+    # `"name"` appears once per artifact line, inside its `target`.
+    matches=$(printf '%s\n' "$matches" | grep -F "\"name\":\"$target\"")
+fi
 count=$(printf '%s\n' "$matches" | grep -c '"executable":"')
-[ "$count" -eq 1 ] || die "expected exactly one test executable for $package, found $count"
+[ "$count" -eq 1 ] ||
+    die "expected exactly one test executable for $package${target:+ target $target}, found $count; name one as the second argument"
 binary=$(printf '%s\n' "$matches" | sed 's/.*"executable":"\([^"]*\)".*/\1/')
 manifest=$(printf '%s\n' "$matches" | sed 's/.*"manifest_path":"\([^"]*\)".*/\1/')
 [ -x "$binary" ] || die "not executable: $binary"

--- a/tools/ci/contention.sh
+++ b/tools/ci/contention.sh
@@ -21,6 +21,8 @@
 #   CONTENTION_CORES    cores they share, from core 0   (default 4)
 #   CONTENTION_TIMEOUT  seconds before a copy is killed (default 360)
 #   CONTENTION_LOGS     where each copy's output goes   (default target/contention)
+#   CONTENTION_ROUNDS   batches run back to back, stopping at the first red
+#                       one; the copies' logs are the last round's (default 1)
 #   CONTENTION_KNOWN_ISSUES  the skip list              (default: beside this script)
 #
 # The skip list, `contention-known-issues.txt`, names tests already known to
@@ -49,6 +51,7 @@ target=${2:-}
 copies=${CONTENTION_COPIES:-24}
 cores=${CONTENTION_CORES:-4}
 limit=${CONTENTION_TIMEOUT:-360}
+rounds=${CONTENTION_ROUNDS:-1}
 logs=${CONTENTION_LOGS:-target/contention}
 known=${CONTENTION_KNOWN_ISSUES:-$(dirname "$0")/contention-known-issues.txt}
 
@@ -61,6 +64,7 @@ command -v taskset >/dev/null 2>&1 || die "taskset not found (util-linux); this 
 command -v timeout >/dev/null 2>&1 || die "timeout not found (coreutils)"
 [ "$copies" -gt "$cores" ] 2>/dev/null || die "CONTENTION_COPIES ($copies) must exceed CONTENTION_CORES ($cores), or nothing contends"
 [ "$cores" -ge 1 ] || die "CONTENTION_CORES must be at least 1"
+[ "$rounds" -ge 1 ] 2>/dev/null || die "CONTENTION_ROUNDS must be at least 1"
 online=$(nproc)
 [ "$cores" -le "$online" ] || die "CONTENTION_CORES ($cores) exceeds the $online online cores"
 
@@ -119,55 +123,60 @@ echo "contention: $copies copies of $binary on cores 0-$last of $online, ${limit
 echo "contention: logs in $logs"
 
 started=$(date +%s)
-i=1
-while [ "$i" -le "$copies" ]; do
-    (
-        cd "$workdir" &&
-            exec timeout --kill-after=10 "$limit" taskset -c "0-$last" "$binary" "$@"
-    ) >"$logs/copy-$i.log" 2>&1 &
-    eval "pid_$i=$!"
-    i=$((i + 1))
-done
-
+round=1
 failed=0
-i=1
-while [ "$i" -le "$copies" ]; do
-    eval "pid=\$pid_$i"
-    wait "$pid"
-    status=$?
-    log="$logs/copy-$i.log"
-    if [ "$status" -eq 0 ] && grep -q '^test result: ok\.' "$log"; then
+while [ "$round" -le "$rounds" ] && [ "$failed" -eq 0 ]; do
+    [ "$rounds" -gt 1 ] && echo "contention: round $round of $rounds"
+    i=1
+    while [ "$i" -le "$copies" ]; do
+        (
+            cd "$workdir" &&
+                exec timeout --kill-after=10 "$limit" taskset -c "0-$last" "$binary" "$@"
+        ) >"$logs/copy-$i.log" 2>&1 &
+        eval "pid_$i=$!"
         i=$((i + 1))
-        continue
-    fi
-    failed=$((failed + 1))
-    echo
-    case "$status" in
-        124 | 137) echo "== copy $i of $copies: TIMED OUT after ${limit}s (exit $status)" ;;
-        0) echo "== copy $i of $copies: exited 0 without a passing test summary" ;;
-        *) echo "== copy $i of $copies: FAILED (exit $status)" ;;
-    esac
-    # The names, one per line, as libtest prints them while running.
-    grep -E '^test .* \.\.\. FAILED$' "$log" | sed 's/^test \(.*\) \.\.\. FAILED$/   failed: \1/'
-    # A hung test is announced but never finishes.
-    grep -E 'has been running for over' "$log" | sed 's/^/   /'
-    # libtest's own failure report: every failing test's captured output and
-    # panic message, then the list of names.
-    sed -n '/^failures:$/,/^test result:/p' "$log"
-    if [ "$status" -eq 124 ] || [ "$status" -eq 137 ]; then
-        tail -n 20 "$log"
-    fi
-    i=$((i + 1))
-done
+    done
 
+    i=1
+    while [ "$i" -le "$copies" ]; do
+        eval "pid=\$pid_$i"
+        wait "$pid"
+        status=$?
+        log="$logs/copy-$i.log"
+        if [ "$status" -eq 0 ] && grep -q '^test result: ok\.' "$log"; then
+            i=$((i + 1))
+            continue
+        fi
+        failed=$((failed + 1))
+        echo
+        case "$status" in
+            124 | 137) echo "== copy $i of $copies: TIMED OUT after ${limit}s (exit $status)" ;;
+            0) echo "== copy $i of $copies: exited 0 without a passing test summary" ;;
+            *) echo "== copy $i of $copies: FAILED (exit $status)" ;;
+        esac
+        # The names, one per line, as libtest prints them while running.
+        grep -E '^test .* \.\.\. FAILED$' "$log" | sed 's/^test \(.*\) \.\.\. FAILED$/   failed: \1/'
+        # A hung test is announced but never finishes.
+        grep -E 'has been running for over' "$log" | sed 's/^/   /'
+        # libtest's own failure report: every failing test's captured output and
+        # panic message, then the list of names.
+        sed -n '/^failures:$/,/^test result:/p' "$log"
+        if [ "$status" -eq 124 ] || [ "$status" -eq 137 ]; then
+            tail -n 20 "$log"
+        fi
+        i=$((i + 1))
+    done
+
+    round=$((round + 1))
+done
 elapsed=$(($(date +%s) - started))
 echo
 if [ "$failed" -eq 0 ]; then
-    echo "contention: all $copies copies passed on $cores core(s) in ${elapsed}s"
+    echo "contention: all $copies copies passed on $cores core(s), $rounds round(s) in a row, in ${elapsed}s"
     exit 0
 fi
 
-echo "contention: $failed of $copies copies failed on $cores core(s) in ${elapsed}s"
+echo "contention: round $((round - 1)) of $rounds: $failed of $copies copies failed on $cores core(s) in ${elapsed}s"
 names=$(cat "$logs"/copy-*.log | grep -E '^test .* \.\.\. FAILED$' |
     sed 's/^test \(.*\) \.\.\. FAILED$/\1/')
 if [ -z "$names" ]; then

--- a/tools/ci/contention_test.sh
+++ b/tools/ci/contention_test.sh
@@ -1,0 +1,128 @@
+#!/bin/sh
+# Tests for tools/ci/contention.sh: every exit path, driven without cargo, a
+# real test binary or `taskset`. PATH shims stand in for `cargo` (which prints
+# canned artifact JSON) and `taskset` (which drops its `-c` mask and runs the
+# command), and a fake libtest binary prints libtest's output shapes.
+#
+#   sh tools/ci/contention_test.sh
+#
+# Exit 0 when every case passed, 1 otherwise. POSIX sh; runs in a second or
+# two, so CI runs it before the slow steps.
+
+set -u
+
+here=$(cd "$(dirname "$0")" && pwd)
+harness="$here/contention.sh"
+work=$(mktemp -d) || exit 1
+trap 'rm -rf "$work"' EXIT INT TERM
+mkdir -p "$work/bin" "$work/pkg/app" "$work/pkg/multi"
+
+cat >"$work/bin/taskset" <<'EOF'
+#!/bin/sh
+shift 2
+exec "$@"
+EOF
+
+# Two packages: `quantick-app` with one test executable, `multi` with a unit
+# test binary and an integration test binary. A library artifact with a null
+# executable, and another package's executable, must both be ignored.
+cat >"$work/bin/cargo" <<EOF
+#!/bin/sh
+echo '{"reason":"compiler-artifact","package_id":"path+file:///w/crates/app#quantick-app@0.1.0","manifest_path":"$work/pkg/app/Cargo.toml","target":{"kind":["lib"],"name":"quantick_app_lib"},"executable":null}'
+echo '{"reason":"compiler-artifact","package_id":"path+file:///w/crates/app#quantick-app@0.1.0","manifest_path":"$work/pkg/app/Cargo.toml","target":{"kind":["bin"],"name":"quantick-app"},"executable":"$work/fake"}'
+echo '{"reason":"compiler-artifact","package_id":"path+file:///w/crates/multi#0.1.0","manifest_path":"$work/pkg/multi/Cargo.toml","target":{"kind":["lib"],"name":"multi"},"executable":"$work/fake"}'
+echo '{"reason":"compiler-artifact","package_id":"path+file:///w/crates/multi#0.1.0","manifest_path":"$work/pkg/multi/Cargo.toml","target":{"kind":["test"],"name":"golden"},"executable":"$work/fake"}'
+echo '{"reason":"compiler-artifact","package_id":"path+file:///w/crates/engine#quantick-engine@0.1.0","manifest_path":"/w/crates/engine/Cargo.toml","target":{"kind":["lib"],"name":"quantick_engine"},"executable":"/w/engine"}'
+echo '{"reason":"build-finished","success":true}'
+EOF
+
+# The fake binary. FAKE_MODE: pass | fail_once | hang_once | list_fails.
+# `*_once` modes act in exactly one copy, claimed with an atomic mkdir.
+cat >"$work/fake" <<EOF
+#!/bin/sh
+if [ "\${1:-}" = "--list" ]; then
+    [ "\${FAKE_MODE:-pass}" = list_fails ] && exit 3
+    printf 'a::ok: test\na::flaky: test\na::known: test\n\n3 tests, 0 benchmarks\n'
+    exit 0
+fi
+echo "cwd=\$(pwd) args=\$*"
+echo "running 3 tests"
+echo "test a::ok ... ok"
+case "\${FAKE_MODE:-pass}" in
+    fail_once)
+        if mkdir "$work/claimed" 2>/dev/null; then
+            printf 'test a::flaky ... FAILED\n\nfailures:\n\n---- a::flaky stdout ----\nboom (309 vs 224)\n\nfailures:\n    a::flaky\n\n'
+            echo "test result: FAILED. 2 passed; 1 failed; 0 ignored; finished in 0.01s"
+            exit 101
+        fi ;;
+    hang_once)
+        if mkdir "$work/claimed" 2>/dev/null; then
+            echo "test a::flaky has been running for over 60 seconds"
+            sleep 30
+        fi ;;
+esac
+echo "test a::flaky ... ok"
+echo "test result: ok. 3 passed; 0 failed; 0 ignored; finished in 0.01s"
+EOF
+chmod +x "$work/bin/taskset" "$work/bin/cargo" "$work/fake"
+
+printf '# a comment\n\na::known #999\n' >"$work/good.txt"
+printf 'a::known\n' >"$work/no-issue.txt"
+printf 'a::gone #1\n' >"$work/stale.txt"
+
+passed=0
+failed=0
+
+# check <name> <expected exit> <text the output must contain> -- env... -- args...
+check() {
+    name=$1 want=$2 text=$3
+    shift 3
+    rm -rf "$work/claimed" "$work/logs"
+    out=$(env PATH="$work/bin:$PATH" CONTENTION_COPIES=3 CONTENTION_CORES=1 \
+        CONTENTION_LOGS="$work/logs" CONTENTION_KNOWN_ISSUES="$work/good.txt" \
+        "$@" 2>&1)
+    got=$?
+    if [ "$got" -eq "$want" ] && printf '%s\n' "$out" | grep -Fq -- "$text"; then
+        passed=$((passed + 1))
+    else
+        failed=$((failed + 1))
+        echo "FAIL: $name: exit $got (wanted $want), output lacks '$text':"
+        printf '%s\n' "$out" | sed 's/^/    /'
+    fi
+}
+
+check "every copy passes" 0 "all 3 copies passed" \
+    sh "$harness"
+check "the skip list reaches every copy as --exact --skip" 0 "args=--exact --skip a::known" \
+    sh -c "sh '$harness' >/dev/null && cat '$work/logs/copy-2.log'"
+check "copies run from the package root" 0 "cwd=$work/pkg/app" \
+    sh -c "sh '$harness' >/dev/null && cat '$work/logs/copy-1.log'"
+check "a failing copy is named" 1 "== copy" \
+    env FAKE_MODE=fail_once sh "$harness"
+check "the failing test is named" 1 "failed: a::flaky" \
+    env FAKE_MODE=fail_once sh "$harness"
+check "libtest's failure report is printed" 1 "boom (309 vs 224)" \
+    env FAKE_MODE=fail_once sh "$harness"
+check "failures are counted per test" 1 "1 a::flaky" \
+    env FAKE_MODE=fail_once sh "$harness"
+check "a hung copy is killed and reported" 1 "TIMED OUT after 2s" \
+    env FAKE_MODE=hang_once CONTENTION_TIMEOUT=2 sh "$harness"
+check "a skip-list line with no issue stops the harness" 2 "every line is" \
+    env CONTENTION_KNOWN_ISSUES="$work/no-issue.txt" sh "$harness"
+check "a skip-list name the binary lacks stops the harness" 2 "no test named a::gone" \
+    env CONTENTION_KNOWN_ISSUES="$work/stale.txt" sh "$harness"
+check "a missing skip list stops the harness" 2 "cannot read the skip list" \
+    env CONTENTION_KNOWN_ISSUES="$work/absent.txt" sh "$harness"
+check "a binary that cannot list is reported as that" 2 "cannot list the tests" \
+    env FAKE_MODE=list_fails sh "$harness"
+check "no more copies than cores is refused" 2 "must exceed" \
+    env CONTENTION_COPIES=1 sh "$harness"
+check "an unknown package is refused" 2 "found 0" \
+    sh "$harness" quantick-nope
+check "a package with two test targets needs one named" 2 "name one as the second argument" \
+    sh "$harness" multi
+check "a named target selects one executable" 0 "all 3 copies passed" \
+    env CONTENTION_KNOWN_ISSUES="$work/good.txt" sh "$harness" multi golden
+
+echo "$passed passed, $failed failed"
+[ "$failed" -eq 0 ]

--- a/tools/ci/contention_test.sh
+++ b/tools/ci/contention_test.sh
@@ -107,6 +107,12 @@ check "failures are counted per test" 1 "1 a::flaky" \
     env FAKE_MODE=fail_once sh "$harness"
 check "a hung copy is killed and reported" 1 "TIMED OUT after 2s" \
     env FAKE_MODE=hang_once CONTENTION_TIMEOUT=2 sh "$harness"
+check "rounds run back to back when every one passes" 0 "3 round(s) in a row" \
+    env CONTENTION_ROUNDS=3 sh "$harness"
+check "a red round stops the rounds and says which" 1 "round 1 of 3: 1 of 3 copies failed" \
+    env FAKE_MODE=fail_once CONTENTION_ROUNDS=3 sh "$harness"
+check "zero rounds is refused" 2 "CONTENTION_ROUNDS must be at least 1" \
+    env CONTENTION_ROUNDS=0 sh "$harness"
 check "a skip-list line with no issue stops the harness" 2 "every line is" \
     env CONTENTION_KNOWN_ISSUES="$work/no-issue.txt" sh "$harness"
 check "a skip-list name the binary lacks stops the harness" 2 "no test named a::gone" \


### PR DESCRIPTION
Run the `quantick-app` test binary under deliberate CPU contention in CI, so a load-sensitive test fails in the pull request that introduces it instead of later on an unrelated one.

**Tier:** `medium`. Campaign child of #367 (Q9); closes on integration: #407.

**Not to be merged on green alone (coordinator decision D19).** The coordinator lands this only after a follow-up mission (Q10) fixes #408–#411, #413 and #415–#417 and removes their skip-list lines, the branch is rebased, and the harness shows 10 consecutive green runs at that tip. One command runs those rounds: `CONTENTION_ROUNDS=10 sh tools/ci/contention.sh`. The doc's *Landing condition* section has the recipe for the CI runner.

## What it adds

- **`App tests under CPU contention`**, a step in the Linux job right after `Test`, blocking. It runs `tools/ci/contention.sh`, which finds the binary with the `Test` step's own `cargo test --workspace --no-run --message-format=json`. That compiles nothing: the step log shows `Finished ... in 0.31s` and no `Compiling` line. The script then starts 24 copies of the binary at once, each under `taskset -c 0-3` with a 360 s `timeout`, from the package root. The step fails if any copy fails, times out or ends without a passing summary. For each failed copy it prints the copy number, the failing tests and libtest's failure report, then a count of failures per test and one `::error` annotation per test. Capped by `timeout-minutes: 8`.
- **`Keep the contention logs`** uploads every copy's log as the `contention-logs` artifact (14 days), only when the contention step failed.
- **`tools/ci/contention-known-issues.txt`** (D14): tests the copies skip, one exact name and its issue per line. **`Test` still runs every one.** The harness refuses a line without an issue, and a name the binary no longer has. The PR that fixes a test removes its line.
- **`Contention harness tests`**: `tools/ci/contention_test.sh` drives every exit path through PATH shims (19 cases: pass, named failing copy/test/report, hung copy, rounds, each refusal, target selection). It runs early in the job and takes 2 s.
- **Doc:** `docs/quality/app-tests-under-contention.md` (why, how, calibration table, skip list, landing condition, what to do when it goes red), indexed from `docs/README.md`. **`CLAUDE.md` is unchanged.** Its context ceiling is 9,551 bytes against 9,548 measured, and a 118-byte pointer line failed `the_repository_is_within_its_context_budget` (+115). #407 says *"only if the context ratchet allows; otherwise in `docs/`"*.

## N = 24 copies, K = 4 cores

Measured on the 4-vCPU `ubuntu-latest` runner, before = `f36cc022` (the parent of #404's fix, #403's test unfixed), tip = `52e35a1b`/`2452e577`:

| Copies × cores | Runs (before / tip) | #403's test caught before its fix | Copies' wall time |
| --- | --- | --- | --- |
| 20 × 1 (#404's harness, 1 test thread per copy) | 1 / 1 | 0 of 1 | 329–450 s |
| 8 × 2 | 1 / 1 | 0 of 1 | 96–131 s |
| 12 × 2 | 1 / 1 | 0 of 1 | 145–198 s |
| 16 × 3 | 1 / 1 | 0 of 1 | 201–224 s |
| 24 × 3 | 2 / 2 | 0 of 2 | 305–337 s |
| 16 × 4 | 2 / 2 | 0 of 2 | 100–199 s |
| 20 × 4 | 3 / 3 | 1 of 3 | 125–234 s |
| **24 × 4** | **9 / 9** | **3 of 9** | **154–300 s** |

Two things mattered: each copy being parallel (libtest's default `--test-threads` follows the affinity mask) and copies outnumbering cores. D1 suggested starting from #404's 20 copies on 1 core; that setting and every 2- or 3-core setting caught nothing. K = 4 is every vCPU the runner has, so on this runner `taskset` only states the mask; N = 24 > K keeps D1's shape. 24 copies and 20 copies caught #403's test at about the same rate on these small samples. 24 stays for the heavier contention per run; 20 × 4 (2:06–3:54) is the measured fallback.

## Cost

This PR's own CI, the step at each head (`Test` unchanged):

| Head | Run | `App tests under CPU contention` | `Contention harness tests` |
| --- | --- | --- | --- |
| `40999d9b` | https://github.com/milocaetano/quantick/actions/runs/34712074424 | 3 min 29 s | — |
| `e683c678` | https://github.com/milocaetano/quantick/actions/runs/34712937755 | 4 min 45 s | — |
| `c007d29f` | https://github.com/milocaetano/quantick/actions/runs/34713517423 | 3 min 33 s | 2 s |
| **`efaf2354` (final)** | https://github.com/milocaetano/quantick/actions/runs/34714325715 | **4 min 49 s** | **2 s** |

Across 28 measured runs at 24 × 4 (this PR's four plus 24 on throwaway branches) the step took 2 min 34 s to 5 min 0 s: **added wall-clock about 3.5–5 minutes**, at the five-minute target but not comfortably under it. `timeout-minutes: 8` caps it.

## Proof (A2 of #407)

Throwaway push-only branches `tmp/q9-proof-prefix`, `tmp/q9-proof-tip` and `tmp/q9-proof-tip2`. None had a PR, none targeted `campaign/lean-a-plus` or `main`, and all are deleted.

**Before the fix, the step fails naming the test.** https://github.com/milocaetano/quantick/actions/runs/34710577586, job "24 copies on 4 cores (3)". This ran the skip-list script before its final defaults and the #413 line; the parsing and reporting logic was the same.

```text
== copy N of 24: FAILED (exit 101)
   failed: app::tests::layers_tests::the_trade_paint_layer_switch_stops_the_marks
thread 'app::tests::layers_tests::the_trade_paint_layer_switch_stops_the_marks' panicked at crates/app/src/app/tests/layers_tests.rs:565:5:
contention: 1 of 24 copies failed on 4 core(s) in 279s
contention: failing tests, by the number of copies each failed in:
      1 app::tests::layers_tests::the_trade_paint_layer_switch_stops_the_marks
```

`layers_tests.rs:565` is the `309 vs 224` assertion #403 recorded. It also failed at 24 × 4 in both runs of https://github.com/milocaetano/quantick/actions/runs/34708700068 (2 copies, then 1). Overall: caught in 3 of 9 runs before the fix.

**At the tip, that test passes.** 0 failures in 19 runs at 24 × 4 across `52e35a1b` and `2452e577`, and the final head's own run is green: all 24 copies passed, 8 known issues skipped, 288 s.

The committed script with its CI defaults at the pre-fix tree (https://github.com/milocaetano/quantick/actions/runs/34712034171): 1 of 4 jobs red, on another pre-existing test (#416). Its artifact `contention-logs-2` shows the failure upload working.

## New load-sensitive tests found (D4, D14)

Each is filed per D14 (`area:app`, `type:fix`, milestone v0.1, the skip-list line sentence) with the failing copy's output and the config that reproduced it. Each is skipped by the copies only:

| Test | Issue |
| --- | --- |
| `control_plane_tests::gateway_client_reads_the_running_application_and_wrong_tokens_fail_closed` (`:935`, observer-read revisions) | #408 |
| `control_plane_tests::attaching_a_script_and_detaching_it_leaves_the_pane_as_it_was` (`:3135`) | #409 |
| `control_plane_tests::a_keyed_call_that_expired_before_the_application_saw_it_leaves_its_key_free` (`:5435`) | #410 |
| `control_plane_tests::gateway_rejects_a_duplicate_request_id_while_a_wait_is_parked` (`:2702`) | #411 |
| `screenshot_evidence_tests::synthetic_fractional_geometry_round_trips_original_png_and_clipped_regions` (`:92`) | #413 |
| `control_plane_tests::an_operator_cannot_detach_the_traders_own_indicator` (`:2910`) | #415 |
| `control_plane_tests::a_bundle_with_a_screenshot_maps_every_named_control_to_a_region_of_the_image` (`:4231`) | #416 |
| `control_plane_tests::a_capture_that_wants_an_image_waits_for_the_frame_instead_of_answering_blind` (`:4628`) | #417 |

**Residual rate (D19):** the list had not converged when hunting stopped. At the tip, 1 of 3 jobs and then 1 of 4 were red with five tests skipped, and 1 of 6 with seven skipped: about one run in five red on a test that was already there. The rate with all eight skipped has not been measured. #413, #416 and #417 share one symptom, a Null `capture_revision` in the evidence bundle under load. Each of those issues says that this may be a product race, not only test timing, and should be investigated there first.

No test source is edited (`git diff --name-only origin/campaign/lean-a-plus...HEAD`: `.github/workflows/ci.yml`, `docs/README.md`, `docs/quality/app-tests-under-contention.md`, `tools/ci/contention.sh`, `tools/ci/contention_test.sh`, `tools/ci/contention-known-issues.txt`, `.claude/GOAL-archive-app-tests-under-contention.md`). No Windows step is added.

## Performance impact

CI only, rate *rare* (once per CI job). No production path, and no per-trade, per-depth or per-frame code, is touched. The cost is the CI wall-clock above.

## Verification

- **Run locally at `52e35a1b` + this diff (before the rebase onto `2452e577`), each command on its own:** `cargo fmt --all -- --check` exit 0; `cargo clippy --workspace --all-targets` exit 0, 0 warnings; `cargo build --workspace` exit 0; `env -u QUANTICK_BUBBLES cargo test --workspace` exit 0 (96 binaries ok).
- **Run locally at the final head:** `cargo test -p quantick-guards` all ok; `sh .claude/hooks/guardrails_test.sh` 227 passed; `sh tools/ci/contention_test.sh` 19 passed. A mutation check was also run: a parser change that lets an issue-less line through fails the test. The workflow YAML parses.
- **CI at the final head `efaf2354`:** `ci` and `windows` green, run https://github.com/milocaetano/quantick/actions/runs/34714325715.

## Reviews

Graded at `efaf2354` against `origin/campaign/lean-a-plus` at `2452e577`, review key `6f4f7487e9a575e83c9f9a25c2de104b0a90c097`.

**arch-review:** step 0 is `code-review` at `low` (effort-first, no reuse notice), three rounds.
- Round 1 at `40999d9b`: 1 finding, confirmed. `contention.sh` read `sed`'s exit status for `--list`, so a listing failure surfaced as a misleading "remove its line". Fixed in `e683c678`.
- Rounds 2 (`e683c678`) and 3 (`efaf2354`): 0 findings.

The shape pass read the touched dimensions (CI, tests, standardisation, operability, English, trunk). Nothing open; see the verdict comment.

**ai-review:** round 1 at `e683c678` found 2 WEAK (4 Agent-tested: no committed harness test; 5 Extensible: one-executable limit). Both were fixed in `c007d29f` and the threads resolved. The follow-up at `efaf2354` is 6 of 6 PASS with 0 open threads. Reports: https://github.com/milocaetano/quantick/pull/414#issuecomment-5648035179 and https://github.com/milocaetano/quantick/pull/414#issuecomment-5648233257

**delivery-review:** completeness pass (tier `medium`), inline; see its comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VdP84bYEGeyCg7KwsNb1X2
