### PR TITLE
fix(control): keep a parked capture's image under load, and force what eight load-sensitive tests assert

### DIFF
--- a/.claude/GOAL-archive-contention-listed-tests.md
+++ b/.claude/GOAL-archive-contention-listed-tests.md
@@ -68,10 +68,11 @@ Campaign child of #367 (Q10). Base: `campaign/lean-a-plus`. Issue: #418.
   `an_operator_detaching_its_own_slot_leaves_the_traders_slot_of_the_same_number`
   (same module, 200 back-to-back frames after an attach), failed this
   mission's own `cargo test --workspace` while contention runs shared the
-  host, and one local contention round. It gets the same flush helper: a
-  detour stated here and in the PR, because the verification loop cannot be
-  green without it and R7 needs the step to land. Other tests the local
-  harness found failing are filed, not fixed.
+  host, and one local contention round. It gets the same fix as #409 and
+  #415 (the suite's `settle_indicators`): a detour stated here and in the
+  PR, because the verification loop cannot be green without it and R7 needs
+  the step to land. Other tests the local harness found failing are filed,
+  not fixed: #427, #428, #429, #430; the #411 gateway ordering is #425.
 
 ## Acceptance criteria
 

--- a/.claude/GOAL-archive-contention-listed-tests.md
+++ b/.claude/GOAL-archive-contention-listed-tests.md
@@ -1,0 +1,183 @@
+# Mission: contention-listed-tests
+
+Fix the eight load-sensitive tests the CPU-contention CI step found (#408, #409,
+#410, #411, #413, #415, #416, #417), and first answer whether the three Null
+`capture_revision` failures (#413, #416, #417) are a product race in the
+evidence path. Why it matters: the contention step (#414) cannot merge until the
+skip list is empty of these tests, and an evidence bundle must say which
+revision its picture shows (data honesty).
+
+**Tier:** `high` — set by the campaign coordinator (issue #418: one item may be a
+product race in evidence capture, so a production change is possible and must
+be reviewed under the full gates).
+
+Campaign child of #367 (Q10). Base: `campaign/lean-a-plus`. Issue: #418.
+
+## Request ledger
+
+- **R1** — Answer, with evidence, whether a bundle or snapshot can be published
+  with a Null `capture_revision` in production under load ("a product race in
+  the evidence path"). *(#418 scope 1, D2)*
+- **R2** — If product: fix the product path so the revision is always stamped or
+  the bundle states it is unavailable (typed, not a silent Null), with a
+  real-gateway regression test that forces the interleaving; no wire-shape
+  change, and if one were needed, stop and record a `human_decision` instead.
+  If not: fix the tests. *(#418 scope 1, D2)*
+- **R3** — #408, #409, #410, #411, #415: force the interleaving each assertion
+  depends on (a frame, a worker flush, a publish), bounded waits on observable
+  conditions, the #382/#400/#404 shape. *(#418 scope 2, D3)*
+- **R4** — No assertion weakened ("Weakening an assertion is not a fix"). *(#418
+  scope 2, A3)*
+- **R5** — Each of the eight passes 24-copies-on-4-cores contention (or local
+  equivalent) with 0 failures over at least 10 runs; before/after table in the
+  PR. *(#418 A2, D4)*
+- **R6** — Record which skip-list lines (`tools/ci/contention-known-issues.txt`
+  on #414's branch) the fixes allow removing; the coordinator applies them.
+  *(#418 scope 3, D4)*
+- **R7** — Purpose: the contention step can land with these tests no longer
+  excused, so load-sensitive tests fail in their own PR. *(#418 context)*
+
+## Decisions (from the coordinator)
+
+- **D1** — one PR for all eight.
+- **D2** — #413/#416/#417 first; product fix only if the product can emit such a
+  bundle; a wire-shape change is a `human_decision`, not a guess.
+- **D3** — the other five: force what each assertion depends on.
+- **D4** — proof: contention runs, 0 failures over >= 10 runs after, the issue's
+  before evidence; table in the PR body; skip-list lines to remove.
+- **D5** — `arch-review` with `code-review` at `medium`, full shape pass;
+  `ai-review` completion; `delivery-review` in full; at most three step-0 rounds.
+- **D6** — `gh pr ready` once, cd-prefixed, from the Bash tool; never merge.
+
+## Assumptions
+
+- **S1** — "Local equivalent" of 24 copies on 4 cores is the Windows harness in
+  the scratchpad: 24 concurrent copies of the whole `quantick-app` test binary,
+  all held to processor mask `0xF` (4 of 12 cores), `--test-threads=4`, as Q9's
+  doc names for its local reproductions. Safe: the doc itself reports local
+  reproductions this way; CI runs the same step at the final head.
+- **S2** — The gateway server's own ordering (answer written before the request
+  ID is released) is outside D2's evidence-path authorization; #411 is fixed at
+  the test layer under D3 and the product ordering is raised as a
+  `human_decision`. Safe: no product behaviour changes without a decision.
+- **S3** — A `#[cfg(test)]` seam in `control/gateway.rs` that runs one frame
+  whose budget is already spent is part of the evidence regression test, not a
+  production change. Safe: compiled into the test build only.
+
+- **S4** — A ninth test with #415's exact mechanism,
+  `an_operator_detaching_its_own_slot_leaves_the_traders_slot_of_the_same_number`
+  (same module, 200 back-to-back frames after an attach), failed this
+  mission's own `cargo test --workspace` while contention runs shared the
+  host, and one local contention round. It gets the same flush helper: a
+  detour stated here and in the PR, because the verification loop cannot be
+  green without it and R7 needs the step to land. Other tests the local
+  harness found failing are filed, not fixed.
+
+## Acceptance criteria
+
+- [ ] **A1** — The Null `capture_revision` question is answered with evidence
+      (the code path and a captured failing bundle's coverage) in the PR body.
+      *Evidence:* PR body section "D2 finding". → PR body. *(R1)*
+- [ ] **A2** — If the product can drop a delivered image, a capture parked for an
+      image is served in the frame whose image it waited for even when the
+      frame's time budget is spent, and a real-gateway test forcing a spent
+      budget proves it (fails before the fix, passes after); no serialized
+      type or field changes (had one been needed, the mission stops with a
+      `human_decision`). *Evidence:* the new test's name and its before/after
+      result; the diff touches no wire type. → PR body. *(R2, R4)*
+- [ ] **A3** — #408, #409, #410, #411, #415 each force the state their assertion
+      depends on; every original assertion is still made.
+      *Evidence:* the diff; the per-test table. → PR body. *(R3, R4)*
+- [ ] **A4** — Contention table: before (issue evidence plus local runs of the
+      base binary) and after (>= 10 whole-binary rounds of 24 copies on mask
+      `0xF`, 0 failures in the eight). *Evidence:* the table. → PR body. *(R5, R7)*
+- [ ] **A5** — The skip-list lines each fix allows removing are listed.
+      *Evidence:* PR body section. → PR body. *(R6, R7)*
+
+## Gates
+
+- **G1** — English everywhere (`CLAUDE.md`), graded by `arch-review` dimension 8.
+- **G2** — Four checks green, run separately; performance impact declared (the
+  product change is on a rare path: once per frame only while a capture is
+  parked and an image is held).
+- **G3** — `arch-review` (`code-review` at `medium`, full shape pass) with every
+  Blocker/Should-fix resolved or deferred in the PR body; `ai-review` complete
+  with zero unresolved threads.
+- **G4** — Final-head CI green.
+
+## Closing steps
+
+- **C1** — `delivery-review` returns PASS.
+- **C2** — The PR is open against `campaign/lean-a-plus` and marked ready (D6).
+- **C3** — Owned by the coordinator, not this mission: #418's A4 (merge into
+  `campaign/lean-a-plus`, merge read back, #408-#417 closed with integration
+  evidence). Archiving this file is step 8's, before the reviews, not a
+  closing step.
+
+## Preflight record
+
+The source-first completeness pass (delivery contract, high tier) ran after
+implementation had started, not before: an independent read-only pass over
+#418 and D1-D6, then this map. It found the D2 stop clause and #418 A4 without
+a line here; R2/A2 and C3 now carry them. Chronology recorded as it happened.
+
+## Not applicable
+
+- Hot-path bench: the product change runs only while a capture waits for an
+  image (rare), not per trade, per depth, or per idle frame.
+- UI rows (`ui-harness`, `visual-qa`, `trader-ux-review`): nothing user-visible
+  changes; the screenshot toast and the bundle's wire shape are unchanged.
+- New capability / trader action / engine determinism: none added or touched.
+
+## The request as received
+
+> Attributed quotation, verbatim: the campaign coordinator's task prompt for
+> Q10 (campaign #367), followed by issue #418's acceptance criteria.
+
+> You are executing campaign child mission **Q10** of campaign #367 (https://github.com/milocaetano/quantick/issues/367) for milocaetano/quantick: fix the eight load-sensitive tests the new CPU-contention CI step found, and first answer whether the three Null `capture_revision` failures are a product race in the evidence path. You are a subagent: you cannot ask the trader; decisions D1..Dn below answer the mission's step-3 questions. A doubt that would need a new decision becomes a `human_decision` in your handoff, never a guess.
+>
+> ## Read first, in this order
+> 1. `C:\src\quantick\CLAUDE.md` (data honesty: evidence must say which revision it shows; inferred or incomplete data is labelled, never silently patched).
+> 2. `C:\src\quantick\.claude\skills\mission\SKILL.md` — you are a **campaign child at tier `high`**; follow steps 1, 2, 4, 5, 7, 8, 9. Step 3 is answered below. Step 6 is done (worktree, `mission-base`, `mission-tier`, guards armed); still run `cargo check -p quantick-app --all-targets` before the first edit.
+> 3. `C:\src\quantick\docs\campaign\integration.md`, `C:\src\quantick\docs\workflow\delivery.md`.
+> 4. The task: issue #418 (`gh issue view 418`) and each listed issue: #408, #409, #410, #411, #413, #415, #416, #417 (`gh issue view <n>`), each with the failing copy's output and the configuration that reproduced it.
+> 5. The contention harness from Q9, not yet merged: `git -C C:\src\quantick fetch origin ci/app-tests-under-contention` then read `git show origin/ci/app-tests-under-contention:tools/ci/contention.sh`, `...:tools/ci/contention-known-issues.txt` and `...:docs/quality/app-tests-under-contention.md`. You may copy the script into your scratchpad to run it locally; do NOT commit it to your branch (it lands with PR #414).
+> 6. How the campaign fixed this class before: PR #382, #400, #404 (`gh pr view <n>`): force the interleaving the assertion depends on; never weaken an assertion.
+> 7. The evidence path: `crates/app/src/control/evidence.rs` and its `evidence/` siblings (store, image), the screenshot arc in `crates/app/src/control/gateway/screenshot.rs`, `crates/control/src/evidence.rs`, and the tests `crates/app/src/app/tests/screenshot_evidence_tests.rs` and the control-plane test modules.
+>
+> ## Worktree (the only place you write)
+> - `C:\src\quantick-worktrees\fix-contention-listed-tests` (Git Bash `/c/src/quantick-worktrees/fix-contention-listed-tests`), branch `fix/contention-listed-tests`, cut from `origin/campaign/lean-a-plus` at `c55a4222`. Every command starts with `cd /c/src/quantick-worktrees/fix-contention-listed-tests &&`. Never write to `C:\src\quantick` or other worktrees.
+> - You own the control-plane test modules under `crates/app/src/app/tests/`, `screenshot_evidence_tests.rs`, and (only if D2 finds a product race) the evidence capture path under `crates/app/src/control/evidence*` and `gateway/screenshot.rs`. A sibling (Q11) owns `crates/mcp/*`; Q4's PR (in integration) touches `crates/app/src/app/tests/mod.rs`: avoid editing that shared helper file unless indispensable, and say so.
+>
+> ## Decisions
+> - D1: one PR for all eight.
+> - D2: #413, #416, #417 first. Determine from the code whether a bundle or snapshot can be published with a Null `capture_revision` in production under load (a race between frame capture and revision stamping, or a slot read before it is filled). If yes: fix the product path so the revision is always stamped, or the bundle states typed "revision unavailable" instead of a silent Null; add a real-gateway regression test that forces the interleaving; this is a product fix on the evidence contract's semantics but not a wire-shape change; if it would need a wire-shape change (a new field or type), stop and record a `human_decision`. If no: fix the tests.
+> - D3: the other five: force what each assertion depends on (a frame, a worker flush, a publish), bounded waits on observable conditions, the shapes #382/#400/#404 used.
+> - D4: proof: for each of the eight, contention runs (24 copies on 4 cores or its local equivalent) with 0 failures over at least 10 runs after, and the before evidence from the issue; a table in the PR body. Record in the PR body which lines of Q9's skip list (`tools/ci/contention-known-issues.txt` on #414's branch) your fixes allow removing; the coordinator applies that to #414.
+> - D5: tier `high`: `arch-review` with `code-review` at `medium`, full shape pass; `ai-review` completion; `delivery-review` in full. At most three step-0 rounds.
+> - D6: `gh pr ready` works with the cd-prefixed form from the Bash tool. Run it once after reviews, markers and green CI; if denied because the campaign tip moved or the PR is DIRTY, stop and report; the coordinator rebases. **Never use the PowerShell tool for `gh pr` commands; never merge; never touch main.**
+>
+> ## Environment notes
+> - Use `python`, not `python3`. Run the four checks one at a time, never `||` or `| head`; read whole failures. Do not wait on background commands; foreground with an adequate timeout. `taskset` is Linux-only; locally use Windows processor affinity (Q9's doc says how) or a throwaway push-only branch on CI (delete it afterwards; never a PR, never targeting `campaign/lean-a-plus` or `main`).
+> - App tests: `env -u QUANTICK_BUBBLES cargo test -p quantick-app ...`.
+> - Keep every scratchpad file of yours under a `-q10` path; never a generic shared path.
+> - Check `df -h /c` before the first build; if under 15 GB free, `cargo clean` only in your own worktree and report.
+> - If writing review markers into the git dir is denied by the permission classifier, put the exact `printf` lines in your handoff, marked pending.
+> - Commit trailers: `Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>` and `Claude-Session: https://claude.ai/code/session_01VdP84bYEGeyCg7KwsNb1X2`.
+>
+> ## Delivery
+> 1. Implement with the verification loop.
+> 2. Before every commit: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets`, `cargo build --workspace`, `env -u QUANTICK_BUBBLES cargo test --workspace`, each separately.
+> 3. Archive `GOAL.md` per mission step 8 (slug `contention-listed-tests`) as the last commit before reviews.
+> 4. Push; open a **draft** PR: `cd /c/src/quantick-worktrees/fix-contention-listed-tests && gh pr create --draft --base campaign/lean-a-plus --title "test(app): force the interleavings eight load-sensitive tests assert, and stamp every evidence revision" --body-file -` (adjust the title if D2 finds no product race) with a heredoc body per the PR template: tier, "Campaign child of #367 (Q10); closes on integration: #418, #408, #409, #410, #411, #413, #415, #416, #417", the D2 finding with evidence, the per-test table, the skip-list lines to remove, local verification, then `🤖 Generated with [Claude Code](https://claude.com/claude-code)` and `https://claude.ai/code/session_01VdP84bYEGeyCg7KwsNb1X2`.
+> 5. `/arch-review`, `/ai-review`, `/delivery-review`; resolve Blockers/Should-fixes; record markers with the shared key per integration.md.
+> 6. Watch CI at the head (`gh pr checks <n> --watch`, bounded).
+> 7. `gh pr ready <n>` once (D6).
+> 8. Return a HANDOFF BLOCK: issues; branch; worktree; PR URL; head SHA; base tip; the D2 answer with evidence; per-test root cause and fix; the contention table; skip-list lines to remove; review verdicts with URLs; markers yes/no; CI run URL and conclusion; findings closed/open; ready accepted or denied; any human_decision; the coordinator's next action.
+
+> Issue #418, *Acceptance criteria*, verbatim:
+>
+> - [ ] A1: the Null `capture_revision` question answered with evidence (product race or test timing), and fixed at the right layer, with a real-gateway regression test if product.
+> - [ ] A2: each of the eight tests passes 24-copies-on-4-cores contention runs with 0 failures over at least 10 runs (the harness `tools/ci/contention.sh` from #414 with `CONTENTION_ROUNDS=10`, or its local equivalent), before/after table in the PR.
+> - [ ] A3: no assertion weakened; any production change reviewed under the full gates.
+> - [ ] A4: merged into `campaign/lean-a-plus` through a PR whose base is exactly that branch, with the merge read back; #408-#417 closed with integration evidence.

--- a/crates/app/src/app/tests/control_plane_tests.rs
+++ b/crates/app/src/app/tests/control_plane_tests.rs
@@ -2752,7 +2752,9 @@ fn gateway_rejects_a_duplicate_request_id_while_a_wait_is_parked() {
             std::time::Instant::now() < deadline,
             "the answered wait's request ID was never released"
         );
-        std::thread::sleep(std::time::Duration::from_millis(5));
+        // Slower than the connection's request rate limit, or the refusal
+        // that comes back is the limiter's rather than the duplicate check's.
+        std::thread::sleep(std::time::Duration::from_millis(50));
     };
     assert!(
         matches!(
@@ -2931,18 +2933,6 @@ fn an_operator_cannot_remove_an_object_the_trader_drew() {
     assert_eq!(result["removed"], true);
 }
 
-/// Let every pane's indicator worker finish what an attach or a detach sent
-/// it, then run the frame that applies the result: the application loop's own
-/// order, with the worker's half made deterministic. A fixed count of frames
-/// is not a wait; on a loaded machine they all pass before the worker thread
-/// has run at all (#409, #415, and the slot-number test below).
-fn flush_indicators_then_frame(app: &mut QuantickApp, ctx: &egui::Context) {
-    for pane in app.active_tab_mut().panes_mut() {
-        pane.indicator_worker.flush();
-    }
-    run_frame(app, ctx);
-}
-
 /// The tier's floor, again, on the surface the review found open: an
 /// operator detaches what an operator attached, and the trader's own
 /// indicator stays on the chart whatever slot id is named.
@@ -2963,7 +2953,8 @@ plot(close)
         .to_owned(),
         false,
     );
-    flush_indicators_then_frame(&mut app, &ctx);
+    // Settled, not waited out over a count of frames (#415).
+    settle_indicators(&mut app);
     assert_eq!(
         indicator_kinds(&app).len(),
         1,
@@ -3015,14 +3006,15 @@ plot(close)
     // The trader's own, on the first tab.
     let (traders_tab, _, traders_slot) =
         app.attach_script_indicator("the trader's".to_owned(), SCRIPT.to_owned(), false);
-    flush_indicators_then_frame(&mut app, &ctx);
+    // Settled, not waited out over a count of frames, as in #415.
+    settle_indicators(&mut app);
 
     // The second chart, whose slot numbering starts over from zero.
     app.cycle_tab(1);
     run_frame(&mut app, &ctx);
     let (operators_tab, _, operators_slot) =
         app.attach_script_indicator("an assistant's".to_owned(), SCRIPT.to_owned(), true);
-    flush_indicators_then_frame(&mut app, &ctx);
+    settle_indicators(&mut app);
     assert_ne!(traders_tab, operators_tab, "two charts, not one");
     assert_eq!(
         traders_slot.0, operators_slot.0,
@@ -3185,9 +3177,10 @@ fn attaching_a_script_and_detaching_it_leaves_the_pane_as_it_was() {
         )
         .expect("a script that compiles is attached");
     let slot_id = attached["slot_id"].as_str().unwrap().to_owned();
-    // The worker builds off the application thread; frames apply what it
-    // produced, exactly as the library's own click path is served.
-    flush_indicators_then_frame(&mut app, &ctx);
+    // The worker builds off the application thread. Settled rather than
+    // waited out over a count of frames: on a loaded machine 200 frames pass
+    // before the worker thread has run at all (#409).
+    settle_indicators(&mut app);
     assert_eq!(
         indicator_kinds(&app).len(),
         before.len() + 1,
@@ -3201,7 +3194,7 @@ fn attaching_a_script_and_detaching_it_leaves_the_pane_as_it_was() {
         )
         .expect("what an operator attached, an operator detaches");
     assert_eq!(detached["detached"], true);
-    flush_indicators_then_frame(&mut app, &ctx);
+    settle_indicators(&mut app);
     assert_eq!(
         indicator_kinds(&app),
         before,

--- a/crates/app/src/app/tests/control_plane_tests.rs
+++ b/crates/app/src/app/tests/control_plane_tests.rs
@@ -2724,9 +2724,10 @@ fn gateway_rejects_a_duplicate_request_id_while_a_wait_is_parked() {
     // Free again. The gateway writes the wait's answer before it releases
     // the ID, so a client that reuses the ID the instant it reads that answer
     // can still meet the duplicate refusal: on a loaded machine the wait
-    // thread is preempted between the two (#411). The reuse is retried on
-    // exactly that refusal, inside the shared test budget, and must then
-    // succeed; an ID the gateway never released fails here.
+    // thread is preempted between the two (#411; the ordering itself is
+    // #425). The reuse is retried on exactly that refusal, inside the shared
+    // test budget, and must then succeed; an ID the gateway never released
+    // fails here.
     let deadline = std::time::Instant::now() + GATEWAY_TEST_WAIT;
     let reused = loop {
         client
@@ -2934,7 +2935,7 @@ fn an_operator_cannot_remove_an_object_the_trader_drew() {
 /// it, then run the frame that applies the result: the application loop's own
 /// order, with the worker's half made deterministic. A fixed count of frames
 /// is not a wait; on a loaded machine they all pass before the worker thread
-/// has run at all (#409, #415).
+/// has run at all (#409, #415, and the slot-number test below).
 fn flush_indicators_then_frame(app: &mut QuantickApp, ctx: &egui::Context) {
     for pane in app.active_tab_mut().panes_mut() {
         pane.indicator_worker.flush();
@@ -3014,24 +3015,14 @@ plot(close)
     // The trader's own, on the first tab.
     let (traders_tab, _, traders_slot) =
         app.attach_script_indicator("the trader's".to_owned(), SCRIPT.to_owned(), false);
-    for _ in 0..200 {
-        run_frame(&mut app, &ctx);
-        if !indicator_kinds(&app).is_empty() {
-            break;
-        }
-    }
+    flush_indicators_then_frame(&mut app, &ctx);
 
     // The second chart, whose slot numbering starts over from zero.
     app.cycle_tab(1);
     run_frame(&mut app, &ctx);
     let (operators_tab, _, operators_slot) =
         app.attach_script_indicator("an assistant's".to_owned(), SCRIPT.to_owned(), true);
-    for _ in 0..200 {
-        run_frame(&mut app, &ctx);
-        if !indicator_kinds(&app).is_empty() {
-            break;
-        }
-    }
+    flush_indicators_then_frame(&mut app, &ctx);
     assert_ne!(traders_tab, operators_tab, "two charts, not one");
     assert_eq!(
         traders_slot.0, operators_slot.0,

--- a/crates/app/src/app/tests/control_plane_tests.rs
+++ b/crates/app/src/app/tests/control_plane_tests.rs
@@ -818,6 +818,30 @@ fn refused_handshake_code(
     );
 }
 
+/// Let the flow pane's order-flow worker publish everything it was sent, and
+/// run the frame that adopts it, until one such round changes nothing the
+/// chart projection reads from the pane. The frame can hand the worker new
+/// input (a price grid, a projection request), so one round is not always
+/// enough; a bounded number is.
+fn settle_flow_pane(app: &mut QuantickApp, ctx: &egui::Context) {
+    let observed = |app: &QuantickApp| {
+        let pane = &app.active_tab().flow_pane;
+        (
+            pane.state.timeline_revision(),
+            crate::control::chart::viewport_snapshot(pane),
+        )
+    };
+    for _ in 0..8 {
+        let before = observed(app);
+        app.active_tab_mut().tape_mut().flush_for_test();
+        run_frame(app, ctx);
+        if observed(app) == before {
+            return;
+        }
+    }
+    panic!("the flow pane kept changing after eight worker flushes and frames");
+}
+
 #[test]
 fn gateway_client_reads_the_running_application_and_wrong_tokens_fail_closed() {
     use quantick_control::{
@@ -830,6 +854,12 @@ fn gateway_client_reads_the_running_application_and_wrong_tokens_fail_closed() {
     let (mut app, _commands) = app_with_history(12);
     let directory = gateway_test_directory("read");
     let _descriptor_path = enable_test_gateway(&mut app, &ctx, &directory, 8);
+    // The observer-read claim below compares two reads, so nothing but those
+    // reads may move the chart between them. The order-flow worker is still
+    // publishing what the backfill sent it, and the frame that adopts its
+    // capture bucket refolds the footprints, which moves the chart's timeline
+    // revision (#408).
+    settle_flow_pane(&mut app, &ctx);
     let discovery =
         quantick_control_local::client::discover_in(&directory, &gateway_test_options()).unwrap();
     assert!(discovery.issues.is_empty());
@@ -2691,18 +2721,46 @@ fn gateway_rejects_a_duplicate_request_id_while_a_wait_is_parked() {
     let page = reply.expect("the parked wait was answered");
     assert_eq!(page.request_id, request_id);
     assert_eq!(success_result(&page)["timed_out"], true);
-    client
-        .send_with_request_id(
-            request_id.clone(),
-            crate::control::DESCRIBE_CAPABILITY_ID,
-            1,
-            serde_json::json!({}),
-        )
-        .unwrap();
-    assert!(matches!(
-        client.read().unwrap().outcome,
-        quantick_control::wire::ResponseOutcome::Success { .. }
-    ));
+    // Free again. The gateway writes the wait's answer before it releases
+    // the ID, so a client that reuses the ID the instant it reads that answer
+    // can still meet the duplicate refusal: on a loaded machine the wait
+    // thread is preempted between the two (#411). The reuse is retried on
+    // exactly that refusal, inside the shared test budget, and must then
+    // succeed; an ID the gateway never released fails here.
+    let deadline = std::time::Instant::now() + GATEWAY_TEST_WAIT;
+    let reused = loop {
+        client
+            .send_with_request_id(
+                request_id.clone(),
+                crate::control::DESCRIBE_CAPABILITY_ID,
+                1,
+                serde_json::json!({}),
+            )
+            .unwrap();
+        let reply = client.read().unwrap();
+        assert_eq!(reply.request_id, request_id);
+        let still_held = matches!(
+            &reply.outcome,
+            quantick_control::wire::ResponseOutcome::Failure { error }
+                if error.code.as_str() == codes::INVALID_REQUEST
+        );
+        if !still_held {
+            break reply;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "the answered wait's request ID was never released"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(5));
+    };
+    assert!(
+        matches!(
+            reused.outcome,
+            quantick_control::wire::ResponseOutcome::Success { .. }
+        ),
+        "the ID is free once the wait is answered: {:?}",
+        reused.outcome
+    );
 
     disable_test_gateway(&mut app, &ctx);
     std::fs::remove_dir_all(directory).unwrap();
@@ -2872,6 +2930,18 @@ fn an_operator_cannot_remove_an_object_the_trader_drew() {
     assert_eq!(result["removed"], true);
 }
 
+/// Let every pane's indicator worker finish what an attach or a detach sent
+/// it, then run the frame that applies the result: the application loop's own
+/// order, with the worker's half made deterministic. A fixed count of frames
+/// is not a wait; on a loaded machine they all pass before the worker thread
+/// has run at all (#409, #415).
+fn flush_indicators_then_frame(app: &mut QuantickApp, ctx: &egui::Context) {
+    for pane in app.active_tab_mut().panes_mut() {
+        pane.indicator_worker.flush();
+    }
+    run_frame(app, ctx);
+}
+
 /// The tier's floor, again, on the surface the review found open: an
 /// operator detaches what an operator attached, and the trader's own
 /// indicator stays on the chart whatever slot id is named.
@@ -2892,12 +2962,12 @@ plot(close)
         .to_owned(),
         false,
     );
-    for _ in 0..200 {
-        run_frame(&mut app, &ctx);
-        if !indicator_kinds(&app).is_empty() {
-            break;
-        }
-    }
+    flush_indicators_then_frame(&mut app, &ctx);
+    assert_eq!(
+        indicator_kinds(&app).len(),
+        1,
+        "the trader's indicator is on the pane"
+    );
     let refused = app
         .control_action(
             "indicator.script.detach",
@@ -3126,12 +3196,7 @@ fn attaching_a_script_and_detaching_it_leaves_the_pane_as_it_was() {
     let slot_id = attached["slot_id"].as_str().unwrap().to_owned();
     // The worker builds off the application thread; frames apply what it
     // produced, exactly as the library's own click path is served.
-    for _ in 0..200 {
-        run_frame(&mut app, &ctx);
-        if indicator_kinds(&app).len() > before.len() {
-            break;
-        }
-    }
+    flush_indicators_then_frame(&mut app, &ctx);
     assert_eq!(
         indicator_kinds(&app).len(),
         before.len() + 1,
@@ -3145,12 +3210,7 @@ fn attaching_a_script_and_detaching_it_leaves_the_pane_as_it_was() {
         )
         .expect("what an operator attached, an operator detaches");
     assert_eq!(detached["detached"], true);
-    for _ in 0..200 {
-        run_frame(&mut app, &ctx);
-        if indicator_kinds(&app).len() == before.len() {
-            break;
-        }
-    }
+    flush_indicators_then_frame(&mut app, &ctx);
     assert_eq!(
         indicator_kinds(&app),
         before,
@@ -4594,19 +4654,7 @@ fn a_capture_that_wants_an_image_waits_for_the_frame_instead_of_answering_blind(
         .expect("the request is sent");
     // Frames pass and the capture does not answer: it is waiting for the
     // window, which a headless context never rasterises on its own.
-    let mut waited = 0;
-    for _ in 0..PARK_WAIT_FRAMES {
-        run_frame(&mut app, &ctx);
-        waited = app
-            .control
-            .control_access
-            .as_ref()
-            .expect("control access is installed")
-            .awaiting_screenshot_for_test();
-        if waited > 0 {
-            break;
-        }
-    }
+    let waited = run_frames_until_capture_parks(&mut app, &ctx);
     assert_eq!(waited, 1, "the capture parked instead of answering blind");
 
     let mut access = app
@@ -4636,6 +4684,70 @@ fn a_capture_that_wants_an_image_waits_for_the_frame_instead_of_answering_blind(
             .expect("control access is installed")
             .awaiting_screenshot_for_test(),
         0
+    );
+
+    disable_test_gateway(&mut app, &ctx);
+    std::fs::remove_dir_all(directory).unwrap();
+}
+
+/// An image can be claimed only in the frame that holds it: `begin_frame`
+/// drops an unclaimed one when the frame ends. A loaded machine can spend the
+/// frame's whole request budget before the parked captures are served, and a
+/// capture held back on that budget lost the picture it parked for, waited
+/// out its deadline, and reported `frame_not_delivered` for a frame that was
+/// delivered (#413, #416, #417). This spends the budget on purpose.
+#[test]
+fn a_parked_capture_claims_its_image_in_a_frame_whose_budget_is_already_spent() {
+    let ctx = egui::Context::default();
+    let (mut app, _commands) = app_with_history(6);
+    run_frame(&mut app, &ctx);
+    let directory = gateway_test_directory("evidence-image-over-budget");
+    grant_annotate_for_test(&mut app, "all-reads,observe.evidence,observe.screenshot");
+    enable_test_gateway(&mut app, &ctx, &directory, 4);
+    let mut client =
+        quantick_control_local::client::discover_in(&directory, &evidence_test_options())
+            .unwrap()
+            .select(None)
+            .unwrap();
+
+    let request_id = client
+        .send(
+            "evidence.capture",
+            serde_json::json!({ "scopes": ["scene.controls"], "screenshot": true }),
+        )
+        .expect("the request is sent");
+    assert_eq!(run_frames_until_capture_parks(&mut app, &ctx), 1);
+
+    let mut access = app
+        .control
+        .control_access
+        .take()
+        .expect("control access is installed");
+    access.publish_screenshot_for_test(&mut app, test_screenshot(320, 200));
+    access.begin_frame_over_budget_for_test(&mut app, &ctx);
+    let still_parked = access.awaiting_screenshot_for_test();
+    app.control.control_access = Some(access);
+    assert_eq!(
+        still_parked, 0,
+        "the capture is served in the frame that holds its image, whatever that frame has spent"
+    );
+
+    let response = client.read().expect("the gateway answered");
+    assert_eq!(response.request_id, request_id);
+    let manifest = success_result(&response);
+    assert_eq!(
+        manifest["screenshot"]["capture_revision"], manifest["capture_revision"],
+        "the image is stamped with the capture that parked for it"
+    );
+    assert!(
+        !manifest["coverage"]["not_captured"]
+            .as_array()
+            .expect("the coverage lists what is missing")
+            .contains(&serde_json::json!({
+                "subject": "screenshot",
+                "reason": "frame_not_delivered"
+            })),
+        "a delivered frame is never reported as undelivered"
     );
 
     disable_test_gateway(&mut app, &ctx);
@@ -5368,7 +5480,12 @@ fn a_keyed_call_that_expired_before_the_application_saw_it_leaves_its_key_free()
     run_frame(&mut app, &ctx);
     let directory = gateway_test_directory("idempotency-settle");
     grant_annotate_for_test(&mut app, "all-reads,cockpit,cockpit.layout");
-    enable_test_gateway_with_limits(&mut app, &ctx, &directory, 4, Duration::from_millis(50), 4);
+    // One window serves both calls: the first must outlive it, the retry must
+    // not. 50 ms was short enough that a loaded machine let the retry expire
+    // too (#410). The first call expires however long the window is, because
+    // nothing serves it until its refusal has been read.
+    let window = Duration::from_millis(750);
+    enable_test_gateway_with_limits(&mut app, &ctx, &directory, 4, window, 4);
     let mut client =
         quantick_control_local::client::discover_in(&directory, &cockpit_test_options())
             .unwrap()
@@ -5388,7 +5505,12 @@ fn a_keyed_call_that_expired_before_the_application_saw_it_leaves_its_key_free()
             key(),
         )
         .unwrap();
-    let expired = client.read().unwrap();
+    // The refusal is written when the response worker's own timer fires, and a
+    // loaded machine can wake that thread after the client's ordinary read
+    // timeout: waited for as long as the shared test budget allows.
+    let expired = client
+        .read_with_extra_patience(GATEWAY_TEST_WAIT.as_millis() as u64)
+        .unwrap();
     assert_eq!(expired.request_id, first);
     assert_eq!(response_error(&expired).code.as_str(), codes::TIMEOUT);
     assert!(
@@ -5407,30 +5529,56 @@ fn a_keyed_call_that_expired_before_the_application_saw_it_leaves_its_key_free()
 
     // The invited retry. `control.request_in_progress` while the settle window
     // is still open is the contract's own instruction to ask again, so this
-    // asks again rather than treating it as the answer.
-    let mut answered = None;
-    for attempt in 0..40 {
-        let response = remote_call_with_key(
-            &mut app,
-            &ctx,
-            &mut client,
-            &format!("retry-{attempt}"),
-            "layout.tab.create",
-            serde_json::json!({}),
-            "layout-key-1",
-        );
+    // asks again rather than treating it as the answer. Each retry is served
+    // the moment it is queued, through the same `execute_on_ui` a frame's
+    // drain calls, so its own deadline is never spent waiting for a frame
+    // whose budget the frame's other work used up.
+    let deadline = std::time::Instant::now() + GATEWAY_TEST_WAIT;
+    let mut attempt = 0;
+    let answered = loop {
+        attempt += 1;
+        let sent = client
+            .send_with_idempotency_key(
+                RequestId::new(format!("retry-{attempt}")).unwrap(),
+                "layout.tab.create",
+                1,
+                serde_json::json!({}),
+                key(),
+            )
+            .unwrap();
+        let response = loop {
+            let mut access = app
+                .control
+                .control_access
+                .take()
+                .expect("control access is installed");
+            access.serve_queued_for_test(&mut app);
+            app.control.control_access = Some(access);
+            if client.reply_pending(Duration::from_millis(5)) {
+                break client.read().unwrap();
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "no answer to retry-{attempt}"
+            );
+        };
+        assert_eq!(response.request_id, sent);
         let still_running = matches!(
             &response.outcome,
             quantick_control::wire::ResponseOutcome::Failure { error }
                 if error.code.as_str() == codes::REQUEST_IN_PROGRESS
         );
         if !still_running {
-            answered = Some(response);
-            break;
+            break response;
         }
-        std::thread::sleep(Duration::from_millis(10));
-    }
-    let answered = answered.expect("the settle window closes and the key comes back");
+        assert!(
+            std::time::Instant::now() < deadline,
+            "the settle window closes and the key comes back"
+        );
+        // Slower than the connection's request rate limit, or the refusal
+        // that comes back is the limiter's rather than the store's.
+        std::thread::sleep(Duration::from_millis(50));
+    };
 
     assert!(
         matches!(

--- a/crates/app/src/app/tests/mod.rs
+++ b/crates/app/src/app/tests/mod.rs
@@ -2431,19 +2431,7 @@ fn capture_with_screenshot(
     // wait for one that never comes. Asserted rather than assumed, so a
     // machine slow enough to break the precondition says so here instead
     // of failing later on a confusing assertion about the manifest.
-    let parked = (0..PARK_WAIT_FRAMES).any(|_| {
-        run_frame(app, ctx);
-        app.control
-            .control_access
-            .as_ref()
-            .expect("control access is installed")
-            .awaiting_screenshot_for_test()
-            > 0
-    });
-    assert!(
-        parked,
-        "the capture did not park for an image within {PARK_WAIT_FRAMES} frames"
-    );
+    run_frames_until_capture_parks(app, ctx);
     let mut access = app
         .control
         .control_access
@@ -2462,12 +2450,34 @@ fn capture_with_screenshot(
     response
 }
 
-/// Frames a test spends waiting for a capture to park on an image.
+/// Run application frames until a capture has parked on an image, and return
+/// how many are parked.
 ///
-/// Generous: the request crosses a socket and two threads, and these tests
-/// run alongside every other crate's test binary. The gateways they use
-/// have their request timeout raised for the same reason.
-const PARK_WAIT_FRAMES: usize = 600;
+/// Bounded by time, not by frames. The request crosses a socket and the
+/// gateway's reader thread before any frame can park it, and on a loaded
+/// machine a fixed count of back-to-back frames runs out before that thread
+/// has run at all (#416). The sleep between frames hands it the core.
+fn run_frames_until_capture_parks(app: &mut QuantickApp, ctx: &egui::Context) -> usize {
+    let deadline = std::time::Instant::now() + GATEWAY_TEST_WAIT;
+    loop {
+        run_frame(app, ctx);
+        let parked = app
+            .control
+            .control_access
+            .as_ref()
+            .expect("control access is installed")
+            .awaiting_screenshot_for_test();
+        if parked > 0 {
+            return parked;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "the capture did not park for an image within {GATEWAY_TEST_WAIT:?}"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(1));
+    }
+}
+
 /// Frames a test spends waiting for the gateway's reply.
 const REPLY_WAIT_FRAMES: usize = 600;
 

--- a/crates/app/src/app/tests/screenshot_evidence_tests.rs
+++ b/crates/app/src/app/tests/screenshot_evidence_tests.rs
@@ -20,15 +20,7 @@ fn capture_fixture(
             serde_json::json!({ "scopes": EVIDENCE_TEST_SCOPES, "screenshot": true }),
         )
         .unwrap();
-    assert!((0..PARK_WAIT_FRAMES).any(|_| {
-        run_frame(app, ctx);
-        app.control
-            .control_access
-            .as_ref()
-            .unwrap()
-            .awaiting_screenshot_for_test()
-            > 0
-    }));
+    run_frames_until_capture_parks(app, ctx);
     let tab = app.active_tab_mut();
     assert_eq!(tab.time_panes.len(), 2);
     tab.time_panes[0].frame.chart_area = rectangles[0];

--- a/crates/app/src/control/gateway.rs
+++ b/crates/app/src/control/gateway.rs
@@ -692,7 +692,19 @@ impl ControlAccess {
     }
 
     pub fn begin_frame(&mut self, app: &mut QuantickApp, ctx: &eframe::egui::Context) {
-        let frame_started = Instant::now();
+        self.begin_frame_since(app, ctx, Instant::now());
+    }
+
+    /// [`Self::begin_frame`], timed from `frame_started` rather than from the
+    /// call. Production passes the call's own instant; the test seam passes
+    /// one far enough back that the frame's request budget is already spent,
+    /// which is what a loaded machine's frame prelude does.
+    fn begin_frame_since(
+        &mut self,
+        app: &mut QuantickApp,
+        ctx: &eframe::egui::Context,
+        frame_started: Instant,
+    ) {
         self.poll_lifecycle();
         let statuses_have_more = self.poll_statuses(frame_started);
         let (requests, generation) = match &self.state {
@@ -1168,6 +1180,22 @@ impl ControlAccess {
             ..GatewayOptions::default()
         };
         self.request_enable(ctx, options);
+    }
+
+    /// One frame whose request budget was spent before the frame service ran,
+    /// as a loaded machine's frame prelude spends it. Everything the frame
+    /// does after that is the production path, unchanged.
+    #[cfg(test)]
+    pub(crate) fn begin_frame_over_budget_for_test(
+        &mut self,
+        app: &mut QuantickApp,
+        ctx: &eframe::egui::Context,
+    ) {
+        let spent = Duration::from_micros(CONTROL_UI_BUDGET_US + 1);
+        let started = Instant::now()
+            .checked_sub(spent)
+            .expect("the monotonic clock reaches back one frame budget");
+        self.begin_frame_since(app, ctx, started);
     }
 
     #[cfg(test)]

--- a/crates/app/src/control/gateway/screenshot.rs
+++ b/crates/app/src/control/gateway/screenshot.rs
@@ -194,9 +194,17 @@ impl ControlAccess {
             // against a documented ceiling of four, and the drain would find
             // its budget already gone. A waiter this frame cannot serve stays
             // queued and is served by the next one.
-            if served >= CONTROL_UI_MAX_REQUESTS_PER_FRAME
-                || elapsed_us_since(frame_started) > CONTROL_UI_BUDGET_US
-            {
+            //
+            // Except while this frame holds an image. `begin_frame` drops the
+            // image when the frame ends, so a waiter held back on *time* here
+            // would lose the picture it parked for, then wait out its deadline
+            // and report `frame_not_delivered` for a frame that was delivered.
+            // A loaded machine can spend the whole budget before this point on
+            // every frame, so that would repeat on every frame. The count
+            // ceiling still applies, and the first waiter is always under it.
+            let out_of_time =
+                elapsed_us_since(frame_started) > CONTROL_UI_BUDGET_US && self.screenshot.is_none();
+            if served >= CONTROL_UI_MAX_REQUESTS_PER_FRAME || out_of_time {
                 self.awaiting_screenshot.push_back(request);
                 self.awaiting_screenshot.extend(waiting);
                 ctx.request_repaint();


### PR DESCRIPTION
## Summary

Fix the eight load-sensitive tests the CPU-contention step found, after first establishing that the three Null `capture_revision` failures come from a product race in the screenshot arc.

**Tier:** `high` (set by the coordinator: one item was a possible product race in evidence capture). Campaign child of #367 (Q10); closes on integration: #418, #408, #409, #410, #411, #413, #415, #416, #417.

## D2 finding: a product race, but never a Null revision on the wire

**No bundle can carry a screenshot without its revision.** `EvidenceScreenshot::capture_revision` is a non-optional `WireU64` (`control/evidence.rs`), set from the snapshot's own revision in `encode_screenshot` (`control/evidence/image.rs`). The manifest's `screenshot` is `Option<_>` with `skip_serializing_if = "Option::is_none"`. The `Null` in #413, #416 and #417 is `serde_json::Value` indexing into an **absent** `screenshot` object, not a descriptor missing its field. #413's own failure shows it: line 91 (`descriptor == manifest["screenshot"]`) passed because both were absent, and line 92 then compared `Null` with `"1"`.

**Why the image was absent: a delivered frame was dropped.** In `ControlAccess::begin_frame` (`control/gateway.rs`) the frame harvests the image, then `serve_awaiting_screenshot` (`control/gateway/screenshot.rs`) serves the parked captures, and at the end of the frame the unclaimed image is dropped (`self.screenshot = None`, "a rasterised frame is worth exactly one frame"). `serve_awaiting_screenshot` held a waiter back as soon as `elapsed_us_since(frame_started) > CONTROL_UI_BUDGET_US` (250 us), **before** the first waiter too. Under load the frame prelude alone (lifecycle and status polls, semantic events, the harvest) spends 250 us, so the waiter was held back and its image dropped. The capture then re-armed, waited out `deadline - CONTROL_SCREENSHOT_GRACE_MS`, and was answered with `coverage.not_captured: {subject: "screenshot", reason: "frame_not_delivered"}`. That label is false: the frame had been delivered. On a machine that spends the budget on *every* frame it is worse: the waiter is held back on every frame, never reaches its give-up, and the response worker answers its deadline with a bare `control.timeout` and no bundle at all.

Captured, not inferred: one instrumented copy under local contention printed the failing bundle's coverage:

```text
Q10DIAG coverage=[..., {"reason":"frame_not_delivered","subject":"screenshot"}, ...]
```

(the other 194 instrumented captures carried `screenshot.state_skew`, the gap an image-bearing bundle always lists).

**The fix is in the product, with no wire-shape change.** Two lines in `serve_awaiting_screenshot`:

1. A waiter is held back on time only while the frame holds no image: `out_of_time = elapsed > budget && self.screenshot.is_none()`. The count ceiling (`CONTROL_UI_MAX_REQUESTS_PER_FRAME`) still applies, and the first waiter is always under it.
2. A waiter that *is* held back re-arms the rasterise (`arm_screenshot`) instead of only requesting a repaint. Step 0's second round found this: once the first capture took the image, the captures parked behind it were held back with nothing asking the window for another frame, so they waited on an image nothing had requested.

The three tests pass without changing their assertions.

**Pre-existing, not changed:** a capture that reaches its give-up point (`deadline - CONTROL_SCREENSHOT_GRACE_MS`) with no image, on a machine that spends the budget on every frame, is still held back on time and ends in a bare `control.timeout` rather than `frame_not_delivered`. Exempting the give-up as well would be new behaviour with no deterministic test (it depends on the 250 ms grace window), so it is left as it was and named here.

**Real-gateway regression test.** `control_plane_tests::a_parked_capture_claims_its_image_in_a_frame_whose_budget_is_already_spent` parks a capture through a real socket, hands over the image, and runs one frame whose budget is already spent (`ControlAccess::begin_frame_over_budget_for_test`, a `#[cfg(test)]` seam over the production `begin_frame_since`). It asserts the capture is served in that frame, that its image is stamped with the capture's revision, and that the coverage does not say `frame_not_delivered`. A second test, `captures_parked_behind_the_first_ask_for_the_next_frame_when_the_budget_is_spent`, parks two captures, spends the budget on two frames, and asserts that the second capture re-arms after the first takes the image, then claims the next image (answers matched by request ID, since two response workers encode them). Without line 2 it fails at `the capture still parked asks the window for the next frame`. Before the fix, the first test fails deterministically:

```text
assertion `left == right` failed: the capture is served in the frame that holds its image, whatever that frame has spent
  left: 1
 right: 0
```

**A second, test-side exposure in the same three tests.** The park waits spun at most 600 back-to-back frames (`PARK_WAIT_FRAMES`) for the request to cross the socket and park. On a loaded machine they ran out first (`the capture did not park for an image within 600 frames`, `mod.rs:2442`, seen locally for #416). They are now one time-bounded helper, `run_frames_until_capture_parks`, with a 1 ms sleep between frames so the reader thread gets a core. The bound is `GATEWAY_TEST_WAIT`, as in #382 and #400.

## The other five (D3)

| Issue | Test | Root cause (captured) | What the test now forces |
| --- | --- | --- | --- |
| #408 | `gateway_client_reads_the_running_application_and_wrong_tokens_fail_closed` | The chart module's revision key is the whole chart projection. Between the two observer reads `timeline_revision` went `3 → 4` (instrumented diff, nothing else changed): the order-flow worker published the capture bucket late, and the next frame's `set_footprint_group` refolded the footprints. | `settle_flow_pane`: flush the order-flow worker, run the frame that adopts it, and repeat until a round changes neither the flow pane's timeline revision nor its viewport projection (at most 8 rounds, else it panics). The observer-read assertion is unchanged. |
| #409 | `attaching_a_script_and_detaching_it_leaves_the_pane_as_it_was` | 200 back-to-back frames passed before the indicator worker built the script. | The suite's existing `settle_indicators`: flush every pane's indicator worker, then apply its events (the frame loop's two steps). Used after the attach and after the detach. Both assertions unchanged. |
| #415 | `an_operator_cannot_detach_the_traders_own_indicator` | Same as #409. | `settle_indicators`. It also asserts the trader's indicator is on the pane **before** the refused detach, so "still on the pane" can no longer pass or fail on timing. |
| #410 | `a_keyed_call_that_expired_before_the_application_saw_it_leaves_its_key_free` | One 50 ms request window served both the call that must expire and the retry that must not. Under load the retry also expired before dispatch (`control.timeout`, "request expired before application-thread dispatch"). | The window is 750 ms (the precedent in `retry_readback_tests`). The first call still expires, since nothing serves it until its refusal is read. Each retry is served the moment it is queued, through `serve_queued_for_test` (the production `execute_on_ui`), paced by `pause_one_request_interval` (one interval of `CONTROL_CLIENT_RATE_PER_SECOND`, 50 ms today) so the connection's rate limit does not answer instead (a first cut at 10 ms met `control.backpressure`). The expired call's refusal is read with `read_with_extra_patience`. The success and "exactly one layout" assertions are unchanged. |
| #411 | `gateway_rejects_a_duplicate_request_id_while_a_wait_is_parked` | Instrumented: the final reuse came back `control.invalid_request` / "request_id is already in flight on this connection" (15 of 65 runs). Every terminal path in `gateway/server.rs` writes the answer **before** `slots.forget(request_id)`, so an immediate reuse can race the release. Filed as **#425**. | The reuse is retried on exactly `control.invalid_request`, paced by the same `pause_one_request_interval` (slower than the connection's rate limit, so the limiter's refusal cannot end the loop; step 0 caught a first cut at 5 ms, and ai-review asked for the pause to be derived from the limit), within `GATEWAY_TEST_WAIT`, then must succeed. An ID the gateway never released still fails. The product ordering is out of D3's scope (see *human decision* below). |

**A ninth test, by the same mechanism.** `an_operator_detaching_its_own_slot_leaves_the_traders_slot_of_the_same_number`, which sits beside #415 and uses the same 200-frame spin, failed this mission's own `cargo test --workspace` while contention runs shared the host, and one local contention round. It gets the same `settle_indicators`. That is a stated detour (mission S4): the verification loop could not be green without it.

No assertion was removed or loosened. Every waiting loop is bounded by time and fails with a message that names what it waited for.

## Contention proof (D4)

Local equivalent of `tools/ci/contention.sh` (Linux-only `taskset`): a PowerShell harness starts **24 concurrent copies of the whole `quantick-app` test binary**, each held to processor mask `0xF` (4 of this machine's 12 cores; children inherit the mask) with `--test-threads=4`, from `crates/app`. This is the shape Q9 used for its local reproductions. The host is shared (an Edge WebView and other sessions were using CPU), so these runs are at least as contended as CI, not less. *Before* is the base binary (`c55a4222`). *After* is the binary built from this branch. The branch was rebased onto `a3c962fa` (#419, #424) during the mission.

**The D4 proof: 24 copies of the whole binary on mask `0xF`, ten rounds at the final code (`01a367b3`, base `a3c962fa`).** 240 copies ran each test. The tree differs from the head `5a9c5c26` only by a 1 ms sleep inside the new `captures_parked_behind_the_first…` test's park wait.

| Issue | Test | Before: CI (issue evidence, 24 × 4) | Before: local 0xF, 3 rounds at `c55a4222` | After: local 0xF, 10 rounds at `01a367b3` |
| --- | --- | --- | --- | --- |
| #408 | `gateway_client_reads_…_fail_closed` | 1–3 of 24 per run, in 4 runs | 0 / 72 | **0 / 240** |
| #409 | `attaching_a_script_and_detaching_it_…` | 1 of 16 | 0 / 72 | **0 / 240** |
| #410 | `a_keyed_call_that_expired_…_key_free` | 1 of 24, twice | **2 / 72** (1, 1, 0) | **0 / 240** |
| #411 | `gateway_rejects_a_duplicate_request_id_…` | 1 of 24 | **15 / 72** (1, 5, 9) | **0 / 240** |
| #413 | `synthetic_fractional_geometry_round_trips_…` | 1 of 24 | 0 / 72 | **0 / 240** |
| #415 | `an_operator_cannot_detach_the_traders_own_indicator` | 1 of 24 | 0 / 72 | **0 / 240** |
| #416 | `a_bundle_with_a_screenshot_maps_…` | 1 of 24 | 0 / 72 | **0 / 240** |
| #417 | `a_capture_that_wants_an_image_waits_…` | 1 of 24 | 0 / 72 | **0 / 240** |
| new | `a_parked_capture_claims_its_image_…` | n/a | n/a | **0 / 240** |
| new | `captures_parked_behind_the_first_…` | n/a | n/a | **0 / 240** |
| S4 | `an_operator_detaching_its_own_slot_…` | not listed | 0 / 72 (plus 1 in 10 rounds at `efbada89` before its fix, and once in this mission's own `cargo test --workspace`) | **0 / 240** |

An earlier ten rounds at `efbada89` (the first fix, base `c55a4222`, binary built with `-p`) also had 0 / 240 for each of the eight. Their failures elsewhere are counted below.

**A harsher local configuration, to reproduce what 0xF rarely does:** the eight tests only, 24 copies on mask `0x3` (2 cores).

| Build | Rounds | What failed |
| --- | ---: | --- |
| before (`c55a4222`) | 3 | #411 at its assertion 17 times; #416 at the frame-counted park wait (`the capture did not park for an image within 600 frames`) twice; #409 at `:3135` once; #415 at `:2910` once. The instrumented copy of the base (3 more rounds) also showed #408 at `:941` (`timeline_revision` 3 → 4) twice, #413 at `:93` (`Null` vs `"1"`, coverage `frame_not_delivered`) once, and #411's reuse refused as `already in flight` 15 times. |
| after (`01a367b3`) | 6 | 3 copies in one round, all at the connect handshake (`discover_in(...).select(None).unwrap()` → `control.instance_gone`, the client's 2 s `CONTROL_HANDSHAKE_TIMEOUT_MS`), none at any of the issues' assertions. That exposure is shared by every gateway test on 24 copies over 2 cores. It did not appear in any 0xF round. |

**Not caused by this branch:** in the same 0xF runs, other tests failed in both builds. None is touched by this branch, and each is filed:

| Test | Before, 3 rounds | After, 10 rounds at `01a367b3` | Issue |
| --- | --- | --- | --- |
| `gateway_a_client_that_never_reads_does_not_stall_another` | 0, 9, 1 | 1, 11, 6, 8, 10, 6, 5, 6, 6, 8 | #427 |
| `a_keyed_action_held_past_its_deadline_…_by_readback` | 0, 2, 3 | 0, 8, 0, 2, 0, 0, 0, 0, 9, 1 | #428 |
| `every_reachable_optional_row_replays_a_dropped_answer_and_begins_once` | 0, 0, 0 | 0, 0, 0, 0, 0, 0, 0, 5, 8, 1 | #432 |
| `gateway_request_timeout_is_structured_and_late_ui_work_is_discarded` | 1, 0, 0 | 0 (1 in the `efbada89` rounds) | #430 |
| `live_envelope_tests::burst::inside_the_envelope_every_print_arrives_and_no_queue_fills` | not measured | 13 / 24 in one probe round at `efbada89`; skipped afterwards so the rounds could measure the eight | #429 |

So **the contention step's 10-green landing condition (D19) is not met by this PR alone**: a whole-binary round was red in most rounds locally, on these tests. On a shared 12-core host they fail more often than on the CI runner, where Q9's calibration did not list them.

## Skip-list lines this allows removing

On #414's branch, `tools/ci/contention-known-issues.txt`: **all eight entries, lines 11 to 18** (#408, #409, #410, #411, #413, #415, #416, #417). Once they are gone the file holds only its header. The coordinator applies this to #414.

## Findings filed on the way

- **#425**: the gateway writes an answer before releasing its request ID (the #411 product race; see *human decision*).
- **#427, #428, #429, #430, #432**: load-sensitive tests outside the eight (table above). Each needs a fix, or a skip-list line citing its issue, before the contention step can hold ten consecutive green runs.

## Performance impact

- `serve_awaiting_screenshot` (product): **rare**. It returns before the changed line on every frame with no parked capture. With one parked, the change costs one `Option::is_none` per waiter. The only behavioural difference: a frame that holds an image can run one capture past the 250 us budget, a capture that would otherwise have run on a later frame, or never.
- `begin_frame` → `begin_frame_since(Instant::now())`: per frame, an extra call with identical work.
- Everything else is `#[cfg(test)]`.

## Human decision

- **#425: release a request ID before writing its answer.** The gateway's terminal paths write, then forget. A client that reuses an ID right after reading its answer can be refused with a **non-retryable** `control.invalid_request`. That contradicts contract §5.2 ("while the first request is in flight"). The fix is a reorder on each terminal path in `gateway/server.rs`. It is outside D2's evidence-path authorization, so this PR fixes #411 at the test layer and the product decision is the coordinator's or trader's. Once #425 lands, #411's wait can go.

## Verification loop

Run locally at ``5a9c5c26` (the head)`, each command on its own:

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets`
- [x] `cargo build --workspace`
- [x] `env -u QUANTICK_BUBBLES cargo test --workspace` (`quantick-app` binary: 2060 passed, 0 failed, 9 ignored. The first run at this head hit #428's test once while the contention rounds shared the host; the rerun was green.)
- [x] `cargo test -p quantick-guards`

Plus the contention runs above (local), and required CI at the final head.

## Reviews

- `arch-review`: https://github.com/milocaetano/quantick/pull/426#issuecomment-5651453581. Step 0 was `code-review` at medium, three rounds, 3 findings (one Blocker in the product path), all fixed. The shape pass is clean; two Consider items are recorded there.
- `ai-review`: https://github.com/milocaetano/quantick/pull/426#issuecomment-5651287033 (full), then https://github.com/milocaetano/quantick/pull/426#issuecomment-5651457726 (follow-up at `5a9c5c26`). One WEAK (retry pacing) was fixed and its thread resolved; 0 open threads.
- `delivery-review`: FAIL at `5a9c5c26` on one traceability gap (DR-Q10-1: the write scope was not ledgered; https://github.com/milocaetano/quantick/pull/426#issuecomment-5651844726). `60ef4053` fixed it by adding G5 and rewording S3. The follow-up **PASS** is at https://github.com/milocaetano/quantick/pull/426#issuecomment-5651887292.
- Follow-ups at `60ef4053`: arch-review https://github.com/milocaetano/quantick/pull/426#issuecomment-5651849401, ai-review https://github.com/milocaetano/quantick/pull/426#issuecomment-5651852376.

CI at the head `60ef4053`: https://github.com/milocaetano/quantick/actions/runs/34744430953 (`ci` and `windows` pass). `60ef4053` changes only the mission archive's prose. The local checks were run at `5a9c5c26`.

## Notes for the reviewer

- `crates/app/src/app/tests/mod.rs` is the shared helper file. The only edit there is the park-wait helper that replaces `PARK_WAIT_FRAMES`, because `capture_with_screenshot` (used by #416) lives there. No open campaign PR touches that file.
- `control/gateway.rs` is outside this child's owned file list (mission G5). The `#[cfg(test)]` seam `begin_frame_over_budget_for_test` sits there, beside the other `*_for_test` gateway seams, because the frame it runs is `begin_frame`'s. The only production line is the split of `begin_frame` into a private `begin_frame_since(Instant::now())`, which does identical work. No other open campaign PR touches the file. The coordinator decides whether to accept it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VdP84bYEGeyCg7KwsNb1X2
