### PR TITLE
Copy and paste chart drawings with Ctrl+C and Ctrl+V

### DIFF
--- a/.claude/GOAL-archive-copy-paste-drawings.md
+++ b/.claude/GOAL-archive-copy-paste-drawings.md
@@ -1,0 +1,82 @@
+# Copy and paste chart drawings
+
+Allow traders to copy and paste existing chart drawings using only Ctrl+C and Ctrl+V, so duplicating a mark does not interrupt chart work with a mouse gesture or another shortcut.
+
+**Tier:** medium — the keyboard change remains bounded and adds no market action, but extracting its state and actions from the protected application root plus the required regression matrix exceeds the small tier's 300-line review exemption.
+
+## Request ledger
+
+- **R1** — Ctrl+C captures the currently selected chart drawing without mutating the chart. Source: “copiar”.
+- **R2** — Ctrl+V creates an independent copy of the captured drawing. Source: “colar desenhos no grafico”.
+- **R3** — The complete copy/paste workflow requires only Ctrl+C followed by Ctrl+V, with no mouse step, dialog, or additional shortcut. Source: “com apenas CTRL C + CTRL V”.
+
+## Assumptions
+
+- **S1** — The clipboard holds one drawing in memory for the lifetime of the application window and may be pasted into the currently focused pane or tab. This is the conventional scope for an internal chart-object clipboard and is reversible without persisted-data migration.
+- **S2** — Paste preserves the drawing payload and appearance while applying the existing duplicate normalization: a fresh identity, no ambiguous copied name, unlocked geometry, a visible two-bar offset, selection of the copy, and one undo entry. Reusing established semantics avoids a second kind of duplicate.
+- **S3** — Copy/paste copies the drawing only, not an armed strategy attached to its source. The request names drawings, and silently arming a strategy from a clipboard action would expand the requested action into market automation.
+- **S4** — The existing Duplicate button and Ctrl+D shortcut remain compatible, but neither is required by the new workflow. “Only Ctrl+C + Ctrl+V” is read as the complete gesture requested, not as removal of existing access paths.
+- **S5** — Egui's command modifier is Ctrl on Windows and Command on macOS. Tests use the repository's cross-platform command modifier while proving the requested Windows keys.
+
+## Acceptance criteria
+
+- [x] **A1** — With one drawing selected and no text widget focused, Ctrl+C stores a snapshot without changing the drawing collection, selection, or undo history.
+      *Evidence:* a focused application interaction test that fails before the change.
+      → `crates/app/src/app/tests/input_ui_tests.rs`. *(R1, R3)*
+- [x] **A2** — After Ctrl+C, Ctrl+V inserts a visually equivalent drawing with a fresh identity using the established offset/unlocked/unnamed/selected semantics, as exactly one undoable edit.
+      *Evidence:* application interaction and drawing-store unit tests.
+      → `crates/app/src/app/tests/input_ui_tests.rs` and `crates/app/src/drawings/tests/mod.rs`. *(R2, R3)*
+- [x] **A3** — Paste uses the copied snapshot rather than the current selection, works in the currently focused pane, supports repeated pastes without overlapping copies, and is a no-op before any copy.
+      *Evidence:* application interaction regression tests covering selection changes, empty clipboard, pane targeting, and repeated paste.
+      → `crates/app/src/app/tests/input_ui_tests.rs`. *(R1, R2, R3)*
+- [x] **A4** — The selected-drawing affordance identifies Ctrl+C followed by Ctrl+V as the keyboard workflow, without adding a button, menu, dialog, or focus interruption.
+      *Evidence:* context-bar unit assertion, visual QA screenshots, and trader UX verdict.
+      → `crates/app/src/drawings/context_bar.rs` and `docs/quality/copy-paste-drawings-evidence.md`. *(R3)*
+- [x] **G1** — Every authored repository artifact is in English.
+      *Evidence:* quantick-guards language test plus manual review of prose, branch name, commits, PR title, and PR body.
+      → `docs/quality/copy-paste-drawings-evidence.md`.
+- [x] **G2** — Targeted tests and the final ordered `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets`, `cargo build --workspace`, and `cargo test --workspace` checks pass after rebasing on the latest `origin/main`.
+      *Evidence:* command exit codes recorded at the verified head.
+      → `docs/quality/copy-paste-drawings-evidence.md` and the PR body.
+- [x] **G3** — Performance impact is flat at operating rates: the input path adds two boolean key checks per frame, while cloning/insertion happens only on a trader copy or paste gesture; no per-trade or per-depth path changes.
+      *Evidence:* code inspection, targeted regression tests, and dense-tape `APP_HEALTH_SUMMARY` captured during visual QA with no attributable slow-frame burst.
+      → `docs/quality/copy-paste-drawings-evidence.md` and the PR body.
+- [x] **G4** — The changed selected-drawing flow is reachable through the existing drawing demo/select hooks and passes visual QA in normal and narrow windows with no attributable integrity, readability, occlusion, state-honesty, motion, consistency, or performance defect.
+      *Evidence:* screenshots, scene/diagnostic readings where available, and a surface-by-state PASS table.
+      → `docs/quality/copy-paste-drawings-evidence.md`.
+- [x] **G5** — Trader UX review finds no unresolved Blocker or Should-fix for Rafa, Marina, or Duda; the flow costs exactly two keyboard gestures, steals no focus, and preserves the workspace.
+      *Evidence:* persona walkthrough and verdict.
+      → `docs/quality/copy-paste-drawings-evidence.md` and the PR body.
+- [ ] **G6** — `arch-review` runs the medium-tier pass across all nine dimensions and resolves or validly defers every Blocker and Should-fix.
+      *Evidence:* durable arch-review report and exact-head marker.
+      → PR conversation, PR body, and git-dir `arch-review-ok` receipt.
+
+<!-- required-ai-review-goal-gates:v1 -->
+- [ ] **G-AI1** — AI review is executed for the current PR review.
+- [ ] **G-AI2** — A durable AI-review report is published on the PR.
+- [ ] **G-AI3** — `ai_review_threads.sh list` returns zero unresolved threads.
+- [ ] **G-AI4** — `ai-review-complete` is valid for the current review key.
+<!-- end required-ai-review-goal-gates:v1 -->
+
+The G-AI evidence destinations are the durable PR report, the review-thread
+listing, and the exact-head `ai-review-complete` receipt. They remain unchecked
+before archival because the reviews run against the archived mission commit.
+
+## Not applicable
+
+- Engine/determinism gate — no engine, bar construction, replay clock, or deterministic market-data path changes.
+- Hot-path benchmark gate — no per-trade, per-depth, or rendering work is added; the dense-tape UI health reading remains part of visual QA.
+- New-extension gate — this changes the gesture for the existing drawing duplication capability and adds no feed, bar type, indicator, layer, panel, crate, or new trader action.
+- New UI hook — no surface or state visible only through the new shortcut is introduced; the existing `QUANTICK_DRAWINGS_DEMO` and `QUANTICK_DRAWINGS_DEMO_SELECT` hooks reach the affected selected-drawing canvas and context bar.
+- Second-operator capability expansion — drawing duplication already has a named host action, its result is enumerable in drawing snapshots, and drawing types are discoverable through `DRAWING_TOOLS`; this mission changes only the human keyboard grammar and does not add a new chart mutation.
+
+## Closing steps
+
+- [ ] **C1** — Run `delivery-review` over the final branch and receive PASS. Source: mission workflow; evidence in the durable review report and exact-head marker.
+- [ ] **C2** — Open the pull request, publish current review evidence, obtain green final-head CI, resolve every required AI-review thread, and mark the PR ready for the trader to evaluate. Source: mission workflow and delivery contract; evidence in the PR URL, checks, review progress, and PR body.
+
+## Request as received
+
+Attributed trader quotation under the repository language exemption:
+
+> $mission small permitir copiar e colar desenhos no grafico, com apenas CTRL C + CTRL V

--- a/crates/app/src/app/drawing_input.rs
+++ b/crates/app/src/app/drawing_input.rs
@@ -12,30 +12,30 @@ use std::time::Instant;
 use eframe::egui;
 
 use crate::drawings::DeleteOutcome;
+use crate::surfaces::DrawingChromeSurface;
+use crate::tab::Tab;
 use crate::toolrail::Tool;
 
-use super::QuantickApp;
+use super::{QuantickApp, replay_and_history::DUPLICATE_OFFSET_BARS};
 
-impl QuantickApp {
-    /// Keyboard grammar for drawings. Any focused widget wins: while an input
-    /// owns the keyboard, chart shortcuts stay suspended.
-    pub(super) fn handle_drawing_keys(&mut self, ctx: &egui::Context, now: Instant) {
-        if ctx.memory(|memory| memory.focused().is_some()) {
-            return;
-        }
-        struct DrawingKeys {
-            escape: bool,
-            delete: bool,
-            backspace: bool,
-            undo: bool,
-            redo: bool,
-            lock: bool,
-            hide: bool,
-            duplicate: bool,
-            nudge_bars: f32,
-            nudge_px: f32,
-        }
-        let keys = ctx.input(|input| {
+struct DrawingKeys {
+    escape: bool,
+    delete: bool,
+    backspace: bool,
+    undo: bool,
+    redo: bool,
+    lock: bool,
+    hide: bool,
+    duplicate: bool,
+    copy: bool,
+    paste: bool,
+    nudge_bars: f32,
+    nudge_px: f32,
+}
+
+impl DrawingKeys {
+    fn read(ctx: &egui::Context) -> Self {
+        ctx.input(|input| {
             let command = input.modifiers.command;
             let shift = input.modifiers.shift;
             let alt = input.modifiers.alt;
@@ -45,7 +45,7 @@ impl QuantickApp {
                 - f32::from(input.key_pressed(egui::Key::ArrowLeft));
             let vertical = f32::from(input.key_pressed(egui::Key::ArrowUp))
                 - f32::from(input.key_pressed(egui::Key::ArrowDown));
-            DrawingKeys {
+            Self {
                 escape: input.key_pressed(egui::Key::Escape),
                 delete: input.key_pressed(egui::Key::Delete),
                 backspace: input.key_pressed(egui::Key::Backspace),
@@ -55,10 +55,57 @@ impl QuantickApp {
                 lock: alt && input.key_pressed(egui::Key::L),
                 hide: alt && input.key_pressed(egui::Key::H),
                 duplicate: command && input.key_pressed(egui::Key::D),
+                copy: command && input.key_pressed(egui::Key::C),
+                paste: command && input.key_pressed(egui::Key::V),
                 nudge_bars: horizontal * step,
                 nudge_px: vertical * step,
             }
-        });
+        })
+    }
+}
+
+/// Capture the selected drawing without changing the chart.
+///
+/// Rate: rare — one trader keystroke; the per-frame path only reads key state.
+fn copy_selected_drawing(tab: &Tab, clipboard: &mut DrawingChromeSurface) -> bool {
+    let copied = tab
+        .drawing_pane()
+        .drawings
+        .selected()
+        .and_then(|index| tab.drawing_pane().drawings.items().get(index).cloned());
+    if let Some(drawing) = copied {
+        clipboard.copy_drawing(&drawing);
+        true
+    } else {
+        false
+    }
+}
+
+/// Paste the clipboard into the pane the drawing keyboard currently owns.
+///
+/// The clipboard holds a snapshot, not a source index, so changing or
+/// deleting the original cannot redirect the operation to another drawing.
+/// Rate: rare — one trader keystroke and one drawing clone.
+fn paste_copied_drawing(tab: &mut Tab, clipboard: &mut DrawingChromeSurface) {
+    let Some((drawing, paste_count)) = clipboard.next_drawing_paste() else {
+        return;
+    };
+    let offset_bars = DUPLICATE_OFFSET_BARS * paste_count as f32;
+    let focused = tab.focused_side();
+    for pane in tab.panes_mut() {
+        pane.drawings.select(None);
+    }
+    let _ = tab.pane_mut(focused).drawings.paste(&drawing, offset_bars);
+}
+
+impl QuantickApp {
+    /// Keyboard grammar for drawings. Any focused widget wins: while an input
+    /// owns the keyboard, chart shortcuts stay suspended.
+    pub(super) fn handle_drawing_keys(&mut self, ctx: &egui::Context, now: Instant) {
+        if ctx.memory(|memory| memory.focused().is_some()) {
+            return;
+        }
+        let keys = DrawingKeys::read(ctx);
         // The escape stack: rail drag → paper interaction → pending
         // confirmation → draft → selection → Pointer, one layer per press.
         // Paper trading's armed placement / grabbed line reads Escape here,
@@ -143,6 +190,20 @@ impl QuantickApp {
         }
         if keys.duplicate {
             self.duplicate_selected_drawing();
+        }
+        if keys.copy
+            && copy_selected_drawing(
+                &self.tabs[self.active_tab],
+                &mut self.surfaces.drawing_chrome,
+            )
+        {
+            self.note_workspace("Drawing copied. Press Ctrl+V to paste.".to_owned());
+        }
+        if keys.paste {
+            paste_copied_drawing(
+                &mut self.tabs[self.active_tab],
+                &mut self.surfaces.drawing_chrome,
+            );
         }
         if (keys.nudge_bars != 0.0 || keys.nudge_px != 0.0)
             && self.drawing_pane().drawings.selected().is_some()

--- a/crates/app/src/app/tests/input_ui_tests.rs
+++ b/crates/app/src/app/tests/input_ui_tests.rs
@@ -554,6 +554,136 @@ fn ctrl_d_duplicates_the_selection_offset_and_selected() {
 }
 
 #[test]
+fn ctrl_c_then_ctrl_v_pastes_the_copied_drawing_not_the_current_selection() {
+    let (mut app, _commands) = app_with_history(200);
+    let ctx = egui::Context::default();
+    run_frame(&mut app, &ctx);
+    app.toolrail
+        .arm(Tool::Drawing(drawing_tool("horizontal-line")));
+    click_chart(&mut app, &ctx, egui::pos2(700.0, 300.0));
+    let original = app.active_tab().flow_pane.drawings.items()[0].clone();
+    let undo_before_copy = app.active_tab().flow_pane.drawings.undo_depth();
+
+    run_frame_with_modifiers(
+        &mut app,
+        &ctx,
+        vec![key_press_with(egui::Key::C, egui::Modifiers::COMMAND)],
+        egui::Modifiers::COMMAND,
+    );
+    assert_eq!(
+        app.active_tab().flow_pane.drawings.items(),
+        &[original.clone()]
+    );
+    assert_eq!(app.active_tab().flow_pane.drawings.selected(), Some(0));
+    assert_eq!(
+        app.active_tab().flow_pane.drawings.undo_depth(),
+        undo_before_copy,
+        "copy is not a chart edit"
+    );
+
+    app.toolrail
+        .arm(Tool::Drawing(drawing_tool("vertical-line")));
+    click_chart(&mut app, &ctx, egui::pos2(760.0, 360.0));
+    let other = app.active_tab().flow_pane.drawings.items()[1].clone();
+    assert_ne!(other.tool, original.tool, "the current selection differs");
+    let undo_before_paste = app.active_tab().flow_pane.drawings.undo_depth();
+
+    run_frame_with_modifiers(
+        &mut app,
+        &ctx,
+        vec![key_press_with(egui::Key::V, egui::Modifiers::COMMAND)],
+        egui::Modifiers::COMMAND,
+    );
+    let drawings = &app.active_tab().flow_pane.drawings;
+    assert_eq!(drawings.items().len(), 3);
+    assert_eq!(drawings.selected(), Some(2), "the pasted copy is selected");
+    let pasted = &drawings.items()[2];
+    assert_ne!(pasted.id, original.id, "paste allocates a fresh identity");
+    assert_eq!(
+        pasted.tool, original.tool,
+        "paste uses the clipboard snapshot"
+    );
+    assert_eq!(pasted.style, original.style);
+    assert_eq!(
+        pasted.points[0].bar,
+        original.points[0].bar + DUPLICATE_OFFSET_BARS
+    );
+    assert!(!pasted.locked, "a pasted drawing is editable");
+    assert_eq!(
+        pasted.name, None,
+        "a pasted drawing has no ambiguous copied name"
+    );
+    assert_eq!(
+        drawings.undo_depth(),
+        undo_before_paste + 1,
+        "paste is exactly one undo entry"
+    );
+}
+
+#[test]
+fn drawing_clipboard_targets_the_focused_pane_and_repeated_pastes_do_not_overlap() {
+    let ctx = egui::Context::default();
+    let (mut app, _commands) = split_app(&ctx, 200);
+    place_level(&mut app, PaneSide::Time(0), 101.0);
+    app.active_tab_mut().focus = PaneSide::Time(0);
+    let source = app.active_tab().pane(PaneSide::Time(0)).drawings.items()[0].clone();
+
+    run_frame_with_modifiers(
+        &mut app,
+        &ctx,
+        vec![key_press_with(egui::Key::C, egui::Modifiers::COMMAND)],
+        egui::Modifiers::COMMAND,
+    );
+    let flow = pane_point(&app, PaneSide::Flow);
+    click_chart(&mut app, &ctx, flow);
+    assert_eq!(app.active_tab().focused_side(), PaneSide::Flow);
+    for _ in 0..2 {
+        run_frame_with_modifiers(
+            &mut app,
+            &ctx,
+            vec![key_press_with(egui::Key::V, egui::Modifiers::COMMAND)],
+            egui::Modifiers::COMMAND,
+        );
+    }
+
+    assert_eq!(
+        app.active_tab().pane(PaneSide::Time(0)).drawings.items(),
+        &[source.clone()],
+        "paste leaves the source pane untouched"
+    );
+    let pasted = app.active_tab().pane(PaneSide::Flow).drawings.items();
+    assert_eq!(pasted.len(), 2);
+    assert_eq!(pasted[0].tool, source.tool);
+    assert_eq!(pasted[1].tool, source.tool);
+    assert_eq!(
+        pasted[0].points[0].bar,
+        source.points[0].bar + DUPLICATE_OFFSET_BARS
+    );
+    assert_eq!(
+        pasted[1].points[0].bar,
+        source.points[0].bar + DUPLICATE_OFFSET_BARS * 2.0,
+        "each paste advances from the clipboard source"
+    );
+}
+
+#[test]
+fn ctrl_v_before_copy_is_a_no_op() {
+    let (mut app, _commands) = app_with_history(200);
+    let ctx = egui::Context::default();
+    run_frame(&mut app, &ctx);
+
+    run_frame_with_modifiers(
+        &mut app,
+        &ctx,
+        vec![key_press_with(egui::Key::V, egui::Modifiers::COMMAND)],
+        egui::Modifiers::COMMAND,
+    );
+
+    assert!(app.active_tab().flow_pane.drawings.items().is_empty());
+    assert_eq!(app.active_tab().flow_pane.drawings.undo_depth(), 0);
+}
+
+#[test]
 fn arrow_nudges_move_the_selection_and_shift_multiplies_by_ten() {
     let (mut app, _commands) = app_with_history(200);
     let ctx = egui::Context::default();

--- a/crates/app/src/app/tests/input_ui_tests.rs
+++ b/crates/app/src/app/tests/input_ui_tests.rs
@@ -572,7 +572,7 @@ fn ctrl_c_then_ctrl_v_pastes_the_copied_drawing_not_the_current_selection() {
     );
     assert_eq!(
         app.active_tab().flow_pane.drawings.items(),
-        &[original.clone()]
+        std::slice::from_ref(&original)
     );
     assert_eq!(app.active_tab().flow_pane.drawings.selected(), Some(0));
     assert_eq!(
@@ -648,7 +648,7 @@ fn drawing_clipboard_targets_the_focused_pane_and_repeated_pastes_do_not_overlap
 
     assert_eq!(
         app.active_tab().pane(PaneSide::Time(0)).drawings.items(),
-        &[source.clone()],
+        std::slice::from_ref(&source),
         "paste leaves the source pane untouched"
     );
     let pasted = app.active_tab().pane(PaneSide::Flow).drawings.items();

--- a/crates/app/src/drawings/clipboard.rs
+++ b/crates/app/src/drawings/clipboard.rs
@@ -1,0 +1,36 @@
+//! Copy insertion for chart drawings.
+//!
+//! Keyboard paste and the older Duplicate action share the normalization in
+//! this module, so a chart never grows two subtly different kinds of copy.
+
+use super::{Drawing, DrawingId, Drawings};
+
+impl Drawings {
+    /// Paste a drawing snapshot as one undo entry and return its fresh id.
+    ///
+    /// The snapshot need not come from this store. That lets one window-level
+    /// clipboard cross panes and tabs without remembering a Vec index that
+    /// can change under deletes or z-order edits.
+    #[must_use]
+    pub fn paste(&mut self, drawing: &Drawing, offset_bars: f32) -> DrawingId {
+        let before = self.snapshot();
+        let mut copy = drawing.clone();
+        // A copy is a new object: its own identity, and never the original's
+        // name, because two objects answering to one trader-authored name
+        // would make every reference ambiguous.
+        copy.id = self.alloc_id();
+        copy.name = None;
+        for point in &mut copy.points {
+            point.bar += offset_bars;
+            // Keeping the source's market instants would snap the offset copy
+            // back onto the original after a re-cut, seek, or reconnect.
+            point.time_ms = None;
+        }
+        copy.locked = false;
+        let id = copy.id;
+        self.items.push(copy);
+        self.selected = Some(self.items.len() - 1);
+        self.record(before);
+        id
+    }
+}

--- a/crates/app/src/drawings/context_bar.rs
+++ b/crates/app/src/drawings/context_bar.rs
@@ -33,6 +33,7 @@ use crate::widgets::{IconButton, TOOLRAIL_ICON};
 pub const BAR_HEIGHT_PX: f32 = 2.0 * BAR_PAD_Y_PX + TOOLRAIL_ICON.hit;
 const BAR_PAD_X_PX: f32 = 6.0;
 const BAR_PAD_Y_PX: f32 = 4.0;
+const DUPLICATE_HOVER_TEXT: &str = "Duplicate (Ctrl+D) · Copy and paste (Ctrl+C, Ctrl+V)";
 /// Gap between two neighbouring slots.
 const ITEM_GAP_PX: f32 = 4.0;
 /// Width of the hairline that isolates a group.
@@ -637,7 +638,7 @@ fn draw_slot(
         Slot::GlyphSize => draw_glyph_size_slot(ui, bar),
         Slot::Duplicate => {
             if IconButton::new(icons::COPY_SIMPLE, TOOLRAIL_ICON)
-                .hover_text("Duplicate (Ctrl+D)")
+                .hover_text(DUPLICATE_HOVER_TEXT)
                 .show(ui)
                 .clicked()
             {
@@ -1210,6 +1211,11 @@ mod tests {
             functional <= 8,
             "the bar holds at most 8 functional slots; found {functional}"
         );
+    }
+
+    #[test]
+    fn duplicate_names_the_two_key_copy_paste_workflow() {
+        assert!(DUPLICATE_HOVER_TEXT.contains("Ctrl+C, Ctrl+V"));
     }
 
     #[test]

--- a/crates/app/src/drawings/mod.rs
+++ b/crates/app/src/drawings/mod.rs
@@ -13,6 +13,7 @@ pub mod presets;
 
 // Geometry shared by a family of tools. Not tools themselves, so they are not
 // in the registry — a family core exists so its members stay declarations.
+mod clipboard;
 mod line_core;
 mod mark_core;
 mod measure_core;
@@ -1848,37 +1849,10 @@ impl Drawings {
     #[must_use]
     pub fn duplicate_selected(&mut self, offset_bars: f32) -> Option<Duplicated> {
         let index = self.selected.filter(|&index| index < self.items.len())?;
-        let before = self.snapshot();
-        let mut copy = self.items[index].clone();
-        // A copy is a new object: its own identity, and never the
-        // original's name — two drawings answering to "congestão 108k"
-        // would make every reference ambiguous.
-        copy.id = self.alloc_id();
-        copy.name = None;
-        for point in &mut copy.points {
-            point.bar += offset_bars;
-            // The offset moves the copy in *bar* space, and the instant an
-            // anchor remembers is what survives a re-cut: `reanchor` puts
-            // every timestamped anchor back where its own market moment
-            // landed. Carrying the source's instants would therefore snap
-            // the copy onto the original at the next bar-spec change,
-            // replay seek, reconnect or symbol switch — two rectangles at
-            // one place, and since this branch hangs a bot on the copy, two
-            // bots there too. The copy is a mark the trader placed just
-            // now, at no market moment of its own; that is what an anchor
-            // dropped past the newest bar already carries, and it is the
-            // honest reading here.
-            point.time_ms = None;
-        }
-        copy.locked = false;
-        let duplicated = Duplicated {
-            source: self.items[index].id,
-            copy: copy.id,
-        };
-        self.items.push(copy);
-        self.selected = Some(self.items.len() - 1);
-        self.record(before);
-        Some(duplicated)
+        let source = self.items[index].id;
+        let drawing = self.items[index].clone();
+        let copy = self.paste(&drawing, offset_bars);
+        Some(Duplicated { source, copy })
     }
 
     /// Re-express every anchor against a series that was cut again — a

--- a/crates/app/src/surfaces/drawing_chrome/mod.rs
+++ b/crates/app/src/surfaces/drawing_chrome/mod.rs
@@ -668,6 +668,11 @@ pub(crate) struct DrawingChromeSurface {
     /// *after* the new-selection reset, because the placement that made the
     /// request also made the selection change that clears it.
     pending_open_settings: bool,
+    /// One window-level snapshot, kept here so copy/paste crosses panes and
+    /// tabs without adding feature state to `QuantickApp`.
+    clipboard: Option<Drawing>,
+    /// Number of copies already pasted from the current snapshot.
+    paste_count: u32,
 }
 
 impl DrawingChromeSurface {
@@ -708,6 +713,22 @@ impl DrawingChromeSurface {
     }
 
     // ---- What the host commands -----------------------------------------
+
+    /// Replace the internal clipboard with this drawing snapshot.
+    pub fn copy_drawing(&mut self, drawing: &Drawing) {
+        self.clipboard = Some(drawing.clone());
+        self.paste_count = 0;
+    }
+
+    /// Return the copied snapshot and its next one-based paste count.
+    ///
+    /// The count makes repeated pastes advance instead of stacking at the
+    /// same offset. Cloning is paid only for the explicit paste gesture.
+    pub fn next_drawing_paste(&mut self) -> Option<(Drawing, u32)> {
+        let drawing = self.clipboard.as_ref()?.clone();
+        self.paste_count = self.paste_count.saturating_add(1);
+        Some((drawing, self.paste_count))
+    }
 
     /// Open the object manager, or shut it.
     pub fn set_manager_open(&mut self, open: bool) {

--- a/crates/guards/extension-roots-baseline.txt
+++ b/crates/guards/extension-roots-baseline.txt
@@ -2,6 +2,6 @@
 # Pull request #306 adds retained deal readings to ChartState and 23 lines of
 # window docking. The recording policy and window wiring remain in dedicated
 # owners; this amendment records the reviewed integration surface explicitly.
-!budget 10851
+!budget 10830
 ChartState 588
-QuantickApp 10263
+QuantickApp 10242

--- a/docs/quality/copy-paste-drawings-evidence.md
+++ b/docs/quality/copy-paste-drawings-evidence.md
@@ -1,0 +1,120 @@
+# Copy and paste chart drawings evidence
+
+This evidence covers the rare, trader-initiated drawing clipboard added on
+`feat/copy-paste-drawings`, based on `origin/main` at `32fda5ec`. The change
+does not touch bar construction, market-data ingestion, rendering geometry,
+paper trading, or strategy state.
+
+## Behaviour and regression oracles
+
+The application-level tests drive the real egui keyboard input path. They
+establish that Ctrl+C snapshots the selected drawing without changing the
+chart, and Ctrl+V inserts that snapshot through the drawing store's shared copy
+normalisation. The inserted drawing has a fresh identity, is unlocked and
+unnamed, is offset visibly, becomes selected, and costs exactly one undo entry.
+
+The matrix also changes the selection after copying, pastes into another
+focused pane, pastes twice, and presses Ctrl+V with an empty clipboard. These
+cases distinguish a clipboard snapshot from a retained collection index and
+prove that paste does not mutate the source pane. Existing Ctrl+D duplication
+and attached-strategy tests remain green; clipboard paste intentionally copies
+only the drawing and cannot silently arm automation.
+
+Focused commands, all passing:
+
+```text
+cargo test -p quantick-app ctrl_c_then_ctrl_v
+cargo test -p quantick-app drawing_clipboard_targets
+cargo test -p quantick-app ctrl_v_before_copy
+cargo test -p quantick-app duplicate_names_the_two_key_copy_paste_workflow
+cargo test -p quantick-app ctrl_d_duplicates_the_selection_offset_and_selected
+cargo test -p quantick-app drawings::tests::duplicate_lands_offset_unlocked_and_selected_as_one_entry
+cargo test -p quantick-app paper_trading_tests::duplicating_a_band_carries_its_armed_strategy_but_not_its_state
+```
+
+The selected-drawing bar keeps its existing Duplicate button and adds no new
+control. Its tooltip now names `Ctrl+C, Ctrl+V`; a unit assertion freezes that
+discoverability text. Copy also raises the existing workspace-note surface with
+the next step, while paste itself is visible as the newly selected offset copy.
+
+## Visual QA
+
+The screenshots named below were captured locally and are intentionally not
+tracked; `.gitignore` excludes `.claude/evidence/**/*.png`. Every run used the
+worktree-built executable, selected a real drawing through an existing harness
+hook, and pointed all persistent cockpit stores at a run-specific scratch
+directory. No trader store or unrelated Quantick process was changed.
+
+| Surface and state | Requested window | Semantic state | Health | Verdict |
+| --- | --- | --- | --- | --- |
+| Normal split chart, all registered drawings, horizontal line selected | 1400 x 900 pt | 22 drawings, context bar visible | 59-60 fps, no `APP_SLOW_FRAMES` or error | PASS |
+| Narrow split chart, one fixed-range profile selected | 1000 x 650 pt | 1 drawing, complete context bar visible | 59 fps, worst sampled frame 17.26 ms, no `APP_SLOW_FRAMES` or error | PASS |
+
+Pixel readings:
+
+- `shots/normal-1.png` and `shots/normal-2.png` are 1415 x 937 physical pixels.
+  The selected line and every existing context-bar action remain visible; the
+  changed tooltip does not alter the bar's dimensions or chart layout.
+- `shots/narrow-frvp-1.png` and `shots/narrow-frvp-2.png` are 1015 x 687
+  physical pixels. The selected profile, handles, chart provenance, and full
+  one-row context bar remain inside the window.
+- The pair captures and advancing health summaries provide motion sanity. No
+  blank, frozen, clipped, misleading, or newly occluded changed surface was
+  observed. The bar retains its established overlay placement over chart
+  content; this patch changes only hover copy and keyboard handling.
+
+One deliberately dense setup was rejected as a performance capture rather than
+hidden: a 1000 x 650 split window with all 22 demo drawings and the full tape
+measured 36-40 fps and logged 23 slow-frame summaries. A scoped single-pane run
+of those same 22 drawings reached 59-60 fps, and the realistic narrow
+single-drawing split above reached 59 fps. There is no control-build comparison,
+so the dense composite observation is not attributed to this patch and is not
+used to claim performance. The changed code adds only two key-state booleans per
+frame; drawing clones and insertions occur solely on explicit keystrokes.
+
+The observer adapter initialized successfully against the instrumented build,
+and the app logged one enabled gateway. `quantick_describe` did not answer
+within 30 seconds, so scene and diagnostic reads are reported unavailable for
+this pass. The screenshots plus structured `APP_HEALTH_SUMMARY` readings are the
+visual verdict's evidence; no control-plane result is claimed.
+
+## Trader UX review
+
+- **Rafa (fast scalper): PASS.** With a mark already selected, the complete
+  action is Ctrl+C then Ctrl+V. There is no pointer trip, modal surface, focus
+  change, or extra confirmation. Repeated paste advances each copy instead of
+  stacking it invisibly.
+- **Marina (precision workflow): PASS.** Copy is read-only, paste targets the
+  focused pane, the source remains unchanged, and one undo removes one pasted
+  object. The clipboard holds a value snapshot, so a later selection or delete
+  cannot redirect it.
+- **Duda (new user): PASS.** The familiar keys work while the chart owns the
+  keyboard. The existing Duplicate affordance advertises the two-key workflow,
+  and the copy acknowledgement says which key completes it. Focused text inputs
+  continue to own ordinary text copy and paste.
+
+Verdict: no Blocker or Should-fix. The workflow costs exactly two keyboard
+gestures and preserves existing Ctrl+D and button access for compatibility.
+
+## Verification results
+
+The final ordered local loop after the implementation and latest
+`origin/main` fetch passed:
+
+```text
+cargo fmt --all -- --check                 PASS
+cargo clippy --workspace --all-targets     PASS
+cargo build --workspace                    PASS
+cargo test --workspace                     PASS
+```
+
+The first Clippy attempt found two test-only `&[value.clone()]` expressions.
+They were replaced with `std::slice::from_ref`, then the ordered four-command
+loop was restarted from formatting and passed. The workspace test command was
+run with the caller's unrelated `QUANTICK_BUBBLES` override removed from that
+child shell; with the override present, two existing order-flow configuration
+tests read the user's external preset and fail independently of this diff.
+
+Architecture review, delivery review, exact-head CI, and PR review evidence are
+closing gates and are published on the containing pull request. Main merge
+remains exclusively the user's action.


### PR DESCRIPTION
Mission tier: medium

## Summary

- Let traders copy the selected chart drawing with Ctrl+C and paste an independent copy with Ctrl+V.
- Preserve the existing drawing-copy semantics: fresh identity, visible offset, unlocked geometry, no duplicate name, selected result, and one undo entry.
- Keep Ctrl+D and the Duplicate button compatible while advertising the two-key workflow in the existing tooltip.

Direct trader mission; no linked issue.

## Verification loop

Local execution at `8127196b14910f2c7fb32a95aab565811a7a6270` after fetching `origin/main` (`32fda5ece2a5b8433c0eeb24cf15252dc25a2689`):

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets`
- [x] `cargo build --workspace`
- [x] `cargo test --workspace`

Final-head CI: PASS on the same head (`ci` 5m34s; `windows` 8m7s).

## Evidence

- Focused egui interaction tests cover read-only copy, snapshot identity after selection changes, focused-pane paste, repeated offsets, empty clipboard, and atomic undo.
- Visual QA passed at 1400 x 900 and 1000 x 650 with selected drawings and 59-60 fps steady health readings.
- Trader UX review passed for Rafa, Marina, and Duda with no Blocker or Should-fix.
- Full evidence: `docs/quality/copy-paste-drawings-evidence.md`.

## Reviews

- Architecture review (medium tier, all nine dimensions; direct low-equivalent bug pass): PASS, zero findings ? https://github.com/milocaetano/quantick/pull/420#issuecomment-5648655594
- AI review (six dimensions): COMPLETE, zero findings and zero unresolved threads ? https://github.com/milocaetano/quantick/pull/420#issuecomment-5648660728
- Delivery review (medium completeness-only): PASS, zero unledgered requirements ? https://github.com/milocaetano/quantick/pull/420#issuecomment-5648664838

## Notes for the reviewer

- Per-frame cost is two key-state booleans. Cloning and insertion occur only on explicit copy or paste keystrokes.
- Clipboard paste copies only drawing data; it never copies or arms an attached strategy.
- The observer adapter initialized during visual QA, but the live `quantick_describe` call timed out, so the visual verdict relies on screenshots and structured `APP_HEALTH_SUMMARY` readings.
- The branch tightened the protected `QuantickApp` root and aggregate extension budget by 21 lines; no ceiling increased.

<!-- quantick-delivery-evidence:v1 -->
Head: 8127196b14910f2c7fb32a95aab565811a7a6270
Review key: 6bfbd612de2e3b8d7f48bf2363c4f3f9a95656d3
Architecture report: https://github.com/milocaetano/quantick/pull/420#issuecomment-5648655594
Delivery report: https://github.com/milocaetano/quantick/pull/420#issuecomment-5648664838
AI report: https://github.com/milocaetano/quantick/pull/420#issuecomment-5648660728
CI: all registered exact-head checks passed
AI review threads: zero returned by ai_review_threads.sh list
<!-- end quantick-delivery-evidence:v1 -->
