### PR TITLE
feat(mcp): default quantick_invoke to the newest registered version

### DIFF
--- a/.claude/GOAL-archive-mcp-newest-version-default.md
+++ b/.claude/GOAL-archive-mcp-newest-version-default.md
@@ -1,0 +1,232 @@
+# Mission: default the MCP adapter's `quantick_invoke` to the newest registered version of each capability
+
+When an MCP agent calls `quantick_invoke` without `capability_version`, the
+adapter resolves the version to the highest one the connected instance
+registers for that capability ID, read from the instance's own
+`control.describe` registry; an explicit version passes through unchanged.
+Why it matters: Q2 (PR #421) added version 2 of seven `layout.*` capabilities
+and kept version 1 registered, and v1 now answers an honest refusal pointing
+at v2. The adapter's hard-coded default of 1 sends every version-less MCP call
+to that refusal instead of the working answer.
+
+Campaign child of https://github.com/milocaetano/quantick/issues/367 (task key
+Q11); task issue https://github.com/milocaetano/quantick/issues/422. Base:
+`origin/campaign/lean-a-plus` at `c55a4222`; PR base exactly
+`campaign/lean-a-plus`.
+
+**Tier:** `medium` — it changes the default of a published tool (the trader
+authorized it as D20), in one leaf crate with no UI and no hot path; the
+campaign parent classes the risk as medium. A `low` bug pass, the full shape
+pass on the touched dimensions and an inline `delivery-review` completeness
+pass are owed.
+
+## Request ledger
+
+- **R0** — Purpose: an MCP agent that omits the version gets the working
+  answer of the newest version, not v1's refusal. *"so an MCP agent that omits
+  the version gets the refusal instead of the working answer"*.
+- **R1** — An omitted version resolves to the newest version the connected
+  instance registers for that capability, from the discovery/registry data the
+  adapter already reads, not a hard-coded 1 or a hard-coded table. Issue scope
+  bullet 1; D20 *"padrão = mais nova"*; coordinator D1.
+- **R2** — An explicit version passes through unchanged. Issue scope bullet 1;
+  D20 *"a caller that asks for v1 explicitly still gets v1"*.
+- **R3** — A capability registered only at v1 still works without a version;
+  an ID the registry does not list keeps today's error path. Issue scope
+  bullet 3; coordinator D1.
+- **R4** — The tool's published description and argument schema say
+  "omitted: the newest version the instance registers"; the MCP tool
+  documentation is updated; a published MCP schema snapshot, if one exists, is
+  regenerated through the normal mechanism and its diff shown. Issue scope
+  bullet 2, A3; coordinator D2.
+- **R5** — Tests in `crates/mcp/tests/` against the fake gateway: omitted
+  version picks the newest of two; explicit v1 gets v1; v1-only works without
+  a version. Issue scope bullet 3, A1, A2; coordinator D3.
+- **R6** — Merged into `campaign/lean-a-plus` through a PR whose base is
+  exactly that branch, with the merge read back. Issue A4. The child owns the
+  PR base; the merge and its readback are the coordinator's.
+
+## Decisions
+
+- **D1** (coordinator) — omitted version resolves to the highest version the
+  connected instance registers for that ID, read from registry/discovery data
+  the adapter already has; explicit version unchanged; no listed version keeps
+  today's error path.
+- **D2** (coordinator) — say it in the published description and argument
+  schema; regenerate a published MCP schema snapshot if one exists.
+- **D3** (coordinator) — fake-gateway tests: v1+v2 without a version reaches
+  v2; `version: 1` reaches v1; v1-only works without a version.
+- **D4** (coordinator) — tier `medium`, `code-review` at `low`, shape pass on
+  the touched dimensions, `ai-review` completion, inline `delivery-review`
+  completeness pass; at most three step-0 rounds.
+- **D5** (coordinator) — `gh pr ready` once, cd-prefixed, from the Bash tool.
+- **D20** (trader, https://github.com/milocaetano/quantick/issues/367#issuecomment-5650222968)
+  — *"Sim, padrão = mais nova (Recommended)"*.
+
+## Assumptions
+
+- **S1** — "The registry the adapter already reads" is `control.describe`:
+  `quantick_search_capabilities` already reads it, and it lists every
+  registered `(id, version)` row (`crates/app/src/control/contract.rs`
+  `describe`). The resolution asks it once per version-less call rather than
+  caching it — safe because the registry is the instance's to change and a
+  cache would need its own invalidation; the cost is one local round trip on
+  an agent-initiated call.
+- **S2** — "Today's error path" for an ID the registry does not list means
+  forwarding at version 1 exactly as before, so the instance's own refusal
+  (`control.capability_unknown`, `control.permission_denied`) answers
+  unchanged. A describe that fails leaves version 1 as well, and the call
+  itself meets and reports whatever stopped it, so a caller never receives
+  describe's error for a call it did not make. When describe answers, the call
+  is sent to the instance that answered it, so the version and the answer come
+  from one registry. Safe: both keep every existing refusal the caller could
+  see. (Revised after the step-0 bug pass noted the describe error and the
+  two-routing race; tests `a_refused_describe_leaves_the_first_version_rather_than_its_error`
+  and `a_resolved_version_is_sent_to_the_instance_whose_registry_chose_it`.)
+- **S3** — The success result of `quantick_invoke` carries the
+  `capability_version` that answered, so a caller that omitted it can read
+  which version it reached (operability: a readable result). Safe: the tool
+  declares no output schema, the field is additive, and data honesty asks that
+  an inferred value be labelled.
+- **S4** — The named tools (`quantick_get_snapshot` and the rest) stay pinned
+  at version 1: their input and output schemas are the committed v1 documents
+  they embed, so resolving them to a newer version would publish a schema the
+  instance no longer answers with. Out of scope for D20, which names
+  `quantick_invoke`.
+
+## Acceptance criteria
+
+- [x] **A1** — A fake-gateway test registers one capability at v1 and v2,
+      invokes it through `quantick_invoke` without a version, and the gateway
+      receives version 2 and the result reports `capability_version: 2`.
+      *Evidence:* `cargo test -p quantick-mcp --test fake_gateway` passing,
+      test name in the PR body. → `crates/mcp/tests/fake_gateway.rs`. *(R0,
+      R1, R5)*
+- [x] **A2** — The same test invokes it with `capability_version: 1` and the
+      gateway receives version 1. *Evidence:* same test run. →
+      `crates/mcp/tests/fake_gateway.rs`. *(R2, R5)*
+- [x] **A3** — A v1-only capability invoked without a version reaches v1, and
+      an ID the instance does not register still answers
+      `control.capability_unknown`. *Evidence:* same test run plus the
+      existing `paper.order.place` assertion still green. →
+      `crates/mcp/tests/fake_gateway.rs`. *(R3, R5)*
+- [x] **A4** — The version comes from the instance's describe document: a
+      unit test over a describe document picks the highest version of the
+      matching ID and `None` for an unlisted one; no version table exists in
+      the crate. *Evidence:* unit test in `crates/mcp/src/tools.rs`; grep
+      shows no version literal besides the fallback. → `crates/mcp/src/tools.rs`.
+      *(R1)*
+- [x] **A5** — The published `quantick_invoke` description and the
+      `capability_version` schema say an omitted version resolves to the
+      newest version the instance registers; `crates/mcp/README.md` and
+      `docs/control-plane/control-contract.md` say the same; the PR body
+      states whether an MCP tool-schema snapshot exists (none found:
+      `grep` for the tool description outside `tools.rs`). *Evidence:* a
+      unit test asserting the schema text, the doc diff, the PR body. →
+      `crates/mcp/src/tools.rs`, `crates/mcp/README.md`,
+      `docs/control-plane/control-contract.md`. *(R4)*
+- [ ] **A6** — The PR's base is exactly `campaign/lean-a-plus`. *Evidence:*
+      `gh pr view <n> --json baseRefName`. → PR body. *(R6)*
+
+## Injected gates
+
+- [ ] **G1** — Every artifact in English (`CLAUDE.md`). *Evidence:*
+      `arch-review` dimension 8, `cargo test -p quantick-guards`. → review
+      report.
+- [x] **G2** — `cargo fmt --all -- --check`, `cargo clippy --workspace
+      --all-targets`, `cargo build --workspace`, `env -u QUANTICK_BUBBLES
+      cargo test --workspace` green, each run separately, on the campaign
+      base. *Evidence:* command exits in the PR body. → PR body.
+- [x] **G3** — Performance impact declared. Touched paths: the
+      `quantick_invoke` dispatch in the MCP adapter, rate **rare**
+      (agent-initiated, one call per tool call); a version-less call adds one
+      `control.describe` round trip on the local loopback. No per-trade,
+      per-depth or per-frame path is touched. *Evidence:* this line and the PR
+      body. → PR body.
+- [ ] **G4** — `arch-review` (step 0 `code-review` at `low`, shape pass on
+      operability, English and the leaf/headless rule) with every Blocker and
+      Should-fix resolved or deferred in the PR body. *Evidence:* review
+      verdict and `arch-review-ok` marker. → PR comment, git dir.
+- [x] **G5** — Operable without a hand: the default is reachable by a named
+      call (`quantick_invoke`), readable in its result (`capability_version`)
+      and discoverable in the published schema. *Evidence:* A1, A5. → tests.
+- [ ] **G6** — `ai-review` completion recorded with zero unresolved threads.
+      *Evidence:* PR report and `ai-review-complete`. → PR, git dir.
+
+## Evidence (run at `f677d4c2` on base `c55a4222`; the four checks rerun at `204d5b2c` after rebasing onto the campaign tip `eb60ed41`, again at `ac969a6d` after the step-0 repair, and at `69d57928` after the ai-review repair)
+
+- A1, A2, A3 — `an_omitted_version_reaches_the_newest_registered_one_and_an_explicit_one_is_kept`
+  in `crates/mcp/tests/fake_gateway.rs`: no version reaches v2 and reports
+  `capability_version: 2`; `capability_version: 1` reaches v1; the
+  v1-only `snapshot.read` answers at v1 without one; an explicit v3 is
+  `control.capability_unknown`. The existing `paper.order.place` assertion
+  (no version, unregistered ID, `control.capability_unknown`) stays green.
+  `cargo test -p quantick-mcp`: 36 + 1 + 5 + 3 passed, 0 failed at `69d57928`.
+- A4 — `an_omitted_version_is_the_highest_row_the_registry_lists_for_that_id`
+  and `the_version_resolution_reads_the_keys_the_describe_contract_requires`
+  (added for ai-review finding AI-Q11-1, thread `PRRT_kwDOTfuoRs6h17QB`) in
+  `crates/mcp/src/tools.rs`; the only version literal left is
+  `FIRST_CAPABILITY_VERSION`, the named tools' pin and the unlisted-ID
+  fallback.
+- A5 — `the_invoke_schema_publishes_the_newest_version_default`; the
+  schema's `default: 1` is gone and its description reads "Omitted: the
+  newest version the instance registers for capability_id". Docs:
+  `crates/mcp/README.md` (the `quantick_invoke` row) and
+  `docs/control-plane/control-contract.md` (`quantick_invoke` section). No
+  MCP tool-schema snapshot exists: the tool description appears nowhere
+  outside `crates/mcp/src/tools.rs` (the development plan carries an older
+  one-line summary, not a snapshot), so nothing was regenerated.
+- G2 — `cargo fmt --all -- --check` exit 0; `cargo clippy --workspace
+  --all-targets` exit 0; `cargo build --workspace` exit 0; `env -u
+  QUANTICK_BUBBLES cargo test --workspace` exit 0, 0 failed (96 result
+  lines at `f677d4c2`, 97 at `204d5b2c`, `ac969a6d` and `69d57928`; the rebase added a binary); `cargo test -p quantick-guards` green.
+- G3 — rate **rare**, declared above; one extra local `control.describe`
+  round trip per version-less `quantick_invoke`.
+- G5 — the result's `capability_version` (A1) and the published schema (A5).
+
+## Not applicable
+
+- *Touches a hot path* — no per-trade, per-depth or per-frame code; the MCP
+  adapter runs in its own process on agent-initiated calls.
+- *Touches anything user-visible* — no UI surface; the adapter is a STDIO
+  server.
+- *Adds a capability* — no new capability, port or crate; the default of an
+  existing tool changes.
+- *Engine / determinism territory* — the engine is untouched.
+
+## Closing steps
+
+- **C1** — `delivery-review` completeness pass (inline, tier `medium`)
+  returns PASS and records `delivery-review-ok`.
+- **C2** — Draft PR opened against `campaign/lean-a-plus`, CI green at the
+  final head, `gh pr ready` accepted once.
+
+## The request as received
+
+Attributed quotation of the coordinator's delegated request (campaign #367,
+child Q11), verbatim:
+
+> You are executing campaign child mission **Q11** of campaign #367 (https://github.com/milocaetano/quantick/issues/367) for milocaetano/quantick: make the MCP adapter's `quantick_invoke` default to the newest registered version of each capability when the caller omits the version. You are a subagent: you cannot ask the trader; decisions D1..Dn below answer the mission's step-3 questions. A doubt that would need a new decision is reported back, never guessed.
+>
+> ## Decisions
+> - D1: an omitted version resolves to the highest version the connected instance registers for that capability id, read from the registry/discovery data the adapter already has (no hard-coded table); an explicit version passes through unchanged; if the registry lists no versions for the id, keep today's error path.
+> - D2: say it in the tool's published description and argument schema ("omitted: the newest version the instance registers"); if a published MCP schema snapshot exists, regenerate it through the repo's normal mechanism and show the diff in the PR.
+> - D3: tests with the fake gateway: a capability registered at v1 and v2 is invoked without a version and reaches v2; with `version: 1` reaches v1; a v1-only capability works without a version.
+> - D4: tier `medium`: `arch-review` with `code-review` at `low`, shape pass on the touched dimensions (operability, English, the leaf rule); `ai-review` completion; `delivery-review` completeness pass inline. At most three step-0 rounds.
+> - D5: `gh pr ready` works with the cd-prefixed form from the Bash tool. Run it once after reviews, markers and green CI; if denied because the campaign tip moved or the PR is DIRTY, stop and report. **Never use the PowerShell tool for `gh pr` commands; never merge; never touch main.**
+
+Task issue #422, as filed (attributed quotation, verbatim scope and
+criteria):
+
+> ## Scope
+>
+> - `quantick_invoke` resolves an omitted version to the newest version the connected instance registers for that capability (from the discovery/registry the adapter already reads), not a hard-coded 1; an explicit version passes through unchanged.
+> - The tool's published description and schema say so; the MCP tool documentation is updated.
+> - Tests in `crates/mcp/tests/` (the fake gateway) for: omitted version picks the newest; explicit v1 still gets v1; a capability with only v1 still works.
+>
+> ## Acceptance criteria
+>
+> - [ ] A1: omitted version resolves to the newest registered version, proven by a fake-gateway test with two versions of one capability.
+> - [ ] A2: explicit version is honoured, proven by a test.
+> - [ ] A3: the published tool description/schema and docs state the default; any schema snapshot updated through the repo's normal regeneration with the change reviewed.
+> - [ ] A4: merged into `campaign/lean-a-plus` through a PR whose base is exactly that branch, with the merge read back.

--- a/crates/mcp/README.md
+++ b/crates/mcp/README.md
@@ -28,7 +28,7 @@ one, the routed ones name a fixed set and let a property pick which, and
 | `quantick_read_events` | `events.read` | A page of the semantic event journal after a cursor or from `oldest`/`latest`, with `dropped_before` when retention passed the cursor. |
 | `quantick_wait_for_change` | `events.wait` | Parks (≤ 30 s) until the journal moves past the cursor, then the page that completes the call. |
 | `quantick_search_capabilities` | `control.describe`, filtered | Capabilities and scopes by substring or module, with availability and the reason when one is unavailable. |
-| `quantick_invoke` | any registered capability | The long tail, under the same authority checks as the named tools. |
+| `quantick_invoke` | any registered capability | The long tail, under the same authority checks as the named tools. Omit `capability_version` and it calls the newest version the instance registers for that ID, read from `control.describe`; the result's `capability_version` says which one answered. An explicit version is sent as given. |
 
 With the **annotator** profile the trader granted, the tool set also carries
 the half of the loop that answers on the chart:

--- a/crates/mcp/src/tools.rs
+++ b/crates/mcp/src/tools.rs
@@ -81,8 +81,9 @@ const CHANNEL_PROPERTY: &str = "channel";
 
 /// Every first-generation observer capability is registered at version 1.
 /// The named tools stay on it, since the schemas they embed are the v1
-/// documents; `quantick_invoke` falls back to it only for an ID the
-/// instance's registry does not list, so the instance refuses it as before.
+/// documents. `quantick_invoke` falls back to it only for an ID the
+/// instance's registry does not list, or when that registry cannot be read,
+/// so the call itself meets the instance's refusal exactly as before.
 const FIRST_CAPABILITY_VERSION: u32 = 1;
 
 const INSTANCE_ID_PROPERTY: &str = "instance_id";
@@ -513,13 +514,21 @@ pub fn call(
                 .and_then(Value::as_str)
                 .ok_or_else(|| RpcError::new(INVALID_PARAMS, "capability_id is required"))?
                 .to_owned();
+            let mut target = instance;
             let capability_version = match arguments.get("capability_version") {
                 // D20: an omitted version is the newest the instance
                 // registers, read from its own registry — never a table here.
-                None => match described(link, instance.as_ref()) {
-                    Ok((_, document)) => newest_registered_version(&document, &capability_id)
-                        .unwrap_or(FIRST_CAPABILITY_VERSION),
-                    Err(refused) => return Ok(refused),
+                // The call then goes to the instance that answered, so the
+                // version and the answer come from one registry. A describe
+                // that fails leaves the first version, and the call itself
+                // meets and reports whatever stopped it.
+                None => match described(link, target.as_ref()) {
+                    Ok((answered_by, document)) => {
+                        target = Some(answered_by);
+                        newest_registered_version(&document, &capability_id)
+                            .unwrap_or(FIRST_CAPABILITY_VERSION)
+                    }
+                    Err(_) => FIRST_CAPABILITY_VERSION,
                 },
                 Some(value) => value
                     .as_u64()
@@ -533,12 +542,7 @@ pub fn call(
                 .get("payload")
                 .cloned()
                 .unwrap_or_else(|| Value::Object(Map::new()));
-            match link.invoke(
-                instance.as_ref(),
-                &capability_id,
-                capability_version,
-                payload,
-            ) {
+            match link.invoke(target.as_ref(), &capability_id, capability_version, payload) {
                 Ok(response) => Ok(result_of(response, Some(capability_version))),
                 Err(error) => Ok(ToolResult::control_error(&error)),
             }
@@ -1006,7 +1010,7 @@ fn definitions_of(document: &Value) -> BTreeMap<String, Value> {
 
 #[cfg(test)]
 mod tests {
-    use quantick_control::schema::validate_schema;
+    use quantick_control::{error::ControlError, schema::validate_schema};
 
     use super::*;
 
@@ -1201,6 +1205,85 @@ mod tests {
             "an unlisted ID has no newest version; the instance refuses it"
         );
         assert_eq!(newest_registered_version(&json!({}), "snapshot.read"), None);
+    }
+
+    /// The version is read from one instance's registry, so the call goes to
+    /// that instance — never re-routed to whichever one is live a moment later.
+    #[test]
+    fn a_resolved_version_is_sent_to_the_instance_whose_registry_chose_it() {
+        let mut link = crate::fake::FakeLink::default();
+        let instance = InstanceId::from_bytes([4; 16]);
+        link.add_instance(instance.clone());
+        let result = call(
+            &mut link,
+            INVOKE,
+            json!({ "capability_id": CHART_WINDOW_CAPABILITY, "payload": {} }),
+        )
+        .expect("invoke forwards");
+        assert!(!result.is_error, "{:?}", result.structured_content);
+        assert_eq!(link.calls.len(), 2, "one describe, then the call");
+        assert_eq!(link.calls[0].capability_id, DESCRIBE_CAPABILITY);
+        assert_eq!(link.calls[0].instance, None, "the caller named none");
+        assert_eq!(link.calls[1].capability_id, CHART_WINDOW_CAPABILITY);
+        assert_eq!(link.calls[1].capability_version, 1);
+        assert_eq!(
+            link.calls[1].instance,
+            Some(instance),
+            "the call is pinned to the instance that answered the describe"
+        );
+    }
+
+    /// A link whose describe is refused while every other call answers, to
+    /// prove the default never swaps the caller's answer for describe's error.
+    struct DescribeRefused(Vec<u32>);
+
+    impl ControlLink for DescribeRefused {
+        fn instances(&mut self) -> Result<crate::link::Instances, ControlError> {
+            Ok(crate::link::Instances::default())
+        }
+
+        fn invoke(
+            &mut self,
+            _instance: Option<&InstanceId>,
+            capability_id: &str,
+            capability_version: u32,
+            _payload: Value,
+        ) -> Result<quantick_control::wire::ResponseEnvelope, ControlError> {
+            if capability_id == DESCRIBE_CAPABILITY {
+                return Err(ControlError::invalid_request("describe is refused"));
+            }
+            self.0.push(capability_version);
+            Ok(quantick_control::wire::ResponseEnvelope {
+                protocol_version: 1,
+                request_id: quantick_control::id::RequestId::new("test").expect("valid id"),
+                instance_id: InstanceId::from_bytes([5; 16]),
+                capture_revision: None,
+                module_revisions: Vec::new(),
+                outcome: quantick_control::wire::ResponseOutcome::Success { result: json!({}) },
+                warnings: Vec::new(),
+            })
+        }
+    }
+
+    #[test]
+    fn a_refused_describe_leaves_the_first_version_rather_than_its_error() {
+        let mut link = DescribeRefused(Vec::new());
+        let result = call(
+            &mut link,
+            INVOKE,
+            json!({ "capability_id": SNAPSHOT_CAPABILITY, "payload": {} }),
+        )
+        .expect("invoke forwards");
+        assert!(
+            !result.is_error,
+            "the caller got describe's refusal for a call it never made: {:?}",
+            result.structured_content
+        );
+        assert_eq!(link.0, vec![FIRST_CAPABILITY_VERSION]);
+        assert_eq!(
+            result.structured_content.as_ref().unwrap()["capability_version"],
+            FIRST_CAPABILITY_VERSION
+        );
     }
 
     /// The default is part of the tool's published contract, so the tool

--- a/crates/mcp/src/tools.rs
+++ b/crates/mcp/src/tools.rs
@@ -732,16 +732,29 @@ fn described(
     }
 }
 
+/// The describe document's keys the version resolution reads. Named once so
+/// a test can hold them to the committed describe contract: a renamed key
+/// would otherwise leave every version-less call quietly on version 1.
+const DESCRIBED_CAPABILITIES_KEY: &str = "capabilities";
+const CAPABILITY_ID_KEY: &str = "id";
+const CAPABILITY_VERSION_KEY: &str = "version";
+
 /// The highest version a describe document registers for `capability_id`.
 /// The registry lists one row per version, so a capability that kept v1 when
 /// v2 arrived appears twice. `None` when the ID is not listed at all.
 fn newest_registered_version(described: &Value, capability_id: &str) -> Option<u32> {
     described
-        .get("capabilities")
+        .get(DESCRIBED_CAPABILITIES_KEY)
         .and_then(Value::as_array)?
         .iter()
-        .filter(|capability| capability.get("id").and_then(Value::as_str) == Some(capability_id))
-        .filter_map(|capability| capability.get("version").and_then(Value::as_u64))
+        .filter(|capability| {
+            capability.get(CAPABILITY_ID_KEY).and_then(Value::as_str) == Some(capability_id)
+        })
+        .filter_map(|capability| {
+            capability
+                .get(CAPABILITY_VERSION_KEY)
+                .and_then(Value::as_u64)
+        })
         .filter_map(|version| u32::try_from(version).ok())
         .max()
 }
@@ -1178,6 +1191,36 @@ mod tests {
         assert_eq!(take_instance_id(&mut arguments).unwrap(), Some(id));
         assert!(!arguments.contains_key("instance_id"));
         assert!(arguments.contains_key("scopes"));
+    }
+
+    /// The resolver's fixtures are hand-written, so this is what ties its keys
+    /// to the contract the application publishes: every capability row of the
+    /// committed describe document requires a string-typed ID and an integer
+    /// version under exactly the keys the resolver reads.
+    #[test]
+    fn the_version_resolution_reads_the_keys_the_describe_contract_requires() {
+        let describe = parse_schema(DESCRIBE_RESULT_SCHEMA);
+        let rows = &describe["properties"][DESCRIBED_CAPABILITIES_KEY];
+        assert_eq!(rows["type"], "array", "capabilities is a list of rows");
+        let reference = rows["items"]["$ref"]
+            .as_str()
+            .expect("capability rows are a named definition");
+        let name = reference
+            .strip_prefix("#/$defs/")
+            .expect("a local definition");
+        let row = &describe["$defs"][name];
+        let required = row["required"].as_array().expect("required keys");
+        for key in [CAPABILITY_ID_KEY, CAPABILITY_VERSION_KEY] {
+            assert!(
+                required.iter().any(|entry| entry == key),
+                "the describe contract no longer requires `{key}` on a capability row"
+            );
+        }
+        assert_eq!(row["properties"][CAPABILITY_VERSION_KEY]["type"], "integer");
+        assert!(
+            row["properties"][CAPABILITY_ID_KEY].is_object(),
+            "the ID is a declared property"
+        );
     }
 
     /// D20: the default is read from the instance's registry, one row per

--- a/crates/mcp/src/tools.rs
+++ b/crates/mcp/src/tools.rs
@@ -80,6 +80,9 @@ const OBJECT_PROPERTY: &str = "object";
 const CHANNEL_PROPERTY: &str = "channel";
 
 /// Every first-generation observer capability is registered at version 1.
+/// The named tools stay on it, since the schemas they embed are the v1
+/// documents; `quantick_invoke` falls back to it only for an ID the
+/// instance's registry does not list, so the instance refuses it as before.
 const FIRST_CAPABILITY_VERSION: u32 = 1;
 
 const INSTANCE_ID_PROPERTY: &str = "instance_id";
@@ -253,7 +256,7 @@ pub fn tools(profile_ceiling: &str) -> Vec<Tool> {
         Tool {
             name: INVOKE.to_owned(),
             title: "Invoke a registered capability by ID".to_owned(),
-            description: "Execute one registered capability by ID and version with its declared input. Availability, permission, revision and idempotency rules are enforced by the instance exactly as for the named tools, whatever this connection's ceiling: a capability ID the trader did not grant is refused with control.permission_denied. Use quantick_describe or quantick_search_capabilities to learn which IDs this instance registers.".to_owned(),
+            description: "Execute one registered capability by ID and version with its declared input. Omit capability_version to call the newest version the instance registers for that ID; the result's capability_version says which one answered. Availability, permission, revision and idempotency rules are enforced by the instance exactly as for the named tools, whatever this connection's ceiling: a capability ID the trader did not grant is refused with control.permission_denied. Use quantick_describe or quantick_search_capabilities to learn which IDs and versions this instance registers.".to_owned(),
             input_schema: invoke_schema(),
             output_schema: None,
             annotations: invoke_annotations,
@@ -511,7 +514,13 @@ pub fn call(
                 .ok_or_else(|| RpcError::new(INVALID_PARAMS, "capability_id is required"))?
                 .to_owned();
             let capability_version = match arguments.get("capability_version") {
-                None => FIRST_CAPABILITY_VERSION,
+                // D20: an omitted version is the newest the instance
+                // registers, read from its own registry — never a table here.
+                None => match described(link, instance.as_ref()) {
+                    Ok((_, document)) => newest_registered_version(&document, &capability_id)
+                        .unwrap_or(FIRST_CAPABILITY_VERSION),
+                    Err(refused) => return Ok(refused),
+                },
                 Some(value) => value
                     .as_u64()
                     .and_then(|version| u32::try_from(version).ok())
@@ -530,7 +539,7 @@ pub fn call(
                 capability_version,
                 payload,
             ) {
-                Ok(response) => Ok(result_of(response)),
+                Ok(response) => Ok(result_of(response, Some(capability_version))),
                 Err(error) => Ok(ToolResult::control_error(&error)),
             }
         }
@@ -564,23 +573,33 @@ fn forward(
     payload: Value,
 ) -> Result<ToolResult, RpcError> {
     match link.invoke(instance, capability_id, FIRST_CAPABILITY_VERSION, payload) {
-        Ok(response) => Ok(result_of(response)),
+        Ok(response) => Ok(result_of(response, None)),
         Err(error) => Ok(ToolResult::control_error(&error)),
     }
 }
 
 /// A capability response as a tool result: the result itself plus the
 /// revisions that let a follow-up call reason about staleness.
-fn result_of(response: quantick_control::wire::ResponseEnvelope) -> ToolResult {
+/// `quantick_invoke` also names the version that answered, which its caller
+/// may have left to the instance; the named tools declare an output schema
+/// without that field and pass `None`.
+fn result_of(
+    response: quantick_control::wire::ResponseEnvelope,
+    answered_version: Option<u32>,
+) -> ToolResult {
     match response.outcome {
         quantick_control::wire::ResponseOutcome::Success { result } => {
-            ToolResult::structured(json!({
+            let mut envelope = json!({
                 "instance_id": response.instance_id,
                 "capture_revision": response.capture_revision,
                 "module_revisions": response.module_revisions,
                 "warnings": response.warnings,
                 "result": result,
-            }))
+            });
+            if let (Some(version), Some(fields)) = (answered_version, envelope.as_object_mut()) {
+                fields.insert("capability_version".to_owned(), json!(version));
+            }
+            ToolResult::structured(envelope)
         }
         quantick_control::wire::ResponseOutcome::Failure { error } => {
             ToolResult::control_error(&error)
@@ -595,20 +614,9 @@ fn search(
 ) -> Result<ToolResult, RpcError> {
     let query = optional_string(arguments, "query")?.map(|query| query.to_lowercase());
     let module = optional_string(arguments, "module")?;
-    let response = match link.invoke(
-        instance,
-        DESCRIBE_CAPABILITY,
-        FIRST_CAPABILITY_VERSION,
-        json!({}),
-    ) {
-        Ok(response) => response,
-        Err(error) => return Ok(ToolResult::control_error(&error)),
-    };
-    let described = match response.outcome {
-        quantick_control::wire::ResponseOutcome::Success { result } => result,
-        quantick_control::wire::ResponseOutcome::Failure { error } => {
-            return Ok(ToolResult::control_error(&error));
-        }
+    let (instance_id, described) = match described(link, instance) {
+        Ok(described) => described,
+        Err(refused) => return Ok(refused),
     };
     let matches = |candidate: &Value, fields: &[&str]| -> bool {
         if let Some(module) = &module
@@ -687,12 +695,51 @@ fn search(
         })
         .unwrap_or_default();
     Ok(ToolResult::structured(json!({
-        "instance_id": response.instance_id,
+        "instance_id": instance_id,
         "capability_count": capabilities.len(),
         "capabilities": capabilities,
         "snapshot_scope_count": snapshot_scopes.len(),
         "snapshot_scopes": snapshot_scopes,
     })))
+}
+
+/// The instance's `control.describe` document and the instance that answered
+/// it, or the tool result that says why there is none — the same control
+/// error the caller's own call would have met.
+fn described(
+    link: &mut dyn ControlLink,
+    instance: Option<&InstanceId>,
+) -> Result<(InstanceId, Value), ToolResult> {
+    let response = link
+        .invoke(
+            instance,
+            DESCRIBE_CAPABILITY,
+            FIRST_CAPABILITY_VERSION,
+            json!({}),
+        )
+        .map_err(|error| ToolResult::control_error(&error))?;
+    match response.outcome {
+        quantick_control::wire::ResponseOutcome::Success { result } => {
+            Ok((response.instance_id, result))
+        }
+        quantick_control::wire::ResponseOutcome::Failure { error } => {
+            Err(ToolResult::control_error(&error))
+        }
+    }
+}
+
+/// The highest version a describe document registers for `capability_id`.
+/// The registry lists one row per version, so a capability that kept v1 when
+/// v2 arrived appears twice. `None` when the ID is not listed at all.
+fn newest_registered_version(described: &Value, capability_id: &str) -> Option<u32> {
+    described
+        .get("capabilities")
+        .and_then(Value::as_array)?
+        .iter()
+        .filter(|capability| capability.get("id").and_then(Value::as_str) == Some(capability_id))
+        .filter_map(|capability| capability.get("version").and_then(Value::as_u64))
+        .filter_map(|version| u32::try_from(version).ok())
+        .max()
 }
 
 fn optional_string(arguments: &Map<String, Value>, key: &str) -> Result<Option<String>, RpcError> {
@@ -800,7 +847,7 @@ fn invoke_schema() -> Value {
             "capability_version": {
                 "type": "integer",
                 "minimum": 1,
-                "default": 1
+                "description": "Which registered version to call. Omitted: the newest version the instance registers for capability_id, as quantick_describe lists them. An ID the instance does not register is refused as unknown either way."
             },
             "payload": {
                 "type": "object",
@@ -1127,6 +1174,51 @@ mod tests {
         assert_eq!(take_instance_id(&mut arguments).unwrap(), Some(id));
         assert!(!arguments.contains_key("instance_id"));
         assert!(arguments.contains_key("scopes"));
+    }
+
+    /// D20: the default is read from the instance's registry, one row per
+    /// version, whatever order the rows come in — never from a table here.
+    #[test]
+    fn an_omitted_version_is_the_highest_row_the_registry_lists_for_that_id() {
+        let described = json!({
+            "capabilities": [
+                { "id": "layout.pane.resize", "version": 2 },
+                { "id": "snapshot.read", "version": 1 },
+                { "id": "layout.pane.resize", "version": 1 },
+            ]
+        });
+        assert_eq!(
+            newest_registered_version(&described, "layout.pane.resize"),
+            Some(2)
+        );
+        assert_eq!(
+            newest_registered_version(&described, "snapshot.read"),
+            Some(1)
+        );
+        assert_eq!(
+            newest_registered_version(&described, "paper.order.place"),
+            None,
+            "an unlisted ID has no newest version; the instance refuses it"
+        );
+        assert_eq!(newest_registered_version(&json!({}), "snapshot.read"), None);
+    }
+
+    /// The default is part of the tool's published contract, so the tool
+    /// list has to say it rather than leave a client to find out.
+    #[test]
+    fn the_invoke_schema_publishes_the_newest_version_default() {
+        let invoke = tools("observer")
+            .into_iter()
+            .find(|tool| tool.name == INVOKE)
+            .expect("every ceiling lists quantick_invoke");
+        let version = &invoke.input_schema["properties"]["capability_version"];
+        assert!(
+            version.get("default").is_none(),
+            "a fixed default would contradict the registry-driven one"
+        );
+        let said = version["description"].as_str().expect("described");
+        assert!(said.contains("Omitted: the newest version the instance registers"));
+        assert!(invoke.description.contains("Omit capability_version"));
     }
 }
 

--- a/crates/mcp/tests/fake_gateway.rs
+++ b/crates/mcp/tests/fake_gateway.rs
@@ -177,26 +177,42 @@ fn serve_connection(
     }
 }
 
+/// A capability the fake registers twice, the way `layout.pane.resize` kept
+/// version 1 when version 2 arrived: one registry row per version.
+const VERSIONED_CAPABILITY: &str = "layout.pane.resize";
+
 fn answer(instance_id: &InstanceId, request: &RequestEnvelope) -> ResponseOutcome {
-    match request.capability_id.as_str() {
-        tools::DESCRIBE_CAPABILITY => ResponseOutcome::Success {
+    // Keyed on the version as well as the ID, as the real registry is: a
+    // version it does not register is refused, never answered by another.
+    match (request.capability_id.as_str(), request.capability_version) {
+        (tools::DESCRIBE_CAPABILITY, 1) => ResponseOutcome::Success {
             result: json!({
                 "instance_id": instance_id,
                 "application_version": "0.1.0-fake",
                 "capabilities": [
                     { "id": tools::DESCRIBE_CAPABILITY, "version": 1, "title": "Describe", "description": "Report the instance", "module": "control", "read_only": true, "availability": {"status": "available"} },
-                    { "id": tools::SNAPSHOT_CAPABILITY, "version": 1, "title": "Snapshot", "description": "Coherent capture", "module": "snapshot", "read_only": true, "availability": {"status": "available"} }
+                    { "id": tools::SNAPSHOT_CAPABILITY, "version": 1, "title": "Snapshot", "description": "Coherent capture", "module": "snapshot", "read_only": true, "availability": {"status": "available"} },
+                    { "id": VERSIONED_CAPABILITY, "version": 2, "title": "Resize a pane", "description": "Answers an exact decimal share", "module": "layout", "read_only": false, "availability": {"status": "available"} },
+                    { "id": VERSIONED_CAPABILITY, "version": 1, "title": "Resize a pane", "description": "The first contract", "module": "layout", "read_only": false, "availability": {"status": "available"} }
                 ],
                 "snapshot_scopes": [
                     { "id": "system.info", "module_id": "system", "title": "System", "description": "Build identity", "schema_version": 1, "required_permissions": ["observe"], "schema": { "type": "object" } }
                 ]
             }),
         },
-        tools::SNAPSHOT_CAPABILITY
-        | tools::DIAGNOSTICS_CAPABILITY
-        | tools::CHART_WINDOW_CAPABILITY
-        | tools::SCENE_CAPABILITY => ResponseOutcome::Success {
-            result: json!({ "echo": request.payload, "capability": request.capability_id }),
+        (
+            tools::SNAPSHOT_CAPABILITY
+            | tools::DIAGNOSTICS_CAPABILITY
+            | tools::CHART_WINDOW_CAPABILITY
+            | tools::SCENE_CAPABILITY,
+            1,
+        )
+        | (VERSIONED_CAPABILITY, 1 | 2) => ResponseOutcome::Success {
+            result: json!({
+                "echo": request.payload,
+                "capability": request.capability_id,
+                "version": request.capability_version,
+            }),
         },
         _ => ResponseOutcome::Failure {
             error: ControlError::new(
@@ -323,6 +339,76 @@ fn the_adapter_discovers_authenticates_and_reads_through_the_real_transport() {
 
     drop(gateway);
     let _ = std::fs::remove_dir_all(&directory);
+}
+
+/// D20 through the real transport: an omitted version is the newest the
+/// instance registers for that ID, an explicit one is honoured, and a
+/// capability that only ever had version 1 still answers without one.
+#[test]
+fn an_omitted_version_reaches_the_newest_registered_one_and_an_explicit_one_is_kept() {
+    let directory = scratch_directory("versions");
+    let gateway = FakeGateway::start(&directory, 0x77, 1_700_000_000_000);
+    let mut server = server_over(&directory);
+
+    let newest = call(
+        &mut server,
+        2,
+        tools::INVOKE,
+        json!({ "capability_id": VERSIONED_CAPABILITY, "payload": { "fraction": "0.4" } }),
+    );
+    assert_eq!(newest["isError"], false, "{newest}");
+    assert_eq!(
+        newest["structuredContent"]["result"]["version"], 2,
+        "the gateway was asked for version 2, the newest it registers"
+    );
+    assert_eq!(
+        newest["structuredContent"]["capability_version"], 2,
+        "and the result says which version answered"
+    );
+    assert_eq!(
+        newest["structuredContent"]["result"]["echo"],
+        json!({ "fraction": "0.4" }),
+        "the payload reaches the resolved version untouched"
+    );
+
+    let first = call(
+        &mut server,
+        3,
+        tools::INVOKE,
+        json!({ "capability_id": VERSIONED_CAPABILITY, "capability_version": 1, "payload": {} }),
+    );
+    assert_eq!(first["isError"], false, "{first}");
+    assert_eq!(
+        first["structuredContent"]["result"]["version"], 1,
+        "an explicit version passes through unchanged"
+    );
+    assert_eq!(first["structuredContent"]["capability_version"], 1);
+
+    let only = call(
+        &mut server,
+        4,
+        tools::INVOKE,
+        json!({ "capability_id": tools::SNAPSHOT_CAPABILITY, "payload": { "scopes": ["system.info"] } }),
+    );
+    assert_eq!(only["isError"], false, "{only}");
+    assert_eq!(
+        only["structuredContent"]["result"]["version"], 1,
+        "a capability registered only at version 1 still answers without one"
+    );
+
+    let unregistered = call(
+        &mut server,
+        5,
+        tools::INVOKE,
+        json!({ "capability_id": VERSIONED_CAPABILITY, "capability_version": 3, "payload": {} }),
+    );
+    assert_eq!(unregistered["isError"], true);
+    assert_eq!(
+        unregistered["structuredContent"]["error"]["code"], "control.capability_unknown",
+        "an explicit version the instance lacks is refused, not rounded down"
+    );
+
+    drop(gateway);
 }
 
 #[test]

--- a/docs/control-plane/control-contract.md
+++ b/docs/control-plane/control-contract.md
@@ -459,6 +459,12 @@ not bypass availability, permission, confirmation, revision, idempotency, or
 audit checks. A capability unavailable to the current profile remains
 unavailable through `invoke`.
 
+An omitted version resolves to the newest version the instance registers for
+that ID, read from its `control.describe` registry at call time; the result
+names the `capability_version` that answered. An explicit version is sent
+unchanged, and an ID the instance does not register is refused as unknown
+either way. Clients that depend on one version's shape pass it explicitly.
+
 High-frequency workflows may earn a named tool after usage evidence. The first
 planned write tools are `quantick_annotate`, `quantick_notify`, and
 `quantick_attach_script`; each still resolves to the same registry entry that


### PR DESCRIPTION
Default the MCP adapter's `quantick_invoke` to the newest version the connected instance registers for each capability when the caller omits `capability_version`.

**Tier:** `medium`. Campaign child of #367 (Q11); closes on integration: #422. Base: `campaign/lean-a-plus` (rebased onto `eb60ed41`). Authorized by the trader's D20 (https://github.com/milocaetano/quantick/issues/367#issuecomment-5650222968, "Sim, padrão = mais nova").

## Why

PR #421 added version 2 of seven `layout.*` capabilities and kept v1 registered; v1 now answers an honest refusal pointing at v2. `quantick_invoke` hard-coded version 1 for a version-less call, so an MCP agent that omitted the version met the refusal instead of the working answer.

## The resolution rule

- **Omitted version** → the highest `version` among the rows the instance's own `control.describe` registry lists for that `capability_id` (one row per registered version). Read at call time; no table in the adapter, no cache. The call is then sent to the instance that answered the describe, so the version and the answer come from one registry.
- **Explicit version** → sent unchanged, routed exactly as before. An explicit version the instance lacks is refused `control.capability_unknown`, never rounded down.
- **ID the registry does not list** → forwarded at version 1 as before, so the instance's own refusal (`control.capability_unknown` / `control.permission_denied`) answers unchanged.
- **Describe itself fails** → version 1, and the call itself meets and reports whatever stopped it; a caller never receives describe's error for a call it did not make.
- The success result now carries `capability_version`, the version that answered, so a caller that left the choice to the instance can read it (the tool declares no output schema; the field is additive).
- The named tools (`quantick_get_snapshot` and the rest) stay pinned at v1: their embedded input/output schemas are the committed v1 documents.

## Tests

- `crates/mcp/tests/fake_gateway.rs` — `an_omitted_version_reaches_the_newest_registered_one_and_an_explicit_one_is_kept`, through the real discovery, `LocalClient`, `LocalLink` and `McpServer`: a capability registered at v1 and v2 invoked without a version reaches v2 and reports `capability_version: 2`; `capability_version: 1` reaches v1; the v1-only `snapshot.read` answers at v1 without one; an explicit v3 is `control.capability_unknown`. The fake gateway now keys its answers on `(id, version)` like the real registry. The existing no-version `paper.order.place` assertion (unregistered ID → `control.capability_unknown`) stays green.
- `crates/mcp/src/tools.rs` unit tests — `an_omitted_version_is_the_highest_row_the_registry_lists_for_that_id`, `the_version_resolution_reads_the_keys_the_describe_contract_requires` (binds the resolver's keys to the committed describe schema), `a_resolved_version_is_sent_to_the_instance_whose_registry_chose_it`, `a_refused_describe_leaves_the_first_version_rather_than_its_error`, `the_invoke_schema_publishes_the_newest_version_default`.

## Published schema and docs

- `quantick_invoke` description adds: "Omit capability_version to call the newest version the instance registers for that ID; the result's capability_version says which one answered." (and "which IDs and versions").
- `capability_version` argument schema: `"default": 1` removed; description added: "Which registered version to call. Omitted: the newest version the instance registers for capability_id, as quantick_describe lists them. An ID the instance does not register is refused as unknown either way."
- `crates/mcp/README.md` (the `quantick_invoke` row) and `docs/control-plane/control-contract.md` (the `quantick_invoke` section) state the default.
- **No MCP tool-schema snapshot exists** in the repository: the tool list is built in `tools.rs` and its description appears nowhere else (the development plan has an older one-line summary, not a snapshot), so nothing was regenerated. The control-plane catalog under `schemas/control/` describes capabilities, not MCP tools, and is untouched.

## Performance

Touched path: `quantick_invoke` dispatch in the MCP adapter, rate **rare** (agent-initiated). A version-less call adds one local `control.describe` round trip (the describe document is the full catalog, a few hundred KB over loopback). No per-trade, per-depth or per-frame path.

## Reviews

- **arch-review** at `76094f46`, key `ba34d493`: step 0: `code-review` at `low` (effort-first, no reuse notice). There were three rounds, the D4 budget:
  - Round 1 over the feature commit `204d5b2c`: 0 findings, two non-finding notes (a describe error surfacing for a granted call; describe and invoke routing independently). Both were closed in `ac969a6d`.
  - Round 2 over `204d5b2c..ac969a6d`: clean.
  - Round 3 over `ac969a6d..69d57928`: clean. Prior verdicts carried forward.
  - Residual note, not a finding: a failed describe falls back to v1 without a trace other than the result's `capability_version`.
  - Shape pass: no Blocker or Should-fix. Correctness: none open. Docking: a new capability version needs no adapter edit. Performance: rare path, one extra local describe. Operability: named call, readable `capability_version`, published schema. Proof: the fake-gateway test fails on its v2 assertion if the default reverts to 1 (integration), plus unit tests. Accumulation: trunk flat (`tools.rs` is below the size threshold, no ceiling moved). Language: guards pass; the branch name, commits and this body read in English (the Portuguese D20 label is an attributed quotation).
- **delivery-review**: completeness-only pass (tier `medium`, inline), source = `.claude/GOAL-archive-mcp-newest-version-default.md`: nothing unledgered; R6's merge and readback belong to the coordinator. PASS, carried to `76094f46`, whose delta adds a test and evidence lines and no ledger change.
- **ai-review**: round 1 at `8d45ffc4` (https://github.com/milocaetano/quantick/pull/424#issuecomment-5650604960) found one WEAK, AI-Q11-1: the resolver's describe keys were not tied to the contract. It was fixed in `69d57928` and the thread resolved; the follow-up at `76094f46` (https://github.com/milocaetano/quantick/pull/424#issuecomment-5650644526) is all PASS. 0 unresolved threads. Deferrals: none.

## Verification

Local, run at `69d57928` (rebased on `eb60ed41`): `cargo fmt --all -- --check` exit 0; `cargo clippy --workspace --all-targets` exit 0; `cargo build --workspace` exit 0; `env -u QUANTICK_BUBBLES cargo test --workspace` exit 0, 0 failed; `cargo test -p quantick-guards` green. `76094f46` only re-commits the mission archive (prose). CI: pending at the final head.

Mission record: `.claude/GOAL-archive-mcp-newest-version-default.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VdP84bYEGeyCg7KwsNb1X2

